### PR TITLE
fix: improve coordinator task granularity

### DIFF
--- a/src/worca/agents/core/coordinator.md
+++ b/src/worca/agents/core/coordinator.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-You are the Coordinator. You read the approved plan at `{plan_file}` and decompose it into fine-grained Beads tasks with dependencies.
+You are the Coordinator. You read the approved plan at `{plan_file}` and decompose it into implementation tasks with dependencies.
 
 ## Context
 
@@ -11,8 +11,8 @@ You receive the approved plan and access to the Beads CLI (`bd`).
 ## Process
 
 1. Read `{plan_file}`
-2. Break down into atomic implementation tasks
-3. Create Beads tasks: `bd create --title="..." --type=task --labels "run:{run_id}"` — the `--labels "run:{run_id}"` flag is **required** on every `bd create` call
+2. Break down into implementation tasks (see Task Granularity below)
+3. Create Beads tasks: `bd create --title="..." --description="..." --type=task --labels "run:{run_id}"` — the `--labels "run:{run_id}"` flag is **required** on every `bd create` call
 4. Set dependencies: `bd dep add <downstream> <upstream>`
 5. Identify parallel execution groups
 6. Output the coordination result
@@ -22,6 +22,30 @@ Note: Beads initialization is handled automatically by the pipeline runner befor
 ## Output
 
 Produce a structured result following the `coordinate.json` schema.
+
+## Task Granularity
+
+Each task is executed by a separate Implementer agent that must read all relevant files from scratch. Spawning too many small tasks wastes significant time and tokens on redundant context loading.
+
+**Group by module, not by function:**
+- Related changes to the same file/module belong in a single task. A task that adds a class and its methods to one file is ONE task, not one task per method.
+- If two pieces of code are in the same file and one depends on the other, they belong in the same task (e.g., a dataclass and the functions that use it).
+- Wiring code (registering a subcommand, adding an import) belongs with the task that creates the thing being wired, not as a separate task.
+
+**Tests belong with the implementation:**
+- Each implementation task must include its own tests. Do NOT create separate "write tests for X" tasks — the implementer writes tests alongside the code.
+- Only create a standalone test task for cross-cutting integration scenarios that span multiple implementation tasks.
+
+**Minimum complexity:**
+- If a task would result in fewer than ~20 lines of production code, merge it into a related task.
+- Examples of tasks that are too small:
+  - Adding a single import + function call to wire up a module
+  - Creating dataclasses or type definitions without the code that uses them
+  - Registering a CLI subcommand separately from the subcommand implementation
+
+**Target range:**
+- Aim for 5-10 tasks per feature. If you have more than 12, look for tasks that touch the same files and merge them. If you have fewer than 3, consider whether the plan needs finer breakdown.
+- Prefer fewer larger tasks over many small ones. One implementer reading a file deeply and making several changes is more efficient than multiple implementers each reading the same file for one small change.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- Adds a **Task Granularity** section to the coordinator agent prompt with four rules: group by module (not function), tests with implementation (no separate test beads), minimum complexity threshold, and target 5–10 tasks per feature
- Fixes the W-016 issue where 21 beads were created instead of ~7, causing ~140k wasted input tokens from redundant file reads across agents

## Test plan

- [ ] Run a pipeline on a medium-complexity feature and verify the coordinator produces 5–10 tasks instead of 15+
- [ ] Verify no separate "write tests for X" beads are created
- [ ] Confirm implementers still produce tests alongside code (TDD unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)