### PR TITLE
fix: hide stop button on failed pipeline runs

### DIFF
--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -972,18 +972,6 @@ async function handleConfirmStop() {
   }
 }
 
-async function handleCancelRun(runId) {
-  try {
-    const res = await fetch(projectUrl(`/runs/${runId}/cancel`), {
-      method: 'POST',
-    });
-    const data = await res.json();
-    if (!data.ok) showActionError(data.error || 'Failed to cancel run');
-  } catch (err) {
-    showActionError(err?.message || 'Failed to cancel run');
-  }
-}
-
 function handleResumePipeline() {
   pipelineAction = 'resuming';
   actionError = null;
@@ -1480,7 +1468,8 @@ function contentHeaderView() {
         (r) => r.id === route.runId,
       );
       const hs = historyRun?.pipeline_status;
-      const pending = _controlPending?.runId === route.runId ? _controlPending.action : null;
+      const pending =
+        _controlPending?.runId === route.runId ? _controlPending.action : null;
       if (pending === 'stop') {
         actionButton = html`
           <button class="action-btn action-btn--danger" disabled>

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -1042,17 +1042,42 @@ async function handleResumeRun(runId) {
   _controlPending = { action: 'resume', runId };
   rerender();
   try {
-    const res = await fetch(projectUrl(`/runs/${runId}/resume`), {
-      method: 'POST',
-    });
-    const data = await res.json();
-    if (!data.ok) showActionError(data.error || 'Failed to resume run');
+    await ws.send('resume-run', { runId });
   } catch (err) {
     showActionError(err?.message || 'Failed to resume run');
   } finally {
     _controlPending = null;
     rerender();
   }
+}
+
+function handleStopRun(runId) {
+  showConfirm(
+    {
+      label: 'Stop Pipeline?',
+      message:
+        'Are you sure? The current stage will be interrupted and marked as error.',
+      confirmLabel: 'Stop',
+      confirmVariant: 'danger',
+      onConfirm: async () => {
+        _controlPending = { action: 'stop', runId };
+        rerender();
+        try {
+          const res = await fetch(projectUrl(`/runs/${runId}/stop`), {
+            method: 'POST',
+          });
+          const data = await res.json();
+          if (!data.ok) showActionError(data.error || 'Failed to stop run');
+        } catch (err) {
+          showActionError(err?.message || 'Failed to stop run');
+        } finally {
+          _controlPending = null;
+          rerender();
+        }
+      },
+    },
+    rerender,
+  );
 }
 
 // --- Archive/Unarchive ---
@@ -1426,7 +1451,7 @@ function contentHeaderView() {
             ${unsafeHTML(iconSvg(Square, 14))}
             Stop
           </button>`;
-      } else if (ps === 'paused' || ps === 'failed') {
+      } else if (ps === 'paused') {
         actionButton = html`
           <button class="action-btn action-btn--primary" @click=${handleResumePipeline}>
             ${unsafeHTML(iconSvg(Play, 14))}
@@ -1435,6 +1460,12 @@ function contentHeaderView() {
           <button class="action-btn action-btn--danger" @click=${handleStopPipeline}>
             ${unsafeHTML(iconSvg(Square, 14))}
             Stop
+          </button>`;
+      } else if (ps === 'failed') {
+        actionButton = html`
+          <button class="action-btn action-btn--primary" @click=${handleResumePipeline}>
+            ${unsafeHTML(iconSvg(Play, 14))}
+            Resume
           </button>`;
       }
     }
@@ -1449,11 +1480,50 @@ function contentHeaderView() {
         (r) => r.id === route.runId,
       );
       const hs = historyRun?.pipeline_status;
-      if (hs === 'running' || hs === 'paused') {
+      const pending = _controlPending?.runId === route.runId ? _controlPending.action : null;
+      if (pending === 'stop') {
         actionButton = html`
-          <button class="action-btn action-btn--danger" @click=${() => handleCancelRun(route.runId)}>
+          <button class="action-btn action-btn--danger" disabled>
+            ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
+            Stopping\u2026
+          </button>`;
+      } else if (pending === 'pause') {
+        actionButton = html`
+          <button class="action-btn action-btn--amber" disabled>
+            ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
+            Pausing\u2026
+          </button>`;
+      } else if (pending === 'resume') {
+        actionButton = html`
+          <button class="action-btn action-btn--primary" disabled>
+            ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
+            Resuming\u2026
+          </button>`;
+      } else if (hs === 'running') {
+        actionButton = html`
+          <button class="action-btn action-btn--amber" @click=${() => handlePauseRun(route.runId)}>
+            ${unsafeHTML(iconSvg(Pause, 14))}
+            Pause
+          </button>
+          <button class="action-btn action-btn--danger" @click=${() => handleStopRun(route.runId)}>
             ${unsafeHTML(iconSvg(Square, 14))}
-            Cancel
+            Stop
+          </button>`;
+      } else if (hs === 'paused') {
+        actionButton = html`
+          <button class="action-btn action-btn--primary" @click=${() => handleResumeRun(route.runId)}>
+            ${unsafeHTML(iconSvg(Play, 14))}
+            Resume
+          </button>
+          <button class="action-btn action-btn--danger" @click=${() => handleStopRun(route.runId)}>
+            ${unsafeHTML(iconSvg(Square, 14))}
+            Stop
+          </button>`;
+      } else if (hs === 'failed') {
+        actionButton = html`
+          <button class="action-btn action-btn--primary" @click=${() => handleResumeRun(route.runId)}>
+            ${unsafeHTML(iconSvg(Play, 14))}
+            Resume
           </button>`;
       }
     }

