### PR TITLE
fix(init): non-destructive settings upgrade + review agent rename

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -54,7 +54,11 @@ The entire `.claude/worca/` directory is replaced with a fresh copy from the ins
 
 ### Settings deep-merge
 
-New default keys from the package's `src/worca/settings.json` are merged into the project's `.claude/settings.json`. Existing user settings are overwritten by the template defaults (use `.claude/settings.local.json` for project-specific customizations that should survive upgrades).
+New default keys from the package's `src/worca/settings.json` are merged into the project's `.claude/settings.json` **non-destructively**: missing keys are added, but existing user values are preserved. This means user-chosen agent models (`worca.agents.<name>.model`), custom `permissions.allow` entries, webhooks, loop counts, and other tuned values survive `--upgrade`.
+
+Forward-incompatible renames (e.g. `stages.review.agent: guardian -> reviewer` in W-037) are applied explicitly via `_migrate_settings_paths` *before* the merge, so they land deterministically and show up under `worca init --check`.
+
+If you want to hard-reset your settings to the current template, use `worca init --force` (destructive). Project-specific overrides that should never be touched by any upgrade still belong in `.claude/settings.local.json`.
 
 ### .gitignore entries
 

--- a/src/worca/cli/init.py
+++ b/src/worca/cli/init.py
@@ -517,17 +517,21 @@ def run_init(
             shutil.copy2(str(source_settings), str(settings_path))
             print("Settings: replaced with template (--force)")
     elif settings_path.exists():
-        # Deep-merge: template values overwrite base, user customizations live in .local.json
+        # Non-destructive deep-merge: add new template keys, preserve user values
+        # (permissions.allow, worca.agents.*.model, worca.loops.*, webhooks, etc.).
+        # Forward-incompatible changes must go through _migrate_settings_paths so they
+        # apply deterministically and are visible under `worca init --check`. Use --force
+        # to replace the file with the template wholesale.
         with open(settings_path) as f:
             current = json.load(f)
         if source_settings.exists():
             with open(source_settings) as f:
                 template = json.load(f)
-            merged = _deep_merge_overwrite(current, template)
+            merged = _deep_merge(current, template)
             with open(settings_path, "w") as f:
                 json.dump(merged, f, indent=2)
                 f.write("\n")
-            print("Settings: updated to latest defaults")
+            print("Settings: added new template keys (user values preserved)")
     else:
         # Create from template
         if source_settings.exists():

--- a/src/worca/settings.json
+++ b/src/worca/settings.json
@@ -112,7 +112,7 @@
         "enabled": true
       },
       "review": {
-        "agent": "guardian",
+        "agent": "reviewer",
         "enabled": true
       },
       "pr": {

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -151,6 +151,94 @@ class TestMigrateSettingsPaths:
         _, changes = _migrate_settings_paths(settings)
         assert len(changes) == 0
 
+    def test_migrates_review_agent_guardian_to_reviewer(self):
+        settings = {
+            "worca": {"stages": {"review": {"agent": "guardian", "enabled": True}}}
+        }
+        migrated, changes = _migrate_settings_paths(settings)
+        assert migrated["worca"]["stages"]["review"]["agent"] == "reviewer"
+        assert any("stages.review.agent" in c for c in changes)
+
+    def test_upgrade_end_state_review_agent_is_reviewer(self):
+        """Regression: migration + non-destructive merge must end at 'reviewer'.
+
+        Reproduces the bug where _migrate_settings_paths rewrote guardian->reviewer
+        but the subsequent merge with the template clobbered it back to guardian
+        because (a) the template still carried the stale value and (b) the merge
+        used template-wins semantics. Both fixes are asserted here.
+        """
+        from pathlib import Path
+
+        template_path = Path(__file__).parent.parent / "src" / "worca" / "settings.json"
+        with open(template_path) as f:
+            template = json.load(f)
+
+        # Template itself must carry the renamed value (new-install correctness).
+        assert template["worca"]["stages"]["review"]["agent"] == "reviewer"
+
+        current = {
+            "worca": {"stages": {"review": {"agent": "guardian", "enabled": True}}}
+        }
+        migrated, _ = _migrate_settings_paths(current)
+        merged = _deep_merge(migrated, template)
+
+        assert merged["worca"]["stages"]["review"]["agent"] == "reviewer"
+
+
+class TestUpgradePreservesUserValues:
+    """Upgrade must preserve user customizations outside of explicit migrations."""
+
+    def test_preserves_user_model_choices(self):
+        """User-chosen agent models survive --upgrade (no template clobber)."""
+        from pathlib import Path
+
+        template_path = Path(__file__).parent.parent / "src" / "worca" / "settings.json"
+        with open(template_path) as f:
+            template = json.load(f)
+
+        current = {
+            "worca": {
+                "agents": {
+                    "planner": {"model": "sonnet", "max_turns": 100},
+                    "implementer": {"model": "haiku", "max_turns": 42},
+                }
+            }
+        }
+        merged = _deep_merge(current, template)
+
+        assert merged["worca"]["agents"]["planner"]["model"] == "sonnet"
+        assert merged["worca"]["agents"]["implementer"]["model"] == "haiku"
+        assert merged["worca"]["agents"]["implementer"]["max_turns"] == 42
+        # New agents from the template are still added.
+        assert "tester" in merged["worca"]["agents"]
+
+    def test_preserves_permissions_allow_list(self):
+        """The permissions.allow list is user-owned and must not be overwritten."""
+        from pathlib import Path
+
+        template_path = Path(__file__).parent.parent / "src" / "worca" / "settings.json"
+        with open(template_path) as f:
+            template = json.load(f)
+
+        current = {"permissions": {"allow": ["Bash(my-custom-tool:*)"]}}
+        merged = _deep_merge(current, template)
+
+        assert merged["permissions"]["allow"] == ["Bash(my-custom-tool:*)"]
+
+    def test_adds_new_template_keys(self):
+        """Missing keys from the template are still added (the whole point of upgrade)."""
+        current = {"worca": {"stages": {"plan": {"agent": "planner"}}}}
+        template = {
+            "worca": {
+                "stages": {"plan": {"agent": "planner"}, "test": {"agent": "tester"}},
+                "new_feature": {"enabled": True},
+            }
+        }
+        merged = _deep_merge(current, template)
+
+        assert merged["worca"]["stages"]["test"] == {"agent": "tester"}
+        assert merged["worca"]["new_feature"] == {"enabled": True}
+
 
 # ---------------------------------------------------------------------------
 # Agent override migration


### PR DESCRIPTION
## Summary

Two linked bugs made `worca init --upgrade` silently clobber user customizations and left the W-037 `stages.review.agent` rename perpetually "pending" under `worca init --check`.

### Bug 1 — template carries the pre-W-037 value

`src/worca/settings.json` still had `stages.review.agent: "guardian"`. `_migrate_settings_paths` correctly rewrote user settings to `reviewer`, but the template itself never got the memo.

### Bug 2 — upgrade merge is destructive

The upgrade path at `src/worca/cli/init.py:526` used `_deep_merge_overwrite` (template wins for scalars). Two consequences:

1. It reverted the just-migrated `reviewer` value back to `guardian` on every run, so `worca init --check` kept re-reporting the same pending migration forever.
2. It silently wiped any user-tuned value outside `.claude/settings.local.json` — agent models, `permissions.allow` entries, loop counts, webhooks, etc. Nothing warned the user.

Meanwhile `worca init --check` at `src/worca/cli/init.py:364` uses the non-destructive `_deep_merge`, so **`--check` and `--upgrade` disagreed** about what the upgrade would do.

## Fix

- Rename the template value so fresh installs are correct.
- Switch the upgrade merge to `_deep_merge` (base wins, new keys added), matching `--check`.
- Forward-incompatible changes still flow through `_migrate_settings_paths` so they apply deterministically and show up under `--check` exactly once.
- Users who really want a hard reset can use `worca init --force` (unchanged).

## Behavior change

| Before | After |
|---|---|
| User's `agents.planner.model = "sonnet"` silently reverted to `opus` | Preserved |
| User's custom `permissions.allow` entries wiped | Preserved |
| `stages.review.agent` re-reported as pending on every `--check` | Applied once, sticks |
| `--check` and `--upgrade` diverged | Same semantics |

## Test plan

- [x] `pytest tests/test_cli_init.py -x -q` — new tests pass, 45 total
- [x] `pytest tests/ -x -q --timeout=60` — full suite green
- [x] New regression tests cover: template value, migration + merge end-state, user model preservation, `permissions.allow` preservation, new-key addition
- [x] `MIGRATION.md` updated with the new merge semantics
- [ ] Manual: run `worca init --upgrade` on a project with a user-customized `agents.planner.model` and verify the value survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)