### PR TITLE
fix: resolve all 191 ruff lint warnings and make ruff CI step blocking

### DIFF
--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -2,7 +2,6 @@
 # requires-python = ">=3.8"
 # ///
 """UserPromptSubmit hook: runs milestone approval gates."""
-import json
 import sys
 import os
 

--- a/.claude/scripts/run_learn.py
+++ b/.claude/scripts/run_learn.py
@@ -8,7 +8,6 @@ for the given run, initializes a PromptBuilder, and calls
 _run_learn_stage() from runner.py.
 """
 import argparse
-import json
 import os
 import sys
 

--- a/.claude/scripts/run_parallel.py
+++ b/.claude/scripts/run_parallel.py
@@ -23,11 +23,10 @@ import sys
 import tempfile
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from worca.orchestrator.work_request import normalize, WorkRequest
+from worca.orchestrator.work_request import normalize
 from worca.utils.claude_cli import _ARG_INLINE_LIMIT
 
 

--- a/.claude/scripts/run_pipeline.py
+++ b/.claude/scripts/run_pipeline.py
@@ -150,7 +150,7 @@ def main():
     if args.branch:
         print(f"  Using existing branch: {args.branch}")
     if args.skip_preflight:
-        print(f"  Skipping preflight checks")
+        print("  Skipping preflight checks")
 
     try:
         # For resume, always use default .worca/status.json so runner derives

--- a/.claude/scripts/worca.py
+++ b/.claude/scripts/worca.py
@@ -10,7 +10,6 @@ When run_id is omitted, the active run is read from .worca/active_run.
 """
 
 import argparse
-import json
 import os
 import signal
 import subprocess
@@ -22,8 +21,8 @@ _SCRIPTS_DIR = Path(__file__).parent
 _CLAUDE_DIR = _SCRIPTS_DIR.parent
 sys.path.insert(0, str(_CLAUDE_DIR))
 
-from worca.orchestrator.control import write_control
-from worca.state.status import load_status
+from worca.orchestrator.control import write_control  # noqa: E402
+from worca.state.status import load_status  # noqa: E402
 
 
 _DEFAULT_BASE = ".worca"

--- a/.claude/worca/events/webhook.py
+++ b/.claude/worca/events/webhook.py
@@ -24,7 +24,7 @@ import sys
 import threading
 import time
 from fnmatch import fnmatch
-from typing import Any, Optional
+from typing import Optional
 from urllib import request
 from urllib.error import URLError
 

--- a/.claude/worca/hooks/session.py
+++ b/.claude/worca/hooks/session.py
@@ -15,7 +15,8 @@ import sys
 try:
     from worca.utils.env import get_env
 except ImportError:
-    get_env = lambda **kw: None
+    def get_env(**kw):
+        return None
 
 
 def handle_session_start() -> str:

--- a/.claude/worca/orchestrator/__init__.py
+++ b/.claude/worca/orchestrator/__init__.py
@@ -1,1 +1,1 @@
-from worca.orchestrator.overlay import OverlayResolver
+from worca.orchestrator.overlay import OverlayResolver as OverlayResolver

--- a/.claude/worca/orchestrator/batch.py
+++ b/.claude/worca/orchestrator/batch.py
@@ -8,7 +8,6 @@ import hashlib
 import json
 import os
 import time
-from typing import List
 
 from worca.orchestrator.runner import run_pipeline
 from worca.orchestrator.work_request import WorkRequest

--- a/.claude/worca/orchestrator/overlay.py
+++ b/.claude/worca/orchestrator/overlay.py
@@ -3,7 +3,6 @@
 import os
 import re
 import sys
-from pathlib import Path
 
 
 def _parse_sections(content: str) -> list:

--- a/.claude/worca/orchestrator/runner.py
+++ b/.claude/worca/orchestrator/runner.py
@@ -23,7 +23,7 @@ from worca.orchestrator.control import read_control, delete_control
 from worca.orchestrator.overlay import OverlayResolver
 from worca.orchestrator.prompt_builder import PromptBuilder
 from worca.orchestrator.stages import (
-    Stage, can_transition, get_stage_config, get_enabled_stages, STAGE_AGENT_MAP,
+    Stage, get_stage_config, get_enabled_stages, STAGE_AGENT_MAP,
     is_learn_enabled,
 )
 from worca.orchestrator.work_request import WorkRequest

--- a/.claude/worca/orchestrator/stages.py
+++ b/.claude/worca/orchestrator/stages.py
@@ -1,7 +1,5 @@
 """Pipeline stage definitions and transition validation."""
-import json
 from enum import Enum
-from typing import Optional
 
 from worca.utils.settings import load_settings
 

--- a/.claude/worca/orchestrator/work_request.py
+++ b/.claude/worca/orchestrator/work_request.py
@@ -3,7 +3,7 @@ import json
 import os
 import re
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 from worca.utils.env import get_env

