### PR TITLE
feat(runner): emit pipeline.run.interrupted on signal/SIGKILL stop (#W-042)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,16 @@ cd worca-ui && npm run lint:fix && npx vitest run
 
 Run both checks from inside `worca-ui/` so config paths resolve correctly. Do not commit if either fails — fix them first.
 
+**Whenever you add a new file or directory under `worca-ui/server/` or `worca-ui/app/`, verify it ships in the npm package.** The `files` field in `worca-ui/package.json` is an allowlist — anything not matched is silently dropped from the published tarball. The CLI spawns the server with `stdio: 'ignore'`, so a missing-module crash in the published package looks like "started (PID …)" followed by the browser failing to connect — the underlying error is invisible.
+
+Run this before committing any new `server/` or `app/` path:
+
+```bash
+cd worca-ui && npm pack --dry-run | grep <new-path>
+```
+
+If the new file is absent, extend the `files` glob (e.g. `server/**/*.js` rather than `server/*.js`) and re-check.
+
 ### Running the UI
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "worca-cc"
-version = "0.15.0rc2"
+version = "0.15.0rc3"
 description = "Autonomous software development pipeline combining orchestration with governance enforcement"
 readme = "src/worca/README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "worca-cc"
-version = "0.15.0rc1"
+version = "0.15.0rc2"
 description = "Autonomous software development pipeline combining orchestration with governance enforcement"
 readme = "src/worca/README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "worca-cc"
-version = "0.15.0"
+version = "0.15.0rc1"
 description = "Autonomous software development pipeline combining orchestration with governance enforcement"
 readme = "src/worca/README.md"
 license = "MIT"

--- a/src/worca/__init__.py
+++ b/src/worca/__init__.py
@@ -1,3 +1,3 @@
 """worca-cc: Autonomous software development pipeline with governance enforcement."""
 
-__version__ = "0.15.0"
+__version__ = "0.15.0rc1"

--- a/src/worca/__init__.py
+++ b/src/worca/__init__.py
@@ -1,3 +1,3 @@
 """worca-cc: Autonomous software development pipeline with governance enforcement."""
 
-__version__ = "0.15.0rc1"
+__version__ = "0.15.0rc2"

--- a/src/worca/__init__.py
+++ b/src/worca/__init__.py
@@ -1,3 +1,3 @@
 """worca-cc: Autonomous software development pipeline with governance enforcement."""
 
-__version__ = "0.15.0rc2"
+__version__ = "0.15.0rc3"

--- a/src/worca/events/emitter.py
+++ b/src/worca/events/emitter.py
@@ -204,8 +204,19 @@ def emit_event(
         print(f"[worca.events] Write error for {event_type}: {exc}", file=sys.stderr)
         return None
 
-    # Queue webhook delivery (non-blocking, best-effort) for observer webhooks only.
-    # Control webhooks receive sync delivery only at pause points via _check_control_response().
+    dispatch_event(ctx, event)
+    return event
+
+
+def dispatch_event(ctx: "EventContext", event: dict) -> None:
+    """Deliver an already-built event to observer webhooks and shell hooks.
+
+    Used both as the tail of emit_event() and standalone for events that were
+    written to events.jsonl by a signal-safe path (where network I/O and
+    threaded webhook delivery are unsafe). Never raises.
+    """
+    # Observer webhooks: queued non-blocking, best-effort.
+    # Control webhooks are sync-only at pause points via _check_control_response().
     if ctx._webhooks:
         try:
             from worca.events.webhook import deliver_webhook
@@ -214,15 +225,14 @@ def emit_event(
         except Exception as exc:
             print(f"[worca.events] Webhook dispatch error: {exc}", file=sys.stderr)
 
-    # Shell hook dispatch (worca.hooks config): fire-and-forget, never raises.
+    # Shell hook dispatch (worca.hooks config) — this is what fires integrations
+    # (Discord, Slack, Telegram, webhook_out, etc.). Fire-and-forget, never raises.
     if ctx._shell_hooks:
         try:
             from worca.orchestrator.events import dispatch_shell_hooks
             dispatch_shell_hooks(event, ctx._shell_hooks)
         except Exception as exc:
             print(f"[worca.events] Shell hook dispatch error: {exc}", file=sys.stderr)
-
-    return event
 
 
 # ---------------------------------------------------------------------------

--- a/src/worca/events/types.py
+++ b/src/worca/events/types.py
@@ -197,8 +197,14 @@ def run_failed_payload(
     return p
 
 
-def run_interrupted_payload(interrupted_stage: str, elapsed_ms: int) -> dict:
-    return {"interrupted_stage": interrupted_stage, "elapsed_ms": elapsed_ms}
+def run_interrupted_payload(
+    interrupted_stage: str, elapsed_ms: int, source: str = "orchestrator"
+) -> dict:
+    return {
+        "interrupted_stage": interrupted_stage,
+        "elapsed_ms": elapsed_ms,
+        "source": source,
+    }
 
 
 def run_resumed_payload(

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -428,6 +428,8 @@ def _atexit_cleanup():
             if _signal_status.get("pipeline_status") == "running":
                 if _signal_event_ctx is not None:
                     _signal_status["pipeline_status"] = "interrupted"
+                    if not _signal_status.get("stop_reason"):
+                        _signal_status["stop_reason"] = "unexpected_exit"
                     save_status(_signal_status, _signal_status_path)
                     _emit_interrupted_event(_signal_event_ctx, _signal_status, "atexit")
                 else:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -340,6 +340,49 @@ def _remove_pid(status_path: str) -> None:
         pass
 
 
+def _emit_interrupted_event(ctx, status, source: str) -> None:
+    """Append a pipeline.run.interrupted event using only signal-safe file I/O.
+
+    Shared by the signal handler and atexit cleanup so the on-disk event shape
+    stays in lockstep across both paths. Swallows all errors — callers run in
+    contexts where exceptions cannot be propagated.
+    """
+    import json as _json
+    import uuid as _uuid
+    from datetime import datetime as _dt, timezone as _tz
+
+    fh = None
+    try:
+        event = {
+            "schema_version": "1",
+            "event_id": str(_uuid.uuid4()),
+            "event_type": RUN_INTERRUPTED,
+            "timestamp": _dt.now(_tz.utc).isoformat(),
+            "run_id": ctx.run_id,
+            "pipeline": {
+                "branch": ctx.branch,
+                "work_request": ctx.work_request,
+            },
+            "payload": {
+                "interrupted_stage": status.get("current_stage", "unknown"),
+                "elapsed_ms": 0,
+                "source": source,
+            },
+        }
+        line = _json.dumps(event, ensure_ascii=False)
+        fh = open(ctx.events_path, "a", encoding="utf-8")
+        fh.write(line + "\n")
+        fh.flush()
+    except Exception:
+        pass
+    finally:
+        if fh is not None:
+            try:
+                fh.close()
+            except Exception:
+                pass
+
+
 def _install_signal_handlers():
     """Install SIGTERM/SIGINT handlers that set the shutdown flag and kill the subprocess."""
     global _shutdown_requested
@@ -357,32 +400,8 @@ def _install_signal_handlers():
                 save_status(_signal_status, _signal_status_path)
             except Exception:
                 pass
-            # Emit pipeline.run.interrupted via signal-safe file I/O only
             if _signal_event_ctx is not None:
-                try:
-                    interrupted_stage = _signal_status.get("current_stage", "unknown")
-                    import json as _json
-                    import uuid as _uuid
-                    from datetime import datetime as _dt, timezone as _tz
-                    event = {
-                        "schema_version": "1",
-                        "event_id": str(_uuid.uuid4()),
-                        "event_type": RUN_INTERRUPTED,
-                        "timestamp": _dt.now(_tz.utc).isoformat(),
-                        "run_id": _signal_event_ctx.run_id,
-                        "pipeline": {
-                            "branch": _signal_event_ctx.branch,
-                            "work_request": _signal_event_ctx.work_request,
-                        },
-                        "payload": {"interrupted_stage": interrupted_stage, "elapsed_ms": 0, "source": "signal"},
-                    }
-                    line = _json.dumps(event, ensure_ascii=False)
-                    fh = open(_signal_event_ctx.events_path, "a", encoding="utf-8")
-                    fh.write(line + "\n")
-                    fh.flush()
-                    fh.close()
-                except Exception:
-                    pass
+                _emit_interrupted_event(_signal_event_ctx, _signal_status, "signal")
             # Clean up PID files (per-run + project-level)
             _remove_pid(_signal_status_path)
             if _signal_project_status_path:
@@ -410,34 +429,7 @@ def _atexit_cleanup():
                 if _signal_event_ctx is not None:
                     _signal_status["pipeline_status"] = "interrupted"
                     save_status(_signal_status, _signal_status_path)
-                    # Emit pipeline.run.interrupted via signal-safe file I/O only
-                    try:
-                        import json as _json
-                        import uuid as _uuid
-                        from datetime import datetime as _dt, timezone as _tz
-                        event = {
-                            "schema_version": "1",
-                            "event_id": str(_uuid.uuid4()),
-                            "event_type": RUN_INTERRUPTED,
-                            "timestamp": _dt.now(_tz.utc).isoformat(),
-                            "run_id": _signal_event_ctx.run_id,
-                            "pipeline": {
-                                "branch": _signal_event_ctx.branch,
-                                "work_request": _signal_event_ctx.work_request,
-                            },
-                            "payload": {
-                                "interrupted_stage": _signal_status.get("current_stage", "unknown"),
-                                "elapsed_ms": 0,
-                                "source": "atexit",
-                            },
-                        }
-                        line = _json.dumps(event, ensure_ascii=False)
-                        fh = open(_signal_event_ctx.events_path, "a", encoding="utf-8")
-                        fh.write(line + "\n")
-                        fh.flush()
-                        fh.close()
-                    except Exception:
-                        pass
+                    _emit_interrupted_event(_signal_event_ctx, _signal_status, "atexit")
                 else:
                     _signal_status["pipeline_status"] = "failed"
                     if not _signal_status.get("stop_reason"):

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -115,6 +115,7 @@ _shutdown_requested = False
 _signal_status = None
 _signal_status_path = None
 _signal_project_status_path = None  # project-level status.json for PID cleanup
+_signal_event_ctx = None  # set to EventContext when run starts; signal-safe event emission
 
 
 def _check_control_file(
@@ -347,15 +348,41 @@ def _install_signal_handlers():
         global _shutdown_requested
         _shutdown_requested = True
         terminate_current()
-        # Layer 1: immediately persist failed status on signal
+        # Layer 1: immediately persist interrupted status on signal
         if _signal_status is not None and _signal_status_path is not None:
             try:
-                _signal_status["pipeline_status"] = "failed"
+                _signal_status["pipeline_status"] = "interrupted"
                 if not _signal_status.get("stop_reason"):
                     _signal_status["stop_reason"] = "signal"
                 save_status(_signal_status, _signal_status_path)
             except Exception:
                 pass
+            # Emit pipeline.run.interrupted via signal-safe file I/O only
+            if _signal_event_ctx is not None:
+                try:
+                    interrupted_stage = _signal_status.get("current_stage", "unknown")
+                    import json as _json
+                    import uuid as _uuid
+                    from datetime import datetime as _dt, timezone as _tz
+                    event = {
+                        "schema_version": "1",
+                        "event_id": str(_uuid.uuid4()),
+                        "event_type": RUN_INTERRUPTED,
+                        "timestamp": _dt.now(_tz.utc).isoformat(),
+                        "run_id": _signal_event_ctx.run_id,
+                        "pipeline": {
+                            "branch": _signal_event_ctx.branch,
+                            "work_request": _signal_event_ctx.work_request,
+                        },
+                        "payload": {"interrupted_stage": interrupted_stage, "elapsed_ms": 0, "source": "signal"},
+                    }
+                    line = _json.dumps(event, ensure_ascii=False)
+                    fh = open(_signal_event_ctx.events_path, "a", encoding="utf-8")
+                    fh.write(line + "\n")
+                    fh.flush()
+                    fh.close()
+                except Exception:
+                    pass
             # Clean up PID files (per-run + project-level)
             _remove_pid(_signal_status_path)
             if _signal_project_status_path:
@@ -380,10 +407,42 @@ def _atexit_cleanup():
     if _signal_status is not None and _signal_status_path is not None:
         try:
             if _signal_status.get("pipeline_status") == "running":
-                _signal_status["pipeline_status"] = "failed"
-                if not _signal_status.get("stop_reason"):
-                    _signal_status["stop_reason"] = "unexpected_exit"
-                save_status(_signal_status, _signal_status_path)
+                if _signal_event_ctx is not None:
+                    _signal_status["pipeline_status"] = "interrupted"
+                    save_status(_signal_status, _signal_status_path)
+                    # Emit pipeline.run.interrupted via signal-safe file I/O only
+                    try:
+                        import json as _json
+                        import uuid as _uuid
+                        from datetime import datetime as _dt, timezone as _tz
+                        event = {
+                            "schema_version": "1",
+                            "event_id": str(_uuid.uuid4()),
+                            "event_type": RUN_INTERRUPTED,
+                            "timestamp": _dt.now(_tz.utc).isoformat(),
+                            "run_id": _signal_event_ctx.run_id,
+                            "pipeline": {
+                                "branch": _signal_event_ctx.branch,
+                                "work_request": _signal_event_ctx.work_request,
+                            },
+                            "payload": {
+                                "interrupted_stage": _signal_status.get("current_stage", "unknown"),
+                                "elapsed_ms": 0,
+                                "source": "atexit",
+                            },
+                        }
+                        line = _json.dumps(event, ensure_ascii=False)
+                        fh = open(_signal_event_ctx.events_path, "a", encoding="utf-8")
+                        fh.write(line + "\n")
+                        fh.flush()
+                        fh.close()
+                    except Exception:
+                        pass
+                else:
+                    _signal_status["pipeline_status"] = "failed"
+                    if not _signal_status.get("stop_reason"):
+                        _signal_status["stop_reason"] = "unexpected_exit"
+                    save_status(_signal_status, _signal_status_path)
         except Exception:
             pass
         # Clean up PID files (per-run + project-level)
@@ -1036,7 +1095,7 @@ def run_pipeline(
     Saves status after each stage transition.
     Returns final status.
     """
-    global _shutdown_requested, _signal_status, _signal_status_path, _signal_project_status_path
+    global _shutdown_requested, _signal_status, _signal_status_path, _signal_project_status_path, _signal_event_ctx
     _shutdown_requested = False
 
     worca_dir = os.path.dirname(status_path)  # e.g. ".worca"
@@ -1187,6 +1246,7 @@ def run_pipeline(
                 events_path=events_path,
                 settings_path=settings_path,
             )
+            _signal_event_ctx = ctx
             os.environ["WORCA_EVENTS_PATH"] = events_path
 
             # Validate control webhooks: warn and skip those without a secret.
@@ -2608,6 +2668,7 @@ def run_pipeline(
         _signal_status = None
         _signal_status_path = None
         _signal_project_status_path = None
+        _signal_event_ctx = None
         try:
             atexit.unregister(_atexit_cleanup)
         except Exception:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -340,12 +340,32 @@ def _remove_pid(status_path: str) -> None:
         pass
 
 
+def _elapsed_ms_since(started_at_iso: str) -> int:
+    """Return milliseconds elapsed since an ISO 8601 timestamp, or 0 if unparseable."""
+    if not started_at_iso:
+        return 0
+    try:
+        from datetime import datetime as _dt, timezone as _tz
+        started = _dt.fromisoformat(started_at_iso)
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=_tz.utc)
+        delta = _dt.now(_tz.utc) - started
+        return max(0, int(delta.total_seconds() * 1000))
+    except (ValueError, TypeError):
+        return 0
+
+
 def _emit_interrupted_event(ctx, status, source: str) -> None:
-    """Append a pipeline.run.interrupted event using only signal-safe file I/O.
+    """Append a pipeline.run.interrupted event from a signal handler or atexit hook.
 
     Shared by the signal handler and atexit cleanup so the on-disk event shape
     stays in lockstep across both paths. Swallows all errors — callers run in
     contexts where exceptions cannot be propagated.
+
+    Signal-safety note: json.dumps, uuid.uuid4, and open() are not POSIX
+    async-signal-safe in the strict sense. This relies on CPython's behavior of
+    delivering signals between bytecode operations rather than mid-instruction,
+    which makes it safe in practice but not portable to other Python runtimes.
     """
     import json as _json
     import uuid as _uuid
@@ -365,7 +385,7 @@ def _emit_interrupted_event(ctx, status, source: str) -> None:
             },
             "payload": {
                 "interrupted_stage": status.get("current_stage", "unknown"),
-                "elapsed_ms": 0,
+                "elapsed_ms": _elapsed_ms_since(status.get("started_at", "")),
                 "source": source,
             },
         }
@@ -426,17 +446,16 @@ def _atexit_cleanup():
     if _signal_status is not None and _signal_status_path is not None:
         try:
             if _signal_status.get("pipeline_status") == "running":
+                # ctx-present → emit interrupted event; ctx-absent → fall back to failed.
+                # Both paths default stop_reason to "unexpected_exit" and persist status.
+                _signal_status["pipeline_status"] = (
+                    "interrupted" if _signal_event_ctx is not None else "failed"
+                )
+                if not _signal_status.get("stop_reason"):
+                    _signal_status["stop_reason"] = "unexpected_exit"
+                save_status(_signal_status, _signal_status_path)
                 if _signal_event_ctx is not None:
-                    _signal_status["pipeline_status"] = "interrupted"
-                    if not _signal_status.get("stop_reason"):
-                        _signal_status["stop_reason"] = "unexpected_exit"
-                    save_status(_signal_status, _signal_status_path)
                     _emit_interrupted_event(_signal_event_ctx, _signal_status, "atexit")
-                else:
-                    _signal_status["pipeline_status"] = "failed"
-                    if not _signal_status.get("stop_reason"):
-                        _signal_status["stop_reason"] = "unexpected_exit"
-                    save_status(_signal_status, _signal_status_path)
         except Exception:
             pass
         # Clean up PID files (per-run + project-level)

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -39,7 +39,7 @@ from worca.utils.git import create_branch, current_branch, get_current_git_head
 from worca.utils.settings import load_settings
 from worca.utils.token_usage import extract_token_usage, aggregate_token_usage, aggregate_by_model
 from worca.utils.stats import update_cumulative_stats
-from worca.events.emitter import EventContext, emit_event, _check_control_response
+from worca.events.emitter import EventContext, emit_event, dispatch_event, _check_control_response
 from worca.events.types import (
     RUN_STARTED, RUN_COMPLETED, RUN_FAILED, RUN_INTERRUPTED,
     RUN_RESUMED, RUN_PAUSED, RUN_RESUMED_FROM_PAUSE,
@@ -116,6 +116,7 @@ _signal_status = None
 _signal_status_path = None
 _signal_project_status_path = None  # project-level status.json for PID cleanup
 _signal_event_ctx = None  # set to EventContext when run starts; signal-safe event emission
+_pending_signal_event = None  # signal handler stashes interrupted-event dict here for deferred dispatch
 
 
 def _check_control_file(
@@ -355,18 +356,23 @@ def _elapsed_ms_since(started_at_iso: str) -> int:
         return 0
 
 
-def _emit_interrupted_event(ctx, status, source: str) -> None:
-    """Append a pipeline.run.interrupted event from a signal handler or atexit hook.
+def _emit_interrupted_event_signal_safe(ctx, status) -> None:
+    """Append a pipeline.run.interrupted event from a signal handler.
 
-    Shared by the signal handler and atexit cleanup so the on-disk event shape
-    stays in lockstep across both paths. Swallows all errors — callers run in
-    contexts where exceptions cannot be propagated.
+    Writes the event to events.jsonl using only signal-safe file I/O AND stashes
+    the event dict in _pending_signal_event so the main thread (run_pipeline's
+    finally block) or atexit can later dispatch it to webhooks and integration
+    shell-hooks. Webhook and shell-hook delivery cannot run in a signal handler
+    because they perform network I/O, spawn threads, and import urllib/requests.
+
+    Swallows all errors — signal-context callers cannot propagate exceptions.
 
     Signal-safety note: json.dumps, uuid.uuid4, and open() are not POSIX
     async-signal-safe in the strict sense. This relies on CPython's behavior of
     delivering signals between bytecode operations rather than mid-instruction,
     which makes it safe in practice but not portable to other Python runtimes.
     """
+    global _pending_signal_event
     import json as _json
     import uuid as _uuid
     from datetime import datetime as _dt, timezone as _tz
@@ -386,13 +392,15 @@ def _emit_interrupted_event(ctx, status, source: str) -> None:
             "payload": {
                 "interrupted_stage": status.get("current_stage", "unknown"),
                 "elapsed_ms": _elapsed_ms_since(status.get("started_at", "")),
-                "source": source,
+                "source": "signal",
             },
         }
         line = _json.dumps(event, ensure_ascii=False)
         fh = open(ctx.events_path, "a", encoding="utf-8")
         fh.write(line + "\n")
         fh.flush()
+        # Stash for deferred dispatch — signal context cannot run network/thread I/O.
+        _pending_signal_event = event
     except Exception:
         pass
     finally:
@@ -401,6 +409,24 @@ def _emit_interrupted_event(ctx, status, source: str) -> None:
                 fh.close()
             except Exception:
                 pass
+
+
+def _dispatch_pending_signal_event(ctx) -> None:
+    """Dispatch the signal-stashed interrupted event to webhooks and shell hooks.
+
+    Called from run_pipeline's finally block (normal exit after signal) and from
+    _atexit_cleanup (process exit before finally completed). Idempotent: clears
+    _pending_signal_event after dispatch so a follow-up call is a no-op.
+    """
+    global _pending_signal_event
+    if _pending_signal_event is None or ctx is None:
+        return
+    event = _pending_signal_event
+    _pending_signal_event = None
+    try:
+        dispatch_event(ctx, event)
+    except Exception:
+        pass
 
 
 def _install_signal_handlers():
@@ -421,7 +447,7 @@ def _install_signal_handlers():
             except Exception:
                 pass
             if _signal_event_ctx is not None:
-                _emit_interrupted_event(_signal_event_ctx, _signal_status, "signal")
+                _emit_interrupted_event_signal_safe(_signal_event_ctx, _signal_status)
             # Clean up PID files (per-run + project-level)
             _remove_pid(_signal_status_path)
             if _signal_project_status_path:
@@ -455,7 +481,18 @@ def _atexit_cleanup():
                     _signal_status["stop_reason"] = "unexpected_exit"
                 save_status(_signal_status, _signal_status_path)
                 if _signal_event_ctx is not None:
-                    _emit_interrupted_event(_signal_event_ctx, _signal_status, "atexit")
+                    # Full emit: writes to events.jsonl AND fires webhooks/integrations.
+                    # atexit runs in normal Python context — network I/O is safe here.
+                    emit_event(_signal_event_ctx, RUN_INTERRUPTED, run_interrupted_payload(
+                        interrupted_stage=_signal_status.get("current_stage", "unknown"),
+                        elapsed_ms=_elapsed_ms_since(_signal_status.get("started_at", "")),
+                        source="atexit",
+                    ))
+            elif _signal_event_ctx is not None and _pending_signal_event is not None:
+                # Signal handler already wrote an interrupted event but the main
+                # thread's finally block didn't run (e.g. os._exit). Dispatch the
+                # stashed event to webhooks/integrations now.
+                _dispatch_pending_signal_event(_signal_event_ctx)
         except Exception:
             pass
         # Clean up PID files (per-run + project-level)
@@ -1108,8 +1145,9 @@ def run_pipeline(
     Saves status after each stage transition.
     Returns final status.
     """
-    global _shutdown_requested, _signal_status, _signal_status_path, _signal_project_status_path, _signal_event_ctx
+    global _shutdown_requested, _signal_status, _signal_status_path, _signal_project_status_path, _signal_event_ctx, _pending_signal_event
     _shutdown_requested = False
+    _pending_signal_event = None
 
     worca_dir = os.path.dirname(status_path)  # e.g. ".worca"
     run_dir = None
@@ -2652,6 +2690,13 @@ def run_pipeline(
             ))
         raise
     finally:
+        # Dispatch any signal-stashed interrupted event to webhooks/integrations.
+        # Must run BEFORE ctx.close() so the dispatch helper can read ctx state.
+        # No-op if the signal handler didn't fire or the dispatch already happened.
+        try:
+            _dispatch_pending_signal_event(ctx)
+        except Exception:
+            pass
         if ctx is not None:
             ctx.close()
         # Safety net: ensure pipeline_status is never left as "running" on exit
@@ -2682,6 +2727,7 @@ def run_pipeline(
         _signal_status_path = None
         _signal_project_status_path = None
         _signal_event_ctx = None
+        _pending_signal_event = None
         try:
             atexit.unregister(_atexit_cleanup)
         except Exception:

--- a/tests/test_event_types.py
+++ b/tests/test_event_types.py
@@ -282,6 +282,9 @@ def test_run_interrupted_payload_required_fields():
     p = run_interrupted_payload(interrupted_stage="IMPLEMENT", elapsed_ms=30000)
     assert p["interrupted_stage"] == "IMPLEMENT"
     assert p["elapsed_ms"] == 30000
+    assert p["source"] == "orchestrator"  # default
+    p2 = run_interrupted_payload(interrupted_stage="PLAN", elapsed_ms=1, source="signal")
+    assert p2["source"] == "signal"
 
 
 def test_run_resumed_payload_required_fields():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3782,3 +3782,82 @@ def test_signal_and_atexit_emit_identical_event_shape(tmp_path):
     # Source distinguishes the two paths.
     assert sig_event["payload"]["source"] == "signal"
     assert atexit_event["payload"]["source"] == "atexit"
+
+
+def test_emit_interrupted_event_swallows_io_failure(tmp_path):
+    """The helper must never propagate exceptions — callers run in signal/atexit context."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    # Point events_path at the directory itself so open(..., "a") raises IsADirectoryError.
+    bad_path = str(tmp_path)
+
+    ctx = EventContext(
+        run_id="io-fail",
+        branch="feat/io",
+        work_request={"title": "IO"},
+        events_path=bad_path,
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+    status = {"pipeline_status": "running", "current_stage": "implement"}
+
+    # Must not raise.
+    runner_mod._emit_interrupted_event(ctx, status, "signal")
+
+
+def test_emit_interrupted_event_uses_started_at_for_elapsed_ms(tmp_path):
+    """elapsed_ms is computed from status.started_at (not hardcoded to 0)."""
+    from datetime import datetime, timezone, timedelta
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    events_path = str(tmp_path / "events.jsonl")
+    started = (datetime.now(timezone.utc) - timedelta(milliseconds=2500)).isoformat()
+
+    ctx = EventContext(
+        run_id="elapsed-1",
+        branch="feat/elapsed",
+        work_request={"title": "Elapsed"},
+        events_path=events_path,
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+    status = {"pipeline_status": "running", "current_stage": "implement", "started_at": started}
+
+    runner_mod._emit_interrupted_event(ctx, status, "signal")
+
+    event = json.loads((tmp_path / "events.jsonl").read_text().strip())
+    assert event["payload"]["elapsed_ms"] >= 2500
+    assert event["payload"]["elapsed_ms"] < 60_000
+
+
+def test_emit_interrupted_event_falls_back_to_zero_on_bad_started_at(tmp_path):
+    """elapsed_ms falls back to 0 when started_at is missing or unparseable."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    events_path = str(tmp_path / "events.jsonl")
+    ctx = EventContext(
+        run_id="elapsed-2",
+        branch="feat/elapsed",
+        work_request={"title": "Elapsed"},
+        events_path=events_path,
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+    status = {"pipeline_status": "running", "current_stage": "plan", "started_at": "garbage"}
+
+    runner_mod._emit_interrupted_event(ctx, status, "signal")
+
+    event = json.loads((tmp_path / "events.jsonl").read_text().strip())
+    assert event["payload"]["elapsed_ms"] == 0

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3658,3 +3658,87 @@ def test_atexit_cleanup_falls_back_to_failed_without_ctx(tmp_path):
     assert saved_statuses, "save_status was never called"
     assert saved_statuses[-1]["pipeline_status"] == "failed"
     assert saved_statuses[-1]["stop_reason"] == "unexpected_exit"
+
+
+def test_signal_and_atexit_emit_identical_event_shape(tmp_path):
+    """Both stop paths must emit the same event keys/shape so consumers see one schema."""
+    import signal as _signal
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    def _run_signal_path(events_path):
+        ctx = EventContext(
+            run_id="parity-signal",
+            branch="feat/parity",
+            work_request={"title": "Parity"},
+            events_path=events_path,
+            settings_path="",
+            enabled=True,
+            _webhooks=[],
+            _control_webhooks=[],
+            _shell_hooks={},
+        )
+        status = {"pipeline_status": "running", "current_stage": "implement", "stop_reason": ""}
+        runner_mod._signal_event_ctx = ctx
+        runner_mod._signal_status = status
+        runner_mod._signal_status_path = str(tmp_path / "status_signal.json")
+        runner_mod._signal_project_status_path = None
+        original = _signal.getsignal(_signal.SIGTERM)
+        try:
+            with patch("worca.orchestrator.runner.terminate_current"):
+                with patch("worca.orchestrator.runner.save_status"):
+                    with patch("worca.orchestrator.runner._remove_pid"):
+                        runner_mod._install_signal_handlers()
+                        _signal.getsignal(_signal.SIGTERM)(_signal.SIGTERM, None)
+        finally:
+            _signal.signal(_signal.SIGTERM, original)
+            runner_mod._signal_event_ctx = None
+            runner_mod._signal_status = None
+            runner_mod._signal_status_path = None
+
+    def _run_atexit_path(events_path):
+        ctx = EventContext(
+            run_id="parity-atexit",
+            branch="feat/parity",
+            work_request={"title": "Parity"},
+            events_path=events_path,
+            settings_path="",
+            enabled=True,
+            _webhooks=[],
+            _control_webhooks=[],
+            _shell_hooks={},
+        )
+        status = {"pipeline_status": "running", "current_stage": "implement", "stop_reason": ""}
+        runner_mod._signal_event_ctx = ctx
+        runner_mod._signal_status = status
+        runner_mod._signal_status_path = str(tmp_path / "status_atexit.json")
+        runner_mod._signal_project_status_path = None
+        try:
+            with patch("worca.orchestrator.runner.save_status"):
+                with patch("worca.orchestrator.runner._remove_pid"):
+                    runner_mod._atexit_cleanup()
+        finally:
+            runner_mod._signal_event_ctx = None
+            runner_mod._signal_status = None
+            runner_mod._signal_status_path = None
+
+    sig_path = tmp_path / "events_signal.jsonl"
+    atexit_path = tmp_path / "events_atexit.jsonl"
+    _run_signal_path(str(sig_path))
+    _run_atexit_path(str(atexit_path))
+
+    sig_event = json.loads(sig_path.read_text().strip().splitlines()[0])
+    atexit_event = json.loads(atexit_path.read_text().strip().splitlines()[0])
+
+    # Top-level keys identical.
+    assert set(sig_event.keys()) == set(atexit_event.keys())
+    # Nested keys identical.
+    assert set(sig_event["pipeline"].keys()) == set(atexit_event["pipeline"].keys())
+    assert set(sig_event["payload"].keys()) == set(atexit_event["payload"].keys())
+    # Static fields match.
+    assert sig_event["schema_version"] == atexit_event["schema_version"] == "1"
+    assert sig_event["event_type"] == atexit_event["event_type"] == "pipeline.run.interrupted"
+    assert sig_event["payload"]["interrupted_stage"] == atexit_event["payload"]["interrupted_stage"]
+    # Source distinguishes the two paths.
+    assert sig_event["payload"]["source"] == "signal"
+    assert atexit_event["payload"]["source"] == "atexit"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3806,7 +3806,7 @@ def test_emit_interrupted_event_swallows_io_failure(tmp_path):
     status = {"pipeline_status": "running", "current_stage": "implement"}
 
     # Must not raise.
-    runner_mod._emit_interrupted_event(ctx, status, "signal")
+    runner_mod._emit_interrupted_event_signal_safe(ctx, status)
 
 
 def test_emit_interrupted_event_uses_started_at_for_elapsed_ms(tmp_path):
@@ -3831,7 +3831,7 @@ def test_emit_interrupted_event_uses_started_at_for_elapsed_ms(tmp_path):
     )
     status = {"pipeline_status": "running", "current_stage": "implement", "started_at": started}
 
-    runner_mod._emit_interrupted_event(ctx, status, "signal")
+    runner_mod._emit_interrupted_event_signal_safe(ctx, status)
 
     event = json.loads((tmp_path / "events.jsonl").read_text().strip())
     assert event["payload"]["elapsed_ms"] >= 2500
@@ -3857,7 +3857,193 @@ def test_emit_interrupted_event_falls_back_to_zero_on_bad_started_at(tmp_path):
     )
     status = {"pipeline_status": "running", "current_stage": "plan", "started_at": "garbage"}
 
-    runner_mod._emit_interrupted_event(ctx, status, "signal")
+    runner_mod._emit_interrupted_event_signal_safe(ctx, status)
 
     event = json.loads((tmp_path / "events.jsonl").read_text().strip())
     assert event["payload"]["elapsed_ms"] == 0
+
+
+def test_signal_handler_stashes_event_for_deferred_dispatch(tmp_path):
+    """Signal-safe write must stash the event in _pending_signal_event for later dispatch."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    ctx = EventContext(
+        run_id="stash-1",
+        branch="feat/stash",
+        work_request={"title": "Stash"},
+        events_path=str(tmp_path / "events.jsonl"),
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+    status = {"pipeline_status": "running", "current_stage": "implement", "started_at": ""}
+
+    runner_mod._pending_signal_event = None
+    try:
+        runner_mod._emit_interrupted_event_signal_safe(ctx, status)
+        stashed = runner_mod._pending_signal_event
+    finally:
+        runner_mod._pending_signal_event = None
+
+    assert stashed is not None
+    assert stashed["event_type"] == "pipeline.run.interrupted"
+    assert stashed["payload"]["source"] == "signal"
+
+
+def test_dispatch_pending_signal_event_fires_webhooks_and_clears(tmp_path):
+    """The deferred-dispatch helper must call dispatch_event and clear the stash (idempotent)."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    delivered = []
+
+    def fake_dispatch(_ctx, event):
+        delivered.append(event)
+
+    ctx = EventContext(
+        run_id="dispatch-1",
+        branch="feat/dispatch",
+        work_request={"title": "Dispatch"},
+        events_path=str(tmp_path / "events.jsonl"),
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    sample = {"event_type": "pipeline.run.interrupted", "payload": {"source": "signal"}}
+    runner_mod._pending_signal_event = sample
+
+    try:
+        with patch("worca.orchestrator.runner.dispatch_event", side_effect=fake_dispatch):
+            runner_mod._dispatch_pending_signal_event(ctx)
+            # Second call must be a no-op (stash cleared after first dispatch).
+            runner_mod._dispatch_pending_signal_event(ctx)
+    finally:
+        runner_mod._pending_signal_event = None
+
+    assert delivered == [sample], "dispatch_event must be called exactly once"
+    assert runner_mod._pending_signal_event is None
+
+
+def test_dispatch_pending_signal_event_noop_when_unset(tmp_path):
+    """When no signal happened, deferred dispatch must be a no-op (no error, no calls)."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    ctx = EventContext(
+        run_id="noop",
+        branch="feat/noop",
+        work_request={"title": "Noop"},
+        events_path=str(tmp_path / "events.jsonl"),
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    runner_mod._pending_signal_event = None
+    with patch("worca.orchestrator.runner.dispatch_event") as m:
+        runner_mod._dispatch_pending_signal_event(ctx)
+    m.assert_not_called()
+
+
+def test_atexit_full_emit_dispatches_webhooks_and_hooks(tmp_path):
+    """When atexit emits an interrupted event (status was 'running'), it must use full emit_event
+    so webhooks AND integration shell-hooks fire — not just write to events.jsonl.
+    """
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    delivered_webhooks = []
+    dispatched_hooks = []
+
+    def fake_deliver(event, wh):
+        delivered_webhooks.append((event["event_type"], wh))
+
+    def fake_dispatch_hooks(event, hooks):
+        dispatched_hooks.append((event["event_type"], hooks))
+
+    ctx = EventContext(
+        run_id="atexit-fire",
+        branch="feat/fire",
+        work_request={"title": "Fire"},
+        events_path=str(tmp_path / "events.jsonl"),
+        settings_path="",
+        enabled=True,
+        _webhooks=[{"url": "https://example.test/webhook"}],
+        _control_webhooks=[],
+        _shell_hooks={"pipeline.run.interrupted": [{"command": "echo hi"}]},
+    )
+
+    status = {"pipeline_status": "running", "current_stage": "plan", "stop_reason": "", "started_at": ""}
+    runner_mod._signal_event_ctx = ctx
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = str(tmp_path / "status.json")
+    runner_mod._signal_project_status_path = None
+    runner_mod._pending_signal_event = None
+
+    try:
+        with patch("worca.events.webhook.deliver_webhook", side_effect=fake_deliver):
+            with patch("worca.orchestrator.events.dispatch_shell_hooks", side_effect=fake_dispatch_hooks):
+                with patch("worca.orchestrator.runner.save_status"):
+                    with patch("worca.orchestrator.runner._remove_pid"):
+                        runner_mod._atexit_cleanup()
+    finally:
+        runner_mod._signal_event_ctx = None
+        runner_mod._signal_status = None
+        runner_mod._signal_status_path = None
+        runner_mod._pending_signal_event = None
+
+    assert len(delivered_webhooks) == 1, "webhook must fire from atexit path"
+    assert delivered_webhooks[0][0] == "pipeline.run.interrupted"
+    assert len(dispatched_hooks) == 1, "shell hook (integration) must fire from atexit path"
+    assert dispatched_hooks[0][0] == "pipeline.run.interrupted"
+
+
+def test_atexit_dispatches_pending_signal_event_when_status_already_interrupted(tmp_path):
+    """If the signal handler ran but finally didn't, atexit must dispatch the stashed event."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    delivered = []
+
+    ctx = EventContext(
+        run_id="atexit-stash",
+        branch="feat/stash",
+        work_request={"title": "Stash"},
+        events_path=str(tmp_path / "events.jsonl"),
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    sample = {"event_type": "pipeline.run.interrupted", "payload": {"source": "signal"}}
+
+    # Status reflects post-signal state: already "interrupted" with stop_reason=signal.
+    status = {"pipeline_status": "interrupted", "stop_reason": "signal", "current_stage": "plan"}
+    runner_mod._signal_event_ctx = ctx
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = str(tmp_path / "status.json")
+    runner_mod._signal_project_status_path = None
+    runner_mod._pending_signal_event = sample
+
+    try:
+        with patch("worca.orchestrator.runner.dispatch_event",
+                   side_effect=lambda c, e: delivered.append(e)):
+            with patch("worca.orchestrator.runner._remove_pid"):
+                runner_mod._atexit_cleanup()
+    finally:
+        runner_mod._signal_event_ctx = None
+        runner_mod._signal_status = None
+        runner_mod._signal_status_path = None
+        runner_mod._pending_signal_event = None
+
+    assert delivered == [sample], "atexit must dispatch the stashed signal event when finally didn't"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3629,6 +3629,46 @@ def test_atexit_cleanup_sets_interrupted_status_when_ctx_available(tmp_path):
 
     assert saved_statuses, "save_status was never called"
     assert saved_statuses[-1]["pipeline_status"] == "interrupted"
+    # Stop reason must be set so consumers can distinguish atexit from signal.
+    assert saved_statuses[-1]["stop_reason"] == "unexpected_exit"
+
+
+def test_atexit_cleanup_preserves_existing_stop_reason_when_ctx_set(tmp_path):
+    """_atexit_cleanup() does not overwrite a stop_reason that callers set earlier."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    ctx = EventContext(
+        run_id="atexit-run-preserve",
+        branch="feat/preserve",
+        work_request={"title": "Preserve"},
+        events_path=str(tmp_path / "events.jsonl"),
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    status = {"pipeline_status": "running", "current_stage": "test", "stop_reason": "user_stop"}
+    saved_statuses = []
+
+    runner_mod._signal_event_ctx = ctx
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = str(tmp_path / "status.json")
+    runner_mod._signal_project_status_path = None
+
+    try:
+        with patch("worca.orchestrator.runner.save_status",
+                   side_effect=lambda s, _p: saved_statuses.append(dict(s))):
+            with patch("worca.orchestrator.runner._remove_pid"):
+                runner_mod._atexit_cleanup()
+    finally:
+        runner_mod._signal_event_ctx = None
+        runner_mod._signal_status = None
+        runner_mod._signal_status_path = None
+
+    assert saved_statuses[-1]["stop_reason"] == "user_stop"
 
 
 def test_atexit_cleanup_falls_back_to_failed_without_ctx(tmp_path):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3381,3 +3381,280 @@ def test_run_stage_agent_override_none_uses_default_path():
         with patch("worca.orchestrator.runner.run_agent", return_value={}) as mock_run:
             run_stage(Stage.TEST, {"prompt": "x"}, agent_override=None)
     assert ".claude/worca/agents/core/tester.md" in mock_run.call_args.kwargs.get("agent", "")
+
+
+def test_signal_event_ctx_module_level_exists():
+    """_signal_event_ctx module-level reference exists in runner."""
+    import worca.orchestrator.runner as runner_mod
+    assert hasattr(runner_mod, "_signal_event_ctx")
+
+
+def test_handler_emits_interrupted_event_to_jsonl(tmp_path):
+    """_handler() writes pipeline.run.interrupted to events.jsonl after saving status."""
+    import signal as _signal
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    events_path = str(tmp_path / "events.jsonl")
+    status_path = str(tmp_path / "status.json")
+
+    ctx = EventContext(
+        run_id="test-run-1",
+        branch="feat/test",
+        work_request={"title": "Test"},
+        events_path=events_path,
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    status = {"pipeline_status": "running", "current_stage": "implement", "stop_reason": ""}
+
+    runner_mod._signal_event_ctx = ctx
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = status_path
+    runner_mod._signal_project_status_path = None
+
+    with patch("worca.orchestrator.runner.terminate_current"):
+        with patch("worca.orchestrator.runner.save_status"):
+            with patch("worca.orchestrator.runner._remove_pid"):
+                # Invoke handler directly
+                handler = None
+                original = _signal.getsignal(_signal.SIGTERM)
+                try:
+                    runner_mod._install_signal_handlers()
+                    handler = _signal.getsignal(_signal.SIGTERM)
+                    handler(_signal.SIGTERM, None)
+                finally:
+                    _signal.signal(_signal.SIGTERM, original)
+                    runner_mod._signal_event_ctx = None
+                    runner_mod._signal_status = None
+                    runner_mod._signal_status_path = None
+
+    assert (tmp_path / "events.jsonl").exists()
+    lines = (tmp_path / "events.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 1
+    event = json.loads(lines[0])
+    assert event["event_type"] == "pipeline.run.interrupted"
+    assert event["payload"]["interrupted_stage"] == "implement"
+    assert event["payload"]["source"] == "signal"
+
+
+def test_handler_sets_interrupted_status(tmp_path):
+    """_handler() sets pipeline_status='interrupted' not 'failed'."""
+    import signal as _signal
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    events_path = str(tmp_path / "events.jsonl")
+    status_path = str(tmp_path / "status.json")
+
+    ctx = EventContext(
+        run_id="test-run-2",
+        branch="feat/test",
+        work_request={"title": "Test"},
+        events_path=events_path,
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    status = {"pipeline_status": "running", "current_stage": "test", "stop_reason": ""}
+
+    saved_statuses = []
+
+    def capture_save(s, path):
+        saved_statuses.append(dict(s))
+
+    runner_mod._signal_event_ctx = ctx
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = status_path
+    runner_mod._signal_project_status_path = None
+
+    with patch("worca.orchestrator.runner.terminate_current"):
+        with patch("worca.orchestrator.runner.save_status", side_effect=capture_save):
+            with patch("worca.orchestrator.runner._remove_pid"):
+                original = _signal.getsignal(_signal.SIGTERM)
+                try:
+                    runner_mod._install_signal_handlers()
+                    handler = _signal.getsignal(_signal.SIGTERM)
+                    handler(_signal.SIGTERM, None)
+                finally:
+                    _signal.signal(_signal.SIGTERM, original)
+                    runner_mod._signal_event_ctx = None
+                    runner_mod._signal_status = None
+                    runner_mod._signal_status_path = None
+
+    assert saved_statuses, "save_status was never called"
+    assert saved_statuses[-1]["pipeline_status"] == "interrupted"
+
+
+def test_handler_emits_interrupted_with_unknown_stage_when_no_current_stage(tmp_path):
+    """_handler() uses 'unknown' for interrupted_stage when current_stage is absent."""
+    import signal as _signal
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    events_path = str(tmp_path / "events.jsonl")
+    status_path = str(tmp_path / "status.json")
+
+    ctx = EventContext(
+        run_id="test-run-3",
+        branch="feat/test",
+        work_request={"title": "Test"},
+        events_path=events_path,
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    status = {"pipeline_status": "running"}  # no current_stage key
+
+    runner_mod._signal_event_ctx = ctx
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = status_path
+    runner_mod._signal_project_status_path = None
+
+    with patch("worca.orchestrator.runner.terminate_current"):
+        with patch("worca.orchestrator.runner.save_status"):
+            with patch("worca.orchestrator.runner._remove_pid"):
+                original = _signal.getsignal(_signal.SIGTERM)
+                try:
+                    runner_mod._install_signal_handlers()
+                    handler = _signal.getsignal(_signal.SIGTERM)
+                    handler(_signal.SIGTERM, None)
+                finally:
+                    _signal.signal(_signal.SIGTERM, original)
+                    runner_mod._signal_event_ctx = None
+                    runner_mod._signal_status = None
+                    runner_mod._signal_status_path = None
+
+    lines = (tmp_path / "events.jsonl").read_text().strip().splitlines()
+    event = json.loads(lines[0])
+    assert event["payload"]["interrupted_stage"] == "unknown"
+    assert runner_mod._signal_event_ctx is None
+
+
+def test_atexit_cleanup_emits_interrupted_event_when_ctx_available(tmp_path):
+    """_atexit_cleanup() writes pipeline.run.interrupted to events.jsonl when ctx is set."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    events_path = str(tmp_path / "events.jsonl")
+    status_path = str(tmp_path / "status.json")
+
+    ctx = EventContext(
+        run_id="atexit-run-1",
+        branch="feat/stop",
+        work_request={"title": "Test"},
+        events_path=events_path,
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    status = {"pipeline_status": "running", "current_stage": "implement", "stop_reason": ""}
+
+    runner_mod._signal_event_ctx = ctx
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = status_path
+    runner_mod._signal_project_status_path = None
+
+    try:
+        with patch("worca.orchestrator.runner.save_status"):
+            with patch("worca.orchestrator.runner._remove_pid"):
+                runner_mod._atexit_cleanup()
+    finally:
+        runner_mod._signal_event_ctx = None
+        runner_mod._signal_status = None
+        runner_mod._signal_status_path = None
+
+    assert (tmp_path / "events.jsonl").exists()
+    lines = (tmp_path / "events.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 1
+    event = json.loads(lines[0])
+    assert event["event_type"] == "pipeline.run.interrupted"
+    assert event["run_id"] == "atexit-run-1"
+    assert event["payload"]["source"] == "atexit"
+    assert event["payload"]["interrupted_stage"] == "implement"
+
+
+def test_atexit_cleanup_sets_interrupted_status_when_ctx_available(tmp_path):
+    """_atexit_cleanup() sets pipeline_status='interrupted' when ctx is set."""
+    import worca.orchestrator.runner as runner_mod
+    from worca.events.emitter import EventContext
+
+    events_path = str(tmp_path / "events.jsonl")
+    status_path = str(tmp_path / "status.json")
+
+    ctx = EventContext(
+        run_id="atexit-run-2",
+        branch="feat/stop",
+        work_request={"title": "Test"},
+        events_path=events_path,
+        settings_path="",
+        enabled=True,
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+    status = {"pipeline_status": "running", "current_stage": "test", "stop_reason": ""}
+    saved_statuses = []
+
+    def capture_save(s, path):
+        saved_statuses.append(dict(s))
+
+    runner_mod._signal_event_ctx = ctx
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = status_path
+    runner_mod._signal_project_status_path = None
+
+    try:
+        with patch("worca.orchestrator.runner.save_status", side_effect=capture_save):
+            with patch("worca.orchestrator.runner._remove_pid"):
+                runner_mod._atexit_cleanup()
+    finally:
+        runner_mod._signal_event_ctx = None
+        runner_mod._signal_status = None
+        runner_mod._signal_status_path = None
+
+    assert saved_statuses, "save_status was never called"
+    assert saved_statuses[-1]["pipeline_status"] == "interrupted"
+
+
+def test_atexit_cleanup_falls_back_to_failed_without_ctx(tmp_path):
+    """_atexit_cleanup() uses 'failed'/'unexpected_exit' when no ctx is set."""
+    import worca.orchestrator.runner as runner_mod
+
+    status_path = str(tmp_path / "status.json")
+    status = {"pipeline_status": "running", "stop_reason": ""}
+    saved_statuses = []
+
+    def capture_save(s, path):
+        saved_statuses.append(dict(s))
+
+    runner_mod._signal_event_ctx = None
+    runner_mod._signal_status = status
+    runner_mod._signal_status_path = status_path
+    runner_mod._signal_project_status_path = None
+
+    try:
+        with patch("worca.orchestrator.runner.save_status", side_effect=capture_save):
+            with patch("worca.orchestrator.runner._remove_pid"):
+                runner_mod._atexit_cleanup()
+    finally:
+        runner_mod._signal_status = None
+        runner_mod._signal_status_path = None
+
+    assert saved_statuses, "save_status was never called"
+    assert saved_statuses[-1]["pipeline_status"] == "failed"
+    assert saved_statuses[-1]["stop_reason"] == "unexpected_exit"

--- a/tests/test_runner_lifecycle.py
+++ b/tests/test_runner_lifecycle.py
@@ -1,37 +1,58 @@
 """Tests for pipeline lifecycle state management (signal handler, atexit, finally, resume, beads)."""
 
+import json
 import os
 import signal
 from unittest.mock import patch
 
-
 import worca.orchestrator.runner as runner
+from worca.events.emitter import EventContext
 from worca.orchestrator.control import write_control, control_path
 from worca.state.status import save_status, load_status
 
 
-# --- Layer 1: signal handler saves failed status ---
+def _make_ctx(tmp_path, run_id="test-run-1"):
+    events_path = str(tmp_path / "events.jsonl")
+    return EventContext(
+        run_id=run_id,
+        branch="main",
+        work_request={},
+        events_path=events_path,
+        settings_path=str(tmp_path / "settings.json"),
+        _webhooks=[],
+        _control_webhooks=[],
+        _shell_hooks={},
+    )
+
+
+# --- Layer 1: signal handler saves interrupted status ---
 
 
 def test_signal_handler_saves_failed_status(tmp_path):
-    """Calling the signal handler writes pipeline_status='failed' with stop_reason='signal'."""
+    """Calling the signal handler writes pipeline_status='interrupted' with stop_reason='signal'
+    and emits a pipeline.run.interrupted event to events.jsonl."""
     status_path = str(tmp_path / "status.json")
-    status = {"pipeline_status": "running", "stage": "plan"}
+    status = {"pipeline_status": "running", "current_stage": "plan", "stop_reason": ""}
     save_status(status, status_path)
+    ctx = _make_ctx(tmp_path)
 
-    # Wire up module-level refs
     runner._signal_status = status
     runner._signal_status_path = status_path
+    runner._signal_event_ctx = ctx
     try:
-        # Install handlers so we can invoke the internal handler
         runner._install_signal_handlers()
-        # Send SIGINT to ourselves — the handler should save status
         os.kill(os.getpid(), signal.SIGINT)
 
         on_disk = load_status(status_path)
-        assert on_disk["pipeline_status"] == "failed"
+        assert on_disk["pipeline_status"] == "interrupted"
         assert on_disk["stop_reason"] == "signal"
+
+        lines = (tmp_path / "events.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "pipeline.run.interrupted"
     finally:
+        runner._signal_event_ctx = None
         runner._signal_status = None
         runner._signal_status_path = None
         runner._shutdown_requested = False
@@ -66,9 +87,85 @@ def test_signal_handler_preserves_existing_stop_reason(tmp_path):
         os.kill(os.getpid(), signal.SIGINT)
 
         on_disk = load_status(status_path)
-        assert on_disk["pipeline_status"] == "failed"
+        assert on_disk["pipeline_status"] == "interrupted"
         assert on_disk["stop_reason"] == "stopped"  # preserved, not "signal"
     finally:
+        runner._signal_status = None
+        runner._signal_status_path = None
+        runner._shutdown_requested = False
+        runner._restore_signal_handlers()
+
+
+def test_signal_handler_emits_interrupted_event(tmp_path):
+    """_handler() writes pipeline.run.interrupted to events.jsonl when _signal_event_ctx is set."""
+    status_path = str(tmp_path / "status.json")
+    status = {"pipeline_status": "running", "current_stage": "implement", "stop_reason": ""}
+    save_status(status, status_path)
+    ctx = _make_ctx(tmp_path)
+
+    runner._signal_status = status
+    runner._signal_status_path = status_path
+    runner._signal_event_ctx = ctx
+    try:
+        runner._install_signal_handlers()
+        os.kill(os.getpid(), signal.SIGINT)
+
+        lines = (tmp_path / "events.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "pipeline.run.interrupted"
+        assert event["payload"]["interrupted_stage"] == "implement"
+        assert event["payload"]["source"] == "signal"
+        assert event["run_id"] == "test-run-1"
+    finally:
+        runner._signal_event_ctx = None
+        runner._signal_status = None
+        runner._signal_status_path = None
+        runner._shutdown_requested = False
+        runner._restore_signal_handlers()
+
+
+def test_signal_handler_no_event_when_ctx_not_set(tmp_path):
+    """_handler() is safe when _signal_event_ctx is None — no crash, no events file."""
+    status_path = str(tmp_path / "status.json")
+    status = {"pipeline_status": "running", "stop_reason": ""}
+    save_status(status, status_path)
+
+    runner._signal_status = status
+    runner._signal_status_path = status_path
+    runner._signal_event_ctx = None
+    try:
+        runner._install_signal_handlers()
+        os.kill(os.getpid(), signal.SIGINT)
+
+        assert not (tmp_path / "events.jsonl").exists()
+        on_disk = load_status(status_path)
+        assert on_disk["pipeline_status"] == "interrupted"
+    finally:
+        runner._signal_status = None
+        runner._signal_status_path = None
+        runner._shutdown_requested = False
+        runner._restore_signal_handlers()
+
+
+def test_signal_handler_sets_interrupted_status(tmp_path):
+    """_handler() sets pipeline_status='interrupted', not 'failed'."""
+    status_path = str(tmp_path / "status.json")
+    status = {"pipeline_status": "running", "current_stage": "test", "stop_reason": ""}
+    save_status(status, status_path)
+    ctx = _make_ctx(tmp_path)
+
+    runner._signal_status = status
+    runner._signal_status_path = status_path
+    runner._signal_event_ctx = ctx
+    try:
+        runner._install_signal_handlers()
+        os.kill(os.getpid(), signal.SIGINT)
+
+        on_disk = load_status(status_path)
+        assert on_disk["pipeline_status"] == "interrupted"
+    finally:
+        runner._signal_event_ctx = None
         runner._signal_status = None
         runner._signal_status_path = None
         runner._shutdown_requested = False
@@ -79,13 +176,14 @@ def test_signal_handler_preserves_existing_stop_reason(tmp_path):
 
 
 def test_atexit_cleanup_saves_when_running(tmp_path):
-    """atexit handler transitions 'running' → 'failed' with stop_reason='unexpected_exit'."""
+    """atexit handler transitions 'running' → 'failed' (no ctx) with stop_reason='unexpected_exit'."""
     status_path = str(tmp_path / "status.json")
     status = {"pipeline_status": "running"}
     save_status(status, status_path)
 
     runner._signal_status = status
     runner._signal_status_path = status_path
+    runner._signal_event_ctx = None
     try:
         runner._atexit_cleanup()
 
@@ -112,6 +210,54 @@ def test_atexit_cleanup_noop_when_already_failed(tmp_path):
         assert on_disk["pipeline_status"] == "failed"
         assert on_disk["stop_reason"] == "signal"  # unchanged
     finally:
+        runner._signal_status = None
+        runner._signal_status_path = None
+
+
+def test_atexit_emits_event(tmp_path):
+    """_atexit_cleanup() writes pipeline.run.interrupted to events.jsonl when status was 'running'."""
+    status_path = str(tmp_path / "status.json")
+    status = {"pipeline_status": "running", "current_stage": "review", "stop_reason": ""}
+    save_status(status, status_path)
+    ctx = _make_ctx(tmp_path, run_id="atexit-run-1")
+
+    runner._signal_status = status
+    runner._signal_status_path = status_path
+    runner._signal_event_ctx = ctx
+    try:
+        runner._atexit_cleanup()
+
+        lines = (tmp_path / "events.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "pipeline.run.interrupted"
+        assert event["run_id"] == "atexit-run-1"
+        assert event["payload"]["source"] == "atexit"
+        assert event["payload"]["interrupted_stage"] == "review"
+    finally:
+        runner._signal_event_ctx = None
+        runner._signal_status = None
+        runner._signal_status_path = None
+
+
+def test_atexit_no_event_when_already_terminal(tmp_path):
+    """_atexit_cleanup() skips event emission when status is already terminal ('failed')."""
+    status_path = str(tmp_path / "status.json")
+    status = {"pipeline_status": "failed", "stop_reason": "error"}
+    save_status(status, status_path)
+    ctx = _make_ctx(tmp_path)
+
+    runner._signal_status = status
+    runner._signal_status_path = status_path
+    runner._signal_event_ctx = ctx
+    try:
+        runner._atexit_cleanup()
+
+        assert not (tmp_path / "events.jsonl").exists()
+        on_disk = load_status(status_path)
+        assert on_disk["pipeline_status"] == "failed"
+    finally:
+        runner._signal_event_ctx = None
         runner._signal_status = None
         runner._signal_status_path = None
 

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -4351,23 +4351,12 @@ sl-tooltip.bead-tooltip::part(body) {
   opacity: 0.7;
 }
 
-.ig-card--pending {
-  border-left: 3px solid var(--sl-color-warning-500);
-}
-
 .ig-card-footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-top: 0.75rem;
   padding-left: 2.75rem;
-}
-
-.ig-card-pending-hint {
-  font-size: 0.8rem;
-  color: var(--sl-color-warning-700);
-  padding-left: 2.75rem;
-  margin-top: 0.4rem;
 }
 
 .ig-card--disconnected {

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -24,6 +24,7 @@
   --status-failed: #ef4444;
   --status-resuming: #3b82f6;
   --status-skipped: #94a3b8;
+  --status-interrupted: #f59e0b;
   /* legacy */
   --status-in-progress: #3b82f6;
   --status-error: #ef4444;
@@ -730,8 +731,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .stage-node.status-interrupted .stage-icon {
-  border-color: var(--status-in-progress);
-  opacity: 0.6;
+  border-color: var(--status-interrupted);
 }
 
 .stage-label {
@@ -1110,8 +1110,7 @@ sl-details.log-history-panel::part(content) {
 }
 
 .status-interrupted {
-  color: var(--status-in-progress);
-  opacity: 0.6;
+  color: var(--status-interrupted);
 }
 
 .status-running {

--- a/worca-ui/app/utils/status-badge.test.js
+++ b/worca-ui/app/utils/status-badge.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { statusClass, statusIcon } from './status-badge.js';
+import { resolveStatus, statusClass, statusIcon } from './status-badge.js';
 
 describe('status-badge', () => {
   it('maps pending to correct class', () => {
@@ -64,5 +64,25 @@ describe('status-badge', () => {
   });
   it('statusIcon adds icon-spin class for resuming', () => {
     expect(statusIcon('resuming')).toContain('class="icon-spin"');
+  });
+
+  // interrupted status
+  it('maps interrupted to status-interrupted', () => {
+    expect(statusClass('interrupted')).toBe('status-interrupted');
+  });
+  it('statusIcon returns SVG for interrupted', () => {
+    expect(statusIcon('interrupted')).toContain('<svg');
+  });
+  it('statusIcon does NOT add icon-spin for interrupted', () => {
+    expect(statusIcon('interrupted')).not.toContain('icon-spin');
+  });
+  it('resolveStatus returns interrupted for in_progress when not active', () => {
+    expect(resolveStatus('in_progress', false)).toBe('interrupted');
+  });
+  it('resolveStatus preserves in_progress when active', () => {
+    expect(resolveStatus('in_progress', true)).toBe('in_progress');
+  });
+  it('resolveStatus passes through interrupted unchanged', () => {
+    expect(resolveStatus('interrupted', false)).toBe('interrupted');
   });
 });

--- a/worca-ui/app/views/integrations.js
+++ b/worca-ui/app/views/integrations.js
@@ -171,34 +171,6 @@ function configuredCard(
   `;
 }
 
-// ── Pending card (configured but adapter not started) ───────────────────
-
-function pendingCard(meta, cfg, { onEdit, onRemove, onToggleEnabled }) {
-  const isEnabled = cfg?.enabled !== false;
-  return html`
-    <div class="ig-card ig-card--pending">
-      <div class="ig-card-header">
-        <span class="ig-card-icon">${unsafeHTML(meta.icon)}</span>
-        <div class="ig-card-title">
-          <span class="ig-card-name">${meta.label}</span>
-          <span class="ig-card-desc">${meta.desc}</span>
-        </div>
-        <sl-badge variant="warning" pill>Not connected</sl-badge>
-      </div>
-      <div class="ig-card-pending-hint">Configuration saved but adapter failed to connect. Check the token and server logs.</div>
-      <div class="ig-card-footer">
-        <div class="ig-card-actions">
-          <sl-button size="small" @click=${onEdit}>Edit</sl-button>
-          <sl-button size="small" variant="danger" outline @click=${onRemove}>Remove</sl-button>
-        </div>
-        <sl-switch size="small" ?checked=${isEnabled}
-          @sl-change=${(e) => onToggleEnabled(e.target.checked)}
-        >${isEnabled ? 'Enabled' : 'Disabled'}</sl-switch>
-      </div>
-    </div>
-  `;
-}
-
 // ── Unconfigured card ───────────────────────────────────────────────────
 
 function unconfiguredCard(

--- a/worca-ui/app/views/status-color-vars.test.js
+++ b/worca-ui/app/views/status-color-vars.test.js
@@ -29,4 +29,17 @@ describe('CSS status color variables', () => {
     expect(match[1]).toContain('stroke: var(--status-blocked)');
     expect(match[1]).not.toContain('var(--status-in-progress)');
   });
+
+  it('--status-interrupted uses amber (#f59e0b) for caution/warning state', () => {
+    const match = css.match(/--status-interrupted:\s*([^;]+);/);
+    expect(match).not.toBeNull();
+    expect(match[1].trim()).toBe('#f59e0b');
+  });
+
+  it('.status-interrupted uses var(--status-interrupted) not blue', () => {
+    const match = css.match(/\.status-interrupted\s*\{([^}]+)\}/);
+    expect(match).not.toBeNull();
+    expect(match[1]).toContain('var(--status-interrupted)');
+    expect(match[1]).not.toContain('var(--status-in-progress)');
+  });
 });

--- a/worca-ui/package.json
+++ b/worca-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worca/ui",
-  "version": "0.9.0-rc.2",
+  "version": "0.9.0-rc.3",
   "description": "Pipeline monitoring UI for worca-cc",
   "license": "MIT",
   "author": "Sinisha Djukic",

--- a/worca-ui/package.json
+++ b/worca-ui/package.json
@@ -23,9 +23,10 @@
   },
   "files": [
     "bin/worca-ui.js",
-    "server/*.js",
-    "!server/*.test.js",
-    "!server/test/",
+    "server/**/*.js",
+    "!server/**/*.test.js",
+    "!server/test/**",
+    "!server/**/test/**",
     "app/favicon-*.svg",
     "app/index.html",
     "app/main.bundle.js",

--- a/worca-ui/package.json
+++ b/worca-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worca/ui",
-  "version": "0.9.0",
+  "version": "0.9.0-rc.1",
   "description": "Pipeline monitoring UI for worca-cc",
   "license": "MIT",
   "author": "Sinisha Djukic",

--- a/worca-ui/package.json
+++ b/worca-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worca/ui",
-  "version": "0.9.0-rc.1",
+  "version": "0.9.0-rc.2",
   "description": "Pipeline monitoring UI for worca-cc",
   "license": "MIT",
   "author": "Sinisha Djukic",

--- a/worca-ui/server/integrations/adapters/discord.test.js
+++ b/worca-ui/server/integrations/adapters/discord.test.js
@@ -185,7 +185,7 @@ describe('createDiscordAdapter.send', () => {
     });
     await adapter.send('c', { title: null, body: [], severity: 'info' });
     const [, init] = fetchFn.mock.calls[0];
-    expect(init.headers['Authorization']).toBe('Bot myrawtoken');
+    expect(init.headers.Authorization).toBe('Bot myrawtoken');
   });
 
   it('does not double-prefix Bot when token already starts with Bot', async () => {
@@ -197,7 +197,7 @@ describe('createDiscordAdapter.send', () => {
     });
     await adapter.send('c', { title: null, body: [], severity: 'info' });
     const [, init] = fetchFn.mock.calls[0];
-    expect(init.headers['Authorization']).toBe('Bot alreadyprefixed');
+    expect(init.headers.Authorization).toBe('Bot alreadyprefixed');
   });
 
   it('retries on 429 with retry_after from response', async () => {

--- a/worca-ui/server/integrations/verify.test.js
+++ b/worca-ui/server/integrations/verify.test.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { verify } from './verify.js';
 
 function sign(body, secret) {
-  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex');
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
 }
 
 const BODY = 'hello world';

--- a/worca-ui/server/process-manager.js
+++ b/worca-ui/server/process-manager.js
@@ -29,6 +29,13 @@ const TERMINAL_EVENTS = [
   'pipeline.run.completed',
 ];
 
+function elapsedMsSince(startedAtIso) {
+  if (!startedAtIso) return 0;
+  const started = Date.parse(startedAtIso);
+  if (Number.isNaN(started)) return 0;
+  return Math.max(0, Date.now() - started);
+}
+
 /**
  * Write content to a temp file with restricted permissions (0o600) and return its path.
  * Used to avoid E2BIG when passing large prompts as CLI arguments.
@@ -220,7 +227,7 @@ export class ProcessManager {
             },
             payload: {
               interrupted_stage: status.current_stage ?? 'unknown',
-              elapsed_ms: 0,
+              elapsed_ms: elapsedMsSince(status.started_at),
               source: 'reconcile',
             },
           };

--- a/worca-ui/server/process-manager.js
+++ b/worca-ui/server/process-manager.js
@@ -4,8 +4,9 @@
  */
 
 import { spawn } from 'node:child_process';
-import { randomBytes } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import {
+  appendFileSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -21,6 +22,12 @@ import { join } from 'node:path';
 
 /** Byte threshold — must match claude_cli.py _ARG_INLINE_LIMIT */
 const ARG_INLINE_LIMIT = 128 * 1024;
+
+const TERMINAL_EVENTS = [
+  'pipeline.run.interrupted',
+  'pipeline.run.failed',
+  'pipeline.run.completed',
+];
 
 /**
  * Write content to a temp file with restricted permissions (0o600) and return its path.
@@ -163,10 +170,11 @@ export class ProcessManager {
 
       if (status.pipeline_status !== 'running') continue;
 
-      status.pipeline_status = 'failed';
       if (!status.stop_reason) {
         status.stop_reason = 'stale';
       }
+      status.pipeline_status =
+        status.stop_reason === 'stale' ? 'interrupted' : 'failed';
       try {
         writeFileSync(
           statusPath,
@@ -176,6 +184,41 @@ export class ProcessManager {
         fixed = true;
       } catch {
         /* ignore */
+      }
+
+      // Append synthetic interrupted event if no terminal event exists yet
+      const eventsPath = join(this.worcaDir, 'runs', runId, 'events.jsonl');
+      let hasTerminalEvent = false;
+      if (existsSync(eventsPath)) {
+        try {
+          const lines = readFileSync(eventsPath, 'utf8')
+            .split('\n')
+            .filter(Boolean);
+          hasTerminalEvent = lines.some((line) => {
+            try {
+              const evt = JSON.parse(line);
+              return TERMINAL_EVENTS.includes(evt.event_type);
+            } catch {
+              return false;
+            }
+          });
+        } catch {
+          /* ignore */
+        }
+      }
+      if (!hasTerminalEvent) {
+        try {
+          const evt = {
+            event_type: 'pipeline.run.interrupted',
+            event_id: randomUUID(),
+            timestamp: new Date().toISOString(),
+            source: 'reconcile',
+            ...(status.run_id ? { run_id: status.run_id } : {}),
+          };
+          appendFileSync(eventsPath, `${JSON.stringify(evt)}\n`, 'utf8');
+        } catch {
+          /* ignore */
+        }
       }
     }
 

--- a/worca-ui/server/process-manager.js
+++ b/worca-ui/server/process-manager.js
@@ -213,7 +213,7 @@ export class ProcessManager {
             event_id: randomUUID(),
             event_type: 'pipeline.run.interrupted',
             timestamp: new Date().toISOString(),
-            ...(status.run_id ? { run_id: status.run_id } : {}),
+            run_id: status.run_id ?? runId,
             pipeline: {
               branch: status.branch ?? null,
               work_request: status.work_request ?? null,

--- a/worca-ui/server/process-manager.js
+++ b/worca-ui/server/process-manager.js
@@ -209,11 +209,20 @@ export class ProcessManager {
       if (!hasTerminalEvent) {
         try {
           const evt = {
-            event_type: 'pipeline.run.interrupted',
+            schema_version: '1',
             event_id: randomUUID(),
+            event_type: 'pipeline.run.interrupted',
             timestamp: new Date().toISOString(),
-            source: 'reconcile',
             ...(status.run_id ? { run_id: status.run_id } : {}),
+            pipeline: {
+              branch: status.branch ?? null,
+              work_request: status.work_request ?? null,
+            },
+            payload: {
+              interrupted_stage: status.current_stage ?? 'unknown',
+              elapsed_ms: 0,
+              source: 'reconcile',
+            },
           };
           appendFileSync(eventsPath, `${JSON.stringify(evt)}\n`, 'utf8');
         } catch {

--- a/worca-ui/server/test/process-manager-reconcile.test.js
+++ b/worca-ui/server/test/process-manager-reconcile.test.js
@@ -128,7 +128,9 @@ describe('reconcileStatus', () => {
     writeStatus(worcaDir, 'run-evt-1', {
       pipeline_status: 'running',
       run_id: 'run-evt-1',
-      stage: 'plan',
+      branch: 'feat/reconcile',
+      work_request: { title: 'Test reconcile' },
+      current_stage: 'plan',
     });
 
     reconcileStatus(worcaDir);
@@ -137,14 +139,40 @@ describe('reconcileStatus', () => {
     const lines = readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean);
     expect(lines).toHaveLength(1);
     const evt = JSON.parse(lines[0]);
+    expect(evt.schema_version).toBe('1');
     expect(evt.event_type).toBe('pipeline.run.interrupted');
     expect(evt.event_id).toBeDefined();
     expect(evt.timestamp).toBeDefined();
-    expect(evt.source).toBe('reconcile');
     expect(evt.run_id).toBe('run-evt-1');
+    expect(evt.pipeline).toEqual({
+      branch: 'feat/reconcile',
+      work_request: { title: 'Test reconcile' },
+    });
+    expect(evt.payload).toEqual({
+      interrupted_stage: 'plan',
+      elapsed_ms: 0,
+      source: 'reconcile',
+    });
     expect(evt.event).toBeUndefined();
     expect(evt.id).toBeUndefined();
     expect(evt.ts).toBeUndefined();
+  });
+
+  it('synthetic event falls back to nulls/unknown when status fields are missing', () => {
+    writeStatus(worcaDir, 'run-evt-3', {
+      pipeline_status: 'running',
+      run_id: 'run-evt-3',
+    });
+
+    reconcileStatus(worcaDir);
+
+    const eventsPath = join(worcaDir, 'runs', 'run-evt-3', 'events.jsonl');
+    const evt = JSON.parse(
+      readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean)[0],
+    );
+    expect(evt.pipeline).toEqual({ branch: null, work_request: null });
+    expect(evt.payload.interrupted_stage).toBe('unknown');
+    expect(evt.payload.source).toBe('reconcile');
   });
 
   it('does not append synthetic event when terminal event already exists', () => {

--- a/worca-ui/server/test/process-manager-reconcile.test.js
+++ b/worca-ui/server/test/process-manager-reconcile.test.js
@@ -190,6 +190,40 @@ describe('reconcileStatus', () => {
     expect(evt.run_id).toBe('run-evt-4');
   });
 
+  it('synthetic event computes elapsed_ms from status.started_at', () => {
+    const startedAt = new Date(Date.now() - 1500).toISOString();
+    writeStatus(worcaDir, 'run-evt-5', {
+      pipeline_status: 'running',
+      run_id: 'run-evt-5',
+      started_at: startedAt,
+    });
+
+    reconcileStatus(worcaDir);
+
+    const eventsPath = join(worcaDir, 'runs', 'run-evt-5', 'events.jsonl');
+    const evt = JSON.parse(
+      readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean)[0],
+    );
+    expect(evt.payload.elapsed_ms).toBeGreaterThanOrEqual(1500);
+    expect(evt.payload.elapsed_ms).toBeLessThan(60_000);
+  });
+
+  it('synthetic event falls back to elapsed_ms=0 when started_at is unparseable', () => {
+    writeStatus(worcaDir, 'run-evt-6', {
+      pipeline_status: 'running',
+      run_id: 'run-evt-6',
+      started_at: 'not-a-date',
+    });
+
+    reconcileStatus(worcaDir);
+
+    const eventsPath = join(worcaDir, 'runs', 'run-evt-6', 'events.jsonl');
+    const evt = JSON.parse(
+      readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean)[0],
+    );
+    expect(evt.payload.elapsed_ms).toBe(0);
+  });
+
   it('does not append synthetic event when terminal event already exists', () => {
     writeStatus(worcaDir, 'run-evt-2', {
       pipeline_status: 'running',

--- a/worca-ui/server/test/process-manager-reconcile.test.js
+++ b/worca-ui/server/test/process-manager-reconcile.test.js
@@ -50,7 +50,7 @@ describe('reconcileStatus', () => {
 
     expect(fixed).toBe(true);
     const status = readStatus(worcaDir, 'run-001');
-    expect(status.pipeline_status).toBe('failed');
+    expect(status.pipeline_status).toBe('interrupted');
     expect(status.stop_reason).toBe('stale');
   });
 
@@ -124,6 +124,50 @@ describe('reconcileStatus', () => {
     expect(fixed).toBe(false);
   });
 
+  it('appends synthetic event with Python schema fields when no terminal event exists', () => {
+    writeStatus(worcaDir, 'run-evt-1', {
+      pipeline_status: 'running',
+      run_id: 'run-evt-1',
+      stage: 'plan',
+    });
+
+    reconcileStatus(worcaDir);
+
+    const eventsPath = join(worcaDir, 'runs', 'run-evt-1', 'events.jsonl');
+    const lines = readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+    const evt = JSON.parse(lines[0]);
+    expect(evt.event_type).toBe('pipeline.run.interrupted');
+    expect(evt.event_id).toBeDefined();
+    expect(evt.timestamp).toBeDefined();
+    expect(evt.source).toBe('reconcile');
+    expect(evt.run_id).toBe('run-evt-1');
+    expect(evt.event).toBeUndefined();
+    expect(evt.id).toBeUndefined();
+    expect(evt.ts).toBeUndefined();
+  });
+
+  it('does not append synthetic event when terminal event already exists', () => {
+    writeStatus(worcaDir, 'run-evt-2', {
+      pipeline_status: 'running',
+      stage: 'implement',
+    });
+    const runDir = join(worcaDir, 'runs', 'run-evt-2');
+    const eventsPath = join(runDir, 'events.jsonl');
+    const existing = {
+      event_type: 'pipeline.run.interrupted',
+      event_id: 'abc',
+      timestamp: '2024-01-01T00:00:00Z',
+      source: 'signal',
+    };
+    writeFileSync(eventsPath, `${JSON.stringify(existing)}\n`, 'utf8');
+
+    reconcileStatus(worcaDir);
+
+    const lines = readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+  });
+
   it('fixes multiple stale runs with per-run PID files', () => {
     // Two runs both with stale PID files (non-existent PIDs)
     writeStatus(worcaDir, 'run-multi-1', {
@@ -152,9 +196,13 @@ describe('reconcileStatus', () => {
     const fixed = reconcileStatus(worcaDir);
 
     expect(fixed).toBe(true);
-    expect(readStatus(worcaDir, 'run-multi-1').pipeline_status).toBe('failed');
+    expect(readStatus(worcaDir, 'run-multi-1').pipeline_status).toBe(
+      'interrupted',
+    );
     expect(readStatus(worcaDir, 'run-multi-1').stop_reason).toBe('stale');
-    expect(readStatus(worcaDir, 'run-multi-2').pipeline_status).toBe('failed');
+    expect(readStatus(worcaDir, 'run-multi-2').pipeline_status).toBe(
+      'interrupted',
+    );
     expect(readStatus(worcaDir, 'run-multi-2').stop_reason).toBe('stale');
   });
 });

--- a/worca-ui/server/test/process-manager-reconcile.test.js
+++ b/worca-ui/server/test/process-manager-reconcile.test.js
@@ -175,6 +175,21 @@ describe('reconcileStatus', () => {
     expect(evt.payload.source).toBe('reconcile');
   });
 
+  it('synthetic event uses the runId directory as run_id fallback when status omits it', () => {
+    writeStatus(worcaDir, 'run-evt-4', {
+      pipeline_status: 'running',
+      branch: 'feat/x',
+    });
+
+    reconcileStatus(worcaDir);
+
+    const eventsPath = join(worcaDir, 'runs', 'run-evt-4', 'events.jsonl');
+    const evt = JSON.parse(
+      readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean)[0],
+    );
+    expect(evt.run_id).toBe('run-evt-4');
+  });
+
   it('does not append synthetic event when terminal event already exists', () => {
     writeStatus(worcaDir, 'run-evt-2', {
       pipeline_status: 'running',


### PR DESCRIPTION
## Summary

- **Python signal handler** (`runner.py:_handler()`) now writes `pipeline.run.interrupted` directly to `events.jsonl` after saving status, using signal-safe file I/O only (no threads, no HTTP)
- **Python atexit handler** does the same for unexpected exits with `source: "atexit"`
- **JS `reconcileStatus()`** (`process-manager.js`) appends a synthetic `pipeline.run.interrupted` event as SIGKILL fallback when no terminal event exists in `events.jsonl`
- Both Python and JS paths now set `pipeline_status="interrupted"` instead of `"failed"` to distinguish explicit stops from actual errors
- UI gets a dedicated `--status-interrupted` amber color variable (`#f59e0b`) replacing the old blue-with-opacity treatment

## Test plan

- [x] `test_handler_emits_interrupted_event_to_jsonl` — signal handler writes event with correct type, stage, and source
- [x] `test_handler_sets_interrupted_status` — status is `"interrupted"` not `"failed"`
- [x] `test_signal_handler_saves_failed_status` (lifecycle) — end-to-end SIGINT test
- [x] `test_signal_handler_emits_interrupted_event` (lifecycle) — event written on real signal
- [x] `test_atexit_emits_interrupted_event` — atexit path writes event with `source: "atexit"`
- [x] `test_atexit_sets_interrupted_when_event_ctx_set` — atexit uses interrupted status
- [x] JS: `appends synthetic interrupted event when no terminal event` — reconcile SIGKILL fallback
- [x] JS: `does not append synthetic event when terminal event already exists` — idempotency
- [x] JS: `fixes multiple stale runs` — multi-run reconciliation uses interrupted status
- [x] UI: `--status-interrupted` CSS variable and `.status-interrupted` class tests
- [x] UI: `resolveStatus` returns interrupted for stale in_progress runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)