### PR TITLE
Add run/branch metadata to beads details view

### DIFF
--- a/.claude/worca-ui/app/main.js
+++ b/.claude/worca-ui/app/main.js
@@ -916,6 +916,8 @@ function mainContentView() {
         onStartIssue: handleStartBeadsIssue,
         onDismissError: handleDismissBeadsError,
         loading: beadsRunLoading,
+        run: state.runs[route.runId],
+        runId: route.runId,
       });
     }
     return beadsRunListView(runs, {

--- a/.claude/worca-ui/app/utils/icons.js
+++ b/.claude/worca-ui/app/utils/icons.js
@@ -47,6 +47,7 @@ import Database from 'lucide/dist/esm/icons/database';
 import X from 'lucide/dist/esm/icons/x';
 import Lightbulb from 'lucide/dist/esm/icons/lightbulb';
 import Trash2 from 'lucide/dist/esm/icons/trash-2';
+import Hash from 'lucide/dist/esm/icons/hash';
 
 function renderChildren(nodes) {
   return nodes.map(([tag, attrs]) => {
@@ -79,5 +80,6 @@ export {
   Lightbulb,
   Trash2,
   RotateCw,
-  CircleSlash
+  CircleSlash,
+  Hash
 };

--- a/.claude/worca-ui/app/views/beads-panel.js
+++ b/.claude/worca-ui/app/views/beads-panel.js
@@ -1,6 +1,6 @@
-import { html } from 'lit-html';
+import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import { iconSvg, Lock, Loader, Circle, CircleCheck, CircleAlert } from '../utils/icons.js';
+import { iconSvg, Lock, Loader, Circle, CircleCheck, CircleAlert, GitBranch, Hash } from '../utils/icons.js';
 import { runCardView } from './run-card.js';
 
 export function priorityVariant(priority) {
@@ -274,7 +274,7 @@ function beadsKanbanView(issues, { starting, onStartIssue }) {
 export function beadsPanelView(issues, {
   statusFilter, priorityFilter, starting, startError,
   onStatusFilter, onPriorityFilter, onStartIssue, onDismissError,
-  loading = false,
+  loading = false, run, runId,
 }) {
   if (loading) {
     return html`<div class="empty-state">Loading issues...</div>`;
@@ -286,6 +286,28 @@ export function beadsPanelView(issues, {
   let filtered = displayIssues;
   if (statusFilter !== 'all') filtered = filtered.filter(i => i.status === statusFilter);
   if (priorityFilter !== 'all') filtered = filtered.filter(i => String(i.priority) === priorityFilter);
+
+  const branch = run?.branch || run?.work_request?.branch || '';
+  const displayRunId = runId || run?.run_id || '';
+  const pr = run?.pr_url || null;
+
+  const metaStripView = (branch || displayRunId) ? html`
+    <div class="run-info-section">
+      ${displayRunId ? html`
+        <div class="run-branch">
+          <span class="stage-meta-icon">${unsafeHTML(iconSvg(Hash, 14))}</span>
+          <span>Run ${displayRunId}</span>
+        </div>
+      ` : nothing}
+      ${branch ? html`
+        <div class="run-branch">
+          <span class="stage-meta-icon">${unsafeHTML(iconSvg(GitBranch, 14))}</span>
+          <span>${branch}</span>
+          ${pr ? html`<a class="run-pr-link" href="${pr}" target="_blank">View PR</a>` : nothing}
+        </div>
+      ` : nothing}
+    </div>
+  ` : nothing;
 
   const filtersView = html`
     <div class="beads-filters">
@@ -310,6 +332,7 @@ export function beadsPanelView(issues, {
   if (filtered.length === 0) {
     return html`
       <div class="beads-panel">
+        ${metaStripView}
         ${filtersView}
         <div class="empty-state">${displayIssues.length === 0 ? 'No issues found for this run.' : 'No issues match the current filters.'}</div>
       </div>
@@ -318,6 +341,7 @@ export function beadsPanelView(issues, {
 
   return html`
     <div class="beads-panel">
+      ${metaStripView}
       ${filtersView}
       ${beadsKanbanView(filtered, { starting, onStartIssue })}
       ${startError ? html`

--- a/.claude/worca-ui/app/views/beads-panel.test.js
+++ b/.claude/worca-ui/app/views/beads-panel.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { beadsPanelView } from './beads-panel.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v && v.strings) result += renderToString(v);
+      // unsafeHTML directives / functions — skip
+    }
+  });
+  return result;
+}
+
+const baseOptions = {
+  statusFilter: 'all',
+  priorityFilter: 'all',
+  starting: null,
+  startError: null,
+  onStatusFilter: () => {},
+  onPriorityFilter: () => {},
+  onStartIssue: () => {},
+  onDismissError: () => {},
+};
+
+describe('beadsPanelView - run/branch metadata strip', () => {
+  it('shows run ID when runId is provided', () => {
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      runId: '20260322-161722',
+    }));
+    expect(output).toContain('20260322-161722');
+  });
+
+  it('shows branch when run.branch is set', () => {
+    const run = { branch: 'worca/my-feature-abc' };
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      run,
+    }));
+    expect(output).toContain('worca/my-feature-abc');
+  });
+
+  it('shows PR link when run.pr_url is set', () => {
+    const run = { branch: 'worca/feature', pr_url: 'https://github.com/owner/repo/pull/42' };
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      run,
+    }));
+    expect(output).toContain('View PR');
+    expect(output).toContain('https://github.com/owner/repo/pull/42');
+  });
+
+  it('hides PR link when run.pr_url is absent', () => {
+    const run = { branch: 'worca/feature' };
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      run,
+    }));
+    expect(output).not.toContain('View PR');
+  });
+
+  it('shows both run ID and branch when both present', () => {
+    const run = { branch: 'worca/feature-xyz' };
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      run,
+      runId: '20260322-170556',
+    }));
+    expect(output).toContain('20260322-170556');
+    expect(output).toContain('worca/feature-xyz');
+  });
+
+  it('shows nothing when neither run nor runId provided', () => {
+    const output = renderToString(beadsPanelView([], { ...baseOptions }));
+    expect(output).not.toContain('run-info-section');
+  });
+
+  it('uses run-info-section CSS class for the metadata strip', () => {
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      runId: '20260322-161722',
+    }));
+    expect(output).toContain('run-info-section');
+  });
+
+  it('uses run-branch CSS class for each metadata row', () => {
+    const run = { branch: 'worca/feature' };
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      run,
+      runId: '20260322-161722',
+    }));
+    expect(output).toContain('run-branch');
+  });
+
+  it('falls back to run.work_request.branch if run.branch is absent', () => {
+    const run = { work_request: { branch: 'worca/fallback-branch' } };
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      run,
+    }));
+    expect(output).toContain('worca/fallback-branch');
+  });
+
+  it('shows "Run" label prefix before the run ID', () => {
+    const output = renderToString(beadsPanelView([], {
+      ...baseOptions,
+      runId: '20260322-161722',
+    }));
+    expect(output).toContain('Run ');
+    expect(output).toContain('20260322-161722');
+  });
+});