--- a/.claude/worca/utils/claude_cli.py
+++ b/.claude/worca/utils/claude_cli.py
@@ -331,7 +331,6 @@ def run_agent(
     if proc.returncode < 0:
         raise InterruptedError(f"claude agent killed by signal {-proc.returncode}")
     if proc.returncode != 0:
-        is_error = result_event.get("is_error", False) if result_event else True
         error_msg = result_event.get("result", "") if result_event else ""
         raise RuntimeError(
             f"claude agent failed (exit code {proc.returncode})"

--- a/.claude/worca/utils/rebuild_stats.py
+++ b/.claude/worca/utils/rebuild_stats.py
@@ -5,7 +5,6 @@ Usage:
 """
 
 import argparse
-import sys
 
 from worca.utils.stats import rebuild_from_results
 

--- a/.claude/worca/utils/settings.py
+++ b/.claude/worca/utils/settings.py
@@ -9,7 +9,6 @@ out of version control.
 import json
 import os
 import sys
-from typing import Any
 
 
 def deep_merge(base: dict, override: dict) -> dict:

--- a/.claude/worca/utils/test_claude_cli.py
+++ b/.claude/worca/utils/test_claude_cli.py
@@ -4,9 +4,6 @@ import io
 import json
 import os
 import signal
-import subprocess
-import textwrap
-import threading
 from unittest import mock
 
 import pytest

--- a/.claude/worca/utils/token_usage.py
+++ b/.claude/worca/utils/token_usage.py
@@ -4,7 +4,6 @@ Provides functions to extract token usage from Claude CLI result events,
 aggregate usage across iterations/stages, and estimate costs from pricing tables.
 """
 
-import json
 from typing import Optional
 
 from worca.utils.settings import load_settings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Lint with ruff
-        continue-on-error: true
         run: ruff check .
 
       - name: Run pytest

--- a/tests/integration/test_preflight_circuit_breaker.py
+++ b/tests/integration/test_preflight_circuit_breaker.py
@@ -13,9 +13,7 @@ Scenarios:
 """
 
 import json
-import sys
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -283,7 +281,7 @@ class TestResumeRerunsPreflight:
 
     def test_circuit_breaker_state_preserved_on_resume(self):
         """CB state in status dict persists across resume (not cleared)."""
-        from worca.orchestrator.error_classifier import get_circuit_breaker_state, record_failure
+        from worca.orchestrator.error_classifier import get_circuit_breaker_state
 
         status = {
             "stages": {"plan": {"status": "in_progress"}},
@@ -314,7 +312,7 @@ class TestCircuitBreakerStateIntegration:
         from worca.orchestrator.error_classifier import (
             record_failure, get_circuit_breaker_state
         )
-        settings_path = _make_settings(tmp_path, max_consecutive=3)
+        _settings_path = _make_settings(tmp_path, max_consecutive=3)
         status = {}
         classification = {"category": "infra_transient", "retriable": True,
                           "remediation": "wait", "similar_to_previous": False}

--- a/tests/integration/test_token_tracking_e2e.py
+++ b/tests/integration/test_token_tracking_e2e.py
@@ -1,14 +1,12 @@
 """Integration tests for end-to-end token tracking through the pipeline."""
 
 import json
-import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-from worca.orchestrator.runner import run_stage, _save_stage_output
+from worca.orchestrator.runner import run_stage
 from worca.orchestrator.stages import Stage
 from worca.state.status import (
-    init_status, start_iteration, complete_iteration, update_stage, save_status, load_status,
-    get_stage_token_usage, get_run_token_usage,
+    init_status, start_iteration, complete_iteration, update_stage, get_stage_token_usage, get_run_token_usage,
 )
 from worca.utils.token_usage import extract_token_usage, aggregate_token_usage
 

--- a/tests/test_agent_telemetry.py
+++ b/tests/test_agent_telemetry.py
@@ -3,8 +3,7 @@
 Tests the _make_agent_event_handler() factory and _summarize_tool_input() helper.
 """
 import json
-import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from worca.orchestrator.runner import _summarize_tool_input, _make_agent_event_handler
 from worca.orchestrator.stages import Stage

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -2,13 +2,12 @@
 
 import json
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from worca.orchestrator.batch import (
     run_batch,
     should_skip,
     CircuitBreakerError,
-    RateLimitError,
     _request_id,
 )
 from worca.orchestrator.work_request import WorkRequest

--- a/tests/test_bd_create_hook.py
+++ b/tests/test_bd_create_hook.py
@@ -2,9 +2,8 @@
 import json
 import os
 import sys
-from unittest.mock import patch, call, MagicMock
+from unittest.mock import patch
 
-import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude"))
 
@@ -127,7 +126,7 @@ class TestBeadCreatedEvent:
                 {"stdout": "✓ Created issue: bd-xyz", "exit_code": 0},
             )
         assert os.path.exists(events_file)
-        events = [json.loads(l) for l in open(events_file).readlines() if l.strip()]
+        events = [json.loads(line) for line in open(events_file).readlines() if line.strip()]
         types = [e["event_type"] for e in events]
         assert "pipeline.bead.created" in types
         created = next(e for e in events if e["event_type"] == "pipeline.bead.created")
@@ -157,7 +156,7 @@ class TestBeadCreatedEvent:
                 {"command": 'bd create --title="A" && bd create --title="B"'},
                 {"stdout": "✓ Created issue: bd-aaa\n✓ Created issue: bd-bbb", "exit_code": 0},
             )
-        events = [json.loads(l) for l in open(events_file).readlines() if l.strip()]
+        events = [json.loads(line) for line in open(events_file).readlines() if line.strip()]
         created_events = [e for e in events if e["event_type"] == "pipeline.bead.created"]
         assert len(created_events) == 2
         ids = {e["payload"]["bead_id"] for e in created_events}

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -1,7 +1,7 @@
 """Tests for worca.utils.claude_cli - Claude CLI wrapper."""
 
 import json
-from unittest.mock import patch, MagicMock, ANY
+from unittest.mock import patch, MagicMock
 
 from worca.utils.claude_cli import run_agent, build_command
 

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,8 +1,7 @@
 """Tests for worca.orchestrator.control — control file protocol utilities."""
 
 import json
-import os
-from datetime import datetime, timezone
+from datetime import datetime
 
 import pytest
 

--- a/tests/test_control_webhook_handling.py
+++ b/tests/test_control_webhook_handling.py
@@ -12,15 +12,13 @@ Covers:
 
 import json
 import sys
