### PR TITLE
fix: active pipeline shows wrong duration and Finished timestamp

### DIFF
--- a/worca-ui/app/views/run-card.js
+++ b/worca-ui/app/views/run-card.js
@@ -80,12 +80,13 @@ export function runCardView(
     run.pipeline_status ||
     (isActive ? 'running' : run.stage === 'error' ? 'failed' : 'completed');
   const tooltip = _statusTooltip(run, overallStatus);
-  const endTime = run.completed_at || _lastStageEnd(run.stages);
+  const endTime =
+    run.completed_at || (isActive ? null : _lastStageEnd(run.stages));
   const duration =
-    run.started_at && endTime
-      ? formatDuration(elapsed(run.started_at, endTime))
-      : run.started_at && isActive
-        ? formatDuration(elapsed(run.started_at, null))
+    run.started_at && isActive
+      ? formatDuration(elapsed(run.started_at, null))
+      : run.started_at && endTime
+        ? formatDuration(elapsed(run.started_at, endTime))
         : 'N/A';
   const branch = run.branch || run.work_request?.branch || '';
   const stages = run.stages ? _sortedEntries(run.stages) : [];

--- a/worca-ui/app/views/run-card.test.js
+++ b/worca-ui/app/views/run-card.test.js
@@ -327,3 +327,89 @@ describe('runCardView - archive/unarchive buttons', () => {
     expect(output).not.toContain('Unarchive');
   });
 });
