### PR TITLE
feat: add distinct favicons for global and project worca-ui instances

### DIFF
--- a/worca-ui/app/favicon-global.svg
+++ b/worca-ui/app/favicon-global.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#00e5a0"/>
+  <text x="4" y="24" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="22" fill="#ffffff">w</text>
+  <text x="21" y="24" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="22" fill="#ffffff">.</text>
+</svg>

--- a/worca-ui/app/favicon-project.svg
+++ b/worca-ui/app/favicon-project.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#f59e0b"/>
+  <text x="4" y="24" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="22" fill="#ffffff">w</text>
+  <text x="21" y="24" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="22" fill="#ffffff">.</text>
+</svg>

--- a/worca-ui/app/index.html
+++ b/worca-ui/app/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>worca-ui</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">

--- a/worca-ui/package.json
+++ b/worca-ui/package.json
@@ -26,6 +26,7 @@
     "server/*.js",
     "!server/*.test.js",
     "!server/test/",
+    "app/favicon-*.svg",
     "app/index.html",
     "app/main.bundle.js",
     "app/main.bundle.js.map",

--- a/worca-ui/server/app.js
+++ b/worca-ui/server/app.js
@@ -427,6 +427,14 @@ export function createApp(options = {}) {
     );
   }
 
+  // ─── Dynamic favicon ──────────────────────────────────────────────────
+  // Serve mode-specific favicon before express.static so it takes precedence.
+  app.get('/favicon.svg', (_req, res) => {
+    const faviconFile = projectRoot ? 'favicon-project.svg' : 'favicon-global.svg';
+    res.setHeader('Content-Type', 'image/svg+xml');
+    res.sendFile(faviconFile, { root: appDir });
+  });
+
   app.use(express.static(appDir));
   app.get('/{*splat}', (_req, res) => {
     res.sendFile('index.html', { root: appDir });

--- a/worca-ui/server/test/favicon-route.test.js
+++ b/worca-ui/server/test/favicon-route.test.js
@@ -1,0 +1,80 @@
+import { createServer } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import { createApp } from '../app.js';
+
+function startServer(options = {}) {
+  const app = createApp(options);
+  const server = createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const base = `http://127.0.0.1:${port}`;
+      resolve({ server, base });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+describe('GET /favicon.svg', () => {
+  it('serves favicon-global.svg with image/svg+xml when projectRoot is null', async () => {
+    const { server, base } = await startServer({ projectRoot: null });
+    try {
+      const res = await fetch(`${base}/favicon.svg`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/image\/svg\+xml/);
+      const body = await res.text();
+      expect(body).toContain('#00e5a0');
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it('serves favicon-global.svg when projectRoot is undefined', async () => {
+    const { server, base } = await startServer({});
+    try {
+      const res = await fetch(`${base}/favicon.svg`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/image\/svg\+xml/);
+      const body = await res.text();
+      expect(body).toContain('#00e5a0');
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it('serves favicon-project.svg with image/svg+xml when projectRoot is set', async () => {
+    const { server, base } = await startServer({
+      projectRoot: '/home/user/projects/my-app',
+    });
+    try {
+      const res = await fetch(`${base}/favicon.svg`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toMatch(/image\/svg\+xml/);
+      const body = await res.text();
+      expect(body).toContain('#f59e0b');
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it('favicon route is registered before static middleware', async () => {
+    // Verifies the dynamic route takes precedence over express.static
+    // (if static served it first, content-type might differ or wrong file served)
+    const { server, base } = await startServer({
+      projectRoot: '/some/project',
+    });
+    try {
+      const res = await fetch(`${base}/favicon.svg`);
+      expect(res.status).toBe(200);
+      // Must be dynamic route (project favicon has amber color)
+      const body = await res.text();
+      expect(body).toContain('#f59e0b');
+      expect(body).not.toContain('#00e5a0');
+    } finally {
+      await stopServer(server);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add two SVG favicons (`favicon-global.svg` green, `favicon-project.svg` amber) so browser tabs are visually distinguishable when running both global and project-scoped worca-ui instances
- Add a dynamic `GET /favicon.svg` Express route that selects the correct SVG based on whether `projectRoot` is set (project mode) or null (global mode)
- Update `index.html` with a `<link rel="icon">` tag and include both SVGs in `package.json` `files` for npm publishing

## Test plan

- [x] Server unit tests verify correct favicon is served per mode (4 tests passing)
- [ ] Manual: run global instance (`worca-ui start`) and project instance (`worca-ui start --project .`) side by side — tabs should show green vs amber icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)