### PR TITLE
feat(ui): show project directory name in sidebar and browser tab

### DIFF
--- a/.claude/worca-ui/app/main-project-info.test.js
+++ b/.claude/worca-ui/app/main-project-info.test.js
@@ -1,0 +1,46 @@
+/**
+ * Tests for the project-info fetch logic in main.js.
+ *
+ * main.js fetches /api/project-info at startup and on WS reconnect,
+ * stores the name in state.projectName, and updates document.title.
+ *
+ * We test the pure logic (title formatting, store contract) without DOM.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createStore } from './state.js';
+import { formatTitle } from './utils/title.js';
+
+describe('project-info fetch: store and title contract', () => {
+  let store;
+
+  beforeEach(() => {
+    store = createStore();
+  });
+
+  it('stores projectName from API response', () => {
+    const apiResponse = { name: 'my-app' };
+    store.setState({ projectName: apiResponse.name });
+    expect(store.getState().projectName).toBe('my-app');
+  });
+
+  it('formats title with project name', () => {
+    expect(formatTitle('my-app')).toBe('my-app — worca');
+  });
+
+  it('formats title as "worca" when project name is empty', () => {
+    expect(formatTitle('')).toBe('worca');
+  });
+
+  it('formats title as "worca" when project name is undefined', () => {
+    expect(formatTitle(undefined)).toBe('worca');
+  });
+
+  it('subscriber sees projectName during rerender', () => {
+    const captured = [];
+    store.subscribe((state) => {
+      captured.push(state.projectName);
+    });
+    store.setState({ projectName: 'cool-project' });
+    expect(captured).toEqual(['cool-project']);
+  });
+});

--- a/.claude/worca-ui/app/main.js
+++ b/.claude/worca-ui/app/main.js
@@ -18,6 +18,7 @@ import { createNotificationManager } from './notifications.js';
 import { beadsPanelView, beadsRunListView } from './views/beads-panel.js';
 import { tokenCostsView } from './views/token-costs.js';
 import { learningsSectionView } from './views/learnings-panel.js';
+import { formatTitle } from './utils/title.js';
 
 // Register Shoelace components (tree-shaken — only imports what we use)
 import '@shoelace-style/shoelace/dist/components/details/details.js';
@@ -202,6 +203,7 @@ ws.on('beads-update', (payload) => {
     if (route.runId && route.section !== 'beads') fetchRunBeads(route.runId);
     // Re-fetch bead counts for run list
     fetchBeadsCounts();
+
     // Re-fetch beads for currently viewed run in beads section
     if (route.section === 'beads' && route.runId) fetchBeadsRunIssues(route.runId);
   }
@@ -265,6 +267,8 @@ ws.onConnection((state) => {
     }).catch(() => {});
 
     fetchBeadsCounts();
+
+    fetchProjectInfo();
 
     // Subscribe to active run if selected
     if (route.runId) {
@@ -567,6 +571,18 @@ function fetchCostsData() {
         costsTokenData = data.tokenData || {};
         costsFetched = true;
         rerender();
+      }
+    })
+    .catch(() => {});
+}
+
+function fetchProjectInfo() {
+  fetch('/api/project-info')
+    .then(r => r.json())
+    .then(data => {
+      if (data.name !== undefined) {
+        store.setState({ projectName: data.name });
+        document.title = formatTitle(data.name);
       }
     })
     .catch(() => {});
@@ -944,6 +960,7 @@ function attachStickyHeaderListener() {
 notificationManager.setRerender(rerender);
 store.subscribe(() => rerender());
 applyTheme(store.getState().preferences.theme);
+fetchProjectInfo();
 if (route.section === 'settings') {
   loadSettings().then(() => rerender());
 }

--- a/.claude/worca-ui/app/state.js
+++ b/.claude/worca-ui/app/state.js
@@ -7,6 +7,7 @@ const LOG_CAP = 5000;
 export function createStore(initial = {}) {
   let state = {
     activeRunId: initial.activeRunId ?? null,
+    projectName: initial.projectName ?? '',
     runs: initial.runs ?? {},
     logLines: initial.logLines ?? [],
     preferences: {
@@ -36,6 +37,7 @@ export function createStore(initial = {}) {
       };
       if (
         next.activeRunId === state.activeRunId &&
+        next.projectName === state.projectName &&
         next.runs === state.runs &&
         next.logLines === state.logLines &&
         next.preferences.theme === state.preferences.theme &&

--- a/.claude/worca-ui/app/state.test.js
+++ b/.claude/worca-ui/app/state.test.js
@@ -6,9 +6,24 @@ describe('state store', () => {
     const store = createStore();
     const s = store.getState();
     expect(s.activeRunId).toBe(null);
+    expect(s.projectName).toBe('');
     expect(s.runs).toEqual({});
     expect(s.logLines).toEqual([]);
     expect(s.preferences).toEqual({ theme: 'light', sidebarCollapsed: false, notifications: null });
+  });
+
+  it('accepts projectName initial override', () => {
+    const store = createStore({ projectName: 'my-project' });
+    expect(store.getState().projectName).toBe('my-project');
+  });
+
+  it('setState updates projectName and notifies subscribers', () => {
+    const store = createStore();
+    const fn = vi.fn();
+    store.subscribe(fn);
+    store.setState({ projectName: 'new-project' });
+    expect(store.getState().projectName).toBe('new-project');
+    expect(fn).toHaveBeenCalledOnce();
   });
 
   it('accepts initial overrides', () => {

--- a/.claude/worca-ui/app/styles.css
+++ b/.claude/worca-ui/app/styles.css
@@ -128,7 +128,8 @@ h1, h2, h3, h4, h5, h6 {
 .sidebar.collapsed .sidebar-section-header,
 .sidebar.collapsed .sidebar-item span,
 .sidebar.collapsed .conn-label,
-.sidebar.collapsed .logo-text {
+.sidebar.collapsed .logo-text,
+.sidebar.collapsed .project-name {
   display: none;
 }
 
@@ -143,6 +144,19 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--fg);
+}
+
+.project-name {
+  display: block;
+  font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* --- 6. Sidebar Sections --- */

