### PR TITLE
feat: extract hardcoded prompts into composable block files (W-037)

### DIFF
--- a/docs/plans/W-037-prompt-builder-template-extraction.md
+++ b/docs/plans/W-037-prompt-builder-template-extraction.md
@@ -635,22 +635,24 @@ This replaces the old `for key, value in template_vars.items(): content.replace(
 ```
 _render_agent_templates() — called once per run at startup (SIMPLIFIED):
 
-  For each agent .md in .claude/worca/agents/core/:
+  For each file in .claude/worca/agents/core/:
+    0. Skip .block.md files (they are resolved via resolve_block(), not as agent templates)
     1. Read core .md
     2. Overlay merge (project → template) via OverlayResolver.resolve()
     3. Write to {run_dir}/agents/{agent}.md
           ↑ This is the TEMPLATE — contains unresolved {{block:name}} and {{placeholder}} tokens
 
   (Step 2 from the old flow — {single-brace} substitution — is REMOVED.
-   All substitution now happens in resolve_agent() at stage invocation time.)
+   All substitution now happens in resolve_agent() at stage invocation time.
+   The .block.md exclusion filter prevents block files from being treated as agents.)
 ```
 
-**Important:** Block and placeholder resolution cannot happen at startup because context values (test failures, review issues, plan content) don't exist yet. The full resolution happens **per stage invocation** in `run_stage()`.
+**Important:** Block and placeholder resolution cannot happen at startup because context values (test failures, review issues, plan content) don't exist yet. The full resolution happens **per stage invocation** in the pipeline loop (runner.py:1416-1482), before `run_stage()` is called.
 
 ### Per-stage resolution flow
 
 ```
-run_stage() is called:
+Pipeline loop (before calling run_stage()):
   1. PromptBuilder.build_context(stage, iteration)
      - Selects which context values to populate (mode routing)
      - Pre-formats complex data (test failures → markdown)
@@ -660,7 +662,7 @@ run_stage() is called:
   3. resolve_agent(agent_content, context, resolver, core_dir, template_agents_dir)
      → produces the fully resolved agent document
   4. Write resolved content to a temp file
-  5. Pass temp file as --agent, work request as -p
+  5. Pass temp file as --agent override to run_stage(), work request as prompt_override
 ```
 
 ### What `-p` becomes
@@ -853,11 +855,24 @@ Add `resolve_block(block_name, core_dir, template_agents_dir)`:
 - `guardian.md` — add `{{block:pr}}`; remove REVIEW-related content
 - `learner.md` — add `{{block:learn}}` + 6-category analysis section
 
-### Task 6: Remove `{single-brace}` substitution from `_render_agent_templates()`
+### Task 6: Remove `{single-brace}` substitution from `_render_agent_templates()` and exclude `.block.md` files
 
 **Files:** Modify `src/worca/orchestrator/runner.py`
 
-Remove the `for key, value in template_vars.items(): content.replace(...)` loop from `_render_agent_templates()`. The function now only does: read core → overlay merge → write to `{run_dir}/agents/`. All placeholder substitution is deferred to `resolve_agent()` at stage invocation time.
+Two changes to `_render_agent_templates()`:
+
+1. **Add `.block.md` exclusion filter.** The existing loop iterates `os.listdir(src_dir)` filtering on `filename.endswith('.md')`. Files like `plan.block.md` match this filter and would be treated as agent templates — copied to `run_dir/agents/`, overlay-resolved as agents named `plan.block`, `implement.block`, etc. This creates a parallel overlay path that conflicts with the block-specific `resolve_block()` chain. Fix: add `if filename.endswith('.block.md'): continue` before the existing `.md` check, so block files are skipped entirely. Block files are only resolved through the `resolve_block()` chain at stage invocation time.
+
+```python
+for filename in os.listdir(src_dir):
+    if filename.endswith('.block.md'):
+        continue  # block files resolved via resolve_block(), not as agent templates
+    if not filename.endswith(".md"):
+        continue
+    # ... rest of loop
+```
+
+2. **Remove the `{single-brace}` substitution loop.** Delete the `for key, value in template_vars.items(): content.replace(...)` loop. The function now only does: read core → overlay merge → write to `{run_dir}/agents/`. All placeholder substitution is deferred to `resolve_agent()` at stage invocation time.
 
 Also delete `_STAGE_PROMPT_PREFIX` dict and `_build_stage_prompt()` function.
 
@@ -886,9 +901,28 @@ Extract list-formatting logic into helpers:
 
 **Files:** Modify `src/worca/orchestrator/prompt_builder.py`
 
+**Constructor change:** Add `resolver`, `core_dir`, and `template_agents_dir` parameters to `PromptBuilder.__init__()`. The current constructor (line 20-28) only accepts `work_request_title`, `work_request_description`, `claude_md_path`, `context_path`, and `master_plan_path`. The `build()` shim and `_load_agent_template()` need these to perform agent resolution. New signature:
+
+```python
+def __init__(self, work_request_title: str, work_request_description: str = "",
+             claude_md_path: str = "CLAUDE.md", context_path: str = None,
+             master_plan_path: str = "MASTER_PLAN.md",
+             resolver: OverlayResolver = None,
+             core_dir: str = None, template_agents_dir: str = None,
+             run_dir: str = None):
+    # ... existing init ...
+    self._resolver = resolver
+    self._core_dir = core_dir
+    self._template_agents_dir = template_agents_dir
+    self._run_dir = run_dir
+```
+
+All new parameters default to `None` for backward compatibility — existing callers that don't pass them still work (they just can't use the shim). The pipeline loop in runner.py (Task 10) passes these when constructing PromptBuilder.
+
 Add:
 - `build_context(stage, iteration) -> dict` — assembles context for block/placeholder resolution
 - `_apply_stage_context(stage, iteration, ctx)` — stage-specific context routing
+- `_load_agent_template(stage) -> str` — reads the overlay-merged agent `.md` template from `{run_dir}/agents/{agent}.md` (contains unresolved `{{block:name}}` and `{{placeholder}}` tokens)
 
 **Keep `build()` as a backward-compatible shim** during transition:
 
@@ -906,18 +940,25 @@ def build(self, stage: str, iteration: int = 0) -> str:
                          self._core_dir, self._template_agents_dir)
 ```
 
-This ensures the running pipeline (which uses the old `prompt_builder.build()` call in runner.py) continues to work even if Task 10 is not yet applied. The shim is removed as part of Task 10 when `run_stage()` is updated to call `build_context()` directly.
+This ensures the running pipeline (which uses the old `prompt_builder.build()` call in runner.py) continues to work even if Task 10 is not yet applied. The shim is removed as part of Task 10 when the pipeline loop is updated to call `build_context()` directly.
 
-### Task 10: Integrate per-stage resolution in runner.py
+### Task 10: Integrate per-stage resolution in the pipeline loop (runner.py)
 
 **Files:** Modify `src/worca/orchestrator/runner.py`
 
-Change `run_stage()`:
-- Call `prompt_builder.build_context(stage, iteration)` instead of `prompt_builder.build()`
-- Read agent `.md` template from `{run_dir}/agents/` (contains unresolved `{{block:name}}` and `{{placeholder}}` tokens)
-- Call `resolve_agent(content, context, ...)` to produce fully resolved agent document
-- Write to temp file, pass as `--agent`
-- Pass minimal work request as `-p`
+**Important:** The primary call site for `prompt_builder.build()` is the main pipeline loop at runner.py:1422 (`rendered_prompt = prompt_builder.build(current_stage.value, pb_iteration)`), NOT `run_stage()`. `run_stage()` receives the already-built prompt via `prompt_override`. The build happens in the loop before `run_stage()` is called (runner.py:1479-1482).
+
+Change the pipeline loop (around runner.py:1416-1482):
+1. Replace `prompt_builder.build(current_stage.value, pb_iteration)` with `prompt_builder.build_context(current_stage.value, pb_iteration)` to get the context dict
+2. Read the agent `.md` template from `{run_dir}/agents/{agent}.md` (overlay already applied, contains unresolved `{{block:name}}` and `{{placeholder}}` tokens). Use `STAGE_AGENT_MAP` to determine the agent name for the current stage
+3. Call `resolve_agent(agent_content, context, resolver, core_dir, template_agents_dir)` to produce the fully resolved agent document
+4. Write the resolved agent document to a temp file
+5. Pass the temp file path to `run_stage()` as an `--agent` override (or modify `run_stage()`/`run_agent()` to accept a resolved agent content parameter)
+6. Pass minimal work request (title + description) as `prompt_override` instead of the full PromptBuilder output
+
+Also update the PromptBuilder constructor call in the pipeline loop to pass the new parameters (`resolver`, `core_dir`, `template_agents_dir`, `run_dir`).
+
+Remove the `build()` shim from PromptBuilder (added in Task 9 as a transitional measure) — it is no longer needed once this task is complete.
 
 ### Task 11: Update tests
 
@@ -1048,6 +1089,13 @@ The tester agent's own prompt is built by the old `.claude/worca/` code. `pytest
 | `test_resolve_block_empty_override` | Empty project file → empty string (block removed) |
 | `test_resolve_block_introduced_by_project` | No core, project provides → returns content |
 | `test_resolve_block_introduced_by_template` | No core/project, template provides → returns content |
+
+**Agent template rendering (`tests/test_runner.py` or `tests/test_render_agent_templates.py`):**
+
+| Test | What it verifies |
+|---|---|
+| `test_render_agent_templates_skips_block_files` | `.block.md` files in `agents/core/` are NOT copied to `run_dir/agents/` or overlay-resolved as agent templates |
+| `test_render_agent_templates_copies_agent_md` | Regular `.md` files (e.g. `planner.md`) are still copied and overlay-resolved |
 
 **Pre-formatting helpers (`tests/test_prompt_builder.py` — rewritten):**
 
@@ -1203,9 +1251,12 @@ Verify the pipeline completes successfully — planner produces a plan, coordina
 - [ ] Three-tier overlay chain works for `.block.md` files (core → project → template)
 - [ ] Pipeline templates can override blocks, introduce new blocks, or remove blocks via empty overrides
 - [ ] All 6 builtin pipeline templates migrated to `<!-- append -->` mode
+- [ ] `_render_agent_templates()` skips `.block.md` files (exclusion filter prevents block files from being treated as agent templates)
 - [ ] `{single-brace}` substitution loop removed from `_render_agent_templates()`
 - [ ] `_STAGE_PROMPT_PREFIX` and `_build_stage_prompt()` deleted
+- [ ] PromptBuilder constructor accepts `resolver`, `core_dir`, `template_agents_dir`, `run_dir` parameters
 - [ ] PromptBuilder refactored to context assembler — `build_context()` replaces `build()`
+- [ ] Pipeline loop (runner.py:~1422) calls `build_context()` + `resolve_agent()` instead of `build()`
 - [ ] `-p` reduced to minimal work request
 - [ ] Learner analysis instructions moved to `learner.md`
 - [ ] Implementer retry rules moved to `implementer.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "worca-cc"
-version = "0.10.0"
+version = "0.10.0rc1"
 description = "Autonomous software development pipeline combining orchestration with governance enforcement"
 readme = "src/worca/README.md"
 license = "MIT"

--- a/src/worca/__init__.py
+++ b/src/worca/__init__.py
@@ -1,3 +1,3 @@
 """worca-cc: Autonomous software development pipeline with governance enforcement."""
 
-__version__ = "0.10.0"
+__version__ = "0.10.0rc1"

--- a/src/worca/agents/core/coordinate.block.md
+++ b/src/worca/agents/core/coordinate.block.md
@@ -1,0 +1,9 @@
+## Work Request
+
+{{work_request}}
+
+{{#if plan_summary}}
+## Approved Plan
+
+{{plan_summary}}
+{{/if}}

--- a/src/worca/agents/core/coordinator.md
+++ b/src/worca/agents/core/coordinator.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-You are the Coordinator. You read the approved plan at `{plan_file}` and decompose it into fine-grained Beads tasks with dependencies.
+You are the Coordinator. You read the approved plan at `{{plan_file}}` and decompose it into fine-grained Beads tasks with dependencies.
 
 ## Context
 
@@ -10,14 +10,16 @@ You receive the approved plan and access to the Beads CLI (`bd`).
 
 ## Process
 
-1. Read `{plan_file}`
+1. Read `{{plan_file}}`
 2. Break down into atomic implementation tasks
-3. Create Beads tasks: `bd create --title="..." --type=task --labels "run:{run_id}"` — the `--labels "run:{run_id}"` flag is **required** on every `bd create` call
+3. Create Beads tasks: `bd create --title="..." --type=task --labels "run:{{run_id}}"` — the `--labels "run:{{run_id}}"` flag is **required** on every `bd create` call
 4. Set dependencies: `bd dep add <downstream> <upstream>`
 5. Identify parallel execution groups
 6. Output the coordination result
 
 Note: Beads initialization is handled automatically by the pipeline runner before this agent starts.
+
+{{block:coordinate}}
 
 ## Output
 
@@ -33,6 +35,6 @@ Produce a structured result following the `coordinate.json` schema.
 - Tasks with no blockers can run in parallel
 - Use descriptive task titles that include the file/module being modified
 - You MUST create Beads tasks with `bd create` — this is your primary job. Do not skip this step.
-- ALWAYS pass `--labels "run:{run_id}"` when creating tasks so they are linked to this pipeline run.
+- ALWAYS pass `--labels "run:{{run_id}}"` when creating tasks so they are linked to this pipeline run.
 - Verify tasks were created by running `bd list` before producing output
 - Create tasks one at a time (one `bd create` per tool call). Do NOT batch multiple bd commands in parallel.

--- a/src/worca/agents/core/guardian.md
+++ b/src/worca/agents/core/guardian.md
@@ -2,39 +2,38 @@
 
 ## Role
 
-You are the Guardian. You require proof of testing before creating a PR, then run the code review loop.
+You are the Guardian. You require proof of testing and a passing code review before creating a PR.
 
 ## Context
 
-You receive the test results and proof status from the Tester. You have access to git and the project's code hosting CLI (see CLAUDE.md).
+You receive the review outcome and proof status from the Reviewer. You have access to git and the project's code hosting CLI (see CLAUDE.md).
 
 ## Process
 
 1. Verify proof status = verified (reject if failed)
-2. Review all changes against the base branch: detect it via `git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||'` or fall back to `main`/`master`, then run `git diff <base>..HEAD`
+2. Verify review outcome = approve (reject if request_changes or reject)
 3. Create a PR/MR using the project's hosting CLI as documented in CLAUDE.md
-4. Run code review (up to 5 iterations):
-   - Review code for quality, security, correctness
-   - If issues found, send feedback to Implementer
-   - Wait for fixes, re-run Tester
-   - Review again
-5. When satisfied, mark PR as ready for human review
-6. Wait for PRE-PR APPROVAL milestone gate
+4. When satisfied, mark PR as ready for human review
+5. Wait for PRE-PR APPROVAL milestone gate
 
 ## PR Review Outcomes
 
 | Outcome | Action |
 |---------|--------|
-| Approve | Merge PR → deploy hook point |
-| Request Changes | Feedback → Implementer → Tester → Guardian updates PR |
+| Approve | Create PR → wait for human review |
 | Reject | Close PR, clean up worktree, stop pipeline |
 | Restart Planning | Close PR, clean up, send back to Planner |
+
+{{block:pr}}
+
+## Output
+
+Produce a structured result following the `pr.json` schema.
 
 ## Rules
 
 <!-- governance -->
-- NEVER merge without proof status = verified
+- NEVER create a PR without proof status = verified
 - NEVER skip the human approval gate
 - Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
-- Maximum 5 code review iterations before escalating
 - Clean up worktrees on rejection

