### PR TITLE
W-049: Settings UI for execution, approval gates, circuit breaker, and disk threshold

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -60,6 +60,37 @@ Forward-incompatible renames (e.g. `stages.review.agent: guardian -> reviewer` i
 
 If you want to hard-reset your settings to the current template, use `worca init --force` (destructive). Project-specific overrides that should never be touched by any upgrade still belong in `.claude/settings.local.json`.
 
+### Global key extraction (W-049)
+
+Four settings keys that are naturally global (apply across all projects) are extracted from `.claude/settings.json` into `~/.worca/settings.json`:
+
+| Key (under `worca.`) | Default | Scope after migration |
+|---|---|---|
+| `parallel.cleanup_policy` | `never` | Global (`~/.worca/settings.json`) |
+| `parallel.max_concurrent_pipelines` | `10` | Global |
+| `ui.worktree_disk_warning_bytes` | `2000000000` | Global |
+| `circuit_breaker.classifier_model` | `haiku` | Global |
+
+If `~/.worca/settings.json` does not exist, it is created. Existing values in the global file are preserved (project values merge in). After extraction, the keys are removed from the project file.
+
+Idempotent: runs silently on second invocation.
+
+Source: `_migrate_global_keys_to_preferences` in `src/worca/cli/init.py`.
+
+### Inert milestone key stripping (W-049)
+
+`pr_approval` and `deploy_approval` under `worca.milestones` are removed from `.claude/settings.json` **if and only if** their value is exactly `true` (the old template default). Any other value (`false`, a string, etc.) is left alone as an intentional user override.
+
+Why: these keys were inert before W-049 — the runner ignored them. After W-049, the runner gates on `pr_approval is True`, so leaving the template default in place would activate the PR-creation approval gate on every upgraded project, hanging autonomous flows.
+
+Stripping the default lets the runner's missing-key behavior (`false`) take effect, keeping the gate opt-in.
+
+If both keys are removed and `worca.milestones` becomes empty, the empty object is cleaned up.
+
+Idempotent: runs silently on second invocation.
+
+Source: `_strip_inert_milestone_keys` in `src/worca/cli/init.py`.
+
 ### .gitignore entries
 
 These entries are added if missing: `.worca/`, `logs/`, `.claude/settings.local.json`.
@@ -256,6 +287,45 @@ W-048: Worktree-based pipeline isolation and unified run aggregation.
 - **`pipelines.d/` fan-out in `discoverRuns`** — Worktree runs are now visible in the unified runs list alongside root project runs. No UI changes required.
 
 **No automatic migrations required** — these are runtime behavior and protocol changes. Run `worca init --upgrade` once to remove the stale `active_run` file from `.worca/`. Update any external integrations or scripts that depend on the removed batch scripts, WebSocket protocol types, or `active_run` file.
+
+### 0.18.x → 0.19.0
+
+W-049: Settings UI for execution, approval gates, circuit breaker, and worktree disk threshold.
+
+**Default changes:**
+
+| Setting | Old default | New default | Rationale |
+|---|---|---|---|
+| `cleanup_policy` | `on-success` | `never` | Auto-deletion would silently break worktree inspection workflows |
+| `max_concurrent_pipelines` | `3` | `10` | A cap of 3 immediately blocks users with 4+ projects |
+| `pr_approval` | `true` (inert) | `false` (active) | Default-true would hang every autonomous run at the PR-creation gate |
+
+**Project/global settings split:**
+
+Four keys move from project-scoped (`.claude/settings.json`) to global-scoped (`~/.worca/settings.json`): `cleanup_policy`, `max_concurrent_pipelines`, `worktree_disk_warning_bytes`, `classifier_model`. The canonical list and defaults live in `src/worca/schemas/keys.json`.
+
+**Automatic migration via `worca init --upgrade`:**
+
+1. Global keys are extracted from the project file into `~/.worca/settings.json` (created if absent).
+2. Template-default `pr_approval: true` and `deploy_approval: true` are stripped from the project file to prevent the new PR-approval gate from activating unexpectedly.
+
+Both steps are idempotent. Run output:
+
+```
+Migrated 4 key(s) to ~/.worca/settings.json
+Reset 2 template-default milestone key(s) (pr_approval, deploy_approval) — gate now opt-in via Pipeline tab
+```
+
+**If you skip `worca init --upgrade`:**
+
+The UI's settings editor handles migration automatically. When you open project settings, a banner appears if misplaced global keys or inert milestone defaults are detected. Clicking "Migrate now" (or simply saving settings) triggers the same extraction — the server's save handler auto-migrates on every save. No data is lost; no separate endpoint or manual JSON editing is required.
+
+**New features:**
+
+- Settings UI panels for Execution & Parallelism, Approval Gates, and Circuit Breaker configuration.
+- Global Preferences tab (`~/.worca/settings.json`) for cross-project settings (worktree cleanup, concurrency cap, disk threshold, classifier model).
+- PR-approval gate: when `worca.milestones.pr_approval` is `true`, the pipeline pauses before PR creation and waits for user approval via the run-detail UI.
+- Server-enforced `max_concurrent_pipelines` cap with launch mutex (returns 409 when at capacity).
 
 ## Getting help
 

--- a/src/worca/cli/init.py
+++ b/src/worca/cli/init.py
@@ -8,12 +8,18 @@ Source resolution order:
   3. Installed pip package (default)
 """
 
+import importlib.resources
 import json
 import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+_schema = json.loads(
+    importlib.resources.files("worca.schemas").joinpath("keys.json").read_text()
+)
+_GLOBAL_ONLY_KEYS = [tuple(k) for k in _schema["global_only_keys"]]
 
 
 def _find_git_root() -> Path:
@@ -260,6 +266,86 @@ def _migrate_agent_overrides(git_root: Path) -> list[str]:
         pass  # Directory not empty, leave it
 
     return changes
+
+
+def _migrate_global_keys_to_preferences(
+    project_settings_path: str,
+    global_path: str | None = None,
+) -> dict:
+    """One-shot: extract to-be-global keys from .claude/settings.json,
+    write them into ~/.worca/settings.json, then strip from the project file.
+    Idempotent: returns {} on second run."""
+    if not os.path.exists(project_settings_path):
+        return {}
+    with open(project_settings_path) as f:
+        project = json.load(f)
+
+    extracted: dict = {}
+    worca = project.get("worca", {})
+    for section, key in _GLOBAL_ONLY_KEYS:
+        val = worca.get(section, {}).get(key)
+        if val is not None:
+            extracted.setdefault(section, {})[key] = val
+            del worca[section][key]
+            if not worca[section]:
+                del worca[section]
+
+    if not extracted:
+        return {}
+
+    if global_path is None:
+        global_path = os.path.expanduser("~/.worca/settings.json")
+    os.makedirs(os.path.dirname(global_path), exist_ok=True)
+    try:
+        with open(global_path) as f:
+            global_blob = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        global_blob = {}
+    global_blob.setdefault("worca", {})
+    for section, kvs in extracted.items():
+        global_blob["worca"].setdefault(section, {}).update(kvs)
+    with open(global_path, "w") as f:
+        json.dump(global_blob, f, indent=2)
+        f.write("\n")
+
+    with open(project_settings_path, "w") as f:
+        json.dump(project, f, indent=2)
+        f.write("\n")
+
+    return extracted
+
+
+def _strip_inert_milestone_keys(project_settings_path: str) -> list[str]:
+    """One-shot: remove pr_approval and deploy_approval from .claude/settings.json
+    if they were template-default values (true).
+
+    Only strips when value is exactly True. False, strings, ints etc. are
+    treated as intentional user overrides and left alone.
+
+    Returns the list of removed keys. Idempotent: returns [] on second run."""
+    if not os.path.exists(project_settings_path):
+        return []
+    with open(project_settings_path) as f:
+        project = json.load(f)
+
+    milestones = project.get("worca", {}).get("milestones", {})
+    removed = []
+    for key in ("pr_approval", "deploy_approval"):
+        if milestones.get(key) is True:
+            del milestones[key]
+            removed.append(key)
+
+    if not removed:
+        return []
+
+    if "worca" in project and "milestones" in project["worca"] and not project["worca"]["milestones"]:
+        del project["worca"]["milestones"]
+
+    with open(project_settings_path, "w") as f:
+        json.dump(project, f, indent=2)
+        f.write("\n")
+
+    return removed
 
 
 def _remove_files_from_dir(directory: Path, filenames: list[str], changes: list[str]) -> None:
@@ -619,6 +705,21 @@ def run_init(
         if source_settings.exists():
             shutil.copy2(str(source_settings), str(settings_path))
             print("Settings: created from template")
+
+    # --- Global key migration (only on --upgrade, after settings merge) ---
+    if upgrade and settings_path.exists():
+        extracted = _migrate_global_keys_to_preferences(str(settings_path))
+        if extracted:
+            n = sum(len(v) for v in extracted.values())
+            print(f"Migrated {n} key(s) to ~/.worca/settings.json")
+
+        stripped = _strip_inert_milestone_keys(str(settings_path))
+        if stripped:
+            keys_str = ", ".join(stripped)
+            print(
+                f"Reset {len(stripped)} template-default milestone key(s) "
+                f"({keys_str}) — gate now opt-in via Pipeline tab"
+            )
 
     # --- .gitignore ---
     gitignore_changes = _ensure_gitignore(git_root)

--- a/src/worca/cli/init.py
+++ b/src/worca/cli/init.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 _schema = json.loads(
@@ -68,8 +69,37 @@ def _get_worca_source(source_flag: str | None, git_root: Path) -> Path:
         raise SystemExit(1)
 
 
+def _atomic_write_json(path: str, data: dict) -> None:
+    """Atomically write JSON to path via tempfile + os.replace.
+
+    Mirrors the JS atomicWriteSync helper so concurrent readers (the UI
+    server) never observe a half-written ~/.worca/settings.json during
+    `worca init --upgrade`.
+    """
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".tmp-", dir=directory)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 def _deep_merge(base: dict, overlay: dict) -> dict:
-    """Deep-merge overlay into base. Overlay values win for scalars; dicts merge recursively."""
+    """Non-destructive deep-merge: base wins for scalars; nested dicts merge recursively.
+
+    Overlay only contributes keys absent from base. This is the upgrade
+    semantic — user values in `base` are always preserved, and the template
+    `overlay` only fills in keys the user does not yet have. To get the
+    opposite (overlay wins for scalars), use `_deep_merge_overwrite`.
+    """
     result = base.copy()
     for key, value in overlay.items():
         if key in result and isinstance(result[key], dict) and isinstance(value, dict):
@@ -295,7 +325,6 @@ def _migrate_global_keys_to_preferences(
 
     if global_path is None:
         global_path = os.path.expanduser("~/.worca/settings.json")
-    os.makedirs(os.path.dirname(global_path), exist_ok=True)
     try:
         with open(global_path) as f:
             global_blob = json.load(f)
@@ -304,13 +333,9 @@ def _migrate_global_keys_to_preferences(
     global_blob.setdefault("worca", {})
     for section, kvs in extracted.items():
         global_blob["worca"].setdefault(section, {}).update(kvs)
-    with open(global_path, "w") as f:
-        json.dump(global_blob, f, indent=2)
-        f.write("\n")
+    _atomic_write_json(global_path, global_blob)
 
-    with open(project_settings_path, "w") as f:
-        json.dump(project, f, indent=2)
-        f.write("\n")
+    _atomic_write_json(project_settings_path, project)
 
     return extracted
 
@@ -341,9 +366,7 @@ def _strip_inert_milestone_keys(project_settings_path: str) -> list[str]:
     if "worca" in project and "milestones" in project["worca"] and not project["worca"]["milestones"]:
         del project["worca"]["milestones"]
 
-    with open(project_settings_path, "w") as f:
-        json.dump(project, f, indent=2)
-        f.write("\n")
+    _atomic_write_json(project_settings_path, project)
 
     return removed
 

--- a/src/worca/orchestrator/error_classifier.py
+++ b/src/worca/orchestrator/error_classifier.py
@@ -10,7 +10,7 @@ import traceback
 from typing import Optional
 
 from worca.utils.claude_cli import _ARG_INLINE_LIMIT
-from worca.utils.settings import load_settings
+from worca.utils.settings import load_settings_with_global_fallback
 
 CATEGORY_TRANSIENT = "infra_transient"
 CATEGORY_PERMANENT = "infra_permanent"
@@ -56,7 +56,7 @@ _SCHEMA = {
 
 
 def _read_settings(settings_path: str) -> dict:
-    return load_settings(settings_path)
+    return load_settings_with_global_fallback(settings_path)
 
 
 def _get_cb_settings(settings_path: str) -> dict:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -194,6 +194,29 @@ def _handle_pause(ctx: EventContext, reason: str) -> None:
             raise PipelineInterrupted(f"Aborted via control webhook: {reason}", stop_reason="control_webhook")
 
 
+def _check_control_response_with_timeout(
+    ctx: EventContext,
+    event: dict,
+    *,
+    timeout_seconds: int,
+    timeout_default: str,
+) -> str:
+    """Deadline-aware wrapper around _check_control_response.
+
+    Polls until the helper returns a non-None action OR the deadline elapses,
+    in which case returns timeout_default and emits a log line.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    poll_interval = 5
+    while time.monotonic() < deadline:
+        action = _check_control_response(ctx, event)
+        if action is not None:
+            return action
+        time.sleep(poll_interval)
+    _log(f"pr_approval gate auto-approved on {timeout_seconds}s timeout (event={event.get('id')})", "warn")
+    return timeout_default
+
+
 def _base62(n: int, length: int = 3) -> str:
     """Encode an integer as a base62 string of fixed length."""
     chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -2646,6 +2669,79 @@ def run_pipeline(
                         stage_idx = stage_order.index(Stage.PLAN)
                         continue
 
+            # PR stage: approval gate + completion
+            elif current_stage == Stage.PR:
+                # Milestone semantics intentionally asymmetric across approval gates:
+                #   - plan_approval: default-true (opt-out). Already in production at this default;
+                #     flipping it would silently disable an existing gate on every upgraded project.
+                #   - pr_approval:   default-false (opt-in). New in W-049; default-true would hang
+                #     every autonomous run waiting for an approval event nobody sends.
+                _ms_cfg = load_settings(settings_path).get("worca", {}).get("milestones", {})
+                if _ms_cfg.get("pr_approval") is not True:
+                    pr_approved = True
+                else:
+                    set_milestone(status, "pr_approved", False)
+                    status["pipeline_status"] = "paused"
+                    save_status(status, actual_status_path)
+                    pr_approved = False
+                    if ctx:
+                        _ms_event = emit_event(ctx, MILESTONE_SET, milestone_set_payload(
+                            milestone="pr_approved", value=False, stage=Stage.PR.value,
+                        ))
+                        if _ms_event:
+                            _action = _check_control_response_with_timeout(
+                                ctx, _ms_event,
+                                timeout_seconds=_ms_cfg.get("pr_approval_timeout_seconds", 3600),
+                                timeout_default="approve",
+                            )
+                            if _action == "approve":
+                                pr_approved = True
+                                set_milestone(status, "pr_approved", True)
+                                status["pipeline_status"] = "running"
+                            elif _action == "reject":
+                                raise PipelineInterrupted("PR creation rejected by user", stop_reason="pr_rejected")
+                            elif _action == "pause":
+                                _handle_pause(ctx, "pr_approved milestone")
+                            elif _action == "abort":
+                                raise PipelineInterrupted("Aborted via control webhook", stop_reason="control_webhook")
+                    else:
+                        pr_approved = True
+                        set_milestone(status, "pr_approved", True)
+                        status["pipeline_status"] = "running"
+
+                if not pr_approved:
+                    save_status(status, actual_status_path)
+                    return
+
+                iter_extras["outcome"] = "success"
+                complete_iteration(status, current_stage.value, **iter_extras)
+                update_stage(status, current_stage.value, **stage_extras)
+                save_status(status, actual_status_path)
+                if ctx:
+                    _sc_event = emit_event(ctx, STAGE_COMPLETED, stage_completed_payload(
+                        stage=current_stage.value, iteration=iter_num,
+                        duration_ms=iter_extras.get("duration_ms", 0),
+                        cost_usd=iter_extras.get("cost_usd", 0.0),
+                        turns=iter_extras.get("turns", 0),
+                        outcome=iter_extras["outcome"],
+                        token_usage=iter_extras.get("token_usage"),
+                    ))
+                    if _sc_event:
+                        _action = _check_control_response(ctx, _sc_event)
+                        if _action == "pause":
+                            _handle_pause(ctx, f"{current_stage.value} stage.completed")
+                        elif _action == "abort":
+                            raise PipelineInterrupted("Aborted via control webhook", stop_reason="control_webhook")
+                if ctx and isinstance(result, dict):
+                    _pr_url = result.get("pr_url")
+                    _pr_number = result.get("pr_number")
+                    if _pr_url and _pr_number is not None:
+                        emit_event(ctx, GIT_PR_CREATED, git_pr_created_payload(
+                            pr_url=_pr_url,
+                            pr_number=_pr_number,
+                            title=work_request.title,
+                        ))
+
             # Default: complete iteration for stages without special handling
             else:
                 iter_extras["outcome"] = "success"
@@ -2667,16 +2763,6 @@ def run_pipeline(
                             _handle_pause(ctx, f"{current_stage.value} stage.completed")
                         elif _action == "abort":
                             raise PipelineInterrupted("Aborted via control webhook", stop_reason="control_webhook")
-                # PR stage: emit git.pr_created if result has pr_url
-                if ctx and current_stage == Stage.PR and isinstance(result, dict):
-                    _pr_url = result.get("pr_url")
-                    _pr_number = result.get("pr_number")
-                    if _pr_url and _pr_number is not None:
-                        emit_event(ctx, GIT_PR_CREATED, git_pr_created_payload(
-                            pr_url=_pr_url,
-                            pr_number=_pr_number,
-                            title=work_request.title,
-                        ))
 
             # Persist context and loop counters after each completed stage
             status["loop_counters"] = dict(loop_counters)

--- a/src/worca/schemas/keys.json
+++ b/src/worca/schemas/keys.json
@@ -1,0 +1,39 @@
+{
+  "global_only_keys": [
+    ["parallel", "cleanup_policy"],
+    ["parallel", "max_concurrent_pipelines"],
+    ["ui", "worktree_disk_warning_bytes"],
+    ["circuit_breaker", "classifier_model"]
+  ],
+  "normalize_skip_keys": [
+    ["milestones", "pr_approval"]
+  ],
+  "defaults": {
+    "global": {
+      "parallel": {
+        "cleanup_policy": "never",
+        "max_concurrent_pipelines": 10
+      },
+      "ui": {
+        "worktree_disk_warning_bytes": 2000000000
+      },
+      "circuit_breaker": {
+        "classifier_model": "haiku"
+      }
+    },
+    "project": {
+      "parallel": {
+        "worktree_base_dir": ".worktrees",
+        "default_base_branch": "main"
+      },
+      "circuit_breaker": {
+        "enabled": true,
+        "max_consecutive_failures": 3
+      },
+      "milestones": {
+        "plan_approval": true,
+        "pr_approval": false
+      }
+    }
+  }
+}

--- a/src/worca/scripts/run_worktree.py
+++ b/src/worca/scripts/run_worktree.py
@@ -27,7 +27,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from worca.orchestrator.registry import register_pipeline
 from worca.orchestrator.work_request import normalize
+from worca.state.status import write_status_field
 from worca.utils.git import create_pipeline_worktree, init_worktree_beads
+from worca.utils.settings import load_settings
 
 
 def _generate_run_id() -> str:
@@ -214,22 +216,24 @@ def main(argv=None) -> int:
     # Steps 1-2: generate run_id and derive slug
     run_id = _generate_run_id()
     slug = _slugify(wr.title)
-    base_branch = args.branch or "HEAD"
 
     # Step 3: create git worktree at the configured base dir
-    # (worca.parallel.worktree_base_dir, default .worktrees relative to
-    # the project root; absolute and ~-prefixed paths are honored).
-    from worca.utils.settings import load_settings
     _settings = load_settings(args.settings)
-    _wt_base = (
-        _settings.get("worca", {})
-        .get("parallel", {})
-        .get("worktree_base_dir", ".worktrees")
-    )
+    _parallel = _settings.get("worca", {}).get("parallel", {})
+    _default_branch = _parallel.get("default_base_branch", "main")
+    base_branch = args.branch or _default_branch
+    _wt_base = _parallel.get("worktree_base_dir", ".worktrees")
     worktree_path = create_pipeline_worktree(run_id, slug, base_branch, _wt_base)
     if not worktree_path:
         print(f"error: failed to create worktree for run {run_id}", file=sys.stderr)
         return 1
+
+    # Step 3b: persist worktree_path to status.json so the cleanup hook
+    # can read it without taking a registry dependency.
+    _status_path = os.path.join(
+        worktree_path, ".worca", "runs", run_id, "status.json"
+    )
+    write_status_field(_status_path, "worktree_path", worktree_path)
 
     # Step 4: copy .claude/ into the worktree (settings.json, agents/, hooks/,
     # scripts/, skills/, templates/, worca/, etc.). Most projects gitignore

--- a/src/worca/settings.json
+++ b/src/worca/settings.json
@@ -199,9 +199,7 @@
       "plan_review": 2
     },
     "milestones": {
-      "plan_approval": true,
-      "pr_approval": true,
-      "deploy_approval": true
+      "plan_approval": true
     },
     "plan_path_template": "docs/plans/{timestamp}-{title_slug}.md",
     "agent_overrides_dir": ".claude/agents",
@@ -244,8 +242,7 @@
         10,
         30,
         90
-      ],
-      "classifier_model": "haiku"
+      ]
     },
     "events": {
       "enabled": true,
@@ -283,9 +280,7 @@
       "mloops": 1
     },
     "parallel": {
-      "max_concurrent_pipelines": 3,
       "default_base_branch": "main",
-      "cleanup_policy": "on-success",
       "worktree_base_dir": ".worktrees"
     }
   }

--- a/src/worca/state/status.py
+++ b/src/worca/state/status.py
@@ -227,6 +227,7 @@ def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_
         "run_id": None,
         "branch": branch,
         "worktree": None,
+        "worktree_path": None,
         "plan_file": None,
         "pipeline_template": pipeline_template,
         "git_head": git_head,
@@ -242,3 +243,14 @@ def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_
         "pr_review_outcome": None,
     }
     return status
+
+
+def write_status_field(path: str, field: str, value) -> None:
+    """Load status.json (or create empty dict), set field, save atomically."""
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            data = json.load(f)
+    else:
+        data = {}
+    data[field] = value
+    save_status(data, path)

--- a/src/worca/utils/settings.py
+++ b/src/worca/utils/settings.py
@@ -6,9 +6,18 @@ directly. This merges the base settings.json with a sibling settings.local.json
 out of version control.
 """
 
+import importlib.resources
 import json
 import os
 import sys
+
+_schema = json.loads(
+    importlib.resources.files("worca.schemas").joinpath("keys.json").read_text()
+)
+GLOBAL_ONLY_KEYS = [tuple(k) for k in _schema["global_only_keys"]]
+NORMALIZE_SKIP_KEYS = [tuple(k) for k in _schema["normalize_skip_keys"]]
+GLOBAL_DEFAULTS = _schema["defaults"]["global"]
+PROJECT_DEFAULTS = _schema["defaults"]["project"]
 
 
 def deep_merge(base: dict, override: dict) -> dict:
@@ -63,3 +72,39 @@ def load_settings(settings_path: str) -> dict:
         return base
 
     return deep_merge(base, local)
+
+
+def _default_global_path() -> str:
+    return os.path.expanduser("~/.worca/settings.json")
+
+
+def load_settings_with_global_fallback(
+    settings_path: str,
+    *,
+    global_path: str | None = None,
+) -> dict:
+    """Load project settings deep-merged over global (~/.worca/settings.json).
+
+    Global values form the base; project values win on overlap.
+    Missing or malformed global file is silently tolerated (warning on bad JSON).
+    """
+    if global_path is None:
+        global_path = _default_global_path()
+
+    try:
+        with open(global_path) as f:
+            global_blob = json.load(f)
+    except FileNotFoundError:
+        global_blob = {}
+    except json.JSONDecodeError:
+        print(
+            f"[settings] Warning: {global_path} contains invalid JSON, ignoring global preferences",
+            file=sys.stderr,
+        )
+        global_blob = {}
+
+    project = load_settings(settings_path)
+    if not global_blob:
+        return project
+
+    return deep_merge(global_blob, project)

--- a/tests/fixtures/migration_strip_io.json
+++ b/tests/fixtures/migration_strip_io.json
@@ -1,0 +1,171 @@
+{
+  "cases": [
+    {
+      "name": "global_keys_extracted_to_preferences",
+      "input": {
+        "worca": {
+          "parallel": {
+            "worktree_base_dir": ".worktrees",
+            "default_base_branch": "main",
+            "cleanup_policy": "on-success",
+            "max_concurrent_pipelines": 3
+          },
+          "circuit_breaker": {
+            "enabled": true,
+            "max_consecutive_failures": 3,
+            "classifier_model": "haiku"
+          },
+          "ui": {
+            "worktree_disk_warning_bytes": 5000000000
+          },
+          "milestones": {
+            "plan_approval": true
+          }
+        }
+      },
+      "expected_project": {
+        "worca": {
+          "parallel": {
+            "worktree_base_dir": ".worktrees",
+            "default_base_branch": "main"
+          },
+          "circuit_breaker": {
+            "enabled": true,
+            "max_consecutive_failures": 3
+          },
+          "milestones": {
+            "plan_approval": true
+          }
+        }
+      },
+      "expected_global_extracted": {
+        "parallel": {
+          "cleanup_policy": "on-success",
+          "max_concurrent_pipelines": 3
+        },
+        "circuit_breaker": {
+          "classifier_model": "haiku"
+        },
+        "ui": {
+          "worktree_disk_warning_bytes": 5000000000
+        }
+      }
+    },
+    {
+      "name": "global_keys_already_stripped",
+      "input": {
+        "worca": {
+          "parallel": {
+            "worktree_base_dir": ".worktrees",
+            "default_base_branch": "main"
+          },
+          "milestones": {
+            "plan_approval": true
+          }
+        }
+      },
+      "expected_project": {
+        "worca": {
+          "parallel": {
+            "worktree_base_dir": ".worktrees",
+            "default_base_branch": "main"
+          },
+          "milestones": {
+            "plan_approval": true
+          }
+        }
+      },
+      "expected_global_extracted": {}
+    },
+    {
+      "name": "empty_section_cleaned_up",
+      "input": {
+        "worca": {
+          "ui": {
+            "worktree_disk_warning_bytes": 2000000000
+          }
+        }
+      },
+      "expected_project": {
+        "worca": {}
+      },
+      "expected_global_extracted": {
+        "ui": {
+          "worktree_disk_warning_bytes": 2000000000
+        }
+      }
+    },
+    {
+      "name": "milestone_strip_pr_approval_true",
+      "input": {
+        "worca": {
+          "milestones": {
+            "plan_approval": true,
+            "pr_approval": true,
+            "deploy_approval": true
+          }
+        }
+      },
+      "expected_project_after_milestone_strip": {
+        "worca": {
+          "milestones": {
+            "plan_approval": true
+          }
+        }
+      },
+      "expected_removed_keys": ["pr_approval", "deploy_approval"]
+    },
+    {
+      "name": "milestone_strip_pr_approval_false_kept",
+      "input": {
+        "worca": {
+          "milestones": {
+            "plan_approval": true,
+            "pr_approval": false
+          }
+        }
+      },
+      "expected_project_after_milestone_strip": {
+        "worca": {
+          "milestones": {
+            "plan_approval": true,
+            "pr_approval": false
+          }
+        }
+      },
+      "expected_removed_keys": []
+    },
+    {
+      "name": "milestone_strip_empty_milestones_cleaned",
+      "input": {
+        "worca": {
+          "milestones": {
+            "pr_approval": true
+          }
+        }
+      },
+      "expected_project_after_milestone_strip": {
+        "worca": {}
+      },
+      "expected_removed_keys": ["pr_approval"]
+    },
+    {
+      "name": "milestone_strip_no_milestones",
+      "input": {
+        "worca": {
+          "parallel": {
+            "worktree_base_dir": ".worktrees"
+          }
+        }
+      },
+      "expected_project_after_milestone_strip": {
+        "worca": {
+          "parallel": {
+            "worktree_base_dir": ".worktrees"
+          }
+        }
+      },
+      "expected_removed_keys": []
+    }
+  ]
+}

--- a/tests/test_hook_governance_events.py
+++ b/tests/test_hook_governance_events.py
@@ -120,15 +120,18 @@ class TestPreToolUseBlockedEvent:
 class TestPostToolUseTestGateEvent:
     """post_tool_use emits pipeline.hook.test_gate when test gate blocks."""
 
+    _ENV_KEYS = ["WORCA_EVENTS_PATH", "WORCA_RUN_ID", "WORCA_AGENT", "WORCA_RUN_DIR"]
+
     def setup_method(self):
-        for k in ["WORCA_EVENTS_PATH", "WORCA_RUN_ID", "WORCA_AGENT"]:
-            os.environ.pop(k, None)
+        self._saved_env = {k: os.environ.pop(k, None) for k in self._ENV_KEYS}
         from worca.hooks import test_gate
         test_gate._state["strikes"] = 0
 
     def teardown_method(self):
-        for k in ["WORCA_EVENTS_PATH", "WORCA_RUN_ID", "WORCA_AGENT"]:
+        for k in self._ENV_KEYS:
             os.environ.pop(k, None)
+            if self._saved_env.get(k) is not None:
+                os.environ[k] = self._saved_env[k]
         from worca.hooks import test_gate
         test_gate._state["strikes"] = 0
 

--- a/tests/test_init_migration.py
+++ b/tests/test_init_migration.py
@@ -1,9 +1,37 @@
 """Tests for settings migration logic in src/worca/cli/init.py.
 
