### PR TITLE
W-027: Optional prompt + smart title generation

### DIFF
--- a/.claude/scripts/run_pipeline.py
+++ b/.claude/scripts/run_pipeline.py
@@ -15,12 +15,12 @@ from worca.state.status import load_status
 from worca.utils.gh_issues import gh_issue_fail
 
 
-def main():
+def create_parser():
+    """Create the argument parser for the pipeline CLI."""
     parser = argparse.ArgumentParser(description="Run worca-cc pipeline")
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--prompt", help="Text prompt for work request")
-    group.add_argument("--source", help="Source reference (gh:issue:42, bd:bd-abc)")
-    group.add_argument("--spec", help="Path to spec file")
+    parser.add_argument("--prompt", help="Text prompt for work request")
+    parser.add_argument("--source", help="Source reference (gh:issue:42, bd:bd-abc)")
+    parser.add_argument("--spec", help="Path to spec file")
     parser.add_argument("--settings", default=".claude/settings.json",
                         help="Path to settings.json")
     parser.add_argument("--status-dir", default=".worca",
@@ -35,20 +35,56 @@ def main():
     parser.add_argument("--resume", action="store_true",
                         help="Resume a previous run from status.json instead of starting fresh")
     parser.add_argument("--branch", help="Use an existing branch instead of creating a new one")
+    return parser
 
-    args = parser.parse_args()
 
-    # Normalize input to WorkRequest
-    if args.prompt:
-        work_request = normalize("prompt", args.prompt)
-        # When --plan is also provided, read the plan file as the description
-        if args.plan and os.path.isfile(args.plan):
-            with open(args.plan) as f:
-                work_request.description = f.read()
+def build_work_request(args):
+    """Validate args and build a WorkRequest with prompt merging.
+
+    Validation:
+    - --source and --spec are mutually exclusive
+    - At least one of --prompt/--source/--spec/--plan is required
+
+    Prompt merging: when --prompt accompanies a source/spec/plan,
+    it is appended as '## Additional Instructions' to the description.
+    """
+    # Validation: --source and --spec are mutually exclusive
+    if args.source and args.spec:
+        print("error: --source and --spec are mutually exclusive", file=sys.stderr)
+        raise SystemExit(2)
+
+    # Validation: at least one arg required
+    if not any([args.prompt, args.source, args.spec, args.plan]):
+        print("error: at least one of --prompt, --source, --spec, or --plan is required",
+              file=sys.stderr)
+        raise SystemExit(2)
+
+    # Normalize: source/spec/plan take priority, prompt-only is fallback
+    has_primary = args.source or args.spec or args.plan
+    if args.source:
+        work_request = normalize("source", args.source)
     elif args.spec:
         work_request = normalize("spec", args.spec)
-    elif args.source:
-        work_request = normalize("source", args.source)
+    elif args.plan:
+        work_request = normalize("plan", args.plan)
+    else:
+        work_request = normalize("prompt", args.prompt)
+
+    # Prompt merging: append as Additional Instructions when prompt
+    # accompanies a primary source
+    if args.prompt and has_primary:
+        if work_request.description:
+            work_request.description += f"\n\n## Additional Instructions\n\n{args.prompt}"
+        else:
+            work_request.description = f"## Additional Instructions\n\n{args.prompt}"
+
+    return work_request
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+    work_request = build_work_request(args)
 
     # Resolve plan: explicit --plan wins, then auto-detected from issue body
     plan_file = args.plan or work_request.plan_path

--- a/.claude/worca-ui/app/views/new-run-submit.test.js
+++ b/.claude/worca-ui/app/views/new-run-submit.test.js
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock lit-html since it requires DOM APIs (createTreeWalker)
+vi.mock('lit-html', () => ({
+  html: () => null,
+  nothing: null,
+}));
+vi.mock('lit-html/directives/unsafe-html.js', () => ({
+  unsafeHTML: () => null,
+}));
+vi.mock('../utils/icons.js', () => ({
+  iconSvg: () => '',
+  FileText: 'FileText',
+}));
+
+// Minimal DOM stub for tests
+function createDocStub() {
+  const elements = {};
+  return {
+    getElementById: vi.fn((id) => elements[id] || null),
+    _set(id, value) { elements[id] = { value, id }; },
+    _clear() { Object.keys(elements).forEach(k => delete elements[k]); },
+  };
+}
+
+describe('submitNewRun — new format validation and payload', () => {
+  let origFetch;
+  let submitNewRun, resetNewRunState;
+  let docStub;
+
+  beforeEach(async () => {
+    origFetch = globalThis.fetch;
+    docStub = createDocStub();
+    globalThis.document = docStub;
+
+    vi.resetModules();
+    // Re-apply mocks after resetModules
+    vi.doMock('lit-html', () => ({ html: () => null, nothing: null }));
+    vi.doMock('lit-html/directives/unsafe-html.js', () => ({ unsafeHTML: () => null }));
+    vi.doMock('../utils/icons.js', () => ({ iconSvg: () => '', FileText: 'FileText' }));
+
+    const mod = await import('./new-run.js');
+    submitNewRun = mod.submitNewRun;
+    resetNewRunState = mod.resetNewRunState;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  function setupDOM({ sourceValue = '', prompt = '' } = {}) {
+    docStub._clear();
+    if (sourceValue) docStub._set('new-run-source-value', sourceValue);
+    if (prompt) docStub._set('new-run-prompt', prompt);
+    docStub._set('new-run-msize', '1');
+    docStub._set('new-run-mloops', '1');
+  }
+
+  function mockFetch() {
+    let capturedBody;
+    globalThis.fetch = vi.fn().mockImplementation((_url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, pid: 123 }),
+      });
+    });
+    return () => capturedBody;
+  }
+
+  it('rejects when no source, plan, or prompt provided', async () => {
+    setupDOM();
+    resetNewRunState();
+
+    const rerender = vi.fn();
+    await submitNewRun({ rerender, onStarted: vi.fn() });
+
+    expect(rerender).toHaveBeenCalled();
+    // No fetch call should have been made
+    expect(globalThis.fetch).toBe(origFetch);
+  });
+
+  it('accepts prompt-only submission', async () => {
+    const getBody = mockFetch();
+    setupDOM({ prompt: 'Add user auth' });
+    resetNewRunState({ sourceType: 'none' });
+
+    const onStarted = vi.fn();
+    await submitNewRun({ rerender: vi.fn(), onStarted });
+
+    expect(globalThis.fetch).toHaveBeenCalled();
+    const body = getBody();
+    expect(body.sourceType).toBe('none');
+    expect(body.prompt).toBe('Add user auth');
+    expect(onStarted).toHaveBeenCalled();
+  });
+
+  it('sends sourceType and sourceValue for GitHub Issue', async () => {
+    const getBody = mockFetch();
+    setupDOM({ sourceValue: 'https://github.com/org/repo/issues/42' });
+    resetNewRunState({ sourceType: 'source' });
+
+    await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
+
+    const body = getBody();
+    expect(body.sourceType).toBe('source');
+    expect(body.sourceValue).toBe('https://github.com/org/repo/issues/42');
+  });
+
+  it('sends sourceType and sourceValue for spec file', async () => {
+    const getBody = mockFetch();
+    setupDOM({ sourceValue: 'docs/spec.md' });
+    resetNewRunState({ sourceType: 'spec' });
+
+    await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
+
+    const body = getBody();
+    expect(body.sourceType).toBe('spec');
+    expect(body.sourceValue).toBe('docs/spec.md');
+  });
+
+  it('sends planFile when selected', async () => {
+    const getBody = mockFetch();
+    setupDOM();
+    resetNewRunState({ sourceType: 'none', selectedPlan: 'docs/plans/my-plan.md' });
+
+    await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
+
+    const body = getBody();
+    expect(body.planFile).toBe('docs/plans/my-plan.md');
+    expect(body.sourceType).toBe('none');
+  });
+
+  it('sends source + prompt together', async () => {
+    const getBody = mockFetch();
+    setupDOM({ sourceValue: 'gh:issue:42', prompt: 'focus on auth' });
+    resetNewRunState({ sourceType: 'source' });
+
+    await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
+
+    const body = getBody();
+    expect(body.sourceType).toBe('source');
+    expect(body.sourceValue).toBe('gh:issue:42');
+    expect(body.prompt).toBe('focus on auth');
+  });
+
+  it('rejects sourceType=source with empty sourceValue', async () => {
+    setupDOM({ sourceValue: '  ' });
+    resetNewRunState({ sourceType: 'source' });
+
+    const rerender = vi.fn();
+    await submitNewRun({ rerender, onStarted: vi.fn() });
+
+    expect(rerender).toHaveBeenCalled();
+    // No fetch call
+    expect(globalThis.fetch).toBe(origFetch);
+  });
+
+  it('planFile-only is valid (no source, no prompt)', async () => {
+    const getBody = mockFetch();
+    setupDOM();
+    resetNewRunState({ sourceType: 'none', selectedPlan: 'docs/plans/my-plan.md' });
+
+    const onStarted = vi.fn();
+    await submitNewRun({ rerender: vi.fn(), onStarted });
+
+    expect(globalThis.fetch).toHaveBeenCalled();
+    const body = getBody();
+    expect(body.planFile).toBe('docs/plans/my-plan.md');
+    expect(body.sourceValue).toBeUndefined();
+    expect(body.prompt).toBeUndefined();
+    expect(onStarted).toHaveBeenCalled();
+  });
+
+  it('does not include sourceValue in body when sourceType is none', async () => {
+    const getBody = mockFetch();
+    setupDOM({ prompt: 'test' });
+    resetNewRunState({ sourceType: 'none' });
+
+    await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
+
+    const body = getBody();
+    expect(body.sourceValue).toBeUndefined();
+  });
+});
+
+describe('module exports', () => {
+  it('exports newRunView, submitNewRun, resetNewRunState, getNewRunSubmitState', async () => {
+    const mod = await import('./new-run.js');
+    expect(typeof mod.newRunView).toBe('function');
+    expect(typeof mod.submitNewRun).toBe('function');
+    expect(typeof mod.resetNewRunState).toBe('function');
+    expect(typeof mod.getNewRunSubmitState).toBe('function');
+  });
+});