+
+describe('runCardView - duration for active run with completed stages', () => {
+  it('shows a duration greater than the last stage end when active run has been running longer', () => {
+    const startedAt = '2026-04-10T10:00:00Z';
+    const stageEnd = '2026-04-10T10:05:43Z'; // 5m 43s into run
+    // Run is active and started 35 minutes ago (stage only completed 5m in)
+    const run = {
+      id: '1',
+      pipeline_status: 'running',
+      active: true,
+      started_at: startedAt,
+      stages: {
+        coordinate: { status: 'completed', completed_at: stageEnd },
+      },
+    };
+    const output = renderToString(runCardView(run));
+    // Duration should NOT be "5m 43s" (the last stage end) but rather actual elapsed time
+    expect(output).not.toContain('5m 43s');
+  });
+
+  it('uses elapsed-to-now for duration when run is active regardless of stage completion', () => {
+    const run = {
+      id: '1',
+      pipeline_status: 'running',
+      active: true,
+      started_at: new Date(Date.now() - 10 * 60 * 1000).toISOString(), // 10 minutes ago
+      stages: {
+        coordinate: {
+          status: 'completed',
+          completed_at: new Date(Date.now() - 8 * 60 * 1000).toISOString(), // completed 8 min ago
+        },
+      },
+    };
+    const output = renderToString(runCardView(run));
+    // Should contain "10m" not "2m" (duration from start to now, not from start to stage-end)
+    expect(output).toContain('10m');
+  });
+});
+
+describe('runCardView - Finished timestamp visibility', () => {
+  it('shows elapsed time from started_at to now for active run without completed_at', () => {
+    const run = {
+      id: '1',
+      pipeline_status: 'running',
+      active: true,
+      started_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(), // 5 minutes ago
+    };
+    const output = renderToString(runCardView(run));
+    expect(output).toContain('5m');
+  });
+
+  it('does not show a Finished timestamp for active runs', () => {
+    const run = {
+      id: '1',
+      pipeline_status: 'running',
+      active: true,
+      started_at: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
+    };
+    const output = renderToString(runCardView(run));
+    // endTime is null for active runs — formatTimestamp(null) returns 'N/A', not a real date
+    const finishedMatch = output.match(
+      /Finished:<\/span>\s*<span[^>]*>([^<]+)<\/span>/,
+    );
+    expect(finishedMatch).not.toBeNull();
+    expect(finishedMatch[1].trim()).toBe('N/A');
+  });
+
+  it('shows Finished timestamp for completed runs', () => {
+    const completedAt = '2026-04-10T12:30:00Z';
+    const run = {
+      id: '1',
+      pipeline_status: 'completed',
+      active: false,
+      started_at: '2026-04-10T12:00:00Z',
+      completed_at: completedAt,
+    };
+    const output = renderToString(runCardView(run));
+    // formatTimestamp returns a formatted date string (not 'N/A') for a real completed_at
+    const finishedMatch = output.match(
+      /Finished:<\/span>\s*<span[^>]*>([^<]+)<\/span>/,
+    );
+    expect(finishedMatch).not.toBeNull();
+    expect(finishedMatch[1].trim()).not.toBe('N/A');
+    expect(finishedMatch[1].trim()).toContain('2026');
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -358,10 +358,7 @@ function _stageWallMs(stage) {
 }
 
 function timingStripView(startedAt, completedAt, extra = nothing) {
-  const dur =
-    startedAt && completedAt
-      ? formatDuration(elapsed(startedAt, completedAt))
-      : '';
+  const dur = startedAt ? formatDuration(elapsed(startedAt, completedAt)) : '';
   return html`
     <div class="timing-strip">
       ${startedAt ? html`<span class="timing-strip-item"><span class="meta-label">Started:</span> <span class="meta-value">${formatTimestamp(startedAt)}</span></span>` : nothing}
@@ -535,9 +532,7 @@ export function runDetailView(run, settings = {}, options = {}) {
   const pipelineTemplate = formatPipelineTemplate(run.pipeline_template);
   const pr = run.pr_url || null;
   const endTime =
-    run.completed_at ||
-    _lastStageEnd(run.stages) ||
-    (run.active ? new Date().toISOString() : null);
+    run.completed_at || (run.active ? null : _lastStageEnd(run.stages));
   const rawStages = run.stages || {};
   // Ensure preflight and learn exist (may be absent in old runs)
   let stages = rawStages;
@@ -587,8 +582,9 @@ export function runDetailView(run, settings = {}, options = {}) {
             (sum, it) => sum + (it.turns || 0),
             0,
           );
-          const pipelineWallMs =
-            run.started_at && endTime ? elapsed(run.started_at, endTime) : 0;
+          const pipelineWallMs = run.started_at
+            ? elapsed(run.started_at, endTime || null)
+            : 0;
           return html`
             ${
               pipelineCost > 0 || pipelineTurns > 0

--- a/worca-ui/app/views/run-detail.test.js
+++ b/worca-ui/app/views/run-detail.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { runBeadsSectionView } from './run-detail.js';
+import { runBeadsSectionView, runDetailView } from './run-detail.js';
 
 function renderToString(template) {
   if (!template) return '';
@@ -80,5 +80,55 @@ describe('runBeadsSectionView - blocked state', () => {
     // Only "open" badge text, no "blocked" badge text
     const blockedCount = (out.match(/\bblocked\b/g) || []).length;
     expect(blockedCount).toBe(0);
+  });
+});
+
+describe('runDetailView - endTime for active runs', () => {
+  const startedAt = '2026-04-10T10:00:00Z';
+  const stageEnd = '2026-04-10T10:05:43Z';
+
+  function render(template) {
+    return renderToString(template?.overview ?? template);
+  }
+
+  it('does not show Finished label for an active run even if a stage has completed', () => {
+    const run = {
+      id: 'r1',
+      active: true,
+      started_at: startedAt,
+      stages: {
+        coordinate: { status: 'completed', completed_at: stageEnd },
+      },
+    };
+    const out = render(runDetailView(run));
+    expect(out).not.toContain('Finished:');
+  });
+
+  it('shows Finished label for a completed run', () => {
+    const run = {
+      id: 'r2',
+      active: false,
+      started_at: startedAt,
+      completed_at: '2026-04-10T11:00:00Z',
+      stages: {
+        coordinate: { status: 'completed', completed_at: stageEnd },
+      },
+    };
+    const out = render(runDetailView(run));
+    expect(out).toContain('Finished:');
+  });
+
+  it('does not show Finished for an inactive run with no completed_at but a finished stage', () => {
+    // Inactive run with no completed_at should still show stage-based end time
+    const run = {
+      id: 'r3',
+      active: false,
+      started_at: startedAt,
+      stages: {
+        coordinate: { status: 'completed', completed_at: stageEnd },
+      },
+    };
+    const out = render(runDetailView(run));
+    expect(out).toContain('Finished:');
   });
 });


### PR DESCRIPTION
## Summary

- **run-detail.js**: Check `run.active` before falling back to `_lastStageEnd()` when computing `endTime`, so active runs use `null` (current time) instead of the last completed stage's timestamp. Also fix `timingStripView` to show duration even without a `completedAt` (using `elapsed(start, null)` which falls back to `Date.now()`), and fix `pipelineWallMs` to use `elapsed(start, null)` for active runs — preventing timing bar overflow.
- **run-card.js**: Apply the same `endTime` fix, and reorder the duration ternary so the `isActive` branch is evaluated first (before `endTime`), ensuring active runs always show elapsed-to-now duration.
- Added tests in both test files covering: active run duration ignores stage end times, no "Finished" timestamp for active runs, correct "Finished" for completed/inactive runs.

## Test plan

- [x] `npm run lint` passes
- [x] `npx vitest run` — all 40 tests pass (33 run-card + 7 run-detail)
- [ ] Manual: start a pipeline, verify duration counts up and no "Finished" timestamp appears
- [ ] Manual: verify completed runs still show correct "Finished" timestamp and duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)