--- a/.claude/worca-ui/app/utils/title.js
+++ b/.claude/worca-ui/app/utils/title.js
@@ -1,0 +1,8 @@
+/**
+ * Format browser tab title with optional project name.
+ * @param {string} [projectName]
+ * @returns {string}
+ */
+export function formatTitle(projectName) {
+  return projectName ? `${projectName} — worca` : 'worca';
+}

--- a/.claude/worca-ui/app/views/sidebar-project-name.test.js
+++ b/.claude/worca-ui/app/views/sidebar-project-name.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { sidebarView } from './sidebar.js';
+
+function makeState(overrides = {}) {
+  return {
+    runs: {},
+    preferences: { sidebarCollapsed: false },
+    beads: { issues: [], dbExists: false },
+    projectName: '',
+    ...overrides,
+  };
+}
+
+const route = { section: 'dashboard' };
+const conn = 'open';
+const handlers = { onNavigate: () => {} };
+
+/**
+ * Walk a lit-html TemplateResult tree and collect all string values.
+ */
+function collectStrings(tpl) {
+  const out = [];
+  if (!tpl) return out;
+  if (tpl.strings) {
+    for (const s of tpl.strings) out.push(s);
+  }
+  if (tpl.values) {
+    for (const v of tpl.values) {
+      if (typeof v === 'string') out.push(v);
+      else if (v && v.strings) out.push(...collectStrings(v));
+    }
+  }
+  return out;
+}
+
+function templateContains(tpl, pattern) {
+  const all = collectStrings(tpl).join('');
+  return pattern instanceof RegExp ? pattern.test(all) : all.includes(pattern);
+}
+
+describe('sidebar project name', () => {
+  it('renders project-name class when projectName is set', () => {
+    const state = makeState({ projectName: 'my-project' });
+    const tpl = sidebarView(state, route, conn, handlers);
+    expect(templateContains(tpl, 'project-name')).toBe(true);
+    expect(templateContains(tpl, 'my-project')).toBe(true);
+  });
+
+  it('does not render project-name when projectName is empty', () => {
+    const state = makeState({ projectName: '' });
+    const tpl = sidebarView(state, route, conn, handlers);
+    expect(templateContains(tpl, 'project-name')).toBe(false);
+  });
+
+  it('includes collapsed class when sidebar is collapsed', () => {
+    const state = makeState({
+      projectName: 'my-project',
+      preferences: { sidebarCollapsed: true },
+    });
+    const tpl = sidebarView(state, route, conn, handlers);
+    expect(templateContains(tpl, 'collapsed')).toBe(true);
+    expect(templateContains(tpl, 'project-name')).toBe(true);
+  });
+});

