### PR TITLE
fix(ui): add settings.json merge, .gitignore, and beads init to worca…

### DIFF
--- a/.claude/worca-ui/server/worca-setup.js
+++ b/.claude/worca-ui/server/worca-setup.js
@@ -146,7 +146,7 @@ cd "$DEST/worca-ui" && npm install && npm run build
 
 # --- Step 4: ensure .gitignore entries ---
 GITIGNORE="$TARGET_ROOT/.gitignore"
-for pattern in ".worca/" ".claude/worca-ui/node_modules/" ".claude/settings.local.json"; do
+for pattern in "__pycache__/" ".worca/" ".claude/worca-ui/node_modules/" ".claude/settings.local.json"; do
   if [ -f "$GITIGNORE" ]; then
     grep -qxF "$pattern" "$GITIGNORE" 2>/dev/null || echo "$pattern" >> "$GITIGNORE"
   else


### PR DESCRIPTION
…-setup

The worca-setup endpoint (used by add/update project in the UI) only rsynced files and built the UI bundle. It was missing three critical steps that the /worca-install and /worca-sync skills perform: deep-merging hooks and worca config into settings.json, ensuring .gitignore entries, and initializing beads. New projects added via the UI would lack pipeline configuration and issue tracking.