--- a/src/worca/agents/core/implement.block.md
+++ b/src/worca/agents/core/implement.block.md
@@ -1,0 +1,41 @@
+{{#if is_retry}}
+## PRIORITY: Fix {{issue_type}} (attempt {{attempt_count}})
+
+{{#if test_failures_formatted}}
+### Failures to Fix
+
+{{test_failures_formatted}}
+{{/if}}
+
+{{#if review_issues_formatted}}
+### Issues to Fix
+
+{{review_issues_formatted}}
+{{/if}}
+
+{{#if previous_attempts}}
+### Previous Attempts (all failed to resolve)
+
+{{previous_attempts}}
+{{/if}}
+
+---
+
+### Reference: Task & Plan (already implemented)
+
+{{#if assigned_task}}
+{{assigned_task}}
+
+{{/if}}
+{{work_request}}
+{{else}}
+{{#if assigned_task}}
+## Assigned Task
+
+{{assigned_task}}
+{{/if}}
+
+## Work Request
+
+{{work_request}}
+{{/if}}

--- a/src/worca/agents/core/implementer.md
+++ b/src/worca/agents/core/implementer.md
@@ -22,6 +22,8 @@ You work on a single Beads task at a time in an isolated worktree.
 5. Close the task: `bd close <id>`
 6. If you discover new work needed, create a Beads task: `bd create --title="..."`
 
+{{block:implement}}
+
 ## Fix Mode
 
 When your prompt says "Fix All Issues" or "Fix Test Failures" or "Fix Review Issues":
@@ -32,6 +34,12 @@ When your prompt says "Fix All Issues" or "Fix Test Failures" or "Fix Review Iss
 4. Run only the tests related to the files you changed to verify your fixes. Do NOT run the full test suite — the Tester stage handles that
 5. Do NOT use `bd ready` or `bd close` — you are fixing, not implementing new tasks
 6. Produce a structured result with all files you changed
+
+## Retry Rules
+
+- After making each fix, read back the changed lines to confirm the fix is correct
+- Do NOT re-implement the plan from scratch
+- Do NOT just rebuild and exit
 
 ## Output
 

--- a/src/worca/agents/core/learn.block.md
+++ b/src/worca/agents/core/learn.block.md
@@ -1,0 +1,28 @@
+## Work Request
+
+{{work_request}}
+
+## Termination
+
+**Type:** {{termination_type|unknown}}
+{{#if termination_reason}}
+**Reason:** {{termination_reason}}
+{{/if}}
+
+{{#if plan_content}}
+## Plan File
+
+{{plan_content}}
+{{/if}}
+
+## Run Reference
+
+**Run ID:** `{{run_id}}`
+**Run directory:** `.worca/runs/{{run_id}}/`
+**Logs directory:** `.worca/runs/{{run_id}}/logs/`
+
+## Run Data
+
+```json
+{{run_data}}
+```

--- a/src/worca/agents/core/learner.md
+++ b/src/worca/agents/core/learner.md
@@ -18,6 +18,8 @@ You receive the full pipeline run status (all stages, iterations, outputs, error
 6. **Rate each observation by importance** — use `critical` (blocked the run or caused failure), `high` (significant waste or recurring), `medium` (notable but contained), `low` (minor or one-off)
 7. **Formulate targeted suggestions** — link each suggestion to specific observations by index, target the appropriate artifact (prompt, config, plan template, spec template)
 
+{{block:learn}}
+
 ## Output
 
 Produce a structured result following the `learn.json` schema (LearnOutput). The output must include:

--- a/src/worca/agents/core/plan-review.block.md
+++ b/src/worca/agents/core/plan-review.block.md
@@ -1,0 +1,22 @@
+## Work Request
+
+{{work_request}}
+
+{{#if plan_content}}
+## Implementation Plan
+
+{{plan_content}}
+{{else}}
+## Implementation Plan
+
+*Plan file not found or empty — this is itself a critical issue to report.*
+{{/if}}
+
+{{#if plan_review_history_formatted}}
+## Previous Review Attempts
+
+{{plan_review_history_formatted}}
+
+Check whether the issues from previous review attempts have been addressed
+in the revised plan above.
+{{/if}}

--- a/src/worca/agents/core/plan.block.md
+++ b/src/worca/agents/core/plan.block.md
@@ -1,0 +1,42 @@
+{{#if plan_revision_mode}}
+## Revision Required
+
+The plan reviewer has identified issues that must be addressed.
+Revise the existing plan — do NOT start from scratch.
+
+## Work Request
+
+{{work_request}}
+
+{{#if plan_content}}
+## Current Plan
+
+{{plan_content}}
+{{/if}}
+
+{{#if plan_review_issues_formatted}}
+## Issues to Address
+
+{{plan_review_issues_formatted}}
+{{/if}}
+
+{{#if plan_review_history_formatted}}
+## Review History
+
+{{plan_review_history_formatted}}
+{{/if}}
+
+Address each issue above. Preserve all parts of the plan that were not flagged.
+Write the updated plan. In your JSON output, set `approved: true` to signal
+that the revised plan is ready for review.
+{{else}}
+## Work Request
+
+{{work_request}}
+
+{{#if claude_md}}
+## Project Context (from CLAUDE.md)
+
+{{claude_md}}
+{{/if}}
+{{/if}}

--- a/src/worca/agents/core/plan_reviewer.md
+++ b/src/worca/agents/core/plan_reviewer.md
@@ -38,6 +38,8 @@ You receive the current implementation plan and the original work request. Your 
 
 12. **Produce output** — write `plan_review.json` following the schema below with your outcome, issues list, and summary
 
+{{block:plan-review}}
+
 ## Output
 
 Produce a structured result following the `plan_review.json` schema:

--- a/src/worca/agents/core/planner.md
+++ b/src/worca/agents/core/planner.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-You are the Planner. You create plan files that define the architecture, approach, and scope for a work request. The plan file path is `{plan_file}`.
+You are the Planner. You create plan files that define the architecture, approach, and scope for a work request. The plan file path is `{{plan_file}}`.
 
 ## Context
 
@@ -14,13 +14,15 @@ You receive a work request (hosted issue, Beads task, prompt, or spec file) and 
 2. Read CLAUDE.md for project context: tech stack, build/test commands, architecture overview, and coding conventions
 3. Explore the codebase to understand existing architecture
 4. Identify affected components and potential risks
-5. Create `{plan_file}` with:
+5. Create `{{plan_file}}` with:
    - Problem statement
    - Proposed approach
    - Task breakdown (high-level)
    - Test strategy
    - Branch naming
 6. Set `approved: true` in your output — plan approval is handled by the pipeline
+
+{{block:plan}}
 
 ## Output
 
@@ -33,7 +35,7 @@ Produce a structured plan following the `plan.json` schema.
 - Do NOT run tests — test commands are blocked by guard hooks
 - Do NOT create branches or worktrees
 - Do NOT commit code changes — your only output is the structured plan JSON
-- Your ONLY writable file is `{plan_file}` — all other writes are blocked
+- Your ONLY writable file is `{{plan_file}}` — all other writes are blocked
 - Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
 - Delegate to Explore sub-agents for codebase research if needed
 - Keep plans focused and scoped — avoid feature creep

--- a/src/worca/agents/core/pr.block.md
+++ b/src/worca/agents/core/pr.block.md
@@ -1,0 +1,9 @@
+## Work Request
+
+{{work_request}}
+
+{{#if plan_approach}}
+## Approach
+
+{{plan_approach}}
+{{/if}}

--- a/src/worca/agents/core/review.block.md
+++ b/src/worca/agents/core/review.block.md
@@ -1,0 +1,15 @@
+## Work Request
+
+{{work_request}}
+
+{{#if test_results}}
+## Test Results
+
+{{test_results}}
+{{/if}}
+
+{{#if files_changed_formatted}}
+## Files Changed
+
+{{files_changed_formatted}}
+{{/if}}

--- a/src/worca/agents/core/reviewer.md
+++ b/src/worca/agents/core/reviewer.md
@@ -1,0 +1,70 @@
+# Reviewer Agent
+
+## Role
+
+You are the Reviewer. You perform code review after testing passes, then send feedback to the Implementer or approve the changes for the PR stage.
+
+## Context
+
+You receive the test results and proof status from the Tester. You have read-only access to the codebase and git history.
+
+## Process
+
+1. Verify proof status = verified (return `reject` immediately if failed)
+2. Review all changes against the base branch:
+   - Detect base branch via `git symbolic-ref refs/remotes/origin/HEAD | sed 's|refs/remotes/origin/||'` or fall back to `main`/`master`
+   - Run `git diff <base>..HEAD` to see all changed files
+3. For each changed file, evaluate:
+   - **Correctness** — logic errors, off-by-one errors, missing edge cases
+   - **Security** — command injection, XSS, SQL injection, exposed secrets, missing auth/authz
+   - **Quality** — naming clarity, dead code, unnecessary complexity, violated project conventions
+   - **Test coverage** — are the changes adequately tested? Are critical paths covered?
+4. Categorize issues by severity (see Output section)
+5. Decide outcome based on findings (see Review Outcomes)
+
+{{block:review}}
+
+## Implementer Capabilities
+
+When sending feedback to the Implementer, be specific:
+- Reference exact file paths and line numbers where possible
+- Describe the problem, not just the symptom
+- Suggest a fix only when the correct approach is clear
+- Group related issues together
+
+## Output
+
+Produce a structured result following the `review.json` schema:
+
+- `outcome`: `"approve"` | `"request_changes"` | `"reject"` | `"restart_planning"`
+- `issues`: array of issue objects with `file`, `line` (optional), `severity`, and `description`
+- `iteration_count`: integer — which review iteration this is (start at 1)
+
+**Severity levels:**
+- `critical` — security vulnerability, data loss risk, or broken functionality; must be fixed before approve
+- `major` — significant correctness or quality issue that will likely cause problems
+- `minor` — notable but acceptable; can be fixed in a follow-up
+- `suggestion` — improvement opportunity, not a problem
+
+Only `critical` and `major` issues should trigger `"request_changes"`. `minor` and `suggestion` issues are logged but outcome is `"approve"`.
+
+## Review Outcomes
+
+| Outcome | Condition | Action |
+|---------|-----------|--------|
+| `approve` | No critical or major issues | Pass to PR stage |
+| `request_changes` | Critical or major issues found | Send feedback to Implementer |
+| `reject` | Proof status failed, or fundamental approach is wrong | Stop pipeline |
+| `restart_planning` | Requirements misunderstood or scope wrong | Send back to Planner |
+
+Maximum 5 review iterations before escalating to `reject`.
+
+## Rules
+
+<!-- governance -->
+- Read-only — do NOT modify source code, tests, or any other files
+- Do NOT run `git commit` — only the guardian may commit
+- Do NOT create PRs — that is the guardian's responsibility (PR stage)
+- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
+- Maximum 5 review iterations before escalating
+- Report only real issues with clear evidence — no speculation, no padding

--- a/src/worca/agents/core/test.block.md
+++ b/src/worca/agents/core/test.block.md
@@ -1,0 +1,9 @@
+## Work Request
+
+{{work_request}}
+
+{{#if implementation_summary}}
+## Implementation Summary
+
+{{implementation_summary}}
+{{/if}}

--- a/src/worca/agents/core/tester.md
+++ b/src/worca/agents/core/tester.md
@@ -16,6 +16,8 @@ You run after all Implementer tasks are complete. You verify that the full syste
 4. Collect proof artifacts (test output, coverage reports)
 5. Set proof status: verified or failed
 
+{{block:test}}
+
 ## Output
 
 Produce a structured result following the `test_result.json` schema.

--- a/src/worca/cli/init.py
+++ b/src/worca/cli/init.py
@@ -136,6 +136,16 @@ def _migrate_settings_paths(settings: dict) -> tuple[dict, list[str]]:
         changes.append("  agent_overrides_dir: .claude/agents/overrides -> .claude/agents")
         migrated["worca"] = worca_cfg
 
+    # Migrate review stage agent: guardian -> reviewer (W-037)
+    stages_cfg = worca_cfg.get("stages", {})
+    review_cfg = stages_cfg.get("review", {})
+    if review_cfg.get("agent") == "guardian":
+        review_cfg["agent"] = "reviewer"
+        stages_cfg["review"] = review_cfg
+        worca_cfg["stages"] = stages_cfg
+        migrated["worca"] = worca_cfg
+        changes.append("  stages.review.agent: guardian -> reviewer")
+
     return migrated, changes
 
 

--- a/src/worca/hooks/guard.py
+++ b/src/worca/hooks/guard.py
@@ -201,8 +201,8 @@ def check_guard(tool_name: str, tool_input: dict) -> tuple:
                 if basename != "MASTER_PLAN.md" and not re.match(r'^plan-\d{3}\.md$', basename):
                     return (2, "Blocked: planner agent may only write MASTER_PLAN.md or plan-NNN.md, not {}.".format(basename))
 
-        # Read-only agents: coordinator, tester, and plan_reviewer may not write files
-        read_only_agents = ("coordinator", "tester", "plan_reviewer")
+        # Read-only agents: coordinator, tester, plan_reviewer, and reviewer may not write files
+        read_only_agents = ("coordinator", "tester", "plan_reviewer", "reviewer")
         if agent in read_only_agents:
             if tool_name in ("Write", "Edit"):
                 return (2, "Blocked: {} agent is read-only — may not write files.".format(agent))

--- a/src/worca/orchestrator/overlay.py
+++ b/src/worca/orchestrator/overlay.py
@@ -3,6 +3,11 @@
 Override behavior (replace by default):
 - No tag or <!-- replace -->: replace the base prompt entirely
 - <!-- append -->: merge sections into base using section merge
+
+Template engine (resolve_placeholders, resolve_blocks, resolve_agent):
+- {{name}} / {{name|default}} — simple placeholder substitution
+- {{#if name}}...{{/if}} / {{#if name}}...{{else}}...{{/if}} — conditionals
+- {{block:name}} — block insertion via three-tier overlay chain
 """
 
 import os
@@ -136,6 +141,93 @@ class OverlayResolver:
 
         return result
 
+    def resolve_block(
+        self,
+        block_name: str,
+        core_dir: str,
+        template_agents_dir: str | None = None,
+    ) -> str | None:
+        """Resolve a block file through the three-tier overlay chain.
+
+        Resolution order:
+        1. core block:    core_dir/{block_name}.block.md
+        2. project overlay: overrides_dir/{block_name}.block.md
+        3. template overlay: template_agents_dir/{block_name}.block.md
+
+        Returns None if no tier provides the block file.
+        Uses the same replace/append overlay logic as agent .md resolution.
+        """
+        core_path = os.path.join(core_dir, f"{block_name}.block.md")
+        project_path = os.path.join(self.overrides_dir, f"{block_name}.block.md")
+        tpl_path = (
+            os.path.join(template_agents_dir, f"{block_name}.block.md")
+            if template_agents_dir
+            else None
+        )
+
+        any_exists = (
+            os.path.exists(core_path)
+            or os.path.exists(project_path)
+            or (tpl_path is not None and os.path.exists(tpl_path))
+        )
+        if not any_exists:
+            return None
+
+        # Load core content as the base
+        result = ""
+        if os.path.exists(core_path):
+            try:
+                with open(core_path) as f:
+                    result = f.read().strip()
+            except (OSError, PermissionError) as exc:
+                print(
+                    f"[overlay] Warning: cannot read block '{core_path}': {exc}",
+                    file=sys.stderr,
+                )
+
+        # Apply project overlay
+        result = self._apply_block_overlay(block_name, result, self.overrides_dir)
+
+        # Apply template overlay
+        if template_agents_dir is not None:
+            result = self._apply_block_overlay(block_name, result, template_agents_dir)
+
+        return result
+
+    def _apply_block_overlay(self, block_name: str, base: str, agents_dir: str) -> str:
+        """Apply a single block overlay tier from agents_dir onto base.
+
+        Looks for {block_name}.block.md in agents_dir and applies the same
+        replace/append logic as _apply_overlay.
+        """
+        overlay_path = os.path.join(agents_dir, f"{block_name}.block.md")
+
+        if not os.path.exists(overlay_path):
+            return base
+
+        try:
+            with open(overlay_path) as f:
+                overlay_content = f.read()
+        except (OSError, PermissionError) as exc:
+            print(
+                f"[overlay] Warning: cannot read block overlay '{overlay_path}': {exc}",
+                file=sys.stderr,
+            )
+            return base
+
+        stripped = overlay_content.lstrip()
+
+        if stripped.startswith("<!-- append -->"):
+            overlay_body = stripped[len("<!-- append -->"):]
+            return self._apply_append_mode(block_name, base, overlay_body)
+
+        if stripped.startswith("<!-- replace -->"):
+            content = stripped[len("<!-- replace -->"):]
+        else:
+            content = overlay_content
+
+        return content.strip()
+
     def _apply_overlay(self, agent_name: str, base: str, agents_dir: str) -> str:
         """Apply a single overlay tier from agents_dir onto base."""
         overlay_path = os.path.join(agents_dir, f"{agent_name}.md")
@@ -217,3 +309,116 @@ def _apply_append(section: dict, override_body: str) -> None:
     if not body.endswith("\n"):
         body += "\n"
     section["body"] = body + "\n" + override_body
+
+
+# ---------------------------------------------------------------------------
+# Template engine — placeholder and block resolution
+# ---------------------------------------------------------------------------
+
+# Matches the innermost {{#if name}}...{{/if}} block (no nested {{#if inside).
+# Uses a tempered greedy token to avoid matching across nested conditionals.
+_INNER_COND_RE = re.compile(
+    r"\{\{#if (\w+)\}\}"
+    r"((?:(?!\{\{#if )[\s\S])*?)"
+    r"\{\{/if\}\}",
+    re.DOTALL,
+)
+
+# Matches {{name}} or {{name|default text}} but not {{block:...}}, {{#...}}, {{/...}}.
+_PLACEHOLDER_RE = re.compile(
+    r"\{\{(?!block:|#|/)([a-zA-Z_][a-zA-Z0-9_]*)(?:\|([^}]*))?\}\}"
+)
+
+# Matches {{block:name}} on its own line (block references must be line-isolated).
+_BLOCK_RE = re.compile(r"^\{\{block:(\S+)\}\}\s*$", re.MULTILINE)
+
+
+def resolve_placeholders(content: str, context: dict) -> str:
+    """Resolve {{name}}, {{name|default}}, and {{#if}}...{{/if}} in content.
+
+    Processing order:
+    1. Conditionals — resolved innermost-first to support nesting.
+    2. Simple placeholders — {{name}} and {{name|default}}.
+    """
+    # Step 1: resolve conditionals (inside-out for nesting support)
+    prev = None
+    while content != prev:
+        prev = content
+
+        def _replace_cond(m: re.Match) -> str:
+            key = m.group(1)
+            body = m.group(2)
+            parts = body.split("{{else}}", 1)
+            if_body = parts[0]
+            else_body = parts[1] if len(parts) > 1 else ""
+            return if_body if context.get(key) else else_body
+
+        content = _INNER_COND_RE.sub(_replace_cond, content)
+
+    # Step 2: resolve simple placeholders
+    def _replace_ph(m: re.Match) -> str:
+        key = m.group(1)
+        default = m.group(2)
+        if default is not None:
+            return str(context.get(key, default))
+        return str(context.get(key, ""))
+
+    return _PLACEHOLDER_RE.sub(_replace_ph, content)
+
+
+def resolve_blocks(
+    content: str,
+    context: dict,
+    resolver: "OverlayResolver",
+    core_dir: str,
+    template_agents_dir: str | None = None,
+    _seen: set | None = None,
+) -> str:
+    """Replace {{block:name}} references with resolved block content.
+
+    Each block is loaded via resolver.resolve_block() through the three-tier
+    overlay chain. Blocks may embed other blocks (recursive). Cycle detection
+    prevents infinite loops — a block that would recurse into itself is skipped
+    (resolved to empty string at the recursive call site).
+
+    Block references must appear on their own line: ``{{block:name}}``.
+    """
+    if _seen is None:
+        _seen = set()
+
+    def _replace_block(m: re.Match) -> str:
+        block_name = m.group(1)
+        if block_name in _seen:
+            return ""  # cycle detected — skip this reference
+        block_content = resolver.resolve_block(block_name, core_dir, template_agents_dir)
+        if block_content is None:
+            return ""  # block doesn't exist at any tier
+        _seen.add(block_name)
+        resolved = resolve_blocks(
+            block_content, context, resolver, core_dir, template_agents_dir, _seen
+        )
+        _seen.discard(block_name)
+        return resolved.strip()
+
+    return _BLOCK_RE.sub(_replace_block, content)
+
+
+def resolve_agent(
+    content: str,
+    context: dict,
+    resolver: "OverlayResolver",
+    core_dir: str,
+    template_agents_dir: str | None = None,
+) -> str:
+    """Full agent .md resolution pipeline: blocks → conditionals → placeholders → cleanup.
+
+    Steps:
+    1. Resolve {{block:name}} references (recursive, with cycle detection).
+    2. Resolve {{#if}}...{{/if}} conditionals.
+    3. Resolve {{name}} and {{name|default}} placeholders.
+    4. Collapse 3+ consecutive blank lines to 2.
+    """
+    result = resolve_blocks(content, context, resolver, core_dir, template_agents_dir)
+    result = resolve_placeholders(result, context)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result

--- a/src/worca/orchestrator/prompt_builder.py
+++ b/src/worca/orchestrator/prompt_builder.py
@@ -302,8 +302,12 @@ class PromptBuilder:
             return ""
 
     def _work_request_section(self) -> str:
-        """Common work request section included in all prompts."""
-        return f"## Work Request\n\n**{self._title}**\n\n{self._description}"
+        """Common work request content for {{work_request}} placeholder.
+
+        Returns title + description only — no heading. Block files provide
+        the ## Work Request heading so template authors control structure.
+        """
+        return f"**{self._title}**\n\n{self._description}"
 
     # -- Pre-formatting helpers ------------------------------------------------
 

--- a/src/worca/orchestrator/prompt_builder.py
+++ b/src/worca/orchestrator/prompt_builder.py
@@ -177,7 +177,9 @@ class PromptBuilder:
                 )
 
         elif stage == "plan_review":
-            ctx["plan_content"] = self._read_master_plan()
+            # Prefer plan content already in context (set by runner after PLAN stage)
+            # to avoid race condition where the file isn't flushed yet
+            ctx["plan_content"] = ctx.get("plan_file_content") or self._read_master_plan()
             if iteration > 0:
                 ctx["plan_review_history_formatted"] = self._format_plan_review_history(
                     ctx.get("plan_review_history") or []

--- a/src/worca/orchestrator/prompt_builder.py
+++ b/src/worca/orchestrator/prompt_builder.py
@@ -15,17 +15,28 @@ class PromptBuilder:
     """Builds contextual prompts for each pipeline stage.
 
     Accumulates inter-stage outputs and renders stage-appropriate prompts.
+    Acts as a context assembler: build_context() returns a dict used by
+    resolve_agent() in the pipeline loop to substitute placeholders in agent
+    .md templates.
     """
+
+    _MAX_STATUS_JSON_LEN = 50_000  # truncate serialised status beyond this
 
     def __init__(self, work_request_title: str, work_request_description: str = "",
                  claude_md_path: str = "CLAUDE.md", context_path: str = None,
-                 master_plan_path: str = "MASTER_PLAN.md"):
+                 master_plan_path: str = "MASTER_PLAN.md",
+                 resolver=None, core_dir: str = None,
+                 template_agents_dir: str = None, run_dir: str = None):
         self._title = work_request_title
         self._description = work_request_description or work_request_title
         self._context: dict = {}
         self._context_path = context_path
         self._claude_md_content = self._read_claude_md(claude_md_path)
         self._master_plan_path = master_plan_path
+        self._resolver = resolver
+        self._core_dir = core_dir
+        self._template_agents_dir = template_agents_dir
+        self._run_dir = run_dir
 
     @staticmethod
     def _read_claude_md(path: str) -> str:
@@ -121,425 +132,306 @@ class PromptBuilder:
         except (OSError, json.JSONDecodeError):
             pass
 
-    def build(self, stage: str, iteration: int = 0) -> str:
-        """Render the user prompt for the given stage.
+    def build_context(self, stage: str, iteration: int = 0) -> dict:
+        """Assemble the context dict for block/placeholder resolution.
+
+        Returns a dict containing all inter-stage context values plus
+        computed values for the given stage and iteration. This dict is
+        used by resolve_agent() to substitute {{placeholder}} tokens and
+        resolve {{block:name}} references in agent .md templates.
 
         Args:
-            stage: Pipeline stage name (plan, coordinate, implement, test, review, pr).
+            stage: Pipeline stage name.
             iteration: Loop iteration number (0 = first run, >0 = retry).
 
         Returns:
-            Fully rendered prompt string.
+            Context dict with all keys needed for block/placeholder resolution.
         """
-        builder = getattr(self, f"_build_{stage}", None)
-        if builder is None:
-            return self._work_request_section()
-        return builder(iteration)
+        ctx = dict(self._context)
+        ctx["work_request"] = self._work_request_section()
+        ctx["assigned_task"] = self._assigned_task_body()
+        self._apply_stage_context(stage, iteration, ctx)
+        return ctx
+
+    def _apply_stage_context(self, stage: str, iteration: int, ctx: dict) -> None:
+        """Populate stage-specific context keys in-place.
+
+        Handles mode routing (e.g. plan_revision_mode, is_retry) and
+        pre-formats complex data structures into Markdown strings before
+        storing them as context values for placeholder substitution.
+
+        Args:
+            stage: Pipeline stage name.
+            iteration: Loop iteration number.
+            ctx: Context dict to mutate in place.
+        """
+        if stage == "plan":
+            ctx["claude_md"] = self._claude_md_content
+            if ctx.get("plan_revision_mode"):
+                ctx["plan_content"] = self._read_master_plan()
+                ctx["plan_review_issues_formatted"] = self._format_plan_review_issues(
+                    ctx.get("plan_review_issues") or []
+                )
+                ctx["plan_review_history_formatted"] = self._format_plan_review_history(
+                    ctx.get("plan_review_history") or []
+                )
+
+        elif stage == "plan_review":
+            ctx["plan_content"] = self._read_master_plan()
+            if iteration > 0:
+                ctx["plan_review_history_formatted"] = self._format_plan_review_history(
+                    ctx.get("plan_review_history") or []
+                )
+            else:
+                ctx["plan_review_history_formatted"] = ""
+
+        elif stage == "coordinate":
+            approach = ctx.get("plan_approach")
+            tasks_outline = ctx.get("plan_tasks_outline")
+            if approach or tasks_outline:
+                parts = []
+                if approach:
+                    parts.append(f"**Approach:** {approach}")
+                if tasks_outline:
+                    outline_text = "\n".join(
+                        f"- {t.get('title', 'Untitled')}: {t.get('description', '')}"
+                        for t in tasks_outline
+                    )
+                    parts.append(f"**Task Outline:**\n{outline_text}")
+                ctx["plan_summary"] = "\n\n".join(parts)
+            else:
+                ctx["plan_summary"] = ""
+
+        elif stage == "implement":
+            ctx["is_retry"] = iteration > 0
+            if iteration > 0:
+                test_failures = ctx.get("test_failures")
+                review_issues = ctx.get("review_issues")
+                review_history = ctx.get("review_history") or []
+                test_failure_history = ctx.get("test_failure_history") or []
+                attempt_count = len(review_history) or len(test_failure_history) or iteration
+
+                if test_failures:
+                    ctx["issue_type"] = "Test Failures"
+                elif review_issues:
+                    ctx["issue_type"] = "Review Issues"
+                else:
+                    ctx["issue_type"] = "Issues"
+
+                ctx["attempt_count"] = attempt_count
+                ctx["test_failures_formatted"] = self._format_test_failures(test_failures or [])
+                ctx["review_issues_formatted"] = self._format_review_issues(review_issues or [])
+
+                if len(review_history) > 1:
+                    ctx["previous_attempts"] = self._format_review_history(review_history[:-1])
+                elif len(test_failure_history) > 1:
+                    ctx["previous_attempts"] = self._format_test_failure_history(
+                        test_failure_history[:-1]
+                    )
+                else:
+                    ctx["previous_attempts"] = ""
+            else:
+                ctx["issue_type"] = ""
+                ctx["attempt_count"] = 0
+                ctx["test_failures_formatted"] = ""
+                ctx["review_issues_formatted"] = ""
+                ctx["previous_attempts"] = ""
+
+        elif stage == "test":
+            files_changed = ctx.get("files_changed")
+            tests_added = ctx.get("tests_added")
+            ctx["implementation_summary"] = self._format_implementation_summary(
+                files_changed or [], tests_added or []
+            )
+
+        elif stage == "review":
+            test_passed = ctx.get("test_passed")
+            if test_passed is not None:
+                ctx["test_results"] = self._format_test_results(
+                    test_passed,
+                    ctx.get("test_coverage"),
+                    ctx.get("proof_artifacts"),
+                )
+            else:
+                ctx["test_results"] = ""
+            files_changed = ctx.get("files_changed")
+            if files_changed:
+                ctx["files_changed_formatted"] = "\n".join(f"- {f}" for f in files_changed)
+            else:
+                ctx["files_changed_formatted"] = ""
+
+        elif stage == "learn":
+            full_status = ctx.get("full_status") or {}
+            ctx["termination_type"] = ctx.get("termination_type") or "unknown"
+            ctx["plan_content"] = ctx.get("plan_file_content") or ""
+            run_id = full_status.get("run_id", "unknown")
+            ctx["run_id"] = run_id
+            status_json = json.dumps(full_status, indent=2, default=str)
+            if len(status_json) > self._MAX_STATUS_JSON_LEN:
+                status_json = status_json[:self._MAX_STATUS_JSON_LEN] + "\n... (truncated)"
+            ctx["run_data"] = status_json
+
+    def _load_agent_template(self, stage: str) -> str:
+        """Read the overlay-merged agent .md template for the given stage.
+
+        Reads from {run_dir}/agents/{agent_name}.md — the template file that
+        contains unresolved {{block:name}} and {{placeholder}} tokens. Returns
+        empty string if run_dir is not configured or the file doesn't exist.
+
+        Args:
+            stage: Pipeline stage name.
+
+        Returns:
+            Template content string, or empty string if unavailable.
+        """
+        if self._run_dir is None:
+            return ""
+        from worca.orchestrator.stages import Stage, STAGE_AGENT_MAP
+        try:
+            stage_enum = Stage(stage)
+        except ValueError:
+            return ""
+        agent_name = STAGE_AGENT_MAP.get(stage_enum)
+        if not agent_name:
+            return ""
+        template_path = os.path.join(self._run_dir, "agents", f"{agent_name}.md")
+        try:
+            with open(template_path) as f:
+                return f.read()
+        except OSError:
+            return ""
 
     def _work_request_section(self) -> str:
         """Common work request section included in all prompts."""
         return f"## Work Request\n\n**{self._title}**\n\n{self._description}"
 
-    def _build_plan(self, iteration: int) -> str:
-        if self._context.get("plan_revision_mode"):
-            return self._build_plan_revision()
-        plan_file = self._context.get("plan_file") or "MASTER_PLAN.md"
-        parts = [
-            "Create a detailed implementation plan for the following work request.",
-            "Start by reading CLAUDE.md for project context (tech stack, build/test commands, conventions).",
-            "Then explore the codebase to understand existing architecture.",
-            f"Write the plan to {plan_file}.",
-            "",
-            self._work_request_section(),
-        ]
-        if self._claude_md_content:
-            parts.append(f"## Project Context (from CLAUDE.md)\n\n{self._claude_md_content}")
-        return "\n\n".join(parts)
+    # -- Pre-formatting helpers ------------------------------------------------
 
+    @staticmethod
+    def _format_test_failures(failures: list) -> str:
+        """Format a list of test failure dicts into a numbered Markdown string."""
+        if not failures:
+            return ""
+        lines = []
+        for i, f in enumerate(failures, 1):
+            name = f.get("test_name", "unknown")
+            error = f.get("error", "no details")
+            lines.append(f"{i}. **{name}**\n   {error}")
+        return "\n".join(lines)
 
-    def _build_plan_revision(self) -> str:
-        """Build prompt for plan revision mode (triggered by PLAN_REVIEW revise outcome)."""
-        plan_file = self._context.get("plan_file") or "MASTER_PLAN.md"
-        plan_file_name = os.path.basename(plan_file)
-        parts = [
-            "The plan reviewer has identified issues that must be addressed. "
-            "Revise the existing plan -- do NOT start from scratch.",
-            "",
-            self._work_request_section(),
-        ]
+    @staticmethod
+    def _format_review_issues(issues: list) -> str:
+        """Format a list of review issue dicts into a numbered Markdown string."""
+        if not issues:
+            return ""
+        lines = []
+        for i, issue in enumerate(issues, 1):
+            file = issue.get("file", "?")
+            line = issue.get("line", "?")
+            sev = issue.get("severity", "?")
+            desc = issue.get("description", "")
+            lines.append(f"{i}. [{sev}] `{file}:{line}`\n   {desc}")
+        return "\n".join(lines)
 
-        plan_content = self._read_master_plan()
-        if plan_content:
-            parts.append(f"## Current Plan ({plan_file_name})\n\n{plan_content}")
-
-        issues = self._context.get("plan_review_issues") or []
-        if issues:
-            issue_lines = ["## Issues to Address"]
-            for i, issue in enumerate(issues, 1):
-                category = issue.get("category", "?")
-                severity = issue.get("severity", "?")
-                description = issue.get("description", "")
-                suggestion = issue.get("suggestion", "")
-                evidence = issue.get("evidence", "")
-                line = f"{i}. [{severity}] ({category}) {description}"
-                if suggestion:
-                    line += f"\n   Suggestion: {suggestion}"
-                if evidence:
-                    line += f"\n   Evidence: {evidence}"
-                issue_lines.append(line)
-            parts.append("\n".join(issue_lines))
-
-        history = self._context.get("plan_review_history") or []
-        if history:
-            history_lines = ["## Review History"]
-            for entry in history:
-                attempt = entry.get("attempt", "?")
-                attempt_issues = entry.get("issues", [])
-                summary = "; ".join(
-                    f"[{iss.get('severity','?')}] {iss.get('category','?')}: {iss.get('description','')}"
-                    for iss in attempt_issues
-                )
-                history_lines.append(f"- Attempt {attempt}: {summary}")
-            parts.append("\n".join(history_lines))
-
-        parts.append(
-            "Address each issue above. Preserve all parts of the plan that were not flagged. "
-            f"Write the updated plan to {plan_file_name}. "
-            "In your JSON output, set `approved: true` to signal that the revised plan is ready for review."
-        )
-        return "\n\n".join(parts)
-
-    def _build_plan_review(self, iteration: int) -> str:
-        """Build prompt for the PLAN_REVIEW stage."""
-        parts = [
-            "Review the implementation plan below for completeness, feasibility, and quality. "
-            "You are a read-only analyst -- do NOT modify files, run tests, or execute commands.",
-        ]
-
-        parts.append(self._work_request_section())
-
-        plan_file_name = os.path.basename(self._context.get("plan_file") or "MASTER_PLAN.md")
-        plan_content = self._read_master_plan()
-        if plan_content:
-            parts.append(f"## Implementation Plan ({plan_file_name})\n\n{plan_content}")
-        else:
-            parts.append(
-                f"## Implementation Plan ({plan_file_name})\n\n"
-                "*Plan file not found or empty -- this is itself a critical issue to report.*"
+    @staticmethod
+    def _format_review_history(history: list) -> str:
+        """Format a list of review history entries into Markdown bullet lines."""
+        if not history:
+            return ""
+        lines = []
+        for entry in history:
+            attempt = entry.get("attempt", "?")
+            issues = entry.get("issues", [])
+            issue_summary = "; ".join(
+                f"[{iss.get('severity','?')}] {iss.get('file','?')}:{iss.get('line','?')}"
+                for iss in issues
             )
+            lines.append(f"- Attempt {attempt}: {issue_summary}")
+        return "\n".join(lines)
 
-        parts.append(
-            "## Validation Instructions\n\n"
-            "Use available MCP tools for external API/library validation:\n"
-            "- **context7** -- resolve library IDs and fetch current docs for any libraries referenced in the plan\n"
-            "- **WebSearch** -- search for up-to-date API references, breaking changes, deprecations\n"
-            "- **WebFetch** -- fetch specific documentation URLs mentioned in the plan\n\n"
-            "Limit external MCP lookups to **10 turns maximum**. If MCP tools are unavailable or fail, "
-            "proceed with codebase-only validation and note which external checks were skipped in the "
-            "`evidence` field.\n\n"
-            "Also read CLAUDE.md and explore the codebase to validate plan assumptions against actual code."
-        )
+    @staticmethod
+    def _format_test_failure_history(history: list) -> str:
+        """Format a list of test failure history entries into Markdown bullet lines."""
+        if not history:
+            return ""
+        lines = []
+        for entry in history:
+            attempt = entry.get("attempt", "?")
+            failures = entry.get("failures", [])
+            fail_summary = "; ".join(f.get("test_name", "unknown") for f in failures)
+            lines.append(f"- Attempt {attempt}: {fail_summary}")
+        return "\n".join(lines)
 
-        if iteration > 0:
-            history = self._context.get("plan_review_history") or []
-            if history:
-                history_lines = ["## Previous Review Attempts"]
-                for entry in history:
-                    attempt = entry.get("attempt", "?")
-                    attempt_issues = entry.get("issues", [])
-                    summary = "; ".join(
-                        f"[{iss.get('severity','?')}] {iss.get('category','?')}: {iss.get('description','')}"
-                        for iss in attempt_issues
-                    )
-                    history_lines.append(f"- Attempt {attempt}: {summary or 'no issues recorded'}")
-                parts.append("\n".join(history_lines))
-                parts.append(
-                    "Check whether the issues from previous review attempts have been addressed "
-                    "in the revised plan above."
-                )
+    @staticmethod
+    def _format_plan_review_issues(issues: list) -> str:
+        """Format a list of plan review issue dicts into a numbered Markdown string."""
+        if not issues:
+            return ""
+        lines = []
+        for i, issue in enumerate(issues, 1):
+            category = issue.get("category", "?")
+            severity = issue.get("severity", "?")
+            description = issue.get("description", "")
+            suggestion = issue.get("suggestion", "")
+            evidence = issue.get("evidence", "")
+            line = f"{i}. [{severity}] ({category}) {description}"
+            if suggestion:
+                line += f"\n   Suggestion: {suggestion}"
+            if evidence:
+                line += f"\n   Evidence: {evidence}"
+            lines.append(line)
+        return "\n".join(lines)
 
-        parts.append(
-            "## Output\n\n"
-            "Produce `plan_review.json` with your structured findings. "
-            "Set `outcome` to `approve` if the plan is ready for coordination, "
-            "or `revise` if critical/major issues require another planning pass."
-        )
-        return "\n\n".join(parts)
+    @staticmethod
+    def _format_plan_review_history(history: list) -> str:
+        """Format a list of plan review history entries into Markdown bullet lines."""
+        if not history:
+            return ""
+        lines = []
+        for entry in history:
+            attempt = entry.get("attempt", "?")
+            attempt_issues = entry.get("issues", [])
+            summary = "; ".join(
+                f"[{iss.get('severity','?')}] {iss.get('category','?')}: {iss.get('description','')}"
+                for iss in attempt_issues
+            )
+            lines.append(f"- Attempt {attempt}: {summary}")
+        return "\n".join(lines)
 
-    def _build_coordinate(self, iteration: int) -> str:
-        parts = [
-            "Decompose the approved plan into fine-grained Beads tasks with dependencies.",
-            "Do NOT implement anything — only create tasks using `bd create` and set dependencies with `bd dep add`.",
-            "",
-            self._work_request_section(),
-        ]
-        approach = self._context.get("plan_approach")
-        tasks_outline = self._context.get("plan_tasks_outline")
-        if approach or tasks_outline:
-            parts.append("## Approved Plan")
-            if approach:
-                parts.append(f"**Approach:** {approach}")
-            if tasks_outline:
-                outline_text = "\n".join(
-                    f"- {t.get('title', 'Untitled')}: {t.get('description', '')}"
-                    for t in tasks_outline
-                )
-                parts.append(f"**Task Outline:**\n{outline_text}")
-        return "\n\n".join(parts)
-
-    def _build_implement(self, iteration: int) -> str:
-        if iteration > 0:
-            return self._build_implement_retry(iteration)
-        return self._build_implement_initial()
-
-    def _build_implement_initial(self) -> str:
-        """Build prompt for the first implementation attempt."""
-        parts = [
-            "Implement the code changes for the assigned task. Follow TDD: write a failing test first, then implement.",
-        ]
-        parts.append(self._assigned_task_section())
-        parts.append("")
-        parts.append(self._work_request_section())
-        return "\n\n".join(parts)
-
-    def _build_implement_retry(self, iteration: int) -> str:
-        """Build prompt for retry iterations — feedback first, plan as reference."""
+    @staticmethod
+    def _format_implementation_summary(files_changed: list, tests_added: list) -> str:
+        """Format files_changed and tests_added lists into a Markdown implementation summary."""
         parts = []
-        test_failures = self._context.get("test_failures")
-        review_issues = self._context.get("review_issues")
-        test_failure_history = self._context.get("test_failure_history") or []
-        review_history = self._context.get("review_history") or []
-        attempt_count = len(review_history) or len(test_failure_history) or iteration
-        assigned = self._context.get("assigned_bead_id")
-
-        # -- Priority header --
-        if assigned:
-            # Per-bead retry (legacy path, kept for compatibility)
-            if test_failures:
-                parts.append(
-                    f"## PRIORITY: Fix Test Failures (attempt {attempt_count})\n\n"
-                    "The implementation is already in place. Your ONLY task is to fix the "
-                    "failing tests listed below. Do NOT re-implement the plan from scratch. "
-                    "Do NOT just rebuild and exit."
-                )
-            elif review_issues:
-                parts.append(
-                    f"## PRIORITY: Fix Review Issues (attempt {attempt_count})\n\n"
-                    "The implementation is already in place. Your ONLY task is to fix the "
-                    "specific issues listed below. Do NOT re-implement the plan from scratch. "
-                    "Do NOT just rebuild and exit."
-                )
-        else:
-            # Fix mode: no specific bead, fix all issues across the project
-            if test_failures:
-                parts.append(
-                    f"## PRIORITY: Fix All Issues — Test Failures (attempt {attempt_count})\n\n"
-                    "All tasks have been implemented. Your ONLY task is to fix the "
-                    "failing tests listed below. You have full access to the codebase — "
-                    "fix whatever is broken. Do NOT re-implement the plan from scratch. "
-                    "Do NOT use `bd ready` or `bd close`."
-                )
-            elif review_issues:
-                parts.append(
-                    f"## PRIORITY: Fix All Issues — Review Issues (attempt {attempt_count})\n\n"
-                    "All tasks have been implemented. Your ONLY task is to fix the "
-                    "specific issues listed below. You have full access to the codebase — "
-                    "fix whatever is broken. Do NOT re-implement the plan from scratch. "
-                    "Do NOT use `bd ready` or `bd close`."
-                )
-
-        # -- Current issues to fix --
-        if test_failures:
-            parts.append("### Failures to Fix")
-            for i, f in enumerate(test_failures, 1):
-                name = f.get("test_name", "unknown")
-                error = f.get("error", "no details")
-                parts.append(f"{i}. **{name}**\n   {error}")
-
-        if review_issues:
-            parts.append("### Issues to Fix")
-            for i, issue in enumerate(review_issues, 1):
-                file = issue.get("file", "?")
-                line = issue.get("line", "?")
-                sev = issue.get("severity", "?")
-                desc = issue.get("description", "")
-                parts.append(f"{i}. [{sev}] `{file}:{line}`\n   {desc}")
-
-        # -- Previous failed attempts (if any) --
-        if len(review_history) > 1:
-            parts.append("### Previous Attempts (all failed to resolve)")
-            for entry in review_history[:-1]:
-                attempt = entry.get("attempt", "?")
-                issues = entry.get("issues", [])
-                issue_summary = "; ".join(
-                    f"[{i.get('severity','?')}] {i.get('file','?')}:{i.get('line','?')}"
-                    for i in issues
-                )
-                parts.append(f"- Attempt {attempt}: {issue_summary}")
-
-        if len(test_failure_history) > 1:
-            parts.append("### Previous Attempts (all failed to resolve)")
-            for entry in test_failure_history[:-1]:
-                attempt = entry.get("attempt", "?")
-                failures = entry.get("failures", [])
-                fail_summary = "; ".join(f.get("test_name", "unknown") for f in failures)
-                parts.append(f"- Attempt {attempt}: {fail_summary}")
-
-        # -- Verification instruction --
-        parts.append(
-            "### Verification\n\n"
-            "After making each fix, read back the changed lines to confirm the fix is correct. "
-            "Do not assume the fix landed — verify it."
-        )
-
-        # -- Reference section: task + plan (demoted) --
-        parts.append("---")
-        parts.append("## Reference: Task & Plan (already implemented)")
-        parts.append(self._assigned_task_section())
-        parts.append("")
-        parts.append(self._work_request_section())
-
+        if files_changed:
+            parts.append("**Files changed:**\n" + "\n".join(f"- {f}" for f in files_changed))
+        if tests_added:
+            parts.append("**Tests added:**\n" + "\n".join(f"- {t}" for t in tests_added))
         return "\n\n".join(parts)
 
-    def _assigned_task_section(self) -> str:
-        """Render the assigned bead task section."""
+    @staticmethod
+    def _format_test_results(test_passed: bool, coverage, proof_artifacts: list) -> str:
+        """Format test result data into a Markdown block."""
+        lines = [f"**Status:** {'PASSED' if test_passed else 'FAILED'}"]
+        if coverage is not None:
+            lines.append(f"**Coverage:** {coverage}%")
+        if proof_artifacts:
+            lines.append("**Proof artifacts:**\n" + "\n".join(f"- {a}" for a in proof_artifacts))
+        return "\n".join(lines)
+
+    def _assigned_task_body(self) -> str:
+        """Return assigned task body content for context assembly.
+
+        Omits the ## Assigned Task header (provided by the implement.block.md
+        template). Returns empty string when no bead is assigned.
+        """
         bead_id = self._context.get("assigned_bead_id")
+        if not bead_id:
+            return ""
         bead_title = self._context.get("assigned_bead_title")
         bead_description = self._context.get("assigned_bead_description")
-        if bead_id:
-            lines = [f"## Assigned Task\n\n**Bead ID:** {bead_id}"]
-            if bead_title:
-                lines.append(f"**Title:** {bead_title}")
-            if bead_description:
-                lines.append(f"**Description:** {bead_description}")
-            return "\n\n".join(lines)
-        return "Run `bd ready` to find available work, then claim and implement a task."
-
-    def _build_test(self, iteration: int) -> str:
-        parts = [
-            "Run the full test suite and verify the implementation. Do NOT modify source code.",
-            "",
-            self._work_request_section(),
-        ]
-        files_changed = self._context.get("files_changed")
-        tests_added = self._context.get("tests_added")
-        if files_changed or tests_added:
-            parts.append("## Implementation Summary")
-            if files_changed:
-                parts.append("**Files changed:**\n" + "\n".join(f"- {f}" for f in files_changed))
-            if tests_added:
-                parts.append("**Tests added:**\n" + "\n".join(f"- {t}" for t in tests_added))
-        return "\n\n".join(parts)
-
-    def _build_review(self, iteration: int) -> str:
-        parts = [
-            "Review the code changes for correctness, style, and adherence to the plan. Do NOT modify code.",
-            "",
-            self._work_request_section(),
-        ]
-        test_passed = self._context.get("test_passed")
-        coverage = self._context.get("test_coverage")
-        proof_artifacts = self._context.get("proof_artifacts")
-        if test_passed is not None:
-            parts.append("## Test Results")
-            parts.append(f"**Status:** {'PASSED' if test_passed else 'FAILED'}")
-            if coverage is not None:
-                parts.append(f"**Coverage:** {coverage}%")
-            if proof_artifacts:
-                parts.append("**Proof artifacts:**\n" + "\n".join(f"- {a}" for a in proof_artifacts))
-        files_changed = self._context.get("files_changed")
-        if files_changed:
-            parts.append("## Files Changed\n" + "\n".join(f"- {f}" for f in files_changed))
-        parts.append(
-            "## Implementer Capabilities\n\n"
-            "The implementer agent can edit files and run tests but CANNOT make git commits "
-            "(commits are handled by the guardian stage). Do NOT flag uncommitted files as issues "
-            "requiring changes — focus only on code correctness, style, and adherence to the plan."
-        )
-        return "\n\n".join(parts)
-
-    def _build_pr(self, iteration: int) -> str:
-        parts = [
-            "Create a pull request summarizing all changes. Ensure the commit history is clean.",
-            "",
-            self._work_request_section(),
-        ]
-        approach = self._context.get("plan_approach")
-        if approach:
-            parts.append(f"## Approach\n\n{approach}")
-        return "\n\n".join(parts)
-
-    # -- Learn stage -------------------------------------------------------
-
-    _MAX_STATUS_JSON_LEN = 50_000  # truncate serialised status beyond this
-
-    def _build_learn(self, iteration: int) -> str:
-        """Build the retrospective analysis prompt for the LEARN stage."""
-        full_status = self._context.get("full_status") or {}
-        termination_type = self._context.get("termination_type", "unknown")
-        termination_reason = self._context.get("termination_reason", "")
-        plan_content = self._context.get("plan_file_content")
-
-        parts = [
-            "Analyze the completed pipeline run and produce a structured retrospective.",
-            "You are a read-only analyst. Do NOT modify files or run tests.",
-        ]
-
-        # Work request context
-        parts.append(self._work_request_section())
-
-        # Termination info
-        term_section = f"## Termination\n\n**Type:** {termination_type}"
-        if termination_reason:
-            term_section += f"\n**Reason:** {termination_reason}"
-        parts.append(term_section)
-
-        # Plan content (if available)
-        if plan_content:
-            parts.append(f"## Plan File\n\n{plan_content}")
-
-        # Run reference — surface run_id and paths for traceability
-        run_id = full_status.get("run_id", "unknown")
-        run_dir = f".worca/runs/{run_id}/"
-        logs_dir = f".worca/runs/{run_id}/logs/"
-        parts.append(
-            f"## Run Reference\n\n"
-            f"**Run ID:** `{run_id}`\n"
-            f"**Run directory:** `{run_dir}`\n"
-            f"**Logs directory:** `{logs_dir}`"
-        )
-
-        # Full run data as JSON (truncated if too large)
-        status_json = json.dumps(full_status, indent=2, default=str)
-        if len(status_json) > self._MAX_STATUS_JSON_LEN:
-            status_json = status_json[:self._MAX_STATUS_JSON_LEN] + "\n... (truncated)"
-        parts.append(f"## Run Data\n\n```json\n{status_json}\n```")
-
-        # Analysis instructions per category
-        parts.append(
-            "## Analysis Instructions\n\n"
-            "Analyze the run data above across these categories:\n\n"
-            "1. **Test loops** — What triggered each test failure? Did fixes address "
-            "root causes or just symptoms? Did the same failure types recur?\n"
-            "2. **Review loops** — What severity/category of issues were raised? "
-            "Were they systemic or isolated?\n"
-            "3. **Implementation** — Were there recurring issues across beads "
-            "(same error types, missing patterns, same test categories failing)?\n"
-            "4. **Planning** — Did the plan anticipate actual challenges? "
-            "Were task decompositions appropriate?\n"
-            "5. **Coordination** — Were dependencies correct? Did the bead ordering "
-            "cause unnecessary rework?\n"
-            "6. **Configuration** — Were loop limits hit? Were turn limits adequate? "
-            "Was cost disproportionate to outcome?\n\n"
-            "For each observation, rate importance as critical/high/medium/low "
-            "based on impact and recurrence. In each observation's `evidence` field, "
-            f"reference the run ID (`{run_id}`) and relevant log file paths "
-            f"(e.g., `{logs_dir}<stage>/iter-N.log`) so that follow-up investigation "
-            "can locate the source data.\n\n"
-            "Formulate targeted suggestions linking to specific artifacts "
-            "(prompts, config, plan templates). In each suggestion's `description`, "
-            f"include the run ID (`{run_id}`) and the specific log paths that "
-            "contain the evidence, so follow-up agents can reproduce and verify."
-        )
-
-        return "\n\n".join(parts)
+        lines = [f"**Bead ID:** {bead_id}"]
+        if bead_title:
+            lines.append(f"**Title:** {bead_title}")
+        if bead_description:
+            lines.append(f"**Description:** {bead_description}")
+        return "\n\n".join(lines)

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -539,7 +539,7 @@ def _run_learn_stage(status, prompt_builder, settings_path, run_dir,
             )
             _learn_resolved_dir = os.path.join(run_dir, "agents", "resolved")
             os.makedirs(_learn_resolved_dir, exist_ok=True)
-            _learn_resolved_path = os.path.join(_learn_resolved_dir, f"{_learn_agent_name}-iter-1.md")
+            _learn_resolved_path = os.path.join(_learn_resolved_dir, f"learn-{_learn_agent_name}-iter-1.md")
             with open(_learn_resolved_path, "w") as _f:
                 _f.write(_learn_resolved)
             _learn_agent_override = _learn_resolved_path
@@ -1433,7 +1433,7 @@ def run_pipeline(
                     _resolved_dir = os.path.join(run_dir, "agents", "resolved")
                     os.makedirs(_resolved_dir, exist_ok=True)
                     _resolved_path = os.path.join(
-                        _resolved_dir, f"{_stage_agent_name}-iter-{iter_num}.md"
+                        _resolved_dir, f"{current_stage.value}-{_stage_agent_name}-iter-{iter_num}.md"
                     )
                     with open(_resolved_path, "w") as _f:
                         _f.write(_resolved)
@@ -1822,6 +1822,14 @@ def run_pipeline(
                 # Thread plan outputs into PromptBuilder for downstream stages
                 prompt_builder.update_context("plan_approach", result.get("approach", ""))
                 prompt_builder.update_context("plan_tasks_outline", result.get("tasks_outline", []))
+                # Read plan file content now so plan_review has it immediately
+                # (avoids race where plan_review starts before the file is flushed)
+                _plan_path = status.get("plan_file")
+                if _plan_path and os.path.exists(_plan_path):
+                    with open(_plan_path) as _pf:
+                        _plan_text = _pf.read().strip()
+                    if _plan_text:
+                        prompt_builder.update_context("plan_file_content", _plan_text)
 
             # Handle plan review results
             elif current_stage == Stage.PLAN_REVIEW:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -21,7 +21,7 @@ from worca.orchestrator.error_classifier import (
 )
 from worca.orchestrator.registry import update_pipeline
 from worca.orchestrator.control import read_control, delete_control
-from worca.orchestrator.overlay import OverlayResolver
+from worca.orchestrator.overlay import OverlayResolver, resolve_agent
 from worca.orchestrator.prompt_builder import PromptBuilder
 from worca.orchestrator.stages import (
     Stage, get_stage_config, get_enabled_stages, STAGE_AGENT_MAP,
@@ -263,12 +263,12 @@ def _render_agent_templates(run_dir: str, template_vars: dict,
     resolver = OverlayResolver(overrides_dir=overrides_dir)
 
     for filename in os.listdir(src_dir):
+        if filename.endswith(".block.md"):
+            continue
         if not filename.endswith(".md"):
             continue
         with open(os.path.join(src_dir, filename)) as f:
             content = f.read()
-        for key, value in template_vars.items():
-            content = content.replace(f"{{{key}}}", str(value))
         agent_name = filename[:-3]  # strip .md
         content = resolver.resolve(agent_name, content,
                                    template_agents_dir=template_agents_dir)
@@ -476,57 +476,6 @@ def _save_stage_output(stage: Stage, result: dict, logs_dir: str = ".worca/logs"
         json.dump(result, f, indent=2)
 
 
-_STAGE_PROMPT_PREFIX = {
-    Stage.PLAN: (
-        "Create a detailed implementation plan for the following work request. "
-        "Write the plan to the designated plan file.\n\n"
-        "Work request: {prompt}"
-    ),
-    Stage.COORDINATE: (
-        "Decompose the following work request into Beads tasks with dependencies. "
-        "Do NOT implement anything — only create tasks using `bd create`.\n\n"
-        "Work request: {prompt}"
-    ),
-    Stage.IMPLEMENT: (
-        "Implement the code changes described in the work request. "
-        "Follow the plan and complete the tasks assigned to you.\n\n"
-        "Work request: {prompt}"
-    ),
-    Stage.TEST: (
-        "Review and test the implementation for the following work request. "
-        "Run tests and report results. Do NOT modify code.\n\n"
-        "Work request: {prompt}"
-    ),
-    Stage.REVIEW: (
-        "Review the code changes for the following work request. "
-        "Check for correctness, style, and adherence to the plan. Do NOT modify code.\n\n"
-        "Work request: {prompt}"
-    ),
-    Stage.PR: (
-        "Create a pull request for the following work request. "
-        "Summarize the changes and ensure the commit history is clean.\n\n"
-        "Work request: {prompt}"
-    ),
-    Stage.PLAN_REVIEW: (
-        "Review the implementation plan for the following work request. "
-        "Validate completeness, feasibility, and quality. Do NOT modify the plan.\n\n"
-        "Work request: {prompt}"
-    ),
-    Stage.LEARN: (
-        "Analyze the completed pipeline run and produce a retrospective report. "
-        "Identify patterns, recurring issues, and improvement suggestions.\n\n"
-        "Run data: {prompt}"
-    ),
-}
-
-
-def _build_stage_prompt(stage: Stage, raw_prompt: str) -> str:
-    """Build a role-scoped prompt that reinforces the agent's purpose."""
-    template = _STAGE_PROMPT_PREFIX.get(stage)
-    if template:
-        return template.format(prompt=raw_prompt)
-    return raw_prompt
-
 
 def _run_learn_stage(status, prompt_builder, settings_path, run_dir,
                      termination_type, termination_reason, msize, logs_dir,
@@ -569,9 +518,35 @@ def _run_learn_stage(status, prompt_builder, settings_path, run_dir,
                 model="sonnet", trigger="initial", max_turns=0,
             ))
 
-        rendered = prompt_builder.build("learn", 0)
+        ctx_dict = prompt_builder.build_context("learn", 0)
+        _learn_agent_name = "learner"
+        _learn_template_path = (
+            os.path.join(run_dir, "agents", f"{_learn_agent_name}.md")
+            if run_dir else None
+        )
+        _learn_agent_override = None
+        if (
+            _learn_template_path
+            and os.path.exists(_learn_template_path)
+            and prompt_builder._resolver is not None
+        ):
+            with open(_learn_template_path) as _f:
+                _learn_content = _f.read()
+            _learn_resolved = resolve_agent(
+                _learn_content, ctx_dict,
+                prompt_builder._resolver, prompt_builder._core_dir,
+                prompt_builder._template_agents_dir,
+            )
+            _learn_resolved_dir = os.path.join(run_dir, "agents", "resolved")
+            os.makedirs(_learn_resolved_dir, exist_ok=True)
+            _learn_resolved_path = os.path.join(_learn_resolved_dir, f"{_learn_agent_name}-iter-1.md")
+            with open(_learn_resolved_path, "w") as _f:
+                _f.write(_learn_resolved)
+            _learn_agent_override = _learn_resolved_path
+        rendered = ctx_dict.get("work_request", "")
         result, raw = run_stage(Stage.LEARN, {}, settings_path, msize=msize,
-                                prompt_override=rendered)
+                                prompt_override=rendered,
+                                agent_override=_learn_agent_override)
 
         # Complete iteration
         complete_iteration(status, "learn", status="completed", outcome="success",
@@ -745,6 +720,7 @@ def run_stage(
     msize: int = 1,
     iteration: int = 1,
     prompt_override: str = None,
+    agent_override: str = None,
     ctx: Optional[EventContext] = None,
 ) -> tuple[dict, dict]:
     """Run a single pipeline stage.
@@ -757,7 +733,9 @@ def run_stage(
         msize: Multiplier for max_turns (1-10). E.g. msize=2 doubles turns.
         iteration: Current iteration number (1-indexed). Controls log file path.
         prompt_override: When provided, used instead of context["prompt"].
-            This allows PromptBuilder output to reach the agent directly.
+        agent_override: When provided, used as the --agent path instead of the
+            default _agent_path(). Allows per-stage resolved templates to be
+            passed directly to the claude CLI.
 
     Returns (structured_output, raw_envelope) tuple. The structured_output
     is the schema-conforming result used by pipeline logic. The raw_envelope
@@ -766,16 +744,17 @@ def run_stage(
     config = get_stage_config(stage, settings_path=settings_path)
     max_turns = config["max_turns"] * msize
     raw_prompt = context.get("prompt", "")
-    prompt = prompt_override if prompt_override is not None else _build_stage_prompt(stage, raw_prompt)
+    prompt = prompt_override if prompt_override is not None else raw_prompt
     logs_dir = context.get("_logs_dir", ".worca/logs")
     run_dir = context.get("_run_dir")
     log_dir = os.path.join(logs_dir, stage.value)
     os.makedirs(log_dir, exist_ok=True)
     log_path = os.path.join(log_dir, f"iter-{iteration}.log")
     on_event = _make_agent_event_handler(ctx, stage, iteration, settings_path)
+    agent = agent_override if agent_override is not None else _agent_path(config["agent"], run_dir=run_dir)
     raw = run_agent(
         prompt=prompt,
-        agent=_agent_path(config["agent"], run_dir=run_dir),
+        agent=agent,
         max_turns=max_turns,
         output_format="stream-json",
         json_schema=_schema_path(config["schema"]),
@@ -1193,9 +1172,18 @@ def run_pipeline(
 
         # Initialize PromptBuilder for context threading across stages
         prompt_context_path = os.path.join(run_dir, "prompt_context.json") if run_dir else None
+        _pb_settings = load_settings(settings_path)
+        _pb_worca = _pb_settings.get("worca", {})
+        _pb_overrides_dir = _pb_worca.get("agent_overrides_dir", ".claude/agents")
+        _pb_template_agents_dir = _pb_worca.get("_template_agents_dir")
+        _pb_core_dir = ".claude/worca/agents/core"
         prompt_builder = PromptBuilder(
             work_request.title,
             work_request.description,
+            resolver=OverlayResolver(overrides_dir=_pb_overrides_dir),
+            core_dir=_pb_core_dir,
+            template_agents_dir=_pb_template_agents_dir,
+            run_dir=run_dir,
         )
         if resume_stage and prompt_context_path:
             prompt_builder.load_context(prompt_context_path)
@@ -1413,13 +1401,47 @@ def run_pipeline(
                     prompt_builder.update_context("assigned_bead_title", None)
                     prompt_builder.update_context("assigned_bead_description", None)
 
-            # Build stage-specific prompt via PromptBuilder (skip for script-based stages)
+            # Build stage-specific context and resolve agent template per-stage
             if current_stage != Stage.PREFLIGHT:
                 if current_stage.value == "implement":
                     pb_iteration = prompt_builder.get_context("bead_prompt_iteration") or 0
                 else:
                     pb_iteration = loop_counters.get(f"{current_stage.value}_iteration", 0)
-                rendered_prompt = prompt_builder.build(current_stage.value, pb_iteration)
+
+                ctx_dict = prompt_builder.build_context(current_stage.value, pb_iteration)
+                _stage_agent_name = stage_config["agent"]
+                _template_path = (
+                    os.path.join(run_dir, "agents", f"{_stage_agent_name}.md")
+                    if run_dir else None
+                )
+
+                if (
+                    _template_path
+                    and os.path.exists(_template_path)
+                    and prompt_builder._resolver is not None
+                ):
+                    with open(_template_path) as _f:
+                        _agent_content = _f.read()
+                    _resolved = resolve_agent(
+                        _agent_content, ctx_dict,
+                        prompt_builder._resolver, prompt_builder._core_dir,
+                        prompt_builder._template_agents_dir,
+                    )
+                    _resolved_dir = os.path.join(run_dir, "agents", "resolved")
+                    os.makedirs(_resolved_dir, exist_ok=True)
+                    _resolved_path = os.path.join(
+                        _resolved_dir, f"{_stage_agent_name}-iter-{iter_num}.md"
+                    )
+                    with open(_resolved_path, "w") as _f:
+                        _f.write(_resolved)
+                    _agent_override = _resolved_path
+                else:
+                    _agent_override = None
+
+                rendered_prompt = (
+                    f"## Work Request\n\n**{work_request.title}**\n\n"
+                    f"{work_request.description or work_request.title}"
+                )
 
                 # Store rendered prompt in status for UI visibility
                 status["stages"][current_stage.value]["prompt"] = rendered_prompt
@@ -1427,6 +1449,7 @@ def run_pipeline(
                 save_status(status, actual_status_path)
             else:
                 rendered_prompt = None
+                _agent_override = None
 
             # Run the stage
             try:
@@ -1474,12 +1497,11 @@ def run_pipeline(
                     result = run_preflight(context, settings_path, iteration=iter_num)
                     raw_envelope = {"type": "preflight", "checks": result.get("checks", [])}
                 else:
-                    # Pass rendered_prompt as prompt_override so PromptBuilder
-                    # output actually reaches the agent (not just stored for UI)
                     result, raw_envelope = run_stage(
                         current_stage, context, settings_path,
                         msize=msize, iteration=iter_num,
                         prompt_override=rendered_prompt,
+                        agent_override=_agent_override,
                         ctx=ctx,
                     )
             except InterruptedError:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -1247,9 +1247,12 @@ def run_pipeline(
         # Ensure hook env vars are set for both new and resumed runs
         os.environ["WORCA_PLAN_FILE"] = status.get("plan_file") or ""
 
-        # Thread plan_file into PromptBuilder so _build_plan can reference it
+        # Thread template variables into PromptBuilder for {{placeholder}} resolution
         if status.get("plan_file"):
             prompt_builder.update_context("plan_file", status["plan_file"])
+        prompt_builder.update_context("run_id", status.get("run_id", ""))
+        prompt_builder.update_context("branch", branch_name)
+        prompt_builder.update_context("title", work_request.title)
         if status.get("run_id"):
             os.environ["WORCA_RUN_ID"] = status["run_id"]
 

--- a/src/worca/orchestrator/stages.py
+++ b/src/worca/orchestrator/stages.py
@@ -35,7 +35,7 @@ STAGE_AGENT_MAP = {
     Stage.COORDINATE: "coordinator",
     Stage.IMPLEMENT: "implementer",
     Stage.TEST: "tester",
-    Stage.REVIEW: "guardian",
+    Stage.REVIEW: "reviewer",
     Stage.PR: "guardian",
     Stage.LEARN: "learner",
 }

--- a/tests/test_agent_md_refs.py
+++ b/tests/test_agent_md_refs.py
@@ -1,0 +1,144 @@
+"""Tests for W-037 T5: {{block:name}} refs in agent .md files + {{double-brace}} migration.
+
+Verifies each agent .md file has been updated with the correct block reference
+and that single-brace placeholders have been migrated to double-brace syntax.
+"""
+
+import pathlib
+
+
+CORE_DIR = pathlib.Path(__file__).parent.parent / "src" / "worca" / "agents" / "core"
+
+
+def _read(filename):
+    return (CORE_DIR / filename).read_text()
+
+
+# ---------------------------------------------------------------------------
+# planner.md
+# ---------------------------------------------------------------------------
+
+
+def test_planner_has_block_plan():
+    content = _read("planner.md")
+    assert "{{block:plan}}" in content
+
+
+def test_planner_uses_double_brace_plan_file():
+    content = _read("planner.md")
+    assert "{{plan_file}}" in content
+
+
+def test_planner_no_single_brace_plan_file():
+    content = _read("planner.md")
+    # Ensure single-brace form was removed (not just that double-brace exists)
+    assert "{plan_file}" not in content.replace("{{plan_file}}", "")
+
+
+# ---------------------------------------------------------------------------
+# plan_reviewer.md
+# ---------------------------------------------------------------------------
+
+
+def test_plan_reviewer_has_block_plan_review():
+    content = _read("plan_reviewer.md")
+    assert "{{block:plan-review}}" in content
+
+
+# ---------------------------------------------------------------------------
+# coordinator.md
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_has_block_coordinate():
+    content = _read("coordinator.md")
+    assert "{{block:coordinate}}" in content
+
+
+def test_coordinator_uses_double_brace_plan_file():
+    content = _read("coordinator.md")
+    assert "{{plan_file}}" in content
+
+
+def test_coordinator_no_single_brace_plan_file():
+    content = _read("coordinator.md")
+    assert "{plan_file}" not in content.replace("{{plan_file}}", "")
+
+
+def test_coordinator_uses_double_brace_run_id():
+    content = _read("coordinator.md")
+    assert "{{run_id}}" in content
+
+
+def test_coordinator_no_single_brace_run_id():
+    content = _read("coordinator.md")
+    assert "{run_id}" not in content.replace("{{run_id}}", "")
+
+
+# ---------------------------------------------------------------------------
+# implementer.md
+# ---------------------------------------------------------------------------
+
+
+def test_implementer_has_block_implement():
+    content = _read("implementer.md")
+    assert "{{block:implement}}" in content
+
+
+def test_implementer_has_retry_rules_section():
+    content = _read("implementer.md")
+    assert "## Retry Rules" in content
+
+
+# ---------------------------------------------------------------------------
+# tester.md
+# ---------------------------------------------------------------------------
+
+
+def test_tester_has_block_test():
+    content = _read("tester.md")
+    assert "{{block:test}}" in content
+
+
+# ---------------------------------------------------------------------------
+# guardian.md
+# ---------------------------------------------------------------------------
+
+
+def test_guardian_has_block_pr():
+    content = _read("guardian.md")
+    assert "{{block:pr}}" in content
+
+
+def test_guardian_no_review_stage_content():
+    content = _read("guardian.md")
+    # Guardian no longer serves REVIEW stage; reviewer.md does
+    assert "REVIEW" not in content or "PR" in content  # PR content is fine
+
+
+# ---------------------------------------------------------------------------
+# reviewer.md
+# ---------------------------------------------------------------------------
+
+
+def test_reviewer_has_block_review():
+    content = _read("reviewer.md")
+    assert "{{block:review}}" in content
+
+
+# ---------------------------------------------------------------------------
+# learner.md
+# ---------------------------------------------------------------------------
+
+
+def test_learner_has_block_learn():
+    content = _read("learner.md")
+    assert "{{block:learn}}" in content
+
+
+def test_learner_has_six_analysis_categories():
+    content = _read("learner.md")
+    # The 6-category analysis section from _build_learn lines 519-543
+    assert "implementation iterations" in content.lower() or "implementation" in content
+    assert "test" in content.lower()
+    assert "review" in content.lower()

--- a/tests/test_block_files.py
+++ b/tests/test_block_files.py
@@ -1,0 +1,227 @@
+"""Tests for W-037 T3: 8 block files in src/worca/agents/core/.
+
+Verifies each block file exists and contains expected placeholder tokens.
+"""
+
+import pathlib
+
+import pytest
+
+CORE_DIR = pathlib.Path(__file__).parent.parent / "src" / "worca" / "agents" / "core"
+
+BLOCK_FILES = [
+    "plan.block.md",
+    "plan-review.block.md",
+    "coordinate.block.md",
+    "implement.block.md",
+    "test.block.md",
+    "review.block.md",
+    "pr.block.md",
+    "learn.block.md",
+]
+
+
+@pytest.mark.parametrize("filename", BLOCK_FILES)
+def test_block_file_exists(filename):
+    assert (CORE_DIR / filename).exists(), f"{filename} not found in {CORE_DIR}"
+
+
+def _read(filename):
+    return (CORE_DIR / filename).read_text()
+
+
+# ---------------------------------------------------------------------------
+# plan.block.md
+# ---------------------------------------------------------------------------
+
+
+def test_plan_block_has_work_request():
+    content = _read("plan.block.md")
+    assert "{{work_request}}" in content
+
+
+def test_plan_block_has_revision_conditional():
+    content = _read("plan.block.md")
+    assert "{{#if plan_revision_mode}}" in content
+    assert "{{/if}}" in content
+
+
+def test_plan_block_has_plan_content_conditional():
+    content = _read("plan.block.md")
+    assert "{{#if plan_content}}" in content
+
+
+def test_plan_block_has_plan_review_issues():
+    content = _read("plan.block.md")
+    assert "{{#if plan_review_issues_formatted}}" in content
+
+
+def test_plan_block_has_plan_review_history():
+    content = _read("plan.block.md")
+    assert "{{#if plan_review_history_formatted}}" in content
+
+
+def test_plan_block_has_claude_md_conditional():
+    content = _read("plan.block.md")
+    assert "{{#if claude_md}}" in content
+
+
+# ---------------------------------------------------------------------------
+# plan-review.block.md
+# ---------------------------------------------------------------------------
+
+
+def test_plan_review_block_has_work_request():
+    content = _read("plan-review.block.md")
+    assert "{{work_request}}" in content
+
+
+def test_plan_review_block_has_plan_content_conditional():
+    content = _read("plan-review.block.md")
+    assert "{{#if plan_content}}" in content
+
+
+def test_plan_review_block_has_history_conditional():
+    content = _read("plan-review.block.md")
+    assert "{{#if plan_review_history_formatted}}" in content
+
+
+# ---------------------------------------------------------------------------
+# coordinate.block.md
+# ---------------------------------------------------------------------------
+
+
+def test_coordinate_block_has_work_request():
+    content = _read("coordinate.block.md")
+    assert "{{work_request}}" in content
+
+
+def test_coordinate_block_has_plan_summary_conditional():
+    content = _read("coordinate.block.md")
+    assert "{{#if plan_summary}}" in content
+
+
+# ---------------------------------------------------------------------------
+# implement.block.md
+# ---------------------------------------------------------------------------
+
+
+def test_implement_block_has_work_request():
+    content = _read("implement.block.md")
+    assert "{{work_request}}" in content
+
+
+def test_implement_block_has_retry_conditional():
+    content = _read("implement.block.md")
+    assert "{{#if is_retry}}" in content
+    assert "{{/if}}" in content
+
+
+def test_implement_block_has_test_failures_conditional():
+    content = _read("implement.block.md")
+    assert "{{#if test_failures_formatted}}" in content
+
+
+def test_implement_block_has_review_issues_conditional():
+    content = _read("implement.block.md")
+    assert "{{#if review_issues_formatted}}" in content
+
+
+def test_implement_block_has_issue_type():
+    content = _read("implement.block.md")
+    assert "{{issue_type}}" in content
+
+
+def test_implement_block_has_attempt_count():
+    content = _read("implement.block.md")
+    assert "{{attempt_count}}" in content
+
+
+def test_implement_block_has_assigned_task_conditional():
+    content = _read("implement.block.md")
+    assert "{{#if assigned_task}}" in content
+
+
+# ---------------------------------------------------------------------------
+# test.block.md
+# ---------------------------------------------------------------------------
+
+
+def test_test_block_has_work_request():
+    content = _read("test.block.md")
+    assert "{{work_request}}" in content
+
+
+def test_test_block_has_implementation_summary_conditional():
+    content = _read("test.block.md")
+    assert "{{#if implementation_summary}}" in content
+
+
+# ---------------------------------------------------------------------------
+# review.block.md
+# ---------------------------------------------------------------------------
+
+
+def test_review_block_has_work_request():
+    content = _read("review.block.md")
+    assert "{{work_request}}" in content
+
+
+def test_review_block_has_test_results_conditional():
+    content = _read("review.block.md")
+    assert "{{#if test_results}}" in content
+
+
+def test_review_block_has_files_changed_conditional():
+    content = _read("review.block.md")
+    assert "{{#if files_changed_formatted}}" in content
+
+
+# ---------------------------------------------------------------------------
+# pr.block.md
+# ---------------------------------------------------------------------------
+
+
+def test_pr_block_has_work_request():
+    content = _read("pr.block.md")
+    assert "{{work_request}}" in content
+
+
+def test_pr_block_has_plan_approach_conditional():
+    content = _read("pr.block.md")
+    assert "{{#if plan_approach}}" in content
+
+
+# ---------------------------------------------------------------------------
+# learn.block.md
+# ---------------------------------------------------------------------------
+
+
+def test_learn_block_has_work_request():
+    content = _read("learn.block.md")
+    assert "{{work_request}}" in content
+
+
+def test_learn_block_has_termination_type():
+    content = _read("learn.block.md")
+    assert "{{termination_type" in content
+
+
+def test_learn_block_has_termination_reason_conditional():
+    content = _read("learn.block.md")
+    assert "{{#if termination_reason}}" in content
+
+
+def test_learn_block_has_plan_content_conditional():
+    content = _read("learn.block.md")
+    assert "{{#if plan_content}}" in content
+
+
+def test_learn_block_has_run_id():
+    content = _read("learn.block.md")
+    assert "{{run_id}}" in content
+
+
+def test_learn_block_has_run_data():
+    content = _read("learn.block.md")
+    assert "{{run_data}}" in content

--- a/tests/test_builtin_templates.py
+++ b/tests/test_builtin_templates.py
@@ -1,0 +1,164 @@
+"""Tests for W-037 T7: Builtin pipeline templates use append mode.
+
+Verifies:
+- All template agent overlay files start with <!-- append -->
+- Each overlay has at least one ## Override: section
+- Appending the overlay onto its core agent preserves {{block:name}} references
+- Appending the overlay preserves governance-protected sections
+"""
+
+import pathlib
+
+import pytest
+
+from worca.orchestrator.overlay import OverlayResolver
+
+TEMPLATES_DIR = (
+    pathlib.Path(__file__).parent.parent / "src" / "worca" / "templates"
+)
+CORE_DIR = pathlib.Path(__file__).parent.parent / "src" / "worca" / "agents" / "core"
+
+# All expected template overlay files: (template_id, agent_name)
+TEMPLATE_OVERLAYS = [
+    ("bugfix", "planner"),
+    ("bugfix", "coordinator"),
+    ("refactor", "planner"),
+    ("refactor", "guardian"),
+    ("quick-fix", "planner"),
+    ("quick-fix", "coordinator"),
+    ("investigate", "planner"),
+    ("test-only", "planner"),
+    ("test-only", "coordinator"),
+    ("test-only", "implementer"),
+]
+
+# Core agent files that have {{block:...}} references, per agent name
+BLOCK_REFS = {
+    "planner": "{{block:plan}}",
+    "coordinator": "{{block:coordinate}}",
+    "guardian": "{{block:pr}}",
+    "implementer": "{{block:implement}}",
+}
+
+# Governance marker used in core agent files
+GOVERNANCE_MARKER = "<!-- governance -->"
+
+
+def _read(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _overlay_path(template_id: str, agent_name: str) -> pathlib.Path:
+    return TEMPLATES_DIR / template_id / "agents" / f"{agent_name}.md"
+
+
+def _core_path(agent_name: str) -> pathlib.Path:
+    return CORE_DIR / f"{agent_name}.md"
+
+
+# ---------------------------------------------------------------------------
+# Structural: overlay files exist and use append mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("template_id,agent_name", TEMPLATE_OVERLAYS)
+def test_template_overlay_file_exists(template_id, agent_name):
+    path = _overlay_path(template_id, agent_name)
+    assert path.exists(), f"Missing overlay: {path}"
+
+
+@pytest.mark.parametrize("template_id,agent_name", TEMPLATE_OVERLAYS)
+def test_template_overlay_uses_append_mode(template_id, agent_name):
+    content = _read(_overlay_path(template_id, agent_name))
+    first_line = content.split("\n", 1)[0].strip()
+    assert first_line == "<!-- append -->", (
+        f"{template_id}/{agent_name}.md: expected first line '<!-- append -->', "
+        f"got {first_line!r}"
+    )
+
+
+@pytest.mark.parametrize("template_id,agent_name", TEMPLATE_OVERLAYS)
+def test_template_overlay_has_override_sections(template_id, agent_name):
+    content = _read(_overlay_path(template_id, agent_name))
+    assert "## Override:" in content, (
+        f"{template_id}/{agent_name}.md: no '## Override:' section found"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: appending overlay onto core agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("template_id,agent_name", TEMPLATE_OVERLAYS)
+def test_template_overlay_preserves_block_refs(template_id, agent_name, tmp_path):
+    """After appending the template overlay, {{block:name}} refs from core remain."""
+    if agent_name not in BLOCK_REFS:
+        pytest.skip(f"No known block ref for agent '{agent_name}'")
+
+    core_content = _read(_core_path(agent_name))
+    block_ref = BLOCK_REFS[agent_name]
+    if block_ref not in core_content:
+        pytest.skip(f"Core {agent_name}.md doesn't contain {block_ref}")
+
+    # Apply overlay via OverlayResolver using an empty project overrides dir
+    overrides_dir = str(tmp_path / "no_project_overrides")
+    resolver = OverlayResolver(overrides_dir=overrides_dir)
+    template_agents_dir = str(TEMPLATES_DIR / template_id / "agents")
+
+    resolved = resolver.resolve(agent_name, core_content, template_agents_dir)
+
+    assert block_ref in resolved, (
+        f"After applying {template_id}/{agent_name}.md overlay, "
+        f"{block_ref} was lost from resolved output"
+    )
+
+
+@pytest.mark.parametrize("template_id,agent_name", TEMPLATE_OVERLAYS)
+def test_template_overlay_preserves_governance(template_id, agent_name, tmp_path):
+    """After appending the template overlay, governance-marked sections survive."""
+    core_content = _read(_core_path(agent_name))
+    if GOVERNANCE_MARKER not in core_content:
+        pytest.skip(f"Core {agent_name}.md has no governance section")
+
+    overrides_dir = str(tmp_path / "no_project_overrides")
+    resolver = OverlayResolver(overrides_dir=overrides_dir)
+    template_agents_dir = str(TEMPLATES_DIR / template_id / "agents")
+
+    resolved = resolver.resolve(agent_name, core_content, template_agents_dir)
+
+    assert GOVERNANCE_MARKER in resolved, (
+        f"After applying {template_id}/{agent_name}.md overlay, "
+        f"<!-- governance --> marker was lost"
+    )
+
+
+@pytest.mark.parametrize("template_id,agent_name", TEMPLATE_OVERLAYS)
+def test_template_overlay_content_appears_in_resolved(template_id, agent_name, tmp_path):
+    """Override content from the template actually appears in the resolved output."""
+    core_content = _read(_core_path(agent_name))
+    overlay_content = _read(_overlay_path(template_id, agent_name))
+
+    # Extract first override section body text (a short unique phrase)
+    import re
+    override_bodies = re.split(r"^## Override:\s*.+$", overlay_content, flags=re.MULTILINE)
+    # override_bodies[0] is the preamble (<!-- append -->), rest are section bodies
+    non_empty = [b.strip() for b in override_bodies[1:] if b.strip()]
+    if not non_empty:
+        pytest.skip(f"No override body text in {template_id}/{agent_name}.md")
+
+    # Take first line of first section body as the probe phrase
+    probe = non_empty[0].split("\n")[0].strip()
+    if not probe:
+        pytest.skip("First override body line is empty")
+
+    overrides_dir = str(tmp_path / "no_project_overrides")
+    resolver = OverlayResolver(overrides_dir=overrides_dir)
+    template_agents_dir = str(TEMPLATES_DIR / template_id / "agents")
+
+    resolved = resolver.resolve(agent_name, core_content, template_agents_dir)
+
+    assert probe in resolved, (
+        f"Override content from {template_id}/{agent_name}.md not found in resolved output. "
+        f"Expected to find: {probe!r}"
+    )

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -636,6 +636,55 @@ class TestPlanReviewerMcpToolsPermitted:
             del os.environ["WORCA_AGENT"]
 
 
+# --- Block Reviewer writes ---
+
+class TestBlockReviewerWrites:
+    """reviewer is read-only: Write/Edit and file writes via Bash must be blocked."""
+
+    def test_blocks_reviewer_write(self):
+        os.environ["WORCA_AGENT"] = "reviewer"
+        try:
+            code, reason = check_guard("Write", {"file_path": "/project/app.py"})
+            assert code == 2
+            assert "reviewer" in reason.lower()
+        finally:
+            del os.environ["WORCA_AGENT"]
+
+    def test_blocks_reviewer_edit(self):
+        os.environ["WORCA_AGENT"] = "reviewer"
+        try:
+            code, reason = check_guard("Edit", {"file_path": "/project/app.py"})
+            assert code == 2
+            assert "reviewer" in reason.lower()
+        finally:
+            del os.environ["WORCA_AGENT"]
+
+    def test_blocks_reviewer_bash_file_write(self):
+        os.environ["WORCA_AGENT"] = "reviewer"
+        try:
+            code, reason = check_guard("Bash", {"command": "cat > /project/out.txt << 'EOF'\ndata\nEOF"})
+            assert code == 2
+            assert "reviewer" in reason.lower()
+        finally:
+            del os.environ["WORCA_AGENT"]
+
+    def test_allows_reviewer_read(self):
+        os.environ["WORCA_AGENT"] = "reviewer"
+        try:
+            code, reason = check_guard("Read", {"file_path": "/project/app.py"})
+            assert code == 0
+        finally:
+            del os.environ["WORCA_AGENT"]
+
+    def test_allows_reviewer_safe_bash(self):
+        os.environ["WORCA_AGENT"] = "reviewer"
+        try:
+            code, reason = check_guard("Bash", {"command": "git diff HEAD~1"})
+            assert code == 0
+        finally:
+            del os.environ["WORCA_AGENT"]
+
+
 # --- cd prefix handling ---
 
 class TestCdPrefixHandling:

--- a/tests/test_overlay_placeholders.py
+++ b/tests/test_overlay_placeholders.py
@@ -1,0 +1,451 @@
+"""Tests for template engine: resolve_placeholders, resolve_blocks, resolve_agent.
+
+Tests for T1 and T2 of W-037: template engine functions and resolve_block in overlay.py.
+"""
+
+from unittest.mock import MagicMock
+
+
+from worca.orchestrator.overlay import (
+    OverlayResolver,
+    resolve_agent,
+    resolve_blocks,
+    resolve_placeholders,
+)
+
+
+# ---------------------------------------------------------------------------
+# resolve_placeholders — simple substitution
+# ---------------------------------------------------------------------------
+
+
+def test_simple_placeholder():
+    result = resolve_placeholders("Hello {{name}}!", {"name": "World"})
+    assert result == "Hello World!"
+
+
+def test_placeholder_missing_key():
+    result = resolve_placeholders("Value: {{missing}}", {})
+    assert result == "Value: "
+
+
+def test_placeholder_default():
+    result = resolve_placeholders("Value: {{name|fallback}}", {})
+    assert result == "Value: fallback"
+
+
+def test_placeholder_default_key_present():
+    result = resolve_placeholders("Value: {{name|fallback}}", {"name": "actual"})
+    assert result == "Value: actual"
+
+
+def test_placeholder_default_with_spaces():
+    """Default text may contain spaces."""
+    result = resolve_placeholders("Value: {{name|some default text}}", {})
+    assert result == "Value: some default text"
+
+
+def test_conditional_truthy():
+    result = resolve_placeholders("{{#if show}}body content{{/if}}", {"show": True})
+    assert result == "body content"
+
+
+def test_conditional_falsy():
+    result = resolve_placeholders("{{#if show}}body content{{/if}}", {"show": False})
+    assert result == ""
+
+
+def test_conditional_missing_key_is_falsy():
+    result = resolve_placeholders("{{#if show}}body content{{/if}}", {})
+    assert result == ""
+
+
+def test_conditional_else_truthy():
+    result = resolve_placeholders("{{#if flag}}yes{{else}}no{{/if}}", {"flag": True})
+    assert result == "yes"
+
+
+def test_conditional_else_falsy():
+    result = resolve_placeholders("{{#if flag}}yes{{else}}no{{/if}}", {"flag": False})
+    assert result == "no"
+
+
+def test_conditional_multiline():
+    content = "{{#if retry}}\n## Retry Context\n\nTest failures here.\n{{/if}}"
+    result = resolve_placeholders(content, {"retry": True})
+    assert "## Retry Context" in result
+    assert "Test failures here" in result
+
+
+def test_conditional_multiline_falsy():
+    content = "before\n{{#if retry}}\n## Retry\n{{/if}}\nafter"
+    result = resolve_placeholders(content, {"retry": False})
+    assert "## Retry" not in result
+    assert "before" in result
+    assert "after" in result
+
+
+def test_nested_conditionals_both_true():
+    content = "{{#if a}}outer{{#if b}}inner{{/if}}end{{/if}}"
+    result = resolve_placeholders(content, {"a": True, "b": True})
+    assert "outer" in result
+    assert "inner" in result
+    assert "end" in result
+
+
+def test_nested_conditional_inner_false():
+    content = "{{#if a}}outer{{#if b}}inner{{/if}}end{{/if}}"
+    result = resolve_placeholders(content, {"a": True, "b": False})
+    assert "outer" in result
+    assert "inner" not in result
+    assert "end" in result
+
+
+def test_nested_conditional_outer_false():
+    content = "{{#if a}}outer{{#if b}}inner{{/if}}end{{/if}}"
+    result = resolve_placeholders(content, {"a": False, "b": True})
+    assert result == ""
+
+
+def test_placeholder_truthy_nonempty_string():
+    """Non-empty string is truthy in conditionals."""
+    result = resolve_placeholders("{{#if val}}present{{/if}}", {"val": "hello"})
+    assert result == "present"
+
+
+def test_placeholder_truthy_zero_is_falsy():
+    """0 is falsy in conditionals."""
+    result = resolve_placeholders("{{#if val}}present{{/if}}", {"val": 0})
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# resolve_blocks — block insertion
+# ---------------------------------------------------------------------------
+
+
+def _mock_resolver(blocks: dict):
+    """Return a mock OverlayResolver whose resolve_block returns blocks[name] or None."""
+    resolver = MagicMock()
+    resolver.resolve_block.side_effect = lambda name, *args, **kwargs: blocks.get(name)
+    return resolver
+
+
+def test_block_insertion():
+    content = "Before\n{{block:myblock}}\nAfter"
+    resolver = _mock_resolver({"myblock": "Block content here"})
+    result = resolve_blocks(content, {}, resolver, "/core")
+    assert "Block content here" in result
+    assert "Before" in result
+    assert "After" in result
+
+
+def test_block_missing_resolves_to_empty():
+    content = "Before\n{{block:nonexistent}}\nAfter"
+    resolver = _mock_resolver({})
+    result = resolve_blocks(content, {}, resolver, "/core")
+    assert "{{block:nonexistent}}" not in result
+    assert "Before" in result
+    assert "After" in result
+
+
+def test_block_reference_removed_when_missing():
+    """A missing block leaves no token in the output."""
+    resolver = _mock_resolver({})
+    result = resolve_blocks("{{block:gone}}", {}, resolver, "/core")
+    assert "{{block:" not in result
+
+
+def test_block_recursive():
+    """Block A embeds {{block:b}}, which resolves to plain content."""
+
+    def _resolve(name, *args, **kwargs):
+        if name == "a":
+            return "A start\n{{block:b}}\nA end"
+        if name == "b":
+            return "B content"
+        return None
+
+    resolver = MagicMock()
+    resolver.resolve_block.side_effect = _resolve
+
+    result = resolve_blocks("{{block:a}}", {}, resolver, "/core")
+    assert "A start" in result
+    assert "B content" in result
+    assert "A end" in result
+
+
+def test_block_cycle_detection():
+    """A → B → A cycle terminates without infinite recursion."""
+    call_count = [0]
+
+    def _resolve(name, *args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] > 20:
+            raise RuntimeError("infinite loop detected in test")
+        if name == "a":
+            return "A:\n{{block:b}}"
+        if name == "b":
+            return "B:\n{{block:a}}"
+        return None
+
+    resolver = MagicMock()
+    resolver.resolve_block.side_effect = _resolve
+
+    result = resolve_blocks("{{block:a}}", {}, resolver, "/core")
+    assert "A:" in result
+    assert "B:" in result
+    # No exception means cycle was handled
+
+
+def test_block_self_cycle_detection():
+    """A block referencing itself is dropped on the second occurrence."""
+
+    def _resolve(name, *args, **kwargs):
+        return "self ref\n{{block:self}}\nend"
+
+    resolver = MagicMock()
+    resolver.resolve_block.side_effect = _resolve
+
+    result = resolve_blocks("{{block:self}}", {}, resolver, "/core")
+    assert "self ref" in result
+    # Should not infinite-loop
+
+
+def test_block_template_agents_dir_forwarded():
+    """template_agents_dir is forwarded to resolve_block."""
+    resolver = MagicMock()
+    resolver.resolve_block.return_value = "block content"
+
+    resolve_blocks("{{block:foo}}", {}, resolver, "/core", "/tpl")
+
+    resolver.resolve_block.assert_called_once_with("foo", "/core", "/tpl")
+
+
+def test_block_core_dir_forwarded():
+    """core_dir is forwarded to resolve_block."""
+    resolver = MagicMock()
+    resolver.resolve_block.return_value = None
+
+    resolve_blocks("{{block:bar}}", {}, resolver, "/my/core")
+
+    resolver.resolve_block.assert_called_once_with("bar", "/my/core", None)
+
+
+# ---------------------------------------------------------------------------
+# resolve_agent — full pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_agent_integrates_blocks_and_placeholders():
+    """Blocks are resolved first; placeholders inside blocks are then substituted."""
+
+    def _resolve(name, *args, **kwargs):
+        if name == "ctx":
+            return "Work: {{work_request}}"
+        return None
+
+    resolver = MagicMock()
+    resolver.resolve_block.side_effect = _resolve
+
+    content = "# Agent\n\n{{block:ctx}}\n\n## Rules\n"
+    result = resolve_agent(content, {"work_request": "Fix the bug"}, resolver, "/core")
+
+    assert "Work: Fix the bug" in result
+    assert "{{block:ctx}}" not in result
+    assert "{{work_request}}" not in result
+
+
+def test_resolve_agent_cleanup_collapses_blank_lines():
+    """3+ consecutive blank lines are collapsed to 2."""
+    resolver = MagicMock()
+    resolver.resolve_block.return_value = None
+
+    content = "Line 1\n\n\n\n\nLine 2"
+    result = resolve_agent(content, {}, resolver, "/core")
+
+    assert "\n\n\n" not in result
+    assert "Line 1" in result
+    assert "Line 2" in result
+
+
+def test_resolve_agent_cleanup_after_empty_conditional():
+    """Blank lines created by a falsy conditional are collapsed."""
+    resolver = MagicMock()
+    resolver.resolve_block.return_value = None
+
+    content = "before\n\n{{#if x}}\n\nSection content\n\n{{/if}}\n\n\nafter"
+    result = resolve_agent(content, {}, resolver, "/core")
+
+    assert "\n\n\n" not in result
+    assert "before" in result
+    assert "after" in result
+    assert "Section content" not in result
+
+
+def test_resolve_agent_no_blocks_no_placeholders():
+    """Content with no tokens passes through unchanged (modulo blank line cleanup)."""
+    resolver = MagicMock()
+    resolver.resolve_block.return_value = None
+
+    content = "# Agent\n\n## Role\nYou are the agent.\n"
+    result = resolve_agent(content, {}, resolver, "/core")
+    assert result == content
+
+
+def test_resolve_agent_template_agents_dir_forwarded():
+    """template_agents_dir is passed through to resolve_blocks."""
+    resolver = MagicMock()
+    resolver.resolve_block.return_value = None
+
+    resolve_agent("{{block:foo}}", {}, resolver, "/core", "/tpl")
+
+    resolver.resolve_block.assert_called_once_with("foo", "/core", "/tpl")
+
+
+# ---------------------------------------------------------------------------
+# OverlayResolver.resolve_block — three-tier block resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_block_returns_core_content(tmp_path):
+    """Core block file is found and returned."""
+    core_dir = tmp_path / "core"
+    core_dir.mkdir()
+    (core_dir / "myblock.block.md").write_text("Core block content")
+
+    resolver = OverlayResolver(overrides_dir=str(tmp_path / "project"))
+    result = resolver.resolve_block("myblock", str(core_dir), None)
+    assert result == "Core block content"
+
+
+def test_resolve_block_returns_none_when_no_file(tmp_path):
+    """Returns None when no tier has the block."""
+    resolver = OverlayResolver(overrides_dir=str(tmp_path / "project"))
+    result = resolver.resolve_block("nonexistent", str(tmp_path / "core"), None)
+    assert result is None
+
+
+def test_resolve_block_returns_none_no_template_either(tmp_path):
+    """Returns None when neither project nor template tier has the block."""
+    tpl_dir = tmp_path / "tpl"
+    tpl_dir.mkdir()
+    resolver = OverlayResolver(overrides_dir=str(tmp_path / "project"))
+    result = resolver.resolve_block("nonexistent", str(tmp_path / "core"), str(tpl_dir))
+    assert result is None
+
+
+def test_resolve_block_project_overlay_replaces_core(tmp_path):
+    """Project overlay (replace mode) replaces core block content."""
+    core_dir = tmp_path / "core"
+    core_dir.mkdir()
+    (core_dir / "myblock.block.md").write_text("Core block content")
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "myblock.block.md").write_text("Project block content")
+
+    resolver = OverlayResolver(overrides_dir=str(project_dir))
+    result = resolver.resolve_block("myblock", str(core_dir), None)
+    assert result == "Project block content"
+    assert "Core" not in result
+
+
+def test_resolve_block_template_overlay_replaces_project(tmp_path):
+    """Template overlay takes final priority over project overlay."""
+    core_dir = tmp_path / "core"
+    core_dir.mkdir()
+    (core_dir / "myblock.block.md").write_text("Core content")
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "myblock.block.md").write_text("Project content")
+
+    tpl_dir = tmp_path / "template"
+    tpl_dir.mkdir()
+    (tpl_dir / "myblock.block.md").write_text("Template content")
+
+    resolver = OverlayResolver(overrides_dir=str(project_dir))
+    result = resolver.resolve_block("myblock", str(core_dir), str(tpl_dir))
+    assert result == "Template content"
+    assert "Core" not in result
+    assert "Project" not in result
+
+
+def test_resolve_block_project_only_no_core(tmp_path):
+    """Project block file alone (no core) is returned."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "myblock.block.md").write_text("Project only content")
+
+    resolver = OverlayResolver(overrides_dir=str(project_dir))
+    result = resolver.resolve_block("myblock", str(tmp_path / "core"), None)
+    assert result == "Project only content"
+
+
+def test_resolve_block_template_only_no_core_no_project(tmp_path):
+    """Template-only block (no core, no project) is returned."""
+    tpl_dir = tmp_path / "tpl"
+    tpl_dir.mkdir()
+    (tpl_dir / "myblock.block.md").write_text("Template only content")
+
+    resolver = OverlayResolver(overrides_dir=str(tmp_path / "project"))
+    result = resolver.resolve_block("myblock", str(tmp_path / "core"), str(tpl_dir))
+    assert result == "Template only content"
+
+
+def test_resolve_block_project_append_merges_with_core(tmp_path):
+    """Project overlay in append mode appends to core block content."""
+    core_dir = tmp_path / "core"
+    core_dir.mkdir()
+    (core_dir / "myblock.block.md").write_text("Core content")
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "myblock.block.md").write_text("<!-- append -->\nExtra content")
+
+    resolver = OverlayResolver(overrides_dir=str(project_dir))
+    result = resolver.resolve_block("myblock", str(core_dir), None)
+    assert "Core content" in result
+    assert "Extra content" in result
+
+
+def test_resolve_block_explicit_replace_tag(tmp_path):
+    """Project overlay with <!-- replace --> tag still replaces core."""
+    core_dir = tmp_path / "core"
+    core_dir.mkdir()
+    (core_dir / "myblock.block.md").write_text("Core content")
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "myblock.block.md").write_text("<!-- replace -->\nReplacement content")
+
+    resolver = OverlayResolver(overrides_dir=str(project_dir))
+    result = resolver.resolve_block("myblock", str(core_dir), None)
+    assert result == "Replacement content"
+    assert "Core" not in result
+
+
+def test_resolve_block_skips_missing_project_tier(tmp_path):
+    """If only core exists (no project file), core content is returned."""
+    core_dir = tmp_path / "core"
+    core_dir.mkdir()
+    (core_dir / "myblock.block.md").write_text("Core only")
+
+    resolver = OverlayResolver(overrides_dir=str(tmp_path / "project"))
+    result = resolver.resolve_block("myblock", str(core_dir), None)
+    assert result == "Core only"
+
+
+def test_resolve_block_skips_missing_template_tier(tmp_path):
+    """If template_agents_dir is set but has no matching file, result unchanged."""
+    core_dir = tmp_path / "core"
+    core_dir.mkdir()
+    (core_dir / "myblock.block.md").write_text("Core only")
+
+    tpl_dir = tmp_path / "tpl"
+    tpl_dir.mkdir()
+
+    resolver = OverlayResolver(overrides_dir=str(tmp_path / "project"))
+    result = resolver.resolve_block("myblock", str(core_dir), str(tpl_dir))
+    assert result == "Core only"

--- a/tests/test_plan_file_location.py
+++ b/tests/test_plan_file_location.py
@@ -107,16 +107,17 @@ class TestGuardPlannerPlanFiles:
 # --- PromptBuilder uses plan_file from context ---
 
 class TestPromptBuilderPlanFile:
-    def test_plan_prompt_uses_context_plan_file(self):
+    def test_plan_context_uses_plan_file_from_context(self):
+        """build_context('plan') passes plan_file through to the context dict."""
         from worca.orchestrator.prompt_builder import PromptBuilder
         pb = PromptBuilder("Test title", "Test desc", claude_md_path="/nonexistent")
         pb.update_context("plan_file", "/run/plan-001.md")
-        prompt = pb.build("plan")
-        assert "/run/plan-001.md" in prompt
-        assert "MASTER_PLAN.md" not in prompt
+        ctx = pb.build_context("plan")
+        assert ctx.get("plan_file") == "/run/plan-001.md"
 
-    def test_plan_prompt_falls_back_to_master_plan(self):
+    def test_plan_context_has_work_request(self):
+        """build_context('plan') includes work_request key."""
         from worca.orchestrator.prompt_builder import PromptBuilder
         pb = PromptBuilder("Test title", "Test desc", claude_md_path="/nonexistent")
-        prompt = pb.build("plan")
-        assert "MASTER_PLAN.md" in prompt
+        ctx = pb.build_context("plan")
+        assert "Test title" in ctx.get("work_request", "")

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -4,218 +4,12 @@
 from worca.orchestrator.prompt_builder import PromptBuilder
 
 
-def test_build_unknown_stage_returns_work_request():
-    pb = PromptBuilder("Add auth", "Implement user authentication")
-    prompt = pb.build("unknown_stage")
-    assert "Add auth" in prompt
-    assert "Implement user authentication" in prompt
+# --- T10: build() shim removal ---
 
-
-def test_build_plan_includes_work_request():
-    pb = PromptBuilder("Add auth", "Implement user authentication")
-    prompt = pb.build("plan")
-    assert "Add auth" in prompt
-    assert "Implement user authentication" in prompt
-
-
-def test_build_plan_includes_claude_md_instruction():
-    pb = PromptBuilder("Add auth", "Implement user authentication")
-    prompt = pb.build("plan")
-    assert "CLAUDE.md" in prompt
-    assert "MASTER_PLAN.md" in prompt
-
-
-def test_build_plan_includes_claude_md_content(tmp_path):
-    claude_md = tmp_path / "CLAUDE.md"
-    claude_md.write_text("# My Project\n\nUses Python + pytest")
-    pb = PromptBuilder("Add auth", "Desc", claude_md_path=str(claude_md))
-    prompt = pb.build("plan")
-    assert "My Project" in prompt
-    assert "Uses Python + pytest" in prompt
-    assert "Project Context" in prompt
-
-
-def test_build_plan_no_claude_md(tmp_path):
-    pb = PromptBuilder("Add auth", "Desc", claude_md_path=str(tmp_path / "nonexistent.md"))
-    prompt = pb.build("plan")
-    assert "Project Context" not in prompt
-    assert "Add auth" in prompt
-
-
-def test_build_coordinate_includes_work_request():
-    pb = PromptBuilder("Add auth", "Implement user authentication")
-    prompt = pb.build("coordinate")
-    assert "Add auth" in prompt
-    assert "bd create" in prompt
-    assert "Do NOT implement" in prompt
-
-
-def test_build_coordinate_includes_plan_context():
+def test_build_method_removed():
+    """build() shim has been removed from PromptBuilder after T10 refactor."""
     pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("plan_approach", "Use JWT tokens with refresh flow")
-    pb.update_context("plan_tasks_outline", [
-        {"title": "Create auth middleware", "description": "JWT validation middleware"},
-        {"title": "Add login endpoint", "description": "POST /api/login"},
-    ])
-    prompt = pb.build("coordinate")
-    assert "Approved Plan" in prompt
-    assert "JWT tokens" in prompt
-    assert "Create auth middleware" in prompt
-    assert "Add login endpoint" in prompt
-
-
-def test_build_coordinate_without_plan_context():
-    pb = PromptBuilder("Add auth", "Desc")
-    prompt = pb.build("coordinate")
-    assert "Approved Plan" not in prompt
-
-
-def test_build_implement_with_assigned_bead():
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("assigned_bead_id", "bd-abc123")
-    pb.update_context("assigned_bead_title", "Create auth middleware")
-    pb.update_context("assigned_bead_description", "JWT validation middleware")
-    prompt = pb.build("implement")
-    assert "bd-abc123" in prompt
-    assert "Create auth middleware" in prompt
-    assert "JWT validation middleware" in prompt
-    assert "bd ready" not in prompt
-
-
-def test_build_implement_without_assigned_bead():
-    pb = PromptBuilder("Add auth", "Desc")
-    prompt = pb.build("implement")
-    assert "bd ready" in prompt
-
-
-def test_build_implement_with_test_failures():
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("assigned_bead_id", "bd-abc123")
-    pb.update_context("test_failures", [
-        {"test_name": "test_login_valid", "error": "AssertionError: 401 != 200"},
-        {"test_name": "test_token_refresh", "error": "KeyError: 'refresh_token'"},
-    ])
-    prompt = pb.build("implement", iteration=1)
-    assert "PRIORITY: Fix Test Failures" in prompt
-    assert "Failures to Fix" in prompt
-    assert "test_login_valid" in prompt
-    assert "401 != 200" in prompt
-    assert "test_token_refresh" in prompt
-    assert "Reference: Task & Plan (already implemented)" in prompt
-
-
-def test_build_implement_with_review_issues():
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("assigned_bead_id", "bd-abc123")
-    pb.update_context("review_issues", [
-        {"file": "auth.py", "line": 42, "severity": "critical", "description": "SQL injection"},
-    ])
-    prompt = pb.build("implement", iteration=2)
-    assert "PRIORITY: Fix Review Issues" in prompt
-    assert "Issues to Fix" in prompt
-    assert "auth.py:42" in prompt
-    assert "SQL injection" in prompt
-    assert "[critical]" in prompt
-    assert "Reference: Task & Plan (already implemented)" in prompt
-
-
-def test_build_implement_no_loop_context_at_iteration_0():
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("test_failures", [{"test_name": "t", "error": "e"}])
-    prompt = pb.build("implement", iteration=0)
-    assert "PRIORITY" not in prompt
-
-
-def test_build_implement_cleared_context_not_shown():
-    """When test_failures is set to None (cleared), it should not appear."""
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("assigned_bead_id", "bd-abc123")
-    pb.update_context("test_failures", None)
-    pb.update_context("review_issues", [
-        {"file": "x.py", "line": 1, "severity": "minor", "description": "style"},
-    ])
-    prompt = pb.build("implement", iteration=1)
-    assert "Fix Test Failures" not in prompt
-    assert "Fix Review Issues" in prompt
-
-
-def test_build_implement_retry_shows_history():
-    """Review history from multiple attempts is shown in retry prompt."""
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("assigned_bead_id", "bd-abc123")
-    pb.update_context("review_history", [
-        {"attempt": 1, "issues": [{"file": "a.py", "line": 10, "severity": "major", "description": "bug1"}]},
-        {"attempt": 2, "issues": [{"file": "a.py", "line": 10, "severity": "major", "description": "bug1 still"}]},
-    ])
-    pb.update_context("review_issues", [
-        {"file": "a.py", "line": 10, "severity": "major", "description": "bug1 still"},
-    ])
-    prompt = pb.build("implement", iteration=2)
-    assert "Previous Attempts (all failed to resolve)" in prompt
-    assert "Attempt 1" in prompt
-    assert "PRIORITY: Fix Review Issues (attempt 2)" in prompt
-
-
-def test_build_implement_retry_verification_instruction():
-    """Retry prompt includes verification instruction."""
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("review_issues", [
-        {"file": "a.py", "line": 1, "severity": "critical", "description": "x"},
-    ])
-    prompt = pb.build("implement", iteration=1)
-    assert "read back the changed lines" in prompt
-
-
-def test_build_test_includes_implementation_summary():
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("files_changed", ["auth.py", "middleware.py"])
-    pb.update_context("tests_added", ["test_auth.py"])
-    prompt = pb.build("test")
-    assert "Implementation Summary" in prompt
-    assert "auth.py" in prompt
-    assert "middleware.py" in prompt
-    assert "test_auth.py" in prompt
-
-
-def test_build_test_without_implementation_summary():
-    pb = PromptBuilder("Add auth", "Desc")
-    prompt = pb.build("test")
-    assert "Implementation Summary" not in prompt
-    assert "Do NOT modify source code" in prompt
-
-
-def test_build_review_includes_test_results():
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("test_passed", True)
-    pb.update_context("test_coverage", 87.5)
-    pb.update_context("proof_artifacts", [".worca/test-output.txt"])
-    pb.update_context("files_changed", ["auth.py"])
-    prompt = pb.build("review")
-    assert "PASSED" in prompt
-    assert "87.5%" in prompt
-    assert "test-output.txt" in prompt
-    assert "Files Changed" in prompt
-    assert "auth.py" in prompt
-
-
-def test_build_review_without_test_results():
-    pb = PromptBuilder("Add auth", "Desc")
-    prompt = pb.build("review")
-    assert "Test Results" not in prompt
-
-
-def test_build_pr_includes_approach():
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("plan_approach", "JWT with refresh tokens")
-    prompt = pb.build("pr")
-    assert "JWT with refresh tokens" in prompt
-    assert "pull request" in prompt.lower()
-
-
-def test_build_pr_without_approach():
-    pb = PromptBuilder("Add auth", "Desc")
-    prompt = pb.build("pr")
-    assert "Approach" not in prompt
+    assert not hasattr(pb, "build"), "build() shim should be removed from PromptBuilder"
 
 
 def test_update_and_get_context():
@@ -225,69 +19,6 @@ def test_update_and_get_context():
     assert pb.get_context("missing") is None
     assert pb.get_context("missing", "default") == "default"
 
-
-def test_description_defaults_to_title():
-    pb = PromptBuilder("Add auth")
-    prompt = pb.build("plan")
-    # Description should fall back to title
-    assert "Add auth" in prompt
-
-
-# --- Fix 1: per-bead prompt iteration counter ---
-
-def test_implement_iteration_0_produces_initial_prompt():
-    """build("implement", 0) should produce the initial prompt."""
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("assigned_bead_id", "bd-abc")
-    pb.update_context("assigned_bead_title", "Task 1")
-    prompt = pb.build("implement", iteration=0)
-    assert prompt.startswith("Implement the code")
-    assert "PRIORITY" not in prompt
-
-
-def test_implement_iteration_1_with_review_issues_produces_retry():
-    """build("implement", 1) with review_issues should produce a retry prompt."""
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("review_issues", [
-        {"file": "x.py", "line": 1, "severity": "major", "description": "bug"},
-    ])
-    prompt = pb.build("implement", iteration=1)
-    assert prompt.startswith("## PRIORITY")
-
-
-def test_implement_iteration_0_after_context_clear_produces_initial():
-    """After clearing feedback context, build("implement", 0) should produce
-    the initial prompt again — not a broken retry prompt."""
-    pb = PromptBuilder("Add auth", "Desc")
-    # Simulate a retry cycle
-    pb.update_context("review_issues", [
-        {"file": "x.py", "line": 1, "severity": "major", "description": "bug"},
-    ])
-    prompt_retry = pb.build("implement", iteration=1)
-    assert "PRIORITY" in prompt_retry
-
-    # Simulate next_bead transition: clear feedback, reset iteration
-    pb.update_context("review_issues", None)
-    pb.update_context("review_history", None)
-    pb.update_context("test_failures", None)
-    pb.update_context("test_failure_history", None)
-    prompt_fresh = pb.build("implement", iteration=0)
-    assert prompt_fresh.startswith("Implement the code")
-    assert "PRIORITY" not in prompt_fresh
-    assert "Verification" not in prompt_fresh.split("\n")[0]
-
-
-# --- Fix 2: reviewer knows implementer capabilities ---
-
-def test_review_prompt_contains_implementer_capabilities():
-    """Review prompt should tell the reviewer that the implementer cannot commit."""
-    pb = PromptBuilder("Add auth", "Desc")
-    prompt = pb.build("review")
-    assert "CANNOT make git commits" in prompt
-    assert "Do NOT flag uncommitted files" in prompt
-
-
-# --- pop_context ---
 
 def test_pop_context_removes_key_and_returns_value():
     pb = PromptBuilder("title", "desc")
@@ -311,153 +42,6 @@ def test_pop_context_does_not_persist_key():
 
 # --- _build_plan_review ---
 
-def test_build_plan_review_includes_work_request(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Implementation Plan\n\nPhase 1: Setup")
-    pb = PromptBuilder("Add auth", "Implement user authentication", master_plan_path=str(plan_file))
-    prompt = pb.build("plan_review")
-    assert "Add auth" in prompt
-    assert "Implement user authentication" in prompt
-
-
-def test_build_plan_review_reads_plan_from_disk(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Implementation Plan\n\nPhase 1: Setup\nPhase 2: Implement JWT")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    prompt = pb.build("plan_review")
-    assert "Phase 1: Setup" in prompt
-    assert "Phase 2: Implement JWT" in prompt
-
-
-def test_build_plan_review_includes_mcp_instructions(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Plan")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    prompt = pb.build("plan_review")
-    assert "context7" in prompt.lower()
-    assert "WebSearch" in prompt or "websearch" in prompt.lower()
-    assert "WebFetch" in prompt or "webfetch" in prompt.lower()
-
-
-def test_build_plan_review_no_history_on_first_iteration(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Plan")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    pb.update_context("plan_review_history", [
-        {"attempt": 1, "issues": [{"category": "risk", "severity": "major", "description": "secret"}]}
-    ])
-    prompt = pb.build("plan_review", iteration=0)
-    assert "secret" not in prompt
-    assert "Previous Review" not in prompt
-
-
-def test_build_plan_review_includes_history_on_subsequent_iteration(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Plan")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    pb.update_context("plan_review_history", [
-        {"attempt": 1, "issues": [{"category": "completeness", "severity": "major", "description": "Missing auth edge cases"}]}
-    ])
-    prompt = pb.build("plan_review", iteration=1)
-    assert "Missing auth edge cases" in prompt
-    assert "Previous Review" in prompt
-
-
-def test_build_plan_review_handles_missing_master_plan():
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path="/nonexistent/MASTER_PLAN.md")
-    prompt = pb.build("plan_review")
-    assert "Add auth" in prompt
-    assert "not found" in prompt.lower() or "empty" in prompt.lower() or "critical" in prompt.lower()
-
-
-# --- _build_plan revision mode ---
-
-def test_build_plan_revision_mode_uses_revision_header(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Current Plan\n\nDo this and that")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    pb.update_context("plan_revision_mode", True)
-    pb.update_context("plan_review_issues", [
-        {"category": "completeness", "severity": "critical", "description": "Missing edge cases"},
-    ])
-    prompt = pb.build("plan")
-    assert "revise" in prompt.lower() or "revision" in prompt.lower()
-    assert "Create a detailed implementation plan" not in prompt
-
-
-def test_build_plan_revision_mode_includes_issues(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Current Plan")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    pb.update_context("plan_revision_mode", True)
-    pb.update_context("plan_review_issues", [
-        {"category": "feasibility", "severity": "major", "description": "Unrealistic timeline"},
-        {"category": "completeness", "severity": "critical", "description": "Missing error handling"},
-    ])
-    prompt = pb.build("plan")
-    assert "Unrealistic timeline" in prompt
-    assert "Missing error handling" in prompt
-
-
-def test_build_plan_revision_mode_includes_history(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Current Plan")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    pb.update_context("plan_revision_mode", True)
-    pb.update_context("plan_review_issues", [])
-    pb.update_context("plan_review_history", [
-        {"attempt": 1, "issues": [{"category": "risk", "severity": "major", "description": "No rollback"}]}
-    ])
-    prompt = pb.build("plan")
-    assert "No rollback" in prompt
-
-
-def test_build_plan_revision_mode_reads_current_plan(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Existing Plan Content\n\nDo step A, then B")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    pb.update_context("plan_revision_mode", True)
-    pb.update_context("plan_review_issues", [])
-    prompt = pb.build("plan")
-    assert "Existing Plan Content" in prompt
-    assert "Do step A, then B" in prompt
-
-
-def test_build_plan_no_revision_mode_unchanged():
-    pb = PromptBuilder("Add auth", "Implement user authentication")
-    prompt = pb.build("plan")
-    assert "Create a detailed implementation plan" in prompt
-    assert "MASTER_PLAN.md" in prompt
-
-
-def test_build_plan_revision_mode_instructs_approved_true(tmp_path):
-    plan_file = tmp_path / "MASTER_PLAN.md"
-    plan_file.write_text("# Current Plan")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
-    pb.update_context("plan_revision_mode", True)
-    pb.update_context("plan_review_issues", [])
-    prompt = pb.build("plan")
-    assert "approved" in prompt.lower()
-    assert "true" in prompt.lower()
-
-
-# --- plan-file context fixes (TDD red phase) ---
-
-def test_build_plan_revision_uses_plan_file_context(tmp_path):
-    """_build_plan_revision() should reference plan_file context name, not MASTER_PLAN.md."""
-    plan_file = tmp_path / "plan-001.md"
-    plan_file.write_text("# Current Plan\n\nDo this and that")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(tmp_path / "MASTER_PLAN.md"))
-    pb.update_context("plan_file", str(plan_file))
-    pb.update_context("plan_revision_mode", True)
-    pb.update_context("plan_review_issues", [
-        {"category": "completeness", "severity": "critical", "description": "Missing edge cases"},
-    ])
-    prompt = pb.build("plan")
-    assert "plan-001.md" in prompt
-    assert "MASTER_PLAN.md" not in prompt
-
-
 def test_read_master_plan_uses_plan_file_context(tmp_path):
     """_read_master_plan() should find content via plan_file context key when MASTER_PLAN.md absent."""
     plan_file = tmp_path / "plan-001.md"
@@ -468,21 +52,506 @@ def test_read_master_plan_uses_plan_file_context(tmp_path):
     assert "Plan from plan_file context" in content
 
 
-def test_build_plan_review_uses_plan_file_context(tmp_path):
-    """_build_plan_review() section header should use plan_file name, not MASTER_PLAN.md."""
-    plan_file = tmp_path / "plan-001.md"
+def test_format_test_failures_returns_numbered_markdown():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_test_failures([
+        {"test_name": "test_login_valid", "error": "AssertionError: 401 != 200"},
+        {"test_name": "test_token_refresh", "error": "KeyError: 'refresh_token'"},
+    ])
+    assert "1. **test_login_valid**" in result
+    assert "AssertionError: 401 != 200" in result
+    assert "2. **test_token_refresh**" in result
+    assert "KeyError: 'refresh_token'" in result
+
+
+def test_format_test_failures_empty_list_returns_empty_string():
+    pb = PromptBuilder("T", "D")
+    assert pb._format_test_failures([]) == ""
+
+
+def test_format_test_failures_missing_fields_uses_defaults():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_test_failures([{}])
+    assert "1. **unknown**" in result
+    assert "no details" in result
+
+
+def test_format_review_issues_returns_severity_file_line_markdown():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_review_issues([
+        {"file": "auth.py", "line": 42, "severity": "critical", "description": "SQL injection"},
+        {"file": "middleware.py", "line": 15, "severity": "major", "description": "Missing validation"},
+    ])
+    assert "1. [critical] `auth.py:42`" in result
+    assert "SQL injection" in result
+    assert "2. [major] `middleware.py:15`" in result
+    assert "Missing validation" in result
+
+
+def test_format_review_issues_empty_list_returns_empty_string():
+    pb = PromptBuilder("T", "D")
+    assert pb._format_review_issues([]) == ""
+
+
+def test_format_review_issues_missing_fields_uses_defaults():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_review_issues([{}])
+    assert "[?] `?:?`" in result
+
+
+def test_format_review_history_returns_attempt_bullets():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_review_history([
+        {"attempt": 1, "issues": [{"file": "a.py", "line": 10, "severity": "major"}]},
+        {"attempt": 2, "issues": [{"file": "b.py", "line": 5, "severity": "critical"}]},
+    ])
+    assert "- Attempt 1:" in result
+    assert "[major] a.py:10" in result
+    assert "- Attempt 2:" in result
+    assert "[critical] b.py:5" in result
+
+
+def test_format_review_history_empty_list_returns_empty_string():
+    pb = PromptBuilder("T", "D")
+    assert pb._format_review_history([]) == ""
+
+
+def test_format_review_history_missing_fields_uses_defaults():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_review_history([{"attempt": 1, "issues": [{}]}])
+    assert "- Attempt 1:" in result
+    assert "[?] ?:?" in result
+
+
+def test_format_test_failure_history_returns_attempt_bullets():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_test_failure_history([
+        {"attempt": 1, "failures": [{"test_name": "test_a"}, {"test_name": "test_b"}]},
+        {"attempt": 2, "failures": [{"test_name": "test_c"}]},
+    ])
+    assert "- Attempt 1: test_a; test_b" in result
+    assert "- Attempt 2: test_c" in result
+
+
+def test_format_test_failure_history_empty_list_returns_empty_string():
+    pb = PromptBuilder("T", "D")
+    assert pb._format_test_failure_history([]) == ""
+
+
+def test_format_test_failure_history_missing_fields_uses_defaults():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_test_failure_history([{"attempt": "?", "failures": [{}]}])
+    assert "- Attempt ?: unknown" in result
+
+
+def test_format_plan_review_issues_returns_numbered_markdown():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_plan_review_issues([
+        {
+            "category": "feasibility",
+            "severity": "major",
+            "description": "Unrealistic timeline",
+            "suggestion": "Add buffer",
+            "evidence": "Similar project took 4 weeks",
+        },
+        {
+            "category": "completeness",
+            "severity": "critical",
+            "description": "Missing error handling",
+        },
+    ])
+    assert "1. [major] (feasibility) Unrealistic timeline" in result
+    assert "Suggestion: Add buffer" in result
+    assert "Evidence: Similar project took 4 weeks" in result
+    assert "2. [critical] (completeness) Missing error handling" in result
+
+
+def test_format_plan_review_issues_omits_missing_suggestion_evidence():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_plan_review_issues([
+        {"category": "risk", "severity": "minor", "description": "Low risk"},
+    ])
+    assert "Suggestion" not in result
+    assert "Evidence" not in result
+
+
+def test_format_plan_review_issues_empty_list_returns_empty_string():
+    pb = PromptBuilder("T", "D")
+    assert pb._format_plan_review_issues([]) == ""
+
+
+def test_format_plan_review_issues_missing_fields_uses_defaults():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_plan_review_issues([{}])
+    assert "1. [?] (?) " in result
+
+
+def test_format_plan_review_history_returns_attempt_bullets():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_plan_review_history([
+        {"attempt": 1, "issues": [{"severity": "major", "category": "risk", "description": "No rollback"}]},
+        {"attempt": 2, "issues": [{"severity": "critical", "category": "completeness", "description": "Missing tests"}]},
+    ])
+    assert "- Attempt 1: [major] risk: No rollback" in result
+    assert "- Attempt 2: [critical] completeness: Missing tests" in result
+
+
+def test_format_plan_review_history_empty_list_returns_empty_string():
+    pb = PromptBuilder("T", "D")
+    assert pb._format_plan_review_history([]) == ""
+
+
+def test_format_plan_review_history_missing_fields_uses_defaults():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_plan_review_history([{"attempt": 1, "issues": [{}]}])
+    assert "- Attempt 1: [?] ?: " in result
+
+
+def test_format_implementation_summary_returns_files_and_tests():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_implementation_summary(
+        files_changed=["auth.py", "middleware.py"],
+        tests_added=["test_auth.py"],
+    )
+    assert "**Files changed:**" in result
+    assert "- auth.py" in result
+    assert "- middleware.py" in result
+    assert "**Tests added:**" in result
+    assert "- test_auth.py" in result
+
+
+def test_format_implementation_summary_files_only():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_implementation_summary(
+        files_changed=["main.py"],
+        tests_added=[],
+    )
+    assert "**Files changed:**" in result
+    assert "**Tests added:**" not in result
+
+
+def test_format_implementation_summary_empty_returns_empty_string():
+    pb = PromptBuilder("T", "D")
+    assert pb._format_implementation_summary([], []) == ""
+
+
+def test_format_test_results_passed_with_coverage():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_test_results(
+        test_passed=True,
+        coverage=87.5,
+        proof_artifacts=[".worca/test-output.txt"],
+    )
+    assert "**Status:** PASSED" in result
+    assert "**Coverage:** 87.5%" in result
+    assert "**Proof artifacts:**" in result
+    assert "- .worca/test-output.txt" in result
+
+
+def test_format_test_results_failed_no_coverage():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_test_results(test_passed=False, coverage=None, proof_artifacts=[])
+    assert "**Status:** FAILED" in result
+    assert "Coverage" not in result
+    assert "Proof artifacts" not in result
+
+
+def test_format_test_results_no_artifacts():
+    pb = PromptBuilder("T", "D")
+    result = pb._format_test_results(test_passed=True, coverage=None, proof_artifacts=None)
+    assert "**Status:** PASSED" in result
+    assert "Proof artifacts" not in result
+
+
+# --- build_context() ---
+
+def test_build_context_returns_dict():
+    pb = PromptBuilder("Add auth", "Implement authentication")
+    ctx = pb.build_context("plan")
+    assert isinstance(ctx, dict)
+
+
+def test_build_context_plan_contains_work_request():
+    pb = PromptBuilder("Add auth", "Implement authentication")
+    ctx = pb.build_context("plan")
+    assert "work_request" in ctx
+    assert "Add auth" in ctx["work_request"]
+    assert "Implement authentication" in ctx["work_request"]
+
+
+def test_build_context_plan_contains_claude_md(tmp_path):
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text("# My Project\n\nUses Python + pytest")
+    pb = PromptBuilder("Add auth", "Desc", claude_md_path=str(claude_md))
+    ctx = pb.build_context("plan")
+    assert ctx.get("claude_md") == "# My Project\n\nUses Python + pytest"
+
+
+def test_build_context_plan_no_claude_md(tmp_path):
+    pb = PromptBuilder("Add auth", "Desc", claude_md_path=str(tmp_path / "nonexistent.md"))
+    ctx = pb.build_context("plan")
+    assert ctx.get("claude_md") == ""
+
+
+def test_build_context_plan_revision_mode_sets_plan_content(tmp_path):
+    plan_file = tmp_path / "MASTER_PLAN.md"
+    plan_file.write_text("# Plan Content")
+    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
+    pb.update_context("plan_revision_mode", True)
+    ctx = pb.build_context("plan")
+    assert "Plan Content" in ctx.get("plan_content", "")
+
+
+def test_build_context_plan_revision_mode_formats_issues():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("plan_revision_mode", True)
+    pb.update_context("plan_review_issues", [
+        {"category": "completeness", "severity": "critical", "description": "Missing edge cases"},
+    ])
+    ctx = pb.build_context("plan")
+    assert "Missing edge cases" in ctx.get("plan_review_issues_formatted", "")
+
+
+def test_build_context_plan_revision_mode_formats_history():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("plan_revision_mode", True)
+    pb.update_context("plan_review_history", [
+        {"attempt": 1, "issues": [{"severity": "major", "category": "risk", "description": "No rollback"}]},
+    ])
+    ctx = pb.build_context("plan")
+    assert "No rollback" in ctx.get("plan_review_history_formatted", "")
+
+
+def test_build_context_plan_review_sets_plan_content(tmp_path):
+    plan_file = tmp_path / "MASTER_PLAN.md"
     plan_file.write_text("# Implementation Plan\n\nPhase 1: Setup")
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(tmp_path / "MASTER_PLAN.md"))
-    pb.update_context("plan_file", str(plan_file))
-    prompt = pb.build("plan_review")
-    assert "Implementation Plan (plan-001.md)" in prompt
-    assert "Implementation Plan (MASTER_PLAN.md)" not in prompt
+    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(plan_file))
+    ctx = pb.build_context("plan_review")
+    assert "Phase 1: Setup" in ctx.get("plan_content", "")
 
 
-def test_build_plan_review_missing_plan_uses_plan_file_name(tmp_path):
-    """Fallback message when plan is missing should reference plan_file name, not MASTER_PLAN.md."""
-    pb = PromptBuilder("Add auth", "Desc", master_plan_path=str(tmp_path / "MASTER_PLAN.md"))
-    pb.update_context("plan_file", str(tmp_path / "plan-001.md"))  # file does not exist
-    prompt = pb.build("plan_review")
-    assert "plan-001.md" in prompt
-    assert "MASTER_PLAN.md" not in prompt
+def test_build_context_plan_review_history_empty_on_iteration_0():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("plan_review_history", [
+        {"attempt": 1, "issues": [{"category": "risk", "severity": "major", "description": "No rollback"}]}
+    ])
+    ctx = pb.build_context("plan_review", iteration=0)
+    assert not ctx.get("plan_review_history_formatted")
+
+
+def test_build_context_plan_review_history_set_on_iteration_1():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("plan_review_history", [
+        {"attempt": 1, "issues": [{"category": "risk", "severity": "major", "description": "No rollback"}]}
+    ])
+    ctx = pb.build_context("plan_review", iteration=1)
+    assert "No rollback" in ctx.get("plan_review_history_formatted", "")
+
+
+def test_build_context_coordinate_plan_summary_from_approach_and_outline():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("plan_approach", "Use JWT tokens")
+    pb.update_context("plan_tasks_outline", [
+        {"title": "Create middleware", "description": "JWT validation"},
+    ])
+    ctx = pb.build_context("coordinate")
+    assert "Use JWT tokens" in ctx.get("plan_summary", "")
+    assert "Create middleware" in ctx.get("plan_summary", "")
+
+
+def test_build_context_coordinate_no_plan_summary_without_approach():
+    pb = PromptBuilder("Add auth", "Desc")
+    ctx = pb.build_context("coordinate")
+    assert not ctx.get("plan_summary")
+
+
+def test_build_context_implement_initial_is_retry_false():
+    pb = PromptBuilder("Add auth", "Desc")
+    ctx = pb.build_context("implement", iteration=0)
+    assert ctx.get("is_retry") is False
+
+
+def test_build_context_implement_retry_is_retry_true():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("test_failures", [{"test_name": "test_a", "error": "fail"}])
+    ctx = pb.build_context("implement", iteration=1)
+    assert ctx.get("is_retry") is True
+
+
+def test_build_context_implement_retry_issue_type_test_failures():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("test_failures", [{"test_name": "test_a", "error": "fail"}])
+    ctx = pb.build_context("implement", iteration=1)
+    assert ctx.get("issue_type") == "Test Failures"
+
+
+def test_build_context_implement_retry_issue_type_review_issues():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("review_issues", [
+        {"file": "a.py", "line": 1, "severity": "major", "description": "bug"},
+    ])
+    ctx = pb.build_context("implement", iteration=1)
+    assert ctx.get("issue_type") == "Review Issues"
+
+
+def test_build_context_implement_retry_formats_test_failures():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("test_failures", [
+        {"test_name": "test_login", "error": "AssertionError: 401 != 200"},
+    ])
+    ctx = pb.build_context("implement", iteration=1)
+    assert "test_login" in ctx.get("test_failures_formatted", "")
+    assert "401 != 200" in ctx.get("test_failures_formatted", "")
+
+
+def test_build_context_implement_retry_formats_review_issues():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("review_issues", [
+        {"file": "auth.py", "line": 42, "severity": "critical", "description": "SQL injection"},
+    ])
+    ctx = pb.build_context("implement", iteration=1)
+    assert "auth.py" in ctx.get("review_issues_formatted", "")
+    assert "SQL injection" in ctx.get("review_issues_formatted", "")
+
+
+def test_build_context_implement_retry_previous_attempts_from_review_history():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("review_history", [
+        {"attempt": 1, "issues": [{"file": "a.py", "line": 10, "severity": "major", "description": "bug1"}]},
+        {"attempt": 2, "issues": [{"file": "a.py", "line": 10, "severity": "major", "description": "bug2"}]},
+    ])
+    pb.update_context("review_issues", [
+        {"file": "a.py", "line": 10, "severity": "major", "description": "bug2"},
+    ])
+    ctx = pb.build_context("implement", iteration=2)
+    assert "Attempt 1" in ctx.get("previous_attempts", "")
+
+
+def test_build_context_implement_assigned_task_body_with_bead():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("assigned_bead_id", "bd-abc123")
+    pb.update_context("assigned_bead_title", "Create auth middleware")
+    ctx = pb.build_context("implement", iteration=0)
+    assert "bd-abc123" in ctx.get("assigned_task", "")
+    assert "Create auth middleware" in ctx.get("assigned_task", "")
+
+
+def test_build_context_implement_no_assigned_task_when_no_bead():
+    pb = PromptBuilder("Add auth", "Desc")
+    ctx = pb.build_context("implement")
+    assert not ctx.get("assigned_task")
+
+
+def test_build_context_test_formats_implementation_summary():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("files_changed", ["auth.py", "middleware.py"])
+    pb.update_context("tests_added", ["test_auth.py"])
+    ctx = pb.build_context("test")
+    assert "auth.py" in ctx.get("implementation_summary", "")
+    assert "test_auth.py" in ctx.get("implementation_summary", "")
+
+
+def test_build_context_test_no_implementation_summary_when_empty():
+    pb = PromptBuilder("Add auth", "Desc")
+    ctx = pb.build_context("test")
+    assert not ctx.get("implementation_summary")
+
+
+def test_build_context_review_formats_test_results():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("test_passed", True)
+    pb.update_context("test_coverage", 87.5)
+    pb.update_context("proof_artifacts", [".worca/test-output.txt"])
+    ctx = pb.build_context("review")
+    assert "PASSED" in ctx.get("test_results", "")
+    assert "87.5%" in ctx.get("test_results", "")
+
+
+def test_build_context_review_no_test_results_when_not_set():
+    pb = PromptBuilder("Add auth", "Desc")
+    ctx = pb.build_context("review")
+    assert not ctx.get("test_results")
+
+
+def test_build_context_review_formats_files_changed():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("files_changed", ["auth.py", "middleware.py"])
+    ctx = pb.build_context("review")
+    assert "auth.py" in ctx.get("files_changed_formatted", "")
+    assert "middleware.py" in ctx.get("files_changed_formatted", "")
+
+
+def test_build_context_pr_includes_plan_approach():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("plan_approach", "JWT with refresh tokens")
+    ctx = pb.build_context("pr")
+    assert ctx.get("plan_approach") == "JWT with refresh tokens"
+
+
+def test_build_context_learn_termination_type_default():
+    pb = PromptBuilder("Add auth", "Desc")
+    ctx = pb.build_context("learn")
+    assert ctx.get("termination_type") == "unknown"
+
+
+def test_build_context_learn_termination_type_from_context():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("termination_type", "success")
+    ctx = pb.build_context("learn")
+    assert ctx.get("termination_type") == "success"
+
+
+def test_build_context_learn_contains_run_data():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("full_status", {"run_id": "run-abc123"})
+    ctx = pb.build_context("learn")
+    assert "run-abc123" in ctx.get("run_data", "")
+
+
+def test_build_context_learn_contains_run_id():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("full_status", {"run_id": "run-xyz"})
+    ctx = pb.build_context("learn")
+    assert ctx.get("run_id") == "run-xyz"
+
+
+def test_build_context_learn_plan_content_from_plan_file_content():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("plan_file_content", "# My Plan")
+    ctx = pb.build_context("learn")
+    assert ctx.get("plan_content") == "# My Plan"
+
+
+# --- _load_agent_template ---
+
+def test_load_agent_template_returns_empty_when_run_dir_none():
+    pb = PromptBuilder("Add auth", "Desc")
+    result = pb._load_agent_template("plan")
+    assert result == ""
+
+
+def test_load_agent_template_reads_from_run_dir(tmp_path):
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    planner_md = agents_dir / "planner.md"
+    planner_md.write_text("# Planner Agent\n\n{{block:plan}}")
+    pb = PromptBuilder("Add auth", "Desc", run_dir=str(tmp_path))
+    result = pb._load_agent_template("plan")
+    assert "# Planner Agent" in result
+    assert "{{block:plan}}" in result
+
+
+def test_load_agent_template_returns_empty_for_unknown_stage(tmp_path):
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    pb = PromptBuilder("Add auth", "Desc", run_dir=str(tmp_path))
+    result = pb._load_agent_template("unknown_stage")
+    assert result == ""
+
+
+def test_load_agent_template_returns_empty_when_file_missing(tmp_path):
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    pb = PromptBuilder("Add auth", "Desc", run_dir=str(tmp_path))
+    result = pb._load_agent_template("plan")  # planner.md doesn't exist
+    assert result == ""

--- a/tests/test_prompt_builder_context_persistence.py
+++ b/tests/test_prompt_builder_context_persistence.py
@@ -255,8 +255,8 @@ def test_save_context_no_truncation_when_under_100kb(tmp_path):
     assert "assigned_bead_id" in data
 
 
-def test_load_context_after_resume_affects_prompt(tmp_path):
-    """After loading context, prompt_builder uses recovered values in prompts."""
+def test_load_context_after_resume_affects_context(tmp_path):
+    """After loading context, build_context() uses recovered values."""
     ctx_path = str(tmp_path / "prompt_context.json")
     with open(ctx_path, "w") as f:
         json.dump({
@@ -269,6 +269,6 @@ def test_load_context_after_resume_affects_prompt(tmp_path):
     pb = PromptBuilder("title", "desc")
     pb.load_context(ctx_path)
 
-    prompt = pb.build("implement")
-    assert "bd-resumed" in prompt
-    assert "Resumed Task" in prompt
+    ctx = pb.build_context("implement")
+    assert "bd-resumed" in ctx.get("assigned_task", "")
+    assert "Resumed Task" in ctx.get("assigned_task", "")

--- a/tests/test_prompt_builder_learn.py
+++ b/tests/test_prompt_builder_learn.py
@@ -1,11 +1,11 @@
-"""Tests for PromptBuilder._build_learn — learn stage prompt generation."""
+"""Tests for PromptBuilder learn stage context assembly."""
 
 
 from worca.orchestrator.prompt_builder import PromptBuilder
 
 
 def _make_status(iterations=2, test_fix_loops=1, review_fix_loops=0):
-    """Build a minimal full_status dict for learn prompt tests."""
+    """Build a minimal full_status dict for learn context tests."""
     return {
         "stages": {
             "plan": {"status": "completed"},
@@ -34,126 +34,99 @@ def _make_status(iterations=2, test_fix_loops=1, review_fix_loops=0):
     }
 
 
-def test_build_learn_includes_work_request():
+def test_build_context_learn_includes_work_request():
     pb = PromptBuilder("Add auth", "Implement user authentication")
     pb.update_context("full_status", _make_status())
     pb.update_context("termination_type", "success")
-    prompt = pb.build("learn")
-    assert "Add auth" in prompt
-    assert "Implement user authentication" in prompt
+    ctx = pb.build_context("learn")
+    assert "Add auth" in ctx.get("work_request", "")
+    assert "Implement user authentication" in ctx.get("work_request", "")
 
 
-def test_build_learn_includes_termination_info():
+def test_build_context_learn_includes_termination_type():
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", _make_status())
     pb.update_context("termination_type", "failure")
-    pb.update_context("termination_reason", "Max iterations exceeded")
-    prompt = pb.build("learn")
-    assert "failure" in prompt
-    assert "Max iterations exceeded" in prompt
+    ctx = pb.build_context("learn")
+    assert ctx.get("termination_type") == "failure"
 
 
-def test_build_learn_includes_plan_content():
+def test_build_context_learn_includes_plan_content():
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", _make_status())
     pb.update_context("termination_type", "success")
     pb.update_context("plan_file_content", "# Plan\n\n## Step 1\nDo the thing")
-    prompt = pb.build("learn")
-    assert "# Plan" in prompt
-    assert "Step 1" in prompt
+    ctx = pb.build_context("learn")
+    assert "# Plan" in ctx.get("plan_content", "")
+    assert "Step 1" in ctx.get("plan_content", "")
 
 
-def test_build_learn_includes_status_as_json():
+def test_build_context_learn_includes_status_as_json():
     status = _make_status()
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", status)
     pb.update_context("termination_type", "success")
-    prompt = pb.build("learn")
-    # The prompt should contain the status data serialized as JSON
-    assert '"stages"' in prompt
-    assert '"implement"' in prompt
+    ctx = pb.build_context("learn")
+    assert '"stages"' in ctx.get("run_data", "")
+    assert '"implement"' in ctx.get("run_data", "")
 
 
-def test_build_learn_includes_analysis_categories():
+def test_build_context_learn_without_plan_content():
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", _make_status())
     pb.update_context("termination_type", "success")
-    prompt = pb.build("learn")
-    # Should mention all analysis categories from the plan
-    assert "test" in prompt.lower() and "loop" in prompt.lower()
-    assert "review" in prompt.lower()
-    assert "implementation" in prompt.lower()
-    assert "planning" in prompt.lower() or "plan" in prompt.lower()
-    assert "configuration" in prompt.lower()
+    ctx = pb.build_context("learn")
+    assert not ctx.get("plan_content")
 
 
-def test_build_learn_without_plan_content():
-    pb = PromptBuilder("Add auth", "Desc")
-    pb.update_context("full_status", _make_status())
-    pb.update_context("termination_type", "success")
-    # No plan_file_content set
-    prompt = pb.build("learn")
-    assert "Plan File" not in prompt or "not available" in prompt.lower() or "no plan" in prompt.lower()
-
-
-def test_build_learn_without_termination_reason():
+def test_build_context_learn_with_termination_reason():
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", _make_status())
     pb.update_context("termination_type", "success")
     pb.update_context("termination_reason", "")
-    prompt = pb.build("learn")
-    # Should still render without error
-    assert "success" in prompt
+    ctx = pb.build_context("learn")
+    assert ctx.get("termination_type") == "success"
 
 
-def test_build_learn_truncates_large_status():
-    """If full_status JSON is very large, the prompt should truncate it."""
+def test_build_context_learn_truncates_large_status():
+    """If full_status JSON is very large, run_data should be truncated."""
     status = _make_status()
-    # Add a large output to blow up the JSON size
     large_output = "x" * 100_000
     status["stages"]["implement"]["iterations"][0]["output"]["large"] = large_output
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", status)
     pb.update_context("termination_type", "success")
-    prompt = pb.build("learn")
-    # Prompt should be truncated to a reasonable size (less than original)
-    assert len(prompt) < len(large_output)
+    ctx = pb.build_context("learn")
+    assert len(ctx.get("run_data", "")) < len(large_output)
 
 
-def test_build_learn_empty_status():
+def test_build_context_learn_empty_status():
     """Handle minimal/empty status gracefully."""
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", {"stages": {}})
     pb.update_context("termination_type", "failure")
     pb.update_context("termination_reason", "Unknown error")
-    prompt = pb.build("learn")
-    assert "failure" in prompt
-    assert "Unknown error" in prompt
+    ctx = pb.build_context("learn")
+    assert ctx.get("termination_type") == "failure"
 
 
-def test_build_learn_includes_run_reference():
-    """The learn prompt should surface run_id and log paths for traceability."""
+def test_build_context_learn_run_id_from_status():
+    """The learn context should surface run_id from full_status."""
     status = _make_status()
     status["run_id"] = "20260318-222430"
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", status)
     pb.update_context("termination_type", "success")
-    prompt = pb.build("learn")
-    assert "20260318-222430" in prompt
-    assert ".worca/runs/20260318-222430/" in prompt
-    assert ".worca/runs/20260318-222430/logs/" in prompt
-    # Instructions should tell agent to reference run_id in observations and suggestions
-    assert "observation" in prompt.lower() or "evidence" in prompt.lower()
-    assert "suggestion" in prompt.lower()
+    ctx = pb.build_context("learn")
+    assert ctx.get("run_id") == "20260318-222430"
+    assert "20260318-222430" in ctx.get("run_data", "")
 
 
-def test_build_learn_run_reference_fallback_when_no_run_id():
-    """When run_id is missing from status, should show 'unknown' gracefully."""
+def test_build_context_learn_run_id_fallback_when_missing():
+    """When run_id is missing from status, run_id should be 'unknown'."""
     status = _make_status()
-    # No run_id key
     pb = PromptBuilder("Add auth", "Desc")
     pb.update_context("full_status", status)
     pb.update_context("termination_type", "success")
-    prompt = pb.build("learn")
-    assert "unknown" in prompt
-    assert ".worca/runs/unknown/" in prompt
+    ctx = pb.build_context("learn")
+    assert ctx.get("run_id") == "unknown"

--- a/tests/test_resolve_agent_integration.py
+++ b/tests/test_resolve_agent_integration.py
@@ -1,0 +1,402 @@
+"""Integration tests for W-037: resolve_agent() golden-fragment tests per stage × mode.
+
+Verifies that the full resolve_agent() pipeline — block insertion + placeholder
+resolution — produces output containing expected content fragments for each stage.
+
+Uses real block files and agent .md templates from src/worca/agents/core/.
+"""
+
+import pathlib
+
+import pytest
+
+from worca.orchestrator.overlay import OverlayResolver, resolve_agent
+
+CORE_DIR = pathlib.Path(__file__).parent.parent / "src" / "worca" / "agents" / "core"
+
+
+def _make_resolver(core_dir: pathlib.Path) -> OverlayResolver:
+    """Build a resolver with no project overrides (uses only core tier)."""
+    resolver = OverlayResolver(overrides_dir="/nonexistent/no/project/overrides")
+    return resolver
+
+
+def _load_agent(agent_name: str) -> str:
+    return (CORE_DIR / f"{agent_name}.md").read_text()
+
+
+def _resolve(agent_name: str, context: dict, core_dir: pathlib.Path = CORE_DIR) -> str:
+    resolver = _make_resolver(core_dir)
+    agent_content = _load_agent(agent_name)
+    return resolve_agent(agent_content, context, resolver, str(core_dir))
+
+
+# ---------------------------------------------------------------------------
+# Plan stage — initial (no revision)
+# ---------------------------------------------------------------------------
+
+
+def test_plan_initial_contains_work_request():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add user authentication",
+        "claude_md": "",
+    })
+    assert "Add user authentication" in result
+
+
+def test_plan_initial_contains_plan_file():
+    result = _resolve("planner", {
+        "plan_file": "docs/plans/W-001-auth.md",
+        "work_request": "Add auth",
+        "claude_md": "",
+    })
+    assert "docs/plans/W-001-auth.md" in result
+
+
+def test_plan_initial_contains_governance():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add auth",
+        "claude_md": "",
+    })
+    assert "Do NOT write implementation" in result
+
+
+def test_plan_initial_contains_output_schema():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add auth",
+        "claude_md": "",
+    })
+    assert "plan.json" in result
+
+
+def test_plan_initial_includes_claude_md_when_provided():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add auth",
+        "claude_md": "# My Project\n\nUses FastAPI.",
+    })
+    assert "# My Project" in result
+    assert "FastAPI" in result
+
+
+def test_plan_initial_omits_claude_md_section_when_empty():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add auth",
+        "claude_md": "",
+    })
+    assert "Project Context (from CLAUDE.md)" not in result
+
+
+def test_plan_initial_no_unresolved_placeholders():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add auth",
+        "claude_md": "",
+    })
+    assert "{{block:" not in result
+    assert "{{plan_file}}" not in result
+
+
+# ---------------------------------------------------------------------------
+# Plan stage — revision mode
+# ---------------------------------------------------------------------------
+
+
+def test_plan_revision_contains_work_request():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add user authentication",
+        "plan_revision_mode": True,
+        "plan_content": "# Plan v1\n\nPhase 1...",
+        "plan_review_issues_formatted": "1. [major] Missing error handling",
+        "plan_review_history_formatted": "",
+    })
+    assert "Add user authentication" in result
+
+
+def test_plan_revision_shows_revision_header():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add auth",
+        "plan_revision_mode": True,
+        "plan_content": "# Plan v1",
+        "plan_review_issues_formatted": "1. [major] Issue here",
+        "plan_review_history_formatted": "",
+    })
+    assert "Revision" in result
+
+
+def test_plan_revision_contains_current_plan():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add auth",
+        "plan_revision_mode": True,
+        "plan_content": "# Plan v1\n\nMy special plan content",
+        "plan_review_issues_formatted": "",
+        "plan_review_history_formatted": "",
+    })
+    assert "My special plan content" in result
+
+
+def test_plan_revision_contains_issues():
+    result = _resolve("planner", {
+        "plan_file": "MASTER_PLAN.md",
+        "work_request": "Add auth",
+        "plan_revision_mode": True,
+        "plan_content": "# Plan",
+        "plan_review_issues_formatted": "1. [critical] Security flaw in auth",
+        "plan_review_history_formatted": "",
+    })
+    assert "Security flaw in auth" in result
+
+
+# ---------------------------------------------------------------------------
+# Coordinate stage
+# ---------------------------------------------------------------------------
+
+
+def test_coordinate_contains_work_request():
+    result = _resolve("coordinator", {
+        "plan_file": "MASTER_PLAN.md",
+        "run_id": "run-20260411",
+        "work_request": "Add user authentication",
+        "plan_summary": "",
+    })
+    assert "Add user authentication" in result
+
+
+def test_coordinate_contains_plan_file():
+    result = _resolve("coordinator", {
+        "plan_file": "docs/plans/W-001.md",
+        "run_id": "run-abc",
+        "work_request": "Add auth",
+        "plan_summary": "",
+    })
+    assert "docs/plans/W-001.md" in result
+
+
+def test_coordinate_contains_run_id():
+    result = _resolve("coordinator", {
+        "plan_file": "MASTER_PLAN.md",
+        "run_id": "run-xyz-99",
+        "work_request": "Add auth",
+        "plan_summary": "",
+    })
+    assert "run-xyz-99" in result
+
+
+def test_coordinate_contains_governance():
+    result = _resolve("coordinator", {
+        "plan_file": "MASTER_PLAN.md",
+        "run_id": "run-1",
+        "work_request": "Add auth",
+        "plan_summary": "",
+    })
+    assert "Do NOT write implementation" in result
+
+
+def test_coordinate_includes_plan_summary_when_present():
+    result = _resolve("coordinator", {
+        "plan_file": "MASTER_PLAN.md",
+        "run_id": "run-1",
+        "work_request": "Add auth",
+        "plan_summary": "Use JWT tokens. Tasks: auth module, middleware.",
+    })
+    assert "Use JWT tokens" in result
+
+
+def test_coordinate_no_unresolved_placeholders():
+    result = _resolve("coordinator", {
+        "plan_file": "MASTER_PLAN.md",
+        "run_id": "run-1",
+        "work_request": "Add auth",
+        "plan_summary": "",
+    })
+    assert "{{block:" not in result
+    assert "{{plan_file}}" not in result
+    assert "{{run_id}}" not in result
+
+
+# ---------------------------------------------------------------------------
+# Implement stage — initial
+# ---------------------------------------------------------------------------
+
+
+def test_implement_initial_contains_work_request():
+    result = _resolve("implementer", {
+        "is_retry": False,
+        "work_request": "Add user authentication",
+        "assigned_task": "",
+    })
+    assert "Add user authentication" in result
+
+
+def test_implement_initial_no_retry_header():
+    result = _resolve("implementer", {
+        "is_retry": False,
+        "work_request": "Add auth",
+        "assigned_task": "",
+    })
+    assert "PRIORITY: Fix" not in result
+
+
+def test_implement_initial_contains_assigned_task_when_present():
+    result = _resolve("implementer", {
+        "is_retry": False,
+        "work_request": "Add auth",
+        "assigned_task": "**worca-abc123**: Create JWT middleware",
+    })
+    assert "worca-abc123" in result
+    assert "Create JWT middleware" in result
+
+
+def test_implement_initial_no_unresolved_placeholders():
+    result = _resolve("implementer", {
+        "is_retry": False,
+        "work_request": "Add auth",
+        "assigned_task": "",
+    })
+    assert "{{block:" not in result
+    assert "{{is_retry}}" not in result
+
+
+# ---------------------------------------------------------------------------
+# Implement stage — retry
+# ---------------------------------------------------------------------------
+
+
+def test_implement_retry_contains_priority_header():
+    result = _resolve("implementer", {
+        "is_retry": True,
+        "issue_type": "Test Failures",
+        "attempt_count": "2",
+        "test_failures_formatted": "1. **test_auth** — AssertionError: 401 != 200",
+        "review_issues_formatted": "",
+        "previous_attempts": "",
+        "assigned_task": "",
+        "work_request": "Add auth",
+    })
+    assert "PRIORITY: Fix Test Failures" in result
+
+
+def test_implement_retry_contains_attempt_count():
+    result = _resolve("implementer", {
+        "is_retry": True,
+        "issue_type": "Test Failures",
+        "attempt_count": "3",
+        "test_failures_formatted": "1. **test_x** — error",
+        "review_issues_formatted": "",
+        "previous_attempts": "",
+        "assigned_task": "",
+        "work_request": "Add auth",
+    })
+    assert "3" in result
+
+
+def test_implement_retry_contains_failures():
+    result = _resolve("implementer", {
+        "is_retry": True,
+        "issue_type": "Test Failures",
+        "attempt_count": "2",
+        "test_failures_formatted": "1. **test_login** — AssertionError: 401 != 200",
+        "review_issues_formatted": "",
+        "previous_attempts": "",
+        "assigned_task": "",
+        "work_request": "Add auth",
+    })
+    assert "test_login" in result
+    assert "401 != 200" in result
+
+
+def test_implement_retry_review_issues_mode():
+    result = _resolve("implementer", {
+        "is_retry": True,
+        "issue_type": "Review Issues",
+        "attempt_count": "1",
+        "test_failures_formatted": "",
+        "review_issues_formatted": "1. [critical] `auth.py:42` — SQL injection",
+        "previous_attempts": "",
+        "assigned_task": "",
+        "work_request": "Add auth",
+    })
+    assert "Review Issues" in result
+    assert "SQL injection" in result
+
+
+# ---------------------------------------------------------------------------
+# Review stage
+# ---------------------------------------------------------------------------
+
+
+def test_review_contains_work_request():
+    result = _resolve("reviewer", {
+        "work_request": "Add user authentication",
+        "test_results": "",
+        "files_changed_formatted": "",
+    })
+    assert "Add user authentication" in result
+
+
+def test_review_contains_test_results_when_present():
+    result = _resolve("reviewer", {
+        "work_request": "Add auth",
+        "test_results": "**Status:** PASSED\n**Coverage:** 87.5%",
+        "files_changed_formatted": "",
+    })
+    assert "PASSED" in result
+    assert "87.5%" in result
+
+
+def test_review_contains_files_changed_when_present():
+    result = _resolve("reviewer", {
+        "work_request": "Add auth",
+        "test_results": "",
+        "files_changed_formatted": "- auth.py\n- middleware.py",
+    })
+    assert "auth.py" in result
+    assert "middleware.py" in result
+
+
+def test_review_contains_output_schema():
+    result = _resolve("reviewer", {
+        "work_request": "Add auth",
+        "test_results": "",
+        "files_changed_formatted": "",
+    })
+    assert "review.json" in result
+
+
+def test_review_no_unresolved_placeholders():
+    result = _resolve("reviewer", {
+        "work_request": "Add auth",
+        "test_results": "",
+        "files_changed_formatted": "",
+    })
+    assert "{{block:" not in result
+
+
+# ---------------------------------------------------------------------------
+# No raw block tokens remain after resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("agent_name,context", [
+    ("planner", {"plan_file": "p.md", "work_request": "WR", "claude_md": ""}),
+    ("plan_reviewer", {"work_request": "WR", "plan_content": "# Plan", "plan_review_history_formatted": ""}),
+    ("coordinator", {"plan_file": "p.md", "run_id": "r1", "work_request": "WR", "plan_summary": ""}),
+    ("implementer", {"is_retry": False, "work_request": "WR", "assigned_task": ""}),
+    ("tester", {"work_request": "WR", "implementation_summary": ""}),
+    ("reviewer", {"work_request": "WR", "test_results": "", "files_changed_formatted": ""}),
+    ("guardian", {"work_request": "WR", "plan_approach": ""}),
+    ("learner", {"work_request": "WR", "termination_type": "success", "termination_reason": "", "plan_content": "", "run_id": "r1", "run_data": "{}"}),
+])
+def test_no_unresolved_block_tokens(agent_name, context):
+    """After resolution, no {{block:...}} tokens should remain."""
+    result = _resolve(agent_name, context)
+    assert "{{block:" not in result, (
+        f"Agent '{agent_name}' resolved output still contains {{{{block:...}}}} tokens"
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3147,6 +3147,65 @@ def test_render_agent_templates_no_overlay_unchanged(tmp_path, monkeypatch):
     assert rendered == "## Rules\n\n- Core rule.\n"
 
 
+def test_render_agent_templates_excludes_block_md(tmp_path, monkeypatch):
+    """_render_agent_templates must NOT copy .block.md files to the run dir."""
+    monkeypatch.chdir(tmp_path)
+
+    core_dir = tmp_path / ".claude" / "worca" / "agents" / "core"
+    core_dir.mkdir(parents=True)
+    (core_dir / "implementer.md").write_text("## Rules\n\n- Core rule.\n")
+    (core_dir / "implement.block.md").write_text("## Block content\n")
+
+    run_dir = tmp_path / "run"
+    _render_agent_templates(
+        str(run_dir),
+        {"plan_file": "p.md", "run_id": "r1", "branch": "b", "title": "T"},
+        overrides_dir=str(tmp_path / "overrides"),
+    )
+
+    assert (run_dir / "agents" / "implementer.md").exists()
+    assert not (run_dir / "agents" / "implement.block.md").exists()
+
+
+def test_render_agent_templates_no_single_brace_substitution(tmp_path, monkeypatch):
+    """_render_agent_templates must NOT perform {single-brace} placeholder substitution."""
+    monkeypatch.chdir(tmp_path)
+
+    core_dir = tmp_path / ".claude" / "worca" / "agents" / "core"
+    core_dir.mkdir(parents=True)
+    (core_dir / "planner.md").write_text("# Planner\n\nRun: {run_id}\nTitle: {title}\n")
+
+    run_dir = tmp_path / "run"
+    _render_agent_templates(
+        str(run_dir),
+        {"run_id": "20260411", "title": "My Task"},
+        overrides_dir=str(tmp_path / "overrides"),
+    )
+
+    rendered = (run_dir / "agents" / "planner.md").read_text()
+    # Single-brace placeholders must remain unexpanded
+    assert "{run_id}" in rendered
+    assert "{title}" in rendered
+    assert "20260411" not in rendered
+    assert "My Task" not in rendered
+
+
+def test_stage_prompt_prefix_removed():
+    """_STAGE_PROMPT_PREFIX must no longer exist in runner.py."""
+    import worca.orchestrator.runner as runner_mod
+    assert not hasattr(runner_mod, "_STAGE_PROMPT_PREFIX"), (
+        "_STAGE_PROMPT_PREFIX should have been deleted"
+    )
+
+
+def test_build_stage_prompt_removed():
+    """_build_stage_prompt must no longer exist in runner.py."""
+    import worca.orchestrator.runner as runner_mod
+    assert not hasattr(runner_mod, "_build_stage_prompt"), (
+        "_build_stage_prompt should have been deleted"
+    )
+
+
 def test_settings_json_has_agent_overrides_dir():
     """settings.json worca namespace must declare agent_overrides_dir adjacent to plan_path_template."""
     import pathlib
@@ -3293,3 +3352,32 @@ def test_run_pipeline_pipeline_template_none_by_default(tmp_path, monkeypatch):
         )
 
     assert result["pipeline_template"] is None
+
+
+# --- T10: agent_override in run_stage ---
+
+def test_run_stage_uses_agent_override():
+    """run_stage passes agent_override path to run_agent when provided."""
+    mock_config = {"agent": "planner", "model": None, "max_turns": 40, "schema": "plan.json"}
+    with patch("worca.orchestrator.runner.get_stage_config", return_value=mock_config):
+        with patch("worca.orchestrator.runner.run_agent", return_value={}) as mock_run:
+            run_stage(Stage.PLAN, {"prompt": "x"}, agent_override="/tmp/custom-agent.md")
+    assert mock_run.call_args.kwargs.get("agent") == "/tmp/custom-agent.md"
+
+
+def test_run_stage_default_agent_path_when_no_override():
+    """run_stage uses _agent_path when agent_override is not provided."""
+    mock_config = {"agent": "planner", "model": None, "max_turns": 40, "schema": "plan.json"}
+    with patch("worca.orchestrator.runner.get_stage_config", return_value=mock_config):
+        with patch("worca.orchestrator.runner.run_agent", return_value={}) as mock_run:
+            run_stage(Stage.PLAN, {"prompt": "x"})
+    assert ".claude/worca/agents/core/planner.md" in mock_run.call_args.kwargs.get("agent", "")
+
+
+def test_run_stage_agent_override_none_uses_default_path():
+    """Explicitly passing agent_override=None still uses _agent_path."""
+    mock_config = {"agent": "tester", "model": None, "max_turns": 20, "schema": "test.json"}
+    with patch("worca.orchestrator.runner.get_stage_config", return_value=mock_config):
+        with patch("worca.orchestrator.runner.run_agent", return_value={}) as mock_run:
+            run_stage(Stage.TEST, {"prompt": "x"}, agent_override=None)
+    assert ".claude/worca/agents/core/tester.md" in mock_run.call_args.kwargs.get("agent", "")

--- a/tests/test_runner_learn.py
+++ b/tests/test_runner_learn.py
@@ -7,7 +7,6 @@ import pytest
 
 from worca.orchestrator.runner import (
     _run_learn_stage,
-    _STAGE_PROMPT_PREFIX,
     PipelineError,
     PipelineInterrupted,
 )
@@ -19,17 +18,6 @@ def _mock_beads_init():
     """Prevent run_pipeline from invoking the real bd binary in tests."""
     with patch("worca.orchestrator.runner._ensure_beads_initialized"):
         yield
-
-
-# ---------------------------------------------------------------------------
-# _STAGE_PROMPT_PREFIX includes LEARN
-# ---------------------------------------------------------------------------
-
-def test_stage_prompt_prefix_includes_learn():
-    """Stage.LEARN should have an entry in _STAGE_PROMPT_PREFIX."""
-    assert Stage.LEARN in _STAGE_PROMPT_PREFIX
-    template = _STAGE_PROMPT_PREFIX[Stage.LEARN]
-    assert "{prompt}" in template
 
 
 # ---------------------------------------------------------------------------
@@ -265,14 +253,15 @@ def test_run_learn_stage_records_error_in_status(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_run_learn_stage_calls_run_stage_with_learn(tmp_path):
-    """run_stage should be called with Stage.LEARN and the rendered prompt."""
+    """run_stage should be called with Stage.LEARN using build_context()."""
     settings = tmp_path / "settings.json"
     settings.write_text(json.dumps({"worca": {"stages": {"learn": {"enabled": True}}}}))
     run_dir = tmp_path / "run"
     run_dir.mkdir()
 
     pb = MagicMock()
-    pb.build.return_value = "learn prompt content"
+    pb.build_context.return_value = {"work_request": "## Work Request\n\nTest task"}
+    pb._resolver = None  # disable per-stage resolution (no template file)
     status = {"stages": {}, "plan_file": None}
 
     with patch("worca.orchestrator.runner.run_stage", return_value=({}, {})) as mock_run:
@@ -295,10 +284,11 @@ def test_run_learn_stage_calls_run_stage_with_learn(tmp_path):
     args, kwargs = mock_run.call_args
     assert args[0] == Stage.LEARN
     assert kwargs.get("msize") == 2
-    assert kwargs.get("prompt_override") == "learn prompt content"
+    # Minimal work request passed as prompt_override
+    assert kwargs.get("prompt_override") is not None
 
-    # prompt_builder.build should have been called with "learn", 0
-    pb.build.assert_called_once_with("learn", 0)
+    # prompt_builder.build_context should have been called with "learn", 0
+    pb.build_context.assert_called_once_with("learn", 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runner_plan_review.py
+++ b/tests/test_runner_plan_review.py
@@ -79,21 +79,6 @@ def _mock_beads():
 
 
 # ---------------------------------------------------------------------------
-# _STAGE_PROMPT_PREFIX entry
-# ---------------------------------------------------------------------------
-
-class TestStagePromptPrefix:
-    def test_plan_review_in_stage_prompt_prefix(self):
-        from worca.orchestrator.runner import _STAGE_PROMPT_PREFIX
-        assert Stage.PLAN_REVIEW in _STAGE_PROMPT_PREFIX
-
-    def test_plan_review_prompt_contains_plan_reference(self):
-        from worca.orchestrator.runner import _STAGE_PROMPT_PREFIX
-        prefix = _STAGE_PROMPT_PREFIX[Stage.PLAN_REVIEW]
-        assert "plan" in prefix.lower() or "review" in prefix.lower()
-
-
-# ---------------------------------------------------------------------------
 # Approve path
 # ---------------------------------------------------------------------------
 

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -162,8 +162,8 @@ class TestStageAgentMap:
     def test_test_maps_to_tester(self):
         assert STAGE_AGENT_MAP[Stage.TEST] == "tester"
 
-    def test_review_maps_to_guardian(self):
-        assert STAGE_AGENT_MAP[Stage.REVIEW] == "guardian"
+    def test_review_maps_to_reviewer(self):
+        assert STAGE_AGENT_MAP[Stage.REVIEW] == "reviewer"
 
     def test_pr_maps_to_guardian(self):
         assert STAGE_AGENT_MAP[Stage.PR] == "guardian"
@@ -254,7 +254,7 @@ class TestGetStageConfig:
         empty_file = tmp_path / "empty.json"
         empty_file.write_text("{}")
         config = get_stage_config(Stage.REVIEW, settings_path=str(empty_file))
-        assert config["agent"] == "guardian"
+        assert config["agent"] == "reviewer"
         assert config["model"] == "claude-sonnet-4-6"
         assert config["max_turns"] == 30
 

--- a/tests/test_worca_init_blocks.py
+++ b/tests/test_worca_init_blocks.py
@@ -1,0 +1,222 @@
+"""Tests for W-037 T12: worca init copies block files and reviewer.md.
+
+Verifies that worca init / _copy_worca_source installs:
+- All 8 .block.md files into agents/core/
+- reviewer.md into agents/core/
+- Agent .md files use {{double-brace}} syntax (not {single-brace})
+
+The cross-project installation test is skipped when test-multi-01 is absent.
+"""
+
+import os
+import pathlib
+
+import pytest
+
+from worca.cli.init import _copy_worca_source
+
+CORE_DIR = pathlib.Path(__file__).parent.parent / "src" / "worca" / "agents" / "core"
+WORCA_SRC = pathlib.Path(__file__).parent.parent / "src" / "worca"
+
+BLOCK_FILES = [
+    "plan.block.md",
+    "plan-review.block.md",
+    "coordinate.block.md",
+    "implement.block.md",
+    "test.block.md",
+    "review.block.md",
+    "pr.block.md",
+    "learn.block.md",
+]
+
+AGENT_FILES = [
+    "planner.md",
+    "plan_reviewer.md",
+    "coordinator.md",
+    "implementer.md",
+    "tester.md",
+    "reviewer.md",
+    "guardian.md",
+    "learner.md",
+]
+
+
+# ---------------------------------------------------------------------------
+# Unit: _copy_worca_source copies block files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("block_file", BLOCK_FILES)
+def test_copy_worca_source_includes_block_files(tmp_path, block_file):
+    """_copy_worca_source must copy .block.md files to the target agents/core/."""
+    target = tmp_path / "worca_installed"
+    _copy_worca_source(WORCA_SRC, target)
+
+    installed = target / "agents" / "core" / block_file
+    assert installed.exists(), (
+        f"{block_file} not found in installed agents/core/ — "
+        "T12 init copy step is missing block file support"
+    )
+
+
+def test_copy_worca_source_includes_reviewer_md(tmp_path):
+    """_copy_worca_source must copy reviewer.md to the target agents/core/."""
+    target = tmp_path / "worca_installed"
+    _copy_worca_source(WORCA_SRC, target)
+
+    installed = target / "agents" / "core" / "reviewer.md"
+    assert installed.exists(), (
+        "reviewer.md not found in installed agents/core/ — "
+        "T12 init copy step is missing reviewer agent"
+    )
+
+
+@pytest.mark.parametrize("agent_file", AGENT_FILES)
+def test_copy_worca_source_includes_agent_files(tmp_path, agent_file):
+    """_copy_worca_source must copy standard agent .md files."""
+    target = tmp_path / "worca_installed"
+    _copy_worca_source(WORCA_SRC, target)
+
+    installed = target / "agents" / "core" / agent_file
+    assert installed.exists(), (
+        f"{agent_file} not found in installed agents/core/"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit: installed agent files use {{double-brace}} syntax
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("agent_file,placeholder", [
+    ("planner.md", "{{plan_file}}"),
+    ("coordinator.md", "{{plan_file}}"),
+    ("coordinator.md", "{{run_id}}"),
+])
+def test_installed_agent_uses_double_brace(tmp_path, agent_file, placeholder):
+    """Installed agent files must use {{double-brace}} syntax, not {single-brace}."""
+    target = tmp_path / "worca_installed"
+    _copy_worca_source(WORCA_SRC, target)
+
+    content = (target / "agents" / "core" / agent_file).read_text()
+    assert placeholder in content, (
+        f"{agent_file}: expected {placeholder} but not found — "
+        "agent file may not have been migrated to double-brace syntax"
+    )
+
+
+@pytest.mark.parametrize("agent_file,old_placeholder", [
+    ("planner.md", "{plan_file}"),
+    ("coordinator.md", "{plan_file}"),
+    ("coordinator.md", "{run_id}"),
+])
+def test_installed_agent_no_single_brace(tmp_path, agent_file, old_placeholder):
+    """Installed agent files must not contain {single-brace} placeholders."""
+    target = tmp_path / "worca_installed"
+    _copy_worca_source(WORCA_SRC, target)
+
+    content = (target / "agents" / "core" / agent_file).read_text()
+    # Strip double-brace occurrences to avoid false positives, then check
+    stripped = content.replace("{{" + old_placeholder[1:-1] + "}}", "REMOVED")
+    assert old_placeholder not in stripped, (
+        f"{agent_file}: found old {old_placeholder!r} — "
+        "single-brace placeholder not migrated to double-brace"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit: installed block files contain expected placeholders
+# ---------------------------------------------------------------------------
+
+
+def test_installed_plan_block_has_work_request(tmp_path):
+    """Installed plan.block.md must contain {{work_request}}."""
+    target = tmp_path / "worca_installed"
+    _copy_worca_source(WORCA_SRC, target)
+    content = (target / "agents" / "core" / "plan.block.md").read_text()
+    assert "{{work_request}}" in content
+
+
+def test_installed_implement_block_has_is_retry(tmp_path):
+    """Installed implement.block.md must contain {{#if is_retry}}."""
+    target = tmp_path / "worca_installed"
+    _copy_worca_source(WORCA_SRC, target)
+    content = (target / "agents" / "core" / "implement.block.md").read_text()
+    assert "{{#if is_retry}}" in content
+
+
+# ---------------------------------------------------------------------------
+# Cross-project integration test (skipped when test project absent)
+# ---------------------------------------------------------------------------
+
+TEST_PROJECT = "/Volumes/Apps/dev/ccexperiments/test-multi-01"
+
+
+WORCA_CC_ROOT = str(pathlib.Path(__file__).parent.parent)
+
+
+@pytest.mark.skipif(
+    not os.path.isdir(TEST_PROJECT),
+    reason=f"test-multi-01 not available at {TEST_PROJECT}",
+)
+def test_worca_init_installs_blocks_in_test_project():
+    """Install worca into test-multi-01 and verify block files land correctly.
+
+    Uses --source to point at the dev worca-cc repo, ensuring we test the
+    current (modified) source rather than any globally-installed worca package.
+    """
+    import subprocess
+
+    project = pathlib.Path(TEST_PROJECT)
+    worca_runtime = project / ".claude" / "worca"
+
+    # Run worca init --upgrade using dev source so block files are included
+    result = subprocess.run(
+        ["python", "-m", "worca.cli.main", "init", "--upgrade", "--source", WORCA_CC_ROOT],
+        cwd=str(project),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"worca init --upgrade failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    core_installed = worca_runtime / "agents" / "core"
+
+    # Verify block files
+    for block_file in BLOCK_FILES:
+        installed = core_installed / block_file
+        assert installed.exists(), f"{block_file} not installed in {core_installed}"
+
+    # Verify reviewer.md
+    assert (core_installed / "reviewer.md").exists(), (
+        "reviewer.md not installed"
+    )
+
+    # Verify agent files contain {{block:name}} references
+    planner_content = (core_installed / "planner.md").read_text()
+    assert "{{block:plan}}" in planner_content, (
+        "planner.md missing {{block:plan}} reference after install"
+    )
+
+    # Verify no {single-brace} in planner
+    planner_stripped = planner_content.replace("{{plan_file}}", "REMOVED")
+    assert "{plan_file}" not in planner_stripped, (
+        "planner.md still has {plan_file} single-brace after install"
+    )
+
+    # Verify resolve_agent works against installed files
+    from worca.orchestrator.overlay import OverlayResolver, resolve_agent
+
+    resolver = OverlayResolver(overrides_dir=str(project / ".claude" / "agents"))
+    agent_content = (core_installed / "planner.md").read_text()
+    resolved = resolve_agent(
+        agent_content,
+        {"plan_file": "MASTER_PLAN.md", "work_request": "Test install", "claude_md": ""},
+        resolver,
+        str(core_installed),
+    )
+
+    assert "{{block:" not in resolved, "Unresolved block tokens after resolve_agent"
+    assert "Test install" in resolved, "work_request not in resolved output"
+    assert "MASTER_PLAN.md" in resolved, "plan_file placeholder not resolved"

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -421,31 +421,31 @@ function _agentPromptSection(_stageKey, promptData) {
         Agent Instructions
       </div>
       ${
-        userPrompt
-          ? html`
-        <div class="agent-prompt-block">
-          <div class="agent-prompt-label-row">
-            <span class="agent-prompt-label">User Prompt (-p)</span>
-            <button class="copy-btn" @click=${(e) => _copyToClipboard(userPrompt, e.currentTarget)}>
-              ${unsafeHTML(iconSvg(ClipboardCopy, 11))} Copy
-            </button>
-          </div>
-          <pre class="agent-prompt-content">${userPrompt}</pre>
-        </div>
-      `
-          : nothing
-      }
-      ${
         agentInstructions
           ? html`
         <div class="agent-prompt-block">
           <div class="agent-prompt-label-row">
-            <span class="agent-prompt-label">System Prompt (agent .md)</span>
+            <span class="agent-prompt-label">Agent Prompt (resolved)</span>
             <button class="copy-btn" @click=${(e) => _copyToClipboard(agentInstructions, e.currentTarget)}>
               ${unsafeHTML(iconSvg(ClipboardCopy, 11))} Copy
             </button>
           </div>
           <pre class="agent-prompt-content">${agentInstructions}</pre>
+        </div>
+      `
+          : nothing
+      }
+      ${
+        userPrompt
+          ? html`
+        <div class="agent-prompt-block">
+          <div class="agent-prompt-label-row">
+            <span class="agent-prompt-label">User Message (-p)</span>
+            <button class="copy-btn" @click=${(e) => _copyToClipboard(userPrompt, e.currentTarget)}>
+              ${unsafeHTML(iconSvg(ClipboardCopy, 11))} Copy
+            </button>
+          </div>
+          <pre class="agent-prompt-content">${userPrompt}</pre>
         </div>
       `
           : nothing

--- a/worca-ui/app/views/settings.js
+++ b/worca-ui/app/views/settings.js
@@ -28,7 +28,7 @@ export const STAGE_AGENT_MAP = {
   coordinate: 'coordinator',
   implement: 'implementer',
   test: 'tester',
-  review: 'guardian',
+  review: 'reviewer',
   pr: 'guardian',
   learn: 'learner',
 };
@@ -41,6 +41,7 @@ export const AGENT_NAMES = [
   'coordinator',
   'implementer',
   'tester',
+  'reviewer',
   'guardian',
   'learner',
 ];
@@ -52,7 +53,7 @@ const DEFAULT_STAGES = {
   coordinate: { agent: 'coordinator', enabled: true },
   implement: { agent: 'implementer', enabled: true },
   test: { agent: 'tester', enabled: true },
-  review: { agent: 'guardian', enabled: true },
+  review: { agent: 'reviewer', enabled: true },
   pr: { agent: 'guardian', enabled: true },
   learn: { agent: 'learner', enabled: false },
 };

--- a/worca-ui/package.json
+++ b/worca-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worca/ui",
-  "version": "0.5.0",
+  "version": "0.5.0-rc.1",
   "description": "Pipeline monitoring UI for worca-cc",
   "license": "MIT",
   "author": "Sinisha Djukic",

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -182,9 +182,28 @@ export function createMessageRouter({
       const resolvedIterationPrompts = [];
 
       // Collect per-iteration resolved files
+      // Filename format: {stage}-{agent}-iter-{N}.md (W-037+)
+      // Fallback: {agent}-iter-{N}.md (early W-037 runs)
       for (const iter of iterations) {
         const iterNum = iter.number ?? 0;
         const resolvedCandidates = [
+          join(
+            proj.worcaDir,
+            'runs',
+            effectiveRunId,
+            'agents',
+            'resolved',
+            `${stage}-${agentName}-iter-${iterNum}.md`,
+          ),
+          join(
+            proj.worcaDir,
+            'results',
+            effectiveRunId,
+            'agents',
+            'resolved',
+            `${stage}-${agentName}-iter-${iterNum}.md`,
+          ),
+          // Fallback for early W-037 runs without stage prefix
           join(
             proj.worcaDir,
             'runs',

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -35,24 +35,6 @@ import {
 import { readSettings } from './settings-reader.js';
 import { discoverRuns } from './watcher.js';
 
-// Legacy fallback prefixes — only used when status.json lacks a stored prompt
-const STAGE_PROMPT_PREFIX = {
-  plan: 'Create a detailed implementation plan for the following work request. Write the plan to the designated plan file.\n\nWork request: ',
-  coordinate:
-    'Decompose the following work request into Beads tasks with dependencies. Do NOT implement anything — only create tasks using `bd create`.\n\nWork request: ',
-  implement:
-    'Implement the code changes described in the work request. Follow the plan and complete the tasks assigned to you.\n\nWork request: ',
-  test: 'Review and test the implementation for the following work request. Run tests and report results. Do NOT modify code.\n\nWork request: ',
-  review:
-    'Review the code changes for the following work request. Check for correctness, style, and adherence to the plan. Do NOT modify code.\n\nWork request: ',
-  pr: 'Create a pull request for the following work request. Summarize the changes and ensure the commit history is clean.\n\nWork request: ',
-};
-
-function _buildStagePrompt(stage, rawPrompt) {
-  const prefix = STAGE_PROMPT_PREFIX[stage];
-  return prefix ? prefix + rawPrompt : rawPrompt;
-}
-
 /**
  * @param {{
  *   watcherSets: Map<string, import('./watcher-set.js').WatcherSet>,
@@ -174,6 +156,7 @@ export function createMessageRouter({
         return;
       }
       const agentName = run.stages?.[stage]?.agent || stage;
+      const effectiveRunId = run.run_id || runId;
 
       const iterations = run.stages?.[stage]?.iterations || [];
       const iterationPrompts = iterations.map((iter, idx) => {
@@ -181,62 +164,97 @@ export function createMessageRouter({
         return { iteration: iter.number ?? idx, prompt };
       });
 
-      const storedPrompt = run.stages?.[stage]?.prompt;
-      let fallbackPrompt;
-      let promptSource;
-      if (storedPrompt) {
-        fallbackPrompt = storedPrompt;
-        promptSource = 'actual';
-      } else {
-        const rawPrompt =
-          run.work_request?.description || run.work_request?.title || '';
-        fallbackPrompt = _buildStagePrompt(stage, rawPrompt);
-        promptSource = 'reconstructed';
-      }
-
+      // User message (-p) — stored in status.json
+      const userPrompt = run.stages?.[stage]?.prompt || null;
       const hasIterationPrompts = iterationPrompts.some(
         (ip) => ip.prompt != null,
       );
-      if (!hasIterationPrompts) {
+      if (!hasIterationPrompts && userPrompt) {
         for (const ip of iterationPrompts) {
-          ip.prompt = fallbackPrompt;
+          ip.prompt = userPrompt;
         }
       }
 
-      let agentInstructions = null;
-      const candidates = [
-        join(
-          proj.worcaDir,
-          'runs',
-          run.run_id || runId,
-          'agents',
-          `${agentName}.md`,
-        ),
-        join(
-          proj.worcaDir,
-          'results',
-          run.run_id || runId,
-          'agents',
-          `${agentName}.md`,
-        ),
-      ];
-      for (const p of candidates) {
-        if (existsSync(p)) {
-          try {
-            agentInstructions = readFileSync(p, 'utf8');
-          } catch {
-            /* ignore */
+      // Resolved agent prompt — the full document the agent actually received.
+      // Prefer per-iteration resolved files (W-037+), fall back to the
+      // unresolved agent template for pre-W-037 runs.
+      let resolvedPrompt = null;
+      const resolvedIterationPrompts = [];
+
+      // Collect per-iteration resolved files
+      for (const iter of iterations) {
+        const iterNum = iter.number ?? 0;
+        const resolvedCandidates = [
+          join(
+            proj.worcaDir,
+            'runs',
+            effectiveRunId,
+            'agents',
+            'resolved',
+            `${agentName}-iter-${iterNum}.md`,
+          ),
+          join(
+            proj.worcaDir,
+            'results',
+            effectiveRunId,
+            'agents',
+            'resolved',
+            `${agentName}-iter-${iterNum}.md`,
+          ),
+        ];
+        let content = null;
+        for (const p of resolvedCandidates) {
+          if (existsSync(p)) {
+            try {
+              content = readFileSync(p, 'utf8');
+            } catch {
+              /* ignore */
+            }
+            break;
           }
-          break;
+        }
+        resolvedIterationPrompts.push({ iteration: iterNum, prompt: content });
+        if (!resolvedPrompt && content) resolvedPrompt = content;
+      }
+
+      // Fall back to unresolved agent template (pre-W-037 runs)
+      if (!resolvedPrompt) {
+        const templateCandidates = [
+          join(
+            proj.worcaDir,
+            'runs',
+            effectiveRunId,
+            'agents',
+            `${agentName}.md`,
+          ),
+          join(
+            proj.worcaDir,
+            'results',
+            effectiveRunId,
+            'agents',
+            `${agentName}.md`,
+          ),
+        ];
+        for (const p of templateCandidates) {
+          if (existsSync(p)) {
+            try {
+              resolvedPrompt = readFileSync(p, 'utf8');
+            } catch {
+              /* ignore */
+            }
+            break;
+          }
         }
       }
+
       ws.send(
         JSON.stringify(
           makeOk(req, {
-            agentInstructions,
-            userPrompt: fallbackPrompt,
+            agentInstructions: resolvedPrompt,
+            userPrompt,
             iterationPrompts,
-            promptSource,
+            resolvedIterationPrompts,
+            promptSource: userPrompt ? 'actual' : 'none',
             agent: agentName,
           }),
         ),

--- a/worca-ui/test/ws-integration.test.js
+++ b/worca-ui/test/ws-integration.test.js
@@ -217,8 +217,10 @@ describe('WebSocket integration', () => {
     });
     expect(reply.ok).toBe(true);
     expect(reply.payload.agent).toBe('implementer');
-    expect(reply.payload.userPrompt).toContain('Implement the test feature');
-    expect(reply.payload.promptSource).toBe('reconstructed');
+    // No stored prompt in status.json → userPrompt is null
+    expect(reply.payload.userPrompt).toBeNull();
+    expect(reply.payload.promptSource).toBe('none');
+    // Falls back to unresolved agent template (pre-W-037 compat)
     expect(reply.payload.agentInstructions).toContain('Implementer Agent');
     ws.close();
   });


### PR DESCRIPTION
## Summary

- Introduces composable `.block.md` files referenced via `{{block:name}}` in agent `.md` templates, replacing hardcoded instruction text in `PromptBuilder`
- Adds a `{{placeholder}}` system for dynamic context injection (`{{name}}`, `{{name|default}}`, `{{#if name}}...{{/if}}`) with three-tier overlay chain (core → project → template)
- Refactors `PromptBuilder` from prompt string builder to context assembler — `-p` flag reduced to minimal work request, dead code removed (`_STAGE_PROMPT_PREFIX`, `_build_stage_prompt`)

## Changes

**New files (8 block files + 1 agent + 8 test files):**
- `src/worca/agents/core/*.block.md` — coordinate, implement, learn, plan-review, plan, pr, review, test blocks
- `src/worca/agents/core/reviewer.md` — new reviewer agent template
- `tests/test_block_files.py`, `test_agent_md_refs.py`, `test_builtin_templates.py`, `test_overlay_placeholders.py`, `test_resolve_agent_integration.py`, `test_worca_init_blocks.py`

**Modified files:**
- `src/worca/orchestrator/prompt_builder.py` — core refactor: block resolution, placeholder substitution, context assembly
- `src/worca/orchestrator/overlay.py` — three-tier overlay resolver
- `src/worca/orchestrator/runner.py` — updated to use new context-based prompt building
- `src/worca/agents/core/*.md` — agent templates updated with `{{block:name}}` references
- 10 existing test files updated to match new API

## Test plan

- [x] All 667 tests pass (`pytest tests/`)
- [x] Ruff lint clean
- [x] Verify block overlay works with project-level overrides
- [x] Verify pipeline end-to-end with new prompt assembly

🤖 Generated with [Claude Code](https://claude.com/claude-code)