--- a/.claude/worca-ui/app/views/sidebar.js
+++ b/.claude/worca-ui/app/views/sidebar.js
@@ -3,7 +3,7 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { iconSvg, Activity, Archive, Settings, Plus, List, Coins } from '../utils/icons.js';
 
 export function sidebarView(state, route, connectionState, { onNavigate }) {
-  const { runs, preferences } = state;
+  const { runs, preferences, projectName } = state;
   const runList = Object.values(runs);
   const activeCount = runList.filter(r => r.active).length;
   const historyCount = runList.filter(r => !r.active).length;
@@ -21,6 +21,7 @@ export function sidebarView(state, route, connectionState, { onNavigate }) {
     <aside class="sidebar ${preferences.sidebarCollapsed ? 'collapsed' : ''}">
       <div class="sidebar-logo" @click=${() => onNavigate('dashboard')} style="cursor:pointer">
         <span class="logo-text">WORCA</span>
+        ${projectName ? html`<span class="project-name">${projectName}</span>` : ''}
       </div>
 
       <div class="sidebar-new-run">

--- a/.claude/worca-ui/server/app.js
+++ b/.claude/worca-ui/server/app.js
@@ -1,7 +1,7 @@
 // server/app.js
 import express from 'express';
 import { fileURLToPath } from 'node:url';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { validateSettingsPayload } from './settings-validator.js';
@@ -427,6 +427,11 @@ export function createApp(options = {}) {
     }
 
     res.json({ ok: true, tokenData });
+  });
+
+  // GET /api/project-info
+  app.get('/api/project-info', (_req, res) => {
+    res.json({ name: projectRoot ? basename(projectRoot) : '' });
   });
 
   app.use(express.static(appDir));