--- a/.claude/worca-ui/app/views/new-run.js
+++ b/.claude/worca-ui/app/views/new-run.js
@@ -4,7 +4,7 @@ import { iconSvg, FileText } from '../utils/icons.js';
 import { getDefaults } from './settings.js';
 
 // Module-level state
-let inputType = 'prompt';
+let sourceType = 'none';
 let submitStatus = null; // null | 'submitting' | 'error'
 let submitError = '';
 let planFiles = null; // cached response
@@ -14,10 +14,22 @@ let selectedPlan = '';
 let branches = null; // null = not fetched, [] = fetched but empty
 let selectedBranch = ''; // empty = new branch
 
-function inputLabel(type) {
+/**
+ * Reset module state for testing or re-initialization.
+ */
+export function resetNewRunState(overrides = {}) {
+  sourceType = overrides.sourceType ?? 'none';
+  submitStatus = null;
+  submitError = '';
+  selectedPlan = overrides.selectedPlan ?? '';
+  planFilter = overrides.selectedPlan ?? '';
+  selectedBranch = '';
+}
+
+function sourceLabel(type) {
   if (type === 'source') return 'GitHub Issue URL';
   if (type === 'spec') return 'Spec File Path';
-  return 'Prompt';
+  return '';
 }
 
 function fetchBranches() {
@@ -65,14 +77,30 @@ export function getNewRunSubmitState() {
 }
 
 export async function submitNewRun({ rerender, onStarted }) {
-  const inputEl = document.getElementById('new-run-input-value');
+  const sourceValueEl = document.getElementById('new-run-source-value');
+  const promptEl = document.getElementById('new-run-prompt');
   const msizeEl = document.getElementById('new-run-msize');
   const mloopsEl = document.getElementById('new-run-mloops');
 
-  const inputValue = inputEl?.value?.trim() || '';
-  if (!inputValue) {
+  const sourceValue = sourceValueEl?.value?.trim() || '';
+  const promptValue = promptEl?.value?.trim() || '';
+
+  const hasSource = sourceType !== 'none' && sourceValue.length > 0;
+  const hasPlan = !!selectedPlan;
+  const hasPrompt = promptValue.length > 0;
+
+  // Validation: sourceType requires a sourceValue
+  if (sourceType !== 'none' && !sourceValue) {
     submitStatus = 'error';
-    submitError = 'Please enter a value.';
+    submitError = `Please enter a ${sourceLabel(sourceType).toLowerCase()}.`;
+    rerender();
+    return;
+  }
+
+  // Validation: at least one of source, plan, or prompt required
+  if (!hasSource && !hasPlan && !hasPrompt) {
+    submitStatus = 'error';
+    submitError = 'Please provide at least one of: a work source, a plan file, or a prompt.';
     rerender();
     return;
   }
@@ -86,12 +114,13 @@ export async function submitNewRun({ rerender, onStarted }) {
 
   try {
     const body = {
-      inputType,
-      inputValue,
+      sourceType,
       msize: Math.max(1, Math.min(10, msize)),
       mloops: Math.max(1, Math.min(10, mloops)),
     };
-    if (selectedPlan) body.planFile = selectedPlan;
+    if (hasSource) body.sourceValue = sourceValue;
+    if (hasPrompt) body.prompt = promptValue;
+    if (hasPlan) body.planFile = selectedPlan;
     if (selectedBranch) body.branch = selectedBranch;
 
     const res = await fetch('/api/runs', {
@@ -118,8 +147,8 @@ export async function submitNewRun({ rerender, onStarted }) {
 
 export function newRunView(state, { rerender }) {
 
-  function handleInputTypeChange(e) {
-    inputType = e.target.value;
+  function handleSourceTypeChange(e) {
+    sourceType = e.target.value;
     rerender();
   }
 
@@ -171,30 +200,77 @@ export function newRunView(state, { rerender }) {
   const filtered = filteredPlanFiles();
   const grouped = groupedPlanFiles(filtered);
 
+  const hasSource = sourceType !== 'none';
+  const hasPlan = !!selectedPlan;
+  const promptRequired = !hasSource && !hasPlan;
+  const promptLabel = promptRequired ? 'Prompt (required)' : 'Additional Instructions (optional)';
+
   return html`
     <div class="new-run-page">
       ${submitStatus === 'error' ? html`<div class="new-run-error">${submitError}</div>` : nothing}
 
       <div class="new-run-form">
+        <!-- Section 1: Work Source -->
         <div class="new-run-section">
+          <h3 class="new-run-section-title">Work Source</h3>
           <div class="settings-field">
-            <label class="settings-label">Input Type</label>
-            <sl-select id="new-run-input-type" value=${inputType} @sl-change=${handleInputTypeChange}>
-              <sl-option value="prompt">Prompt</sl-option>
+            <label class="settings-label">Source Type</label>
+            <sl-select id="new-run-source-type" value=${sourceType} @sl-change=${handleSourceTypeChange}>
+              <sl-option value="none">None</sl-option>
               <sl-option value="source">GitHub Issue</sl-option>
               <sl-option value="spec">Spec File</sl-option>
             </sl-select>
           </div>
 
+          ${sourceType !== 'none' ? html`
+            <div class="settings-field">
+              <label class="settings-label">${sourceLabel(sourceType)}</label>
+              <sl-input id="new-run-source-value" placeholder=${sourceType === 'source' ? 'https://github.com/...' : 'path/to/spec.md'}></sl-input>
+            </div>
+          ` : nothing}
+
           <div class="settings-field">
-            <label class="settings-label">${inputLabel(inputType)}</label>
-            ${inputType === 'prompt'
-              ? html`<sl-textarea id="new-run-input-value" rows="8" placeholder="Describe what the pipeline should do..."></sl-textarea>`
-              : html`<sl-input id="new-run-input-value" placeholder=${inputType === 'source' ? 'https://github.com/...' : 'path/to/spec.md'}></sl-input>`
-            }
+            <label class="settings-label">Plan File (optional)</label>
+            <div class="plan-autocomplete">
+              <sl-input
+                id="new-run-plan"
+                placeholder="Type to search plan files..."
+                .value=${planFilter}
+                @sl-input=${handlePlanInput}
+                @sl-focus=${handlePlanFocus}
+                @sl-blur=${handlePlanBlur}
+                clearable
+                @sl-clear=${handlePlanClear}
+              >
+                <span slot="prefix">${unsafeHTML(iconSvg(FileText, 14))}</span>
+              </sl-input>
+              ${planDropdownOpen && filtered.length > 0 ? html`
+                <div class="plan-dropdown">
+                  ${Object.entries(grouped).map(([dir, files]) => html`
+                    <div class="plan-group-header">${dir}/</div>
+                    ${files.map(f => html`
+                      <div class="plan-item" @mousedown=${() => handlePlanSelect(f)}>
+                        ${f.name}
+                      </div>
+                    `)}
+                  `)}
+                </div>
+              ` : nothing}
+            </div>
+            <span class="settings-field-hint">Skips the planning stage. Relative to project root.</span>
           </div>
         </div>
 
+        <!-- Section 2: Prompt -->
+        <div class="new-run-section">
+          <h3 class="new-run-section-title">Prompt</h3>
+          <div class="settings-field">
+            <label class="settings-label">${promptLabel}</label>
+            <sl-textarea id="new-run-prompt" rows="8" placeholder="Describe what the pipeline should do..."></sl-textarea>
+          </div>
+        </div>
+
+        <!-- Section 3: Advanced Options -->
         <div class="new-run-section">
           <h3 class="new-run-section-title">Advanced Options</h3>
           <div class="new-run-advanced">
@@ -221,37 +297,6 @@ export function newRunView(state, { rerender }) {
                 `)}
               </sl-select>
               <span class="settings-field-hint">Use an existing branch instead of creating a new one</span>
-            </div>
-
-            <div class="settings-field">
-              <label class="settings-label">Plan File (optional)</label>
-              <div class="plan-autocomplete">
-                <sl-input
-                  id="new-run-plan"
-                  placeholder="Type to search plan files..."
-                  .value=${planFilter}
-                  @sl-input=${handlePlanInput}
-                  @sl-focus=${handlePlanFocus}
-                  @sl-blur=${handlePlanBlur}
-                  clearable
-                  @sl-clear=${handlePlanClear}
-                >
-                  <span slot="prefix">${unsafeHTML(iconSvg(FileText, 14))}</span>
-                </sl-input>
-                ${planDropdownOpen && filtered.length > 0 ? html`
-                  <div class="plan-dropdown">
-                    ${Object.entries(grouped).map(([dir, files]) => html`
-                      <div class="plan-group-header">${dir}/</div>
-                      ${files.map(f => html`
-                        <div class="plan-item" @mousedown=${() => handlePlanSelect(f)}>
-                          ${f.name}
-                        </div>
-                      `)}
-                    `)}
-                  </div>
-                ` : nothing}
-              </div>
-              <span class="settings-field-hint">Skips the planning stage. Relative to project root.</span>
             </div>
           </div>
         </div>

--- a/.claude/worca-ui/server/app.js
+++ b/.claude/worca-ui/server/app.js
@@ -88,39 +88,79 @@ export function createApp(options = {}) {
   app.post('/api/runs', async (req, res) => {
     if (!worcaDir) return res.status(501).json({ ok: false, error: 'worcaDir not configured' });
 
-    const { inputType, inputValue, msize, mloops, planFile, branch } = req.body || {};
+    const body = req.body || {};
 
-    // Validation
-    if (!['prompt', 'source', 'spec'].includes(inputType)) {
-      return res.status(400).json({ ok: false, error: 'inputType must be "prompt", "source", or "spec"' });
+    // Backwards compat: detect old { inputType, inputValue } format
+    let { sourceType, sourceValue, prompt, planFile, msize, mloops, branch } = body;
+    if (body.inputType && sourceType === undefined) {
+      if (body.inputType === 'prompt') {
+        sourceType = 'none';
+        prompt = body.inputValue;
+      } else {
+        sourceType = body.inputType;
+        sourceValue = body.inputValue;
+      }
     }
-    if (typeof inputValue !== 'string' || inputValue.trim().length === 0) {
-      return res.status(400).json({ ok: false, error: 'inputValue must be a non-empty string' });
+
+    // Default sourceType
+    sourceType = sourceType || 'none';
+
+    // Validation: sourceType must be valid
+    if (!['none', 'source', 'spec'].includes(sourceType)) {
+      return res.status(400).json({ ok: false, error: 'sourceType must be "none", "source", or "spec"' });
     }
-    if (inputValue.length > 50000) {
-      return res.status(400).json({ ok: false, error: 'inputValue must be 50,000 characters or less' });
+
+    // Validation: sourceValue required when sourceType is source or spec
+    if (sourceType !== 'none') {
+      if (typeof sourceValue !== 'string' || sourceValue.trim().length === 0) {
+        return res.status(400).json({ ok: false, error: 'sourceValue must be a non-empty string when sourceType is "source" or "spec"' });
+      }
+      if (sourceValue.length > 50000) {
+        return res.status(400).json({ ok: false, error: 'sourceValue must be 50,000 characters or less' });
+      }
+      sourceValue = sourceValue.trim();
     }
+
+    // Validation: prompt length
+    if (prompt != null && typeof prompt === 'string' && prompt.length > 50000) {
+      return res.status(400).json({ ok: false, error: 'prompt must be 50,000 characters or less' });
+    }
+    if (typeof prompt === 'string') prompt = prompt.trim() || undefined;
+
+    // Validation: planFile
+    if (planFile !== undefined && planFile !== null) {
+      if (typeof planFile !== 'string' || planFile.trim().length === 0) {
+        return res.status(400).json({ ok: false, error: 'planFile must be a non-empty string if provided' });
+      }
+    }
+
+    const hasSource = sourceType !== 'none' && sourceValue;
+    const hasPlan = typeof planFile === 'string' && planFile.trim().length > 0;
+    const hasPrompt = typeof prompt === 'string' && prompt.length > 0;
+
+    // Validation: at least one of source, planFile, or prompt required
+    if (!hasSource && !hasPlan && !hasPrompt) {
+      return res.status(400).json({ ok: false, error: 'At least one of source, planFile, or prompt is required' });
+    }
+
     const msizeVal = msize != null ? Math.max(1, Math.min(10, Math.round(Number(msize)))) : 1;
     const mloopsVal = mloops != null ? Math.max(1, Math.min(10, Math.round(Number(mloops)))) : 1;
-    if (planFile !== undefined && planFile !== null && (typeof planFile !== 'string' || planFile.trim().length === 0)) {
-      return res.status(400).json({ ok: false, error: 'planFile must be a non-empty string if provided' });
-    }
 
     try {
       const result = await startPipeline(worcaDir, {
-        inputType,
-        inputValue: inputValue.trim(),
+        sourceType,
+        sourceValue: hasSource ? sourceValue : undefined,
+        prompt: hasPrompt ? prompt : undefined,
         msize: msizeVal,
         mloops: mloopsVal,
-        planFile: planFile || undefined,
+        planFile: hasPlan ? planFile.trim() : undefined,
         branch: branch || undefined,
         projectRoot,
       });
-      // Broadcast run-started if broadcast is available
       if (app.locals.broadcast) {
         app.locals.broadcast('run-started', { pid: result.pid });
       }
-      res.json({ ok: true, pid: result.pid, inputType, inputValue: inputValue.trim() });
+      res.json({ ok: true, pid: result.pid, sourceType, prompt });
     } catch (err) {
       if (err.code === 'already_running') {
         return res.status(409).json({ ok: false, error: err.message });

--- a/.claude/worca-ui/server/process-manager.js
+++ b/.claude/worca-ui/server/process-manager.js
@@ -55,7 +55,13 @@ export async function startPipeline(worcaDir, opts = {}) {
 
   if (opts.resume) {
     args.push('--resume');
+  } else if (opts.sourceType !== undefined) {
+    // New format: separate source and prompt args
+    if (opts.sourceType === 'source') args.push('--source', opts.sourceValue);
+    else if (opts.sourceType === 'spec') args.push('--spec', opts.sourceValue);
+    if (opts.prompt) args.push('--prompt', opts.prompt);
   } else {
+    // Legacy format: inputType/inputValue
     const flag = opts.inputType === 'source' ? '--source'
       : opts.inputType === 'spec' ? '--spec'
       : '--prompt';

--- a/.claude/worca-ui/server/test/process-manager-args.test.js
+++ b/.claude/worca-ui/server/test/process-manager-args.test.js
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Capture spawn calls to inspect args
+let spawnCalls = [];
+const fakeChild = {
+  pid: 99999,
+  unref: vi.fn(),
+  on: vi.fn(),
+  removeAllListeners: vi.fn(),
+};
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn((...args) => {
+    spawnCalls.push(args);
+    // Simulate a child that stays alive (timeout resolves the promise)
+    return fakeChild;
+  }),
+  execFileSync: vi.fn(),
+}));
+
+const { startPipeline } = await import('../process-manager.js');
+
+describe('startPipeline arg building', () => {
+  let tmpDir, worcaDir;
+
+  beforeEach(() => {
+    spawnCalls = [];
+    fakeChild.on.mockReset();
+    fakeChild.unref.mockReset();
+
+    tmpDir = mkdtempSync(join(tmpdir(), 'pm-args-test-'));
+    worcaDir = join(tmpDir, '.worca');
+    mkdirSync(worcaDir, { recursive: true });
+
+    // Create the script file so existsSync passes
+    const scriptDir = join(tmpDir, '.claude', 'scripts');
+    mkdirSync(scriptDir, { recursive: true });
+    writeFileSync(join(scriptDir, 'run_pipeline.py'), '# stub');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function getArgs() {
+    expect(spawnCalls.length).toBe(1);
+    return spawnCalls[0][1]; // spawn(cmd, args, options)
+  }
+
+  // --- New format: sourceType + prompt ---
+
+  it('builds --source arg when sourceType=source', async () => {
+    const p = startPipeline(worcaDir, {
+      sourceType: 'source',
+      sourceValue: 'gh:issue:42',
+      projectRoot: tmpDir,
+    });
+    // Trigger the timeout resolve via the 'on' mock
+    // The promise resolves after 2s timeout, so we need to handle it
+    // Actually, fakeChild.on doesn't fire events, so the timeout fires
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--source');
+    expect(args[args.indexOf('--source') + 1]).toBe('gh:issue:42');
+    expect(args).not.toContain('--prompt');
+  });
+
+  it('builds --spec arg when sourceType=spec', async () => {
+    startPipeline(worcaDir, {
+      sourceType: 'spec',
+      sourceValue: 'docs/spec.md',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--spec');
+    expect(args[args.indexOf('--spec') + 1]).toBe('docs/spec.md');
+    expect(args).not.toContain('--prompt');
+  });
+
+  it('builds --prompt arg when sourceType=none with prompt', async () => {
+    startPipeline(worcaDir, {
+      sourceType: 'none',
+      prompt: 'Add user auth',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--prompt');
+    expect(args[args.indexOf('--prompt') + 1]).toBe('Add user auth');
+    expect(args).not.toContain('--source');
+    expect(args).not.toContain('--spec');
+  });
+
+  it('builds --source + --prompt when both provided', async () => {
+    startPipeline(worcaDir, {
+      sourceType: 'source',
+      sourceValue: 'gh:issue:42',
+      prompt: 'focus on auth',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--source');
+    expect(args[args.indexOf('--source') + 1]).toBe('gh:issue:42');
+    expect(args).toContain('--prompt');
+    expect(args[args.indexOf('--prompt') + 1]).toBe('focus on auth');
+  });
+
+  it('builds only --plan when plan-only (no source, no prompt)', async () => {
+    startPipeline(worcaDir, {
+      sourceType: 'none',
+      planFile: 'docs/plans/my-plan.md',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--plan');
+    expect(args[args.indexOf('--plan') + 1]).toBe('docs/plans/my-plan.md');
+    expect(args).not.toContain('--source');
+    expect(args).not.toContain('--spec');
+    expect(args).not.toContain('--prompt');
+  });
+
+  it('builds --spec + --prompt + --plan when all provided', async () => {
+    startPipeline(worcaDir, {
+      sourceType: 'spec',
+      sourceValue: 'docs/spec.md',
+      prompt: 'extra instructions',
+      planFile: 'docs/plans/my-plan.md',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--spec');
+    expect(args[args.indexOf('--spec') + 1]).toBe('docs/spec.md');
+    expect(args).toContain('--prompt');
+    expect(args[args.indexOf('--prompt') + 1]).toBe('extra instructions');
+    expect(args).toContain('--plan');
+    expect(args[args.indexOf('--plan') + 1]).toBe('docs/plans/my-plan.md');
+  });
+
+  // --- Legacy format: inputType/inputValue ---
+
+  it('legacy: builds --prompt from inputType=prompt', async () => {
+    startPipeline(worcaDir, {
+      inputType: 'prompt',
+      inputValue: 'Add user auth',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--prompt');
+    expect(args[args.indexOf('--prompt') + 1]).toBe('Add user auth');
+  });
+
+  it('legacy: builds --source from inputType=source', async () => {
+    startPipeline(worcaDir, {
+      inputType: 'source',
+      inputValue: 'gh:issue:42',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--source');
+    expect(args[args.indexOf('--source') + 1]).toBe('gh:issue:42');
+  });
+
+  it('legacy: builds --spec from inputType=spec', async () => {
+    startPipeline(worcaDir, {
+      inputType: 'spec',
+      inputValue: 'docs/spec.md',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--spec');
+    expect(args[args.indexOf('--spec') + 1]).toBe('docs/spec.md');
+  });
+
+  // --- Other options ---
+
+  it('includes --msize and --mloops when > 1', async () => {
+    startPipeline(worcaDir, {
+      sourceType: 'none',
+      prompt: 'test',
+      msize: 3,
+      mloops: 2,
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--msize');
+    expect(args[args.indexOf('--msize') + 1]).toBe('3');
+    expect(args).toContain('--mloops');
+    expect(args[args.indexOf('--mloops') + 1]).toBe('2');
+  });
+
+  it('omits --msize and --mloops when 1', async () => {
+    startPipeline(worcaDir, {
+      sourceType: 'none',
+      prompt: 'test',
+      msize: 1,
+      mloops: 1,
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).not.toContain('--msize');
+    expect(args).not.toContain('--mloops');
+  });
+
+  it('includes --branch when provided', async () => {
+    startPipeline(worcaDir, {
+      sourceType: 'none',
+      prompt: 'test',
+      branch: 'feature/my-branch',
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--branch');
+    expect(args[args.indexOf('--branch') + 1]).toBe('feature/my-branch');
+  });
+
+  it('uses --resume when resume=true', async () => {
+    startPipeline(worcaDir, {
+      resume: true,
+      projectRoot: tmpDir,
+    });
+    await vi.waitFor(() => expect(spawnCalls.length).toBe(1), { timeout: 100 });
+
+    const args = getArgs();
+    expect(args).toContain('--resume');
+    expect(args).not.toContain('--source');
+    expect(args).not.toContain('--prompt');
+  });
+});

--- a/.claude/worca-ui/server/test/runs-api.test.js
+++ b/.claude/worca-ui/server/test/runs-api.test.js
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createServer } from 'node:http';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const mockStartPipeline = vi.fn().mockResolvedValue({ pid: 12345 });
+
+vi.mock('../process-manager.js', () => ({
+  startPipeline: mockStartPipeline,
+  stopPipeline: vi.fn(),
+  restartStage: vi.fn(),
+}));
+
+const { createApp } = await import('../app.js');
+
+function startServer(worcaDir) {
+  const app = createApp({ worcaDir });
+  const server = createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const base = `http://127.0.0.1:${port}`;
+      resolve({ server, base });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+async function postRun(base, body) {
+  return fetch(`${base}/api/runs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/runs - new format', () => {
+  let tmpDir, server, base;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'runs-api-test-'));
+    mockStartPipeline.mockClear();
+    mockStartPipeline.mockResolvedValue({ pid: 12345 });
+    ({ server, base } = await startServer(tmpDir));
+  });
+
+  afterEach(async () => {
+    if (server) await stopServer(server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // --- Acceptance: valid payloads ---
+
+  it('accepts sourceType=source with sourceValue', async () => {
+    const res = await postRun(base, { sourceType: 'source', sourceValue: 'gh:issue:42' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(data.pid).toBe(12345);
+  });
+
+  it('accepts sourceType=spec with sourceValue', async () => {
+    const res = await postRun(base, { sourceType: 'spec', sourceValue: 'docs/spec.md' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('accepts sourceType=none with prompt', async () => {
+    const res = await postRun(base, { sourceType: 'none', prompt: 'Add user auth' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('accepts prompt-only (no sourceType field)', async () => {
+    const res = await postRun(base, { prompt: 'Add user auth' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('accepts planFile only', async () => {
+    const res = await postRun(base, { planFile: 'docs/plans/my-plan.md' });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('accepts source + prompt together', async () => {
+    const res = await postRun(base, {
+      sourceType: 'source', sourceValue: 'gh:issue:42', prompt: 'focus on auth',
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('accepts planFile + prompt together', async () => {
+    const res = await postRun(base, {
+      planFile: 'docs/plans/my-plan.md', prompt: 'focus on auth',
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  // --- Rejection: invalid payloads ---
+
+  it('rejects when no source, planFile, or prompt provided', async () => {
+    const res = await postRun(base, { sourceType: 'none' });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/at least one/i);
+  });
+
+  it('rejects empty body', async () => {
+    const res = await postRun(base, {});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects sourceType=source with missing sourceValue', async () => {
+    const res = await postRun(base, { sourceType: 'source' });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/sourceValue/i);
+  });
+
+  it('rejects sourceType=source with empty sourceValue', async () => {
+    const res = await postRun(base, { sourceType: 'source', sourceValue: '  ' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid sourceType', async () => {
+    const res = await postRun(base, { sourceType: 'invalid', sourceValue: 'test' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects prompt longer than 50000 chars', async () => {
+    const res = await postRun(base, { prompt: 'x'.repeat(50001) });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/50,000/);
+  });
+
+  it('rejects sourceValue longer than 50000 chars', async () => {
+    const res = await postRun(base, { sourceType: 'source', sourceValue: 'x'.repeat(50001) });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty-string planFile', async () => {
+    const res = await postRun(base, { planFile: '' });
+    expect(res.status).toBe(400);
+  });
+
+  // --- Clamping ---
+
+  it('clamps msize and mloops to valid range', async () => {
+    await postRun(base, { prompt: 'test', msize: 20, mloops: -5 });
+    expect(mockStartPipeline).toHaveBeenCalledWith(
+      tmpDir,
+      expect.objectContaining({ msize: 10, mloops: 1 }),
+    );
+  });
+
+  // --- Arguments passed to startPipeline ---
+
+  it('passes new-format fields to startPipeline', async () => {
+    await postRun(base, {
+      sourceType: 'source', sourceValue: 'gh:issue:42',
+      prompt: 'focus on auth', planFile: 'docs/plans/my-plan.md',
+    });
+    expect(mockStartPipeline).toHaveBeenCalledWith(
+      tmpDir,
+      expect.objectContaining({
+        sourceType: 'source',
+        sourceValue: 'gh:issue:42',
+        prompt: 'focus on auth',
+        planFile: 'docs/plans/my-plan.md',
+      }),
+    );
+  });
+
+  it('does not pass sourceValue when sourceType is none', async () => {
+    await postRun(base, { prompt: 'test' });
+    const opts = mockStartPipeline.mock.calls[0][1];
+    expect(opts.sourceValue).toBeUndefined();
+  });
+
+  it('trims prompt and sourceValue', async () => {
+    await postRun(base, {
+      sourceType: 'source', sourceValue: '  gh:issue:42  ',
+      prompt: '  focus on auth  ',
+    });
+    expect(mockStartPipeline).toHaveBeenCalledWith(
+      tmpDir,
+      expect.objectContaining({
+        sourceValue: 'gh:issue:42',
+        prompt: 'focus on auth',
+      }),
+    );
+  });
+});
+
+describe('POST /api/runs - backwards compatibility', () => {
+  let tmpDir, server, base;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'runs-api-test-'));
+    mockStartPipeline.mockClear();
+    mockStartPipeline.mockResolvedValue({ pid: 12345 });
+    ({ server, base } = await startServer(tmpDir));
+  });
+
+  afterEach(async () => {
+    if (server) await stopServer(server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('normalizes old inputType=prompt to sourceType=none + prompt', async () => {
+    const res = await postRun(base, { inputType: 'prompt', inputValue: 'Add user auth' });
+    expect(res.status).toBe(200);
+    expect(mockStartPipeline).toHaveBeenCalledWith(
+      tmpDir,
+      expect.objectContaining({
+        sourceType: 'none',
+        prompt: 'Add user auth',
+      }),
+    );
+  });
+
+  it('normalizes old inputType=source to sourceType=source + sourceValue', async () => {
+    const res = await postRun(base, { inputType: 'source', inputValue: 'gh:issue:42' });
+    expect(res.status).toBe(200);
+    expect(mockStartPipeline).toHaveBeenCalledWith(
+      tmpDir,
+      expect.objectContaining({
+        sourceType: 'source',
+        sourceValue: 'gh:issue:42',
+      }),
+    );
+  });
+
+  it('normalizes old inputType=spec to sourceType=spec + sourceValue', async () => {
+    const res = await postRun(base, { inputType: 'spec', inputValue: 'docs/spec.md' });
+    expect(res.status).toBe(200);
+    expect(mockStartPipeline).toHaveBeenCalledWith(
+      tmpDir,
+      expect.objectContaining({
+        sourceType: 'spec',
+        sourceValue: 'docs/spec.md',
+      }),
+    );
+  });
+
+  it('preserves planFile from old format', async () => {
+    const res = await postRun(base, {
+      inputType: 'prompt', inputValue: 'test', planFile: 'docs/plans/p.md',
+    });
+    expect(res.status).toBe(200);
+    expect(mockStartPipeline).toHaveBeenCalledWith(
+      tmpDir,
+      expect.objectContaining({ planFile: 'docs/plans/p.md' }),
+    );
+  });
+
+  it('preserves msize/mloops from old format', async () => {
+    await postRun(base, { inputType: 'prompt', inputValue: 'test', msize: 3, mloops: 2 });
+    expect(mockStartPipeline).toHaveBeenCalledWith(
+      tmpDir,
+      expect.objectContaining({ msize: 3, mloops: 2 }),
+    );
+  });
+});

--- a/.claude/worca/orchestrator/work_request.py
+++ b/.claude/worca/orchestrator/work_request.py
@@ -14,6 +14,50 @@ _PLAN_LINK_RE = re.compile(r"\[.*?\]\((docs/plans/[^\)]+\.md)\)")
 _GH_ISSUE_URL_RE = re.compile(r"https?://github\.com/[^/]+/[^/]+/issues/(\d+)$")
 
 
+_SMART_TITLE_PROMPT = (
+    "Extract a concise 5-8 word title summarizing this content. "
+    "Return ONLY the title, no quotes, no punctuation at the end, no explanation."
+)
+
+
+def generate_smart_title(content: str, source_hint: str = "") -> str:
+    """Use LLM to extract a short title from content.
+
+    Calls claude with haiku model, 30s timeout. Returns empty string on any
+    failure. Sanity checks: non-empty, <100 chars, no newlines.
+    """
+    if not content or not content.strip():
+        return ""
+
+    truncated = content[:10_000]
+    prompt = _SMART_TITLE_PROMPT
+    if source_hint:
+        prompt += f"\n\nSource: {source_hint}"
+    prompt += f"\n\nContent:\n{truncated}"
+
+    try:
+        result = subprocess.run(
+            ["claude", "-p", prompt, "--output-format", "text", "--model", "haiku"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=get_env(),
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+
+    if result.returncode != 0:
+        return ""
+
+    title = result.stdout.strip()
+
+    # Sanity checks
+    if not title or len(title) > 100 or "\n" in title:
+        return ""
+
+    return title
+
+
 @dataclass
 class WorkRequest:
     """Normalized work request from any input source."""
@@ -25,22 +69,62 @@ class WorkRequest:
     plan_path: Optional[str] = None
 
 
+def normalize_plan_file(path: str, content: str = None) -> WorkRequest:
+    """Create a WorkRequest from a plan file.
+
+    Reads file if content not provided. Title priority:
+    generate_smart_title() → first # heading fallback → filename fallback.
+    """
+    if content is None:
+        with open(path, "r") as f:
+            content = f.read()
+
+    # Title priority: smart title → heading → filename
+    title = generate_smart_title(content, source_hint=f"plan file: {os.path.basename(path)}")
+
+    if not title:
+        for line in content.splitlines():
+            if line.startswith("#"):
+                title = line.lstrip("#").strip()
+                break
+
+    if not title:
+        title = os.path.basename(path)
+
+    return WorkRequest(
+        source_type="plan_file",
+        title=title,
+        description=content,
+        source_ref=path,
+        plan_path=path,
+    )
+
+
 def normalize_prompt(text: str) -> WorkRequest:
     """Create a WorkRequest from a plain text prompt."""
     return WorkRequest(source_type="prompt", title=text)
 
 
 def normalize_spec_file(path: str) -> WorkRequest:
-    """Create a WorkRequest from a spec file, extracting title from first markdown heading."""
+    """Create a WorkRequest from a spec file.
+
+    Title priority: generate_smart_title() → first # heading fallback → filename fallback.
+    """
     with open(path, "r") as f:
         content = f.read()
-    title = ""
-    for line in content.splitlines():
-        if line.startswith("#"):
-            title = line.lstrip("#").strip()
-            break
+
+    # Title priority: smart title → heading → filename
+    title = generate_smart_title(content, source_hint=f"spec file: {os.path.basename(path)}")
+
+    if not title:
+        for line in content.splitlines():
+            if line.startswith("#"):
+                title = line.lstrip("#").strip()
+                break
+
     if not title:
         title = os.path.basename(path)
+
     return WorkRequest(
         source_type="spec_file",
         title=title,
@@ -117,14 +201,17 @@ def normalize_beads_task(ref: str) -> WorkRequest:
     )
 
 
-def normalize(source_type: str, source_value: str) -> WorkRequest:
+def normalize(source_type: str, source_value: str, **kwargs) -> WorkRequest:
     """Dispatch to the appropriate normalize_* function.
 
-    source_type can be "prompt", "spec", or "source" (auto-detect from value).
+    source_type can be "prompt", "spec", "plan", or "source" (auto-detect from value).
     For "source", the value is sniffed: gh:issue:N → GitHub, bd:ID → Beads.
+    Extra kwargs are forwarded to the dispatch function (e.g. content for plan).
     """
     if source_type == "prompt":
         return normalize_prompt(source_value)
+    elif source_type == "plan":
+        return normalize_plan_file(source_value, **kwargs)
     elif source_type == "spec":
         return normalize_spec_file(source_value)
     elif source_type == "source" or source_value.startswith(("gh:", "bd:")):

--- a/tests/test_e2e_w027.py
+++ b/tests/test_e2e_w027.py
@@ -1,0 +1,385 @@
+"""End-to-end verification tests for W-027: Optional Prompt + Smart Title Generation.
+
+Covers:
+1. Branch name sanitization from various title sources (LLM, GH, spec, plan)
+2. Full CLI flow: args → work request → branch name for each scenario
+3. Cross-layer compatibility: process-manager.js arg patterns → Python CLI parser
+"""
+import re
+import sys
+import os
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "scripts"))
+
+from run_pipeline import create_parser, build_work_request
+from worca.orchestrator.runner import _sanitize_branch_name
+from worca.orchestrator.work_request import WorkRequest
+
+
+# --- Branch name sanitization ---
+
+class TestSanitizeBranchName:
+    """Verify _sanitize_branch_name() produces good slugs from various title sources."""
+
+    def _name_part(self, branch):
+        """Extract the name part (between 'worca/' and the 3-char suffix)."""
+        assert branch.startswith("worca/")
+        return branch[len("worca/"):].rsplit("-", 1)[0]
+
+    def _suffix(self, branch):
+        """Extract the 3-char base62 suffix."""
+        return branch.rsplit("-", 1)[1]
+
+    def test_simple_prompt_title(self):
+        """Prompt-only: 'Add auth' → worca/add-auth-XXX"""
+        branch = _sanitize_branch_name("Add auth")
+        assert branch.startswith("worca/add-auth-")
+        assert re.match(r"^worca/add-auth-[A-Za-z0-9]{3}$", branch)
+
+    def test_llm_generated_title(self):
+        """LLM title from spec/plan: multi-word → clean slug."""
+        branch = _sanitize_branch_name("Add User Authentication Flow")
+        assert branch.startswith("worca/add-user-authentication-flow-")
+
+    def test_github_issue_title_with_prefix(self):
+        """GH issue: 'W-027: Optional Prompt + Smart Title' → clean slug."""
+        branch = _sanitize_branch_name("W-027: Optional Prompt + Smart Title")
+        name = self._name_part(branch)
+        assert "w-027" in name
+        assert re.match(r"^[a-z0-9\-]+$", name)
+
+    def test_special_chars_cleaned(self):
+        """Special chars replaced with dashes, no double dashes."""
+        branch = _sanitize_branch_name("Fix bug #42 (critical)")
+        name = self._name_part(branch)
+        assert "--" not in name
+        assert re.match(r"^[a-z0-9\-]+$", name)
+
+    def test_long_title_truncated(self):
+        """Long titles are truncated to at most 40 chars in the name part."""
+        branch = _sanitize_branch_name("A" * 60 + " very long title that exceeds limit")
+        name = self._name_part(branch)
+        assert len(name) <= 40
+
+    def test_consecutive_special_chars_collapsed(self):
+        """Multiple special chars become a single dash."""
+        branch = _sanitize_branch_name("Fix   bug!!!  NOW")
+        name = self._name_part(branch)
+        assert "--" not in name
+
+    def test_leading_trailing_dashes_stripped(self):
+        """No leading/trailing dashes in the name part."""
+        branch = _sanitize_branch_name("  --Fix bug--  ")
+        name = self._name_part(branch)
+        assert not name.startswith("-")
+        assert not name.endswith("-")
+
+    def test_unicode_chars_replaced(self):
+        """Unicode chars stripped to dashes."""
+        branch = _sanitize_branch_name("Feat: résumé upload — v2")
+        name = self._name_part(branch)
+        assert re.match(r"^[a-z0-9\-]+$", name)
+
+    def test_suffix_is_3_base62_chars(self):
+        """Suffix is exactly 3 base62 chars."""
+        branch = _sanitize_branch_name("test title")
+        suffix = self._suffix(branch)
+        assert len(suffix) == 3
+        assert re.match(r"^[A-Za-z0-9]{3}$", suffix)
+
+    def test_filename_fallback_title(self):
+        """Filename as title: 'my-spec.md' → clean slug."""
+        branch = _sanitize_branch_name("my-spec.md")
+        assert branch.startswith("worca/my-spec-md-")
+
+    def test_plan_filename_title(self):
+        """Plan filename: 'W-027-optional-prompt-smart-titles.md' → clean slug."""
+        branch = _sanitize_branch_name("W-027-optional-prompt-smart-titles.md")
+        name = self._name_part(branch)
+        assert "w-027" in name
+        assert re.match(r"^[a-z0-9\-]+$", name)
+
+    def test_numbers_preserved(self):
+        """Numbers in titles are preserved."""
+        branch = _sanitize_branch_name("Add OAuth2 support for API v3")
+        name = self._name_part(branch)
+        assert "oauth2" in name
+        assert "v3" in name
+
+    def test_hyphens_preserved(self):
+        """Existing hyphens are kept."""
+        branch = _sanitize_branch_name("add-user-auth")
+        assert branch.startswith("worca/add-user-auth-")
+
+
+# --- Full CLI scenarios ---
+
+class TestCLIScenarioPromptOnly:
+    """Scenario: python run_pipeline.py --prompt 'Add auth' → works as before."""
+
+    @patch("run_pipeline.normalize")
+    def test_full_flow(self, mock_normalize):
+        mock_normalize.return_value = WorkRequest(source_type="prompt", title="Add auth")
+
+        args = create_parser().parse_args(["--prompt", "Add auth"])
+        wr = build_work_request(args)
+
+        assert wr.source_type == "prompt"
+        assert wr.title == "Add auth"
+        branch = _sanitize_branch_name(wr.title)
+        assert branch.startswith("worca/add-auth-")
+        mock_normalize.assert_called_once_with("prompt", "Add auth")
+
+    @patch("run_pipeline.normalize")
+    def test_no_additional_instructions_appended(self, mock_normalize):
+        mock_normalize.return_value = WorkRequest(source_type="prompt", title="Add auth")
+
+        args = create_parser().parse_args(["--prompt", "Add auth"])
+        wr = build_work_request(args)
+
+        assert "Additional Instructions" not in wr.description
+
+
+class TestCLIScenarioSpecOnly:
+    """Scenario: python run_pipeline.py --spec docs/spec.md → LLM-generated title."""
+
+    @patch("run_pipeline.normalize")
+    def test_full_flow(self, mock_normalize):
+        mock_normalize.return_value = WorkRequest(
+            source_type="spec_file",
+            title="Implement OAuth Login Flow",
+            description="# OAuth\n\nAdd OAuth support...",
+            source_ref="docs/spec.md",
+        )
+
+        args = create_parser().parse_args(["--spec", "docs/spec.md"])
+        wr = build_work_request(args)
+
+        assert wr.source_type == "spec_file"
+        assert wr.title == "Implement OAuth Login Flow"
+        branch = _sanitize_branch_name(wr.title)
+        assert branch.startswith("worca/implement-oauth-login-flow-")
+        mock_normalize.assert_called_once_with("spec", "docs/spec.md")
+
+
+class TestCLIScenarioSourceGhIssue:
+    """Scenario: python run_pipeline.py --source gh:issue:42 → GH issue title verbatim."""
+
+    @patch("run_pipeline.normalize")
+    def test_full_flow(self, mock_normalize):
+        mock_normalize.return_value = WorkRequest(
+            source_type="github_issue",
+            title="W-027: Optional Prompt + Smart Title",
+            description="Issue body here...",
+            source_ref="gh:42",
+        )
+
+        args = create_parser().parse_args(["--source", "gh:issue:42"])
+        wr = build_work_request(args)
+
+        assert wr.source_type == "github_issue"
+        assert wr.title == "W-027: Optional Prompt + Smart Title"
+        branch = _sanitize_branch_name(wr.title)
+        assert "w-027" in branch
+        assert re.match(r"^worca/[a-z0-9\-]+-[A-Za-z0-9]{3}$", branch)
+        mock_normalize.assert_called_once_with("source", "gh:issue:42")
+
+
+class TestCLIScenarioPlanOnly:
+    """Scenario: python run_pipeline.py --plan docs/plans/foo.md → plan-only, LLM title."""
+
+    @patch("run_pipeline.normalize")
+    def test_full_flow(self, mock_normalize):
+        mock_normalize.return_value = WorkRequest(
+            source_type="plan_file",
+            title="Database Migration Strategy",
+            description="# Plan\n\nMigrate from SQLite to Postgres...",
+            plan_path="docs/plans/foo.md",
+        )
+
+        args = create_parser().parse_args(["--plan", "docs/plans/foo.md"])
+        wr = build_work_request(args)
+
+        assert wr.source_type == "plan_file"
+        assert wr.plan_path == "docs/plans/foo.md"
+        branch = _sanitize_branch_name(wr.title)
+        assert branch.startswith("worca/database-migration-strategy-")
+        mock_normalize.assert_called_once_with("plan", "docs/plans/foo.md")
+
+    @patch("run_pipeline.normalize")
+    def test_plan_path_resolved_from_args(self, mock_normalize):
+        """Explicit --plan takes priority over auto-detected plan_path."""
+        mock_normalize.return_value = WorkRequest(
+            source_type="plan_file",
+            title="Title",
+            description="Content",
+            plan_path="docs/plans/foo.md",
+        )
+
+        args = create_parser().parse_args(["--plan", "docs/plans/foo.md"])
+        # In main(), plan_file = args.plan or work_request.plan_path
+        plan_file = args.plan or mock_normalize.return_value.plan_path
+        assert plan_file == "docs/plans/foo.md"
+
+
+class TestCLIScenarioSourcePlusPrompt:
+    """Scenario: --source gh:issue:42 --prompt 'focus on auth' → combined."""
+
+    @patch("run_pipeline.normalize")
+    def test_full_flow(self, mock_normalize):
+        mock_normalize.return_value = WorkRequest(
+            source_type="github_issue",
+            title="Add Auth System",
+            description="Implement authentication",
+            source_ref="gh:42",
+        )
+
+        args = create_parser().parse_args([
+            "--source", "gh:issue:42", "--prompt", "focus on auth",
+        ])
+        wr = build_work_request(args)
+
+        # Prompt merged into description
+        assert "## Additional Instructions" in wr.description
+        assert "focus on auth" in wr.description
+        assert "Implement authentication" in wr.description
+        # Title from GH issue, not from prompt
+        assert wr.title == "Add Auth System"
+        branch = _sanitize_branch_name(wr.title)
+        assert branch.startswith("worca/add-auth-system-")
+
+    @patch("run_pipeline.normalize")
+    def test_spec_plus_prompt(self, mock_normalize):
+        """--spec docs/spec.md --prompt 'extra context' → combined."""
+        mock_normalize.return_value = WorkRequest(
+            source_type="spec_file",
+            title="Spec Title",
+            description="Spec content here",
+        )
+
+        args = create_parser().parse_args([
+            "--spec", "docs/spec.md", "--prompt", "extra context",
+        ])
+        wr = build_work_request(args)
+
+        assert "## Additional Instructions" in wr.description
+        assert "extra context" in wr.description
+
+    @patch("run_pipeline.normalize")
+    def test_plan_plus_prompt(self, mock_normalize):
+        """--plan plan.md --prompt 'additional notes' → combined."""
+        mock_normalize.return_value = WorkRequest(
+            source_type="plan_file",
+            title="Plan Title",
+            description="Plan content",
+            plan_path="plan.md",
+        )
+
+        args = create_parser().parse_args([
+            "--plan", "plan.md", "--prompt", "additional notes",
+        ])
+        wr = build_work_request(args)
+
+        assert "## Additional Instructions" in wr.description
+        assert "additional notes" in wr.description
+
+
+class TestCLIValidation:
+    """Verify CLI validation rules for W-027."""
+
+    def test_no_args_fails(self):
+        """At least one of --prompt/--source/--spec/--plan required."""
+        args = create_parser().parse_args([])
+        with pytest.raises(SystemExit):
+            build_work_request(args)
+
+    def test_source_and_spec_mutually_exclusive(self):
+        """--source and --spec cannot be used together."""
+        args = create_parser().parse_args([
+            "--source", "gh:issue:1", "--spec", "spec.md",
+        ])
+        with pytest.raises(SystemExit):
+            build_work_request(args)
+
+
+# --- Cross-layer compatibility ---
+
+class TestCrossLayerArgCompatibility:
+    """Verify that CLI arg patterns from process-manager.js parse correctly.
+
+    These replicate the exact arg patterns that process-manager.js builds
+    (verified in process-manager-args.test.js) and confirm they parse
+    correctly through create_parser() + build_work_request().
+    """
+
+    def test_pm_source_only(self):
+        """process-manager: sourceType=source → ['--source', 'gh:issue:42']"""
+        args = create_parser().parse_args(["--source", "gh:issue:42"])
+        assert args.source == "gh:issue:42"
+        assert args.prompt is None
+        assert args.spec is None
+        assert args.plan is None
+
+    def test_pm_spec_only(self):
+        """process-manager: sourceType=spec → ['--spec', 'docs/spec.md']"""
+        args = create_parser().parse_args(["--spec", "docs/spec.md"])
+        assert args.spec == "docs/spec.md"
+        assert args.prompt is None
+
+    def test_pm_prompt_only(self):
+        """process-manager: sourceType=none + prompt → ['--prompt', 'Add user auth']"""
+        args = create_parser().parse_args(["--prompt", "Add user auth"])
+        assert args.prompt == "Add user auth"
+        assert args.source is None
+        assert args.spec is None
+
+    def test_pm_source_plus_prompt(self):
+        """process-manager: source + prompt → ['--source', ..., '--prompt', ...]"""
+        args = create_parser().parse_args([
+            "--source", "gh:issue:42", "--prompt", "focus on auth",
+        ])
+        assert args.source == "gh:issue:42"
+        assert args.prompt == "focus on auth"
+
+    def test_pm_plan_only(self):
+        """process-manager: planFile only → ['--plan', 'docs/plans/my-plan.md']"""
+        args = create_parser().parse_args(["--plan", "docs/plans/my-plan.md"])
+        assert args.plan == "docs/plans/my-plan.md"
+        assert args.source is None
+        assert args.prompt is None
+
+    def test_pm_spec_plus_prompt_plus_plan(self):
+        """process-manager: spec + prompt + plan → all three flags."""
+        args = create_parser().parse_args([
+            "--spec", "docs/spec.md",
+            "--prompt", "extra instructions",
+            "--plan", "docs/plans/my-plan.md",
+        ])
+        assert args.spec == "docs/spec.md"
+        assert args.prompt == "extra instructions"
+        assert args.plan == "docs/plans/my-plan.md"
+
+    def test_pm_msize_mloops(self):
+        """process-manager: msize/mloops > 1 → ['--msize', '3', '--mloops', '2']"""
+        args = create_parser().parse_args([
+            "--prompt", "test", "--msize", "3", "--mloops", "2",
+        ])
+        assert args.msize == 3
+        assert args.mloops == 2
+
+    def test_pm_branch(self):
+        """process-manager: branch → ['--branch', 'feature/my-branch']"""
+        args = create_parser().parse_args([
+            "--prompt", "test", "--branch", "feature/my-branch",
+        ])
+        assert args.branch == "feature/my-branch"
+
+    def test_pm_resume(self):
+        """process-manager: resume=true → ['--resume'] (no source/prompt)"""
+        args = create_parser().parse_args(["--resume"])
+        assert args.resume is True
+        assert args.source is None
+        assert args.prompt is None

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,201 @@
+"""Tests for .claude/scripts/run_pipeline.py arg parsing and prompt merging."""
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Add scripts dir so we can import run_pipeline
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "scripts"))
+
+from run_pipeline import create_parser, build_work_request
+
+
+class TestCreateParser:
+    """Test that the parser accepts the expected argument combinations."""
+
+    def test_prompt_only(self):
+        parser = create_parser()
+        args = parser.parse_args(["--prompt", "Add auth"])
+        assert args.prompt == "Add auth"
+        assert args.source is None
+        assert args.spec is None
+        assert args.plan is None
+
+    def test_source_only(self):
+        parser = create_parser()
+        args = parser.parse_args(["--source", "gh:issue:42"])
+        assert args.source == "gh:issue:42"
+        assert args.prompt is None
+
+    def test_spec_only(self):
+        parser = create_parser()
+        args = parser.parse_args(["--spec", "docs/spec.md"])
+        assert args.spec == "docs/spec.md"
+        assert args.prompt is None
+
+    def test_plan_only(self):
+        parser = create_parser()
+        args = parser.parse_args(["--plan", "docs/plans/W-027.md"])
+        assert args.plan == "docs/plans/W-027.md"
+        assert args.prompt is None
+        assert args.source is None
+
+    def test_source_plus_prompt(self):
+        parser = create_parser()
+        args = parser.parse_args(["--source", "gh:issue:42", "--prompt", "focus on auth"])
+        assert args.source == "gh:issue:42"
+        assert args.prompt == "focus on auth"
+
+    def test_spec_plus_prompt(self):
+        parser = create_parser()
+        args = parser.parse_args(["--spec", "spec.md", "--prompt", "extra context"])
+        assert args.spec == "spec.md"
+        assert args.prompt == "extra context"
+
+    def test_plan_plus_prompt(self):
+        parser = create_parser()
+        args = parser.parse_args(["--plan", "plan.md", "--prompt", "additional notes"])
+        assert args.plan == "plan.md"
+        assert args.prompt == "additional notes"
+
+    def test_no_args_still_parses(self):
+        """Parser should accept no args — validation happens later."""
+        parser = create_parser()
+        args = parser.parse_args([])
+        assert args.prompt is None
+        assert args.source is None
+        assert args.spec is None
+        assert args.plan is None
+
+
+class TestBuildWorkRequest:
+    """Test build_work_request validation and prompt merging."""
+
+    def test_no_args_raises_system_exit(self):
+        parser = create_parser()
+        args = parser.parse_args([])
+        with pytest.raises(SystemExit):
+            build_work_request(args)
+
+    def test_source_and_spec_raises_system_exit(self):
+        parser = create_parser()
+        args = parser.parse_args(["--source", "gh:issue:1", "--spec", "spec.md"])
+        with pytest.raises(SystemExit):
+            build_work_request(args)
+
+    @patch("run_pipeline.normalize")
+    def test_prompt_only_backwards_compat(self, mock_normalize):
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="prompt", title="Add auth"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--prompt", "Add auth"])
+        wr = build_work_request(args)
+        mock_normalize.assert_called_once_with("prompt", "Add auth")
+        assert wr.title == "Add auth"
+
+    @patch("run_pipeline.normalize")
+    def test_source_dispatches_normalize(self, mock_normalize):
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="github_issue", title="Fix bug", description="Body text"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--source", "gh:issue:42"])
+        wr = build_work_request(args)
+        mock_normalize.assert_called_once_with("source", "gh:issue:42")
+        assert wr.title == "Fix bug"
+
+    @patch("run_pipeline.normalize")
+    def test_spec_dispatches_normalize(self, mock_normalize):
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="spec_file", title="Spec Title", description="Spec body"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--spec", "spec.md"])
+        wr = build_work_request(args)
+        mock_normalize.assert_called_once_with("spec", "spec.md")
+
+    @patch("run_pipeline.normalize")
+    def test_plan_only_dispatches_normalize(self, mock_normalize):
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="plan_file", title="Plan Title",
+            description="Plan content", plan_path="plan.md"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--plan", "plan.md"])
+        wr = build_work_request(args)
+        mock_normalize.assert_called_once_with("plan", "plan.md")
+
+    @patch("run_pipeline.normalize")
+    def test_prompt_merging_with_source(self, mock_normalize):
+        """When --prompt accompanies --source, append as Additional Instructions."""
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="github_issue", title="Fix bug",
+            description="Original issue body"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--source", "gh:issue:42", "--prompt", "focus on auth"])
+        wr = build_work_request(args)
+        assert "Original issue body" in wr.description
+        assert "## Additional Instructions" in wr.description
+        assert "focus on auth" in wr.description
+
+    @patch("run_pipeline.normalize")
+    def test_prompt_merging_with_spec(self, mock_normalize):
+        """When --prompt accompanies --spec, append as Additional Instructions."""
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="spec_file", title="Spec Title",
+            description="Spec content here"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--spec", "spec.md", "--prompt", "extra context"])
+        wr = build_work_request(args)
+        assert "Spec content here" in wr.description
+        assert "## Additional Instructions" in wr.description
+        assert "extra context" in wr.description
+
+    @patch("run_pipeline.normalize")
+    def test_prompt_merging_with_plan(self, mock_normalize):
+        """When --prompt accompanies --plan, append as Additional Instructions."""
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="plan_file", title="Plan Title",
+            description="Plan content", plan_path="plan.md"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--plan", "plan.md", "--prompt", "additional notes"])
+        wr = build_work_request(args)
+        assert "Plan content" in wr.description
+        assert "## Additional Instructions" in wr.description
+        assert "additional notes" in wr.description
+
+    @patch("run_pipeline.normalize")
+    def test_prompt_only_no_merging(self, mock_normalize):
+        """When only --prompt is given, no merging — just normal prompt flow."""
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="prompt", title="Add auth"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--prompt", "Add auth"])
+        wr = build_work_request(args)
+        assert "Additional Instructions" not in wr.description
+
+    @patch("run_pipeline.normalize")
+    def test_source_priority_over_plan(self, mock_normalize):
+        """When both --source and --plan given, source is primary, plan is plan_file."""
+        from worca.orchestrator.work_request import WorkRequest
+        mock_normalize.return_value = WorkRequest(
+            source_type="github_issue", title="Issue Title",
+            description="Issue body"
+        )
+        parser = create_parser()
+        args = parser.parse_args(["--source", "gh:issue:42", "--plan", "plan.md"])
+        wr = build_work_request(args)
+        mock_normalize.assert_called_once_with("source", "gh:issue:42")

--- a/tests/test_work_request.py
+++ b/tests/test_work_request.py
@@ -1,10 +1,13 @@
 """Tests for worca.orchestrator.work_request module."""
 import json
+import subprocess
 from unittest.mock import patch, MagicMock, ANY
 
 from worca.orchestrator.work_request import (
     WorkRequest,
     _extract_plan_path,
+    generate_smart_title,
+    normalize_plan_file,
     normalize_prompt,
     normalize_spec_file,
     normalize_github_issue,
@@ -43,6 +46,151 @@ class TestWorkRequest:
         assert wr.priority == 1
 
 
+# --- generate_smart_title ---
+
+class TestGenerateSmartTitle:
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_returns_title_on_success(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="Add user authentication flow\n"
+        )
+        result = generate_smart_title("# Auth\n\nImplement login and signup...")
+        assert result == "Add user authentication flow"
+        # Verify claude was called with haiku model
+        args = mock_run.call_args
+        cmd = args[0][0]
+        assert "claude" in cmd
+        assert "--model" in cmd
+        assert "haiku" in cmd
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_truncates_content_to_10k(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="Long doc title\n")
+        long_content = "x" * 20_000
+        generate_smart_title(long_content)
+        # The prompt passed to claude should contain truncated content
+        cmd = mock_run.call_args[0][0]
+        prompt_arg_idx = cmd.index("-p") + 1
+        assert len(cmd[prompt_arg_idx]) <= 11_000  # 10k content + prompt text
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_returns_empty_on_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=30)
+        result = generate_smart_title("some content")
+        assert result == ""
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_returns_empty_on_nonzero_exit(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+        result = generate_smart_title("some content")
+        assert result == ""
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_returns_empty_on_exception(self, mock_run):
+        mock_run.side_effect = OSError("command not found")
+        result = generate_smart_title("some content")
+        assert result == ""
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_returns_empty_for_empty_content(self, mock_run):
+        result = generate_smart_title("")
+        assert result == ""
+        mock_run.assert_not_called()
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_strips_whitespace_from_output(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="  Title with spaces  \n\n"
+        )
+        result = generate_smart_title("content")
+        assert result == "Title with spaces"
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_rejects_title_over_100_chars(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="A" * 101 + "\n"
+        )
+        result = generate_smart_title("content")
+        assert result == ""
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_rejects_title_with_newlines(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="Line one\nLine two\n"
+        )
+        result = generate_smart_title("content")
+        assert result == ""
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    def test_passes_source_hint_in_prompt(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="Auth feature\n")
+        generate_smart_title("content", source_hint="spec file: auth.md")
+        cmd = mock_run.call_args[0][0]
+        prompt_arg_idx = cmd.index("-p") + 1
+        assert "auth.md" in cmd[prompt_arg_idx]
+
+
+# --- normalize_plan_file ---
+
+class TestNormalizePlanFile:
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_reads_file_and_uses_smart_title(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = "Smart LLM Generated Title"
+        plan = tmp_path / "plan.md"
+        plan.write_text("# Plan Heading\n\nSome plan content.")
+        wr = normalize_plan_file(str(plan))
+        assert wr.source_type == "plan_file"
+        assert wr.title == "Smart LLM Generated Title"
+        assert "Some plan content" in wr.description
+        assert wr.source_ref == str(plan)
+        assert wr.plan_path == str(plan)
+        mock_smart_title.assert_called_once()
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_falls_back_to_heading_when_smart_title_empty(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = ""
+        plan = tmp_path / "plan.md"
+        plan.write_text("# My Plan Heading\n\nDetails here.")
+        wr = normalize_plan_file(str(plan))
+        assert wr.title == "My Plan Heading"
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_falls_back_to_filename_when_no_heading(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = ""
+        plan = tmp_path / "my-plan.md"
+        plan.write_text("No heading here, just content.")
+        wr = normalize_plan_file(str(plan))
+        assert wr.title == "my-plan.md"
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_uses_provided_content_instead_of_reading_file(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = "Title From Content"
+        plan = tmp_path / "plan.md"
+        plan.write_text("File content on disk")
+        wr = normalize_plan_file(str(plan), content="Provided content override")
+        assert wr.description == "Provided content override"
+        # smart_title called with provided content, not file content
+        mock_smart_title.assert_called_once_with("Provided content override", source_hint=ANY)
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_empty_file(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = ""
+        plan = tmp_path / "empty.md"
+        plan.write_text("")
+        wr = normalize_plan_file(str(plan))
+        assert wr.title == "empty.md"
+        assert wr.description == ""
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_plan_path_set_to_file_path(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = "Title"
+        plan = tmp_path / "docs" / "plans" / "W-027.md"
+        plan.parent.mkdir(parents=True)
+        plan.write_text("# W-027\n\nPlan details.")
+        wr = normalize_plan_file(str(plan))
+        assert wr.plan_path == str(plan)
+
+
 # --- normalize_prompt ---
 
 class TestNormalizePrompt:
@@ -64,33 +212,60 @@ class TestNormalizePrompt:
 # --- normalize_spec_file ---
 
 class TestNormalizeSpecFile:
-    def test_extracts_title_from_heading(self, tmp_path):
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_uses_smart_title_when_available(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = "Smart Spec Title From LLM"
         spec = tmp_path / "auth.md"
         spec.write_text("# User Authentication\n\nAdd login flow.")
         wr = normalize_spec_file(str(spec))
         assert wr.source_type == "spec_file"
-        assert wr.title == "User Authentication"
+        assert wr.title == "Smart Spec Title From LLM"
         assert "login flow" in wr.description
         assert wr.source_ref == str(spec)
+        mock_smart_title.assert_called_once()
 
-    def test_uses_filename_when_no_heading(self, tmp_path):
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_falls_back_to_heading_when_smart_title_empty(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = ""
+        spec = tmp_path / "auth.md"
+        spec.write_text("# User Authentication\n\nAdd login flow.")
+        wr = normalize_spec_file(str(spec))
+        assert wr.title == "User Authentication"
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_falls_back_to_filename_when_no_heading(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = ""
         spec = tmp_path / "notes.md"
         spec.write_text("Just some notes without a heading.")
         wr = normalize_spec_file(str(spec))
         assert wr.title == "notes.md"
 
-    def test_full_content_in_description(self, tmp_path):
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_full_content_in_description(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = "Title"
         content = "# Title\n\nLine 1\nLine 2"
         spec = tmp_path / "full.md"
         spec.write_text(content)
         wr = normalize_spec_file(str(spec))
         assert wr.description == content
 
-    def test_extracts_h2_heading(self, tmp_path):
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_extracts_h2_heading_as_fallback(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = ""
         spec = tmp_path / "h2.md"
         spec.write_text("## Subsection Title\n\nContent here.")
         wr = normalize_spec_file(str(spec))
         assert wr.title == "Subsection Title"
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_passes_source_hint_with_filename(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = "Generated Title"
+        spec = tmp_path / "my-feature.md"
+        spec.write_text("Some content here.")
+        normalize_spec_file(str(spec))
+        mock_smart_title.assert_called_once_with(
+            "Some content here.", source_hint="spec file: my-feature.md"
+        )
 
 
 # --- normalize_github_issue ---
@@ -195,7 +370,9 @@ class TestNormalize:
         assert wr.source_type == "prompt"
         assert wr.title == "Do something"
 
-    def test_dispatches_spec(self, tmp_path):
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_dispatches_spec(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = ""
         spec = tmp_path / "spec.md"
         spec.write_text("# My Spec\n\nDetails.")
         wr = normalize("spec", str(spec))
@@ -221,6 +398,26 @@ class TestNormalize:
 
         wr = normalize("beads", "bd:bd-x1")
         assert wr.source_type == "beads"
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_dispatches_plan(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = "Plan Title"
+        plan = tmp_path / "plan.md"
+        plan.write_text("# Plan\n\nContent.")
+        wr = normalize("plan", str(plan))
+        assert wr.source_type == "plan_file"
+        assert wr.title == "Plan Title"
+        assert wr.plan_path == str(plan)
+
+    @patch("worca.orchestrator.work_request.generate_smart_title")
+    def test_dispatches_plan_with_kwargs(self, mock_smart_title, tmp_path):
+        mock_smart_title.return_value = "Kwargs Title"
+        plan = tmp_path / "plan.md"
+        plan.write_text("File content on disk")
+        wr = normalize("plan", str(plan), content="Overridden content")
+        assert wr.source_type == "plan_file"
+        assert wr.title == "Kwargs Title"
+        assert wr.description == "Overridden content"
 
     def test_raises_on_unknown_source(self):
         try:


### PR DESCRIPTION
## Summary

- **Make prompt optional**: When a work source (GH issue, spec file) or plan file is provided, the prompt textarea becomes optional instead of required
- **Smart title generation**: Titles and branch names are generated from actual content via LLM (`claude --model haiku`) with heading/filename fallbacks, replacing generic prompts
- **Backwards compatible**: Old `inputType`/`inputValue` API format is auto-normalized to the new `sourceType`/`sourceValue`/`prompt` format

## Changes

### Python Backend
- `generate_smart_title()` — LLM-based title extraction with 30s timeout, sanity checks
- `normalize_plan_file()` — new work request type for plan files
- `normalize_spec_file()` — updated with smart title priority chain (LLM → heading → filename)
- `run_pipeline.py` — args no longer mutually exclusive; prompt merging appends as "Additional Instructions"

### Server (JS)
- `POST /api/runs` accepts new `sourceType`/`sourceValue`/`prompt` fields
- Old `inputType`/`inputValue` format auto-normalized for backwards compatibility
- `process-manager.js` builds separate `--source`/`--spec` + `--prompt` CLI args

### UI
- Restructured form: Work Source section → Prompt section → Advanced Options
- Plan file moved from Advanced Options to Work Source section
- Dynamic label: "Prompt (required)" vs "Additional Instructions (optional)"
- Validation: at least one of source, plan, or prompt required

## Test plan

- [x] 69 Python tests pass (`pytest tests/test_work_request.py tests/test_run_pipeline.py`)
- [x] 86 JS tests pass (`npx vitest run` — server + UI tests)
- [ ] Manual: submit run with only a GH issue (no prompt) — should succeed
- [ ] Manual: submit run with only a plan file — should succeed
- [ ] Manual: submit run with source + optional prompt — prompt merged as Additional Instructions
- [ ] Manual: old API clients sending `inputType`/`inputValue` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)