### PR TITLE
feat: browser notifications for pipeline events

### DIFF
--- a/.claude/worca-ui/app/main.js
+++ b/.claude/worca-ui/app/main.js
@@ -12,6 +12,7 @@ import { logViewerView, writeLogLine, writeIterationSeparator, clearTerminal, mo
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { iconSvg, ArrowLeft, Square, Play, Loader, AlertTriangle } from './utils/icons.js';
 import { statusIcon } from './utils/status-badge.js';
+import { createNotificationManager } from './notifications.js';
 
 // Register Shoelace components (tree-shaken — only imports what we use)
 import '@shoelace-style/shoelace/dist/components/details/details.js';
@@ -31,6 +32,7 @@ import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 
 const store = createStore();
 const ws = createWsClient();
+const notificationManager = createNotificationManager({ store, ws, getSettings: () => settings });
 let route = parseHash(location.hash);
 let connectionState = ws.getState();
 let autoScroll = true;
@@ -74,6 +76,8 @@ ws.on('runs-list', (payload) => {
 
 ws.on('run-snapshot', (payload) => {
   if (payload && payload.id) {
+    const prevRun = store.getState().runs[payload.id] ?? null;
+    notificationManager.handleRunUpdate(payload.id, payload, prevRun);
     store.setRun(payload.id, payload);
     if (pipelineAction) {
       pipelineAction = null;
@@ -84,6 +88,8 @@ ws.on('run-snapshot', (payload) => {
 
 ws.on('run-update', (payload) => {
   if (payload && payload.id) {
+    const prevRun = store.getState().runs[payload.id] ?? null;
+    notificationManager.handleRunUpdate(payload.id, payload, prevRun);
     store.setRun(payload.id, payload);
     if (pipelineAction) { pipelineAction = null; rerender(); }
   }
@@ -190,6 +196,11 @@ function handleThemeToggle() {
   ws.send('set-preferences', { theme: next }).catch(() => {});
   store.setState({ preferences: { theme: next } });
   applyTheme(next);
+}
+
+function handleSaveNotifications(notifPrefs) {
+  ws.send('set-preferences', { notifications: notifPrefs }).catch(() => {});
+  store.setState({ preferences: { notifications: notifPrefs } });
 }
 
 function handleStageFilter(stage) {
@@ -391,7 +402,7 @@ function mainContentView() {
   }
 
   if (route.section === 'settings') {
-    return settingsView(state.preferences, { rerender, onThemeToggle: handleThemeToggle });
+    return settingsView(state.preferences, { rerender, onThemeToggle: handleThemeToggle, onSaveNotifications: handleSaveNotifications });
   }
 
   if (route.section === 'history') {
@@ -433,6 +444,7 @@ function rerender() {
         onNavigate: handleNavigate
       })}
       <main class="main-content">
+        ${notificationManager.renderBanner()}
         ${contentHeaderView()}
         ${mainContentView()}
       </main>
@@ -458,6 +470,7 @@ function rerender() {
 
 // --- Bootstrap ---
 
+notificationManager.setRerender(rerender);
 store.subscribe(() => rerender());
 applyTheme(store.getState().preferences.theme);
 if (route.section === 'settings') {

--- a/.claude/worca-ui/app/notifications.js
+++ b/.claude/worca-ui/app/notifications.js
@@ -1,0 +1,365 @@
+/**
+ * Browser notification manager for worca-ui pipeline events.
+ * Detects state changes from WebSocket run updates and fires
+ * Web Notifications API alerts based on user preferences.
+ */
+
+import { html, nothing } from 'lit-html';
+import { navigate } from './router.js';
+
+// --- Event definitions ---
+
+export const NOTIFICATION_EVENTS = [
+  'run_completed',
+  'run_failed',
+  'approval_needed',
+  'test_failures',
+  'loop_limit_warning'
+];
+
+const EVENT_CONFIG = {
+  run_completed: {
+    severity: 'info',
+    title: 'Pipeline Complete',
+    requireInteraction: false,
+  },
+  run_failed: {
+    severity: 'critical',
+    title: 'Pipeline Failed',
+    requireInteraction: false,
+  },
+  approval_needed: {
+    severity: 'critical',
+    title: 'Approval Required',
+    requireInteraction: true,
+  },
+  test_failures: {
+    severity: 'warning',
+    title: 'Tests Failed',
+    requireInteraction: false,
+  },
+  loop_limit_warning: {
+    severity: 'warning',
+    title: 'Loop Limit Warning',
+    requireInteraction: false,
+  },
+};
+
+// --- Detector functions (exported for testing) ---
+
+export function detectRunCompleted(runId, newRun, prevRun) {
+  if (!prevRun || !newRun) return null;
+  const wasActive = prevRun.active === true;
+  const nowInactive = newRun.active === false;
+  if (!wasActive || !nowInactive) return null;
+
+  const stages = newRun.stages || {};
+  const hasError = Object.values(stages).some(s => s.status === 'error');
+  if (hasError) return null;
+
+  const runTitle = getRunTitle(newRun);
+  return {
+    event: 'run_completed',
+    title: EVENT_CONFIG.run_completed.title,
+    body: `"${runTitle}" finished successfully`,
+    tag: `worca-complete-${runId}`,
+    requireInteraction: false,
+    runId,
+  };
+}
+
+export function detectRunFailed(runId, newRun, prevRun) {
+  if (!prevRun || !newRun) return null;
+  const wasActive = prevRun.active === true;
+  const nowInactive = newRun.active === false;
+  if (!wasActive || !nowInactive) return null;
+
+  const stages = newRun.stages || {};
+  const failedStage = Object.entries(stages).find(([, s]) => s.status === 'error');
+  if (!failedStage) return null;
+
+  const runTitle = getRunTitle(newRun);
+  return {
+    event: 'run_failed',
+    title: EVENT_CONFIG.run_failed.title,
+    body: `"${runTitle}" failed at ${failedStage[0]} stage`,
+    tag: `worca-failed-${runId}`,
+    requireInteraction: false,
+    runId,
+  };
+}
+
+export function detectApprovalNeeded(runId, newRun, prevRun) {
+  if (!newRun) return null;
+  const newStages = newRun.stages || {};
+  const prevStages = (prevRun && prevRun.stages) || {};
+
+  for (const [key, stage] of Object.entries(newStages)) {
+    if (stage.status === 'waiting_approval') {
+      const prevStatus = prevStages[key]?.status;
+      if (prevStatus !== 'waiting_approval') {
+        const runTitle = getRunTitle(newRun);
+        const label = key === 'pr' ? 'PR' : key;
+        return {
+          event: 'approval_needed',
+          title: EVENT_CONFIG.approval_needed.title,
+          body: `"${runTitle}" is waiting for ${label} approval`,
+          tag: `worca-approval-${runId}-${key}`,
+          requireInteraction: true,
+          runId,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+export function detectTestFailures(runId, newRun, prevRun) {
+  if (!newRun) return null;
+  const testStage = newRun.stages?.test;
+  if (!testStage) return null;
+
+  const newIters = testStage.iterations || [];
+  const prevIters = (prevRun?.stages?.test?.iterations) || [];
+
+  if (newIters.length > prevIters.length) {
+    const latest = newIters[newIters.length - 1];
+    if (latest && latest.result === 'failed') {
+      const runTitle = getRunTitle(newRun);
+      return {
+        event: 'test_failures',
+        title: EVENT_CONFIG.test_failures.title,
+        body: `"${runTitle}" test iteration ${newIters.length} failed`,
+        tag: `worca-test-${runId}-iter${newIters.length}`,
+        requireInteraction: false,
+        runId,
+      };
+    }
+  }
+  return null;
+}
+
+export function detectLoopLimitWarning(runId, newRun, prevRun, settings, warnedLoops) {
+  if (!newRun || !settings) return null;
+  const loops = settings?.worca?.loops;
+  if (!loops) return null;
+
+  const stages = newRun.stages || {};
+
+  // Map loop config keys to stage names
+  const loopStageMap = {
+    implement_test: ['implement', 'test'],
+    code_review: ['review'],
+    pr_changes: ['pr'],
+    restart_planning: ['plan'],
+  };
+
+  for (const [loopKey, limit] of Object.entries(loops)) {
+    if (!limit || limit < 2) continue;
+    const stageNames = loopStageMap[loopKey];
+    if (!stageNames) continue;
+
+    for (const stageName of stageNames) {
+      const stage = stages[stageName];
+      if (!stage) continue;
+      const iterCount = (stage.iterations || []).length;
+      if (iterCount === limit - 1) {
+        const warnKey = `${runId}-${stageName}`;
+        if (warnedLoops.has(warnKey)) continue;
+        warnedLoops.add(warnKey);
+        const runTitle = getRunTitle(newRun);
+        return {
+          event: 'loop_limit_warning',
+          title: EVENT_CONFIG.loop_limit_warning.title,
+          body: `"${runTitle}" ${stageName} stage approaching loop limit (${iterCount}/${limit})`,
+          tag: `worca-loop-${runId}-${stageName}`,
+          requireInteraction: false,
+          runId,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function getRunTitle(run) {
+  const raw = run?.work_request?.title || run?.id || 'Pipeline';
+  const firstLine = raw.split('\n')[0];
+  return firstLine.length > 60 ? firstLine.slice(0, 60) + '\u2026' : firstLine;
+}
+
+// --- Sound ---
+
+let audioCtx = null;
+
+function playSound() {
+  try {
+    if (!audioCtx) audioCtx = new AudioContext();
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = 440;
+    gain.gain.value = 0.3;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.2);
+  } catch {
+    // AudioContext blocked or unavailable
+  }
+}
+
+// --- Notification Manager Factory ---
+
+const DEFAULT_NOTIFICATION_PREFS = {
+  enabled: true,
+  sound: false,
+  events: {
+    run_completed: true,
+    run_failed: true,
+    approval_needed: true,
+    test_failures: true,
+    loop_limit_warning: true,
+  },
+};
+
+export function createNotificationManager({ store, ws, getSettings }) {
+  let permissionState = typeof Notification !== 'undefined' ? Notification.permission : 'denied';
+  const warnedLoops = new Set();
+  let bannerDismissed = false;
+  let rerender = null;
+
+  function setRerender(fn) {
+    rerender = fn;
+  }
+
+  function checkPermission() {
+    if (typeof Notification !== 'undefined') {
+      permissionState = Notification.permission;
+    }
+    return permissionState;
+  }
+
+  async function requestPermission() {
+    if (typeof Notification === 'undefined') return 'denied';
+    const result = await Notification.requestPermission();
+    permissionState = result;
+    if (rerender) rerender();
+    return result;
+  }
+
+  function getPreferences() {
+    const prefs = store.getState().preferences.notifications;
+    if (!prefs) return { ...DEFAULT_NOTIFICATION_PREFS };
+    return {
+      enabled: prefs.enabled ?? DEFAULT_NOTIFICATION_PREFS.enabled,
+      sound: prefs.sound ?? DEFAULT_NOTIFICATION_PREFS.sound,
+      events: { ...DEFAULT_NOTIFICATION_PREFS.events, ...(prefs.events || {}) },
+    };
+  }
+
+  function fireNotification({ event, title, body, tag, requireInteraction, runId }) {
+    if (typeof Notification === 'undefined') return;
+    const n = new Notification(title, {
+      body,
+      icon: '/favicon.svg',
+      tag,
+      requireInteraction,
+    });
+    n.onclick = () => {
+      window.focus();
+      navigate('active', runId);
+      n.close();
+    };
+
+    const prefs = getPreferences();
+    const config = EVENT_CONFIG[event];
+    if (prefs.sound && config && config.severity === 'critical') {
+      playSound();
+    }
+  }
+
+  function handleRunUpdate(runId, newRun, prevRun) {
+    if (typeof Notification === 'undefined') return;
+    if (Notification.permission !== 'granted') return;
+
+    const prefs = getPreferences();
+    if (!prefs.enabled) return;
+
+    const settings = getSettings();
+
+    const detectors = [
+      detectRunCompleted,
+      detectRunFailed,
+      detectApprovalNeeded,
+      detectTestFailures,
+    ];
+
+    for (const detect of detectors) {
+      const descriptor = detect(runId, newRun, prevRun);
+      if (descriptor && prefs.events[descriptor.event]) {
+        fireNotification(descriptor);
+      }
+    }
+
+    // Loop limit warning needs settings and warnedLoops set
+    const loopDescriptor = detectLoopLimitWarning(runId, newRun, prevRun, settings, warnedLoops);
+    if (loopDescriptor && prefs.events[loopDescriptor.event]) {
+      fireNotification(loopDescriptor);
+    }
+  }
+
+  function renderBanner() {
+    if (typeof Notification === 'undefined') {
+      return nothing;
+    }
+
+    checkPermission();
+
+    if (permissionState === 'default') {
+      return html`
+        <div class="notification-banner notification-banner--info">
+          <span class="notification-banner-text">
+            Enable browser notifications to stay informed about pipeline events
+          </span>
+          <sl-button size="small" variant="primary" @click=${() => requestPermission()}>
+            Enable Notifications
+          </sl-button>
+        </div>
+      `;
+    }
+
+    if (permissionState === 'denied' && !bannerDismissed) {
+      return html`
+        <div class="notification-banner notification-banner--warning">
+          <span class="notification-banner-text">
+            Notifications blocked. Enable in browser settings.
+          </span>
+          <button class="notification-banner-dismiss" @click=${() => {
+            bannerDismissed = true;
+            if (rerender) rerender();
+          }}>&times;</button>
+        </div>
+      `;
+    }
+
+    return nothing;
+  }
+
+  function dispose() {
+    if (audioCtx) {
+      audioCtx.close().catch(() => {});
+      audioCtx = null;
+    }
+  }
+
+  return {
+    checkPermission,
+    requestPermission,
+    handleRunUpdate,
+    renderBanner,
+    getPreferences,
+    setRerender,
+    dispose,
+  };
+}

--- a/.claude/worca-ui/app/notifications.test.js
+++ b/.claude/worca-ui/app/notifications.test.js
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for notification event detector functions.
+ * These are pure functions that take run state and return notification descriptors.
+ */
+
+import {
+  detectRunCompleted,
+  detectRunFailed,
+  detectApprovalNeeded,
+  detectTestFailures,
+  detectLoopLimitWarning,
+} from './notifications.js';
+
+function makeRun(overrides = {}) {
+  return {
+    id: 'run-1',
+    active: true,
+    work_request: { title: 'Test Pipeline' },
+    stages: {},
+    ...overrides,
+  };
+}
+
+// --- detectRunCompleted ---
+
+console.log('--- detectRunCompleted ---');
+
+{
+  const prev = makeRun({ active: true });
+  const next = makeRun({ active: false, stages: { plan: { status: 'completed' }, test: { status: 'completed' } } });
+  const result = detectRunCompleted('run-1', next, prev);
+  console.assert(result !== null, 'should detect run completed');
+  console.assert(result.event === 'run_completed', 'event should be run_completed');
+  console.assert(result.body.includes('Test Pipeline'), 'body should include run title');
+  console.assert(result.tag === 'worca-complete-run-1', 'tag should include runId');
+  console.log('PASS: detects run completion');
+}
+
+{
+  const prev = makeRun({ active: true });
+  const next = makeRun({ active: false, stages: { plan: { status: 'completed' }, test: { status: 'error' } } });
+  const result = detectRunCompleted('run-1', next, prev);
+  console.assert(result === null, 'should not detect completed when errors exist');
+  console.log('PASS: returns null when run has errors');
+}
+
+{
+  const prev = makeRun({ active: true });
+  const next = makeRun({ active: true });
+  const result = detectRunCompleted('run-1', next, prev);
+  console.assert(result === null, 'should not detect completed when still active');
+  console.log('PASS: returns null when run is still active');
+}
+
+{
+  const result = detectRunCompleted('run-1', makeRun(), null);
+  console.assert(result === null, 'should return null when no previous run');
+  console.log('PASS: returns null with no previous run');
+}
+
+// --- detectRunFailed ---
+
+console.log('\n--- detectRunFailed ---');
+
+{
+  const prev = makeRun({ active: true });
+  const next = makeRun({ active: false, stages: { plan: { status: 'completed' }, test: { status: 'error' } } });
+  const result = detectRunFailed('run-1', next, prev);
+  console.assert(result !== null, 'should detect run failure');
+  console.assert(result.event === 'run_failed', 'event should be run_failed');
+  console.assert(result.body.includes('test'), 'body should include failed stage name');
+  console.log('PASS: detects run failure with stage name');
+}
+
+{
+  const prev = makeRun({ active: true });
+  const next = makeRun({ active: false, stages: { plan: { status: 'completed' } } });
+  const result = detectRunFailed('run-1', next, prev);
+  console.assert(result === null, 'should not detect failure when no errors');
+  console.log('PASS: returns null when no errors');
+}
+
+// --- detectApprovalNeeded ---
+
+console.log('\n--- detectApprovalNeeded ---');
+
+{
+  const prev = makeRun({ stages: { plan: { status: 'in_progress' } } });
+  const next = makeRun({ stages: { plan: { status: 'waiting_approval' } } });
+  const result = detectApprovalNeeded('run-1', next, prev);
+  console.assert(result !== null, 'should detect approval needed');
+  console.assert(result.event === 'approval_needed', 'event should be approval_needed');
+  console.assert(result.requireInteraction === true, 'should require interaction');
+  console.assert(result.body.includes('plan'), 'body should include stage name');
+  console.log('PASS: detects approval needed transition');
+}
+
+{
+  const prev = makeRun({ stages: { plan: { status: 'waiting_approval' } } });
+  const next = makeRun({ stages: { plan: { status: 'waiting_approval' } } });
+  const result = detectApprovalNeeded('run-1', next, prev);
+  console.assert(result === null, 'should not re-trigger when already waiting');
+  console.log('PASS: does not re-trigger for same status');
+}
+
+{
+  const next = makeRun({ stages: { pr: { status: 'waiting_approval' } } });
+  const result = detectApprovalNeeded('run-1', next, null);
+  console.assert(result !== null, 'should detect approval on first snapshot');
+  console.assert(result.body.includes('PR'), 'body should show PR for pr stage');
+  console.log('PASS: detects approval on first snapshot, PR label');
+}
+
+// --- detectTestFailures ---
+
+console.log('\n--- detectTestFailures ---');
+
+{
+  const prev = makeRun({ stages: { test: { status: 'in_progress', iterations: [] } } });
+  const next = makeRun({ stages: { test: { status: 'in_progress', iterations: [{ result: 'failed' }] } } });
+  const result = detectTestFailures('run-1', next, prev);
+  console.assert(result !== null, 'should detect test failure');
+  console.assert(result.event === 'test_failures', 'event should be test_failures');
+  console.assert(result.body.includes('iteration 1'), 'body should include iteration number');
+  console.log('PASS: detects new failed test iteration');
+}
+
+{
+  const prev = makeRun({ stages: { test: { status: 'in_progress', iterations: [] } } });
+  const next = makeRun({ stages: { test: { status: 'in_progress', iterations: [{ result: 'passed' }] } } });
+  const result = detectTestFailures('run-1', next, prev);
+  console.assert(result === null, 'should not trigger for passed test');
+  console.log('PASS: does not trigger for passed test');
+}
+
+{
+  const prev = makeRun({ stages: { test: { status: 'in_progress', iterations: [{ result: 'failed' }] } } });
+  const next = makeRun({ stages: { test: { status: 'in_progress', iterations: [{ result: 'failed' }] } } });
+  const result = detectTestFailures('run-1', next, prev);
+  console.assert(result === null, 'should not trigger when iteration count unchanged');
+  console.log('PASS: does not trigger when no new iteration');
+}
+
+// --- detectLoopLimitWarning ---
+
+console.log('\n--- detectLoopLimitWarning ---');
+
+{
+  const warnedLoops = new Set();
+  const settings = { worca: { loops: { implement_test: 3 } } };
+  const prev = makeRun();
+  const next = makeRun({ stages: { implement: { status: 'in_progress', iterations: [{ result: 'done' }, { result: 'done' }] } } });
+  const result = detectLoopLimitWarning('run-1', next, prev, settings, warnedLoops);
+  console.assert(result !== null, 'should detect loop limit warning at limit-1');
+  console.assert(result.event === 'loop_limit_warning', 'event should be loop_limit_warning');
+  console.assert(result.body.includes('2/3'), 'body should show count/limit');
+  console.log('PASS: detects loop limit warning at limit-1');
+}
+
+{
+  const warnedLoops = new Set();
+  const settings = { worca: { loops: { implement_test: 3 } } };
+  const prev = makeRun();
+  const next = makeRun({ stages: { implement: { status: 'in_progress', iterations: [{ result: 'done' }] } } });
+  const result = detectLoopLimitWarning('run-1', next, prev, settings, warnedLoops);
+  console.assert(result === null, 'should not warn below limit-1');
+  console.log('PASS: does not warn below limit-1');
+}
+
+{
+  const warnedLoops = new Set();
+  const settings = { worca: { loops: { implement_test: 3 } } };
+  const prev = makeRun();
+  const next = makeRun({ stages: { implement: { status: 'in_progress', iterations: [{ result: 'done' }, { result: 'done' }] } } });
+
+  detectLoopLimitWarning('run-1', next, prev, settings, warnedLoops);
+  const second = detectLoopLimitWarning('run-1', next, prev, settings, warnedLoops);
+  console.assert(second === null, 'should not warn twice for same stage');
+  console.log('PASS: deduplicates warnings per stage per run');
+}
+
+console.log('\nAll notification detector tests passed.');

--- a/.claude/worca-ui/app/protocol.js
+++ b/.claude/worca-ui/app/protocol.js
@@ -2,7 +2,7 @@
  * Protocol definitions for worca-ui WebSocket communication.
  */
 
-/** @typedef {'subscribe-run'|'unsubscribe-run'|'subscribe-log'|'unsubscribe-log'|'list-runs'|'get-agent-prompt'|'get-preferences'|'set-preferences'|'stop-run'|'run-snapshot'|'run-update'|'runs-list'|'log-line'|'log-bulk'|'preferences'} MessageType */
+/** @typedef {'subscribe-run'|'unsubscribe-run'|'subscribe-log'|'unsubscribe-log'|'list-runs'|'get-agent-prompt'|'get-preferences'|'set-preferences'|'stop-run'|'resume-run'|'run-snapshot'|'run-update'|'runs-list'|'log-line'|'log-bulk'|'preferences'} MessageType */
 
 /** @type {MessageType[]} */
 export const MESSAGE_TYPES = [
@@ -11,7 +11,7 @@ export const MESSAGE_TYPES = [
   'list-runs',
   'get-agent-prompt',
   'get-preferences', 'set-preferences',
-  'stop-run',
+  'stop-run', 'resume-run',
   // Server → Client events
   'run-snapshot', 'run-update', 'runs-list',
   'log-line', 'log-bulk',

--- a/.claude/worca-ui/app/state.js
+++ b/.claude/worca-ui/app/state.js
@@ -11,7 +11,8 @@ export function createStore(initial = {}) {
     logLines: initial.logLines ?? [],
     preferences: {
       theme: initial.preferences?.theme ?? 'light',
-      sidebarCollapsed: initial.preferences?.sidebarCollapsed ?? false
+      sidebarCollapsed: initial.preferences?.sidebarCollapsed ?? false,
+      notifications: initial.preferences?.notifications ?? null
     }
   };
 
@@ -37,7 +38,8 @@ export function createStore(initial = {}) {
         next.runs === state.runs &&
         next.logLines === state.logLines &&
         next.preferences.theme === state.preferences.theme &&
-        next.preferences.sidebarCollapsed === state.preferences.sidebarCollapsed
+        next.preferences.sidebarCollapsed === state.preferences.sidebarCollapsed &&
+        next.preferences.notifications === state.preferences.notifications
       ) return;
       state = next;
       emit();

--- a/.claude/worca-ui/app/styles.css
+++ b/.claude/worca-ui/app/styles.css
@@ -1558,3 +1558,44 @@ sl-details.agent-prompt-section::part(content) {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* --- 29. Notification Banner --- */
+.notification-banner {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.notification-banner--info {
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 25%, var(--border));
+}
+
+.notification-banner--warning {
+  background: color-mix(in srgb, var(--status-in-progress) 8%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--status-in-progress) 25%, var(--border));
+}
+
+.notification-banner-text {
+  flex: 1;
+  font-size: 0.875rem;
+}
+
+.notification-banner-dismiss {
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: var(--muted);
+  opacity: 0.6;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  transition: opacity var(--transition-fast);
+}
+
+.notification-banner-dismiss:hover {
+  opacity: 1;
+}

--- a/.claude/worca-ui/app/utils/icons.js
+++ b/.claude/worca-ui/app/utils/icons.js
@@ -35,6 +35,7 @@ import Star from 'lucide/dist/esm/icons/star';
 import FileText from 'lucide/dist/esm/icons/file-text';
 import ClipboardCopy from 'lucide/dist/esm/icons/clipboard-copy';
 import Coins from 'lucide/dist/esm/icons/coins';
+import Bell from 'lucide/dist/esm/icons/bell';
 
 function renderChildren(nodes) {
   return nodes.map(([tag, attrs]) => {
@@ -61,5 +62,5 @@ export {
   Sun, Moon, Flag, RefreshCw, ArrowDown, Pause,
   Zap, Clock, AlertTriangle,
   Activity, Archive, Search, ArrowLeft,
-  Square, Play, Users, Shield, GitBranch, ChevronRight, Save, Settings, Timer, Cpu, Star, FileText, ClipboardCopy, Coins
+  Square, Play, Users, Shield, GitBranch, ChevronRight, Save, Settings, Timer, Cpu, Star, FileText, ClipboardCopy, Coins, Bell
 };

--- a/.claude/worca-ui/app/views/settings.js
+++ b/.claude/worca-ui/app/views/settings.js
@@ -1,6 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import { iconSvg, Users, Shield, GitBranch, ChevronRight, Save, Settings } from '../utils/icons.js';
+import { iconSvg, Users, Shield, GitBranch, ChevronRight, Save, Settings, Bell } from '../utils/icons.js';
 
 // Stage-to-agent mapping (from stages.py STAGE_AGENT_MAP)
 const STAGE_AGENT_MAP = {
@@ -361,6 +361,96 @@ function preferencesTab(preferences, onThemeToggle) {
   `;
 }
 
+const NOTIF_EVENT_LABELS = {
+  run_completed: { label: 'Run Completed', desc: 'When a pipeline run finishes successfully' },
+  run_failed: { label: 'Run Failed', desc: 'When a pipeline run fails at any stage' },
+  approval_needed: { label: 'Approval Required', desc: 'When a stage is waiting for plan or PR approval' },
+  test_failures: { label: 'Test Failures', desc: 'When a test iteration ends with failures' },
+  loop_limit_warning: { label: 'Loop Limit Warning', desc: 'When a stage approaches its configured loop limit' },
+};
+
+function notificationsTab(preferences, { rerender, onSaveNotifications }) {
+  const notifPrefs = preferences?.notifications || {};
+  const enabled = notifPrefs.enabled ?? true;
+  const sound = notifPrefs.sound ?? false;
+  const events = notifPrefs.events || {};
+
+  const permission = typeof Notification !== 'undefined' ? Notification.permission : 'unsupported';
+  const permBadge = permission === 'granted'
+    ? html`<sl-badge variant="success" pill>Granted</sl-badge>`
+    : permission === 'denied'
+      ? html`<sl-badge variant="danger" pill>Blocked</sl-badge>`
+      : permission === 'default'
+        ? html`<sl-badge variant="neutral" pill>Not Yet Asked</sl-badge>`
+        : html`<sl-badge variant="neutral" pill>Not Supported</sl-badge>`;
+
+  const notGranted = permission !== 'granted';
+
+  return html`
+    <div class="settings-tab-content">
+      <h3 class="settings-section-title">Browser Notifications</h3>
+      <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 8px;">
+        <span style="font-size: 13px; color: var(--muted);">Permission Status:</span>
+        ${permBadge}
+        ${permission === 'default' ? html`
+          <sl-button size="small" variant="primary" @click=${async () => {
+            if (typeof Notification !== 'undefined') {
+              await Notification.requestPermission();
+              rerender();
+            }
+          }}>Enable Notifications</sl-button>
+        ` : ''}
+      </div>
+
+      ${notGranted ? html`
+        <div style="font-size: 12px; color: var(--muted); margin-bottom: 8px;">
+          ${permission === 'denied' ? 'Notifications are blocked. Enable in your browser settings to use these controls.' : 'Grant notification permission to use these controls.'}
+        </div>
+      ` : ''}
+
+      <div class="settings-switches">
+        <div class="settings-switch-row">
+          <sl-switch id="notif-enabled" ?checked=${enabled} size="small" ?disabled=${notGranted}>Notifications Enabled</sl-switch>
+          <span class="settings-switch-desc">Master toggle for all browser notifications</span>
+        </div>
+        <div class="settings-switch-row">
+          <sl-switch id="notif-sound" ?checked=${sound} size="small" ?disabled=${notGranted}>Sound for Critical Events</sl-switch>
+          <span class="settings-switch-desc">Play a short audio cue for failed runs and approval requests</span>
+        </div>
+      </div>
+
+      <h3 class="settings-section-title">Notification Events</h3>
+      <div class="settings-switches">
+        ${Object.entries(NOTIF_EVENT_LABELS).map(([key, { label, desc }]) => html`
+          <div class="settings-switch-row">
+            <sl-switch id="notif-evt-${key}" ?checked=${events[key] ?? true} size="small" ?disabled=${notGranted}>${label}</sl-switch>
+            <span class="settings-switch-desc">${desc}</span>
+          </div>
+        `)}
+      </div>
+
+      <div class="settings-tab-actions">
+        <sl-button variant="primary" size="small" ?disabled=${notGranted} @click=${() => {
+          const notifEnabled = document.getElementById('notif-enabled')?.checked ?? true;
+          const notifSound = document.getElementById('notif-sound')?.checked ?? false;
+          const eventPrefs = {};
+          for (const key of Object.keys(NOTIF_EVENT_LABELS)) {
+            eventPrefs[key] = document.getElementById(`notif-evt-${key}`)?.checked ?? true;
+          }
+          onSaveNotifications({
+            enabled: notifEnabled,
+            sound: notifSound,
+            events: eventPrefs,
+          });
+        }}>
+          ${unsafeHTML(iconSvg(Save, 14))}
+          Save Notifications
+        </sl-button>
+      </div>
+    </div>
+  `;
+}
+
 // --- Feedback alert ---
 
 function feedbackAlert(rerender) {
@@ -378,7 +468,7 @@ function feedbackAlert(rerender) {
 
 // --- Main export ---
 
-export function settingsView(preferences, { rerender, onThemeToggle }) {
+export function settingsView(preferences, { rerender, onThemeToggle, onSaveNotifications }) {
   if (!settingsData) {
     return html`<div class="empty-state">Loading settings\u2026</div>`;
   }
@@ -406,11 +496,16 @@ export function settingsView(preferences, { rerender, onThemeToggle }) {
           ${unsafeHTML(iconSvg(Settings, 14))}
           Preferences
         </sl-tab>
+        <sl-tab slot="nav" panel="notifications">
+          ${unsafeHTML(iconSvg(Bell, 14))}
+          Notifications
+        </sl-tab>
 
         <sl-tab-panel name="agents">${agentsTab(worca, rerender)}</sl-tab-panel>
         <sl-tab-panel name="pipeline">${pipelineTab(worca, rerender)}</sl-tab-panel>
         <sl-tab-panel name="governance">${governanceTab(worca, permissions, rerender)}</sl-tab-panel>
         <sl-tab-panel name="preferences">${preferencesTab(preferences, onThemeToggle)}</sl-tab-panel>
+        <sl-tab-panel name="notifications">${notificationsTab(preferences, { rerender, onSaveNotifications })}</sl-tab-panel>
       </sl-tab-group>
     </div>
   `;


### PR DESCRIPTION
## Summary

- Add Web Notifications API integration that alerts users when pipeline events need attention (run completed/failed, approval needed, test failures, loop limit warnings)
- Include permission request flow with banner UI, per-event preference toggles in Settings tab, optional audio cue for critical events, and click-to-navigate behavior
- Add unit tests for all five event detector functions (pure functions testable without browser APIs)

## Changes

| File | Description |
|---|---|
| `notifications.js` (new) | Notification manager module with event detection, permission flow, sound, and banner rendering |
| `notifications.test.js` (new) | Unit tests for the five detector functions |
| `main.js` | Import manager, hook into WS handlers, render permission banner |
| `state.js` | Add `notifications` to preferences defaults and equality check |
| `views/settings.js` | Add Notifications tab with permission status, master toggle, sound toggle, per-event switches |
| `utils/icons.js` | Add Bell icon import |
| `styles.css` | Add notification banner CSS |
| `protocol.js` | Add `resume-run` to MESSAGE_TYPES (pre-existing gap) |

## Test plan

- [ ] Open app with cleared site data — permission banner appears
- [ ] Click Enable → grant permission → banner disappears, toggles active
- [ ] Trigger pipeline completion → "Pipeline Complete" notification appears
- [ ] Trigger pipeline failure → "Pipeline Failed" notification with stage name
- [ ] Wait for approval gate → "Approval Required" persistent notification
- [ ] Click any notification → tab focuses, navigates to run
- [ ] Disable master toggle → no notifications fire
- [ ] Toggle individual events off → only those are suppressed
- [ ] Enable sound → critical events play 440Hz beep
- [ ] Preferences persist across page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)