### PR TITLE
fix: use dynamic plan file name in revision loops

### DIFF
--- a/src/worca/agents/core/plan_reviewer.md
+++ b/src/worca/agents/core/plan_reviewer.md
@@ -6,7 +6,7 @@ You are the Plan Reviewer. You are a read-only reviewer that evaluates implement
 
 ## Context
 
-You receive the current implementation plan (`MASTER_PLAN.md`) and the original work request. Your job is to validate the plan against the work request, the existing codebase, and external documentation, then produce a structured `plan_review.json` output.
+You receive the current implementation plan and the original work request. Your job is to validate the plan against the work request, the existing codebase, and external documentation, then produce a structured `plan_review.json` output.
 
 ## Process
 

--- a/src/worca/orchestrator/prompt_builder.py
+++ b/src/worca/orchestrator/prompt_builder.py
@@ -55,7 +55,7 @@ class PromptBuilder:
         back to the ``plan_file_path`` context key (set when a pre-made plan is
         provided via CLI and MASTER_PLAN.md is not created).
         Returns empty string if neither is found."""
-        for path in (self._master_plan_path, self._context.get("plan_file_path")):
+        for path in (self._master_plan_path, self._context.get("plan_file"), self._context.get("plan_file_path")):
             if not path:
                 continue
             try:
@@ -159,6 +159,8 @@ class PromptBuilder:
 
     def _build_plan_revision(self) -> str:
         """Build prompt for plan revision mode (triggered by PLAN_REVIEW revise outcome)."""
+        plan_file = self._context.get("plan_file") or "MASTER_PLAN.md"
+        plan_file_name = os.path.basename(plan_file)
         parts = [
             "The plan reviewer has identified issues that must be addressed. "
             "Revise the existing plan -- do NOT start from scratch.",
@@ -168,7 +170,7 @@ class PromptBuilder:
 
         plan_content = self._read_master_plan()
         if plan_content:
-            parts.append(f"## Current Plan (MASTER_PLAN.md)\n\n{plan_content}")
+            parts.append(f"## Current Plan ({plan_file_name})\n\n{plan_content}")
 
         issues = self._context.get("plan_review_issues") or []
         if issues:
@@ -202,7 +204,7 @@ class PromptBuilder:
 
         parts.append(
             "Address each issue above. Preserve all parts of the plan that were not flagged. "
-            "Write the updated plan to MASTER_PLAN.md. "
+            f"Write the updated plan to {plan_file_name}. "
             "In your JSON output, set `approved: true` to signal that the revised plan is ready for review."
         )
         return "\n\n".join(parts)
@@ -216,12 +218,13 @@ class PromptBuilder:
 
         parts.append(self._work_request_section())
 
+        plan_file_name = os.path.basename(self._context.get("plan_file") or "MASTER_PLAN.md")
         plan_content = self._read_master_plan()
         if plan_content:
-            parts.append(f"## Implementation Plan (MASTER_PLAN.md)\n\n{plan_content}")
+            parts.append(f"## Implementation Plan ({plan_file_name})\n\n{plan_content}")
         else:
             parts.append(
-                "## Implementation Plan (MASTER_PLAN.md)\n\n"
+                f"## Implementation Plan ({plan_file_name})\n\n"
                 "*Plan file not found or empty -- this is itself a critical issue to report.*"
             )
 

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -1872,6 +1872,23 @@ def run_pipeline(
                         if prompt_context_path:
                             prompt_builder.save_context(prompt_context_path)
                         save_status(status, actual_status_path)
+                        # 2a. Re-render agent templates so planner.md stays consistent
+                        # with the current plan_file path (defensive: prevents stale
+                        # template instructions if plan_file ever changes mid-revision).
+                        if run_dir:
+                            _lb_settings = load_settings(settings_path)
+                            _lb_worca = _lb_settings.get("worca", {})
+                            _lb_overrides_dir = _lb_worca.get(
+                                "agent_overrides_dir", ".claude/agents"
+                            )
+                            _lb_template_agents_dir = _lb_worca.get("_template_agents_dir")
+                            _render_agent_templates(run_dir, {
+                                "plan_file": status["plan_file"],
+                                "run_id": status.get("run_id", ""),
+                                "branch": branch_name,
+                                "title": work_request.title,
+                            }, overrides_dir=_lb_overrides_dir,
+                               template_agents_dir=_lb_template_agents_dir)
                         # 3. In-memory transitions (context keys drive behavior on crash/resume)
                         _next_trigger[Stage.PLAN.value] = "plan_review_revise"
                         stage_idx = stage_order.index(Stage.PLAN)

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -439,3 +439,50 @@ def test_build_plan_revision_mode_instructs_approved_true(tmp_path):
     prompt = pb.build("plan")
     assert "approved" in prompt.lower()
     assert "true" in prompt.lower()
+
+
+# --- plan-file context fixes (TDD red phase) ---
+
+def test_build_plan_revision_uses_plan_file_context(tmp_path):
+    """_build_plan_revision() should reference plan_file context name, not MASTER_PLAN.md."""
+    plan_file = tmp_path / "plan-001.md"
+    plan_file.write_text("# Current Plan\n\nDo this and that")
+    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(tmp_path / "MASTER_PLAN.md"))
+    pb.update_context("plan_file", str(plan_file))
+    pb.update_context("plan_revision_mode", True)
+    pb.update_context("plan_review_issues", [
+        {"category": "completeness", "severity": "critical", "description": "Missing edge cases"},
+    ])
+    prompt = pb.build("plan")
+    assert "plan-001.md" in prompt
+    assert "MASTER_PLAN.md" not in prompt
+
+
+def test_read_master_plan_uses_plan_file_context(tmp_path):
+    """_read_master_plan() should find content via plan_file context key when MASTER_PLAN.md absent."""
+    plan_file = tmp_path / "plan-001.md"
+    plan_file.write_text("# Plan from plan_file context")
+    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(tmp_path / "MASTER_PLAN.md"))
+    pb.update_context("plan_file", str(plan_file))
+    content = pb._read_master_plan()
+    assert "Plan from plan_file context" in content
+
+
+def test_build_plan_review_uses_plan_file_context(tmp_path):
+    """_build_plan_review() section header should use plan_file name, not MASTER_PLAN.md."""
+    plan_file = tmp_path / "plan-001.md"
+    plan_file.write_text("# Implementation Plan\n\nPhase 1: Setup")
+    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(tmp_path / "MASTER_PLAN.md"))
+    pb.update_context("plan_file", str(plan_file))
+    prompt = pb.build("plan_review")
+    assert "Implementation Plan (plan-001.md)" in prompt
+    assert "Implementation Plan (MASTER_PLAN.md)" not in prompt
+
+
+def test_build_plan_review_missing_plan_uses_plan_file_name(tmp_path):
+    """Fallback message when plan is missing should reference plan_file name, not MASTER_PLAN.md."""
+    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(tmp_path / "MASTER_PLAN.md"))
+    pb.update_context("plan_file", str(tmp_path / "plan-001.md"))  # file does not exist
+    prompt = pb.build("plan_review")
+    assert "plan-001.md" in prompt
+    assert "MASTER_PLAN.md" not in prompt

--- a/tests/test_runner_plan_review.py
+++ b/tests/test_runner_plan_review.py
@@ -1016,3 +1016,106 @@ class TestPlanReviewMalformedOutput:
         # Unrecognized outcome → not "revise" → approve path → PLAN runs once
         assert stages_run.count("plan") == 1
         assert "coordinate" in stages_run
+
+
+# ---------------------------------------------------------------------------
+# Revision loop-back re-renders agent templates (Fix 5: defensive)
+# ---------------------------------------------------------------------------
+
+class TestReviseLoopbackRendersAgentTemplates:
+
+    def test_render_agent_templates_called_on_loopback(self, tmp_path):
+        """_render_agent_templates is called during the revision loop-back."""
+        settings_path, status_path, wr = _make_runner(tmp_path, plan_review_loops=2)
+        critical_issue = {"category": "risk", "severity": "critical",
+                          "description": "Missing rollback"}
+        call_count = {"plan_review": 0}
+        render_calls = []
+
+        def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                           prompt_override=None, **kwargs):
+            if stage == Stage.PLAN:
+                return _mock_stage(stage, {"approved": True, "approach": "x", "tasks_outline": []})
+            if stage == Stage.PLAN_REVIEW:
+                call_count["plan_review"] += 1
+                if call_count["plan_review"] == 1:
+                    return _mock_stage(stage, {
+                        "outcome": "revise",
+                        "issues": [critical_issue],
+                        "summary": "Issues found",
+                    })
+                return _mock_stage(stage, {"outcome": "approve", "issues": [], "summary": "OK"})
+            if stage == Stage.COORDINATE:
+                return _mock_stage(stage, {"beads_ids": [], "dependency_graph": {}})
+            return _mock_stage(stage, {})
+
+        def mock_render(run_dir, template_vars, overrides_dir=".claude/agents",
+                        template_agents_dir=None):
+            render_calls.append({
+                "run_dir": run_dir,
+                "template_vars": dict(template_vars),
+                "overrides_dir": overrides_dir,
+                "template_agents_dir": template_agents_dir,
+            })
+
+        with patch("worca.orchestrator.runner._render_agent_templates", side_effect=mock_render):
+            with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage):
+                with patch("worca.orchestrator.runner.create_branch"):
+                    with patch("worca.orchestrator.runner._write_pid"):
+                        with patch("worca.orchestrator.runner._remove_pid"):
+                            run_pipeline(wr, settings_path=settings_path, status_path=status_path)
+
+        # Should have been called at least twice: once at init, once on loop-back
+        assert len(render_calls) >= 2, (
+            f"Expected _render_agent_templates called >= 2 times, got {len(render_calls)}"
+        )
+        # The loop-back call must include plan_file in template_vars
+        loopback_calls = render_calls[1:]  # Skip the initial render call
+        assert len(loopback_calls) >= 1
+        for call in loopback_calls:
+            assert "plan_file" in call["template_vars"], (
+                f"Loop-back render call missing plan_file: {call}"
+            )
+
+    def test_render_agent_templates_loopback_passes_correct_vars(self, tmp_path):
+        """Loop-back _render_agent_templates call includes plan_file, run_id, branch, title."""
+        settings_path, status_path, wr = _make_runner(tmp_path, plan_review_loops=2)
+        critical_issue = {"category": "feasibility", "severity": "critical",
+                          "description": "Too complex"}
+        call_count = {"plan_review": 0}
+        render_calls = []
+
+        def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                           prompt_override=None, **kwargs):
+            if stage == Stage.PLAN:
+                return _mock_stage(stage, {"approved": True, "approach": "x", "tasks_outline": []})
+            if stage == Stage.PLAN_REVIEW:
+                call_count["plan_review"] += 1
+                if call_count["plan_review"] == 1:
+                    return _mock_stage(stage, {
+                        "outcome": "revise",
+                        "issues": [critical_issue],
+                        "summary": "Issues",
+                    })
+                return _mock_stage(stage, {"outcome": "approve", "issues": [], "summary": "OK"})
+            if stage == Stage.COORDINATE:
+                return _mock_stage(stage, {"beads_ids": [], "dependency_graph": {}})
+            return _mock_stage(stage, {})
+
+        def mock_render(run_dir, template_vars, overrides_dir=".claude/agents",
+                        template_agents_dir=None):
+            render_calls.append(dict(template_vars))
+
+        with patch("worca.orchestrator.runner._render_agent_templates", side_effect=mock_render):
+            with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage):
+                with patch("worca.orchestrator.runner.create_branch"):
+                    with patch("worca.orchestrator.runner._write_pid"):
+                        with patch("worca.orchestrator.runner._remove_pid"):
+                            run_pipeline(wr, settings_path=settings_path, status_path=status_path)
+
+        assert len(render_calls) >= 2
+        loopback_vars = render_calls[1]
+        assert "plan_file" in loopback_vars
+        assert "run_id" in loopback_vars
+        assert "branch" in loopback_vars
+        assert "title" in loopback_vars


### PR DESCRIPTION
## Summary

- Fixes planner receiving contradictory instructions during plan_review revision loops: the rendered template says "write to plan-001.md" (enforced by guard hook) while the revision prompt hardcoded "MASTER_PLAN.md"
- This caused false-positive "No MASTER_PLAN.md exists" review failures, wasting 2+ iterations (~$1.57) per affected run
- Threads `plan_file` context through `_build_plan_revision()`, `_read_master_plan()`, and `_build_plan_review()` in prompt_builder.py
- Updates `plan_reviewer.md` template to remove hardcoded MASTER_PLAN.md reference
- Defensively re-renders agent templates on revision loop-back in runner.py

### Changes

| File | Change |
|---|---|
| `src/worca/orchestrator/prompt_builder.py` | `_build_plan_revision()`, `_read_master_plan()`, `_build_plan_review()` use dynamic `plan_file` context instead of hardcoded MASTER_PLAN.md |
| `src/worca/agents/core/plan_reviewer.md` | Remove hardcoded `MASTER_PLAN.md` reference from context description |
| `src/worca/orchestrator/runner.py` | Re-render agent templates during revision loop-back (defensive fix) |
| `tests/test_prompt_builder.py` | 4 new tests for plan_file context threading |
| `tests/test_runner_plan_review.py` | 2 new tests for template re-rendering on loop-back |

## Test plan

- [x] `test_build_plan_revision_uses_plan_file_context` — revision prompt references plan-001.md, not MASTER_PLAN.md
- [x] `test_read_master_plan_uses_plan_file_context` — finds plan content via `plan_file` context key when MASTER_PLAN.md absent
- [x] `test_build_plan_review_uses_plan_file_context` — section headers use correct file name
- [x] `test_build_plan_review_missing_plan_uses_plan_file_name` — fallback message references plan_file name
- [x] `test_render_agent_templates_called_on_loopback` — templates re-rendered during revision
- [x] `test_render_agent_templates_loopback_passes_correct_vars` — loop-back includes plan_file, run_id, branch, title

🤖 Generated with [Claude Code](https://claude.com/claude-code)