-Focused on governance.dispatch → governance.subagent_dispatch migration (§5.4).
+Covers:
+- governance.dispatch → governance.subagent_dispatch migration (§5.4)
+- Global key extraction to ~/.worca/settings.json (§11b step 1)
+- Inert milestone key stripping (§11b step 2)
 """
 
-from worca.cli.init import _migrate_settings_paths
+import copy
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from worca.cli.init import (
+    _migrate_global_keys_to_preferences,
+    _migrate_settings_paths,
+    _strip_inert_milestone_keys,
+)
+
+_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "migration_strip_io.json"
+
+
+def _load_fixture_cases():
+    with open(_FIXTURE_PATH) as f:
+        return json.load(f)["cases"]
+
+
+def _find_case(name):
+    for case in _load_fixture_cases():
+        if case["name"] == name:
+            return case
+    raise ValueError(f"fixture case not found: {name}")
 
 
 _NEW_DEFAULTS = {
@@ -222,3 +250,212 @@ def test_migrate_normalization_preserves_other_values():
         "feature-dev:code-reviewer",
         "custom",
     ]
+
+
+# ── §11b: _migrate_global_keys_to_preferences ──────────────────────
+
+
+class TestMigrateGlobalKeysToPreferences:
+    def test_extracts_global_keys_to_preferences(self, tmp_path):
+        case = _find_case("global_keys_extracted_to_preferences")
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps(case["input"]))
+
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        global_path = str(global_dir / "settings.json")
+
+        extracted = _migrate_global_keys_to_preferences(
+            str(project_file), global_path=global_path
+        )
+
+        assert extracted == case["expected_global_extracted"]
+
+        with open(project_file) as f:
+            project_after = json.load(f)
+        assert project_after == case["expected_project"]
+
+        with open(global_path) as f:
+            global_after = json.load(f)
+        for section, kvs in case["expected_global_extracted"].items():
+            for key, val in kvs.items():
+                assert global_after["worca"][section][key] == val
+
+    def test_idempotent_on_second_run(self, tmp_path):
+        case = _find_case("global_keys_already_stripped")
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps(case["input"]))
+
+        global_path = str(tmp_path / "global" / "settings.json")
+
+        extracted = _migrate_global_keys_to_preferences(
+            str(project_file), global_path=global_path
+        )
+
+        assert extracted == {}
+        with open(project_file) as f:
+            assert json.load(f) == case["expected_project"]
+
+    def test_empty_section_cleaned_up(self, tmp_path):
+        case = _find_case("empty_section_cleaned_up")
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps(case["input"]))
+
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        global_path = str(global_dir / "settings.json")
+
+        extracted = _migrate_global_keys_to_preferences(
+            str(project_file), global_path=global_path
+        )
+
+        assert extracted == case["expected_global_extracted"]
+        with open(project_file) as f:
+            project_after = json.load(f)
+        assert project_after == case["expected_project"]
+
+    def test_merges_into_existing_global_file(self, tmp_path):
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps({
+            "worca": {
+                "parallel": {"cleanup_policy": "on-success"},
+            }
+        }))
+
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        global_path = str(global_dir / "settings.json")
+        with open(global_path, "w") as f:
+            json.dump({"worca": {"ui": {"theme": "dark"}}}, f)
+
+        _migrate_global_keys_to_preferences(
+            str(project_file), global_path=global_path
+        )
+
+        with open(global_path) as f:
+            global_after = json.load(f)
+        assert global_after["worca"]["ui"]["theme"] == "dark"
+        assert global_after["worca"]["parallel"]["cleanup_policy"] == "on-success"
+
+    def test_creates_global_dir_if_missing(self, tmp_path):
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps({
+            "worca": {
+                "ui": {"worktree_disk_warning_bytes": 1000},
+            }
+        }))
+
+        global_path = str(tmp_path / "nonexistent" / "settings.json")
+        extracted = _migrate_global_keys_to_preferences(
+            str(project_file), global_path=global_path
+        )
+
+        assert extracted == {"ui": {"worktree_disk_warning_bytes": 1000}}
+        assert os.path.exists(global_path)
+
+    def test_missing_project_file_returns_empty(self, tmp_path):
+        result = _migrate_global_keys_to_preferences(
+            str(tmp_path / "nonexistent.json")
+        )
+        assert result == {}
+
+    def test_reads_global_keys_from_schema(self):
+        """GLOBAL_ONLY_KEYS are read from keys.json, not hardcoded."""
+        from worca.utils.settings import GLOBAL_ONLY_KEYS
+        expected_keys = [
+            ("parallel", "cleanup_policy"),
+            ("parallel", "max_concurrent_pipelines"),
+            ("ui", "worktree_disk_warning_bytes"),
+            ("circuit_breaker", "classifier_model"),
+        ]
+        assert set(GLOBAL_ONLY_KEYS) == set(expected_keys)
+
+
+# ── §11b: _strip_inert_milestone_keys ──────────────────────────────
+
+
+class TestStripInertMilestoneKeys:
+    def test_strips_true_pr_and_deploy_approval(self, tmp_path):
+        case = _find_case("milestone_strip_pr_approval_true")
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps(case["input"]))
+
+        removed = _strip_inert_milestone_keys(str(project_file))
+
+        assert removed == case["expected_removed_keys"]
+        with open(project_file) as f:
+            assert json.load(f) == case["expected_project_after_milestone_strip"]
+
+    def test_preserves_false_pr_approval(self, tmp_path):
+        case = _find_case("milestone_strip_pr_approval_false_kept")
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps(case["input"]))
+
+        removed = _strip_inert_milestone_keys(str(project_file))
+
+        assert removed == case["expected_removed_keys"]
+        with open(project_file) as f:
+            assert json.load(f) == case["expected_project_after_milestone_strip"]
+
+    def test_cleans_empty_milestones(self, tmp_path):
+        case = _find_case("milestone_strip_empty_milestones_cleaned")
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps(case["input"]))
+
+        removed = _strip_inert_milestone_keys(str(project_file))
+
+        assert removed == case["expected_removed_keys"]
+        with open(project_file) as f:
+            assert json.load(f) == case["expected_project_after_milestone_strip"]
+
+    def test_no_op_when_no_milestones(self, tmp_path):
+        case = _find_case("milestone_strip_no_milestones")
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps(case["input"]))
+
+        removed = _strip_inert_milestone_keys(str(project_file))
+
+        assert removed == case["expected_removed_keys"]
+        with open(project_file) as f:
+            assert json.load(f) == case["expected_project_after_milestone_strip"]
+
+    def test_idempotent_on_second_run(self, tmp_path):
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps({
+            "worca": {
+                "milestones": {
+                    "plan_approval": True,
+                    "pr_approval": True,
+                }
+            }
+        }))
+
+        removed1 = _strip_inert_milestone_keys(str(project_file))
+        assert removed1 == ["pr_approval"]
+
+        removed2 = _strip_inert_milestone_keys(str(project_file))
+        assert removed2 == []
+
+    def test_missing_project_file_returns_empty(self, tmp_path):
+        result = _strip_inert_milestone_keys(str(tmp_path / "nonexistent.json"))
+        assert result == []
+
+    def test_non_boolean_values_preserved(self, tmp_path):
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps({
+            "worca": {
+                "milestones": {
+                    "plan_approval": True,
+                    "pr_approval": "always",
+                    "deploy_approval": 1,
+                }
+            }
+        }))
+
+        removed = _strip_inert_milestone_keys(str(project_file))
+
+        assert removed == []
+        with open(project_file) as f:
+            ms = json.load(f)["worca"]["milestones"]
+        assert ms["pr_approval"] == "always"
+        assert ms["deploy_approval"] == 1

--- a/tests/test_init_migration.py
+++ b/tests/test_init_migration.py
@@ -6,12 +6,9 @@ Covers:
 - Inert milestone key stripping (§11b step 2)
 """
 
-import copy
 import json
 import os
 from pathlib import Path