-import time
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, ".claude")
 
-from worca.events.emitter import EventContext, emit_event, _check_control_response
+from worca.events.emitter import EventContext, _check_control_response
 from worca.orchestrator.runner import PipelineInterrupted, _handle_pause
 
 

--- a/tests/test_error_classifier.py
+++ b/tests/test_error_classifier.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from worca.orchestrator.error_classifier import (
     CATEGORY_TRANSIENT,
@@ -550,7 +549,7 @@ class TestClassifyErrorCache:
         # Call 2: time.time() for cache check = 400 (>300 TTL) → expired → subprocess called → time.time() for store = 400
         with patch("subprocess.run", return_value=mock_result) as mock_run:
             with patch("worca.orchestrator.error_classifier.time.time", side_effect=[0, 400, 400]):
-                result1 = classify_error("timeout", "implement", [], str(settings_file))
+                _result1 = classify_error("timeout", "implement", [], str(settings_file))
                 result2 = classify_error("timeout", "implement", [], str(settings_file))
 
         assert mock_run.call_count == 2

--- a/tests/test_event_emitter.py
+++ b/tests/test_event_emitter.py
@@ -3,13 +3,10 @@ Tests for worca.events.emitter — EventContext and emit_event().
 """
 
 import json
-import os
-import tempfile
 import uuid
 from datetime import datetime
-from io import StringIO
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -186,7 +183,7 @@ def test_emit_event_unique_event_ids(ctx, tmp_events_file):
     emit_event(ctx, "pipeline.run.completed", {"duration_ms": 1000, "total_cost_usd": 0.0, "total_turns": 1, "total_tokens": 100, "stages_completed": []})
     ctx.close()
     lines = Path(tmp_events_file).read_text().strip().split("\n")
-    ids = [json.loads(l)["event_id"] for l in lines]
+    ids = [json.loads(line)["event_id"] for line in lines]
     assert len(set(ids)) == 2
 
 

--- a/tests/test_event_types.py
+++ b/tests/test_event_types.py
@@ -10,7 +10,7 @@ _CLAUDE_DIR = Path(__file__).parent.parent / ".claude"
 if str(_CLAUDE_DIR) not in sys.path:
     sys.path.insert(0, str(_CLAUDE_DIR))
 
-import pytest
+import pytest  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -12,7 +12,6 @@ Covers:
 import json
 import time
 import uuid
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -127,7 +126,7 @@ def test_multiple_events_each_on_own_line(ctx, tmp_path):
 
     lines = (tmp_path / "events.jsonl").read_text().strip().split("\n")
     assert len(lines) == 3
-    types = [json.loads(l)["event_type"] for l in lines]
+    types = [json.loads(line)["event_type"] for line in lines]
     assert types == [
         "pipeline.run.started",
         "pipeline.stage.started",

--- a/tests/test_gh_issues.py
+++ b/tests/test_gh_issues.py
@@ -1,6 +1,6 @@
 """Tests for worca.utils.gh_issues - GitHub issue lifecycle helpers."""
 
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 import subprocess
 

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -1,6 +1,5 @@
 """Tests for guard.py - PreToolUse safety gates."""
 import os
-import pytest
 from worca.hooks.guard import check_guard
 
 

--- a/tests/test_hook_emitter.py
+++ b/tests/test_hook_emitter.py
@@ -4,10 +4,8 @@ Tests for worca.events.hook_emitter — lightweight emitter for subprocess hooks
 
 import json
 import os
-import uuid
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -146,6 +144,6 @@ def test_emit_from_hook_appends_multiple_events(tmp_path):
 
     lines = open(events_file).readlines()
     assert len(lines) == 2
-    events = [json.loads(l) for l in lines]
+    events = [json.loads(line) for line in lines]
     assert events[0]["event_type"] == "pipeline.hook.blocked"
     assert events[1]["event_type"] == "pipeline.hook.test_gate"

--- a/tests/test_hook_governance_events.py
+++ b/tests/test_hook_governance_events.py
@@ -52,7 +52,7 @@ class TestPreToolUseBlockedEvent:
 
         assert code == 2
         assert os.path.exists(events_file)
-        events = [json.loads(l) for l in open(events_file).readlines() if l.strip()]
+        events = [json.loads(line) for line in open(events_file).readlines() if line.strip()]
         assert len(events) == 1
         e = events[0]
         assert e["event_type"] == "pipeline.hook.blocked"
@@ -110,7 +110,7 @@ class TestPreToolUseBlockedEvent:
         code = self._call_main(data)
 
         assert code == 2
-        events = [json.loads(l) for l in open(events_file).readlines() if l.strip()]
+        events = [json.loads(line) for line in open(events_file).readlines() if line.strip()]
         e = events[0]
         assert "coordinator" in e["payload"]["reason"].lower() or "read-only" in e["payload"]["reason"].lower()
 
@@ -162,7 +162,7 @@ class TestPostToolUseTestGateEvent:
 
         assert code == 2
         assert os.path.exists(events_file)
-        events = [json.loads(l) for l in open(events_file).readlines() if l.strip()]
+        events = [json.loads(line) for line in open(events_file).readlines() if line.strip()]
         test_gate_events = [e for e in events if e["event_type"] == "pipeline.hook.test_gate"]
         assert len(test_gate_events) == 1
         e = test_gate_events[0]
@@ -290,7 +290,7 @@ class TestSubagentStartDispatchBlockedEvent:
 
         assert code == 2
         assert os.path.exists(events_file)
-        events = [json.loads(l) for l in open(events_file).readlines() if l.strip()]
+        events = [json.loads(line) for line in open(events_file).readlines() if line.strip()]
         assert len(events) == 1
         e = events[0]
         assert e["event_type"] == "pipeline.hook.dispatch_blocked"
@@ -343,7 +343,7 @@ class TestSubagentStartDispatchBlockedEvent:
         data = json.dumps({"agent_type": "general-purpose"})
         self._call_main(data, agent="coordinator")
 
-        events = [json.loads(l) for l in open(events_file).readlines() if l.strip()]
+        events = [json.loads(line) for line in open(events_file).readlines() if line.strip()]
         e = events[0]
         assert "coordinator" in e["payload"]["reason"]
         assert "general-purpose" in e["payload"]["reason"]

--- a/tests/test_iteration_resume.py
+++ b/tests/test_iteration_resume.py
@@ -5,11 +5,9 @@ These tests exercise the runner's state management without spawning real Claude
 subprocess calls — all agent calls are mocked.
 """
 
-import json
 import os
-import tempfile
 from datetime import datetime, timezone
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_orchestrator_events.py
+++ b/tests/test_orchestrator_events.py
@@ -7,17 +7,11 @@ raises. Supports '*' catch-all.
 """
 
 import json
-import os
-import subprocess
-import sys
-import tempfile
 import time
 import uuid
 from datetime import datetime, timezone
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import patch
 
-import pytest
 
 from worca.orchestrator.events import dispatch_shell_hooks
 

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,6 +1,5 @@
 """Tests for OverlayResolver — TDD: written before implementation."""
 
-import sys
 import pytest
 
 from worca.orchestrator.overlay import (
@@ -8,7 +7,6 @@ from worca.orchestrator.overlay import (
     _parse_sections,
     _parse_overrides,
     _heading_matches,
-    _reassemble,
 )
 
 
@@ -202,8 +200,8 @@ def test_resolve_case_insensitive_match(tmp_path):
 # Governance tag presence in core agent prompt files (Task 2)
 # ---------------------------------------------------------------------------
 
-import pathlib
-import re
+import pathlib  # noqa: E402
+import re  # noqa: E402
 
 _CORE_AGENTS_DIR = pathlib.Path(__file__).parent.parent / ".claude" / "agents" / "core"
 

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -6,7 +6,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 # Make the scripts directory importable
 sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,7 +1,5 @@
 """Tests for prompt.py - Milestone approval gates for UserPromptSubmit."""
 import json
-import os
-import pytest
 from worca.hooks.prompt import check_milestone
 
 

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,7 +1,5 @@
 """Tests for worca.orchestrator.prompt_builder — stage-specific prompt generation."""
 
-import os
-from unittest.mock import patch
 
 from worca.orchestrator.prompt_builder import PromptBuilder
 

--- a/tests/test_prompt_builder_context_persistence.py
+++ b/tests/test_prompt_builder_context_persistence.py
@@ -2,9 +2,7 @@
 
 import json
 import os
-from pathlib import Path
 
-import pytest
 
 from worca.orchestrator.prompt_builder import PromptBuilder
 

--- a/tests/test_prompt_builder_learn.py
+++ b/tests/test_prompt_builder_learn.py
@@ -1,6 +1,5 @@
 """Tests for PromptBuilder._build_learn — learn stage prompt generation."""
 
-import json
 
 from worca.orchestrator.prompt_builder import PromptBuilder
 

--- a/tests/test_run_learn_script.py
+++ b/tests/test_run_learn_script.py
@@ -94,7 +94,7 @@ class TestRunLearn:
             "run_id": "test-run",
             "result": "success",
         }
-        run_dir = self._setup_run_dir(tmp_path, status)
+        _run_dir = self._setup_run_dir(tmp_path, status)
 
         with patch.object(mod, "_run_learn_stage_standalone") as mock_learn:
             mock_learn.return_value = None
@@ -136,7 +136,7 @@ class TestRunLearn:
             "result": "failure",
             "error": "tests failed",
         }
-        run_dir = self._setup_run_dir(tmp_path, status)
+        _run_dir = self._setup_run_dir(tmp_path, status)
 
         with patch.object(mod, "_run_learn_stage_standalone") as mock_learn:
             mock_learn.return_value = None
@@ -162,7 +162,7 @@ class TestRunLearn:
             "run_id": "test-run",
             "result": "success",
         }
-        run_dir = self._setup_run_dir(tmp_path, status)
+        _run_dir = self._setup_run_dir(tmp_path, status)
 
         with patch.object(mod, "_run_learn_stage_standalone") as mock_learn:
             mock_learn.return_value = None

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -21,7 +21,7 @@ _slugify = run_parallel._slugify
 _run_pipeline_in_worktree = run_parallel._run_pipeline_in_worktree
 
 # _ARG_INLINE_LIMIT is now imported from claude_cli by run_parallel
-from worca.utils.claude_cli import _ARG_INLINE_LIMIT
+from worca.utils.claude_cli import _ARG_INLINE_LIMIT  # noqa: E402
 
 
 # --- _slugify ---

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -2,7 +2,7 @@
 import sys
 import os
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 # Add scripts dir so we can import run_pipeline
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "scripts"))
@@ -120,7 +120,7 @@ class TestBuildWorkRequest:
         )
         parser = create_parser()
         args = parser.parse_args(["--spec", "spec.md"])
-        wr = build_work_request(args)
+        _wr = build_work_request(args)
         mock_normalize.assert_called_once_with("spec", "spec.md")
 
     @patch("run_pipeline.normalize")
@@ -132,7 +132,7 @@ class TestBuildWorkRequest:
         )
         parser = create_parser()
         args = parser.parse_args(["--plan", "plan.md"])
-        wr = build_work_request(args)
+        _wr = build_work_request(args)
         mock_normalize.assert_called_once_with("plan", "plan.md")
 
     @patch("run_pipeline.normalize")
@@ -202,7 +202,7 @@ class TestBuildWorkRequest:
         )
         parser = create_parser()
         args = parser.parse_args(["--source", "gh:issue:42", "--plan", "plan.md"])
-        wr = build_work_request(args)
+        _wr = build_work_request(args)
         mock_normalize.assert_called_once_with("source", "gh:issue:42")
 
 
@@ -245,5 +245,5 @@ class TestPromptFile:
         with open(args.prompt_file) as f:
             args.prompt = f.read()
         os.unlink(args.prompt_file)
-        wr = build_work_request(args)
+        _wr = build_work_request(args)
         mock_normalize.assert_called_once_with("prompt", "Build a feature")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,7 +3,6 @@
 import importlib.util
 import json
 import os
-import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -1279,7 +1278,7 @@ def test_run_pipeline_emits_run_started_event(tmp_path):
     worca_dir = tmp_path / ".worca"
     events_path = worca_dir / "runs" / run_id / "events.jsonl"
     lines = events_path.read_text().strip().split("\n")
-    event_types = [json.loads(l)["event_type"] for l in lines if l.strip()]
+    event_types = [json.loads(line)["event_type"] for line in lines if line.strip()]
     assert "pipeline.run.started" in event_types
 
 
@@ -1289,7 +1288,7 @@ def test_run_pipeline_run_started_payload_resume_false(tmp_path):
     run_id = result["run_id"]
     worca_dir = tmp_path / ".worca"
     events_path = worca_dir / "runs" / run_id / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     started = next(e for e in events if e["event_type"] == "pipeline.run.started")
     assert started["payload"]["resume"] is False
 
@@ -1420,7 +1419,7 @@ def test_run_pipeline_emits_stage_started_event(tmp_path):
     result = _run_pipeline_with_plan(tmp_path)
     run_id = result["run_id"]
     events_path = tmp_path / ".worca" / "runs" / run_id / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.stage.started" in types
 
@@ -1430,7 +1429,7 @@ def test_run_pipeline_emits_stage_completed_event(tmp_path):
     result = _run_pipeline_with_plan(tmp_path)
     run_id = result["run_id"]
     events_path = tmp_path / ".worca" / "runs" / run_id / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.stage.completed" in types
 
@@ -1440,7 +1439,7 @@ def test_run_pipeline_stage_started_payload_fields(tmp_path):
     result = _run_pipeline_with_plan(tmp_path)
     run_id = result["run_id"]
     events_path = tmp_path / ".worca" / "runs" / run_id / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     started = next(e for e in events if e["event_type"] == "pipeline.stage.started")
     p = started["payload"]
     assert "stage" in p
@@ -1459,7 +1458,7 @@ def test_run_pipeline_stage_completed_payload_fields(tmp_path):
     result = _run_pipeline_with_plan(tmp_path)
     run_id = result["run_id"]
     events_path = tmp_path / ".worca" / "runs" / run_id / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     completed = next(e for e in events if e["event_type"] == "pipeline.stage.completed")
     p = completed["payload"]
     assert "stage" in p
@@ -1524,7 +1523,7 @@ def test_run_pipeline_emits_stage_failed_on_exception(tmp_path):
                                      status_path=status_path)
 
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.stage.failed" in types
     failed = next(e for e in events if e["event_type"] == "pipeline.stage.failed")
@@ -1574,7 +1573,7 @@ def test_run_pipeline_emits_stage_interrupted_on_shutdown(tmp_path):
                                      status_path=status_path)
 
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.stage.interrupted" in types
     interrupted = next(e for e in events if e["event_type"] == "pipeline.stage.interrupted")
@@ -1661,7 +1660,7 @@ def test_bead_assigned_event_emitted_after_claim(tmp_path):
     bead_ids = ["beads-aaa"]
     worca_dir = _run_bead_pipeline(tmp_path, bead_ids)
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.bead.assigned" in types
     assigned = next(e for e in events if e["event_type"] == "pipeline.bead.assigned")
@@ -1676,7 +1675,7 @@ def test_bead_completed_event_emitted_after_bd_close(tmp_path):
     bead_ids = ["beads-bbb"]
     worca_dir = _run_bead_pipeline(tmp_path, bead_ids, bd_close_return=True)
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.bead.completed" in types
     completed = next(e for e in events if e["event_type"] == "pipeline.bead.completed")
@@ -1690,7 +1689,7 @@ def test_bead_labeled_event_emitted_after_bd_label_add(tmp_path):
     bead_ids = ["beads-ccc", "beads-ddd"]
     worca_dir = _run_bead_pipeline(tmp_path, bead_ids)
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.bead.labeled" in types
     labeled = next(e for e in events if e["event_type"] == "pipeline.bead.labeled")
@@ -1705,7 +1704,7 @@ def test_bead_next_event_emitted_before_loop_continue(tmp_path):
     bead_ids = ["beads-eee", "beads-fff"]
     worca_dir = _run_bead_pipeline(tmp_path, bead_ids)
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.bead.next" in types
     bead_next = next(e for e in events if e["event_type"] == "pipeline.bead.next")
@@ -1828,7 +1827,7 @@ def test_test_suite_passed_event_emitted(tmp_path):
     """pipeline.test.suite_passed is emitted when TEST stage passes."""
     worca_dir = _run_implement_test_pipeline(tmp_path, [{"passed": True}])
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.test.suite_passed" in [e["event_type"] for e in events]
 
 
@@ -1836,7 +1835,7 @@ def test_test_suite_passed_payload_fields(tmp_path):
     """pipeline.test.suite_passed payload has required iteration field."""
     worca_dir = _run_implement_test_pipeline(tmp_path, [{"passed": True}])
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     evt = next(e for e in events if e["event_type"] == "pipeline.test.suite_passed")
     assert "iteration" in evt["payload"]
 
@@ -1849,7 +1848,7 @@ def test_test_suite_failed_event_emitted(tmp_path):
          {"passed": True}],
     )
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.test.suite_failed" in [e["event_type"] for e in events]
 
 
@@ -1861,7 +1860,7 @@ def test_test_suite_failed_payload_fields(tmp_path):
         [{"passed": False, "failures": failures}, {"passed": True}],
     )
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     evt = next(e for e in events if e["event_type"] == "pipeline.test.suite_failed")
     p = evt["payload"]
     assert "iteration" in p
@@ -1877,7 +1876,7 @@ def test_test_fix_attempt_event_emitted_before_loop(tmp_path):
         [{"passed": False, "failures": [{"test": "t", "error": "err"}]}, {"passed": True}],
     )
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.test.fix_attempt" in [e["event_type"] for e in events]
     evt = next(e for e in events if e["event_type"] == "pipeline.test.fix_attempt")
     p = evt["payload"]
@@ -1893,7 +1892,7 @@ def test_loop_triggered_emitted_on_test_failure_loop(tmp_path):
         [{"passed": False, "failures": [{"test": "t"}]}, {"passed": True}],
     )
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     loop_evts = [e for e in events if e["event_type"] == "pipeline.loop.triggered"]
     assert len(loop_evts) >= 1
     p = loop_evts[0]["payload"]
@@ -1908,7 +1907,7 @@ def test_review_verdict_event_emitted(tmp_path):
     """pipeline.review.verdict is emitted after handle_pr_review()."""
     worca_dir = _run_review_pipeline(tmp_path, [{"outcome": "approve"}])
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.review.verdict" in [e["event_type"] for e in events]
 
 
@@ -1916,7 +1915,7 @@ def test_review_verdict_payload_fields(tmp_path):
     """pipeline.review.verdict payload has required fields."""
     worca_dir = _run_review_pipeline(tmp_path, [{"outcome": "approve", "issues": []}])
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     evt = next(e for e in events if e["event_type"] == "pipeline.review.verdict")
     p = evt["payload"]
     assert p["outcome"] == "approve"
@@ -1934,7 +1933,7 @@ def test_review_fix_attempt_event_emitted_before_loop(tmp_path):
         ],
     )
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.review.fix_attempt" in [e["event_type"] for e in events]
     evt = next(e for e in events if e["event_type"] == "pipeline.review.fix_attempt")
     p = evt["payload"]
@@ -1952,7 +1951,7 @@ def test_loop_triggered_emitted_on_review_changes_loop(tmp_path):
         ],
     )
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     loop_evts = [e for e in events if e["event_type"] == "pipeline.loop.triggered"]
     assert len(loop_evts) >= 1
     p = loop_evts[0]["payload"]
@@ -2008,7 +2007,7 @@ def test_loop_exhausted_emitted_before_raise(tmp_path):
                                          status_path=status_path)
 
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.loop.exhausted" in [e["event_type"] for e in events]
     evt = next(e for e in events if e["event_type"] == "pipeline.loop.exhausted")
     p = evt["payload"]
@@ -2022,7 +2021,7 @@ def test_milestone_set_event_emitted_on_plan_file(tmp_path):
     result = _run_pipeline_with_plan(tmp_path)
     run_id = result["run_id"]
     events_path = tmp_path / ".worca" / "runs" / run_id / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     assert "pipeline.milestone.set" in [e["event_type"] for e in events]
     evt = next(e for e in events if e["event_type"] == "pipeline.milestone.set")
     p = evt["payload"]
@@ -2130,14 +2129,13 @@ def test_cb_failure_recorded_event_emitted(tmp_path):
 
     assert isinstance(exc, (PipelineError, CircuitBreakerTripped, RuntimeError))
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.circuit_breaker.failure_recorded" in types
 
 
 def test_cb_failure_recorded_payload_fields(tmp_path):
     """CB_FAILURE_RECORDED payload has required fields."""
-    from worca.orchestrator.runner import CircuitBreakerTripped
 
     with patch("worca.orchestrator.runner.classify_error",
                return_value=_classification("infra_permanent", False)):
@@ -2149,7 +2147,7 @@ def test_cb_failure_recorded_payload_fields(tmp_path):
             )
 
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     evt = next(e for e in events
                if e["event_type"] == "pipeline.circuit_breaker.failure_recorded")
     p = evt["payload"]
@@ -2175,13 +2173,12 @@ def test_cb_tripped_event_emitted(tmp_path):
 
     assert isinstance(exc, CircuitBreakerTripped)
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.circuit_breaker.tripped" in [e["event_type"] for e in events]
 
 
 def test_cb_tripped_payload_fields(tmp_path):
     """CB_TRIPPED payload has reason, consecutive_failures, category."""
-    from worca.orchestrator.runner import CircuitBreakerTripped
 
     with patch("worca.orchestrator.runner.classify_error",
                return_value=_classification("infra_permanent", False)):
@@ -2193,7 +2190,7 @@ def test_cb_tripped_payload_fields(tmp_path):
             )
 
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     evt = next(e for e in events if e["event_type"] == "pipeline.circuit_breaker.tripped")
     p = evt["payload"]
     assert "reason" in p
@@ -2241,7 +2238,7 @@ def test_cb_retry_event_emitted_on_transient(tmp_path):
                                          status_path=status_path)
 
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.circuit_breaker.retry" in [e["event_type"] for e in events]
     evt = next(e for e in events if e["event_type"] == "pipeline.circuit_breaker.retry")
     p = evt["payload"]
@@ -2290,7 +2287,7 @@ def test_cb_reset_event_emitted_after_success(tmp_path):
                                          status_path=status_path)
 
     events_path = _find_events_path(worca_dir)
-    events = [json.loads(l) for l in open(events_path).read().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in open(events_path).read().strip().split("\n") if line.strip()]
     assert "pipeline.circuit_breaker.reset" in [e["event_type"] for e in events]
     evt = next(e for e in events if e["event_type"] == "pipeline.circuit_breaker.reset")
     p = evt["payload"]
@@ -2357,7 +2354,7 @@ def _run_pipeline_with_cost(tmp_path, cost_usd=1.5, input_tokens=1000,
                     )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     return events
 
 
@@ -2459,7 +2456,7 @@ def test_git_branch_created_event_emitted(tmp_path):
         return {}, {"type": "result"}
 
     with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage):
-        with patch("worca.orchestrator.runner.create_branch") as mock_branch:
+        with patch("worca.orchestrator.runner.create_branch") as _mock_branch:
             with patch("worca.orchestrator.runner._write_pid"):
                 with patch("worca.orchestrator.runner._remove_pid"):
                     result = run_pipeline(
@@ -2469,7 +2466,7 @@ def test_git_branch_created_event_emitted(tmp_path):
                     )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.git.branch_created" in types
 
@@ -2501,7 +2498,7 @@ def test_git_branch_created_payload_fields(tmp_path):
                     )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     evt = next(e for e in events if e["event_type"] == "pipeline.git.branch_created")
     p = evt["payload"]
     assert "branch" in p
@@ -2539,7 +2536,7 @@ def test_git_branch_created_not_emitted_on_resume(tmp_path):
         mock_branch.assert_not_called()
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.git.branch_created" not in types
 
@@ -2584,7 +2581,7 @@ def test_git_pr_created_event_emitted(tmp_path):
                     )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.git.pr_created" in types
 
@@ -2629,7 +2626,7 @@ def test_git_pr_created_payload_fields(tmp_path):
                     )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     evt = next(e for e in events if e["event_type"] == "pipeline.git.pr_created")
     p = evt["payload"]
     assert p["pr_url"] == "https://github.com/org/repo/pull/99"
@@ -2676,7 +2673,7 @@ def test_git_pr_created_not_emitted_without_pr_url(tmp_path):
                     )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.git.pr_created" not in types
 
@@ -2733,7 +2730,7 @@ def test_preflight_completed_event_emitted(tmp_path):
                                       status_path=status_path)
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.preflight.completed" in types
 
@@ -2761,7 +2758,7 @@ def test_preflight_completed_payload_fields(tmp_path):
                                       status_path=status_path)
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     evt = next(e for e in events if e["event_type"] == "pipeline.preflight.completed")
     p = evt["payload"]
     assert "checks" in p
@@ -2786,7 +2783,7 @@ def test_preflight_skipped_event_emitted_explicit(tmp_path):
                                       skip_preflight=True)
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.preflight.skipped" in types
 
@@ -2810,7 +2807,7 @@ def test_preflight_skipped_event_emitted_script_not_found(tmp_path):
                                       status_path=status_path)
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     types = [e["event_type"] for e in events]
     assert "pipeline.preflight.skipped" in types
 
@@ -2875,7 +2872,7 @@ def test_learn_completed_event_emitted(tmp_path):
                         )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     learn_events = [e for e in events
                     if e["event_type"] == "pipeline.stage.completed"
                     and e["payload"].get("stage") == "learn"]
@@ -2911,7 +2908,7 @@ def test_learn_completed_payload_fields(tmp_path):
                         )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     evt = next(e for e in events
                if e["event_type"] == "pipeline.stage.completed"
                and e["payload"].get("stage") == "learn")
@@ -2951,7 +2948,7 @@ def test_learn_started_event_emitted(tmp_path):
                         )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     learn_started = [e for e in events
                      if e["event_type"] == "pipeline.stage.started"
                      and e["payload"].get("stage") == "learn"]
@@ -2992,7 +2989,7 @@ def test_learn_failed_event_emitted(tmp_path):
                         )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     learn_failed = [e for e in events
                     if e["event_type"] == "pipeline.stage.failed"
                     and e["payload"].get("stage") == "learn"]
@@ -3030,7 +3027,7 @@ def test_learn_failed_payload_has_error(tmp_path):
                         )
 
     events_path = worca_dir / "runs" / result["run_id"] / "events.jsonl"
-    events = [json.loads(l) for l in events_path.read_text().strip().split("\n") if l.strip()]
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
     evt = next(e for e in events
                if e["event_type"] == "pipeline.stage.failed"
                and e["payload"].get("stage") == "learn")

--- a/tests/test_runner_circuit_breaker.py
+++ b/tests/test_runner_circuit_breaker.py
@@ -7,9 +7,8 @@ preflight skips CB, CB disabled path.
 """
 
 import json
-import time
 from contextlib import ExitStack
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_runner_control_polling.py
+++ b/tests/test_runner_control_polling.py
@@ -1,8 +1,7 @@
 """Tests for control file polling in the runner iteration loop."""
 
 import json
-import sys
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -12,7 +11,6 @@ from worca.orchestrator.runner import (
     PipelineInterrupted,
 )
 from worca.events.types import RUN_PAUSED
-from worca.state.status import save_status
 
 
 # --- no control file ---

--- a/tests/test_runner_git_divergence.py
+++ b/tests/test_runner_git_divergence.py
@@ -1,10 +1,8 @@
 """Tests for git divergence guard on pipeline resume."""
 
 import json
-import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 
 from worca.orchestrator.runner import run_pipeline
 from worca.orchestrator.work_request import WorkRequest
@@ -120,7 +118,7 @@ def test_runner_calls_divergence_handler_when_head_changed(tmp_path, monkeypatch
     with patch("worca.orchestrator.runner._write_pid"):
         with patch("worca.orchestrator.runner._remove_pid"):
             with patch("worca.orchestrator.resume.get_current_git_head", return_value=SHA_NEW):
-                result = run_pipeline(
+                _result = run_pipeline(
                     wr,
                     resume=True,
                     settings_path=settings,

--- a/tests/test_runner_learn.py
+++ b/tests/test_runner_learn.py
@@ -1,15 +1,13 @@
 """Tests for LEARN stage integration in runner.py."""
 
 import json
-import os
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 import pytest
 
 from worca.orchestrator.runner import (
     _run_learn_stage,
     _STAGE_PROMPT_PREFIX,
-    LoopExhaustedError,
     PipelineError,
     PipelineInterrupted,
 )
@@ -307,9 +305,9 @@ def test_run_learn_stage_calls_run_stage_with_learn(tmp_path):
 # run_pipeline wiring — learn runs on success
 # ---------------------------------------------------------------------------
 
-import pytest
-from worca.orchestrator.runner import run_pipeline
-from worca.orchestrator.work_request import WorkRequest
+import pytest  # noqa: E402
+from worca.orchestrator.runner import run_pipeline  # noqa: E402
+from worca.orchestrator.work_request import WorkRequest  # noqa: E402
 
 
 def _make_work_request():

--- a/tests/test_runner_lifecycle.py
+++ b/tests/test_runner_lifecycle.py
@@ -1,11 +1,9 @@
 """Tests for pipeline lifecycle state management (signal handler, atexit, finally, resume, beads)."""
 
-import json
 import os
 import signal
 from unittest.mock import patch
 
-import pytest
 
 import worca.orchestrator.runner as runner
 from worca.orchestrator.control import write_control, control_path

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,6 +1,6 @@
 """Tests for session lifecycle hooks: SessionStart, PreCompact, SessionEnd."""
 
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 from worca.hooks.session import handle_session_start, handle_pre_compact, handle_session_end
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,9 +4,7 @@
 import json
 import os
 import sys
-import tempfile
 
-import pytest
 
 # Add the .claude directory to sys.path so we can import worca modules
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '.claude'))

--- a/tests/test_skip_preflight.py
+++ b/tests/test_skip_preflight.py
@@ -12,9 +12,8 @@ import json
 import sys
 from contextlib import ExitStack
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 
 # Make .claude/scripts importable for CLI tests
 sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
@@ -88,7 +87,6 @@ class TestRunPipelineSkipPreflightParam:
     def test_run_pipeline_accepts_skip_preflight_param(self, tmp_path):
         """run_pipeline() must accept a skip_preflight keyword argument."""
         from worca.orchestrator.runner import run_pipeline
-        from worca.orchestrator.work_request import WorkRequest
         import inspect
         sig = inspect.signature(run_pipeline)
         assert "skip_preflight" in sig.parameters
@@ -110,7 +108,7 @@ class TestSkipPreflightInStageLoop:
 
     def test_run_preflight_not_called_when_skip_preflight_true(self, tmp_path):
         """When skip_preflight=True, run_preflight() must not be called."""
-        from worca.orchestrator.runner import run_pipeline, PipelineError
+        from worca.orchestrator.runner import run_pipeline
         from worca.orchestrator.work_request import WorkRequest
 
         settings_path = _make_settings(tmp_path, preflight_enabled=True)

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -7,7 +7,6 @@ from worca.orchestrator.stages import (
     STAGE_AGENT_MAP,
     STAGE_SCHEMA_MAP,
     STAGE_ORDER,
-    _DEFAULT_MODEL_MAP,
     _resolve_model,
     can_transition,
     get_stage_config,

--- a/tests/test_webhook_config_validation.py
+++ b/tests/test_webhook_config_validation.py
@@ -16,10 +16,7 @@ Covers:
 
 import json
 import sys
-from io import StringIO
-from pathlib import Path
 
-import pytest
 
 sys.path.insert(0, ".claude")
 

--- a/tests/test_webhook_delivery.py
+++ b/tests/test_webhook_delivery.py
@@ -10,8 +10,7 @@ import json
 import sys
 import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -313,7 +312,6 @@ class TestDeliverWebhook:
         """Retries use 1s, 2s, 4s exponential backoff."""
         from urllib.error import URLError
         sleep_calls = []
-        done = threading.Event()
 
         call_count = [0]
 

--- a/tests/test_webhook_schemas.py
+++ b/tests/test_webhook_schemas.py
@@ -3,7 +3,6 @@ Tests for docs/spec/webhooks/schemas/ — validates JSON Schema (Draft 2020-12)
 files that define the webhook event envelope and all event payloads.
 """
 import json
-import re
 from pathlib import Path
 
 SCHEMAS_DIR = Path(__file__).parent.parent / "docs/spec/webhooks/schemas"

--- a/tests/test_worca_cli.py
+++ b/tests/test_worca_cli.py
@@ -1,11 +1,7 @@
 """Tests for .claude/scripts/worca.py CLI entry point."""
 
 import json
-import os
 import signal
-import subprocess
-import sys
-import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
- Remove unused imports (F401) across 60 files
- Rename ambiguous variable `l` to `line` in list comprehensions (E741)
- Remove/prefix unused variables (F841)
- Convert lambda assignment to def (E731)
- Add noqa comments for necessary E402 (sys.path before imports)
- Use explicit re-export in orchestrator __init__ (F401)
- Remove continue-on-error from ruff CI step