--- a/docs/plans/20260322-170556-in-the-beads-details-view-add-the-run-and-branch-identifier-.md
+++ b/docs/plans/20260322-170556-in-the-beads-details-view-add-the-run-and-branch-identifier-.md
@@ -1,0 +1,108 @@
+# Plan: Add Run & Branch Identifier to Beads Details View
+
+## Problem
+
+When viewing the beads kanban for a specific run (`#/beads?run=<runId>`), there is no metadata showing which run ID or git branch the beads belong to. The content header shows the work request title, but the run identifier (e.g. `20260322-161722`) and branch name (e.g. `worca/add-css-styles-7m8u`) are absent. The run detail view already has a `run-info-section` with branch/timing metadata — the beads detail view should follow the same pattern for consistency.
+
+## Approach
+
+Add a metadata strip between the content header and the beads kanban filters, reusing the existing `run-info-section` / `run-branch` CSS pattern from `run-detail.js`. The data is already available in `state.runs[route.runId]` — no server changes needed.
+
+## Changes
+
+### 1. `main.js` — Pass run data to `beadsPanelView`
+
+**File:** `.claude/worca-ui/app/main.js`
+
+In `mainContentView()` (line ~908), when rendering `beadsPanelView` for a specific run, pass the `run` object as a new option:
+
+```js
+const run = state.runs[route.runId];
+return beadsPanelView(beadsRunIssues, {
+  // ...existing options...
+  run,        // ← new
+  runId: route.runId,  // ← new (fallback identifier)
+});
+```
+
+### 2. `beads-panel.js` — Render run/branch metadata strip
+
+**File:** `.claude/worca-ui/app/views/beads-panel.js`
+
+Add a metadata section at the top of the `beadsPanelView` output, above the filters. Destructure `run` and `runId` from options. Render:
+
+- **Run ID** — with a `Hash` icon and the run ID value (e.g. `20260322-161722`)
+- **Branch** — with a `GitBranch` icon and the branch name (reuse `run-branch` class)
+- **PR link** — if `run.pr_url` exists, show "View PR" link (same as run-detail)
+
+Template structure:
+```js
+const branch = run?.branch || run?.work_request?.branch || '';
+const displayRunId = runId || run?.run_id || '';
+const pr = run?.pr_url || null;
+
+const metaStripView = (branch || displayRunId) ? html`
+  <div class="run-info-section">
+    ${displayRunId ? html`
+      <div class="run-branch">
+        <span class="stage-meta-icon">${unsafeHTML(iconSvg(Hash, 14))}</span>
+        <span>Run ${displayRunId}</span>
+      </div>
+    ` : nothing}
+    ${branch ? html`
+      <div class="run-branch">
+        <span class="stage-meta-icon">${unsafeHTML(iconSvg(GitBranch, 14))}</span>
+        <span>${branch}</span>
+        ${pr ? html`<a class="run-pr-link" href="${pr}" target="_blank">View PR</a>` : nothing}
+      </div>
+    ` : nothing}
+  </div>
+` : nothing;
+```
+
+Insert `${metaStripView}` inside `.beads-panel` before `${filtersView}`.
+
+Import `Hash` and `GitBranch` from lucide (via `icons.js` utility) and `nothing` from lit-html.
+
+### 3. `icons.js` — Export `Hash` icon if not already exported
+
+**File:** `.claude/worca-ui/app/utils/icons.js`
+
+Check if `Hash` and `GitBranch` are already exported. Add any missing icon imports.
+
+### 4. Tests — Unit tests for the metadata strip
+
+**File:** `.claude/worca-ui/app/views/beads-panel.test.js` (or create if doesn't exist)
+
+Write tests using the existing `renderToString` helper pattern:
+
+- **Shows run ID** when `runId` is provided
+- **Shows branch** when `run.branch` is set
+- **Shows PR link** when `run.pr_url` is set
+- **Hides PR link** when `run.pr_url` is absent
+- **Shows both** run ID and branch when both present
+- **Shows nothing** when neither run nor runId provided
+- **CSS class check** — verify `run-info-section` and `run-branch` classes are present
+
+### 5. Build
+
+```bash
+cd .claude/worca-ui && npm run build
+```
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `.claude/worca-ui/app/main.js` | Pass `run` and `runId` to `beadsPanelView` |
+| `.claude/worca-ui/app/views/beads-panel.js` | Add metadata strip with run ID + branch |
+| `.claude/worca-ui/app/utils/icons.js` | Export `Hash` icon (if missing) |
+| `.claude/worca-ui/app/views/beads-panel.test.js` | New tests for metadata strip |
+
+## No CSS changes needed
+
+The existing `.run-info-section` and `.run-branch` styles already handle the layout. Reusing them keeps the beads detail view visually consistent with the run detail view.
+
+## No server changes needed
+
+The run data (including `branch`, `run_id`, `pr_url`) is already in `state.runs` from the WebSocket store. No new API endpoints or data fetching required.


### PR DESCRIPTION
## Summary
- Adds a run ID + git branch metadata strip to the beads kanban detail view, positioned between the header and filter bar
- Reuses existing `run-info-section` / `run-branch` CSS classes from the run detail view for visual consistency
- Shows PR link when available; gracefully hides the strip when no run/branch data exists

## Test plan
- [x] 10 unit tests added in `beads-panel.test.js` covering run ID display, branch display, PR link presence/absence, fallback to `work_request.branch`, and CSS class verification
- [x] Manual: navigate to `#/beads?run=<runId>` and verify the metadata strip appears below the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)