### PR TITLE
fix(ui-server): route worktree-blind callsites through resolver

### DIFF
--- a/worca-ui/server/process-manager.js
+++ b/worca-ui/server/process-manager.js
@@ -201,12 +201,48 @@ export class ProcessManager {
       }
     }
 
+    // Also scan pipelines.d/ for worktree PIDs (worktree runs never appear in runs/)
+    const pipelinesDir = join(this.worcaDir, 'multi', 'pipelines.d');
+    if (existsSync(pipelinesDir)) {
+      try {
+        for (const entry of readdirSync(pipelinesDir)) {
+          if (!entry.endsWith('.json')) continue;
+          const runId = entry.slice(0, -5);
+          try {
+            const reg = JSON.parse(
+              readFileSync(join(pipelinesDir, entry), 'utf8'),
+            );
+            if (reg.worktree_path) {
+              const wtPidPath = join(
+                reg.worktree_path,
+                '.worca',
+                'runs',
+                runId,
+                'pipeline.pid',
+              );
+              if (existsSync(wtPidPath)) runIds.add(runId);
+            }
+          } catch {
+            /* ignore malformed registry entry */
+          }
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+
     for (const runId of runIds) {
       // Check if this run's process is alive
       const alive = this.getRunningPid(runId);
       if (alive) continue;
 
-      const statusPath = join(this.worcaDir, 'runs', runId, 'status.json');
+      // Route all paths through resolveRunContext so worktree runs use
+      // their worktree dir rather than the project-root runs/ dir.
+      const ctx = this.resolveRunContext(runId);
+      if (!ctx) continue;
+      const { runDir } = ctx;
+
+      const statusPath = join(runDir, 'status.json');
       if (!existsSync(statusPath)) continue;
 
       let status;
@@ -236,7 +272,7 @@ export class ProcessManager {
 
       // Append synthetic terminal event if none exists yet.
       // Use pipeline.run.interrupted for signal-killed runs, pipeline.run.failed otherwise.
-      const eventsPath = join(this.worcaDir, 'runs', runId, 'events.jsonl');
+      const eventsPath = join(runDir, 'events.jsonl');
       let hasTerminalEvent = false;
       if (existsSync(eventsPath)) {
         try {
@@ -269,7 +305,7 @@ export class ProcessManager {
         if (this.settingsPath) {
           dispatches.push(
             dispatchExternal({
-              runDir: join(this.worcaDir, 'runs', runId),
+              runDir,
               settingsPath: this.settingsPath,
               eventType,
               payload,
@@ -744,7 +780,9 @@ export class ProcessManager {
    * @param {string} runId
    */
   _killAgentSubprocess(runId) {
-    const pidPath = join(this.worcaDir, 'runs', runId, 'agent.pid');
+    const ctx = this.resolveRunContext(runId);
+    const runDir = ctx ? ctx.runDir : join(this.worcaDir, 'runs', runId);
+    const pidPath = join(runDir, 'agent.pid');
     if (!existsSync(pidPath)) return;
     try {
       const agentPid = parseInt(readFileSync(pidPath, 'utf8').trim(), 10);

--- a/worca-ui/server/test/process-manager-kill-agent.test.js
+++ b/worca-ui/server/test/process-manager-kill-agent.test.js
@@ -1,0 +1,70 @@
+/**
+ * Worktree-blind callsite test for _killAgentSubprocess.
+ *
+ * Must FAIL before Phase 2 fix: the method reads agent.pid from
+ * `this.worcaDir/runs/<runId>/agent.pid` (project-root path), not from
+ * the worktree run dir. For worktree runs the file is absent at that path,
+ * so the SIGTERM is never sent.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProcessManager } from '../process-manager.js';
+
+function makeTmpDir() {
+  const d = join(
+    tmpdir(),
+    `worca-killagent-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+describe('_killAgentSubprocess worktree-blind callsite', () => {
+  let worcaDir;
+
+  beforeEach(() => {
+    worcaDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(worcaDir, { recursive: true, force: true });
+  });
+
+  it('reads agent.pid from worktree runDir when run is a worktree run', () => {
+    const runId = 'run-wt-kill-001';
+    const wtDir = makeTmpDir();
+    try {
+      const wtRunDir = join(wtDir, '.worca', 'runs', runId);
+      mkdirSync(wtRunDir, { recursive: true });
+
+      // Place agent.pid ONLY in the worktree run dir — not in worcaDir/runs/
+      const agentPid = process.pid;
+      writeFileSync(join(wtRunDir, 'agent.pid'), String(agentPid), 'utf8');
+
+      // Register run in pipelines.d/
+      const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
+      mkdirSync(pipelinesDir, { recursive: true });
+      writeFileSync(
+        join(pipelinesDir, `${runId}.json`),
+        JSON.stringify({ run_id: runId, worktree_path: wtDir }),
+        'utf8',
+      );
+
+      // Intercept process.kill so the test doesn't actually signal itself
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {});
+
+      const pm = new ProcessManager({ worcaDir });
+      pm._killAgentSubprocess(runId);
+
+      // FAILS with current code: reads worcaDir/runs/<runId>/agent.pid which
+      // doesn't exist → returns early → process.kill is never called.
+      expect(killSpy).toHaveBeenCalledWith(agentPid, 'SIGTERM');
+    } finally {
+      rmSync(wtDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/worca-ui/server/test/process-manager-reconcile.test.js
+++ b/worca-ui/server/test/process-manager-reconcile.test.js
@@ -1,4 +1,10 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -455,5 +461,85 @@ describe('reconcileStatus signal stop_reason synthetic event type', () => {
       readFileSync(eventsPath, 'utf8').split('\n').filter(Boolean)[0],
     );
     expect(evt.event_type).toBe('pipeline.run.failed');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Worktree-blind callsite tests (must FAIL before Phase 2 fix lands)
+// ──────────────────────────────────────────────────────────────────────────────
+describe('reconcileStatus worktree-blind callsites', () => {
+  let worcaDir;
+
+  beforeEach(() => {
+    worcaDir = makeTmpDir();
+  });
+  afterEach(() => rmSync(worcaDir, { recursive: true, force: true }));
+
+  it('discovers worktree runs via pipelines.d/ (not just runs/)', async () => {
+    // Worktree run: registered in pipelines.d/, no local runs/ entry
+    const wtDir = makeTmpDir();
+    try {
+      const runId = 'run-wt-disc-001';
+      const wtRunDir = join(wtDir, '.worca', 'runs', runId);
+      mkdirSync(wtRunDir, { recursive: true });
+      writeFileSync(
+        join(wtRunDir, 'status.json'),
+        `${JSON.stringify({ pipeline_status: 'running', run_id: runId }, null, 2)}\n`,
+        'utf8',
+      );
+      writeFileSync(join(wtRunDir, 'pipeline.pid'), '999999999', 'utf8');
+
+      const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
+      mkdirSync(pipelinesDir, { recursive: true });
+      writeFileSync(
+        join(pipelinesDir, `${runId}.json`),
+        JSON.stringify({ run_id: runId, worktree_path: wtDir }),
+        'utf8',
+      );
+
+      const fixed = await reconcileStatus(worcaDir);
+
+      // FAILS with current code: reconcileStatus only scans worcaDir/runs/
+      // and never reads pipelines.d/, so the worktree run is invisible.
+      expect(fixed).toBe(true);
+    } finally {
+      rmSync(wtDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes events.jsonl to worktree runDir not projectRoot/runs/', async () => {
+    // Worktree run: registered in pipelines.d/, no local runs/ entry
+    const wtDir = makeTmpDir();
+    try {
+      const runId = 'run-wt-events-001';
+      const wtRunDir = join(wtDir, '.worca', 'runs', runId);
+      mkdirSync(wtRunDir, { recursive: true });
+      writeFileSync(
+        join(wtRunDir, 'status.json'),
+        `${JSON.stringify({ pipeline_status: 'running', run_id: runId }, null, 2)}\n`,
+        'utf8',
+      );
+      writeFileSync(join(wtRunDir, 'pipeline.pid'), '999999999', 'utf8');
+
+      const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
+      mkdirSync(pipelinesDir, { recursive: true });
+      writeFileSync(
+        join(pipelinesDir, `${runId}.json`),
+        JSON.stringify({ run_id: runId, worktree_path: wtDir }),
+        'utf8',
+      );
+
+      await reconcileStatus(worcaDir);
+
+      const wtEventsPath = join(wtRunDir, 'events.jsonl');
+      const localEventsPath = join(worcaDir, 'runs', runId, 'events.jsonl');
+
+      // FAILS with current code: run not discovered via pipelines.d/ so no
+      // events file is written at all; also verifies path is worktree, not local.
+      expect(existsSync(wtEventsPath)).toBe(true);
+      expect(existsSync(localEventsPath)).toBe(false);
+    } finally {
+      rmSync(wtDir, { recursive: true, force: true });
+    }
   });
 });

--- a/worca-ui/server/test/resolve-latest-run-dir.test.js
+++ b/worca-ui/server/test/resolve-latest-run-dir.test.js
@@ -69,4 +69,56 @@ describe('resolveLatestRunDir', () => {
     writeFileSync(join(runDir, 'pipeline.pid'), 'not-a-number', 'utf8');
     expect(resolveLatestRunDir(worcaDir)).toBe(worcaDir);
   });
+
+  it('worktree-only project returns worktree runDir', () => {
+    // No local runs/ at all; only a pipelines.d/ worktree registration with live PID
+    const wtDir = join(worcaDir, 'worktree-only-dir');
+    const runId = 'run-wt-latest-001';
+    const wtRunDir = join(wtDir, '.worca', 'runs', runId);
+    mkdirSync(wtRunDir, { recursive: true });
+    writeFileSync(join(wtRunDir, 'pipeline.pid'), String(process.pid), 'utf8');
+
+    const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
+    mkdirSync(pipelinesDir, { recursive: true });
+    writeFileSync(
+      join(pipelinesDir, `${runId}.json`),
+      JSON.stringify({ run_id: runId, worktree_path: wtDir }),
+      'utf8',
+    );
+
+    // FAILS with current code: current impl only looks in worcaDir/runs/ and
+    // falls back to worcaDir when nothing is found there.
+    expect(resolveLatestRunDir(worcaDir)).toBe(wtRunDir);
+  });
+
+  it('mixed local+worktree returns newest live-PID dir', () => {
+    // Local run (older ID, alphabetically earlier)
+    const localRunId = 'run-2026-01-01-local';
+    const localRunDir = join(worcaDir, 'runs', localRunId);
+    mkdirSync(localRunDir, { recursive: true });
+    writeFileSync(
+      join(localRunDir, 'pipeline.pid'),
+      String(process.pid),
+      'utf8',
+    );
+
+    // Worktree run (newer ID, alphabetically later → should win)
+    const wtRunId = 'run-2026-06-01-worktree';
+    const wtDir = join(worcaDir, 'worktree-newer-dir');
+    const wtRunDir = join(wtDir, '.worca', 'runs', wtRunId);
+    mkdirSync(wtRunDir, { recursive: true });
+    writeFileSync(join(wtRunDir, 'pipeline.pid'), String(process.pid), 'utf8');
+
+    const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
+    mkdirSync(pipelinesDir, { recursive: true });
+    writeFileSync(
+      join(pipelinesDir, `${wtRunId}.json`),
+      JSON.stringify({ run_id: wtRunId, worktree_path: wtDir }),
+      'utf8',
+    );
+
+    // FAILS with current code: returns localRunDir because the worktree run
+    // is invisible (pipelines.d/ is never consulted).
+    expect(resolveLatestRunDir(worcaDir)).toBe(wtRunDir);
+  });
 });

--- a/worca-ui/server/test/ws-message-router-agent-prompt.test.js
+++ b/worca-ui/server/test/ws-message-router-agent-prompt.test.js
@@ -1,0 +1,163 @@
+/**
+ * Worktree-blind callsite test for the get-agent-prompt handler.
+ *
+ * Must FAIL before Phase 2 fix: handler builds all resolved-file candidates
+ * from proj.worcaDir, ignoring run.worktree_worca_dir even when
+ * run.is_worktree_run === true.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMessageRouter } from '../ws-message-router.js';
+
+function makeTmpDir() {
+  const d = join(
+    tmpdir(),
+    `worca-agentprompt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+function mockWatcherSet(worcaDir) {
+  return {
+    get worcaDir() {
+      return worcaDir;
+    },
+    get settingsPath() {
+      return join(worcaDir, 'settings.json');
+    },
+    get projectRoot() {
+      return worcaDir;
+    },
+    statusWatcher: {
+      scheduleRefresh: vi.fn(),
+      lastPipelineStatus: new Map(),
+      resolveLatestRunDir: vi.fn(() => worcaDir),
+      currentActiveRunId: vi.fn(() => null),
+    },
+    logWatcher: {
+      watchLogFile: vi.fn(),
+      watchAllLogFiles: vi.fn(),
+      sendArchivedLogs: vi.fn(),
+      resolveLogsBaseDir: vi.fn(() => worcaDir),
+      clearLogWatchers: vi.fn(),
+    },
+    beadsWatcher: {
+      getBeadsDbPath: vi.fn(() => join(worcaDir, 'beads.db')),
+    },
+    eventWatcher: {
+      readEventsFromFile: vi.fn(() => []),
+      subscribeEvents: vi.fn(),
+      maybeCloseEventWatcher: vi.fn(),
+    },
+  };
+}
+
+function mockClientManager() {
+  const subsMap = new Map();
+  return {
+    ensureSubs(ws) {
+      if (!subsMap.has(ws)) subsMap.set(ws, {});
+      return subsMap.get(ws);
+    },
+    getSubs(ws) {
+      return subsMap.get(ws) || null;
+    },
+    setProtocol(ws, protocol, projectId) {
+      const s = this.ensureSubs(ws);
+      s.protocolVersion = protocol;
+      s.projectId = projectId;
+    },
+  };
+}
+
+describe('get-agent-prompt worktree-blind callsite', () => {
+  let projDir, wtDir;
+
+  const RUN_ID = 'run-wt-prompt-001';
+
+  beforeEach(() => {
+    projDir = makeTmpDir();
+    wtDir = makeTmpDir();
+
+    // Worktree run structure: status.json + resolved prompt file
+    const wtRunDir = join(wtDir, '.worca', 'runs', RUN_ID);
+    mkdirSync(join(wtRunDir, 'agents', 'resolved'), { recursive: true });
+
+    writeFileSync(
+      join(wtRunDir, 'status.json'),
+      JSON.stringify({
+        run_id: RUN_ID,
+        pipeline_status: 'running',
+        stages: {
+          plan: {
+            agent: 'planner',
+            iterations: [{ number: 1, prompt: 'Build a feature' }],
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    // Resolved prompt only in worktree — NOT in projDir/runs/
+    writeFileSync(
+      join(wtRunDir, 'agents', 'resolved', 'plan-planner-iter-1.md'),
+      'RESOLVED PROMPT FOR WORKTREE',
+      'utf8',
+    );
+
+    // Register run in parent project's pipelines.d/
+    const pipelinesDir = join(projDir, 'multi', 'pipelines.d');
+    mkdirSync(pipelinesDir, { recursive: true });
+    writeFileSync(
+      join(pipelinesDir, `${RUN_ID}.json`),
+      JSON.stringify({ run_id: RUN_ID, worktree_path: wtDir }),
+      'utf8',
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(projDir, { recursive: true, force: true });
+    rmSync(wtDir, { recursive: true, force: true });
+  });
+
+  it('resolves file from worktree_worca_dir when is_worktree_run===true', async () => {
+    const ws0 = mockWatcherSet(projDir);
+    const watcherSets = new Map([['default', ws0]]);
+
+    const router = createMessageRouter({
+      watcherSets,
+      getDefaultWs: () => ws0,
+      prefsPath: join(projDir, 'prefs.json'),
+      webhookInbox: null,
+      clientManager: mockClientManager(),
+      broadcaster: { broadcast: vi.fn(), broadcastToSubscribers: vi.fn() },
+    });
+
+    const mockWs = { send: vi.fn(), isAlive: true };
+
+    await router.handleMessage(
+      mockWs,
+      JSON.stringify({
+        id: 'req-agent-prompt',
+        type: 'get-agent-prompt',
+        payload: { runId: RUN_ID, stage: 'plan' },
+      }),
+    );
+
+    expect(mockWs.send).toHaveBeenCalled();
+    const response = JSON.parse(mockWs.send.mock.calls[0][0]);
+
+    // FAILS with current code: handler probes proj.worcaDir/runs/<id>/agents/resolved/...
+    // The file only exists at wtDir/.worca/runs/<id>/agents/resolved/...
+    // so agentInstructions is null instead of the expected content.
+    expect(response.ok).toBe(true);
+    expect(response.payload.agentInstructions).toBe(
+      'RESOLVED PROMPT FOR WORKTREE',
+    );
+  });
+});

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -158,6 +158,7 @@ export function createMessageRouter({
       }
       const agentName = run.stages?.[stage]?.agent || stage;
       const effectiveRunId = run.run_id || runId;
+      const effectiveWorcaDir = run.worktree_worca_dir || proj.worcaDir;
 
       const iterations = run.stages?.[stage]?.iterations || [];
       const iterationPrompts = iterations.map((iter, idx) => {
@@ -189,7 +190,7 @@ export function createMessageRouter({
         const iterNum = iter.number ?? 0;
         const resolvedCandidates = [
           join(
-            proj.worcaDir,
+            effectiveWorcaDir,
             'runs',
             effectiveRunId,
             'agents',
@@ -197,7 +198,7 @@ export function createMessageRouter({
             `${stage}-${agentName}-iter-${iterNum}.md`,
           ),
           join(
-            proj.worcaDir,
+            effectiveWorcaDir,
             'results',
             effectiveRunId,
             'agents',
@@ -206,7 +207,7 @@ export function createMessageRouter({
           ),
           // Fallback for early W-037 runs without stage prefix
           join(
-            proj.worcaDir,
+            effectiveWorcaDir,
             'runs',
             effectiveRunId,
             'agents',
@@ -214,7 +215,7 @@ export function createMessageRouter({
             `${agentName}-iter-${iterNum}.md`,
           ),
           join(
-            proj.worcaDir,
+            effectiveWorcaDir,
             'results',
             effectiveRunId,
             'agents',
@@ -241,14 +242,14 @@ export function createMessageRouter({
       if (!resolvedPrompt) {
         const templateCandidates = [
           join(
-            proj.worcaDir,
+            effectiveWorcaDir,
             'runs',
             effectiveRunId,
             'agents',
             `${agentName}.md`,
           ),
           join(
-            proj.worcaDir,
+            effectiveWorcaDir,
             'results',
             effectiveRunId,
             'agents',

--- a/worca-ui/server/ws-status-watcher.js
+++ b/worca-ui/server/ws-status-watcher.js
@@ -37,9 +37,11 @@ const TERMINAL_STATUSES = new Set([
  * @returns {string}
  */
 export function resolveLatestRunDir(worcaDir) {
+  // Collect (runId → runDir) for all live runs from local runs/ and worktree pipelines.d/
+  const liveRuns = new Map();
+
   const runsDir = join(worcaDir, 'runs');
   if (existsSync(runsDir)) {
-    let latest = null;
     try {
       for (const entry of readdirSync(runsDir, { withFileTypes: true })) {
         if (!entry.isDirectory()) continue;
@@ -49,7 +51,7 @@ export function resolveLatestRunDir(worcaDir) {
           const pid = parseInt(readFileSync(pidPath, 'utf8').trim(), 10);
           if (!Number.isNaN(pid) && pid > 0) {
             process.kill(pid, 0); // throws if dead
-            if (!latest || entry.name > latest) latest = entry.name;
+            liveRuns.set(entry.name, join(runsDir, entry.name));
           }
         } catch {
           /* dead process or invalid PID */
@@ -58,9 +60,45 @@ export function resolveLatestRunDir(worcaDir) {
     } catch {
       /* ignore */
     }
-    if (latest) return join(runsDir, latest);
   }
-  return worcaDir; // legacy fallback
+
+  // Also scan pipelines.d/ for worktree PIDs (worktree runs never appear in runs/)
+  const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
+  if (existsSync(pipelinesDir)) {
+    try {
+      for (const entry of readdirSync(pipelinesDir)) {
+        if (!entry.endsWith('.json')) continue;
+        const runId = entry.slice(0, -5);
+        try {
+          const reg = JSON.parse(
+            readFileSync(join(pipelinesDir, entry), 'utf8'),
+          );
+          if (!reg.worktree_path) continue;
+          const wtRunDir = join(reg.worktree_path, '.worca', 'runs', runId);
+          const pidPath = join(wtRunDir, 'pipeline.pid');
+          if (!existsSync(pidPath)) continue;
+          const pid = parseInt(readFileSync(pidPath, 'utf8').trim(), 10);
+          if (!Number.isNaN(pid) && pid > 0) {
+            process.kill(pid, 0); // throws if dead
+            liveRuns.set(runId, wtRunDir);
+          }
+        } catch {
+          /* dead process or invalid PID */
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (liveRuns.size === 0) return worcaDir; // legacy fallback
+
+  // Return the runDir of the latest (alphabetically largest) live run ID
+  let latestId = null;
+  for (const id of liveRuns.keys()) {
+    if (!latestId || id > latestId) latestId = id;
+  }
+  return liveRuns.get(latestId);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **ws-message-router** `get-agent-prompt` handler now derives `effectiveWorcaDir` from `run.worktree_worca_dir`, fixing empty "Agent Prompt" pane for worktree runs
- **process-manager** `reconcileStatus` scans `pipelines.d/` for worktree PIDs and routes status/events reads through `resolveRunContext`, fixing stale "running" status after abnormal worktree pipeline death
- **process-manager** `_killAgentSubprocess` uses `resolveRunContext` for `agent.pid` lookup, fixing silent stop failure on Windows worktree runs
- **ws-status-watcher** `resolveLatestRunDir` scans `pipelines.d/` for live worktree PIDs, fixing dead-code active-run watcher for worktree-only projects

## Test plan

- [x] 4 new test files / test blocks covering all 4 callsites (35 tests total, all passing)
- [x] Biome lint clean
- [ ] Manual verification: start a worktree run, confirm agent-prompt pane populates
- [ ] Manual verification: kill -9 a worktree pipeline PID, confirm reconcileStatus flips status to failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)