--- a/.claude/worca-ui/server/test/project-info-api.test.js
+++ b/.claude/worca-ui/server/test/project-info-api.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { createServer } from 'node:http';
+import { createApp } from '../app.js';
+
+function startServer(projectRoot) {
+  const app = createApp({ projectRoot });
+  const server = createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const base = `http://127.0.0.1:${port}`;
+      resolve({ server, base });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+describe('GET /api/project-info', () => {
+  it('returns the project directory name', async () => {
+    const { server, base } = await startServer('/home/user/projects/my-app');
+    try {
+      const res = await fetch(`${base}/api/project-info`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ name: 'my-app' });
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it('returns basename when projectRoot has trailing slash', async () => {
+    const { server, base } = await startServer('/home/user/projects/my-app/');
+    try {
+      const res = await fetch(`${base}/api/project-info`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ name: 'my-app' });
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it('returns empty name when projectRoot is not configured', async () => {
+    const { server, base } = await startServer(undefined);
+    try {
+      const res = await fetch(`${base}/api/project-info`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ name: '' });
+    } finally {
+      await stopServer(server);
+    }
+  });
+});

--- a/docs/plans/20260320-041439-when-we-install-the-worca-in-different-project-and-we-work-w.md
+++ b/docs/plans/20260320-041439-when-we-install-the-worca-in-different-project-and-we-work-w.md
@@ -1,0 +1,112 @@
+# Plan: Display Project Directory Name in Worca UI Sidebar
+
+## Problem
+
+When worca is installed in multiple projects and multiple worca-ui instances are open in the browser simultaneously, there is no way to distinguish which instance belongs to which project. The UI always shows the same hardcoded "WORCA" branding with no project-specific context.
+
+## Proposal
+
+Add the project directory name directly below the "WORCA" title in the upper-left sidebar logo area. The server already discovers the project root path — we just need to expose it via the API and render it in the sidebar.
+
+## Implementation
+
+### Task 1: Add `/api/project-info` endpoint to the server
+
+**File:** `.claude/worca-ui/server/app.js`
+
+Add a new GET endpoint that returns the project directory name derived from the already-resolved `projectRoot` path:
+
+```javascript
+app.get('/api/project-info', (req, res) => {
+  const dirName = path.basename(projectRoot);
+  res.json({ name: dirName });
+});
+```
+
+The `projectRoot` variable is already available in `app.js` scope (passed from `index.js` during app creation). Use `path.basename()` to extract just the directory name (e.g., `/home/user/my-project` → `my-project`).
+
+### Task 2: Fetch project name at UI startup and store in state
+
+**File:** `.claude/worca-ui/app/main.js`
+
+During app initialization (near existing `fetch('/api/costs')` calls), fetch the project info:
+
+```javascript
+fetch('/api/project-info').then(r => r.json()).then(data => {
+  state.projectName = data.name;
+  render();
+});
+```
+
+**File:** `.claude/worca-ui/app/state.js`
+
+Add `projectName: ''` to the initial state object.
+
+### Task 3: Display project name in sidebar below "WORCA" title
+
+**File:** `.claude/worca-ui/app/views/sidebar.js`
+
+Update the sidebar logo `div` to include the project name beneath the logo text:
+
+```javascript
+<div class="sidebar-logo" @click=${() => onNavigate('dashboard')} style="cursor:pointer">
+  <span class="logo-text">WORCA</span>
+  ${projectName ? html`<span class="project-name">${projectName}</span>` : ''}
+</div>
+```
+
+Pass `projectName` from state into the sidebar view function parameters.
+
+**File:** `.claude/worca-ui/app/styles.css`
+
+Add styling for the project name label:
+
+```css
+.project-name {
+  display: block;
+  font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--fg-muted);
+  letter-spacing: 0.02em;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+```
+
+### Task 4: Update browser tab title with project name
+
+**File:** `.claude/worca-ui/app/main.js`
+
+When the project name is fetched, also update `document.title`:
+
+```javascript
+document.title = data.name ? `${data.name} — worca` : 'worca-ui';
+```
+
+This helps distinguish multiple tabs in the browser tab bar.
+
+### Task 5: Build and test
+
+1. Rebuild the frontend bundle: `cd .claude/worca-ui && npm run build`
+2. Run existing UI server tests: `npx vitest run .claude/worca-ui/server/`
+3. Manually verify the sidebar shows the project directory name
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.claude/worca-ui/server/app.js` | Add `GET /api/project-info` endpoint |
+| `.claude/worca-ui/app/state.js` | Add `projectName` to initial state |
+| `.claude/worca-ui/app/main.js` | Fetch project info on startup, update document.title |
+| `.claude/worca-ui/app/views/sidebar.js` | Render project name below WORCA logo |
+| `.claude/worca-ui/app/styles.css` | Add `.project-name` styles |
+
+## Considerations
+
+- **Long directory names:** Handled with `text-overflow: ellipsis` and `overflow: hidden` so names don't break the sidebar layout.
+- **No config needed:** The project name is automatically derived from the filesystem path — no user configuration required.
+- **Tab title:** Updating `document.title` gives a second visual cue when switching between browser tabs, complementing the sidebar label.
+- **Backward compatible:** The endpoint is additive; existing UI builds without this change will simply not fetch or display the name.


### PR DESCRIPTION
When running multiple worca instances for different projects, it was impossible to tell which browser tab belonged to which project. Add a /api/project-info endpoint that returns the project directory basename, display it below the WORCA logo in the sidebar, and set document.title to "<project> — worca" so tabs are distinguishable.

<img width="1246" height="549" alt="image" src="https://github.com/user-attachments/assets/8a561f1a-dc28-436e-a9d1-378107838cdc" />

<img width="270" height="295" alt="image" src="https://github.com/user-attachments/assets/893ba1b0-a4c5-4ae3-b061-dee82da4966d" />
