### PR TITLE
fix: correct bead status colors and add consistent blocked state across views

### DIFF
--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -25,9 +25,9 @@
   --status-resuming: #3b82f6;
   --status-skipped: #94a3b8;
   /* legacy */
-  --status-in-progress: #f59e0b;
+  --status-in-progress: #3b82f6;
   --status-error: #ef4444;
-  --status-blocked: #3b82f6;
+  --status-blocked: #f59e0b;
 
   /* Log viewer */
   --log-bg: #0f172a;
@@ -47,7 +47,7 @@
   /* Shoelace token mapping */
   --sl-color-primary-600: var(--accent);
   --sl-color-success-600: var(--status-completed);
-  --sl-color-warning-600: var(--status-in-progress);
+  --sl-color-warning-600: var(--status-blocked);
   --sl-color-danger-600: var(--status-error);
   --sl-color-neutral-600: var(--status-pending);
   --sl-border-radius-medium: var(--radius);
@@ -570,11 +570,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .timing-bar-thinking {
-  background: var(--status-blocked, #3b82f6);
+  background: var(--status-blocked, #f59e0b);
 }
 
 .timing-bar-tools {
-  background: var(--status-in-progress, #f59e0b);
+  background: var(--status-in-progress, #3b82f6);
 }
 
 .timing-bar-rest {
@@ -2522,6 +2522,10 @@ sl-details.live-output-panel::part(content) {
 .beads-kanban-card--blocked {
   border-color: var(--status-blocked);
   border-style: dashed;
+}
+
+.beads-kanban-card--in_progress {
+  border-color: var(--status-in-progress);
 }
 
 .beads-kanban-card-header {

--- a/worca-ui/app/views/beads-panel.js
+++ b/worca-ui/app/views/beads-panel.js
@@ -20,7 +20,7 @@ export function priorityVariant(priority) {
 }
 
 export function statusVariant(status, issue = null) {
-  if (issue && issue.blocked_by && issue.blocked_by.length > 0) return 'warning';
+  if (issue?.blocked_by && issue.blocked_by.length > 0) return 'warning';
   if (status === 'open') return 'success';
   if (status === 'in_progress') return 'primary';
   if (status === 'closed') return 'neutral';

--- a/worca-ui/app/views/beads-panel.js
+++ b/worca-ui/app/views/beads-panel.js
@@ -19,9 +19,10 @@ export function priorityVariant(priority) {
   return 'neutral';
 }
 
-export function statusVariant(status) {
+export function statusVariant(status, issue = null) {
+  if (issue && issue.blocked_by && issue.blocked_by.length > 0) return 'warning';
   if (status === 'open') return 'success';
-  if (status === 'in_progress') return 'warning';
+  if (status === 'in_progress') return 'primary';
   if (status === 'closed') return 'neutral';
   return 'neutral';
 }
@@ -105,7 +106,7 @@ export function beadsDependencyGraph(issues) {
     }
   }
 
-  // Edge color based on dependency (source) status: closed = satisfied (gray), else blocking (red)
+  // Edge color based on dependency (source) status: closed = satisfied (gray), else blocking (amber)
   let edges = '';
   for (const issue of issues) {
     const to = positions.get(issue.id);
@@ -194,7 +195,8 @@ export function beadTooltipContent(issue) {
         <span class="bead-tooltip-id">Bead ID: ${issue.id}</span>
         <span class="bead-tooltip-badges">
           <sl-badge variant="${priorityVariant(issue.priority)}" pill>P${issue.priority}</sl-badge>
-          <sl-badge variant="${statusVariant(issue.status)}" pill>${issue.status}</sl-badge>
+          <sl-badge variant="${statusVariant(issue.status, issue)}" pill>${issue.status}</sl-badge>
+          ${issue.blocked_by && issue.blocked_by.length > 0 ? html`<sl-badge variant="warning" pill>blocked</sl-badge>` : ''}
         </span>
       </div>
       <hr class="bead-tooltip-separator">
@@ -216,7 +218,7 @@ export function beadChipTooltip(depId, issuesById) {
       ${
         dep
           ? html`<span class="bead-chip-tooltip-title">${dep.title}</span>
-        <sl-badge variant="${statusVariant(dep.status)}">${dep.status}</sl-badge>`
+        <sl-badge variant="${statusVariant(dep.status, dep)}">${dep.status}</sl-badge>`
           : ''
       }
     </div>
@@ -352,7 +354,7 @@ function beadsKanbanView(
             return html`
               <sl-tooltip class="bead-tooltip" hoist placement="bottom" distance="4">
                 <div slot="content">${beadTooltipContent(issue)}</div>
-                <div class="beads-kanban-card ${isBlocked ? 'beads-kanban-card--blocked' : ''}">
+                <div class="beads-kanban-card ${isBlocked ? 'beads-kanban-card--blocked' : issue.status === 'in_progress' ? 'beads-kanban-card--in_progress' : ''}">
                   <div class="beads-kanban-card-header">
                     <sl-badge variant="${priorityVariant(issue.priority)}" pill>P${issue.priority}</sl-badge>
                     <span class="beads-kanban-card-id">#${issue.id}</span>

--- a/worca-ui/app/views/beads-panel.test.js
+++ b/worca-ui/app/views/beads-panel.test.js
@@ -52,7 +52,9 @@ describe('statusVariant', () => {
   });
 
   it('returns warning when issue has blocked_by entries, overriding status', () => {
-    expect(statusVariant('in_progress', { blocked_by: ['dep1'] })).toBe('warning');
+    expect(statusVariant('in_progress', { blocked_by: ['dep1'] })).toBe(
+      'warning',
+    );
     expect(statusVariant('open', { blocked_by: ['dep1'] })).toBe('warning');
   });
 
@@ -401,27 +403,31 @@ describe('beadChipTooltip', () => {
 
 describe('beadsKanbanView - card in_progress modifier class', () => {
   it('applies beads-kanban-card--in_progress to in_progress issues', () => {
-    const issues = [{
-      id: 'worca-cc-ip1',
-      title: 'In Progress Issue',
-      status: 'in_progress',
-      priority: 2,
-      depends_on: [],
-      blocked_by: [],
-    }];
+    const issues = [
+      {
+        id: 'worca-cc-ip1',
+        title: 'In Progress Issue',
+        status: 'in_progress',
+        priority: 2,
+        depends_on: [],
+        blocked_by: [],
+      },
+    ];
     const out = renderToString(beadsPanelView(issues, baseOptions));
     expect(out).toContain('beads-kanban-card--in_progress');
   });
 
   it('does not apply beads-kanban-card--in_progress to open issues', () => {
-    const issues = [{
-      id: 'worca-cc-op1',
-      title: 'Open Issue',
-      status: 'open',
-      priority: 2,
-      depends_on: [],
-      blocked_by: [],
-    }];
+    const issues = [
+      {
+        id: 'worca-cc-op1',
+        title: 'Open Issue',
+        status: 'open',
+        priority: 2,
+        depends_on: [],
+        blocked_by: [],
+      },
+    ];
     const out = renderToString(beadsPanelView(issues, baseOptions));
     expect(out).not.toContain('beads-kanban-card--in_progress');
   });
@@ -458,8 +464,20 @@ describe('beadTooltipContent - blocked state', () => {
 });
 
 describe('beadsDependencyGraph - edge CSS classes', () => {
-  const dep = { id: 'dep1', title: 'Dep', status: 'open', depends_on: [], blocked_by: [] };
-  const task = { id: 'task1', title: 'Task', status: 'open', depends_on: ['dep1'], blocked_by: ['dep1'] };
+  const dep = {
+    id: 'dep1',
+    title: 'Dep',
+    status: 'open',
+    depends_on: [],
+    blocked_by: [],
+  };
+  const task = {
+    id: 'task1',
+    title: 'Task',
+    status: 'open',
+    depends_on: ['dep1'],
+    blocked_by: ['dep1'],
+  };
 
   it('assigns beads-graph-edge--blocking class for unsatisfied (non-closed) dependencies', () => {
     const { svg } = beadsDependencyGraph([dep, task]);

--- a/worca-ui/app/views/beads-panel.test.js
+++ b/worca-ui/app/views/beads-panel.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   beadChipTooltip,
+  beadsDependencyGraph,
   beadsPanelView,
   beadsRunListView,
   beadTooltipContent,
+  statusVariant,
 } from './beads-panel.js';
 
 function renderToString(template) {
@@ -35,6 +37,34 @@ const baseOptions = {
   onStartIssue: () => {},
   onDismissError: () => {},
 };
+
+describe('statusVariant', () => {
+  it('returns primary for in_progress', () => {
+    expect(statusVariant('in_progress')).toBe('primary');
+  });
+
+  it('returns success for open', () => {
+    expect(statusVariant('open')).toBe('success');
+  });
+
+  it('returns neutral for closed', () => {
+    expect(statusVariant('closed')).toBe('neutral');
+  });
+
+  it('returns warning when issue has blocked_by entries, overriding status', () => {
+    expect(statusVariant('in_progress', { blocked_by: ['dep1'] })).toBe('warning');
+    expect(statusVariant('open', { blocked_by: ['dep1'] })).toBe('warning');
+  });
+
+  it('returns primary for in_progress when blocked_by is empty', () => {
+    expect(statusVariant('in_progress', { blocked_by: [] })).toBe('primary');
+  });
+
+  it('returns primary for in_progress when issue has no blocked_by field', () => {
+    expect(statusVariant('in_progress', {})).toBe('primary');
+    expect(statusVariant('in_progress', null)).toBe('primary');
+  });
+});
 
 describe('beadsRunListView - active-first + newest-first ordering', () => {
   const options = { onSelectRun: () => {}, beadsCounts: {} };
@@ -286,7 +316,7 @@ describe('beadTooltipContent', () => {
   it('includes status badge with correct variant', () => {
     const out = renderToString(beadTooltipContent(issue));
     expect(out).toContain('in_progress');
-    expect(out).toContain('warning'); // statusVariant('in_progress') = 'warning'
+    expect(out).toContain('primary'); // statusVariant('in_progress') = 'primary'
   });
 
   it('includes priority badge', () => {
@@ -353,5 +383,99 @@ describe('beadChipTooltip', () => {
   it('includes the dep id', () => {
     const out = renderToString(beadChipTooltip('worca-cc-dep1', issuesById));
     expect(out).toContain('worca-cc-dep1');
+  });
+
+  it('shows warning variant for a blocked dep', () => {
+    const blockedDep = {
+      id: 'worca-cc-dep2',
+      title: 'Dep Two Title',
+      status: 'open',
+      depends_on: ['worca-cc-dep3'],
+      blocked_by: ['worca-cc-dep3'],
+    };
+    const blockedMap = new Map([['worca-cc-dep2', blockedDep]]);
+    const out = renderToString(beadChipTooltip('worca-cc-dep2', blockedMap));
+    expect(out).toContain('warning');
+  });
+});
+
+describe('beadsKanbanView - card in_progress modifier class', () => {
+  it('applies beads-kanban-card--in_progress to in_progress issues', () => {
+    const issues = [{
+      id: 'worca-cc-ip1',
+      title: 'In Progress Issue',
+      status: 'in_progress',
+      priority: 2,
+      depends_on: [],
+      blocked_by: [],
+    }];
+    const out = renderToString(beadsPanelView(issues, baseOptions));
+    expect(out).toContain('beads-kanban-card--in_progress');
+  });
+
+  it('does not apply beads-kanban-card--in_progress to open issues', () => {
+    const issues = [{
+      id: 'worca-cc-op1',
+      title: 'Open Issue',
+      status: 'open',
+      priority: 2,
+      depends_on: [],
+      blocked_by: [],
+    }];
+    const out = renderToString(beadsPanelView(issues, baseOptions));
+    expect(out).not.toContain('beads-kanban-card--in_progress');
+  });
+});
+
+describe('beadTooltipContent - blocked state', () => {
+  const blockedIssue = {
+    id: 'worca-cc-abc2',
+    title: 'Blocked Issue Title',
+    status: 'open',
+    priority: 2,
+    depends_on: ['worca-cc-dep1'],
+    blocked_by: ['worca-cc-dep1'],
+  };
+
+  it('shows warning variant for status badge when issue is blocked', () => {
+    const out = renderToString(beadTooltipContent(blockedIssue));
+    expect(out).toContain('warning');
+  });
+
+  it('shows a blocked badge when issue has blocked_by entries', () => {
+    const out = renderToString(beadTooltipContent(blockedIssue));
+    // There should be a badge with text 'blocked'
+    const badgeIndex = out.indexOf('>blocked<');
+    expect(badgeIndex).toBeGreaterThan(-1);
+  });
+
+  it('does not show blocked badge when blocked_by is empty', () => {
+    const unblockedIssue = { ...blockedIssue, blocked_by: [] };
+    const out = renderToString(beadTooltipContent(unblockedIssue));
+    // 'blocked' text should not appear as badge content
+    expect(out).not.toContain('>blocked<');
+  });
+});
+
+describe('beadsDependencyGraph - edge CSS classes', () => {
+  const dep = { id: 'dep1', title: 'Dep', status: 'open', depends_on: [], blocked_by: [] };
+  const task = { id: 'task1', title: 'Task', status: 'open', depends_on: ['dep1'], blocked_by: ['dep1'] };
+
+  it('assigns beads-graph-edge--blocking class for unsatisfied (non-closed) dependencies', () => {
+    const { svg } = beadsDependencyGraph([dep, task]);
+    expect(svg).toContain('beads-graph-edge--blocking');
+    expect(svg).not.toContain('beads-graph-edge--satisfied');
+  });
+
+  it('assigns beads-graph-edge--satisfied class when dependency is closed', () => {
+    const closedDep = { ...dep, status: 'closed' };
+    const { svg } = beadsDependencyGraph([closedDep, task]);
+    expect(svg).toContain('beads-graph-edge--satisfied');
+    expect(svg).not.toContain('beads-graph-edge--blocking');
+  });
+
+  it('blocking arrow marker uses var(--status-blocked) for amber color', () => {
+    const { svg } = beadsDependencyGraph([dep, task]);
+    expect(svg).toContain('fill="var(--status-blocked)"');
   });
 });

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -491,7 +491,8 @@ export function runBeadsSectionView(beads) {
             <sl-tooltip class="bead-tooltip" hoist placement="bottom" distance="4">
               <div slot="content">${beadTooltipContent(issue)}</div>
               <div class="run-bead-row">
-                <sl-badge variant="${statusVariant(issue.status)}" pill>${issue.status}</sl-badge>
+                <sl-badge variant="${statusVariant(issue.status, issue)}" pill>${issue.status}</sl-badge>
+                ${issue.blocked_by?.length ? html`<sl-badge variant="warning" pill>blocked</sl-badge>` : ''}
                 <sl-badge variant="${priorityVariant(issue.priority)}" pill>P${issue.priority}</sl-badge>
                 <span class="run-bead-id">#${issue.id}</span>
                 <span class="run-bead-title">${issue.title}</span>

--- a/worca-ui/app/views/run-detail.test.js
+++ b/worca-ui/app/views/run-detail.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { runBeadsSectionView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+describe('runBeadsSectionView - blocked state', () => {
+  it('shows warning variant badge for a blocked bead', () => {
+    const beads = [
+      {
+        id: 'worca-cc-abc',
+        title: 'Some task',
+        status: 'open',
+        priority: 2,
+        blocked_by: ['worca-cc-dep1'],
+        depends_on: [],
+      },
+    ];
+    const out = renderToString(runBeadsSectionView(beads));
+    expect(out).toContain('warning');
+  });
+
+  it('shows primary variant badge for an in_progress bead that is not blocked', () => {
+    const beads = [
+      {
+        id: 'worca-cc-xyz',
+        title: 'Active task',
+        status: 'in_progress',
+        priority: 2,
+        blocked_by: [],
+        depends_on: [],
+      },
+    ];
+    const out = renderToString(runBeadsSectionView(beads));
+    expect(out).toContain('primary');
+  });
+
+  it('shows explicit blocked badge when blocked_by is non-empty', () => {
+    const beads = [
+      {
+        id: 'worca-cc-abc',
+        title: 'Blocked task',
+        status: 'open',
+        priority: 2,
+        blocked_by: ['worca-cc-dep1'],
+        depends_on: [],
+      },
+    ];
+    const out = renderToString(runBeadsSectionView(beads));
+    expect(out).toContain('blocked');
+  });
+
+  it('does not show blocked badge when blocked_by is empty', () => {
+    const beads = [
+      {
+        id: 'worca-cc-xyz',
+        title: 'Normal task',
+        status: 'open',
+        priority: 2,
+        blocked_by: [],
+        depends_on: [],
+      },
+    ];
+    const out = renderToString(runBeadsSectionView(beads));
+    // Only "open" badge text, no "blocked" badge text
+    const blockedCount = (out.match(/\bblocked\b/g) || []).length;
+    expect(blockedCount).toBe(0);
+  });
+});

--- a/worca-ui/app/views/status-color-vars.test.js
+++ b/worca-ui/app/views/status-color-vars.test.js
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(resolve(__dirname, '../styles.css'), 'utf-8');
+
+describe('CSS status color variables', () => {
+  it('--status-in-progress uses blue (#3b82f6) for active work', () => {
+    const match = css.match(/--status-in-progress:\s*([^;]+);/);
+    expect(match).not.toBeNull();
+    expect(match[1].trim()).toBe('#3b82f6');
+  });
+
+  it('--status-blocked uses amber (#f59e0b) for waiting/blocked state', () => {
+    const match = css.match(/--status-blocked:\s*([^;]+);/);
+    expect(match).not.toBeNull();
+    expect(match[1].trim()).toBe('#f59e0b');
+  });
+
+  it('.beads-kanban-card--in_progress uses border-color: var(--status-in-progress)', () => {
+    const match = css.match(/\.beads-kanban-card--in_progress\s*\{([^}]+)\}/);
+    expect(match).not.toBeNull();
+    expect(match[1]).toContain('border-color: var(--status-in-progress)');
+  });
+
+  it('.beads-graph-edge--blocking uses stroke: var(--status-blocked) for amber blocking edges', () => {
+    const match = css.match(/\.beads-graph-edge--blocking\s*\{([^}]+)\}/);
+    expect(match).not.toBeNull();
+    expect(match[1]).toContain('stroke: var(--status-blocked)');
+    expect(match[1]).not.toContain('var(--status-in-progress)');
+  });
+});

--- a/worca-ui/server/ws-beads-watcher.js
+++ b/worca-ui/server/ws-beads-watcher.js
@@ -8,7 +8,7 @@ import { existsSync, watch } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { listIssues } from './beads-reader.js';
 
-const BEADS_DEBOUNCE_MS = 300;
+const BEADS_DEBOUNCE_MS = 500;
 
 /**
  * @param {{ worcaDir: string, broadcaster: { broadcast: Function }, projectId?: string }} deps

--- a/worca-ui/server/ws-beads-watcher.test.js
+++ b/worca-ui/server/ws-beads-watcher.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+// Verify that the debounce constant is at least 500ms so WAL writes are
+// visible to subsequent bd list subprocess calls before the broadcast fires.
+describe('ws-beads-watcher debounce', () => {
+  it('uses a debounce of at least 500ms for WAL timing', async () => {
+    // Import the module and check that BEADS_DEBOUNCE_MS >= 500.
+    // The constant is not exported, so we verify behaviour by observing
+    // how long after a scheduleBeadsRefresh call the broadcast fires.
+    // We do this indirectly: read the source and assert the literal value.
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, join } = await import('node:path');
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), 'ws-beads-watcher.js'),
+      'utf8',
+    );
+    const match = src.match(/BEADS_DEBOUNCE_MS\s*=\s*(\d+)/);
+    expect(match).not.toBeNull();
+    expect(Number(match[1])).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/worca-ui/server/ws-list-beads-by-run.test.js
+++ b/worca-ui/server/ws-list-beads-by-run.test.js
@@ -1,0 +1,157 @@
+/**
+ * Tests for list-beads-by-run handler diagnostic logging.
+ * TDD: written first, should initially fail until console.log is added.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockListIssuesByLabel = vi.fn();
+const mockBeadsDbExists = vi.fn();
+
+vi.mock('./beads-reader.js', () => ({
+  dbExists: (...args) => mockBeadsDbExists(...args),
+  listIssuesByLabel: (...args) => mockListIssuesByLabel(...args),
+  countIssuesByRunLabel: vi.fn(),
+  getIssue: vi.fn(),
+  listDistinctRunLabels: vi.fn(),
+  listIssues: vi.fn(),
+  listUnlinkedIssues: vi.fn(),
+}));
+
+const { createMessageRouter } = await import('./ws-message-router.js');
+
+function mockWatcherSet(projectId = 'default') {
+  return {
+    projectId,
+    get worcaDir() {
+      return `/mock/${projectId}/.worca`;
+    },
+    get settingsPath() {
+      return `/mock/${projectId}/.claude/settings.json`;
+    },
+    get projectRoot() {
+      return `/mock/${projectId}`;
+    },
+    statusWatcher: {
+      scheduleRefresh: vi.fn(),
+      lastPipelineStatus: new Map(),
+      resolveActiveRunDir: vi.fn(() => `/mock/${projectId}/.worca`),
+      currentActiveRunId: vi.fn(() => null),
+    },
+    logWatcher: {
+      watchLogFile: vi.fn(),
+      watchAllLogFiles: vi.fn(),
+      sendArchivedLogs: vi.fn(),
+      resolveLogsBaseDir: vi.fn(() => `/mock/${projectId}/.worca`),
+      clearLogWatchers: vi.fn(),
+    },
+    beadsWatcher: {
+      getBeadsDbPath: vi.fn(() => `/mock/${projectId}/beads.db`),
+    },
+    eventWatcher: {
+      readEventsFromFile: vi.fn(() => []),
+      subscribeEvents: vi.fn(),
+      maybeCloseEventWatcher: vi.fn(),
+    },
+  };
+}
+
+function makeRouter() {
+  const wset = mockWatcherSet('default');
+  const watcherSets = new Map([['default', wset]]);
+  const clientManager = {
+    ensureSubs(ws) {
+      if (!this._map) this._map = new Map();
+      if (!this._map.has(ws)) this._map.set(ws, {});
+      return this._map.get(ws);
+    },
+    getSubs(ws) {
+      if (!this._map) return null;
+      return this._map.get(ws) || null;
+    },
+    setProtocol(ws, protocol, projectId) {
+      const s = this.ensureSubs(ws);
+      s.protocolVersion = protocol;
+      s.projectId = projectId;
+    },
+  };
+  const broadcaster = { broadcast: vi.fn(), broadcastToSubscribers: vi.fn() };
+  const router = createMessageRouter({
+    watcherSets,
+    getDefaultWs: () => wset,
+    prefsPath: '/mock/prefs.json',
+    webhookInbox: null,
+    clientManager,
+    broadcaster,
+  });
+  return { router, wset };
+}
+
+function makeWs() {
+  return { send: vi.fn(), isAlive: true };
+}
+
+describe('list-beads-by-run diagnostic logging', () => {
+  let consoleSpy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockBeadsDbExists.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('logs runId, issue count, and per-issue statuses after listIssuesByLabel', async () => {
+    const issues = [
+      { id: 1, status: 'in_progress', title: 'bead A' },
+      { id: 2, status: 'open', title: 'bead B' },
+      { id: 3, status: 'closed', title: 'bead C' },
+    ];
+    mockListIssuesByLabel.mockResolvedValue(issues);
+
+    const { router } = makeRouter();
+    const ws = makeWs();
+
+    await router.handleMessage(
+      ws,
+      JSON.stringify({
+        id: 'req-1',
+        type: 'list-beads-by-run',
+        payload: { runId: '20260409-065330-698-fb28' },
+      }),
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[list-beads-by-run] runId=%s count=%d statuses=%o',
+      '20260409-065330-698-fb28',
+      3,
+      ['in_progress', 'open', 'closed'],
+    );
+  });
+
+  it('logs zero count and empty statuses when no issues found', async () => {
+    mockListIssuesByLabel.mockResolvedValue([]);
+
+    const { router } = makeRouter();
+    const ws = makeWs();
+
+    await router.handleMessage(
+      ws,
+      JSON.stringify({
+        id: 'req-2',
+        type: 'list-beads-by-run',
+        payload: { runId: 'run-empty' },
+      }),
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[list-beads-by-run] runId=%s count=%d statuses=%o',
+      'run-empty',
+      0,
+      [],
+    );
+  });
+});

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -613,6 +613,12 @@ export function createMessageRouter({
         return;
       }
       const issues = await listIssuesByLabel(beadsDbPath, `run:${runId}`);
+      console.log(
+        '[list-beads-by-run] runId=%s count=%d statuses=%o',
+        runId,
+        issues.length,
+        issues.map((i) => i.status),
+      );
       ws.send(JSON.stringify(makeOk(req, { issues, runId })));
       return;
     }


### PR DESCRIPTION
## Summary

- **Swap status color mapping**: `in_progress` now uses blue (`#3b82f6`) and `blocked` uses amber (`#f59e0b`), matching common conventions (blue = active work, amber = waiting/needs attention)
- **Consistent blocked-state handling across all four bead views**: run-detail rows, dependency graph nodes, kanban cards, and tooltips now all correctly detect and display the derived "blocked" state (has open dependencies)
- **Server-side diagnostics**: added logging to `list-beads-by-run` to trace returned statuses during live runs; increased beads watcher debounce from 300ms to 500ms to improve WAL visibility for `in_progress` transitions

## Changes

### CSS (`styles.css`)
- Swap hex values for `--status-in-progress` (blue) and `--status-blocked` (amber)
- Update Shoelace `--sl-color-warning-600` to map to blocked (amber)
- Update timing bar fallback colors to match
- Add `.beads-kanban-card--in_progress` class for blue border on active cards

### Views (`beads-panel.js`, `run-detail.js`)
- `statusVariant()` now accepts optional `issue` param — returns `'warning'` when issue has `blocked_by` entries, `'primary'` for `in_progress`
- Run-detail bead rows show explicit "blocked" badge when blocked
- Kanban cards apply `--in_progress` modifier class
- Tooltip badges pass full issue to `statusVariant()` and show "blocked" badge
- Dependency chip tooltips pass full dep to `statusVariant()`

### Server (`ws-beads-watcher.js`, `ws-message-router.js`)
- Increase `BEADS_DEBOUNCE_MS` from 300 to 500 for better WAL timing
- Add `console.log` diagnostic to `list-beads-by-run` handler showing runId, count, and per-issue statuses

### Tests (4 new test files, 1 updated)
- `status-color-vars.test.js` — validates CSS variable hex values and class rules
- `run-detail.test.js` — blocked/in_progress badge rendering in run bead rows
- `ws-beads-watcher.test.js` — debounce constant >= 500ms
- `ws-list-beads-by-run.test.js` — diagnostic logging assertions
- `beads-panel.test.js` — extended with statusVariant, kanban card, tooltip blocked state, and graph edge tests

## Test plan

- [x] All 55 tests pass (`npx vitest run` on all new and modified test files)
- [ ] Visual check: in_progress beads show blue badges/borders; blocked beads show amber badges with dashed borders
- [ ] Live pipeline run: verify `[list-beads-by-run]` log lines appear in server output with correct statuses
- [ ] Manual refresh during implement stage should show `in_progress` status on claimed beads

🤖 Generated with [Claude Code](https://claude.com/claude-code)