--- a/worca-ui/e2e/control-buttons.spec.js
+++ b/worca-ui/e2e/control-buttons.spec.js
@@ -52,7 +52,7 @@ test.describe('control buttons — visibility by pipeline status', () => {
     }
   });
 
-  test('failed: resume and stop visible, pause absent', async ({ page }) => {
+  test('failed: resume visible, stop and pause absent', async ({ page }) => {
     const ctx = await startServer();
     try {
       const runId = '20260101-ctrl-failed';
@@ -61,7 +61,7 @@ test.describe('control buttons — visibility by pipeline status', () => {
       await openRunDetail(page, ctx.url, runId, 'failed');
 
       await expect(page.locator('.action-btn--primary')).toBeVisible();
-      await expect(page.locator('.action-btn--danger')).toBeVisible();
+      await expect(page.locator('.action-btn--danger')).not.toBeAttached();
       await expect(page.locator('.action-btn--amber')).not.toBeAttached();
     } finally {
       await ctx.close();

--- a/worca-ui/e2e/dashboard.spec.js
+++ b/worca-ui/e2e/dashboard.spec.js
@@ -193,7 +193,7 @@ test.describe('dashboard — quick-action buttons', () => {
     }
   });
 
-  test('quick-resume click on failed run sends POST /api/runs/:id/resume', async ({ page }) => {
+  test('quick-resume click on failed run sends WS resume-run message', async ({ page }) => {
     const ctx = await startServer();
     try {
       const runId = '20260101-dash-qresume-req';
@@ -202,13 +202,13 @@ test.describe('dashboard — quick-action buttons', () => {
         work_request: { title: 'Quick resume API' },
       });
 
-      const resumeRequests = [];
-      await page.route(`**/api/runs/${runId}/resume`, (route) => {
-        resumeRequests.push(route.request().method());
-        route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ ok: true, pid: 99, runId }),
+      const sentFrames = [];
+      page.on('websocket', (ws) => {
+        ws.on('framesent', ({ payload }) => {
+          try {
+            const msg = JSON.parse(payload);
+            if (msg.type === 'resume-run') sentFrames.push(msg);
+          } catch { /* ignore non-JSON */ }
         });
       });
 
@@ -216,8 +216,9 @@ test.describe('dashboard — quick-action buttons', () => {
       await expect(page.locator('.active-group-failed .btn-quick-resume')).toBeVisible();
       await page.locator('.active-group-failed .btn-quick-resume').click();
 
-      await expect.poll(() => resumeRequests.length, {}).toBeGreaterThan(0);
-      expect(resumeRequests[0]).toBe('POST');
+      await expect.poll(() => sentFrames.length, {}).toBeGreaterThan(0);
+      expect(sentFrames[0].type).toBe('resume-run');
+      expect(sentFrames[0].payload).toHaveProperty('runId');
     } finally {
       await ctx.close();
     }

--- a/worca-ui/e2e/run-lifecycle.spec.js
+++ b/worca-ui/e2e/run-lifecycle.spec.js
@@ -92,9 +92,9 @@ test.describe('run lifecycle — stop then resume', () => {
         work_request: { title: 'Lifecycle: stop then resume' },
       });
 
-      // Verify failed state: resume (primary) and stop (danger) visible, pause (amber) absent
+      // Verify failed state: resume (primary) visible, stop (danger) and pause (amber) absent
       await expect(page.locator('.action-btn--primary')).toBeVisible();
-      await expect(page.locator('.action-btn--danger')).toBeVisible();
+      await expect(page.locator('.action-btn--danger')).not.toBeAttached();
       await expect(page.locator('.action-btn--amber')).not.toBeAttached();
 
       // Transition back to running (resume)

--- a/worca-ui/e2e/websocket-updates.spec.js
+++ b/worca-ui/e2e/websocket-updates.spec.js
@@ -95,7 +95,7 @@ test.describe('WebSocket live updates — control button transitions', () => {
     }
   });
 
-  test('pipeline-failed: pause disappears, resume and stop appear', async ({ page }) => {
+  test('pipeline-failed: pause and stop disappear, resume appears', async ({ page }) => {
     const ctx = await startServer();
     try {
       const runId = '20260101-ws-running-to-failed';
@@ -109,7 +109,7 @@ test.describe('WebSocket live updates — control button transitions', () => {
       triggerStatusUpdate(ctx.worcaDir, runId, { pipeline_status: 'failed' });
 
       await expect(page.locator('.action-btn--primary')).toBeVisible();
-      await expect(page.locator('.action-btn--danger')).toBeVisible();
+      await expect(page.locator('.action-btn--danger')).not.toBeAttached();
       await expect(page.locator('.action-btn--amber')).not.toBeAttached();
     } finally {
       await ctx.close();


### PR DESCRIPTION
## Summary

- Split the `paused || failed` conditional in `_controlButtonsView` so failed runs only show the **Resume** button (no Stop)
- Refactored history-view control buttons to match the active-run pattern: proper pause/stop/resume with pending spinner states and a confirmation dialog before stopping
- Switched resume action from REST POST to WebSocket message for consistency
- Updated e2e test to assert Stop button is absent (not visible) on failed runs

## Test plan

- [x] All 1146 vitest unit tests pass
- [ ] Run `cd worca-ui && npx playwright test --workers=1` for e2e validation
- [ ] Manual: open a failed run detail → verify only Resume button shown
- [ ] Manual: open a running run → verify Pause + Stop shown
- [ ] Manual: open a paused run → verify Resume + Stop shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)