-
-import pytest
 
 from worca.cli.init import (
     _migrate_global_keys_to_preferences,

--- a/tests/test_keys_schema.py
+++ b/tests/test_keys_schema.py
@@ -1,0 +1,141 @@
+"""Drift tests for src/worca/schemas/keys.json — Python side.
+
+Ensures the Python loader reads the same schema that the JS loader reads,
+and that the exported constants match the canonical JSON structure.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from worca.utils.settings import (
+    GLOBAL_DEFAULTS,
+    GLOBAL_ONLY_KEYS,
+    NORMALIZE_SKIP_KEYS,
+    PROJECT_DEFAULTS,
+)
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "src" / "worca" / "schemas" / "keys.json"
+
+
+@pytest.fixture()
+def raw_schema():
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+class TestKeysSchemaLoaded:
+    def test_global_only_keys_is_list_of_tuples(self):
+        assert isinstance(GLOBAL_ONLY_KEYS, list)
+        for entry in GLOBAL_ONLY_KEYS:
+            assert isinstance(entry, tuple), f"Expected tuple, got {type(entry)}: {entry}"
+            assert len(entry) == 2
+            assert all(isinstance(s, str) for s in entry)
+
+    def test_normalize_skip_keys_is_list_of_tuples(self):
+        assert isinstance(NORMALIZE_SKIP_KEYS, list)
+        for entry in NORMALIZE_SKIP_KEYS:
+            assert isinstance(entry, tuple), f"Expected tuple, got {type(entry)}: {entry}"
+            assert len(entry) == 2
+
+    def test_global_defaults_is_dict(self):
+        assert isinstance(GLOBAL_DEFAULTS, dict)
+        assert len(GLOBAL_DEFAULTS) > 0
+
+    def test_project_defaults_is_dict(self):
+        assert isinstance(PROJECT_DEFAULTS, dict)
+        assert len(PROJECT_DEFAULTS) > 0
+
+
+class TestDriftDetection:
+    """Verify the Python exports match the raw JSON — catches stale imports."""
+
+    def test_global_only_keys_matches_json(self, raw_schema):
+        expected = [tuple(k) for k in raw_schema["global_only_keys"]]
+        assert GLOBAL_ONLY_KEYS == expected
+
+    def test_normalize_skip_keys_matches_json(self, raw_schema):
+        expected = [tuple(k) for k in raw_schema["normalize_skip_keys"]]
+        assert NORMALIZE_SKIP_KEYS == expected
+
+    def test_global_defaults_matches_json(self, raw_schema):
+        assert GLOBAL_DEFAULTS == raw_schema["defaults"]["global"]
+
+    def test_project_defaults_matches_json(self, raw_schema):
+        assert PROJECT_DEFAULTS == raw_schema["defaults"]["project"]
+
+    def test_every_global_only_key_has_a_global_default(self, raw_schema):
+        for section, key in GLOBAL_ONLY_KEYS:
+            assert section in GLOBAL_DEFAULTS, f"Missing section {section!r} in global defaults"
+            assert key in GLOBAL_DEFAULTS[section], (
+                f"Missing key {key!r} in global defaults[{section!r}]"
+            )
+
+    def test_global_only_keys_count(self, raw_schema):
+        assert len(GLOBAL_ONLY_KEYS) == 4
+
+    def test_normalize_skip_keys_count(self, raw_schema):
+        assert len(NORMALIZE_SKIP_KEYS) == 1
+
+    def test_no_overlap_between_global_only_and_project_keys(self, raw_schema):
+        project_keys = set()
+        for section, sub in PROJECT_DEFAULTS.items():
+            for key in sub:
+                project_keys.add((section, key))
+        global_only_set = set(GLOBAL_ONLY_KEYS)
+        overlap = global_only_set & project_keys
+        assert overlap == set(), f"Keys appear in both global_only and project defaults: {overlap}"
+
+
+class TestTemplateSettingsMatchSchema:
+    """The template settings.json must use the same defaults as keys.json.
+
+    Catches fixtures that still hardcode pre-W-049 values
+    (e.g. max_concurrent_pipelines:3, cleanup_policy:'on-success', pr_approval:true).
+    """
+
+    TEMPLATE_PATH = Path(__file__).resolve().parent.parent / "src" / "worca" / "settings.json"
+
+    @pytest.fixture()
+    def template(self):
+        return json.loads(self.TEMPLATE_PATH.read_text())
+
+    def test_template_parallel_matches_project_defaults(self, template):
+        t_parallel = template["worca"]["parallel"]
+        for key, expected in PROJECT_DEFAULTS.get("parallel", {}).items():
+            assert t_parallel.get(key) == expected, (
+                f"template parallel.{key}={t_parallel.get(key)!r}, "
+                f"keys.json project default={expected!r}"
+            )
+
+    def test_template_parallel_matches_global_defaults(self, template):
+        t_parallel = template["worca"]["parallel"]
+        global_only_set = set(GLOBAL_ONLY_KEYS)
+        for key, expected in GLOBAL_DEFAULTS.get("parallel", {}).items():
+            if ("parallel", key) in global_only_set:
+                continue
+            assert t_parallel.get(key) == expected, (
+                f"template parallel.{key}={t_parallel.get(key)!r}, "
+                f"keys.json global default={expected!r}"
+            )
+
+    def test_template_omits_pr_approval(self, template):
+        """pr_approval is intentionally absent from the template (§11a).
+
+        The runner reads missing-key as false. Leaving the template default
+        would activate the PR gate on every upgraded project."""
+        t_ms = template["worca"].get("milestones", {})
+        assert "pr_approval" not in t_ms, (
+            f"template milestones.pr_approval={t_ms.get('pr_approval')!r} "
+            f"— should be absent so the runner's missing-key default (false) takes effect"
+        )
+
+    def test_template_has_no_global_only_keys(self, template):
+        """Global-only keys should not appear in the project template."""
+        w = template.get("worca", {})
+        for section, key in GLOBAL_ONLY_KEYS:
+            section_data = w.get(section, {})
+            assert key not in section_data, (
+                f"template contains global-only key worca.{section}.{key} "
+                f"— it belongs in ~/.worca/settings.json, not the project template"
+            )

--- a/tests/test_run_worktree.py
+++ b/tests/test_run_worktree.py
@@ -495,7 +495,6 @@ class TestDefaultBaseBranch:
     def test_branch_omitted_uses_config_default_base_branch(self, tmp_path):
         """When --branch is not provided, run_worktree reads
         worca.parallel.default_base_branch from settings (fallback 'main')."""
-        import json
         from unittest.mock import patch as _patch
         from worca.scripts.run_worktree import main
 

--- a/tests/test_run_worktree.py
+++ b/tests/test_run_worktree.py
@@ -180,6 +180,7 @@ def _patches(worktree_path=_WORKTREE_PATH):
         patch("worca.scripts.run_worktree.os.path.isdir", return_value=True),
         patch("worca.scripts.run_worktree.subprocess.Popen"),
         patch("worca.scripts.run_worktree._copy_claude_config"),
+        patch("worca.scripts.run_worktree.write_status_field"),
     ]
 
 
@@ -188,19 +189,19 @@ class TestCreatesWorktree:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
         mock_create.assert_called_once_with(
-            _RUN_ID, "add-auth", "HEAD", ".worktrees"
+            _RUN_ID, "add-auth", "main", ".worktrees"
         )
 
     def test_creates_worktree_with_base_branch(self):
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
         assert rc == 0
@@ -221,19 +222,19 @@ class TestCreatesWorktree:
         )
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], \
-             _patch("worca.utils.settings.load_settings",
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], \
+             _patch("worca.scripts.run_worktree.load_settings",
                     return_value={"worca": {"parallel": {"worktree_base_dir": "~/wt-foo"}}}):
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--settings", str(settings_file)])
         assert rc == 0
-        mock_create.assert_called_once_with(_RUN_ID, "add-auth", "HEAD", "~/wt-foo")
+        mock_create.assert_called_once_with(_RUN_ID, "add-auth", "main", "~/wt-foo")
 
     def test_returns_error_when_worktree_creation_fails(self, capsys):
         from worca.scripts.run_worktree import main
         plist = _patches(worktree_path="")
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6] as mock_popen, plist[7]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6] as mock_popen, plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 1
@@ -246,7 +247,7 @@ class TestRegistersInPipelinesD:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -263,7 +264,7 @@ class TestFleetIdPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--fleet-id", "fleet-xyz"])
         assert rc == 0
@@ -274,7 +275,7 @@ class TestFleetIdPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -287,7 +288,7 @@ class TestTargetBranchPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
         assert rc == 0
@@ -298,7 +299,7 @@ class TestTargetBranchPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -312,7 +313,7 @@ class TestGuidePassthrough:
         guide = str(tmp_path / "spec.md")
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--guide", guide])
         assert rc == 0
@@ -327,7 +328,7 @@ class TestGuidePassthrough:
         g2 = str(tmp_path / "spec2.md")
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--guide", g1, "--guide", g2])
         assert rc == 0
@@ -340,7 +341,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -355,7 +356,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -366,7 +367,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -377,7 +378,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6], plist[7]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -488,6 +489,87 @@ class TestCopyClaudeConfig:
         assert (dst / "worca" / "scripts" / "run_pipeline.py").read_text() == "py"
 
 
+class TestDefaultBaseBranch:
+    """--branch omitted uses default_base_branch from settings; --branch provided ignores it."""
+
+    def test_branch_omitted_uses_config_default_base_branch(self, tmp_path):
+        """When --branch is not provided, run_worktree reads
+        worca.parallel.default_base_branch from settings (fallback 'main')."""
+        import json
+        from unittest.mock import patch as _patch
+        from worca.scripts.run_worktree import main
+
+        plist = _patches()
+        settings = {"worca": {"parallel": {"default_base_branch": "develop"}}}
+        with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], \
+             _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
+            mock_norm.return_value = _wr("Add auth")
+            rc = main(["--prompt", "Add auth"])
+        assert rc == 0
+        mock_create.assert_called_once_with(
+            _RUN_ID, "add-auth", "develop", ".worktrees"
+        )
+
+    def test_branch_omitted_falls_back_to_main(self, tmp_path):
+        """When --branch not provided and no default_base_branch in settings,
+        falls back to 'main'."""
+        from unittest.mock import patch as _patch
+        from worca.scripts.run_worktree import main
+
+        plist = _patches()
+        settings = {"worca": {"parallel": {}}}
+        with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], \
+             _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
+            mock_norm.return_value = _wr("Add auth")
+            rc = main(["--prompt", "Add auth"])
+        assert rc == 0
+        mock_create.assert_called_once_with(
+            _RUN_ID, "add-auth", "main", ".worktrees"
+        )
+
+    def test_branch_provided_ignores_config(self, tmp_path):
+        """When --branch is explicitly provided, default_base_branch is ignored."""
+        from unittest.mock import patch as _patch
+        from worca.scripts.run_worktree import main
+
+        plist = _patches()
+        settings = {"worca": {"parallel": {"default_base_branch": "develop"}}}
+        with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], \
+             _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
+            mock_norm.return_value = _wr("Add auth")
+            rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
+        assert rc == 0
+        mock_create.assert_called_once_with(
+            _RUN_ID, "add-auth", "feature/auth", ".worktrees"
+        )
+
+
+class TestWorktreePathWrittenToStatus:
+    """worktree_path is written to status.json after worktree creation."""
+
+    def test_worktree_path_written_to_status_json(self):
+        """run_worktree writes worktree_path to status.json via write_status_field."""
+        from unittest.mock import patch as _patch
+        from worca.scripts.run_worktree import main
+
+        plist = _patches()
+        settings = {"worca": {"parallel": {}}}
+        with plist[0], plist[1] as mock_norm, plist[2], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], \
+             plist[8] as mock_write, \
+             _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
+            mock_norm.return_value = _wr("Add auth")
+            rc = main(["--prompt", "Add auth"])
+        assert rc == 0
+        mock_write.assert_called_once()
+        args = mock_write.call_args
+        assert args[0][1] == "worktree_path"
+        assert args[0][2] == _WORKTREE_PATH
+
+
 class TestMissingWorcaRuntime:
     def test_fails_fast_when_runtime_missing(self, capsys):
         from worca.scripts.run_worktree import main
@@ -496,7 +578,7 @@ class TestMissingWorcaRuntime:
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
              plist[3], plist[4] as mock_reg, \
              patch("worca.scripts.run_worktree.os.path.isdir", return_value=False), \
-             plist[6] as mock_popen, plist[7]:
+             plist[6] as mock_popen, plist[7], plist[8]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 1

--- a/tests/test_runner_pr_approval.py
+++ b/tests/test_runner_pr_approval.py
@@ -1,0 +1,336 @@
+"""Tests for PR-approval gate and _check_control_response_with_timeout in runner.py.
+
+Covers:
+- Default (pr_approval absent or false) skips gate
+- pr_approval=true + approve
+- pr_approval=true + reject
+- No ctx auto-approve
+- Timeout auto-approve
+- _check_control_response_with_timeout: returns action before deadline,
+  returns timeout_default after deadline, respects custom timeout_default
+"""
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from worca.orchestrator.runner import (
+    run_pipeline,
+    _check_control_response_with_timeout,
+    PipelineInterrupted,
+)
+from worca.orchestrator.stages import Stage
+from worca.orchestrator.work_request import WorkRequest
+from worca.events.emitter import EventContext
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _settings(tmp_path, pr_approval=None, plan_approval=False, timeout_seconds=None):
+    milestones = {"plan_approval": plan_approval}
+    if pr_approval is not None:
+        milestones["pr_approval"] = pr_approval
+    if timeout_seconds is not None:
+        milestones["pr_approval_timeout_seconds"] = timeout_seconds
+    data = {
+        "worca": {
+            "stages": {
+                "plan": {"agent": "planner", "enabled": False},
+                "coordinate": {"agent": "coordinator", "enabled": False},
+                "implement": {"agent": "implementer", "enabled": False},
+                "test": {"agent": "tester", "enabled": False},
+                "review": {"agent": "guardian", "enabled": False},
+                "pr": {"agent": "guardian", "enabled": True},
+            },
+            "agents": {
+                "guardian": {"model": "opus", "max_turns": 10},
+            },
+            "milestones": milestones,
+        }
+    }
+    f = tmp_path / "settings.json"
+    f.write_text(json.dumps(data))
+    return str(f)
+
+
+def _worca(tmp_path):
+    d = tmp_path / ".worca"
+    d.mkdir()
+    return str(d), str(d / "status.json")
+
+
+def _wr(title="PR gate test"):
+    return WorkRequest(source_type="prompt", title=title)
+
+
+def _mock_stage(stage, result):
+    return result, {"type": "result"}
+
+
+@pytest.fixture(autouse=True)
+def _mock_beads():
+    with patch("worca.orchestrator.runner._ensure_beads_initialized"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_signal_event_flag():
+    import worca.orchestrator.runner as runner_mod
+    runner_mod._signal_event_emitted = False
+    runner_mod._pending_signal_event = None
+    yield
+    runner_mod._signal_event_emitted = False
+    runner_mod._pending_signal_event = None
+
+
+def _run_pr_pipeline(tmp_path, pr_approval=None, timeout_seconds=None,
+                     control_action=None, emit_returns=None):
+    """Run pipeline with only PR stage enabled, return status dict."""
+    settings_path = _settings(tmp_path, pr_approval=pr_approval,
+                              timeout_seconds=timeout_seconds)
+    _, status_path = _worca(tmp_path)
+    wr = _wr()
+
+    def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                       prompt_override=None, **kwargs):
+        return _mock_stage(stage, {"pr_url": "https://github.com/test/1", "pr_number": 1})
+
+    patches = [
+        patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage),
+        patch("worca.orchestrator.runner.create_branch"),
+        patch("worca.orchestrator.runner._write_pid"),
+        patch("worca.orchestrator.runner._remove_pid"),
+    ]
+    if control_action is not None:
+        patches.append(patch(
+            "worca.orchestrator.runner._check_control_response_with_timeout",
+            return_value=control_action,
+        ))
+    if emit_returns is not None:
+        patches.append(patch(
+            "worca.orchestrator.runner.emit_event",
+            return_value=emit_returns,
+        ))
+
+    for p in patches:
+        p.start()
+    try:
+        return run_pipeline(wr, settings_path=settings_path, status_path=status_path)
+    finally:
+        for p in patches:
+            p.stop()
+
+
+# ---------------------------------------------------------------------------
+# Default: gate is skipped
+# ---------------------------------------------------------------------------
+
+class TestPrApprovalDefault:
+
+    def test_default_skips_gate_when_absent(self, tmp_path):
+        """When pr_approval is absent from settings, PR runs without gating."""
+        status = _run_pr_pipeline(tmp_path, pr_approval=None)
+        assert status["stages"]["pr"]["status"] == "completed"
+
+    def test_default_skips_gate_when_false(self, tmp_path):
+        """When pr_approval is explicitly false, PR runs without gating."""
+        status = _run_pr_pipeline(tmp_path, pr_approval=False)
+        assert status["stages"]["pr"]["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# pr_approval=true + approve
+# ---------------------------------------------------------------------------
+
+class TestPrApprovalApprove:
+
+    def test_approve_completes_pr_stage(self, tmp_path):
+        """When pr_approval=true and control returns approve, PR stage completes."""
+        status = _run_pr_pipeline(
+            tmp_path, pr_approval=True,
+            control_action="approve",
+            emit_returns={"id": "e1"},
+        )
+        assert status["stages"]["pr"]["status"] == "completed"
+        assert status["milestones"]["pr_approved"] is True
+        assert status["pipeline_status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# pr_approval=true + reject
+# ---------------------------------------------------------------------------
+
+class TestPrApprovalReject:
+
+    def test_reject_raises_pipeline_interrupted(self, tmp_path):
+        """When pr_approval=true and control returns reject, pipeline is interrupted."""
+        settings_path = _settings(tmp_path, pr_approval=True)
+        _, status_path = _worca(tmp_path)
+        wr = _wr()
+
+        def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                           prompt_override=None, **kwargs):
+            return _mock_stage(stage, {"pr_url": "https://github.com/test/1", "pr_number": 1})
+
+        with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
+             patch("worca.orchestrator.runner.create_branch"), \
+             patch("worca.orchestrator.runner._write_pid"), \
+             patch("worca.orchestrator.runner._remove_pid"), \
+             patch("worca.orchestrator.runner._check_control_response_with_timeout",
+                   return_value="reject"), \
+             patch("worca.orchestrator.runner.emit_event", return_value={"id": "e1"}):
+            with pytest.raises(PipelineInterrupted) as exc_info:
+                run_pipeline(wr, settings_path=settings_path, status_path=status_path)
+
+        assert exc_info.value.stop_reason == "pr_rejected"
+
+
+# ---------------------------------------------------------------------------
+# No ctx → auto-approve
+# ---------------------------------------------------------------------------
+
+class TestPrApprovalNoCtx:
+
+    def test_no_ctx_auto_approves(self, tmp_path):
+        """When pr_approval=true but no ctx, gate auto-approves without waiting."""
+        settings_path = _settings(tmp_path, pr_approval=True)
+        _, status_path = _worca(tmp_path)
+        wr = _wr()
+
+        def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                           prompt_override=None, **kwargs):
+            return _mock_stage(stage, {"pr_url": "https://github.com/test/1", "pr_number": 1})
+
+        # Prevent ctx from being created by making EventContext raise.
+        # runner.py wraps EventContext construction in `if events_path:` and
+        # initializes ctx = None above it, so we force events_path to be falsy
+        # by intercepting os.path.join for the events.jsonl path.
+        import os.path as osp
+        _orig_join = osp.join
+
+        def null_events_join(*args):
+            if len(args) >= 2 and args[-1] == "events.jsonl":
+                return None
+            return _orig_join(*args)
+
+        with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
+             patch("worca.orchestrator.runner.create_branch"), \
+             patch("worca.orchestrator.runner._write_pid"), \
+             patch("worca.orchestrator.runner._remove_pid"), \
+             patch("os.path.join", side_effect=null_events_join):
+            status = run_pipeline(wr, settings_path=settings_path, status_path=status_path)
+
+        assert status["stages"]["pr"]["status"] == "completed"
+        assert status["milestones"]["pr_approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# Timeout → auto-approve (via _check_control_response_with_timeout unit tests)
+# ---------------------------------------------------------------------------
+
+class TestPrApprovalTimeout:
+
+    def test_timeout_auto_approves(self, tmp_path):
+        """Timeout path results in auto-approve (tested via the helper mock returning approve)."""
+        status = _run_pr_pipeline(
+            tmp_path, pr_approval=True,
+            control_action="approve",
+            emit_returns={"id": "e1"},
+            timeout_seconds=1,
+        )
+        assert status["stages"]["pr"]["status"] == "completed"
+        assert status["milestones"]["pr_approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# _check_control_response_with_timeout
+# ---------------------------------------------------------------------------
+
+class TestCheckControlResponseWithTimeout:
+
+    def test_returns_action_before_deadline(self):
+        """If _check_control_response returns non-None before deadline, return it."""
+        ctx = MagicMock(spec=EventContext)
+        event = {"id": "e1"}
+
+        with patch("worca.orchestrator.runner._check_control_response", return_value="approve"):
+            result = _check_control_response_with_timeout(
+                ctx, event, timeout_seconds=60, timeout_default="approve",
+            )
+        assert result == "approve"
+
+    def test_returns_reject_before_deadline(self):
+        """If _check_control_response returns reject before deadline, return it."""
+        ctx = MagicMock(spec=EventContext)
+        event = {"id": "e1"}
+
+        with patch("worca.orchestrator.runner._check_control_response", return_value="reject"):
+            result = _check_control_response_with_timeout(
+                ctx, event, timeout_seconds=60, timeout_default="approve",
+            )
+        assert result == "reject"
+
+    def test_returns_timeout_default_after_deadline(self):
+        """If deadline elapses with no action, return timeout_default."""
+        ctx = MagicMock(spec=EventContext)
+        event = {"id": "e1"}
+
+        with patch("worca.orchestrator.runner._check_control_response", return_value=None), \
+             patch("time.monotonic", side_effect=[0, 100, 200]):
+            result = _check_control_response_with_timeout(
+                ctx, event, timeout_seconds=1, timeout_default="approve",
+            )
+        assert result == "approve"
+
+    def test_respects_custom_timeout_default(self):
+        """Custom timeout_default is returned when deadline elapses."""
+        ctx = MagicMock(spec=EventContext)
+        event = {"id": "e1"}
+
+        with patch("worca.orchestrator.runner._check_control_response", return_value=None), \
+             patch("time.monotonic", side_effect=[0, 100, 200]):
+            result = _check_control_response_with_timeout(
+                ctx, event, timeout_seconds=1, timeout_default="reject",
+            )
+        assert result == "reject"
+
+    def test_polls_until_action_received(self):
+        """Helper polls multiple times, returning None, then an action."""
+        ctx = MagicMock(spec=EventContext)
+        event = {"id": "e1"}
+        call_count = 0
+
+        def mock_check(ctx, event):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 3:
+                return "approve"
+            return None
+
+        monotonic_values = [0, 1, 2, 3]
+
+        with patch("worca.orchestrator.runner._check_control_response", side_effect=mock_check), \
+             patch("time.monotonic", side_effect=monotonic_values), \
+             patch("time.sleep"):
+            result = _check_control_response_with_timeout(
+                ctx, event, timeout_seconds=60, timeout_default="approve",
+            )
+        assert result == "approve"
+        assert call_count == 3
+
+    def test_timeout_emits_log_warning(self):
+        """On timeout, a warning log line is emitted."""
+        ctx = MagicMock(spec=EventContext)
+        event = {"id": "e1"}
+
+        with patch("worca.orchestrator.runner._check_control_response", return_value=None), \
+             patch("time.monotonic", side_effect=[0, 100, 200]), \
+             patch("worca.orchestrator.runner._log") as mock_log:
+            _check_control_response_with_timeout(
+                ctx, event, timeout_seconds=1, timeout_default="approve",
+            )
+        mock_log.assert_called()
+        log_msg = mock_log.call_args[0][0]
+        assert "auto-approved" in log_msg or "timeout" in log_msg

--- a/tests/test_runner_pr_approval.py
+++ b/tests/test_runner_pr_approval.py
@@ -19,7 +19,6 @@ from worca.orchestrator.runner import (
     _check_control_response_with_timeout,
     PipelineInterrupted,
 )
-from worca.orchestrator.stages import Stage
 from worca.orchestrator.work_request import WorkRequest
 from worca.events.emitter import EventContext
 
@@ -83,6 +82,21 @@ def _reset_signal_event_flag():
     yield
     runner_mod._signal_event_emitted = False
     runner_mod._pending_signal_event = None
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep():
+    """Patch time.sleep across this module so the PR-approval polling loop
+    in _check_control_response_with_timeout never actually blocks.
+
+    Tests that call the helper with timeout_seconds in the tens of seconds
+    would otherwise sleep poll_interval=5s on each iteration whenever the
+    mock _check_control_response returns None on the first poll. Currently
+    the immediate-return paths happen to dodge this, but adding any test
+    that exercises the polling loop would silently slow the suite.
+    """
+    with patch("time.sleep"):
+        yield
 
 
 def _run_pr_pipeline(tmp_path, pr_approval=None, timeout_seconds=None,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -249,18 +249,28 @@ class TestLoadSettings:
 
 
 class TestParallelSettings:
-    """Tests for the worca.parallel settings section."""
+    """Tests for the worca.parallel settings section.
 
-    PARALLEL_DEFAULTS = {
-        "max_concurrent_pipelines": 3,
+    Post-W-049, max_concurrent_pipelines and cleanup_policy are global-only
+    keys (live in ~/.worca/settings.json). The project template only contains
+    project-scoped keys: default_base_branch and worktree_base_dir.
+    """
+
+    PROJECT_PARALLEL_DEFAULTS = {
         "default_base_branch": "main",
-        "cleanup_policy": "on-success",
+        "worktree_base_dir": ".worktrees",
+    }
+
+    ALL_PARALLEL_DEFAULTS = {
+        "max_concurrent_pipelines": 10,
+        "default_base_branch": "main",
+        "cleanup_policy": "never",
         "worktree_base_dir": ".worktrees",
     }
 
     def _base_with_parallel(self, parallel_overrides=None):
         """Return a minimal settings dict containing the parallel section."""
-        parallel = dict(self.PARALLEL_DEFAULTS)
+        parallel = dict(self.ALL_PARALLEL_DEFAULTS)
         if parallel_overrides:
             parallel.update(parallel_overrides)
         return {"worca": {"parallel": parallel}}
@@ -273,9 +283,9 @@ class TestParallelSettings:
         result = load_settings(str(settings_file))
         p = result["worca"]["parallel"]
 
-        assert p["max_concurrent_pipelines"] == 3
+        assert p["max_concurrent_pipelines"] == 10
         assert p["default_base_branch"] == "main"
-        assert p["cleanup_policy"] == "on-success"
+        assert p["cleanup_policy"] == "never"
         assert p["worktree_base_dir"] == ".worktrees"
 
     def test_local_override_max_concurrent(self, tmp_path):
@@ -291,9 +301,8 @@ class TestParallelSettings:
         p = result["worca"]["parallel"]
 
         assert p["max_concurrent_pipelines"] == 5
-        # other parallel keys preserved from base
         assert p["default_base_branch"] == "main"
-        assert p["cleanup_policy"] == "on-success"
+        assert p["cleanup_policy"] == "never"
         assert p["worktree_base_dir"] == ".worktrees"
 
     def test_local_override_cleanup_policy(self, tmp_path):
@@ -336,13 +345,13 @@ class TestParallelSettings:
         """Overriding parallel keys does not affect sibling worca sections."""
         base = {
             "worca": {
-                "parallel": dict(self.PARALLEL_DEFAULTS),
+                "parallel": dict(self.ALL_PARALLEL_DEFAULTS),
                 "budget": {"warning_pct": 80, "max_cost_usd": None},
                 "events": {"enabled": True},
             }
         }
         local = {
-            "worca": {"parallel": {"max_concurrent_pipelines": 10}}
+            "worca": {"parallel": {"max_concurrent_pipelines": 20}}
         }
 
         settings_file = tmp_path / "settings.json"
@@ -351,13 +360,12 @@ class TestParallelSettings:
         local_file.write_text(json.dumps(local))
 
         result = load_settings(str(settings_file))
-        assert result["worca"]["parallel"]["max_concurrent_pipelines"] == 10
-        # siblings untouched
+        assert result["worca"]["parallel"]["max_concurrent_pipelines"] == 20
         assert result["worca"]["budget"]["warning_pct"] == 80
         assert result["worca"]["events"]["enabled"] is True
 
     def test_real_settings_has_parallel_section(self):
-        """The src/worca/settings.json contains the parallel section."""
+        """The src/worca/settings.json contains the project-scoped parallel keys."""
         settings_path = os.path.join(
             os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
         )
@@ -365,7 +373,9 @@ class TestParallelSettings:
         assert "parallel" in result.get("worca", {}), \
             "worca.parallel section missing from src/worca/settings.json"
         p = result["worca"]["parallel"]
-        assert p["max_concurrent_pipelines"] == 3
         assert p["default_base_branch"] == "main"
-        assert p["cleanup_policy"] == "on-success"
         assert p["worktree_base_dir"] == ".worktrees"
+        assert "max_concurrent_pipelines" not in p, \
+            "global-only key max_concurrent_pipelines should not be in project template"
+        assert "cleanup_policy" not in p, \
+            "global-only key cleanup_policy should not be in project template"

--- a/tests/test_settings_circuit_breaker.py
+++ b/tests/test_settings_circuit_breaker.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 SETTINGS_PATH = Path(__file__).resolve().parents[1] / "src" / "worca" / "settings.json"
+KEYS_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "src" / "worca" / "schemas" / "keys.json"
 
 
 class TestSettingsCircuitBreaker:
@@ -26,8 +27,13 @@ class TestSettingsCircuitBreaker:
     def test_circuit_breaker_transient_retry_backoff_seconds(self):
         assert self.worca["circuit_breaker"]["transient_retry_backoff_seconds"] == [10, 30, 90]
 
-    def test_circuit_breaker_classifier_model(self):
-        assert self.worca["circuit_breaker"]["classifier_model"] == "haiku"
+    def test_circuit_breaker_classifier_model_is_global_only(self):
+        """classifier_model is a global-only key (lives in ~/.worca/settings.json),
+        so it must NOT appear in the project settings.json. Its default is in keys.json."""
+        assert "classifier_model" not in self.worca["circuit_breaker"]
+        with open(KEYS_SCHEMA_PATH) as f:
+            keys = json.load(f)
+        assert keys["defaults"]["global"]["circuit_breaker"]["classifier_model"] == "haiku"
 
 
 class TestSettingsPreflightStage:

--- a/tests/test_settings_global_fallback.py
+++ b/tests/test_settings_global_fallback.py
@@ -1,0 +1,141 @@
+"""Tests for load_settings_with_global_fallback."""
+
+import json
+
+from worca.utils.settings import load_settings_with_global_fallback
+
+
+class TestLoadSettingsWithGlobalFallback:
+    """Deep-merges ~/.worca/settings.json under project blob, project wins."""
+
+    def test_merge_project_wins(self, tmp_path):
+        """Project values override global values on overlap."""
+        global_file = tmp_path / "global" / "settings.json"
+        global_file.parent.mkdir()
+        global_file.write_text(json.dumps({
+            "worca": {
+                "circuit_breaker": {"classifier_model": "sonnet"},
+                "parallel": {"cleanup_policy": "always"},
+            }
+        }))
+
+        project_file = tmp_path / "project" / "settings.json"
+        project_file.parent.mkdir()
+        project_file.write_text(json.dumps({
+            "worca": {
+                "circuit_breaker": {"max_consecutive_failures": 5},
+            }
+        }))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        assert result["worca"]["circuit_breaker"]["max_consecutive_failures"] == 5
+        assert result["worca"]["circuit_breaker"]["classifier_model"] == "sonnet"
+        assert result["worca"]["parallel"]["cleanup_policy"] == "always"
+
+    def test_missing_global_file(self, tmp_path):
+        """Missing global file returns project settings unchanged."""
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps({
+            "worca": {"stages": {"plan": {"enabled": True}}}
+        }))
+
+        result = load_settings_with_global_fallback(
+            str(project_file),
+            global_path=str(tmp_path / "nonexistent" / "settings.json"),
+        )
+
+        assert result == {"worca": {"stages": {"plan": {"enabled": True}}}}
+
+    def test_malformed_global_json(self, tmp_path, capsys):
+        """Malformed global JSON logs a warning and returns project settings."""
+        global_file = tmp_path / "global_settings.json"
+        global_file.write_text("{bad json!!!")
+
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps({"worca": {"key": "val"}}))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        assert result == {"worca": {"key": "val"}}
+        captured = capsys.readouterr()
+        assert "invalid JSON" in captured.err
+
+    def test_both_missing(self, tmp_path):
+        """Both files missing returns empty dict."""
+        result = load_settings_with_global_fallback(
+            str(tmp_path / "no_project.json"),
+            global_path=str(tmp_path / "no_global.json"),
+        )
+        assert result == {}
+
+    def test_global_only_no_project(self, tmp_path):
+        """Only global file exists — its values appear in result."""
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "worca": {"parallel": {"max_concurrent_pipelines": 7}}
+        }))
+
+        result = load_settings_with_global_fallback(
+            str(tmp_path / "missing_project.json"),
+            global_path=str(global_file),
+        )
+
+        assert result == {
+            "worca": {"parallel": {"max_concurrent_pipelines": 7}}
+        }
+
+    def test_deep_nested_merge(self, tmp_path):
+        """Deep merge works across multiple nesting levels."""
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "worca": {
+                "parallel": {"cleanup_policy": "always", "max_concurrent_pipelines": 5},
+                "ui": {"worktree_disk_warning_bytes": 1000000},
+            }
+        }))
+
+        project_file = tmp_path / "project.json"
+        project_file.write_text(json.dumps({
+            "worca": {
+                "parallel": {"default_base_branch": "develop"},
+                "stages": {"plan": {"enabled": True}},
+            }
+        }))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        assert result["worca"]["parallel"]["cleanup_policy"] == "always"
+        assert result["worca"]["parallel"]["max_concurrent_pipelines"] == 5
+        assert result["worca"]["parallel"]["default_base_branch"] == "develop"
+        assert result["worca"]["ui"]["worktree_disk_warning_bytes"] == 1000000
+        assert result["worca"]["stages"]["plan"]["enabled"] is True
+
+    def test_default_global_path(self, tmp_path, monkeypatch):
+        """Without explicit global_path, uses ~/.worca/settings.json."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        worca_dir = fake_home / ".worca"
+        worca_dir.mkdir()
+        global_file = worca_dir / "settings.json"
+        global_file.write_text(json.dumps({
+            "worca": {"circuit_breaker": {"classifier_model": "opus"}}
+        }))
+
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        project_file = tmp_path / "settings.json"
+        project_file.write_text(json.dumps({
+            "worca": {"circuit_breaker": {"max_consecutive_failures": 2}}
+        }))
+
+        result = load_settings_with_global_fallback(str(project_file))
+
+        assert result["worca"]["circuit_breaker"]["classifier_model"] == "opus"
+        assert result["worca"]["circuit_breaker"]["max_consecutive_failures"] == 2

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -379,3 +379,48 @@ def test_resolve_status_passthrough_known_values():
 
 def test_resolve_status_passthrough_unknown():
     assert resolve_status("unknown_val") == "unknown_val"
+
+
+# --- init_status worktree_path ---
+
+def test_init_status_has_worktree_path_none_by_default():
+    wr = {"title": "Task"}
+    result = init_status(wr, "feat/task")
+    assert "worktree_path" in result
+    assert result["worktree_path"] is None
+
+
+# --- write_status_field ---
+
+def test_write_status_field_creates_file_and_sets_field(tmp_path):
+    from worca.state.status import write_status_field
+    path = str(tmp_path / "status.json")
+    write_status_field(path, "worktree_path", "/tmp/wt/pipeline-abc")
+    import json
+    with open(path) as f:
+        data = json.load(f)
+    assert data["worktree_path"] == "/tmp/wt/pipeline-abc"
+
+
+def test_write_status_field_preserves_existing_fields(tmp_path):
+    from worca.state.status import write_status_field
+    import json
+    path = str(tmp_path / "status.json")
+    with open(path, "w") as f:
+        json.dump({"pipeline_status": "pending", "run_id": "abc"}, f)
+    write_status_field(path, "worktree_path", "/tmp/wt")
+    with open(path) as f:
+        data = json.load(f)
+    assert data["pipeline_status"] == "pending"
+    assert data["run_id"] == "abc"
+    assert data["worktree_path"] == "/tmp/wt"
+
+
+def test_write_status_field_creates_parent_dirs(tmp_path):
+    from worca.state.status import write_status_field
+    import json
+    path = str(tmp_path / "deep" / "nested" / "status.json")
+    write_status_field(path, "worktree_path", "/tmp/wt")
+    with open(path) as f:
+        data = json.load(f)
+    assert data["worktree_path"] == "/tmp/wt"

--- a/worca-ui/app/main-runs-list.test.js
+++ b/worca-ui/app/main-runs-list.test.js
@@ -11,6 +11,15 @@
 import { describe, expect, it } from 'vitest';
 import { createStore } from './state.js';
 
+function deriveTotalRunning(runs) {
+  let count = 0;
+  for (const r of Object.values(runs)) {
+    const ps = r.pipeline_status || (r.active ? 'running' : 'completed');
+    if (ps === 'running' || ps === 'paused') count++;
+  }
+  return count;
+}
+
 describe('runs-list handler: settings must be updated before store.setState', () => {
   it('settings are visible in store subscriber when updated before setState', () => {
     // Arrange: mirror main.js module-level setup
@@ -57,5 +66,49 @@ describe('runs-list handler: settings must be updated before store.setState', ()
     // Assert: subscriber saw stale (empty) settings — this is the bug
     expect(settingsCapturedDuringRender).toHaveLength(1);
     expect(settingsCapturedDuringRender[0]).toEqual({}); // stale!
+  });
+});
+
+describe('runs-list handler: totalRunning derivation', () => {
+  it('counts running runs', () => {
+    const runs = {
+      r1: { id: 'r1', pipeline_status: 'running' },
+      r2: { id: 'r2', pipeline_status: 'completed' },
+      r3: { id: 'r3', pipeline_status: 'running' },
+    };
+    expect(deriveTotalRunning(runs)).toBe(2);
+  });
+
+  it('counts paused runs as running', () => {
+    const runs = {
+      r1: { id: 'r1', pipeline_status: 'running' },
+      r2: { id: 'r2', pipeline_status: 'paused' },
+      r3: { id: 'r3', pipeline_status: 'failed' },
+    };
+    expect(deriveTotalRunning(runs)).toBe(2);
+  });
+
+  it('falls back to active flag when pipeline_status is missing', () => {
+    const runs = {
+      r1: { id: 'r1', active: true },
+      r2: { id: 'r2', active: false },
+    };
+    expect(deriveTotalRunning(runs)).toBe(1);
+  });
+
+  it('returns 0 for empty runs', () => {
+    expect(deriveTotalRunning({})).toBe(0);
+  });
+
+  it('stores derived totalRunning in state after setRunsBulk', () => {
+    const store = createStore();
+    store.setRunsBulk([
+      { id: 'r1', pipeline_status: 'running' },
+      { id: 'r2', pipeline_status: 'paused' },
+      { id: 'r3', pipeline_status: 'completed' },
+    ]);
+    const total = deriveTotalRunning(store.getState().runs);
+    store.setState({ totalRunning: total });
+    expect(store.getState().totalRunning).toBe(2);
   });
 });

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -49,11 +49,16 @@ import {
 } from './views/log-viewer.js';
 import {
   getNewRunSubmitState,
+  isAtCapacity,
   newRunView,
   submitNewRun,
 } from './views/new-run.js';
 import { runCardView } from './views/run-card.js';
-import { runBeadsSectionView, runDetailView } from './views/run-detail.js';
+import {
+  prApprovalPanelView,
+  runBeadsSectionView,
+  runDetailView,
+} from './views/run-detail.js';
 import { runListView } from './views/run-list.js';
 import {
   loadSettings,
@@ -513,6 +518,13 @@ ws.on('runs-list', (payload, msg) => {
 // count badge and worktrees view stay in sync without a manual reload.
 ws.on('runs-list', () => {
   fetchWorktrees();
+  const runs = store.getState().runs;
+  let totalRunning = 0;
+  for (const r of Object.values(runs)) {
+    const ps = r.pipeline_status || (r.active ? 'running' : 'completed');
+    if (ps === 'running' || ps === 'paused') totalRunning++;
+  }
+  store.setState({ totalRunning });
 });
 
 ws.on('run-snapshot', (payload) => {
@@ -1341,6 +1353,54 @@ function handleCancelRun(runId) {
   );
 }
 
+// --- PR Approval ---
+
+async function handleApprovePR(runId) {
+  try {
+    const res = await fetch(projectUrl(`/runs/${runId}/control`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'approve', source: 'ui-pr-approval' }),
+    });
+    if (res.status === 404) {
+      showActionError('This run has already finished. Refreshing...');
+      return;
+    }
+    if (res.status === 409) {
+      showActionError('This run is no longer awaiting approval.');
+      return;
+    }
+    if (!res.ok) {
+      showActionError('Could not deliver decision; try again.');
+    }
+  } catch {
+    showActionError('Could not deliver decision; try again.');
+  }
+}
+
+async function handleRejectPR(runId) {
+  try {
+    const res = await fetch(projectUrl(`/runs/${runId}/control`), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'reject', source: 'ui-pr-approval' }),
+    });
+    if (res.status === 404) {
+      showActionError('This run has already finished. Refreshing...');
+      return;
+    }
+    if (res.status === 409) {
+      showActionError('This run is no longer awaiting approval.');
+      return;
+    }
+    if (!res.ok) {
+      showActionError('Could not deliver decision; try again.');
+    }
+  } catch {
+    showActionError('Could not deliver decision; try again.');
+  }
+}
+
 // --- Archive/Unarchive ---
 
 const { archiveRun, unarchiveRun } = createArchiveActions({
@@ -1836,8 +1896,9 @@ function contentHeaderView() {
     title = 'New Pipeline';
     showBack = true;
     const nrs = getNewRunSubmitState();
+    const capReached = isAtCapacity(state);
     actionButton = html`
-      <button class="action-btn action-btn--primary" ?disabled=${nrs.isSubmitting}
+      <button class="action-btn action-btn--primary" ?disabled=${nrs.isSubmitting || capReached}
         @click=${() => submitNewRun({ rerender, onStarted: () => navigate('active', null, route.projectId), projectId: store.getState().currentProjectId })}>
 
         ${unsafeHTML(iconSvg(Play, 14))}
@@ -2005,6 +2066,7 @@ function mainContentView() {
         </div>
         <div class="run-detail-layout__logs">
           <div class="run-detail-column-header">Artifacts</div>
+          ${prApprovalPanelView(run, { onApprove: handleApprovePR, onReject: handleRejectPR })}
           ${liveOutputView(getActiveStage(), isRunning)}
           ${logViewerView(logState, {
             onStageFilter: handleStageFilter,
@@ -2071,6 +2133,13 @@ function mainContentView() {
       onSaveSourceRepo: handleSaveSourceRepo,
       onSaveNotifications: handleSaveNotifications,
       onRequestPermission: () => notificationManager.requestPermission(),
+      globals: {
+        worktreeDiskWarningBytes: state.worktreeDiskWarningBytes,
+        classifierModel: state.classifierModel,
+        cleanupPolicy: state.cleanupPolicy,
+        maxConcurrentPipelines: state.maxConcurrentPipelines,
+      },
+      onSaveGlobals: (patch) => store.setState(patch),
       projects: state.projects || [],
       integrations: {
         status: integrationsStatus,
@@ -2147,6 +2216,7 @@ function mainContentView() {
 
   if (route.section === 'worktrees') {
     return worktreesView(state.worktrees || [], {
+      diskWarningBytes: state.worktreeDiskWarningBytes,
       filter: worktreesFilter,
       onFilter: (value) => {
         worktreesFilter = value;
@@ -2332,6 +2402,31 @@ if (route.projectId) {
   store.setState({ currentProjectId: route.projectId });
 }
 fetchProjectInfo();
+Promise.all([
+  fetch('/api/preferences')
+    .then((r) => (r.ok ? r.json() : null))
+    .catch(() => null),
+  fetch('/api/status/runs-count')
+    .then((r) => (r.ok ? r.json() : null))
+    .catch(() => null),
+]).then(([prefsRes, countRes]) => {
+  const patch = {};
+  if (prefsRes?.ok) {
+    const p = prefsRes.preferences?.worca ?? {};
+    if (p.ui?.worktree_disk_warning_bytes != null)
+      patch.worktreeDiskWarningBytes = p.ui.worktree_disk_warning_bytes;
+    if (p.circuit_breaker?.classifier_model != null)
+      patch.classifierModel = p.circuit_breaker.classifier_model;
+    if (p.parallel?.cleanup_policy != null)
+      patch.cleanupPolicy = p.parallel.cleanup_policy;
+    if (p.parallel?.max_concurrent_pipelines != null)
+      patch.maxConcurrentPipelines = p.parallel.max_concurrent_pipelines;
+  }
+  if (countRes?.ok && typeof countRes.totalRunning === 'number') {
+    patch.totalRunning = countRes.totalRunning;
+  }
+  if (Object.keys(patch).length > 0) store.setState(patch);
+});
 if (route.section === 'settings') {
   loadSettings(null).then(() => rerender());
   startIntegrationsPoll();
@@ -2341,5 +2436,23 @@ if (route.section === 'project-settings') {
     rerender(),
   );
 }
+
+// Single-project polling fallback: WS totalRunning derivation only covers
+// the focused project's runs. Poll /api/status/runs-count every 5s so
+// the cap badge and gating stay accurate across all projects.
+setInterval(() => {
+  fetch('/api/status/runs-count')
+    .then((r) => (r.ok ? r.json() : null))
+    .then((data) => {
+      if (data?.ok && typeof data.totalRunning === 'number') {
+        const patch = { totalRunning: data.totalRunning };
+        if (typeof data.cap === 'number')
+          patch.maxConcurrentPipelines = data.cap;
+        store.setState(patch);
+      }
+    })
+    .catch(() => {});
+}, 5000);
+
 rerender();
 attachStickyHeaderListener();

--- a/worca-ui/app/state.js
+++ b/worca-ui/app/state.js
@@ -43,6 +43,11 @@ export function createStore(initial = {}) {
     runsLoaded: initial.runsLoaded ?? false,
     addProjectDialogOpen: initial.addProjectDialogOpen ?? false,
     worktrees: initial.worktrees ?? [],
+    worktreeDiskWarningBytes: initial.worktreeDiskWarningBytes ?? 2_000_000_000,
+    classifierModel: initial.classifierModel ?? 'haiku',
+    cleanupPolicy: initial.cleanupPolicy ?? 'never',
+    maxConcurrentPipelines: initial.maxConcurrentPipelines ?? 10,
+    totalRunning: initial.totalRunning ?? 0,
   };
 
   const subs = new Set();
@@ -84,7 +89,12 @@ export function createStore(initial = {}) {
         next.webhookInbox === state.webhookInbox &&
         next.addProjectDialogOpen === state.addProjectDialogOpen &&
         next.worktrees === state.worktrees &&
-        next.runsLoaded === state.runsLoaded
+        next.runsLoaded === state.runsLoaded &&
+        next.worktreeDiskWarningBytes === state.worktreeDiskWarningBytes &&
+        next.classifierModel === state.classifierModel &&
+        next.cleanupPolicy === state.cleanupPolicy &&
+        next.maxConcurrentPipelines === state.maxConcurrentPipelines &&
+        next.totalRunning === state.totalRunning
       )
         return;
       state = next;

--- a/worca-ui/app/state.test.js
+++ b/worca-ui/app/state.test.js
@@ -279,6 +279,32 @@ describe('state store', () => {
     });
   });
 
+  it('initializes with global-derived scalars', () => {
+    const store = createStore();
+    const s = store.getState();
+    expect(s.worktreeDiskWarningBytes).toBe(2_000_000_000);
+    expect(s.classifierModel).toBe('haiku');
+    expect(s.cleanupPolicy).toBe('never');
+    expect(s.maxConcurrentPipelines).toBe(10);
+    expect(s.totalRunning).toBe(0);
+  });
+
+  it('accepts global-derived scalar overrides', () => {
+    const store = createStore({
+      worktreeDiskWarningBytes: 5_000_000_000,
+      classifierModel: 'sonnet',
+      cleanupPolicy: 'on-success',
+      maxConcurrentPipelines: 3,
+      totalRunning: 5,
+    });
+    const s = store.getState();
+    expect(s.worktreeDiskWarningBytes).toBe(5_000_000_000);
+    expect(s.classifierModel).toBe('sonnet');
+    expect(s.cleanupPolicy).toBe('on-success');
+    expect(s.maxConcurrentPipelines).toBe(3);
+    expect(s.totalRunning).toBe(5);
+  });
+
   it('initializes with currentProjectId=null and projects=[]', () => {
     const store = createStore();
     const s = store.getState();

--- a/worca-ui/app/views/new-run-parallel-block.test.js
+++ b/worca-ui/app/views/new-run-parallel-block.test.js
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { hasActivePipeline, newRunView, resetNewRunState } from './new-run.js';
+import {
+  hasActivePipeline,
+  isAtCapacity,
+  newRunView,
+  resetNewRunState,
+} from './new-run.js';
 
 function renderToString(template) {
   if (!template) return '';
@@ -87,6 +92,68 @@ describe('newRunView worktree info banner', () => {
     resetNewRunState({ bannerDismissed: true });
     const out = renderToString(newRunView({}, { rerender }));
     expect(out).not.toContain('parallel runs no longer collide');
+  });
+});
+
+describe('newRunView cap-disabled state', () => {
+  const rerender = () => {};
+
+  it('renders capacity warning banner when totalRunning >= maxConcurrentPipelines', () => {
+    resetNewRunState();
+    const state = {
+      runs: {},
+      totalRunning: 5,
+      maxConcurrentPipelines: 5,
+    };
+    const out = renderToString(newRunView(state, { rerender }));
+    expect(out).toContain('capacity-warning');
+    expect(out).toContain('5');
+  });
+
+  it('does not render capacity warning when under cap', () => {
+    resetNewRunState();
+    const state = {
+      runs: {},
+      totalRunning: 3,
+      maxConcurrentPipelines: 10,
+    };
+    const out = renderToString(newRunView(state, { rerender }));
+    expect(out).not.toContain('capacity-warning');
+  });
+
+  it('renders capacity warning when totalRunning exceeds cap', () => {
+    resetNewRunState();
+    const state = {
+      runs: {},
+      totalRunning: 7,
+      maxConcurrentPipelines: 5,
+    };
+    const out = renderToString(newRunView(state, { rerender }));
+    expect(out).toContain('capacity-warning');
+  });
+});
+
+describe('isAtCapacity', () => {
+  it('returns true when totalRunning equals maxConcurrentPipelines', () => {
+    expect(isAtCapacity({ totalRunning: 5, maxConcurrentPipelines: 5 })).toBe(
+      true,
+    );
+  });
+
+  it('returns true when totalRunning exceeds maxConcurrentPipelines', () => {
+    expect(isAtCapacity({ totalRunning: 7, maxConcurrentPipelines: 5 })).toBe(
+      true,
+    );
+  });
+
+  it('returns false when under cap', () => {
+    expect(isAtCapacity({ totalRunning: 3, maxConcurrentPipelines: 10 })).toBe(
+      false,
+    );
+  });
+
+  it('returns false with default cap when state has no fields', () => {
+    expect(isAtCapacity({})).toBe(false);
   });
 });
 

--- a/worca-ui/app/views/new-run-submit.test.js
+++ b/worca-ui/app/views/new-run-submit.test.js
@@ -199,12 +199,108 @@ describe('submitNewRun — new format validation and payload', () => {
   });
 });
 
+describe('submitNewRun — 409 max_concurrent_exceeded handling', () => {
+  let origFetch;
+  let submitNewRun, resetNewRunState, getNewRunSubmitState;
+  let docStub;
+
+  beforeEach(async () => {
+    origFetch = globalThis.fetch;
+    const elements = {};
+    docStub = {
+      getElementById: vi.fn((id) => elements[id] || null),
+      _set(id, value) {
+        elements[id] = { value, id };
+      },
+      _clear() {
+        for (const k of Object.keys(elements)) delete elements[k];
+      },
+    };
+    globalThis.document = docStub;
+
+    vi.resetModules();
+    vi.doMock('lit-html', () => ({ html: () => null, nothing: null }));
+    vi.doMock('lit-html/directives/unsafe-html.js', () => ({
+      unsafeHTML: () => null,
+    }));
+    vi.doMock('../utils/icons.js', () => ({
+      iconSvg: () => '',
+      FileText: 'FileText',
+    }));
+
+    const mod = await import('./new-run.js');
+    submitNewRun = mod.submitNewRun;
+    resetNewRunState = mod.resetNewRunState;
+    getNewRunSubmitState = mod.getNewRunSubmitState;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('sets submitError from 409 max_concurrent_exceeded response', async () => {
+    docStub._clear();
+    docStub._set('new-run-prompt', 'test prompt');
+    docStub._set('new-run-msize', '1');
+    docStub._set('new-run-mloops', '1');
+    resetNewRunState({ sourceType: 'none' });
+
+    const serverMsg =
+      'Maximum concurrent pipelines reached (5). Stop a running pipeline or increase the limit in global preferences.';
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: () =>
+        Promise.resolve({
+          ok: false,
+          error: serverMsg,
+          code: 'max_concurrent_exceeded',
+        }),
+    });
+
+    const rerender = vi.fn();
+    await submitNewRun({ rerender, onStarted: vi.fn() });
+
+    const state = getNewRunSubmitState();
+    expect(state.submitStatus).toBe('error');
+    expect(rerender).toHaveBeenCalled();
+  });
+
+  it('includes cap info in error when 409 code is max_concurrent_exceeded', async () => {
+    docStub._clear();
+    docStub._set('new-run-prompt', 'test prompt');
+    docStub._set('new-run-msize', '1');
+    docStub._set('new-run-mloops', '1');
+    resetNewRunState({ sourceType: 'none' });
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: () =>
+        Promise.resolve({
+          ok: false,
+          error: 'Max reached (3)',
+          code: 'max_concurrent_exceeded',
+          cap: 3,
+          totalRunning: 3,
+        }),
+    });
+
+    const rerender = vi.fn();
+    await submitNewRun({ rerender, onStarted: vi.fn() });
+
+    const state = getNewRunSubmitState();
+    expect(state.submitStatus).toBe('error');
+  });
+});
+
 describe('module exports', () => {
-  it('exports newRunView, submitNewRun, resetNewRunState, getNewRunSubmitState', async () => {
+  it('exports newRunView, submitNewRun, resetNewRunState, getNewRunSubmitState, isAtCapacity', async () => {
     const mod = await import('./new-run.js');
     expect(typeof mod.newRunView).toBe('function');
     expect(typeof mod.submitNewRun).toBe('function');
     expect(typeof mod.resetNewRunState).toBe('function');
     expect(typeof mod.getNewRunSubmitState).toBe('function');
+    expect(typeof mod.isAtCapacity).toBe('function');
   });
 });

--- a/worca-ui/app/views/new-run.js
+++ b/worca-ui/app/views/new-run.js
@@ -204,6 +204,12 @@ export async function submitNewRun({ rerender, onStarted, projectId }) {
     });
 
     const data = await res.json();
+    if (res.status === 409 && data.code === 'max_concurrent_exceeded') {
+      submitStatus = 'error';
+      submitError = data.error || 'Concurrent pipeline limit reached.';
+      rerender();
+      return;
+    }
     if (data.ok) {
       submitStatus = null;
       // Don't call refreshRuns() here — the Python process hasn't written
@@ -231,8 +237,15 @@ export function hasActivePipeline(state) {
   return Object.values(runs).some((r) => r.active === true);
 }
 
+export function isAtCapacity(state) {
+  const cap = state?.maxConcurrentPipelines ?? 10;
+  const running = state?.totalRunning ?? 0;
+  return running >= cap;
+}
+
 export function newRunView(_state, { rerender }) {
   const projectId = _state.currentProjectId || null;
+  const atCapacity = isAtCapacity(_state);
 
   function handleSourceTypeChange(e) {
     sourceType = e.target.value;
@@ -337,6 +350,15 @@ export function newRunView(_state, { rerender }) {
           Each pipeline now runs in its own git worktree — parallel runs no longer collide on the working tree.
         </sl-alert>
       `
+      }
+      ${
+        atCapacity
+          ? html`
+        <sl-alert variant="warning" open class="capacity-warning">
+          Pipeline limit reached — ${_state.totalRunning ?? 0} of ${_state.maxConcurrentPipelines ?? 10} slots in use. Stop a running pipeline or increase the limit in Settings.
+        </sl-alert>
+      `
+          : nothing
       }
       ${submitStatus === 'error' ? html`<div class="new-run-error">${submitError}</div>` : nothing}
 

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -506,6 +506,30 @@ function _graphWithTooltips(beads) {
   `;
 }
 
+export function prApprovalPanelView(run, options = {}) {
+  if (
+    !(
+      run?.milestones?.pr_approved === false &&
+      run?.pipeline_status === 'paused'
+    )
+  ) {
+    return nothing;
+  }
+  const { onApprove, onReject } = options;
+  return html`
+    <sl-card class="approval-panel" data-testid="pr-approval-panel">
+      <div slot="header">
+        <strong>PR creation paused — approval required</strong>
+      </div>
+      <p>The pipeline is ready to create a pull request for this run. Approve to proceed, or reject to stop the pipeline.</p>
+      <div class="approval-actions">
+        <sl-button variant="success" id="pr-approve-btn" @click=${() => onApprove?.(run.id)}>Approve &amp; create PR</sl-button>
+        <sl-button variant="danger" outline id="pr-reject-btn" @click=${() => onReject?.(run.id)}>Reject</sl-button>
+      </div>
+    </sl-card>
+  `;
+}
+
 export function runBeadsSectionView(beads) {
   if (!beads) return nothing;
   if (beads.length === 0) {

--- a/worca-ui/app/views/run-detail.test.js
+++ b/worca-ui/app/views/run-detail.test.js
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { runBeadsSectionView, runDetailView } from './run-detail.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  prApprovalPanelView,
+  runBeadsSectionView,
+  runDetailView,
+} from './run-detail.js';
 
 function renderToString(template) {
   if (!template) return '';
@@ -186,5 +190,124 @@ describe('runDetailView - worktree metadata row', () => {
     };
     const out = render(runDetailView(run));
     expect(out).not.toContain('Worktree:');
+  });
+});
+
+describe('prApprovalPanelView', () => {
+  function render(template) {
+    return renderToString(template);
+  }
+
+  const pausedRunAwaitingApproval = {
+    id: 'run-1',
+    pipeline_status: 'paused',
+    milestones: { pr_approved: false },
+    stages: {},
+  };
+
+  describe('render conditions', () => {
+    it('renders approval panel when pr_approved===false and pipeline_status===paused', () => {
+      const out = render(prApprovalPanelView(pausedRunAwaitingApproval));
+      expect(out).toContain('pr-approval-panel');
+      expect(out).toContain('PR creation paused');
+      expect(out).toContain('Approve');
+      expect(out).toContain('Reject');
+    });
+
+    it('does not render when pr_approved is true', () => {
+      const run = {
+        ...pausedRunAwaitingApproval,
+        milestones: { pr_approved: true },
+      };
+      const out = render(prApprovalPanelView(run));
+      expect(out).not.toContain('pr-approval-panel');
+    });
+
+    it('does not render when pr_approved is undefined', () => {
+      const run = {
+        ...pausedRunAwaitingApproval,
+        milestones: {},
+      };
+      const out = render(prApprovalPanelView(run));
+      expect(out).not.toContain('pr-approval-panel');
+    });
+
+    it('does not render when milestones is absent', () => {
+      const run = {
+        id: 'run-1',
+        pipeline_status: 'paused',
+        stages: {},
+      };
+      const out = render(prApprovalPanelView(run));
+      expect(out).not.toContain('pr-approval-panel');
+    });
+
+    it('does not render when pipeline_status is not paused', () => {
+      const run = {
+        ...pausedRunAwaitingApproval,
+        pipeline_status: 'running',
+      };
+      const out = render(prApprovalPanelView(run));
+      expect(out).not.toContain('pr-approval-panel');
+    });
+
+    it('does not render for terminal pipeline_status (completed)', () => {
+      const run = {
+        ...pausedRunAwaitingApproval,
+        pipeline_status: 'completed',
+      };
+      const out = render(prApprovalPanelView(run));
+      expect(out).not.toContain('pr-approval-panel');
+    });
+
+    it('does not render for terminal pipeline_status (failed)', () => {
+      const run = {
+        ...pausedRunAwaitingApproval,
+        pipeline_status: 'failed',
+      };
+      const out = render(prApprovalPanelView(run));
+      expect(out).not.toContain('pr-approval-panel');
+    });
+
+    it('does not render when run is null', () => {
+      const out = render(prApprovalPanelView(null));
+      expect(out).not.toContain('pr-approval-panel');
+    });
+  });
+
+  describe('approve button', () => {
+    it('renders success variant approve button', () => {
+      const out = render(prApprovalPanelView(pausedRunAwaitingApproval));
+      expect(out).toContain('variant="success"');
+      expect(out).toContain('Approve');
+      expect(out).toContain('create PR');
+    });
+
+    it('renders danger outline reject button', () => {
+      const out = render(prApprovalPanelView(pausedRunAwaitingApproval));
+      expect(out).toContain('variant="danger"');
+      expect(out).toContain('outline');
+      expect(out).toContain('Reject');
+    });
+  });
+
+  describe('approve POST handler', () => {
+    it('calls onApprove with run id when approve button clicked', () => {
+      const onApprove = vi.fn();
+      const result = prApprovalPanelView(pausedRunAwaitingApproval, {
+        onApprove,
+      });
+      const out = render(result);
+      expect(out).toContain('pr-approve-btn');
+    });
+
+    it('calls onReject with run id when reject button clicked', () => {
+      const onReject = vi.fn();
+      const result = prApprovalPanelView(pausedRunAwaitingApproval, {
+        onReject,
+      });
+      const out = render(result);
+      expect(out).toContain('pr-reject-btn');
+    });
   });
 });

--- a/worca-ui/app/views/settings-approval-gates.test.js
+++ b/worca-ui/app/views/settings-approval-gates.test.js
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readPipelineFromDom } from './settings.js';
+
+describe('Approval Gates section', () => {
+  let origDocument;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    globalThis.document = {
+      querySelectorAll: () => [],
+      getElementById: () => null,
+    };
+  });
+
+  afterEach(() => {
+    globalThis.document = origDocument;
+  });
+
+  describe('readPipelineFromDom — milestones', () => {
+    it('emits plan_approval from DOM switch', () => {
+      const elements = {
+        'milestone-plan-approval': { checked: false },
+        'milestone-pr-approval': { checked: false },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.milestones).toBeDefined();
+      expect(result.milestones.plan_approval).toBe(false);
+    });
+
+    it('emits plan_approval true when checked', () => {
+      const elements = {
+        'milestone-plan-approval': { checked: true },
+        'milestone-pr-approval': { checked: false },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.milestones.plan_approval).toBe(true);
+    });
+
+    it('omits pr_approval when switch is off (default-false)', () => {
+      const elements = {
+        'milestone-plan-approval': { checked: true },
+        'milestone-pr-approval': { checked: false },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.milestones).not.toHaveProperty('pr_approval');
+    });
+
+    it('emits pr_approval true when user toggles it on', () => {
+      const elements = {
+        'milestone-plan-approval': { checked: true },
+        'milestone-pr-approval': { checked: true },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.milestones.pr_approval).toBe(true);
+    });
+
+    it('defaults plan_approval to true when element missing', () => {
+      globalThis.document.getElementById = () => null;
+
+      const result = readPipelineFromDom();
+      expect(result.milestones.plan_approval).toBe(true);
+    });
+  });
+});

--- a/worca-ui/app/views/settings-circuit-breaker.test.js
+++ b/worca-ui/app/views/settings-circuit-breaker.test.js
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readPipelineFromDom } from './settings.js';
+
+describe('Circuit Breaker section', () => {
+  let origDocument;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    globalThis.document = {
+      querySelectorAll: () => [],
+      getElementById: () => null,
+    };
+  });
+
+  afterEach(() => {
+    globalThis.document = origDocument;
+  });
+
+  describe('readPipelineFromDom — circuit_breaker', () => {
+    it('reads enabled switch and max_consecutive_failures', () => {
+      const elements = {
+        'cb-enabled': { checked: true },
+        'cb-max-failures': { value: '5' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.circuit_breaker).toBeDefined();
+      expect(result.circuit_breaker.enabled).toBe(true);
+      expect(result.circuit_breaker.max_consecutive_failures).toBe(5);
+    });
+
+    it('reads enabled false when unchecked', () => {
+      const elements = {
+        'cb-enabled': { checked: false },
+        'cb-max-failures': { value: '3' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.circuit_breaker.enabled).toBe(false);
+    });
+
+    it('defaults enabled to true and max_consecutive_failures to 3 when elements missing', () => {
+      globalThis.document.getElementById = () => null;
+
+      const result = readPipelineFromDom();
+      expect(result.circuit_breaker.enabled).toBe(true);
+      expect(result.circuit_breaker.max_consecutive_failures).toBe(3);
+    });
+
+    it('parses max_consecutive_failures as integer', () => {
+      const elements = {
+        'cb-enabled': { checked: true },
+        'cb-max-failures': { value: '7' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.circuit_breaker.max_consecutive_failures).toBe(7);
+    });
+
+    it('falls back to 3 for non-numeric max_consecutive_failures', () => {
+      const elements = {
+        'cb-enabled': { checked: true },
+        'cb-max-failures': { value: 'abc' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.circuit_breaker.max_consecutive_failures).toBe(3);
+    });
+  });
+});

--- a/worca-ui/app/views/settings-execution-parallelism.test.js
+++ b/worca-ui/app/views/settings-execution-parallelism.test.js
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readPipelineFromDom } from './settings.js';
+
+describe('Execution & Parallelism section', () => {
+  let origDocument;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    globalThis.document = {
+      querySelectorAll: () => [],
+      getElementById: () => null,
+    };
+  });
+
+  afterEach(() => {
+    globalThis.document = origDocument;
+  });
+
+  describe('readPipelineFromDom — parallel', () => {
+    it('reads worktree_base_dir and default_base_branch', () => {
+      const elements = {
+        'parallel-worktree-base-dir': { value: '/tmp/wt' },
+        'parallel-default-base-branch': { value: 'develop' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.parallel).toBeDefined();
+      expect(result.parallel.worktree_base_dir).toBe('/tmp/wt');
+      expect(result.parallel.default_base_branch).toBe('develop');
+    });
+
+    it('defaults worktree_base_dir to .worktrees and default_base_branch to main', () => {
+      globalThis.document.getElementById = () => null;
+
+      const result = readPipelineFromDom();
+      expect(result.parallel.worktree_base_dir).toBe('.worktrees');
+      expect(result.parallel.default_base_branch).toBe('main');
+    });
+
+    it('trims whitespace from input values', () => {
+      const elements = {
+        'parallel-worktree-base-dir': { value: '  .worktrees  ' },
+        'parallel-default-base-branch': { value: '  main  ' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.parallel.worktree_base_dir).toBe('.worktrees');
+      expect(result.parallel.default_base_branch).toBe('main');
+    });
+
+    it('falls back to defaults for empty strings', () => {
+      const elements = {
+        'parallel-worktree-base-dir': { value: '' },
+        'parallel-default-base-branch': { value: '' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readPipelineFromDom();
+      expect(result.parallel.worktree_base_dir).toBe('.worktrees');
+      expect(result.parallel.default_base_branch).toBe('main');
+    });
+  });
+});

--- a/worca-ui/app/views/settings-flat-dot-audit.test.js
+++ b/worca-ui/app/views/settings-flat-dot-audit.test.js
@@ -1,0 +1,53 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const APP_DIR = join(import.meta.dirname, '..');
+
+function collectJsFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectJsFiles(full));
+    } else if (
+      entry.name.endsWith('.js') &&
+      !entry.name.endsWith('.test.js') &&
+      entry.name !== 'main.bundle.js'
+    ) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const FLAT_DOT_PATTERNS = [
+  /settings\[['"]worca\./,
+  /preferences\[['"]worca\./,
+  /state\.settings\[['"]worca\./,
+];
+
+describe('flat-dot settings audit', () => {
+  const files = collectJsFiles(APP_DIR);
+
+  it('finds app source files to audit', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('no source files use flat-dot settings keys', () => {
+    const violations = [];
+    for (const file of files) {
+      const content = readFileSync(file, 'utf8');
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        for (const pat of FLAT_DOT_PATTERNS) {
+          if (pat.test(lines[i])) {
+            const rel = file.replace(`${APP_DIR}/`, '');
+            violations.push(`${rel}:${i + 1}: ${lines[i].trim()}`);
+          }
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/worca-ui/app/views/settings-form-roundtrip.test.js
+++ b/worca-ui/app/views/settings-form-roundtrip.test.js
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadSettings, readPipelineFromDom } from './settings.js';
+
+describe('Form round-trip: pr_approval stays absent on no-op Save', () => {
+  let origDocument;
+  let origFetch;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    origFetch = globalThis.fetch;
+    globalThis.document = {
+      querySelectorAll: () => [],
+      getElementById: () => null,
+    };
+  });
+
+  afterEach(() => {
+    globalThis.document = origDocument;
+    globalThis.fetch = origFetch;
+  });
+
+  it('load clean project -> readPipelineFromDom -> no pr_approval key', async () => {
+    const serverResponse = {
+      worca: {
+        milestones: {
+          plan_approval: true,
+        },
+      },
+    };
+
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes('/api/subagents')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, subagents: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(serverResponse),
+      });
+    });
+
+    await loadSettings('test-project');
+
+    const elements = {
+      'milestone-plan-approval': { checked: true },
+      'milestone-pr-approval': { checked: false },
+      'cb-enabled': { checked: true },
+      'cb-max-failures': { value: '3' },
+      'parallel-worktree-base-dir': { value: '.worktrees' },
+      'parallel-default-base-branch': { value: 'main' },
+    };
+    globalThis.document.getElementById = (id) => elements[id] || null;
+
+    const result = readPipelineFromDom();
+
+    expect(result.milestones.plan_approval).toBe(true);
+    expect(result.milestones).not.toHaveProperty('pr_approval');
+  });
+});

--- a/worca-ui/app/views/settings-migration-banner.test.js
+++ b/worca-ui/app/views/settings-migration-banner.test.js
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _getMigrationNeeded,
+  countMigrated,
+  detectMigrationNeeded,
+  loadSettings,
+} from './settings.js';
+
+describe('Migration banner (§11c)', () => {
+  describe('detectMigrationNeeded', () => {
+    it('returns false for clean project settings', () => {
+      const worca = {
+        parallel: {
+          worktree_base_dir: '.worktrees',
+          default_base_branch: 'main',
+        },
+        circuit_breaker: { enabled: true, max_consecutive_failures: 3 },
+        milestones: { plan_approval: true },
+      };
+      expect(detectMigrationNeeded(worca)).toBe(false);
+    });
+
+    it('returns false for null/undefined worca', () => {
+      expect(detectMigrationNeeded(null)).toBe(false);
+      expect(detectMigrationNeeded(undefined)).toBe(false);
+    });
+
+    it('detects parallel.cleanup_policy as misplaced', () => {
+      const worca = { parallel: { cleanup_policy: 'on-success' } };
+      expect(detectMigrationNeeded(worca)).toBe(true);
+    });
+
+    it('detects parallel.max_concurrent_pipelines as misplaced', () => {
+      const worca = { parallel: { max_concurrent_pipelines: 3 } };
+      expect(detectMigrationNeeded(worca)).toBe(true);
+    });
+
+    it('detects ui.worktree_disk_warning_bytes as misplaced', () => {
+      const worca = { ui: { worktree_disk_warning_bytes: 2_000_000_000 } };
+      expect(detectMigrationNeeded(worca)).toBe(true);
+    });
+
+    it('detects circuit_breaker.classifier_model as misplaced', () => {
+      const worca = {
+        circuit_breaker: { enabled: true, classifier_model: 'opus' },
+      };
+      expect(detectMigrationNeeded(worca)).toBe(true);
+    });
+
+    it('detects milestones.pr_approval === true', () => {
+      const worca = { milestones: { plan_approval: true, pr_approval: true } };
+      expect(detectMigrationNeeded(worca)).toBe(true);
+    });
+
+    it('ignores milestones.pr_approval === false', () => {
+      const worca = { milestones: { plan_approval: true, pr_approval: false } };
+      expect(detectMigrationNeeded(worca)).toBe(false);
+    });
+
+    it('detects milestones.deploy_approval === true', () => {
+      const worca = { milestones: { deploy_approval: true } };
+      expect(detectMigrationNeeded(worca)).toBe(true);
+    });
+
+    it('ignores milestones.deploy_approval === false', () => {
+      const worca = { milestones: { deploy_approval: false } };
+      expect(detectMigrationNeeded(worca)).toBe(false);
+    });
+
+    it('detects multiple misplaced keys at once', () => {
+      const worca = {
+        parallel: { cleanup_policy: 'never', max_concurrent_pipelines: 5 },
+        milestones: { pr_approval: true },
+      };
+      expect(detectMigrationNeeded(worca)).toBe(true);
+    });
+  });
+
+  describe('countMigrated', () => {
+    it('returns 0 for empty autoMigrated', () => {
+      expect(
+        countMigrated({ globalExtracted: {}, removedMilestones: [] }),
+      ).toBe(0);
+    });
+
+    it('returns 0 for null/undefined', () => {
+      expect(countMigrated(null)).toBe(0);
+      expect(countMigrated(undefined)).toBe(0);
+    });
+
+    it('counts global extracted keys across sections', () => {
+      const autoMigrated = {
+        globalExtracted: {
+          parallel: {
+            cleanup_policy: 'on-success',
+            max_concurrent_pipelines: 3,
+          },
+          circuit_breaker: { classifier_model: 'opus' },
+        },
+        removedMilestones: [],
+      };
+      expect(countMigrated(autoMigrated)).toBe(3);
+    });
+
+    it('counts removed milestones', () => {
+      const autoMigrated = {
+        globalExtracted: {},
+        removedMilestones: ['pr_approval', 'deploy_approval'],
+      };
+      expect(countMigrated(autoMigrated)).toBe(2);
+    });
+
+    it('sums global keys and removed milestones', () => {
+      const autoMigrated = {
+        globalExtracted: {
+          parallel: { cleanup_policy: 'on-success' },
+        },
+        removedMilestones: ['pr_approval'],
+      };
+      expect(countMigrated(autoMigrated)).toBe(2);
+    });
+  });
+
+  describe('loadSettings sets _migrationNeeded', () => {
+    let origFetch;
+    let origDocument;
+
+    beforeEach(() => {
+      origFetch = globalThis.fetch;
+      origDocument = globalThis.document;
+      globalThis.document = {
+        querySelectorAll: () => [],
+        getElementById: () => null,
+      };
+    });
+
+    afterEach(() => {
+      globalThis.fetch = origFetch;
+      globalThis.document = origDocument;
+    });
+
+    it('sets migration needed when project has misplaced global keys', async () => {
+      globalThis.fetch = vi.fn().mockImplementation((url) => {
+        if (url.includes('/api/subagents')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ ok: true, subagents: [] }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              worca: {
+                parallel: {
+                  cleanup_policy: 'on-success',
+                  worktree_base_dir: '.worktrees',
+                },
+              },
+            }),
+        });
+      });
+
+      await loadSettings('test-project');
+      expect(_getMigrationNeeded()).toBe(true);
+    });
+
+    it('sets migration needed when pr_approval is true', async () => {
+      globalThis.fetch = vi.fn().mockImplementation((url) => {
+        if (url.includes('/api/subagents')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ ok: true, subagents: [] }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              worca: {
+                milestones: { plan_approval: true, pr_approval: true },
+              },
+            }),
+        });
+      });
+
+      await loadSettings('test-project');
+      expect(_getMigrationNeeded()).toBe(true);
+    });
+
+    it('clears migration flag for clean project', async () => {
+      globalThis.fetch = vi.fn().mockImplementation((url) => {
+        if (url.includes('/api/subagents')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ ok: true, subagents: [] }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              worca: {
+                milestones: { plan_approval: true },
+              },
+            }),
+        });
+      });
+
+      await loadSettings('test-project');
+      expect(_getMigrationNeeded()).toBe(false);
+    });
+  });
+});

--- a/worca-ui/app/views/settings-preferences-pipeline.test.js
+++ b/worca-ui/app/views/settings-preferences-pipeline.test.js
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readGlobalsFromDom } from './settings.js';
+
+describe('Global Preferences — Pipeline Execution', () => {
+  let origDocument;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    globalThis.document = {
+      querySelectorAll: () => [],
+      getElementById: () => null,
+    };
+  });
+
+  afterEach(() => {
+    globalThis.document = origDocument;
+  });
+
+  describe('readGlobalsFromDom — pipeline fields', () => {
+    it('reads classifier_model from select', () => {
+      const elements = {
+        'global-disk-threshold-value': { value: '2' },
+        'global-disk-threshold-unit': { value: 'GB' },
+        'global-cleanup-policy': { value: 'never' },
+        'global-classifier-model': { value: 'sonnet' },
+        'global-max-concurrent': { value: '10' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.circuit_breaker.classifier_model).toBe('sonnet');
+    });
+
+    it('reads max_concurrent_pipelines from number input', () => {
+      const elements = {
+        'global-disk-threshold-value': { value: '2' },
+        'global-disk-threshold-unit': { value: 'GB' },
+        'global-cleanup-policy': { value: 'never' },
+        'global-classifier-model': { value: 'haiku' },
+        'global-max-concurrent': { value: '5' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.parallel.max_concurrent_pipelines).toBe(5);
+    });
+
+    it('defaults classifier_model to haiku when element missing', () => {
+      globalThis.document.getElementById = () => null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.circuit_breaker.classifier_model).toBe('haiku');
+    });
+
+    it('defaults max_concurrent_pipelines to 10 when element missing', () => {
+      globalThis.document.getElementById = () => null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.parallel.max_concurrent_pipelines).toBe(10);
+    });
+
+    it('parses max_concurrent_pipelines as integer', () => {
+      const elements = {
+        'global-disk-threshold-value': { value: '2' },
+        'global-disk-threshold-unit': { value: 'GB' },
+        'global-cleanup-policy': { value: 'never' },
+        'global-classifier-model': { value: 'haiku' },
+        'global-max-concurrent': { value: '7' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.parallel.max_concurrent_pipelines).toBe(7);
+    });
+
+    it('falls back to 10 for non-numeric max_concurrent_pipelines', () => {
+      const elements = {
+        'global-disk-threshold-value': { value: '2' },
+        'global-disk-threshold-unit': { value: 'GB' },
+        'global-cleanup-policy': { value: 'never' },
+        'global-classifier-model': { value: 'haiku' },
+        'global-max-concurrent': { value: 'abc' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.parallel.max_concurrent_pipelines).toBe(10);
+    });
+
+    it('returns full payload shape matching PUT /api/preferences', () => {
+      const elements = {
+        'global-disk-threshold-value': { value: '3' },
+        'global-disk-threshold-unit': { value: 'GB' },
+        'global-cleanup-policy': { value: 'on-success' },
+        'global-classifier-model': { value: 'opus' },
+        'global-max-concurrent': { value: '4' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readGlobalsFromDom();
+      expect(result).toEqual({
+        worca: {
+          ui: { worktree_disk_warning_bytes: 3_000_000_000 },
+          parallel: {
+            cleanup_policy: 'on-success',
+            max_concurrent_pipelines: 4,
+          },
+          circuit_breaker: { classifier_model: 'opus' },
+        },
+      });
+    });
+  });
+});

--- a/worca-ui/app/views/settings-preferences-worktrees.test.js
+++ b/worca-ui/app/views/settings-preferences-worktrees.test.js
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { formatDiskThreshold, readGlobalsFromDom } from './settings.js';
+
+describe('Global Preferences — Worktrees', () => {
+  let origDocument;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    globalThis.document = {
+      querySelectorAll: () => [],
+      getElementById: () => null,
+    };
+  });
+
+  afterEach(() => {
+    globalThis.document = origDocument;
+  });
+
+  describe('formatDiskThreshold', () => {
+    it('formats bytes as GB when >= 1 GB', () => {
+      expect(formatDiskThreshold(2_000_000_000)).toEqual({
+        value: 2,
+        unit: 'GB',
+      });
+    });
+
+    it('formats bytes as MB when < 1 GB', () => {
+      expect(formatDiskThreshold(500_000_000)).toEqual({
+        value: 500,
+        unit: 'MB',
+      });
+    });
+
+    it('handles fractional GB values', () => {
+      expect(formatDiskThreshold(1_500_000_000)).toEqual({
+        value: 1.5,
+        unit: 'GB',
+      });
+    });
+
+    it('returns 2 GB for default 2 billion bytes', () => {
+      expect(formatDiskThreshold(2_000_000_000)).toEqual({
+        value: 2,
+        unit: 'GB',
+      });
+    });
+  });
+
+  describe('readGlobalsFromDom — worktree fields', () => {
+    it('reads disk threshold in GB and converts to bytes', () => {
+      const elements = {
+        'global-disk-threshold-value': { value: '5' },
+        'global-disk-threshold-unit': { value: 'GB' },
+        'global-cleanup-policy': { value: 'never' },
+        'global-classifier-model': { value: 'haiku' },
+        'global-max-concurrent': { value: '10' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.ui.worktree_disk_warning_bytes).toBe(5_000_000_000);
+    });
+
+    it('reads disk threshold in MB and converts to bytes', () => {
+      const elements = {
+        'global-disk-threshold-value': { value: '500' },
+        'global-disk-threshold-unit': { value: 'MB' },
+        'global-cleanup-policy': { value: 'never' },
+        'global-classifier-model': { value: 'haiku' },
+        'global-max-concurrent': { value: '10' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.ui.worktree_disk_warning_bytes).toBe(500_000_000);
+    });
+
+    it('reads cleanup_policy from select', () => {
+      const elements = {
+        'global-disk-threshold-value': { value: '2' },
+        'global-disk-threshold-unit': { value: 'GB' },
+        'global-cleanup-policy': { value: 'on-success' },
+        'global-classifier-model': { value: 'haiku' },
+        'global-max-concurrent': { value: '10' },
+      };
+      globalThis.document.getElementById = (id) => elements[id] || null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.parallel.cleanup_policy).toBe('on-success');
+    });
+
+    it('defaults cleanup_policy to never when element missing', () => {
+      globalThis.document.getElementById = () => null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.parallel.cleanup_policy).toBe('never');
+    });
+
+    it('defaults disk threshold to 2 GB when elements missing', () => {
+      globalThis.document.getElementById = () => null;
+
+      const result = readGlobalsFromDom();
+      expect(result.worca.ui.worktree_disk_warning_bytes).toBe(2_000_000_000);
+    });
+  });
+});

--- a/worca-ui/app/views/settings.js
+++ b/worca-ui/app/views/settings.js
@@ -57,6 +57,42 @@ export const AGENT_NAMES = [
 ];
 const MODEL_OPTIONS = ['opus', 'sonnet', 'haiku'];
 
+const GLOBAL_ONLY_KEY_PATHS = [
+  ['parallel', 'cleanup_policy'],
+  ['parallel', 'max_concurrent_pipelines'],
+  ['ui', 'worktree_disk_warning_bytes'],
+  ['circuit_breaker', 'classifier_model'],
+];
+const INERT_MILESTONE_KEYS_CLIENT = ['pr_approval', 'deploy_approval'];
+
+export function detectMigrationNeeded(worca) {
+  if (!worca) return false;
+  for (const [section, key] of GLOBAL_ONLY_KEY_PATHS) {
+    if (worca[section]?.[key] !== undefined) return true;
+  }
+  const m = worca.milestones;
+  if (m) {
+    for (const key of INERT_MILESTONE_KEYS_CLIENT) {
+      if (m[key] === true) return true;
+    }
+  }
+  return false;
+}
+
+export function countMigrated(autoMigrated) {
+  if (!autoMigrated) return 0;
+  let count = 0;
+  if (autoMigrated.globalExtracted) {
+    for (const section of Object.values(autoMigrated.globalExtracted)) {
+      count += Object.keys(section).length;
+    }
+  }
+  if (autoMigrated.removedMilestones) {
+    count += autoMigrated.removedMilestones.length;
+  }
+  return count;
+}
+
 const DEFAULT_STAGES = {
   plan: { agent: 'planner', enabled: true },
   plan_review: { agent: 'plan_reviewer', enabled: false },
@@ -128,6 +164,8 @@ let settingsData = null;
 let saveStatus = null; // null | 'saving' | 'success' | 'error'
 let saveMessage = '';
 let _settingsProjectId = null; // track which project settings are loaded for
+let _migrationNeeded = false;
+let _migrationDismissed = false;
 
 // --- Dispatch tag state ---
 let _dispatchTagState = {}; // agent -> { tags, input, showSuggestions, activeIndex }
@@ -233,6 +271,32 @@ export async function loadSettings(projectId) {
         _legacy_dispatch: hasLegacy,
       };
     }
+    // Project defaults from keys.json (§10a). Keys in NORMALIZE_SKIP_KEYS
+    // (pr_approval) are omitted so a load→save round-trip on a clean project
+    // doesn't inject default-false values back into the file.
+    if (!settingsData.worca.milestones) {
+      settingsData.worca.milestones = { plan_approval: true };
+    } else {
+      settingsData.worca.milestones.plan_approval ??= true;
+    }
+    if (!settingsData.worca.circuit_breaker) {
+      settingsData.worca.circuit_breaker = {
+        enabled: true,
+        max_consecutive_failures: 3,
+      };
+    } else {
+      settingsData.worca.circuit_breaker.enabled ??= true;
+      settingsData.worca.circuit_breaker.max_consecutive_failures ??= 3;
+    }
+    if (!settingsData.worca.parallel) {
+      settingsData.worca.parallel = {
+        worktree_base_dir: '.worktrees',
+        default_base_branch: 'main',
+      };
+    } else {
+      settingsData.worca.parallel.worktree_base_dir ??= '.worktrees';
+      settingsData.worca.parallel.default_base_branch ??= 'main';
+    }
     if (!settingsData.worca.events) {
       settingsData.worca.events = {
         enabled: true,
@@ -247,6 +311,8 @@ export async function loadSettings(projectId) {
     if (!settingsData.worca.webhooks) {
       settingsData.worca.webhooks = [];
     }
+    _migrationNeeded = detectMigrationNeeded(settingsData.worca);
+    _migrationDismissed = false;
     _resetDispatchTagState();
     // Fetch the discovered subagents list for the dispatch editor. Best-effort:
     // on failure we keep _discoveredKnownTypes = null and the editor uses the
@@ -282,8 +348,16 @@ async function saveSettings(data, rerender, projectId) {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const result = await res.json();
     settingsData = { worca: result.worca, permissions: result.permissions };
+    const n = countMigrated(result.autoMigrated);
+    if (n > 0) {
+      _migrationNeeded = false;
+      _migrationDismissed = true;
+    }
     saveStatus = 'success';
-    saveMessage = 'Settings saved successfully';
+    saveMessage =
+      n > 0
+        ? `${n} project setting${n === 1 ? ' was' : 's were'} moved to global Preferences`
+        : 'Settings saved successfully';
   } catch (err) {
     saveStatus = 'error';
     saveMessage = `Failed to save: ${err.message}`;
@@ -362,7 +436,7 @@ function readAgentsFromDom() {
   return agents;
 }
 
-function readPipelineFromDom() {
+export function readPipelineFromDom() {
   const loops = {};
   for (const key of ['implement_test', 'pr_changes', 'restart_planning']) {
     const el = document.getElementById(`loop-${key}`);
@@ -376,7 +450,40 @@ function readPipelineFromDom() {
     msize: parseInt(msizeEl?.value, 10) || 1,
     mloops: parseInt(mloopsEl?.value, 10) || 1,
   };
-  return { loops, plan_path_template, defaults };
+
+  const milestones = {
+    plan_approval:
+      document.getElementById('milestone-plan-approval')?.checked ?? true,
+  };
+  const prApprovalToggled =
+    document.getElementById('milestone-pr-approval')?.checked === true;
+  if (prApprovalToggled) {
+    milestones.pr_approval = true;
+  }
+
+  const circuit_breaker = {
+    enabled: document.getElementById('cb-enabled')?.checked ?? true,
+    max_consecutive_failures:
+      parseInt(document.getElementById('cb-max-failures')?.value, 10) || 3,
+  };
+
+  const parallel = {
+    worktree_base_dir:
+      document.getElementById('parallel-worktree-base-dir')?.value?.trim() ||
+      '.worktrees',
+    default_base_branch:
+      document.getElementById('parallel-default-base-branch')?.value?.trim() ||
+      'main',
+  };
+
+  return {
+    loops,
+    plan_path_template,
+    defaults,
+    milestones,
+    circuit_breaker,
+    parallel,
+  };
 }
 
 function readStagesFromDom() {
@@ -425,6 +532,84 @@ function readGovernanceFromDom() {
   }
 
   return { guards, test_gate_strikes, subagent_dispatch };
+}
+
+export function formatDiskThreshold(bytes) {
+  if (bytes >= 1_000_000_000) {
+    return { value: bytes / 1_000_000_000, unit: 'GB' };
+  }
+  return { value: bytes / 1_000_000, unit: 'MB' };
+}
+
+function readDiskThresholdFromDom() {
+  const valueEl = document.getElementById('global-disk-threshold-value');
+  const unitEl = document.getElementById('global-disk-threshold-unit');
+  const value = parseFloat(valueEl?.value) || 2;
+  const unit = unitEl?.value || 'GB';
+  const multiplier = unit === 'GB' ? 1_000_000_000 : 1_000_000;
+  return value * multiplier;
+}
+
+export function readGlobalsFromDom() {
+  const diskBytes = readDiskThresholdFromDom();
+  const cleanupEl = document.getElementById('global-cleanup-policy');
+  const modelEl = document.getElementById('global-classifier-model');
+  const maxConcurrentEl = document.getElementById('global-max-concurrent');
+
+  return {
+    worca: {
+      ui: {
+        worktree_disk_warning_bytes: diskBytes,
+      },
+      parallel: {
+        cleanup_policy: cleanupEl?.value || 'never',
+        max_concurrent_pipelines: parseInt(maxConcurrentEl?.value, 10) || 10,
+      },
+      circuit_breaker: {
+        classifier_model: modelEl?.value || 'haiku',
+      },
+    },
+  };
+}
+
+async function savePreferences(data, rerender, onStoreUpdate) {
+  saveStatus = 'saving';
+  saveMessage = '';
+  rerender();
+  try {
+    const res = await fetch('/api/preferences', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const result = await res.json();
+    if (result.ok && onStoreUpdate) {
+      const p = result.preferences?.worca ?? {};
+      onStoreUpdate({
+        worktreeDiskWarningBytes:
+          p.ui?.worktree_disk_warning_bytes ?? 2_000_000_000,
+        classifierModel: p.circuit_breaker?.classifier_model ?? 'haiku',
+        cleanupPolicy: p.parallel?.cleanup_policy ?? 'never',
+        maxConcurrentPipelines: p.parallel?.max_concurrent_pipelines ?? 10,
+      });
+    }
+    saveStatus = 'success';
+    saveMessage = 'Preferences saved successfully';
+  } catch (err) {
+    saveStatus = 'error';
+    saveMessage = `Failed to save: ${err.message}`;
+  }
+  rerender();
+  if (saveStatus === 'success') {
+    setTimeout(() => {
+      if (saveStatus === 'success') {
+        saveStatus = null;
+        saveMessage = '';
+        rerender();
+      }
+    }, 3000);
+  }
 }
 
 export function readPermissionsFromDom() {
@@ -514,6 +699,9 @@ function agentsTab(worca, rerender) {
 function pipelineTab(worca, rerender) {
   const loops = worca.loops || {};
   const stages = worca.stages || DEFAULT_STAGES;
+  const milestones = worca.milestones || {};
+  const cb = worca.circuit_breaker || {};
+  const parallel = worca.parallel || {};
 
   const preflight = stages.preflight || {
     enabled: true,
@@ -621,13 +809,69 @@ function pipelineTab(worca, rerender) {
         </div>
       </div>
 
+      <h3 class="settings-section-title">Approval Gates</h3>
+      <div class="settings-switches">
+        <div class="settings-switch-row">
+          <sl-switch id="milestone-plan-approval" ?checked=${milestones.plan_approval !== false} size="small">Plan approval required</sl-switch>
+          <span class="settings-switch-desc">Pipeline pauses after Plan stage; pause-control event lets you approve or reject before Coordinate.</span>
+        </div>
+        <div class="settings-switch-row">
+          <sl-switch id="milestone-pr-approval" ?checked=${milestones.pr_approval === true} size="small">PR approval required</sl-switch>
+          <span class="settings-switch-desc">When enabled, pipeline pauses before guardian creates the PR; approve/reject from the run detail view. Off by default to avoid hanging unattended runs.</span>
+        </div>
+      </div>
+
+      <h3 class="settings-section-title">Circuit Breaker</h3>
+      <div class="settings-grid">
+        <div class="settings-field">
+          <div class="settings-switch-row">
+            <sl-switch id="cb-enabled" ?checked=${cb.enabled !== false} size="small">Enabled</sl-switch>
+            <span class="settings-switch-desc">Halt the pipeline after consecutive errors of the same kind</span>
+          </div>
+        </div>
+        <div class="settings-field">
+          <label class="settings-label">Max Consecutive Failures</label>
+          <sl-input id="cb-max-failures" type="number" value="${cb.max_consecutive_failures ?? 3}" size="small" min="1" max="10"></sl-input>
+          <span class="settings-field-hint">Stop after N consecutive errors of the same kind.</span>
+        </div>
+      </div>
+
+      <h3 class="settings-section-title">Execution & Parallelism</h3>
+      <div class="settings-grid">
+        <div class="settings-field">
+          <label class="settings-label">Worktree Base Directory</label>
+          <sl-input id="parallel-worktree-base-dir" value="${parallel.worktree_base_dir || '.worktrees'}" size="small" placeholder=".worktrees"></sl-input>
+          <span class="settings-field-hint">Relative paths resolve from project root. Absolute and ~/-prefixed paths supported.</span>
+        </div>
+        <div class="settings-field">
+          <label class="settings-label">Default PR Base Branch</label>
+          <sl-input id="parallel-default-base-branch" value="${parallel.default_base_branch || 'main'}" size="small" placeholder="main"></sl-input>
+          <span class="settings-field-hint">Used as the default when launching a new worktree-based run if --branch is not specified.</span>
+        </div>
+      </div>
+
       <div class="settings-tab-actions">
         <sl-button variant="primary" size="small" @click=${() => {
-          const { loops, plan_path_template, defaults } = readPipelineFromDom();
+          const {
+            loops,
+            plan_path_template,
+            defaults,
+            milestones,
+            circuit_breaker,
+            parallel,
+          } = readPipelineFromDom();
           const stages = readStagesFromDom();
           stages.preflight = readPreflightFromDom();
           const payload = {
-            worca: { loops, stages, plan_path_template, defaults },
+            worca: {
+              loops,
+              stages,
+              plan_path_template,
+              defaults,
+              milestones,
+              circuit_breaker,
+              parallel,
+            },
           };
           saveSettings(payload, rerender);
         }}>
@@ -1076,10 +1320,17 @@ function versionsSection(rerender) {
 
 function preferencesTab(
   preferences,
-  { onThemeToggle, onSaveSourceRepo, rerender },
+  { onThemeToggle, onSaveSourceRepo, onSaveGlobals, rerender, globals },
 ) {
   const theme = preferences?.theme || 'light';
   const sourceRepo = preferences?.source_repo || '';
+  const g = globals || {};
+  const diskThreshold = formatDiskThreshold(
+    g.worktreeDiskWarningBytes ?? 2_000_000_000,
+  );
+  const cleanupPolicy = g.cleanupPolicy || 'never';
+  const classifierModel = g.classifierModel || 'haiku';
+  const maxConcurrent = g.maxConcurrentPipelines ?? 10;
 
   return html`
     <div class="settings-tab-content">
@@ -1107,6 +1358,56 @@ function preferencesTab(
         }}>
           ${unsafeHTML(iconSvg(Save, 14))}
           Save
+        </sl-button>
+      </div>
+
+      <h3 class="settings-section-title">Worktrees</h3>
+      <div class="settings-grid">
+        <div class="settings-field">
+          <label class="settings-label">Disk Warning Threshold</label>
+          <div style="display: flex; gap: 8px; align-items: center;">
+            <sl-input id="global-disk-threshold-value" type="number" value="${diskThreshold.value}" size="small" min="0.5" max="50" step="0.5" style="flex: 1;"></sl-input>
+            <sl-select id="global-disk-threshold-unit" .value="${diskThreshold.unit}" size="small" style="width: 90px;" hoist>
+              <sl-option value="MB">MB</sl-option>
+              <sl-option value="GB">GB</sl-option>
+            </sl-select>
+          </div>
+          <span class="settings-field-hint">Show a warning badge when worktree disk usage exceeds this value (0.5–50 GB)</span>
+        </div>
+        <div class="settings-field">
+          <label class="settings-label">Cleanup Policy</label>
+          <sl-select id="global-cleanup-policy" .value="${cleanupPolicy}" size="small" hoist>
+            <sl-option value="never">Never</sl-option>
+            <sl-option value="on-success">On Success</sl-option>
+            <sl-option value="manual-only">Manual Only</sl-option>
+          </sl-select>
+          <span class="settings-field-hint">When to automatically remove completed worktrees</span>
+        </div>
+      </div>
+
+      <h3 class="settings-section-title">Pipeline Execution</h3>
+      <div class="settings-grid">
+        <div class="settings-field">
+          <label class="settings-label">Error Classifier Model</label>
+          <sl-select id="global-classifier-model" .value="${classifierModel}" size="small" hoist>
+            ${MODEL_OPTIONS.map((m) => html`<sl-option value="${m}">${m}</sl-option>`)}
+          </sl-select>
+          <span class="settings-field-hint">Model used by the circuit breaker to classify errors</span>
+        </div>
+        <div class="settings-field">
+          <label class="settings-label">Max Concurrent Pipelines</label>
+          <sl-input id="global-max-concurrent" type="number" value="${maxConcurrent}" size="small" min="1" max="20"></sl-input>
+          <span class="settings-field-hint">Maximum number of pipelines that can run simultaneously (1–20)</span>
+        </div>
+      </div>
+
+      <div class="settings-tab-actions">
+        <sl-button variant="primary" size="small" @click=${() => {
+          const payload = readGlobalsFromDom();
+          savePreferences(payload, rerender, onSaveGlobals);
+        }}>
+          ${unsafeHTML(iconSvg(Save, 14))}
+          Save Global Settings
         </sl-button>
       </div>
 
@@ -1610,6 +1911,62 @@ function webhooksTab(worca, rerender) {
   `;
 }
 
+// --- Migration banner ---
+
+async function triggerMigration(rerender) {
+  saveStatus = 'saving';
+  saveMessage = '';
+  rerender();
+  try {
+    const res = await fetch(settingsUrl(_settingsProjectId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ worca: {} }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const result = await res.json();
+    settingsData = { worca: result.worca, permissions: result.permissions };
+    _migrationNeeded = false;
+    _migrationDismissed = true;
+    const n = countMigrated(result.autoMigrated);
+    saveStatus = 'success';
+    saveMessage =
+      n > 0
+        ? `${n} project setting${n === 1 ? ' was' : 's were'} moved to global Preferences`
+        : 'Settings saved successfully';
+  } catch (err) {
+    saveStatus = 'error';
+    saveMessage = `Migration failed: ${err.message}`;
+  }
+  rerender();
+  if (saveStatus === 'success') {
+    setTimeout(() => {
+      if (saveStatus === 'success') {
+        saveStatus = null;
+        saveMessage = '';
+        rerender();
+      }
+    }, 3000);
+  }
+}
+
+function migrationBanner(rerender) {
+  if (!_migrationNeeded || _migrationDismissed) return nothing;
+  return html`
+    <sl-alert variant="warning" open class="migration-banner">
+      <strong>Legacy project settings detected.</strong>
+      Some settings in this project belong in global Preferences.
+      <sl-button
+        size="small"
+        variant="warning"
+        outline
+        style="margin-left: 8px;"
+        @click=${() => triggerMigration(rerender)}
+      >Migrate now</sl-button>
+    </sl-alert>
+  `;
+}
+
 // --- Feedback alert ---
 
 function feedbackAlert(rerender) {
@@ -1754,6 +2111,8 @@ export function settingsView(
     onSaveSourceRepo,
     onSaveNotifications,
     onRequestPermission,
+    globals,
+    onSaveGlobals,
     projects,
     onProjectAdd,
     onProjectRemove,
@@ -1798,7 +2157,7 @@ export function settingsView(
 
         <sl-tab-panel name="projects">${projectsTab(projects, { onProjectAdd, onProjectRemove, onProjectsRefresh, rerender })}</sl-tab-panel>
         <sl-tab-panel name="notifications">${notificationsTab(preferences, { rerender, onSaveNotifications, onRequestPermission })}</sl-tab-panel>
-        <sl-tab-panel name="preferences">${preferencesTab(preferences, { onThemeToggle, onSaveSourceRepo, rerender })}</sl-tab-panel>
+        <sl-tab-panel name="preferences">${preferencesTab(preferences, { onThemeToggle, onSaveSourceRepo, onSaveGlobals, rerender, globals })}</sl-tab-panel>
         <sl-tab-panel name="integrations">${integrationsTab(integrations || {}, { onStartEdit: onIgStartEdit, onCancelEdit: onIgCancelEdit, onFieldChange: onIgFieldChange, onEventToggle: onIgEventToggle, onSave: onIgSave, onRemove: onIgRemove, onDetect: onIgDetect, onToggleEnabled: onIgToggleEnabled })}</sl-tab-panel>
       </sl-tab-group>
     </div>
@@ -1828,6 +2187,7 @@ export function projectSettingsView(
 
   return html`
     ${feedbackAlert(rerender)}
+    ${migrationBanner(rerender)}
     ${confirmDialogTemplate()}
     <div class="settings-page">
       <sl-tab-group>
@@ -1865,3 +2225,6 @@ export function projectSettingsView(
 // Test-only exports
 export { preferencesTab as _preferencesTab };
 export { projectsTab as _projectsTab };
+export function _getMigrationNeeded() {
+  return _migrationNeeded;
+}

--- a/worca-ui/app/views/sidebar.js
+++ b/worca-ui/app/views/sidebar.js
@@ -72,14 +72,18 @@ export function sidebarView(
   connectionState,
   { onNavigate, onProjectChange, onAddProject },
 ) {
+  // Settings use nested shape only — read pre-resolved scalars from state, never flat-dot bracket keys.
   const {
     runs,
     preferences,
     projects,
     currentProjectId,
     worktrees = [],
-    settings = {},
+    worktreeDiskWarningBytes = 2_000_000_000,
+    totalRunning = 0,
+    maxConcurrentPipelines = 10,
   } = state;
+  const atCapacity = totalRunning >= maxConcurrentPipelines;
   const allRunList = Object.values(runs);
   // Filter to selected project for counters (sidebar dots use allRunList via projectStatus)
   const runList =
@@ -101,8 +105,7 @@ export function sidebarView(
   ).length;
 
   const worktreeCount = worktrees.length;
-  const diskWarningThreshold =
-    settings['worca.ui.worktree_disk_warning_bytes'] ?? 2_000_000_000;
+  const diskWarningThreshold = worktreeDiskWarningBytes;
   const totalWorktreeDisk = worktrees.reduce(
     (s, w) => s + (w.disk_bytes || 0),
     0,
@@ -172,6 +175,7 @@ export function sidebarView(
         <button
           type="button"
           class="sidebar-new-run-btn"
+          ?disabled=${atCapacity}
           @click=${() => onNavigate('new-run')}
         >
           ${unsafeHTML(iconSvg(Plus, 14))}
@@ -188,6 +192,7 @@ export function sidebarView(
             <span>Running</span>
           </span>
           ${activeCount > 0 ? html`<sl-badge variant="primary" pill>${activeCount}</sl-badge>` : ''}
+          ${totalRunning > 0 ? html`<sl-badge variant="${atCapacity ? 'warning' : 'neutral'}" pill class="running-cap-badge">${totalRunning}/${maxConcurrentPipelines}</sl-badge>` : ''}
         </div>
         <div class="sidebar-item ${route.section === 'history' ? 'active' : ''}"
              @click=${() => onNavigate('history')}>

--- a/worca-ui/app/views/sidebar.test.js
+++ b/worca-ui/app/views/sidebar.test.js
@@ -33,7 +33,7 @@ function makeState(overrides = {}) {
     beads: { issues: [], dbExists: false },
     webhookInbox: { events: [] },
     worktrees: [],
-    settings: {},
+    worktreeDiskWarningBytes: 2_000_000_000,
     ...overrides,
   };
 }
@@ -131,7 +131,7 @@ describe('sidebar - Worktrees badge disk-pressure threshold', () => {
       worktrees: [
         { run_id: 'r1', disk_bytes: 500_000_000, status: 'completed' },
       ],
-      settings: { 'worca.ui.worktree_disk_warning_bytes': 400_000_000 },
+      worktreeDiskWarningBytes: 400_000_000,
     });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),
@@ -146,13 +146,65 @@ describe('sidebar - Worktrees badge disk-pressure threshold', () => {
       worktrees: [
         { run_id: 'r1', disk_bytes: 300_000_000, status: 'completed' },
       ],
-      settings: { 'worca.ui.worktree_disk_warning_bytes': 400_000_000 },
+      worktreeDiskWarningBytes: 400_000_000,
     });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),
     );
     expect(output).toContain('>Worktrees<');
     expect(output).not.toContain('variant="warning"');
+  });
+});
+
+describe('sidebar - Running N/cap badge', () => {
+  it('shows totalRunning/cap badge when totalRunning > 0', async () => {
+    const { sidebarView } = await import('./sidebar.js');
+    const state = makeState({
+      totalRunning: 3,
+      maxConcurrentPipelines: 10,
+    });
+    const output = renderToString(
+      sidebarView(state, route, 'open', defaultOpts()),
+    );
+    expect(output).toContain('running-cap-badge');
+    expect(output).toContain('3/10');
+  });
+
+  it('does not show running-cap-badge when totalRunning is 0', async () => {
+    const { sidebarView } = await import('./sidebar.js');
+    const state = makeState({
+      totalRunning: 0,
+      maxConcurrentPipelines: 10,
+    });
+    const output = renderToString(
+      sidebarView(state, route, 'open', defaultOpts()),
+    );
+    expect(output).not.toContain('running-cap-badge');
+  });
+
+  it('badge variant is warning when at capacity', async () => {
+    const { sidebarView } = await import('./sidebar.js');
+    const state = makeState({
+      totalRunning: 5,
+      maxConcurrentPipelines: 5,
+    });
+    const output = renderToString(
+      sidebarView(state, route, 'open', defaultOpts()),
+    );
+    expect(output).toContain('running-cap-badge');
+    expect(output).toContain('5/5');
+  });
+
+  it('disables New Pipeline button when at capacity', async () => {
+    const { sidebarView } = await import('./sidebar.js');
+    const state = makeState({
+      totalRunning: 10,
+      maxConcurrentPipelines: 10,
+    });
+    const output = renderToString(
+      sidebarView(state, route, 'open', defaultOpts()),
+    );
+    expect(output).toContain('disabled');
   });
 });
 

--- a/worca-ui/app/views/worktrees.js
+++ b/worca-ui/app/views/worktrees.js
@@ -46,14 +46,14 @@ function _statusBadgeVariant(status) {
   return STATUS_BADGE_VARIANT[status] || 'neutral';
 }
 
-function _diskSummaryView(worktrees) {
+function _diskSummaryView(worktrees, diskWarningBytes = 2_000_000_000) {
   const total = worktrees.reduce((s, w) => s + (w.disk_bytes || 0), 0);
   const cleanable = worktrees
     .filter((w) => w.status === 'completed')
     .reduce((s, w) => s + (w.disk_bytes || 0), 0);
   const resumable = worktrees.filter((w) => w.resumable);
   const resumableBytes = resumable.reduce((s, w) => s + (w.disk_bytes || 0), 0);
-  const over2gb = total > 2_000_000_000;
+  const over2gb = total > diskWarningBytes;
 
   // Warning banner only when over the threshold; otherwise a quiet meta line.
   if (over2gb) {
@@ -306,6 +306,7 @@ function _bulkDialogView(
 export function worktreesView(
   worktrees,
   {
+    diskWarningBytes,
     filter = '',
     onFilter,
     onSelectRun,
@@ -340,7 +341,7 @@ export function worktreesView(
 
   return html`
     <div class="worktrees-view">
-      ${_diskSummaryView(worktrees)}
+      ${_diskSummaryView(worktrees, diskWarningBytes)}
       <div class="worktrees-toolbar">
         <sl-input
           size="small"

--- a/worca-ui/app/views/worktrees.test.js
+++ b/worca-ui/app/views/worktrees.test.js
@@ -245,7 +245,7 @@ describe('worktreesView - disk summary', () => {
     expect(output).not.toContain('Held by resumable');
   });
 
-  it('renders a warning alert when total exceeds 2 GB', () => {
+  it('renders a warning alert when total exceeds default 2 GB', () => {
     // Two 1.2 GB worktrees → 2.4 GB total
     const big = {
       ...completedWorktree,
@@ -255,6 +255,29 @@ describe('worktreesView - disk summary', () => {
     const output = renderToString(worktreesView([completedWorktree, big]));
     expect(output).toContain('worktrees-disk-alert');
     expect(output).toContain('disk usage is high');
+  });
+
+  it('uses custom diskWarningBytes option for threshold', () => {
+    const wt = {
+      ...completedWorktree,
+      disk_bytes: 600_000_000,
+    };
+    const output = renderToString(
+      worktreesView([wt], { diskWarningBytes: 500_000_000 }),
+    );
+    expect(output).toContain('worktrees-disk-alert');
+    expect(output).toContain('disk usage is high');
+  });
+
+  it('does not show warning when below custom diskWarningBytes', () => {
+    const wt = {
+      ...completedWorktree,
+      disk_bytes: 400_000_000,
+    };
+    const output = renderToString(
+      worktreesView([wt], { diskWarningBytes: 500_000_000 }),
+    );
+    expect(output).not.toContain('worktrees-disk-alert');
   });
 });
 

--- a/worca-ui/package-lock.json
+++ b/worca-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worca/ui",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worca/ui",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.20.1",
@@ -17,6 +17,7 @@
         "lit-html": "^3.3.1",
         "lucide": "^0.577.0",
         "marked": "^17.0.1",
+        "proper-lockfile": "^4.1.2",
         "ws": "^8.18.3"
       },
       "bin": {
@@ -2051,6 +2052,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2537,6 +2544,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2613,6 +2631,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -2823,6 +2850,12 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/source-map-js": {

--- a/worca-ui/package.json
+++ b/worca-ui/package.json
@@ -63,6 +63,7 @@
     "lit-html": "^3.3.1",
     "lucide": "^0.577.0",
     "marked": "^17.0.1",
+    "proper-lockfile": "^4.1.2",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/worca-ui/server/app.js
+++ b/worca-ui/server/app.js
@@ -11,6 +11,7 @@ import express from 'express';
 import { dbExists, getIssue, listIssues } from './beads-reader.js';
 import { RAW_BODY } from './integrations/index.js';
 import { verify } from './integrations/verify.js';
+import { LaunchLock } from './launch-lock.js';
 import { createPreferencesRouter } from './preferences-routes.js';
 import { ProcessManager } from './process-manager.js';
 import { scanDirectory } from './project-registry.js';
@@ -91,6 +92,13 @@ export function createApp(options = {}) {
   const webhookInbox = options.webhookInbox || createInbox();
   app.locals.webhookInbox = webhookInbox;
 
+  // Single LaunchLock instance shared across BOTH legacy /api and
+  // /api/projects/:id mounts so the global max_concurrent_pipelines cap is
+  // enforced atomically across all entry points. Without this, two routers
+  // each held their own mutex and concurrent launches via /api/runs +
+  // /api/projects/:id/runs could both pass the cap check and start.
+  const launchLock = new LaunchLock();
+
   // ─── Legacy single-project API ─────────────────────────────────────────
   // Mounts the shared project-scoped routes at /api with a middleware that
   // injects req.project from the closure options, so /api/runs, /api/settings,
@@ -114,7 +122,12 @@ export function createApp(options = {}) {
       };
       next();
     },
-    createProjectScopedRoutes({ serverHost, serverPort }),
+    createProjectScopedRoutes({
+      prefsDir,
+      serverHost,
+      serverPort,
+      launchLock,
+    }),
   );
 
   // ─── Unique routes (not in project-scoped router) ──────────────────────
@@ -530,7 +543,12 @@ export function createApp(options = {}) {
     app.use(
       '/api/projects/:projectId',
       projectResolver({ prefsDir, projectRoot }),
-      createProjectScopedRoutes({ prefsDir, serverHost, serverPort }),
+      createProjectScopedRoutes({
+        prefsDir,
+        serverHost,
+        serverPort,
+        launchLock,
+      }),
     );
   }
 

--- a/worca-ui/server/app.js
+++ b/worca-ui/server/app.js
@@ -11,6 +11,7 @@ import express from 'express';
 import { dbExists, getIssue, listIssues } from './beads-reader.js';
 import { RAW_BODY } from './integrations/index.js';
 import { verify } from './integrations/verify.js';
+import { createPreferencesRouter } from './preferences-routes.js';
 import { ProcessManager } from './process-manager.js';
 import { scanDirectory } from './project-registry.js';
 import {
@@ -19,6 +20,7 @@ import {
   projectResolver,
 } from './project-routes.js';
 import { validateIntegrationsConfig } from './settings-validator.js';
+import { createStatusRouter } from './status-routes.js';
 import { discoverSubagents } from './subagents-discovery.js';
 import { checkWorcaVersion } from './version-check.js';
 import { getVersionInfo } from './versions.js';
@@ -519,6 +521,8 @@ export function createApp(options = {}) {
 
   // ─── Multi-project routes ──────────────────────────────────────────────
   if (prefsDir) {
+    app.use('/api/preferences', createPreferencesRouter({ prefsDir }));
+    app.use('/api/status', createStatusRouter({ prefsDir }));
     app.use(
       '/api/projects',
       createProjectRoutes({ prefsDir, projectRoot, serverHost, serverPort }),

--- a/worca-ui/server/atomic-write.js
+++ b/worca-ui/server/atomic-write.js
@@ -1,0 +1,18 @@
+/**
+ * Atomic file write: write to a temp file then rename into place.
+ * Prevents partial reads when a reader opens the file mid-write.
+ */
+
+import { mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export function atomicWriteSync(filePath, data, options = {}) {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  const tmp = join(
+    dir,
+    `.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`,
+  );
+  writeFileSync(tmp, data, options);
+  renameSync(tmp, filePath);
+}

--- a/worca-ui/server/global-keys.js
+++ b/worca-ui/server/global-keys.js
@@ -1,0 +1,49 @@
+import { GLOBAL_ONLY_KEYS } from './keys-schema.js';
+
+const INERT_MILESTONE_KEYS = ['pr_approval', 'deploy_approval'];
+
+/**
+ * Mutates `blob` in place: extracts misplaced global-only keys and strips
+ * inert milestone keys (pr_approval/deploy_approval when set to `true`).
+ *
+ * Returns { globalExtracted, removedMilestones } for the caller to merge
+ * into ~/.worca/settings.json and to surface in the response.
+ */
+export function extractAndStripGlobalKeys(blob) {
+  const globalExtracted = {};
+  const removedMilestones = [];
+
+  const worca = blob.worca;
+  if (!worca || typeof worca !== 'object') {
+    return { globalExtracted, removedMilestones };
+  }
+
+  for (const [section, key] of GLOBAL_ONLY_KEYS) {
+    const sectionObj = worca[section];
+    if (!sectionObj || typeof sectionObj !== 'object') continue;
+    if (!(key in sectionObj)) continue;
+
+    if (!globalExtracted[section]) globalExtracted[section] = {};
+    globalExtracted[section][key] = sectionObj[key];
+    delete sectionObj[key];
+
+    if (Object.keys(sectionObj).length === 0) {
+      delete worca[section];
+    }
+  }
+
+  const milestones = worca.milestones;
+  if (milestones && typeof milestones === 'object') {
+    for (const key of INERT_MILESTONE_KEYS) {
+      if (milestones[key] === true) {
+        delete milestones[key];
+        removedMilestones.push(key);
+      }
+    }
+    if (Object.keys(milestones).length === 0) {
+      delete worca.milestones;
+    }
+  }
+
+  return { globalExtracted, removedMilestones };
+}

--- a/worca-ui/server/global-keys.test.js
+++ b/worca-ui/server/global-keys.test.js
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { extractAndStripGlobalKeys } from './global-keys.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(
+  readFileSync(
+    resolve(__dirname, '../../tests/fixtures/migration_strip_io.json'),
+    'utf-8',
+  ),
+);
+
+describe('extractAndStripGlobalKeys', () => {
+  describe('fixture-driven cases', () => {
+    for (const tc of fixture.cases) {
+      if (tc.expected_project !== undefined) {
+        it(`global-key extraction: ${tc.name}`, () => {
+          const blob = structuredClone(tc.input);
+          const result = extractAndStripGlobalKeys(blob);
+          expect(blob).toEqual(tc.expected_project);
+          expect(result.globalExtracted).toEqual(tc.expected_global_extracted);
+        });
+      }
+
+      if (tc.expected_project_after_milestone_strip !== undefined) {
+        it(`milestone strip: ${tc.name}`, () => {
+          const blob = structuredClone(tc.input);
+          const result = extractAndStripGlobalKeys(blob);
+          expect(blob).toEqual(tc.expected_project_after_milestone_strip);
+          expect(result.removedMilestones).toEqual(tc.expected_removed_keys);
+        });
+      }
+    }
+  });
+
+  it('handles both global-key extraction and milestone strip in one pass', () => {
+    const blob = {
+      worca: {
+        parallel: {
+          worktree_base_dir: '.worktrees',
+          cleanup_policy: 'on-success',
+        },
+        milestones: {
+          plan_approval: true,
+          pr_approval: true,
+        },
+      },
+    };
+    const result = extractAndStripGlobalKeys(blob);
+    expect(blob).toEqual({
+      worca: {
+        parallel: { worktree_base_dir: '.worktrees' },
+        milestones: { plan_approval: true },
+      },
+    });
+    expect(result.globalExtracted).toEqual({
+      parallel: { cleanup_policy: 'on-success' },
+    });
+    expect(result.removedMilestones).toEqual(['pr_approval']);
+  });
+
+  it('returns empty result for an already-clean blob', () => {
+    const blob = {
+      worca: {
+        parallel: { worktree_base_dir: '.worktrees' },
+        milestones: { plan_approval: true },
+      },
+    };
+    const original = structuredClone(blob);
+    const result = extractAndStripGlobalKeys(blob);
+    expect(blob).toEqual(original);
+    expect(result.globalExtracted).toEqual({});
+    expect(result.removedMilestones).toEqual([]);
+  });
+
+  it('is idempotent — second call on same blob is a no-op', () => {
+    const blob = {
+      worca: {
+        ui: { worktree_disk_warning_bytes: 5000000000 },
+        milestones: { pr_approval: true, deploy_approval: true },
+      },
+    };
+    extractAndStripGlobalKeys(blob);
+    const afterFirst = structuredClone(blob);
+    const result2 = extractAndStripGlobalKeys(blob);
+    expect(blob).toEqual(afterFirst);
+    expect(result2.globalExtracted).toEqual({});
+    expect(result2.removedMilestones).toEqual([]);
+  });
+
+  it('handles missing worca key gracefully', () => {
+    const blob = {};
+    const result = extractAndStripGlobalKeys(blob);
+    expect(blob).toEqual({});
+    expect(result.globalExtracted).toEqual({});
+    expect(result.removedMilestones).toEqual([]);
+  });
+
+  it('handles empty worca object', () => {
+    const blob = { worca: {} };
+    const result = extractAndStripGlobalKeys(blob);
+    expect(blob).toEqual({ worca: {} });
+    expect(result.globalExtracted).toEqual({});
+    expect(result.removedMilestones).toEqual([]);
+  });
+});

--- a/worca-ui/server/integrations/config-loader.test.js
+++ b/worca-ui/server/integrations/config-loader.test.js
@@ -4,6 +4,13 @@ vi.mock('node:fs', () => ({
   readFileSync: vi.fn(),
 }));
 
+vi.mock('../keys-schema.js', () => ({
+  GLOBAL_ONLY_KEYS: [],
+  NORMALIZE_SKIP_KEYS: [],
+  GLOBAL_DEFAULTS: {},
+  PROJECT_DEFAULTS: {},
+}));
+
 import { readFileSync } from 'node:fs';
 import { loadIntegrationsConfig } from './config-loader.js';
 

--- a/worca-ui/server/keys-schema.js
+++ b/worca-ui/server/keys-schema.js
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schema = JSON.parse(
+  readFileSync(
+    resolve(__dirname, '../../src/worca/schemas/keys.json'),
+    'utf-8',
+  ),
+);
+
+export const GLOBAL_ONLY_KEYS = schema.global_only_keys;
+export const NORMALIZE_SKIP_KEYS = schema.normalize_skip_keys;
+export const GLOBAL_DEFAULTS = schema.defaults.global;
+export const PROJECT_DEFAULTS = schema.defaults.project;

--- a/worca-ui/server/keys-schema.test.js
+++ b/worca-ui/server/keys-schema.test.js
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  GLOBAL_DEFAULTS,
+  GLOBAL_ONLY_KEYS,
+  NORMALIZE_SKIP_KEYS,
+  PROJECT_DEFAULTS,
+} from './keys-schema.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const raw = JSON.parse(
+  readFileSync(
+    resolve(__dirname, '../../src/worca/schemas/keys.json'),
+    'utf-8',
+  ),
+);
+
+describe('keys-schema exports', () => {
+  it('GLOBAL_ONLY_KEYS is an array of 2-element arrays', () => {
+    expect(Array.isArray(GLOBAL_ONLY_KEYS)).toBe(true);
+    for (const entry of GLOBAL_ONLY_KEYS) {
+      expect(Array.isArray(entry)).toBe(true);
+      expect(entry).toHaveLength(2);
+      expect(typeof entry[0]).toBe('string');
+      expect(typeof entry[1]).toBe('string');
+    }
+  });
+
+  it('NORMALIZE_SKIP_KEYS is an array of 2-element arrays', () => {
+    expect(Array.isArray(NORMALIZE_SKIP_KEYS)).toBe(true);
+    for (const entry of NORMALIZE_SKIP_KEYS) {
+      expect(Array.isArray(entry)).toBe(true);
+      expect(entry).toHaveLength(2);
+    }
+  });
+
+  it('GLOBAL_DEFAULTS is a non-empty object', () => {
+    expect(typeof GLOBAL_DEFAULTS).toBe('object');
+    expect(Object.keys(GLOBAL_DEFAULTS).length).toBeGreaterThan(0);
+  });
+
+  it('PROJECT_DEFAULTS is a non-empty object', () => {
+    expect(typeof PROJECT_DEFAULTS).toBe('object');
+    expect(Object.keys(PROJECT_DEFAULTS).length).toBeGreaterThan(0);
+  });
+});
+
+describe('drift detection — JS exports match raw JSON', () => {
+  it('GLOBAL_ONLY_KEYS matches JSON', () => {
+    expect(GLOBAL_ONLY_KEYS).toEqual(raw.global_only_keys);
+  });
+
+  it('NORMALIZE_SKIP_KEYS matches JSON', () => {
+    expect(NORMALIZE_SKIP_KEYS).toEqual(raw.normalize_skip_keys);
+  });
+
+  it('GLOBAL_DEFAULTS matches JSON', () => {
+    expect(GLOBAL_DEFAULTS).toEqual(raw.defaults.global);
+  });
+
+  it('PROJECT_DEFAULTS matches JSON', () => {
+    expect(PROJECT_DEFAULTS).toEqual(raw.defaults.project);
+  });
+
+  it('every global-only key has a global default', () => {
+    for (const [section, key] of GLOBAL_ONLY_KEYS) {
+      expect(GLOBAL_DEFAULTS).toHaveProperty(section);
+      expect(GLOBAL_DEFAULTS[section]).toHaveProperty(key);
+    }
+  });
+
+  it('GLOBAL_ONLY_KEYS count is 4', () => {
+    expect(GLOBAL_ONLY_KEYS).toHaveLength(4);
+  });
+
+  it('NORMALIZE_SKIP_KEYS count is 1', () => {
+    expect(NORMALIZE_SKIP_KEYS).toHaveLength(1);
+  });
+
+  it('no overlap between global-only keys and project defaults', () => {
+    const projectKeys = new Set();
+    for (const [section, sub] of Object.entries(PROJECT_DEFAULTS)) {
+      for (const key of Object.keys(sub)) {
+        projectKeys.add(`${section}.${key}`);
+      }
+    }
+    for (const [section, key] of GLOBAL_ONLY_KEYS) {
+      expect(projectKeys.has(`${section}.${key}`)).toBe(false);
+    }
+  });
+});

--- a/worca-ui/server/launch-lock.js
+++ b/worca-ui/server/launch-lock.js
@@ -1,0 +1,25 @@
+/**
+ * In-process async mutex using a promise chain.
+ * Used to serialize pipeline launches so max_concurrent_pipelines is enforced atomically.
+ */
+export class LaunchLock {
+  #tail = Promise.resolve();
+
+  acquire() {
+    let release;
+    const prev = this.#tail;
+    this.#tail = new Promise((resolve) => {
+      release = resolve;
+    });
+    return prev.then(() => release);
+  }
+
+  async withLock(fn) {
+    const release = await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+}

--- a/worca-ui/server/launch-lock.test.js
+++ b/worca-ui/server/launch-lock.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { LaunchLock } from './launch-lock.js';
+
+describe('LaunchLock', () => {
+  it('allows a single acquire without contention', async () => {
+    const lock = new LaunchLock();
+    const release = await lock.acquire();
+    expect(typeof release).toBe('function');
+    release();
+  });
+
+  it('serializes concurrent acquires', async () => {
+    const lock = new LaunchLock();
+    const order = [];
+
+    const p1 = lock.acquire().then((release) => {
+      order.push('a-start');
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          order.push('a-end');
+          release();
+          resolve();
+        }, 20);
+      });
+    });
+
+    const p2 = lock.acquire().then((release) => {
+      order.push('b-start');
+      release();
+    });
+
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(['a-start', 'a-end', 'b-start']);
+  });
+
+  it('releases lock even if holder throws', async () => {
+    const lock = new LaunchLock();
+
+    const release1 = await lock.acquire();
+    release1();
+
+    const release2 = await lock.acquire();
+    release2();
+  });
+
+  it('withLock runs the callback and returns its result', async () => {
+    const lock = new LaunchLock();
+    const result = await lock.withLock(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('withLock serializes concurrent calls', async () => {
+    const lock = new LaunchLock();
+    const order = [];
+
+    const p1 = lock.withLock(async () => {
+      order.push('a-start');
+      await new Promise((r) => setTimeout(r, 20));
+      order.push('a-end');
+    });
+
+    const p2 = lock.withLock(async () => {
+      order.push('b-start');
+      order.push('b-end');
+    });
+
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+
+  it('withLock releases lock when callback throws', async () => {
+    const lock = new LaunchLock();
+
+    await expect(
+      lock.withLock(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const result = await lock.withLock(async () => 'ok');
+    expect(result).toBe('ok');
+  });
+
+  it('handles many concurrent acquires in FIFO order', async () => {
+    const lock = new LaunchLock();
+    const order = [];
+    const count = 10;
+
+    const promises = Array.from({ length: count }, (_, i) =>
+      lock.acquire().then((release) => {
+        order.push(i);
+        release();
+      }),
+    );
+
+    await Promise.all(promises);
+    expect(order).toEqual(Array.from({ length: count }, (_, i) => i));
+  });
+});

--- a/worca-ui/server/preferences-routes.js
+++ b/worca-ui/server/preferences-routes.js
@@ -1,0 +1,143 @@
+import { join } from 'node:path';
+import { Router } from 'express';
+import { readGlobalSettings, writeGlobalSettings } from './settings-reader.js';
+
+const VALID_CLEANUP_POLICIES = ['never', 'on-success', 'manual-only'];
+const VALID_MODELS = ['opus', 'sonnet', 'haiku'];
+const MIN_DISK_BYTES = 500_000_000;
+const MAX_DISK_BYTES = 50_000_000_000;
+
+export function validateGlobalSettingsPayload(body) {
+  const details = [];
+
+  if (body.worca !== undefined) {
+    if (
+      typeof body.worca !== 'object' ||
+      body.worca === null ||
+      Array.isArray(body.worca)
+    ) {
+      details.push('worca must be an object');
+      return { valid: false, details };
+    }
+    const w = body.worca;
+
+    if (w.parallel !== undefined) {
+      if (
+        typeof w.parallel !== 'object' ||
+        w.parallel === null ||
+        Array.isArray(w.parallel)
+      ) {
+        details.push('worca.parallel must be an object');
+      } else {
+        if (w.parallel.max_concurrent_pipelines !== undefined) {
+          const v = w.parallel.max_concurrent_pipelines;
+          if (!Number.isInteger(v) || v < 1 || v > 100) {
+            details.push(
+              'max_concurrent_pipelines must be an integer between 1 and 100',
+            );
+          }
+        }
+        if (w.parallel.cleanup_policy !== undefined) {
+          if (!VALID_CLEANUP_POLICIES.includes(w.parallel.cleanup_policy)) {
+            details.push(
+              `cleanup_policy must be one of: ${VALID_CLEANUP_POLICIES.join(', ')}`,
+            );
+          }
+        }
+      }
+    }
+
+    if (w.ui !== undefined) {
+      if (typeof w.ui !== 'object' || w.ui === null || Array.isArray(w.ui)) {
+        details.push('worca.ui must be an object');
+      } else if (w.ui.worktree_disk_warning_bytes !== undefined) {
+        const v = w.ui.worktree_disk_warning_bytes;
+        if (
+          typeof v !== 'number' ||
+          !Number.isFinite(v) ||
+          v < MIN_DISK_BYTES ||
+          v > MAX_DISK_BYTES
+        ) {
+          details.push(
+            `worktree_disk_warning_bytes must be a number between ${MIN_DISK_BYTES} and ${MAX_DISK_BYTES}`,
+          );
+        }
+      }
+    }
+
+    if (w.circuit_breaker !== undefined) {
+      if (
+        typeof w.circuit_breaker !== 'object' ||
+        w.circuit_breaker === null ||
+        Array.isArray(w.circuit_breaker)
+      ) {
+        details.push('worca.circuit_breaker must be an object');
+      } else if (w.circuit_breaker.classifier_model !== undefined) {
+        if (!VALID_MODELS.includes(w.circuit_breaker.classifier_model)) {
+          details.push(
+            `classifier_model must be one of: ${VALID_MODELS.join(', ')}`,
+          );
+        }
+      }
+    }
+  }
+
+  return details.length ? { valid: false, details } : { valid: true };
+}
+
+export function createPreferencesRouter({ prefsDir }) {
+  const router = Router();
+  const globalSettingsPath = join(prefsDir, 'settings.json');
+
+  router.get('/', (_req, res) => {
+    try {
+      const prefs = readGlobalSettings(globalSettingsPath);
+      res.json({ ok: true, preferences: prefs });
+    } catch (err) {
+      res.status(500).json({
+        ok: false,
+        error: 'Failed to read global preferences',
+        detail: err.message,
+      });
+    }
+  });
+
+  router.put('/', (req, res) => {
+    const body = req.body;
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return res.status(400).json({
+        ok: false,
+        error: {
+          code: 'validation_error',
+          message: 'Request body must be a JSON object',
+          details: [],
+        },
+      });
+    }
+
+    const validation = validateGlobalSettingsPayload(body);
+    if (!validation.valid) {
+      return res.status(400).json({
+        ok: false,
+        error: {
+          code: 'validation_error',
+          message: 'Invalid preferences payload',
+          details: validation.details,
+        },
+      });
+    }
+
+    try {
+      const merged = writeGlobalSettings(globalSettingsPath, body);
+      res.json({ ok: true, preferences: merged });
+    } catch (err) {
+      res.status(500).json({
+        ok: false,
+        error: 'Failed to write global preferences',
+        detail: err.message,
+      });
+    }
+  });
+
+  return router;
+}

--- a/worca-ui/server/preferences-routes.test.js
+++ b/worca-ui/server/preferences-routes.test.js
@@ -1,0 +1,225 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from './app.js';
+
+function startServer(prefsDir) {
+  const app = createApp({ prefsDir });
+  const server = createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const base = `http://127.0.0.1:${port}`;
+      resolve({ server, base });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+describe('GET /api/preferences', () => {
+  let tmpDir, server, base;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'prefs-routes-test-'));
+    ({ server, base } = await startServer(tmpDir));
+  });
+
+  afterEach(async () => {
+    if (server) await stopServer(server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns defaults when settings.json is missing', async () => {
+    const res = await fetch(`${base}/api/preferences`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(data.preferences.worca.parallel.cleanup_policy).toBe('never');
+    expect(data.preferences.worca.parallel.max_concurrent_pipelines).toBe(10);
+    expect(data.preferences.worca.ui.worktree_disk_warning_bytes).toBe(
+      2_000_000_000,
+    );
+    expect(data.preferences.worca.circuit_breaker.classifier_model).toBe(
+      'haiku',
+    );
+  });
+
+  it('returns defaults when settings.json contains malformed JSON', async () => {
+    writeFileSync(join(tmpDir, 'settings.json'), 'not valid json{{{');
+    const res = await fetch(`${base}/api/preferences`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(data.preferences.worca.parallel.cleanup_policy).toBe('never');
+    expect(data.preferences.worca.parallel.max_concurrent_pipelines).toBe(10);
+  });
+
+  it('merges stored values with defaults', async () => {
+    writeFileSync(
+      join(tmpDir, 'settings.json'),
+      JSON.stringify({
+        worca: { parallel: { cleanup_policy: 'on-success' } },
+      }),
+    );
+    const res = await fetch(`${base}/api/preferences`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.preferences.worca.parallel.cleanup_policy).toBe('on-success');
+    expect(data.preferences.worca.parallel.max_concurrent_pipelines).toBe(10);
+    expect(data.preferences.worca.circuit_breaker.classifier_model).toBe(
+      'haiku',
+    );
+  });
+});
+
+describe('PUT /api/preferences', () => {
+  let tmpDir, server, base;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'prefs-routes-test-'));
+    ({ server, base } = await startServer(tmpDir));
+  });
+
+  afterEach(async () => {
+    if (server) await stopServer(server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function put(body) {
+    return fetch(`${base}/api/preferences`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('deep-merges into existing settings', async () => {
+    writeFileSync(
+      join(tmpDir, 'settings.json'),
+      JSON.stringify({
+        worca: {
+          parallel: {
+            cleanup_policy: 'on-success',
+            max_concurrent_pipelines: 5,
+          },
+        },
+      }),
+    );
+    const res = await put({
+      worca: { parallel: { max_concurrent_pipelines: 8 } },
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(data.preferences.worca.parallel.max_concurrent_pipelines).toBe(8);
+    expect(data.preferences.worca.parallel.cleanup_policy).toBe('on-success');
+  });
+
+  it('creates file from scratch when missing', async () => {
+    const res = await put({
+      worca: { parallel: { cleanup_policy: 'on-success' } },
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.preferences.worca.parallel.cleanup_policy).toBe('on-success');
+    expect(data.preferences.worca.parallel.max_concurrent_pipelines).toBe(10);
+  });
+
+  it('rejects max_concurrent_pipelines outside 1-100', async () => {
+    const res = await put({
+      worca: { parallel: { max_concurrent_pipelines: 0 } },
+    });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.error.details).toContainEqual(
+      expect.stringContaining('max_concurrent_pipelines'),
+    );
+  });
+
+  it('rejects max_concurrent_pipelines over 100', async () => {
+    const res = await put({
+      worca: { parallel: { max_concurrent_pipelines: 101 } },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-integer max_concurrent_pipelines', async () => {
+    const res = await put({
+      worca: { parallel: { max_concurrent_pipelines: 3.5 } },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid cleanup_policy', async () => {
+    const res = await put({
+      worca: { parallel: { cleanup_policy: 'delete-everything' } },
+    });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error.details).toContainEqual(
+      expect.stringContaining('cleanup_policy'),
+    );
+  });
+
+  it('rejects invalid classifier_model', async () => {
+    const res = await put({
+      worca: { circuit_breaker: { classifier_model: 'gpt4' } },
+    });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error.details).toContainEqual(
+      expect.stringContaining('classifier_model'),
+    );
+  });
+
+  it('rejects worktree_disk_warning_bytes below 500 MB', async () => {
+    const res = await put({
+      worca: { ui: { worktree_disk_warning_bytes: 100 } },
+    });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error.details).toContainEqual(
+      expect.stringContaining('worktree_disk_warning_bytes'),
+    );
+  });
+
+  it('rejects worktree_disk_warning_bytes above 50 GB', async () => {
+    const res = await put({
+      worca: { ui: { worktree_disk_warning_bytes: 51_000_000_000 } },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-object request body', async () => {
+    const res = await fetch(`${base}/api/preferences`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects when worca is not an object', async () => {
+    const res = await put({ worca: 'bad' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns full merged state after write', async () => {
+    const res = await put({
+      worca: { circuit_breaker: { classifier_model: 'sonnet' } },
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.preferences.worca.circuit_breaker.classifier_model).toBe(
+      'sonnet',
+    );
+    expect(data.preferences.worca.parallel.cleanup_policy).toBe('never');
+    expect(data.preferences.worca.parallel.max_concurrent_pipelines).toBe(10);
+  });
+});

--- a/worca-ui/server/process-manager.js
+++ b/worca-ui/server/process-manager.js
@@ -22,6 +22,8 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 import { dispatchExternal } from './dispatch-external.js';
+import { readGlobalSettings } from './settings-reader.js';
+import { removeWorktree } from './worktree-ops.js';
 
 /** Byte threshold — must match claude_cli.py _ARG_INLINE_LIMIT */
 const ARG_INLINE_LIMIT = 128 * 1024;
@@ -78,10 +80,11 @@ export class ProcessManager {
   /**
    * @param {{ worcaDir: string, projectRoot?: string, settingsPath?: string }} options
    */
-  constructor({ worcaDir, projectRoot, settingsPath }) {
+  constructor({ worcaDir, projectRoot, settingsPath, prefsDir }) {
     this.worcaDir = worcaDir;
     this.projectRoot = projectRoot || process.cwd();
     this.settingsPath = settingsPath ?? null;
+    this.prefsDir = prefsDir ?? null;
   }
 
   /**
@@ -292,10 +295,74 @@ export class ProcessManager {
           }
         }
       }
+
+      this.maybeAutoCleanup(runId);
     }
 
     await Promise.all(dispatches);
     return fixed;
+  }
+
+  /**
+   * Post-completion cleanup hook (§5b).
+   * When cleanup_policy is 'on-success' and the run completed cleanly,
+   * removes the worktree via worktree-ops and emits a worktree.auto_cleanup
+   * event. 'never' (default) and 'manual-only' are both no-ops.
+   * @param {string} runId
+   * @returns {{ cleaned: boolean, runId?: string, path?: string, reason?: string }}
+   */
+  maybeAutoCleanup(runId) {
+    const ctx = this.resolveRunContext(runId);
+    const runDir = ctx ? ctx.runDir : join(this.worcaDir, 'runs', runId);
+    const statusPath = join(runDir, 'status.json');
+
+    if (!existsSync(statusPath)) return { cleaned: false };
+
+    let status;
+    try {
+      status = JSON.parse(readFileSync(statusPath, 'utf8'));
+    } catch {
+      return { cleaned: false };
+    }
+
+    const worktreePath = status.worktree_path;
+    if (!worktreePath) return { cleaned: false };
+
+    const exitOk = status.pipeline_status === 'completed';
+    if (!exitOk) return { cleaned: false };
+
+    let policy = 'never';
+    if (this.prefsDir) {
+      try {
+        const globalPrefs = readGlobalSettings(
+          join(this.prefsDir, 'settings.json'),
+        );
+        policy = globalPrefs?.worca?.parallel?.cleanup_policy ?? 'never';
+      } catch {
+        // Fall back to default 'never'
+      }
+    }
+
+    if (policy !== 'on-success') return { cleaned: false };
+
+    removeWorktree(this.worcaDir, runId);
+
+    try {
+      const eventsPath = join(runDir, 'events.jsonl');
+      const evt = {
+        schema_version: '1',
+        event_id: randomUUID(),
+        event_type: 'worktree.auto_cleanup',
+        timestamp: new Date().toISOString(),
+        run_id: status.run_id ?? runId,
+        payload: { runId, path: worktreePath, reason: 'on-success' },
+      };
+      appendFileSync(eventsPath, `${JSON.stringify(evt)}\n`, 'utf8');
+    } catch {
+      /* non-fatal */
+    }
+
+    return { cleaned: true, runId, path: worktreePath, reason: 'on-success' };
   }
 
   /**
@@ -534,14 +601,17 @@ export class ProcessManager {
     // Fire-and-forget: reconcileStatus is async but we intentionally don't
     // await it — this is a background cleanup path after the response is sent.
     const worcaDir = this.worcaDir;
-    const { settingsPath } = this;
+    const { settingsPath, prefsDir } = this;
     const watchdog = setTimeout(() => {
       try {
         process.kill(pid, 0); // check alive
         process.kill(pid, 'SIGKILL');
-        setTimeout(() => reconcileStatus(worcaDir, settingsPath), 500);
+        setTimeout(
+          () => reconcileStatus(worcaDir, settingsPath, prefsDir),
+          500,
+        );
       } catch {
-        reconcileStatus(worcaDir, settingsPath);
+        reconcileStatus(worcaDir, settingsPath, prefsDir);
       }
     }, 10000);
     watchdog.unref();
@@ -830,9 +900,13 @@ export function getRunningPid(worcaDir, runId) {
   return new ProcessManager({ worcaDir }).getRunningPid(runId);
 }
 
-/** @param {string} worcaDir @param {string} [settingsPath] */
-export function reconcileStatus(worcaDir, settingsPath) {
-  return new ProcessManager({ worcaDir, settingsPath }).reconcileStatus();
+/** @param {string} worcaDir @param {string} [settingsPath] @param {string} [prefsDir] */
+export function reconcileStatus(worcaDir, settingsPath, prefsDir) {
+  return new ProcessManager({
+    worcaDir,
+    settingsPath,
+    prefsDir,
+  }).reconcileStatus();
 }
 
 /** @param {string} worcaDir @param {object} opts */

--- a/worca-ui/server/process-manager.test.js
+++ b/worca-ui/server/process-manager.test.js
@@ -1,0 +1,150 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./worktree-ops.js', () => ({
+  removeWorktree: vi.fn(),
+}));
+
+import { ProcessManager } from './process-manager.js';
+import { removeWorktree } from './worktree-ops.js';
+
+describe('ProcessManager.maybeAutoCleanup', () => {
+  let tmpDir, worcaDir, prefsDir;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `pm-cleanup-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    worcaDir = join(tmpDir, 'project', '.worca');
+    prefsDir = join(tmpDir, 'prefs');
+    mkdirSync(join(worcaDir, 'runs', 'run-001'), { recursive: true });
+    mkdirSync(prefsDir, { recursive: true });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeStatus(runId, status) {
+    const dir = join(worcaDir, 'runs', runId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'status.json'), JSON.stringify(status, null, 2));
+  }
+
+  function writeGlobalPrefs(prefs) {
+    writeFileSync(
+      join(prefsDir, 'settings.json'),
+      JSON.stringify(prefs, null, 2),
+    );
+  }
+
+  it('on-success + completed → calls removeWorktree and emits event', () => {
+    writeStatus('run-001', {
+      pipeline_status: 'completed',
+      worktree_path: '/tmp/wt/run-001',
+      run_id: 'run-001',
+    });
+    writeGlobalPrefs({
+      worca: { parallel: { cleanup_policy: 'on-success' } },
+    });
+
+    const pm = new ProcessManager({ worcaDir, prefsDir });
+    const result = pm.maybeAutoCleanup('run-001');
+
+    expect(result.cleaned).toBe(true);
+    expect(result.runId).toBe('run-001');
+    expect(result.path).toBe('/tmp/wt/run-001');
+    expect(result.reason).toBe('on-success');
+    expect(removeWorktree).toHaveBeenCalledWith(worcaDir, 'run-001');
+
+    const eventsPath = join(worcaDir, 'runs', 'run-001', 'events.jsonl');
+    const events = readFileSync(eventsPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map(JSON.parse);
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('worktree.auto_cleanup');
+    expect(events[0].payload.path).toBe('/tmp/wt/run-001');
+    expect(events[0].payload.reason).toBe('on-success');
+  });
+
+  it('on-success + failed → no cleanup', () => {
+    writeStatus('run-001', {
+      pipeline_status: 'failed',
+      worktree_path: '/tmp/wt/run-001',
+    });
+    writeGlobalPrefs({
+      worca: { parallel: { cleanup_policy: 'on-success' } },
+    });
+
+    const pm = new ProcessManager({ worcaDir, prefsDir });
+    const result = pm.maybeAutoCleanup('run-001');
+
+    expect(result.cleaned).toBe(false);
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('never policy + completed → no cleanup', () => {
+    writeStatus('run-001', {
+      pipeline_status: 'completed',
+      worktree_path: '/tmp/wt/run-001',
+    });
+    writeGlobalPrefs({
+      worca: { parallel: { cleanup_policy: 'never' } },
+    });
+
+    const pm = new ProcessManager({ worcaDir, prefsDir });
+    const result = pm.maybeAutoCleanup('run-001');
+
+    expect(result.cleaned).toBe(false);
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('manual-only policy + completed → no cleanup', () => {
+    writeStatus('run-001', {
+      pipeline_status: 'completed',
+      worktree_path: '/tmp/wt/run-001',
+    });
+    writeGlobalPrefs({
+      worca: { parallel: { cleanup_policy: 'manual-only' } },
+    });
+
+    const pm = new ProcessManager({ worcaDir, prefsDir });
+    const result = pm.maybeAutoCleanup('run-001');
+
+    expect(result.cleaned).toBe(false);
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('no worktree_path in status → no cleanup', () => {
+    writeStatus('run-001', {
+      pipeline_status: 'completed',
+    });
+    writeGlobalPrefs({
+      worca: { parallel: { cleanup_policy: 'on-success' } },
+    });
+
+    const pm = new ProcessManager({ worcaDir, prefsDir });
+    const result = pm.maybeAutoCleanup('run-001');
+
+    expect(result.cleaned).toBe(false);
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('no prefsDir → defaults to never, no cleanup', () => {
+    writeStatus('run-001', {
+      pipeline_status: 'completed',
+      worktree_path: '/tmp/wt/run-001',
+    });
+
+    const pm = new ProcessManager({ worcaDir });
+    const result = pm.maybeAutoCleanup('run-001');
+
+    expect(result.cleaned).toBe(false);
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+});

--- a/worca-ui/server/process-registry.js
+++ b/worca-ui/server/process-registry.js
@@ -1,5 +1,6 @@
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { atomicWriteSync } from './atomic-write.js';
 
 function isPidAlive(pid) {
   try {
@@ -18,7 +19,7 @@ function clearStalePid(statusPath, status) {
       pipeline_status: 'error',
       error: 'Stale PID: process no longer running',
     };
-    writeFileSync(statusPath, `${JSON.stringify(patched, null, 2)}\n`);
+    atomicWriteSync(statusPath, `${JSON.stringify(patched, null, 2)}\n`);
   } catch {
     // best-effort
   }

--- a/worca-ui/server/process-registry.js
+++ b/worca-ui/server/process-registry.js
@@ -1,0 +1,91 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if (err.code === 'EPERM') return true;
+    return false;
+  }
+}
+
+function clearStalePid(statusPath, status) {
+  try {
+    const patched = {
+      ...status,
+      pipeline_status: 'error',
+      error: 'Stale PID: process no longer running',
+    };
+    writeFileSync(statusPath, `${JSON.stringify(patched, null, 2)}\n`);
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Count running pipelines across all registered projects.
+ * Walks ~/.worca/projects.d/, checks each project's .worca/runs/ for
+ * status.json entries with pipeline_status=running, and verifies PID liveness.
+ * Prunes stale PIDs (dead processes still marked as running).
+ */
+export function countRunningPipelinesAcrossProjects(prefsDir) {
+  const projectsDir = join(prefsDir, 'projects.d');
+  if (!existsSync(projectsDir)) return 0;
+
+  let entries;
+  try {
+    entries = readdirSync(projectsDir);
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+
+  for (const file of entries) {
+    if (!file.endsWith('.json')) continue;
+
+    let project;
+    try {
+      project = JSON.parse(readFileSync(join(projectsDir, file), 'utf-8'));
+    } catch {
+      continue;
+    }
+
+    if (!project || typeof project.path !== 'string') continue;
+
+    const runsDir = join(project.path, '.worca', 'runs');
+    if (!existsSync(runsDir)) continue;
+
+    let runEntries;
+    try {
+      runEntries = readdirSync(runsDir);
+    } catch {
+      continue;
+    }
+
+    for (const runEntry of runEntries) {
+      const statusPath = join(runsDir, runEntry, 'status.json');
+      if (!existsSync(statusPath)) continue;
+
+      let status;
+      try {
+        status = JSON.parse(readFileSync(statusPath, 'utf-8'));
+      } catch {
+        continue;
+      }
+
+      if (status.pipeline_status !== 'running') continue;
+      if (!status.pid) continue;
+
+      if (isPidAlive(status.pid)) {
+        count++;
+      } else {
+        clearStalePid(statusPath, status);
+      }
+    }
+  }
+
+  return count;
+}

--- a/worca-ui/server/process-registry.test.js
+++ b/worca-ui/server/process-registry.test.js
@@ -1,0 +1,230 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { countRunningPipelinesAcrossProjects } from './process-registry.js';
+
+describe('countRunningPipelinesAcrossProjects', () => {
+  let prefsDir;
+
+  beforeEach(() => {
+    prefsDir = join(
+      tmpdir(),
+      `proc-reg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(prefsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(prefsDir, { recursive: true, force: true });
+  });
+
+  it('returns 0 when projects.d/ does not exist', () => {
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when projects.d/ is empty', () => {
+    mkdirSync(join(prefsDir, 'projects.d'));
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when projects have no runs', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+    const projectPath = join(tmpdir(), `proj-norun-${Date.now()}`);
+    mkdirSync(join(projectPath, '.worca', 'runs'), { recursive: true });
+    writeFileSync(
+      join(projDir, 'proj-a.json'),
+      JSON.stringify({ name: 'proj-a', path: projectPath }),
+    );
+
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(0);
+
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('counts running pipelines with live PIDs', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+
+    const projectPath = join(tmpdir(), `proj-live-${Date.now()}`);
+    const runDir = join(projectPath, '.worca', 'runs', 'run-001');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        pipeline_status: 'running',
+        pid: process.pid,
+      }),
+    );
+    writeFileSync(
+      join(projDir, 'proj-a.json'),
+      JSON.stringify({ name: 'proj-a', path: projectPath }),
+    );
+
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(1);
+
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('skips ESRCH (dead PID) and does not count it', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+
+    const projectPath = join(tmpdir(), `proj-dead-${Date.now()}`);
+    const runDir = join(projectPath, '.worca', 'runs', 'run-002');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        pipeline_status: 'running',
+        pid: 2147483647,
+      }),
+    );
+    writeFileSync(
+      join(projDir, 'proj-b.json'),
+      JSON.stringify({ name: 'proj-b', path: projectPath }),
+    );
+
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(0);
+
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('counts EPERM as alive (process exists but we lack permission)', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+
+    const projectPath = join(tmpdir(), `proj-eperm-${Date.now()}`);
+    const runDir = join(projectPath, '.worca', 'runs', 'run-003');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        pipeline_status: 'running',
+        pid: 1,
+      }),
+    );
+    writeFileSync(
+      join(projDir, 'proj-c.json'),
+      JSON.stringify({ name: 'proj-c', path: projectPath }),
+    );
+
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(1);
+
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('prunes stale PID from status.json (clearStalePid)', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+
+    const projectPath = join(tmpdir(), `proj-stale-${Date.now()}`);
+    const runDir = join(projectPath, '.worca', 'runs', 'run-004');
+    mkdirSync(runDir, { recursive: true });
+    const statusPath = join(runDir, 'status.json');
+    writeFileSync(
+      statusPath,
+      JSON.stringify({
+        pipeline_status: 'running',
+        pid: 2147483647,
+      }),
+    );
+    writeFileSync(
+      join(projDir, 'proj-d.json'),
+      JSON.stringify({ name: 'proj-d', path: projectPath }),
+    );
+
+    countRunningPipelinesAcrossProjects(prefsDir);
+
+    const updated = JSON.parse(
+      require('node:fs').readFileSync(statusPath, 'utf-8'),
+    );
+    expect(updated.pipeline_status).toBe('error');
+    expect(updated.error).toMatch(/stale/i);
+
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('counts across multiple projects', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+
+    const paths = [];
+    for (let i = 0; i < 3; i++) {
+      const projectPath = join(tmpdir(), `proj-multi-${Date.now()}-${i}`);
+      const runDir = join(projectPath, '.worca', 'runs', `run-${i}`);
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(
+        join(runDir, 'status.json'),
+        JSON.stringify({
+          pipeline_status: 'running',
+          pid: process.pid,
+        }),
+      );
+      writeFileSync(
+        join(projDir, `proj-${i}.json`),
+        JSON.stringify({ name: `proj-${i}`, path: projectPath }),
+      );
+      paths.push(projectPath);
+    }
+
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(3);
+
+    for (const p of paths) rmSync(p, { recursive: true, force: true });
+  });
+
+  it('ignores non-running statuses', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+
+    const projectPath = join(tmpdir(), `proj-done-${Date.now()}`);
+    const runDir = join(projectPath, '.worca', 'runs', 'run-005');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        pipeline_status: 'completed',
+        pid: process.pid,
+      }),
+    );
+    writeFileSync(
+      join(projDir, 'proj-done.json'),
+      JSON.stringify({ name: 'proj-done', path: projectPath }),
+    );
+
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(0);
+
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('skips malformed project entries', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+    writeFileSync(join(projDir, 'bad.json'), 'not json!!!');
+
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(0);
+  });
+
+  it('skips projects whose path does not exist', () => {
+    const projDir = join(prefsDir, 'projects.d');
+    mkdirSync(projDir);
+    writeFileSync(
+      join(projDir, 'missing.json'),
+      JSON.stringify({ name: 'missing', path: '/no/such/dir/ever' }),
+    );
+
+    const result = countRunningPipelinesAcrossProjects(prefsDir);
+    expect(result).toBe(0);
+  });
+});

--- a/worca-ui/server/project-routes.js
+++ b/worca-ui/server/project-routes.js
@@ -19,12 +19,17 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { Router } from 'express';
+import lockfile from 'proper-lockfile';
 import { actionAllowed } from '../app/utils/state-actions.js';
+import { atomicWriteSync } from './atomic-write.js';
 import { dbExists, getIssue, listIssues } from './beads-reader.js';
 import { dispatchExternal } from './dispatch-external.js';
 import { ensureWebhookForUi } from './ensure-webhook.js';
+import { extractAndStripGlobalKeys } from './global-keys.js';
+import { LaunchLock } from './launch-lock.js';
 import { readPreferences } from './preferences.js';
 import { ProcessManager } from './process-manager.js';
+import { countRunningPipelinesAcrossProjects } from './process-registry.js';
 import {
   getMaxProjects,
   readProjects,
@@ -40,6 +45,7 @@ import {
   readLocalSettings,
   readMergedSettings,
 } from './settings-merge.js';
+import { readGlobalSettings, writeGlobalSettings } from './settings-reader.js';
 import { validateSettingsPayload } from './settings-validator.js';
 import { isVersionBehind } from './version-check.js';
 import { getVersionInfo } from './versions.js';
@@ -129,6 +135,7 @@ export function projectResolver({ prefsDir, projectRoot }) {
         settingsPath:
           project.settingsPath ||
           join(project.path, '.claude', 'settings.json'),
+        prefsDir,
       }),
     };
     next();
@@ -323,6 +330,7 @@ export function createProjectScopedRoutes({
 } = {}) {
   const router = Router({ mergeParams: true });
   const prefsPath = prefsDir ? join(prefsDir, 'preferences.json') : null;
+  const launchLock = new LaunchLock();
 
   // Guard: run-related, cost, and pipeline routes require worcaDir
   function requireWorcaDir(req, res, next) {
@@ -437,7 +445,7 @@ export function createProjectScopedRoutes({
   });
 
   // POST /api/projects/:projectId/settings
-  router.post('/settings', (req, res) => {
+  router.post('/settings', async (req, res) => {
     const { settingsPath } = req.project;
     if (!settingsPath) {
       return res.status(501).json({
@@ -471,12 +479,6 @@ export function createProjectScopedRoutes({
     }
 
     try {
-      // Split persistence target: project-shared keys (the worca namespace)
-      // go to settings.json so they propagate to worktree pipelines and to
-      // teammates via git. Per-machine keys (permissions, hooks, mcpServers)
-      // stay in settings.local.json which is gitignored and intentionally
-      // skipped when populating worktrees (see _copy_claude_config in
-      // src/worca/scripts/run_worktree.py).
       let baseChanged = false;
       let base = {};
       try {
@@ -488,16 +490,9 @@ export function createProjectScopedRoutes({
       }
 
       if (body.worca && typeof body.worca === 'object') {
-        // Deep-merge sub-keys so a partial update (e.g. agents.implementer)
-        // doesn't clobber sibling subtrees (agents.planner, governance, etc.).
-        // The previous local-only model relied on read-time deep-merge for
-        // this; writing to base requires us to merge at write time.
         if (!base.worca || typeof base.worca !== 'object') base.worca = {};
         base.worca = deepMerge(base.worca, body.worca);
 
-        // Migration: when the client writes the new governance.subagent_dispatch
-        // shape, drop the legacy governance.dispatch key. Deep-merge alone
-        // would leave both side-by-side because they have different names.
         if (
           body.worca.governance &&
           typeof body.worca.governance === 'object' &&
@@ -511,16 +506,47 @@ export function createProjectScopedRoutes({
         baseChanged = true;
       }
 
-      if (baseChanged) {
-        mkdirSync(dirname(settingsPath), { recursive: true });
-        writeFileSync(
-          settingsPath,
-          `${JSON.stringify(base, null, 2)}\n`,
-          'utf8',
-        );
+      // STEP 1: extract misplaced global keys + inert milestone keys
+      const autoMigrated = extractAndStripGlobalKeys(base);
+
+      // STEP 2: write extracted global keys to ~/.worca/settings.json
+      const globalSettingsPath = prefsDir
+        ? join(prefsDir, 'settings.json')
+        : null;
+
+      if (
+        globalSettingsPath &&
+        Object.keys(autoMigrated.globalExtracted).length > 0
+      ) {
+        let release;
+        try {
+          release = await lockfile.lock(globalSettingsPath, {
+            retries: { retries: 5, minTimeout: 50, maxTimeout: 500 },
+            realpath: false,
+          });
+          writeGlobalSettings(globalSettingsPath, {
+            worca: autoMigrated.globalExtracted,
+          });
+        } catch (err) {
+          return res.status(500).json({
+            error: {
+              code: 'global_write_error',
+              message:
+                'Failed to migrate global keys; project settings not saved.',
+              detail: err.message,
+            },
+          });
+        } finally {
+          if (release) await release();
+        }
       }
 
-      // permissions remains in settings.local.json (machine-specific).
+      // STEP 3: atomic project write
+      if (baseChanged) {
+        mkdirSync(dirname(settingsPath), { recursive: true });
+        atomicWriteSync(settingsPath, `${JSON.stringify(base, null, 2)}\n`);
+      }
+
       if (body.permissions !== undefined) {
         const lp = localPathFor(settingsPath);
         const local = readLocalSettings(settingsPath);
@@ -533,6 +559,7 @@ export function createProjectScopedRoutes({
       res.json({
         worca: merged.worca || {},
         permissions: merged.permissions || {},
+        autoMigrated,
       });
     } catch (err) {
       res
@@ -793,26 +820,47 @@ export function createProjectScopedRoutes({
         ? Math.max(1, Math.min(10, Math.round(Number(mloops))))
         : 1;
 
-    try {
-      const result = await req.project.pm.startPipeline({
-        sourceType,
-        sourceValue: hasSource ? sourceValue : undefined,
-        prompt: hasPrompt ? prompt : undefined,
-        msize: msizeVal,
-        mloops: mloopsVal,
-        planFile: hasPlan ? planFile.trim() : undefined,
-        branch: branch || undefined,
-        template: template || undefined,
-      });
-      const { broadcast } = req.app.locals;
-      if (broadcast) broadcast('run-started', { pid: result.pid });
-      res.json({ ok: true, pid: result.pid, sourceType, prompt });
-    } catch (err) {
-      if (err.code === 'already_running') {
-        return res.status(409).json({ ok: false, error: err.message });
+    // Atomically check global cap and start pipeline under lock
+    await launchLock.withLock(async () => {
+      if (prefsDir) {
+        const globalSettings = readGlobalSettings(
+          join(prefsDir, 'settings.json'),
+        );
+        const cap =
+          globalSettings.worca?.parallel?.max_concurrent_pipelines ?? 10;
+        const totalRunning = countRunningPipelinesAcrossProjects(prefsDir);
+        if (totalRunning >= cap) {
+          res.status(409).json({
+            ok: false,
+            error: `Maximum concurrent pipelines reached (${cap}). Stop a running pipeline or increase the limit in global preferences.`,
+            code: 'max_concurrent_exceeded',
+          });
+          return;
+        }
       }
-      res.status(500).json({ ok: false, error: err.message });
-    }
+
+      try {
+        const result = await req.project.pm.startPipeline({
+          sourceType,
+          sourceValue: hasSource ? sourceValue : undefined,
+          prompt: hasPrompt ? prompt : undefined,
+          msize: msizeVal,
+          mloops: mloopsVal,
+          planFile: hasPlan ? planFile.trim() : undefined,
+          branch: branch || undefined,
+          template: template || undefined,
+        });
+        const { broadcast } = req.app.locals;
+        if (broadcast) broadcast('run-started', { pid: result.pid });
+        res.json({ ok: true, pid: result.pid, sourceType, prompt });
+      } catch (err) {
+        if (err.code === 'already_running') {
+          res.status(409).json({ ok: false, error: err.message });
+          return;
+        }
+        res.status(500).json({ ok: false, error: err.message });
+      }
+    });
   });
 
   // POST /api/projects/:projectId/runs/:id/pause
@@ -1049,6 +1097,57 @@ export function createProjectScopedRoutes({
           }
         });
       }
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // POST /api/projects/:projectId/runs/:id/control — generic run control action
+  const VALID_CONTROL_ACTIONS = new Set(['approve', 'reject']);
+  router.post('/runs/:id/control', requireWorcaDir, (req, res) => {
+    const runId = req.params.id;
+    if (!validateRunId(runId)) {
+      return res.status(400).json({ ok: false, error: 'Invalid runId' });
+    }
+    const { action, source } = req.body || {};
+    if (!action || !VALID_CONTROL_ACTIONS.has(action)) {
+      return res.status(400).json({
+        ok: false,
+        error: `Invalid action. Must be one of: ${[...VALID_CONTROL_ACTIONS].join(', ')}`,
+      });
+    }
+    const { worcaDir } = req.project;
+    const statusPath = findRunStatusPath(worcaDir, runId);
+    if (!statusPath) {
+      return res
+        .status(404)
+        .json({ ok: false, error: `Run "${runId}" not found` });
+    }
+    try {
+      const st = JSON.parse(readFileSync(statusPath, 'utf8'));
+      if (st.pipeline_status !== 'paused') {
+        return res.status(409).json({
+          ok: false,
+          error: 'Run is not paused',
+          pipeline_status: st.pipeline_status,
+        });
+      }
+      const controlDir = join(worcaDir, 'runs', runId);
+      mkdirSync(controlDir, { recursive: true });
+      writeFileSync(
+        join(controlDir, 'control.json'),
+        `${JSON.stringify(
+          {
+            action,
+            requested_at: new Date().toISOString(),
+            source: source || 'ui',
+          },
+          null,
+          2,
+        )}\n`,
+        'utf8',
+      );
+      res.json({ ok: true, action, runId });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-ui/server/project-routes.js
+++ b/worca-ui/server/project-routes.js
@@ -320,17 +320,20 @@ export function createProjectRoutes({
 /**
  * Router for project-scoped sub-routes.
  * The projectResolver middleware must run before this to set req.project.
- * @param {{ prefsDir?: string|null }} [options] — prefsDir enables active
- *   worca-cc version lookup for /worca-status' `outdated` flag.
+ * @param {{ prefsDir?: string|null, launchLock?: LaunchLock }} [options] —
+ *   prefsDir enables active worca-cc version lookup for /worca-status'
+ *   `outdated` flag and gates the global max_concurrent_pipelines check.
+ *   launchLock should be injected by createApp so all routers share the
+ *   same mutex; falls back to a per-router instance if omitted (tests).
  */
 export function createProjectScopedRoutes({
   prefsDir = null,
   serverHost,
   serverPort,
+  launchLock = new LaunchLock(),
 } = {}) {
   const router = Router({ mergeParams: true });
   const prefsPath = prefsDir ? join(prefsDir, 'preferences.json') : null;
-  const launchLock = new LaunchLock();
 
   // Guard: run-related, cost, and pipeline routes require worcaDir
   function requireWorcaDir(req, res, next) {

--- a/worca-ui/server/settings-reader.js
+++ b/worca-ui/server/settings-reader.js
@@ -1,4 +1,7 @@
-import { readMergedSettings } from './settings-merge.js';
+import { readFileSync } from 'node:fs';
+import { atomicWriteSync } from './atomic-write.js';
+import { GLOBAL_DEFAULTS } from './keys-schema.js';
+import { deepMerge, readMergedSettings } from './settings-merge.js';
 
 export function readSettings(path) {
   try {
@@ -20,4 +23,31 @@ export function readSettings(path) {
       learnEnabled: false,
     };
   }
+}
+
+export function readGlobalSettings(globalSettingsPath) {
+  let raw = {};
+  try {
+    raw = JSON.parse(readFileSync(globalSettingsPath, 'utf-8'));
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      // First-run: file doesn't exist yet — return defaults
+    } else if (err instanceof SyntaxError) {
+      console.error(
+        `Invalid JSON in ${globalSettingsPath}: ${err.message}; falling back to defaults`,
+      );
+    } else {
+      throw err;
+    }
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) raw = {};
+  raw.worca = deepMerge(GLOBAL_DEFAULTS, raw.worca || {});
+  return raw;
+}
+
+export function writeGlobalSettings(globalSettingsPath, partial) {
+  const existing = readGlobalSettings(globalSettingsPath);
+  const merged = deepMerge(existing, partial);
+  atomicWriteSync(globalSettingsPath, `${JSON.stringify(merged, null, 2)}\n`);
+  return merged;
 }

--- a/worca-ui/server/settings-validator.js
+++ b/worca-ui/server/settings-validator.js
@@ -1,5 +1,6 @@
 // server/settings-validator.js
 import { STAGE_ORDER } from '../app/utils/stage-order.js';
+import { GLOBAL_ONLY_KEYS } from './keys-schema.js';
 
 const VALID_AGENTS = [
   'planner',
@@ -12,7 +13,7 @@ const VALID_AGENTS = [
   'learner',
 ];
 const VALID_STAGES = STAGE_ORDER;
-const VALID_MODELS = ['opus', 'sonnet', 'haiku'];
+export const VALID_MODELS = ['opus', 'sonnet', 'haiku'];
 const VALID_LOOPS = [
   'implement_test',
   'pr_changes',
@@ -262,6 +263,70 @@ export function validateSettingsPayload(body) {
             details.push(`Milestone "${key}" must be a boolean`);
           }
         }
+      }
+    }
+
+    // parallel
+    if (w.parallel !== undefined) {
+      if (
+        typeof w.parallel !== 'object' ||
+        w.parallel === null ||
+        Array.isArray(w.parallel)
+      ) {
+        details.push('worca.parallel must be an object');
+      } else {
+        const p = w.parallel;
+        if (
+          p.worktree_base_dir !== undefined &&
+          (typeof p.worktree_base_dir !== 'string' ||
+            p.worktree_base_dir.length === 0)
+        ) {
+          details.push('parallel.worktree_base_dir must be a non-empty string');
+        }
+        if (
+          p.default_base_branch !== undefined &&
+          (typeof p.default_base_branch !== 'string' ||
+            p.default_base_branch.length === 0)
+        ) {
+          details.push(
+            'parallel.default_base_branch must be a non-empty string',
+          );
+        }
+      }
+    }
+
+    // circuit_breaker
+    if (w.circuit_breaker !== undefined) {
+      if (
+        typeof w.circuit_breaker !== 'object' ||
+        w.circuit_breaker === null ||
+        Array.isArray(w.circuit_breaker)
+      ) {
+        details.push('worca.circuit_breaker must be an object');
+      } else {
+        const cb = w.circuit_breaker;
+        if (cb.enabled !== undefined && typeof cb.enabled !== 'boolean') {
+          details.push('circuit_breaker.enabled must be a boolean');
+        }
+        if (
+          cb.max_consecutive_failures !== undefined &&
+          (!Number.isInteger(cb.max_consecutive_failures) ||
+            cb.max_consecutive_failures < 1 ||
+            cb.max_consecutive_failures > 10)
+        ) {
+          details.push(
+            'circuit_breaker.max_consecutive_failures must be an integer between 1 and 10',
+          );
+        }
+      }
+    }
+
+    // reject misplaced global keys in project settings
+    for (const [section, key] of GLOBAL_ONLY_KEYS) {
+      if (w?.[section]?.[key] !== undefined) {
+        details.push(
+          `worca.${section}.${key} is a global preference (~/.worca/settings.json), not a project setting. Configure it in the global Preferences tab.`,
+        );
       }
     }
 
@@ -781,4 +846,50 @@ export function validateIntegrationsConfig(cfg) {
   }
 
   return details.length ? { valid: false, details } : { valid: true };
+}
+
+const VALID_CLEANUP_POLICIES = ['never', 'on-success', 'manual-only'];
+
+export function validateGlobalSettings(prefs) {
+  const details = [];
+  const w = prefs?.worca;
+  if (!w) return { ok: true };
+
+  if (w.ui?.worktree_disk_warning_bytes !== undefined) {
+    const v = w.ui.worktree_disk_warning_bytes;
+    if (!Number.isInteger(v) || v < 500_000_000 || v > 50_000_000_000) {
+      details.push(
+        'ui.worktree_disk_warning_bytes must be an integer between 500_000_000 (500 MB) and 50_000_000_000 (50 GB)',
+      );
+    }
+  }
+
+  if (
+    w.circuit_breaker?.classifier_model !== undefined &&
+    !VALID_MODELS.includes(w.circuit_breaker.classifier_model)
+  ) {
+    details.push(
+      `circuit_breaker.classifier_model must be one of: ${VALID_MODELS.join(', ')}`,
+    );
+  }
+
+  if (
+    w.parallel?.cleanup_policy !== undefined &&
+    !VALID_CLEANUP_POLICIES.includes(w.parallel.cleanup_policy)
+  ) {
+    details.push(
+      `parallel.cleanup_policy must be one of: ${VALID_CLEANUP_POLICIES.join(', ')}`,
+    );
+  }
+
+  if (w.parallel?.max_concurrent_pipelines !== undefined) {
+    const n = w.parallel.max_concurrent_pipelines;
+    if (!Number.isInteger(n) || n < 1 || n > 20) {
+      details.push(
+        'parallel.max_concurrent_pipelines must be an integer between 1 and 20',
+      );
+    }
+  }
+
+  return details.length === 0 ? { ok: true } : { ok: false, details };
 }

--- a/worca-ui/server/settings-validator.test.js
+++ b/worca-ui/server/settings-validator.test.js
@@ -1,5 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { validateSettingsPayload } from './settings-validator.js';
+import {
+  VALID_MODELS,
+  validateGlobalSettings,
+  validateSettingsPayload,
+} from './settings-validator.js';
 
 describe('validateSettingsPayload — plan_path_template', () => {
   it('accepts a valid plan_path_template string', () => {
@@ -653,5 +660,440 @@ describe('validateSettingsPayload — worca.webhooks', () => {
       worca: { webhooks: [{ url: 'https://example.com', rate_limit_ms: 0 }] },
     });
     expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateSettingsPayload — worca.parallel', () => {
+  it('accepts valid parallel with worktree_base_dir and default_base_branch', () => {
+    const result = validateSettingsPayload({
+      worca: {
+        parallel: {
+          worktree_base_dir: '.worktrees',
+          default_base_branch: 'main',
+        },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects non-object parallel', () => {
+    const result = validateSettingsPayload({ worca: { parallel: 'bad' } });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('worca.parallel must be an object'),
+    );
+  });
+
+  it('rejects array parallel', () => {
+    const result = validateSettingsPayload({ worca: { parallel: [] } });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('worca.parallel must be an object'),
+    );
+  });
+
+  it('rejects non-string worktree_base_dir', () => {
+    const result = validateSettingsPayload({
+      worca: { parallel: { worktree_base_dir: 123 } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'parallel.worktree_base_dir must be a non-empty string',
+      ),
+    );
+  });
+
+  it('rejects empty string worktree_base_dir', () => {
+    const result = validateSettingsPayload({
+      worca: { parallel: { worktree_base_dir: '' } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'parallel.worktree_base_dir must be a non-empty string',
+      ),
+    );
+  });
+
+  it('rejects non-string default_base_branch', () => {
+    const result = validateSettingsPayload({
+      worca: { parallel: { default_base_branch: false } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'parallel.default_base_branch must be a non-empty string',
+      ),
+    );
+  });
+
+  it('rejects empty string default_base_branch', () => {
+    const result = validateSettingsPayload({
+      worca: { parallel: { default_base_branch: '' } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'parallel.default_base_branch must be a non-empty string',
+      ),
+    );
+  });
+
+  it('accepts parallel with only worktree_base_dir', () => {
+    const result = validateSettingsPayload({
+      worca: { parallel: { worktree_base_dir: '/tmp/trees' } },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts parallel with only default_base_branch', () => {
+    const result = validateSettingsPayload({
+      worca: { parallel: { default_base_branch: 'develop' } },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects misplaced global key cleanup_policy in project settings', () => {
+    const result = validateSettingsPayload({
+      worca: { parallel: { cleanup_policy: 'never' } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'worca.parallel.cleanup_policy is a global preference',
+      ),
+    );
+  });
+
+  it('rejects misplaced global key max_concurrent_pipelines in project settings', () => {
+    const result = validateSettingsPayload({
+      worca: { parallel: { max_concurrent_pipelines: 5 } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'worca.parallel.max_concurrent_pipelines is a global preference',
+      ),
+    );
+  });
+});
+
+describe('validateSettingsPayload — worca.circuit_breaker', () => {
+  it('accepts valid circuit_breaker with enabled and max_consecutive_failures', () => {
+    const result = validateSettingsPayload({
+      worca: {
+        circuit_breaker: { enabled: true, max_consecutive_failures: 3 },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects non-object circuit_breaker', () => {
+    const result = validateSettingsPayload({
+      worca: { circuit_breaker: 'bad' },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('worca.circuit_breaker must be an object'),
+    );
+  });
+
+  it('rejects array circuit_breaker', () => {
+    const result = validateSettingsPayload({
+      worca: { circuit_breaker: [] },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('worca.circuit_breaker must be an object'),
+    );
+  });
+
+  it('rejects non-boolean enabled', () => {
+    const result = validateSettingsPayload({
+      worca: { circuit_breaker: { enabled: 'yes' } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('circuit_breaker.enabled must be a boolean'),
+    );
+  });
+
+  it('rejects non-integer max_consecutive_failures', () => {
+    const result = validateSettingsPayload({
+      worca: { circuit_breaker: { max_consecutive_failures: 2.5 } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'circuit_breaker.max_consecutive_failures must be an integer between 1 and 10',
+      ),
+    );
+  });
+
+  it('rejects max_consecutive_failures below 1', () => {
+    const result = validateSettingsPayload({
+      worca: { circuit_breaker: { max_consecutive_failures: 0 } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'circuit_breaker.max_consecutive_failures must be an integer between 1 and 10',
+      ),
+    );
+  });
+
+  it('rejects max_consecutive_failures above 10', () => {
+    const result = validateSettingsPayload({
+      worca: { circuit_breaker: { max_consecutive_failures: 11 } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'circuit_breaker.max_consecutive_failures must be an integer between 1 and 10',
+      ),
+    );
+  });
+
+  it('accepts max_consecutive_failures at boundaries (1 and 10)', () => {
+    expect(
+      validateSettingsPayload({
+        worca: { circuit_breaker: { max_consecutive_failures: 1 } },
+      }).valid,
+    ).toBe(true);
+    expect(
+      validateSettingsPayload({
+        worca: { circuit_breaker: { max_consecutive_failures: 10 } },
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('rejects misplaced global key classifier_model in project settings', () => {
+    const result = validateSettingsPayload({
+      worca: { circuit_breaker: { classifier_model: 'haiku' } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'worca.circuit_breaker.classifier_model is a global preference',
+      ),
+    );
+  });
+});
+
+describe('validateSettingsPayload — reject misplaced global keys', () => {
+  it('rejects ui.worktree_disk_warning_bytes in project settings', () => {
+    const result = validateSettingsPayload({
+      worca: { ui: { worktree_disk_warning_bytes: 2000000000 } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'worca.ui.worktree_disk_warning_bytes is a global preference',
+      ),
+    );
+  });
+
+  it('accepts project payload with no misplaced global keys', () => {
+    const result = validateSettingsPayload({
+      worca: {
+        parallel: { worktree_base_dir: '.wt' },
+        circuit_breaker: { enabled: false },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateGlobalSettings', () => {
+  it('returns ok for empty worca object', () => {
+    const result = validateGlobalSettings({ worca: {} });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok when worca is absent', () => {
+    const result = validateGlobalSettings({});
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts valid worktree_disk_warning_bytes', () => {
+    const result = validateGlobalSettings({
+      worca: { ui: { worktree_disk_warning_bytes: 2000000000 } },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects worktree_disk_warning_bytes below 500 MB', () => {
+    const result = validateGlobalSettings({
+      worca: { ui: { worktree_disk_warning_bytes: 499999999 } },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('worktree_disk_warning_bytes'),
+    );
+  });
+
+  it('rejects worktree_disk_warning_bytes above 50 GB', () => {
+    const result = validateGlobalSettings({
+      worca: { ui: { worktree_disk_warning_bytes: 50000000001 } },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('worktree_disk_warning_bytes'),
+    );
+  });
+
+  it('rejects non-integer worktree_disk_warning_bytes', () => {
+    const result = validateGlobalSettings({
+      worca: { ui: { worktree_disk_warning_bytes: 1500000000.5 } },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('worktree_disk_warning_bytes'),
+    );
+  });
+
+  it('accepts boundary values for worktree_disk_warning_bytes (500 MB and 50 GB)', () => {
+    expect(
+      validateGlobalSettings({
+        worca: { ui: { worktree_disk_warning_bytes: 500000000 } },
+      }).ok,
+    ).toBe(true);
+    expect(
+      validateGlobalSettings({
+        worca: { ui: { worktree_disk_warning_bytes: 50000000000 } },
+      }).ok,
+    ).toBe(true);
+  });
+
+  it('accepts valid classifier_model', () => {
+    const result = validateGlobalSettings({
+      worca: { circuit_breaker: { classifier_model: 'haiku' } },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects invalid classifier_model', () => {
+    const result = validateGlobalSettings({
+      worca: { circuit_breaker: { classifier_model: 'gpt-4' } },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('classifier_model must be one of'),
+    );
+  });
+
+  it('accepts valid cleanup_policy', () => {
+    for (const policy of ['never', 'on-success', 'manual-only']) {
+      const result = validateGlobalSettings({
+        worca: { parallel: { cleanup_policy: policy } },
+      });
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it('rejects invalid cleanup_policy', () => {
+    const result = validateGlobalSettings({
+      worca: { parallel: { cleanup_policy: 'always' } },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('cleanup_policy must be one of'),
+    );
+  });
+
+  it('accepts valid max_concurrent_pipelines', () => {
+    const result = validateGlobalSettings({
+      worca: { parallel: { max_concurrent_pipelines: 10 } },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects max_concurrent_pipelines below 1', () => {
+    const result = validateGlobalSettings({
+      worca: { parallel: { max_concurrent_pipelines: 0 } },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'max_concurrent_pipelines must be an integer between 1 and 20',
+      ),
+    );
+  });
+
+  it('rejects max_concurrent_pipelines above 20', () => {
+    const result = validateGlobalSettings({
+      worca: { parallel: { max_concurrent_pipelines: 21 } },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'max_concurrent_pipelines must be an integer between 1 and 20',
+      ),
+    );
+  });
+
+  it('rejects non-integer max_concurrent_pipelines', () => {
+    const result = validateGlobalSettings({
+      worca: { parallel: { max_concurrent_pipelines: 5.5 } },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining(
+        'max_concurrent_pipelines must be an integer between 1 and 20',
+      ),
+    );
+  });
+
+  it('accepts max_concurrent_pipelines at boundaries (1 and 20)', () => {
+    expect(
+      validateGlobalSettings({
+        worca: { parallel: { max_concurrent_pipelines: 1 } },
+      }).ok,
+    ).toBe(true);
+    expect(
+      validateGlobalSettings({
+        worca: { parallel: { max_concurrent_pipelines: 20 } },
+      }).ok,
+    ).toBe(true);
+  });
+
+  it('validates all global fields together', () => {
+    const result = validateGlobalSettings({
+      worca: {
+        ui: { worktree_disk_warning_bytes: 2000000000 },
+        circuit_breaker: { classifier_model: 'sonnet' },
+        parallel: { cleanup_policy: 'on-success', max_concurrent_pipelines: 5 },
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('collects multiple errors', () => {
+    const result = validateGlobalSettings({
+      worca: {
+        ui: { worktree_disk_warning_bytes: -1 },
+        circuit_breaker: { classifier_model: 'invalid' },
+        parallel: { cleanup_policy: 'bad', max_concurrent_pipelines: 100 },
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.details.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('VALID_MODELS superset assertion', () => {
+  it('includes every alias from the shipped settings.json template', () => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const template = JSON.parse(
+      readFileSync(
+        resolve(__dirname, '../../src/worca/settings.json'),
+        'utf-8',
+      ),
+    );
+    const aliases = Object.keys(template.worca.models);
+    for (const alias of aliases) {
+      expect(VALID_MODELS).toContain(alias);
+    }
   });
 });

--- a/worca-ui/server/status-routes.js
+++ b/worca-ui/server/status-routes.js
@@ -1,0 +1,23 @@
+import { join } from 'node:path';
+import { Router } from 'express';
+import { countRunningPipelinesAcrossProjects } from './process-registry.js';
+import { readGlobalSettings } from './settings-reader.js';
+
+export function createStatusRouter({ prefsDir }) {
+  const router = Router();
+
+  router.get('/runs-count', (_req, res) => {
+    try {
+      const totalRunning = countRunningPipelinesAcrossProjects(prefsDir);
+      const globalSettingsPath = join(prefsDir, 'settings.json');
+      const globalSettings = readGlobalSettings(globalSettingsPath);
+      const cap =
+        globalSettings.worca?.parallel?.max_concurrent_pipelines ?? 10;
+      res.json({ ok: true, totalRunning, cap });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/worca-ui/server/status-routes.test.js
+++ b/worca-ui/server/status-routes.test.js
@@ -1,0 +1,121 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from './app.js';
+
+function startServer(prefsDir) {
+  const app = createApp({ prefsDir });
+  const server = createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const base = `http://127.0.0.1:${port}`;
+      resolve({ server, base });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+function writeProjectWithRun(prefsDir, name, runId, status) {
+  const projectDir = join(prefsDir, `_proj_${name}`);
+  const runsDir = join(projectDir, '.worca', 'runs', runId);
+  mkdirSync(runsDir, { recursive: true });
+  writeFileSync(join(runsDir, 'status.json'), JSON.stringify(status));
+  const projectsDir = join(prefsDir, 'projects.d');
+  mkdirSync(projectsDir, { recursive: true });
+  writeFileSync(
+    join(projectsDir, `${name}.json`),
+    JSON.stringify({ path: projectDir }),
+  );
+}
+
+describe('GET /api/status/runs-count', () => {
+  let tmpDir, server, base;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'status-routes-test-'));
+    ({ server, base } = await startServer(tmpDir));
+  });
+
+  afterEach(async () => {
+    if (server) await stopServer(server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns ok, totalRunning, and cap', async () => {
+    const res = await fetch(`${base}/api/status/runs-count`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(typeof data.totalRunning).toBe('number');
+    expect(typeof data.cap).toBe('number');
+  });
+
+  it('returns default cap of 10 when no global settings exist', async () => {
+    const res = await fetch(`${base}/api/status/runs-count`);
+    const data = await res.json();
+    expect(data.cap).toBe(10);
+    expect(data.totalRunning).toBe(0);
+  });
+
+  it('reads cap from global settings', async () => {
+    writeFileSync(
+      join(tmpDir, 'settings.json'),
+      JSON.stringify({
+        worca: { parallel: { max_concurrent_pipelines: 5 } },
+      }),
+    );
+    const res = await fetch(`${base}/api/status/runs-count`);
+    const data = await res.json();
+    expect(data.cap).toBe(5);
+  });
+
+  it('counts only liveness-checked running pipelines', async () => {
+    writeProjectWithRun(tmpDir, 'proj1', 'run-1', {
+      pipeline_status: 'running',
+      pid: process.pid,
+    });
+    writeProjectWithRun(tmpDir, 'proj2', 'run-2', {
+      pipeline_status: 'completed',
+      pid: process.pid,
+    });
+
+    const res = await fetch(`${base}/api/status/runs-count`);
+    const data = await res.json();
+    expect(data.totalRunning).toBe(1);
+  });
+
+  it('does not count stale PIDs', async () => {
+    writeProjectWithRun(tmpDir, 'proj1', 'run-1', {
+      pipeline_status: 'running',
+      pid: 999999999,
+    });
+
+    const res = await fetch(`${base}/api/status/runs-count`);
+    const data = await res.json();
+    expect(data.totalRunning).toBe(0);
+  });
+
+  it('is not mounted when prefsDir is not configured', async () => {
+    const app = createApp({});
+    const srv = createServer(app);
+    const { port } = await new Promise((resolve) => {
+      srv.listen(0, '127.0.0.1', () => resolve(srv.address()));
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/status/runs-count`);
+      const contentType = res.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const data = await res.json();
+        expect(data).not.toHaveProperty('totalRunning');
+      }
+    } finally {
+      await new Promise((resolve) => srv.close(resolve));
+    }
+  });
+});

--- a/worca-ui/server/test/app-run-control-action.test.js
+++ b/worca-ui/server/test/app-run-control-action.test.js
@@ -1,0 +1,186 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../process-manager.js', () => {
+  class ProcessManager {
+    constructor(opts = {}) {
+      this.worcaDir = opts.worcaDir;
+      this.projectRoot = opts.projectRoot;
+    }
+    pausePipeline() {
+      return { paused: true };
+    }
+    startPipeline() {
+      return Promise.resolve({ pid: 1 });
+    }
+    stopPipelineSync() {
+      return Promise.resolve({});
+    }
+    getRunningPid() {
+      return null;
+    }
+    reconcileStatus() {
+      return false;
+    }
+    restartStage() {}
+  }
+  return { ProcessManager };
+});
+
+const { createApp } = await import('../app.js');
+
+function startServer(worcaDir) {
+  const app = createApp({ worcaDir });
+  const server = createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, base: `http://127.0.0.1:${port}`, app });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+describe('POST /api/runs/:id/control', () => {
+  let tmpDir, server, base;
+
+  function writeStatus(runId, statusObj, dir = 'runs') {
+    const runDir = join(tmpDir, dir, runId);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify(statusObj, null, 2),
+      'utf8',
+    );
+  }
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'run-control-action-'));
+    ({ server, base } = await startServer(tmpDir));
+  });
+
+  afterEach(async () => {
+    if (server) await stopServer(server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes control.json with approve action', async () => {
+    writeStatus('run-abc', {
+      pipeline_status: 'paused',
+      milestones: { pr_approved: false },
+    });
+    const res = await fetch(`${base}/api/runs/run-abc/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'approve', source: 'ui-pr-approval' }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+
+    const controlPath = join(tmpDir, 'runs', 'run-abc', 'control.json');
+    expect(existsSync(controlPath)).toBe(true);
+    const control = JSON.parse(readFileSync(controlPath, 'utf8'));
+    expect(control.action).toBe('approve');
+    expect(control.source).toBe('ui-pr-approval');
+    expect(control.requested_at).toBeDefined();
+  });
+
+  it('writes control.json with reject action', async () => {
+    writeStatus('run-abc', {
+      pipeline_status: 'paused',
+      milestones: { pr_approved: false },
+    });
+    const res = await fetch(`${base}/api/runs/run-abc/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'reject' }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+
+    const controlPath = join(tmpDir, 'runs', 'run-abc', 'control.json');
+    const control = JSON.parse(readFileSync(controlPath, 'utf8'));
+    expect(control.action).toBe('reject');
+  });
+
+  it('returns 404 when run not found', async () => {
+    const res = await fetch(`${base}/api/runs/nonexistent/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'approve' }),
+    });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+  });
+
+  it('returns 409 when run is not paused', async () => {
+    writeStatus('run-abc', { pipeline_status: 'running' });
+    const res = await fetch(`${base}/api/runs/run-abc/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'approve' }),
+    });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+  });
+
+  it('returns 409 when run is completed', async () => {
+    writeStatus('run-abc', { pipeline_status: 'completed' });
+    const res = await fetch(`${base}/api/runs/run-abc/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'approve' }),
+    });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+  });
+
+  it('returns 400 for invalid action', async () => {
+    writeStatus('run-abc', { pipeline_status: 'paused' });
+    const res = await fetch(`${base}/api/runs/run-abc/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'invalid' }),
+    });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+  });
+
+  it('returns 400 for missing action', async () => {
+    writeStatus('run-abc', { pipeline_status: 'paused' });
+    const res = await fetch(`${base}/api/runs/run-abc/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid runId', async () => {
+    const res = await fetch(`${base}/api/runs/../../../etc/control`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'approve' }),
+    });
+    expect([400, 404]).toContain(res.status);
+  });
+});

--- a/worca-ui/server/test/cap-enforcement.test.js
+++ b/worca-ui/server/test/cap-enforcement.test.js
@@ -1,0 +1,167 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockStartPipeline = vi.fn().mockResolvedValue({ pid: 12345 });
+let mockRunningPid = null;
+let mockGlobalCount = 0;
+
+vi.mock('../process-manager.js', () => {
+  class ProcessManager {
+    constructor(opts = {}) {
+      this.worcaDir = opts.worcaDir;
+      this.projectRoot = opts.projectRoot;
+    }
+    startPipeline(opts) {
+      return mockStartPipeline(this.worcaDir, opts);
+    }
+    stopPipeline(runId) {
+      return vi.fn()(runId);
+    }
+    pausePipeline(runId) {
+      return vi.fn()(runId);
+    }
+    getRunningPid() {
+      return mockRunningPid;
+    }
+    reconcileStatus() {
+      return false;
+    }
+    restartStage() {
+      return vi.fn()();
+    }
+  }
+  return { ProcessManager };
+});
+
+vi.mock('../process-registry.js', () => ({
+  countRunningPipelinesAcrossProjects: () => mockGlobalCount,
+}));
+
+const { createApp } = await import('../app.js');
+
+function startServer(prefsDir, projectRoot) {
+  const app = createApp({ prefsDir, projectRoot });
+  const server = createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      const base = `http://127.0.0.1:${port}`;
+      resolve({ server, base });
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+async function postRun(base, projectName, body) {
+  return fetch(`${base}/api/projects/${projectName}/runs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/projects/:id/runs - max_concurrent_pipelines cap', () => {
+  let prefsDir, projectRoot, server, base, projectName;
+
+  beforeEach(async () => {
+    prefsDir = mkdtempSync(join(tmpdir(), 'cap-test-prefs-'));
+    projectRoot = mkdtempSync(join(tmpdir(), 'cap-test-proj-'));
+    mkdirSync(join(projectRoot, '.worca', 'runs'), { recursive: true });
+    mkdirSync(join(projectRoot, '.claude'), { recursive: true });
+    writeFileSync(join(projectRoot, '.claude', 'settings.json'), '{}');
+
+    // Write global settings with a low cap
+    mkdirSync(prefsDir, { recursive: true });
+    writeFileSync(
+      join(prefsDir, 'settings.json'),
+      JSON.stringify({
+        worca: { parallel: { max_concurrent_pipelines: 2 } },
+      }),
+    );
+
+    // Register the project
+    mkdirSync(join(prefsDir, 'projects.d'), { recursive: true });
+    writeFileSync(
+      join(prefsDir, 'projects.d', 'test-proj.json'),
+      JSON.stringify({ name: 'test-proj', path: projectRoot }),
+    );
+
+    mockStartPipeline.mockClear();
+    mockStartPipeline.mockResolvedValue({ pid: 12345 });
+    mockRunningPid = null;
+    mockGlobalCount = 0;
+    projectName = 'test-proj';
+
+    ({ server, base } = await startServer(prefsDir, projectRoot));
+  });
+
+  afterEach(async () => {
+    if (server) await stopServer(server);
+    rmSync(prefsDir, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('allows start when below cap', async () => {
+    mockGlobalCount = 1;
+    const res = await postRun(base, projectName, { prompt: 'Add feature X' });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(mockStartPipeline).toHaveBeenCalled();
+  });
+
+  it('returns 409 with max_concurrent_exceeded when at cap', async () => {
+    mockGlobalCount = 2;
+    const res = await postRun(base, projectName, { prompt: 'Add feature X' });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.ok).toBe(false);
+    expect(data.code).toBe('max_concurrent_exceeded');
+    expect(data.error).toMatch(/maximum concurrent/i);
+    expect(mockStartPipeline).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 with max_concurrent_exceeded when above cap', async () => {
+    mockGlobalCount = 5;
+    const res = await postRun(base, projectName, { prompt: 'Add feature X' });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.code).toBe('max_concurrent_exceeded');
+    expect(mockStartPipeline).not.toHaveBeenCalled();
+  });
+
+  it('uses default cap of 10 when no global settings exist', async () => {
+    // Remove global settings file
+    rmSync(join(prefsDir, 'settings.json'), { force: true });
+    mockGlobalCount = 9;
+
+    const res = await postRun(base, projectName, { prompt: 'Add feature X' });
+    expect(res.status).toBe(200);
+    expect(mockStartPipeline).toHaveBeenCalled();
+  });
+
+  it('blocks at default cap of 10 when no global settings exist', async () => {
+    rmSync(join(prefsDir, 'settings.json'), { force: true });
+    mockGlobalCount = 10;
+
+    const res = await postRun(base, projectName, { prompt: 'Add feature X' });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.code).toBe('max_concurrent_exceeded');
+  });
+
+  it('still checks per-project running before global cap', async () => {
+    mockRunningPid = 99999;
+    mockGlobalCount = 0;
+    const res = await postRun(base, projectName, { prompt: 'Add feature X' });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.code).toBe('already_running');
+  });
+});

--- a/worca-ui/server/test/settings-api.test.js
+++ b/worca-ui/server/test/settings-api.test.js
@@ -41,8 +41,7 @@ const SAMPLE_SETTINGS = {
     loops: { implement_test: 3, pr_changes: 3, restart_planning: 2 },
     milestones: {
       plan_approval: true,
-      pr_approval: true,
-      deploy_approval: true,
+      pr_approval: false,
     },
     governance: {
       guards: {

--- a/worca-ui/server/test/settings-strip-on-save.test.js
+++ b/worca-ui/server/test/settings-strip-on-save.test.js
@@ -1,0 +1,257 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createPreferencesRouter } from '../preferences-routes.js';
+import { writeProject } from '../project-registry.js';
+import {
+  createProjectScopedRoutes,
+  projectResolver,
+} from '../project-routes.js';
+
+let prefsDir, projectRoot, settingsPath, globalSettingsPath, server, base;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/preferences', createPreferencesRouter({ prefsDir }));
+  app.use(
+    '/api/projects/:projectId',
+    projectResolver({ prefsDir, projectRoot }),
+    createProjectScopedRoutes({ prefsDir }),
+  );
+  return app;
+}
+
+async function startServer() {
+  const app = buildApp();
+  server = createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      base = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+}
+
+function stopServer() {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+async function postSettings(body) {
+  return fetch(`${base}/api/projects/myproj/settings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(async () => {
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  prefsDir = join(tmpdir(), `strip-save-test-prefs-${suffix}`);
+  projectRoot = join(tmpdir(), `strip-save-test-proj-${suffix}`);
+
+  mkdirSync(prefsDir, { recursive: true });
+  mkdirSync(join(projectRoot, '.worca', 'runs'), { recursive: true });
+  mkdirSync(join(projectRoot, '.claude'), { recursive: true });
+
+  settingsPath = join(projectRoot, '.claude', 'settings.json');
+  globalSettingsPath = join(prefsDir, 'settings.json');
+
+  writeProject(prefsDir, { name: 'myproj', path: projectRoot });
+  await startServer();
+});
+
+afterEach(async () => {
+  if (server) await stopServer();
+  rmSync(prefsDir, { recursive: true, force: true });
+  rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('strip-on-save: global key migration', () => {
+  it('extracts misplaced global keys to ~/.worca/settings.json on save', async () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        worca: {
+          parallel: {
+            worktree_base_dir: '.worktrees',
+            cleanup_policy: 'on-success',
+            max_concurrent_pipelines: 3,
+          },
+          circuit_breaker: {
+            enabled: true,
+            classifier_model: 'haiku',
+          },
+          ui: {
+            worktree_disk_warning_bytes: 5000000000,
+          },
+        },
+      }),
+    );
+
+    const res = await postSettings({
+      worca: { parallel: { worktree_base_dir: '.worktrees' } },
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.autoMigrated).toBeDefined();
+    expect(data.autoMigrated.globalExtracted).toEqual(
+      expect.objectContaining({
+        parallel: expect.objectContaining({
+          cleanup_policy: 'on-success',
+          max_concurrent_pipelines: 3,
+        }),
+      }),
+    );
+
+    const projectFile = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(projectFile.worca.parallel.cleanup_policy).toBeUndefined();
+    expect(projectFile.worca.parallel.max_concurrent_pipelines).toBeUndefined();
+    expect(projectFile.worca.circuit_breaker?.classifier_model).toBeUndefined();
+    expect(projectFile.worca.ui?.worktree_disk_warning_bytes).toBeUndefined();
+
+    const globalFile = JSON.parse(readFileSync(globalSettingsPath, 'utf-8'));
+    expect(globalFile.worca.parallel.cleanup_policy).toBe('on-success');
+    expect(globalFile.worca.parallel.max_concurrent_pipelines).toBe(3);
+    expect(globalFile.worca.circuit_breaker.classifier_model).toBe('haiku');
+    expect(globalFile.worca.ui.worktree_disk_warning_bytes).toBe(5000000000);
+  });
+
+  it('strips inert milestone keys (pr_approval: true) on save', async () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        worca: {
+          milestones: {
+            plan_approval: true,
+            pr_approval: true,
+            deploy_approval: true,
+          },
+        },
+      }),
+    );
+
+    const res = await postSettings({
+      worca: { milestones: { plan_approval: true } },
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.autoMigrated.removedMilestones).toContain('pr_approval');
+    expect(data.autoMigrated.removedMilestones).toContain('deploy_approval');
+
+    const projectFile = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(projectFile.worca.milestones.pr_approval).toBeUndefined();
+    expect(projectFile.worca.milestones.deploy_approval).toBeUndefined();
+    expect(projectFile.worca.milestones.plan_approval).toBe(true);
+  });
+
+  it('preserves pr_approval: false (user opted out)', async () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        worca: {
+          milestones: { plan_approval: true, pr_approval: false },
+        },
+      }),
+    );
+
+    const res = await postSettings({
+      worca: { milestones: { plan_approval: true } },
+    });
+    expect(res.status).toBe(200);
+
+    const projectFile = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(projectFile.worca.milestones.pr_approval).toBe(false);
+  });
+});
+
+describe('strip-on-save: round-trip cleanliness', () => {
+  it('clean project stays clean after no-op save (no pr_approval reintroduced)', async () => {
+    const cleanSettings = {
+      worca: {
+        parallel: { worktree_base_dir: '.worktrees' },
+        milestones: { plan_approval: true },
+        agents: { planner: { model: 'opus' } },
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(cleanSettings));
+
+    const res = await postSettings(cleanSettings);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.autoMigrated.globalExtracted).toEqual({});
+    expect(data.autoMigrated.removedMilestones).toEqual([]);
+
+    const projectFile = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(projectFile.worca.milestones.pr_approval).toBeUndefined();
+    expect(projectFile.worca.parallel.cleanup_policy).toBeUndefined();
+
+    expect(existsSync(globalSettingsPath)).toBe(false);
+  });
+});
+
+describe('strip-on-save: validation failure leaves files unchanged', () => {
+  it('validation error leaves both project and global files unchanged', async () => {
+    const originalProject = {
+      worca: {
+        parallel: {
+          worktree_base_dir: '.worktrees',
+          cleanup_policy: 'on-success',
+        },
+        agents: { planner: { model: 'opus' } },
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(originalProject));
+
+    const res = await postSettings({
+      worca: { agents: { hacker: { model: 'opus' } } },
+    });
+    expect(res.status).toBe(400);
+
+    const projectFile = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(projectFile).toEqual(originalProject);
+
+    expect(existsSync(globalSettingsPath)).toBe(false);
+  });
+
+  it('validation error with existing global file leaves it unchanged', async () => {
+    const originalProject = {
+      worca: {
+        parallel: {
+          worktree_base_dir: '.worktrees',
+          cleanup_policy: 'on-success',
+        },
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(originalProject));
+
+    const originalGlobal = {
+      worca: { parallel: { max_concurrent_pipelines: 5 } },
+    };
+    writeFileSync(globalSettingsPath, JSON.stringify(originalGlobal));
+
+    const res = await postSettings({
+      worca: { agents: { hacker: { model: 'opus' } } },
+    });
+    expect(res.status).toBe(400);
+
+    const projectFile = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(projectFile).toEqual(originalProject);
+
+    const globalFile = JSON.parse(readFileSync(globalSettingsPath, 'utf-8'));
+    expect(globalFile).toEqual(originalGlobal);
+  });
+});

--- a/worca-ui/server/worktree-ops.js
+++ b/worca-ui/server/worktree-ops.js
@@ -1,0 +1,72 @@
+/**
+ * Shared worktree operations — single owner of `git worktree remove` shell-out.
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Remove a worktree and its registry entry.
+ * Mirrors WorktreeSource.remove from src/worca/cli/cleanup.py:
+ *   1. Attempt `git worktree remove --force <path>` from the project root
+ *   2. On failure (e.g. non-worktree temp dir in tests), fall back to rmSync
+ *   3. Run `git worktree prune` so git's metadata (`.git/worktrees/<id>/`)
+ *      drops the entry even when the directory was removed manually
+ *   4. Delete the registry file
+ */
+export function removeWorktree(worcaDir, runId) {
+  const regFile = join(worcaDir, 'multi', 'pipelines.d', `${runId}.json`);
+  const projectRoot = join(worcaDir, '..');
+  let worktreePath = null;
+
+  if (existsSync(regFile)) {
+    try {
+      const reg = JSON.parse(readFileSync(regFile, 'utf8'));
+      worktreePath = reg.worktree_path || null;
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (worktreePath && existsSync(worktreePath)) {
+    try {
+      execFileSync('git', ['worktree', 'remove', '--force', worktreePath], {
+        cwd: projectRoot,
+        stdio: 'pipe',
+        timeout: 30_000,
+      });
+    } catch {
+      let isRealDir = false;
+      try {
+        const st = lstatSync(worktreePath);
+        isRealDir = st.isDirectory() && !st.isSymbolicLink();
+      } catch {
+        /* ignore */
+      }
+      if (isRealDir) {
+        rmSync(worktreePath, { recursive: true, force: true });
+      }
+    }
+  }
+
+  try {
+    execFileSync('git', ['worktree', 'prune'], {
+      cwd: projectRoot,
+      stdio: 'pipe',
+      timeout: 30_000,
+    });
+  } catch {
+    /* non-fatal */
+  }
+
+  if (existsSync(regFile)) {
+    unlinkSync(regFile);
+  }
+}

--- a/worca-ui/server/worktrees-routes.js
+++ b/worca-ui/server/worktrees-routes.js
@@ -7,18 +7,10 @@
  * Expects req.project.worcaDir to be set by projectResolver middleware.
  */
 
-import { execFileSync } from 'node:child_process';
-import {
-  existsSync,
-  lstatSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  unlinkSync,
-} from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { Router } from 'express';
+import { removeWorktree } from './worktree-ops.js';
 
 const RESUMABLE_STATUSES = new Set(['failed', 'paused', 'cancelled']);
 
@@ -172,75 +164,6 @@ function _listWorktrees(worcaDir) {
   return entries;
 }
 
-/**
- * Remove a worktree and its registry entry.
- * Mirrors WorktreeSource.remove from src/worca/cli/cleanup.py:
- *   1. Attempt `git worktree remove --force <path>` from the project root
- *   2. On failure (e.g. non-worktree temp dir in tests), fall back to rmSync
- *   3. Run `git worktree prune` so git's metadata (`.git/worktrees/<id>/`)
- *      drops the entry even when the directory was removed manually
- *   4. Delete the registry file
- */
-function _removeWorktree(worcaDir, runId) {
-  const regFile = join(worcaDir, 'multi', 'pipelines.d', `${runId}.json`);
-  // worcaDir is `<projectRoot>/.worca` — git commands must run inside the
-  // project repo, not the server's cwd, or `git worktree remove` errors out
-  // and the .git/worktrees/<id>/ metadata is left as `prunable`.
-  const projectRoot = join(worcaDir, '..');
-  let worktreePath = null;
-
-  if (existsSync(regFile)) {
-    try {
-      const reg = JSON.parse(readFileSync(regFile, 'utf8'));
-      worktreePath = reg.worktree_path || null;
-    } catch {
-      /* ignore */
-    }
-  }
-
-  if (worktreePath && existsSync(worktreePath)) {
-    try {
-      execFileSync('git', ['worktree', 'remove', '--force', worktreePath], {
-        cwd: projectRoot,
-        stdio: 'pipe',
-        timeout: 30_000,
-      });
-    } catch {
-      // Path is not a registered git worktree — brute-force remove.
-      // Refuse to follow symlinks: rmSync on a symlink to a real directory
-      // would delete the link itself (good), but we don't want to risk a
-      // user-symlinked path here being mistaken for a worktree we own.
-      let isRealDir = false;
-      try {
-        const st = lstatSync(worktreePath);
-        isRealDir = st.isDirectory() && !st.isSymbolicLink();
-      } catch {
-        /* ignore */
-      }
-      if (isRealDir) {
-        rmSync(worktreePath, { recursive: true, force: true });
-      }
-    }
-  }
-
-  // Always prune — covers (a) successful remove leaving residual metadata,
-  // (b) brute-force rmSync path, and (c) entries already left prunable by
-  // earlier failures. Errors are non-fatal (e.g. project not a git repo).
-  try {
-    execFileSync('git', ['worktree', 'prune'], {
-      cwd: projectRoot,
-      stdio: 'pipe',
-      timeout: 30_000,
-    });
-  } catch {
-    /* non-fatal */
-  }
-
-  if (existsSync(regFile)) {
-    unlinkSync(regFile);
-  }
-}
-
 const RUN_ID_RE = /^[a-zA-Z0-9_-]+$/;
 function _validateRunId(runId) {
   return (
@@ -338,7 +261,7 @@ export function createWorktreesRouter() {
         });
       }
 
-      _removeWorktree(worcaDir, run_id);
+      removeWorktree(worcaDir, run_id);
       res.json({ ok: true, run_id });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });

--- a/worca-ui/test/fixtures/settings-with-ui.json
+++ b/worca-ui/test/fixtures/settings-with-ui.json
@@ -12,7 +12,7 @@
     },
     "milestones": {
       "plan_approval": true,
-      "pr_approval": true
+      "pr_approval": false
     },
     "ui": {
       "stages": {


### PR DESCRIPTION
## Summary

- **Settings UI panels** for all pipeline-shape and execution-control knobs that were previously JSON-only: Execution & Parallelism (worktree base dir, default PR base branch, max concurrent pipelines, cleanup policy), Approval Gates (plan/PR approval toggles), Circuit Breaker (max failures, classifier model), and Preferences (worktree disk warning threshold)
- **Backend runtime consumers** for 5 previously-inert keys: PR-approval gate in `runner.py`, launch mutex enforcing `max_concurrent_pipelines` in `process-manager.js`, `default_base_branch` passthrough in `run_worktree.py`, `cleanup_policy` lifecycle hook, and global preferences endpoint (`~/.worca/settings.json`) for cross-project keys
- **Shared key/defaults schema** (`src/worca/schemas/keys.json`) as single source of truth for key names, types, defaults, and project-vs-global scope — consumed by both Python backend and UI server
- **Migration path**: `worca init --upgrade` strips deprecated keys (`pr_approval`, `deploy_approval` from milestones; `governance.dispatch`); UI shows a banner when legacy keys are detected

## Details

72 files changed, ~6300 lines (roughly 2100 implementation + 4200 tests).

**Python backend:**
- `runner.py`: PR-approval gate checks `milestones.pr_approval` before creating PR
- `run_worktree.py`: reads `parallel.default_base_branch` as fallback when no `--branch` flag
- `settings.py`: `get_global_setting()` for `~/.worca/settings.json` preferences with project-level override
- `cli/init.py`: `--upgrade` flag strips deprecated keys and migrates settings shape
- `schemas/keys.json`: canonical key registry (type, default, scope, validation constraints)
- `state/status.py`: `worktree_path` field in status JSON for worktree-aware runs

**UI server:**
- `preferences-routes.js`: CRUD for `~/.worca/settings.json` global preferences
- `launch-lock.js`: mutex enforcing `max_concurrent_pipelines` cap at launch time
- `process-registry.js`: extracted from process-manager for testability
- `settings-validator.js`: flat dot-path validation against keys.json schema
- `keys-schema.js` + `global-keys.js`: server-side schema loading and global key identification
- `atomic-write.js` + `worktree-ops.js`: extracted helpers

**UI client:**
- `settings.js`: four new sub-panels with form controls, locked-save during active runs, migration banner
- `main.js`: SSE subscription for `totalRunning` badge, preferences fetch
- `sidebar.js`: totalRunning badge from SSE events
- `run-detail.js`: PR-approval pending state display

**Tests:** 32 new test files covering schema validation, form round-trip fidelity, approval gates, circuit breaker, migration strip I/O, cap enforcement, launch lock, preferences routes, flat dot-path addressing, and more.

Closes #118

## Test plan

- [ ] `pytest tests/test_keys_schema.py tests/test_runner_pr_approval.py tests/test_settings_global_fallback.py tests/test_init_migration.py tests/test_run_worktree.py tests/test_settings.py tests/test_settings_circuit_breaker.py tests/test_status.py` — all Python tests pass
- [ ] `cd worca-ui && npx vitest run` — all UI unit tests pass (server + client)
- [ ] Verify Settings view renders all four panels with correct defaults
- [ ] Toggle approval gates, change max concurrent pipelines, save — verify JSON written correctly
- [ ] Start a pipeline run, confirm Settings save button is locked
- [ ] Verify migration banner appears when legacy `milestones.pr_approval` key exists in settings.json
- [ ] Verify `worca init --upgrade` strips deprecated keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)