### PR TITLE
fix(ui): propagate --project flag from bin to spawned server

### DIFF
--- a/worca-ui/bin/worca-ui.js
+++ b/worca-ui/bin/worca-ui.js
@@ -113,6 +113,23 @@ export function parseArgs(argv) {
   return args;
 }
 
+/** Build the argv array for spawning server/index.js. Exported for testing. */
+export function buildSpawnArgs({
+  serverScript,
+  port,
+  host,
+  isGlobal,
+  projectPath,
+}) {
+  const args = [serverScript, '--port', String(port), '--host', host];
+  if (isGlobal) {
+    args.push('--global');
+  } else if (projectPath) {
+    args.push('--project', projectPath);
+  }
+  return args;
+}
+
 /** Resolve log file path based on mode (mirrors PID file location). */
 function resolveLogPath(isGlobal) {
   if (isGlobal) {
@@ -242,7 +259,7 @@ function describePortOccupant(port) {
   return null;
 }
 
-async function start({ port, host, open, global: isGlobal }) {
+async function start({ port, host, open, global: isGlobal, projectPath }) {
   const { pidDir, pidFile } = resolvePidPaths(isGlobal);
 
   const existing = readPidFile(pidFile);
@@ -281,16 +298,13 @@ async function start({ port, host, open, global: isGlobal }) {
     }
   }
 
-  const spawnArgs = [
-    SERVER_SCRIPT,
-    '--port',
-    String(availablePort),
-    '--host',
+  const spawnArgs = buildSpawnArgs({
+    serverScript: SERVER_SCRIPT,
+    port: availablePort,
     host,
-  ];
-  if (isGlobal) {
-    spawnArgs.push('--global');
-  }
+    isGlobal,
+    projectPath,
+  });
 
   // Capture child stdout+stderr to a log file so startup crashes are visible.
   // Without this, errors thrown during module load (missing files, bad imports,

--- a/worca-ui/bin/worca-ui.test.js
+++ b/worca-ui/bin/worca-ui.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseArgs } from './worca-ui.js';
+import { buildSpawnArgs, parseArgs } from './worca-ui.js';
 
 describe('parseArgs', () => {
   it('sets global flag when --global is passed', () => {
@@ -122,5 +122,64 @@ describe('parseArgs', () => {
     expect(result.subAction).toBe('add');
     expect(result.projectPath).toBe('/tmp/proj');
     expect(result.projectName).toBe('my-slug');
+  });
+});
+
+const SCRIPT = '/fake/server/index.js';
+
+describe('buildSpawnArgs', () => {
+  it('always includes serverScript, --port, and --host', () => {
+    const args = buildSpawnArgs({
+      serverScript: SCRIPT,
+      port: 3401,
+      host: '0.0.0.0',
+      isGlobal: true,
+      projectPath: null,
+    });
+    expect(args[0]).toBe(SCRIPT);
+    const portIdx = args.indexOf('--port');
+    expect(portIdx).toBeGreaterThan(-1);
+    expect(args[portIdx + 1]).toBe('3401');
+    const hostIdx = args.indexOf('--host');
+    expect(hostIdx).toBeGreaterThan(-1);
+    expect(args[hostIdx + 1]).toBe('0.0.0.0');
+  });
+
+  it('pushes --global when isGlobal is true', () => {
+    const args = buildSpawnArgs({
+      serverScript: SCRIPT,
+      port: 3400,
+      host: '127.0.0.1',
+      isGlobal: true,
+      projectPath: null,
+    });
+    expect(args).toContain('--global');
+    expect(args).not.toContain('--project');
+  });
+
+  it('pushes --project <path> when isGlobal is false and projectPath is set', () => {
+    const args = buildSpawnArgs({
+      serverScript: SCRIPT,
+      port: 3400,
+      host: '127.0.0.1',
+      isGlobal: false,
+      projectPath: '/my/proj',
+    });
+    const idx = args.indexOf('--project');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('/my/proj');
+    expect(args).not.toContain('--global');
+  });
+
+  it('omits both --global and --project when isGlobal is false and projectPath is null', () => {
+    const args = buildSpawnArgs({
+      serverScript: SCRIPT,
+      port: 3400,
+      host: '127.0.0.1',
+      isGlobal: false,
+      projectPath: null,
+    });
+    expect(args).not.toContain('--global');
+    expect(args).not.toContain('--project');
   });
 });

--- a/worca-ui/server/argv-parser.js
+++ b/worca-ui/server/argv-parser.js
@@ -1,0 +1,28 @@
+/**
+ * Parse server startup arguments from an argv array.
+ * Returns { port, host, isGlobal, projectPath }.
+ * Pass defaults to seed port/host from env vars before argv overrides them.
+ */
+export function parseServerArgv(argv, defaults = {}) {
+  let port = defaults.port ?? 3400;
+  let host = defaults.host ?? '127.0.0.1';
+  let isGlobal = true;
+  let projectPath = null;
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--port' && argv[i + 1]) {
+      port = parseInt(argv[++i], 10);
+    } else if (argv[i] === '--host' && argv[i + 1]) {
+      host = argv[++i];
+    } else if (argv[i] === '--global') {
+      isGlobal = true;
+    } else if (argv[i] === '--project') {
+      isGlobal = false;
+      if (argv[i + 1] && !argv[i + 1].startsWith('-')) {
+        projectPath = argv[++i];
+      }
+    }
+  }
+
+  return { port, host, isGlobal, projectPath };
+}

--- a/worca-ui/server/index.js
+++ b/worca-ui/server/index.js
@@ -4,21 +4,20 @@ import { createServer } from 'node:http';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { createApp } from './app.js';
+import { parseServerArgv } from './argv-parser.js';
 import { createIntegrations } from './integrations/index.js';
 import { attachWsServer } from './ws.js';
 
-// Parse argv
-let port = parseInt(process.env.PORT, 10) || 3400;
-let host = process.env.HOST || '127.0.0.1';
-let isGlobal = true;
-for (let i = 0; i < process.argv.length; i++) {
-  if (process.argv[i] === '--port' && process.argv[i + 1])
-    port = parseInt(process.argv[++i], 10);
-  if (process.argv[i] === '--host' && process.argv[i + 1])
-    host = process.argv[++i];
-  if (process.argv[i] === '--global') isGlobal = true;
-  if (process.argv[i] === '--project') isGlobal = false;
-}
+// Parse argv (env vars provide defaults; argv flags take precedence)
+const {
+  port,
+  host,
+  isGlobal,
+  projectPath: explicitProjectPath,
+} = parseServerArgv(process.argv, {
+  port: parseInt(process.env.PORT, 10) || 3400,
+  host: process.env.HOST || '127.0.0.1',
+});
 
 // Resolve project root: walk up from cwd until we find .claude/settings.json
 import { existsSync } from 'node:fs';
@@ -44,8 +43,8 @@ if (isGlobal) {
   worcaDir = null;
   settingsPath = null;
 } else {
-  // Per-project mode: resolve from cwd
-  projectRoot = findProjectRoot(process.cwd());
+  // Per-project mode: use explicit path when provided, otherwise walk up from cwd
+  projectRoot = explicitProjectPath ?? findProjectRoot(process.cwd());
   worcaDir = join(projectRoot, '.worca');
   settingsPath = join(projectRoot, '.claude', 'settings.json');
 }

--- a/worca-ui/server/server-argv.test.js
+++ b/worca-ui/server/server-argv.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { parseServerArgv } from './argv-parser.js';
+
+describe('parseServerArgv', () => {
+  it('returns defaults when no flags given', () => {
+    const r = parseServerArgv(['node', 'index.js']);
+    expect(r.port).toBe(3400);
+    expect(r.host).toBe('127.0.0.1');
+    expect(r.isGlobal).toBe(true);
+    expect(r.projectPath).toBeNull();
+  });
+
+  it('parses --port', () => {
+    const r = parseServerArgv(['node', 'index.js', '--port', '4000']);
+    expect(r.port).toBe(4000);
+  });
+
+  it('parses --host', () => {
+    const r = parseServerArgv(['node', 'index.js', '--host', '0.0.0.0']);
+    expect(r.host).toBe('0.0.0.0');
+  });
+
+  it('parses --global', () => {
+    const r = parseServerArgv(['node', 'index.js', '--global']);
+    expect(r.isGlobal).toBe(true);
+    expect(r.projectPath).toBeNull();
+  });
+
+  it('parses --project and captures path', () => {
+    const r = parseServerArgv([
+      'node',
+      'index.js',
+      '--project',
+      '/path/to/proj',
+    ]);
+    expect(r.isGlobal).toBe(false);
+    expect(r.projectPath).toBe('/path/to/proj');
+  });
+
+  it('--project with no following value leaves projectPath null', () => {
+    const r = parseServerArgv(['node', 'index.js', '--project']);
+    expect(r.isGlobal).toBe(false);
+    expect(r.projectPath).toBeNull();
+  });
+
+  it('--project with flag-like next arg leaves projectPath null; subsequent --global wins', () => {
+    const r = parseServerArgv(['node', 'index.js', '--project', '--global']);
+    expect(r.isGlobal).toBe(true);
+    expect(r.projectPath).toBeNull();
+  });
+
+  it('parses combined flags', () => {
+    const r = parseServerArgv([
+      'node',
+      'index.js',
+      '--port',
+      '3401',
+      '--project',
+      '/my/proj',
+    ]);
+    expect(r.port).toBe(3401);
+    expect(r.isGlobal).toBe(false);
+    expect(r.projectPath).toBe('/my/proj');
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug:** `bin/worca-ui.js start --project <path>` never forwarded `--project` to `server/index.js`, causing per-project mode to silently run in global mode (all `/api/runs` calls return 501 "worcaDir not configured")
- **Fix (bin):** Extract `buildSpawnArgs()` that conditionally pushes `--project <path>` to the spawn argv when `isGlobal=false`
- **Fix (server):** Extract `parseServerArgv()` into `server/argv-parser.js` that captures the path value after `--project` and passes it as `explicitProjectPath` to the project root resolver

## Test plan

- [x] 4 new `buildSpawnArgs` unit tests in `bin/worca-ui.test.js` (global, project, null project)
- [x] 7 new `parseServerArgv` unit tests in `server/server-argv.test.js` (defaults, each flag, combined, edge cases)
- [x] All 25 tests pass (`npx vitest run`)
- [x] Lint clean (`biome check`)
- [x] New `server/argv-parser.js` included in `npm pack --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)