### PR TITLE
fix: persist plan_path in work_request and remove dead worktree_path code

### DIFF
--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -4,6 +4,7 @@ Orchestrates the full pipeline from plan through PR.
 """
 
 import atexit
+import dataclasses
 import json
 import os
 import re
@@ -1414,13 +1415,7 @@ def run_pipeline(
             create_branch(branch_name)
             _branch_just_created = True
 
-        wr_dict = {
-            "source_type": work_request.source_type,
-            "title": work_request.title,
-            "description": work_request.description,
-            "source_ref": work_request.source_ref,
-            "priority": work_request.priority,
-        }
+        wr_dict = dataclasses.asdict(work_request)
         status = init_status(wr_dict, branch_name, git_head=get_current_git_head(), pipeline_template=pipeline_template)
 
         if worktree:

--- a/src/worca/scripts/run_worktree.py
+++ b/src/worca/scripts/run_worktree.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from worca.orchestrator.registry import register_pipeline
 from worca.orchestrator.work_request import normalize
-from worca.state.status import write_status_field
+
 from worca.utils.git import (
     branch_exists,
     create_pipeline_worktree,
@@ -353,13 +353,6 @@ def main(argv=None) -> int:
     if not worktree_path:
         print(f"error: failed to create worktree for run {run_id}", file=sys.stderr)
         return 1
-
-    # Step 3b: persist worktree_path to status.json so the cleanup hook
-    # can read it without taking a registry dependency.
-    _status_path = os.path.join(
-        worktree_path, ".worca", "runs", run_id, "status.json"
-    )
-    write_status_field(_status_path, "worktree_path", worktree_path)
 
     # Step 4: copy .claude/ into the worktree (settings.json, agents/, hooks/,
     # scripts/, skills/, templates/, worca/, etc.). Most projects gitignore

--- a/src/worca/state/status.py
+++ b/src/worca/state/status.py
@@ -227,7 +227,6 @@ def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_
         "run_id": None,
         "branch": branch,
         "worktree": None,
-        "worktree_path": None,
         "plan_file": None,
         "pipeline_template": pipeline_template,
         "git_head": git_head,

--- a/tests/integration/test_beads_integration.py
+++ b/tests/integration/test_beads_integration.py
@@ -18,8 +18,11 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 
 import pytest
+
+from tests.integration.helpers import run_and_act, send_sigkill
 
 
 def _setup_stub_path(monkeypatch, pipeline_env) -> None:
@@ -260,11 +263,13 @@ def test_pipeline_with_source_gh_issue_uses_extracted_plan_link(
     assert wr.get("source_type") == "github_issue"
     assert wr.get("source_ref") == "gh:42"
 
-    # The runner promotes the auto-detected plan_path into status.plan_file
-    # (top-level) and marks PLAN as skipped — that's the persisted evidence
-    # that auto-detection ran. NB: ``plan_path`` is currently dropped from
-    # the persisted ``work_request`` dict (runner.py:1417 only copies five
-    # fields), so we assert on what actually reaches status.json.
+    # The runner persists the auto-detected plan_path in work_request (nested)
+    # and promotes it to status.plan_file (top-level). PLAN is auto-completed
+    # (skipped) when plan_file is set at pipeline start.
+    assert wr.get("plan_path", "").endswith("W-050-phase5.md"), (
+        f"work_request.plan_path should be persisted in status; "
+        f"got plan_path={wr.get('plan_path')!r}\nwork_request: {wr}"
+    )
     assert result.status.get("plan_file", "").endswith("W-050-phase5.md"), (
         f"status.plan_file should reflect the auto-detected plan link; "
         f"got plan_file={result.status.get('plan_file')!r}\n"
@@ -276,4 +281,107 @@ def test_pipeline_with_source_gh_issue_uses_extracted_plan_link(
     )
     assert plan_stage.get("skipped") is True, (
         f"PLAN stage should carry skipped=True; got {plan_stage}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resume: plan_path preserved, PLAN stays skipped (regression for the
+# runner.py plan_path persistence fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.skipif(sys.platform == "win32", reason="signal-based tests require Unix")
+def test_gh_issue_plan_path_preserved_on_resume(
+    pipeline_env, monkeypatch, tmp_path
+):
+    """Regression test for runner.py:1417 plan_path persistence fix.
+
+    Before the fix, ``wr_dict`` was built from only 5 hard-coded fields and
+    ``plan_path`` was silently dropped, so a resumed gh-issue run always saw
+    ``plan_path=None`` and could re-run the PLAN stage.  After the fix
+    (``dataclasses.asdict``), ``plan_path`` survives in
+    ``status['work_request']``.  On resume the runner loads the existing
+    status (which already has PLAN completed/skipped) so PLAN is never
+    re-executed."""
+    plans_dir = pipeline_env.project / "docs" / "plans"
+    plans_dir.mkdir(parents=True, exist_ok=True)
+    plan_file = plans_dir / "W-050-resume-regression.md"
+    plan_file.write_text("# Resume regression plan\n")
+
+    response_file = tmp_path / "gh_responses.json"
+    response_file.write_text(json.dumps({
+        "issue view 77 --json title,body": {
+            "stdout": json.dumps({
+                "title": "Resume regression GH issue",
+                "body": (
+                    "## Plan\n\n"
+                    "[the plan]"
+                    "(https://github.com/x/y/blob/main/docs/plans/W-050-resume-regression.md)\n"
+                ),
+            }),
+            "exit": 0,
+        },
+        "default": {"stdout": "", "exit": 0},
+    }))
+
+    pipeline_env.enable_beads()
+    monkeypatch.setenv("WORCA_STUB_GH_RESPONSE_FILE", str(response_file))
+
+    # Kill during implement — by then PLAN is already completed/skipped.
+    first = run_and_act(
+        pipeline_env,
+        {
+            "agents": {"implementer": {"action": "hang"}},
+            "default": {"action": "succeed", "delay_s": 0.05},
+        },
+        send_sigkill,
+        act_after_stage="implement",
+        timeout=20,
+        extra_args=["--source", "gh:issue:77"],
+    )
+
+    # SIGKILL leaves the run non-terminal.
+    assert first.status.get("pipeline_status") not in ("completed", "failed", "interrupted"), (
+        f"first run must be non-terminal after SIGKILL; "
+        f"got {first.status.get('pipeline_status')!r}"
+    )
+
+    # plan_path must be persisted in work_request (was always None before fix).
+    wr = first.status.get("work_request", {})
+    assert wr.get("plan_path", "").endswith("W-050-resume-regression.md"), (
+        f"work_request.plan_path not persisted; got: {wr.get('plan_path')!r}"
+    )
+
+    # PLAN was auto-completed/skipped before implement started.
+    plan_stage = first.status.get("stages", {}).get("plan", {})
+    assert plan_stage.get("status") == "completed"
+    assert plan_stage.get("skipped") is True, (
+        f"PLAN should be skipped before implement stage; got {plan_stage}"
+    )
+
+    # Resume to completion.
+    resumed = pipeline_env.run(
+        {"default": {"action": "succeed", "delay_s": 0.05}},
+        extra_args=["--resume"],
+        timeout=60,
+    )
+    assert resumed.returncode == 0, (
+        f"resume should complete cleanly; rc={resumed.returncode}\n"
+        f"stderr: {resumed.stderr[:400]}"
+    )
+    assert resumed.status.get("pipeline_status") == "completed"
+
+    # plan_path must survive the resume.
+    wr_resumed = resumed.status.get("work_request", {})
+    assert wr_resumed.get("plan_path", "").endswith("W-050-resume-regression.md"), (
+        f"plan_path should be preserved across resume; "
+        f"got: {wr_resumed.get('plan_path')!r}"
+    )
+
+    # PLAN must remain completed/skipped — never re-run.
+    plan_stage_resumed = resumed.status.get("stages", {}).get("plan", {})
+    assert plan_stage_resumed.get("status") == "completed"
+    assert plan_stage_resumed.get("skipped") is True, (
+        f"PLAN should remain skipped after resume; got {plan_stage_resumed}"
     )

--- a/tests/integration/test_run_worktree.py
+++ b/tests/integration/test_run_worktree.py
@@ -55,19 +55,12 @@ def test_run_worktree_creates_worktree_and_emits_run_id(pipeline_env):
     assert Path(result.worktree_path).is_dir()
 
 
-def test_run_worktree_writes_worktree_path_to_status_json(pipeline_env):
-    """Step 3b in run_worktree.py writes ``worktree_path`` into the worktree's
-    own status.json *before* the pipeline subprocess starts (so the cleanup
-    CLI can read it without a registry dependency).
-
-    We assert on the file written by step 3b rather than the post-pipeline
-    status, because the pipeline runner re-initialises the dict via
-    ``_make_initial_status`` and the field is regenerated as ``None`` once the
-    pipeline begins. To capture the step-3b write deterministically we run
-    with ``wait=False`` and read the file the script just wrote."""
+def test_run_worktree_creates_status_json_in_run_dir(pipeline_env):
+    """The pipeline runner initialises status.json inside the worktree's run
+    directory. We verify the file exists and is valid JSON after the pipeline
+    completes."""
     result = pipeline_env.run_worktree(
         _DEFAULT_SCENARIO, prompt="status check",
-        wait=False,
     )
 
     assert result.returncode == 0
@@ -75,16 +68,11 @@ def test_run_worktree_writes_worktree_path_to_status_json(pipeline_env):
         Path(result.worktree_path) / ".worca" / "runs" / result.run_id / "status.json"
     )
     assert status_path.exists(), (
-        f"step 3b should have written status.json at {status_path}"
+        f"pipeline runner should have written status.json at {status_path}"
     )
     import json
     data = json.loads(status_path.read_text())
-    # Either the field was just written by step 3b (canonical case), or the
-    # pipeline has already started and overwritten — accept both, but the key
-    # must always be present after run_worktree returns.
-    assert "worktree_path" in data, (
-        f"status.json missing worktree_path key; keys: {sorted(data.keys())}"
-    )
+    assert isinstance(data, dict)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_run_worktree.py
+++ b/tests/test_run_worktree.py
@@ -172,7 +172,7 @@ _RUN_ID = "20260426-120000-000-abcd"
 def _patches(worktree_path=_WORKTREE_PATH):
     """Return a list of active patch context managers for main() calls.
 
-    Indices 9 and 10 stub the base-branch helpers so existing tests stay
+    Indices 8 and 9 stub the base-branch helpers so existing tests stay
     deterministic without exercising real git: branch_exists defaults to
     True and detect_default_branch defaults to "main", which preserves the
     legacy "main" fallback expected by callers that don't configure
@@ -187,7 +187,6 @@ def _patches(worktree_path=_WORKTREE_PATH):
         patch("worca.scripts.run_worktree.os.path.isdir", return_value=True),
         patch("worca.scripts.run_worktree.subprocess.Popen"),
         patch("worca.scripts.run_worktree._copy_claude_config"),
-        patch("worca.scripts.run_worktree.write_status_field"),
         patch("worca.scripts.run_worktree.branch_exists", return_value=True),
         patch("worca.scripts.run_worktree.detect_default_branch", return_value="main"),
     ]
@@ -198,7 +197,7 @@ class TestCreatesWorktree:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -210,7 +209,7 @@ class TestCreatesWorktree:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
         assert rc == 0
@@ -231,7 +230,7 @@ class TestCreatesWorktree:
         )
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], \
              _patch("worca.scripts.run_worktree.load_settings",
                     return_value={"worca": {"parallel": {"worktree_base_dir": "~/wt-foo"}}}):
             mock_norm.return_value = _wr("Add auth")
@@ -243,7 +242,7 @@ class TestCreatesWorktree:
         from worca.scripts.run_worktree import main
         plist = _patches(worktree_path="")
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 1
@@ -256,7 +255,7 @@ class TestRegistersInPipelinesD:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -273,7 +272,7 @@ class TestFleetIdPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--fleet-id", "fleet-xyz"])
         assert rc == 0
@@ -284,7 +283,7 @@ class TestFleetIdPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -297,7 +296,7 @@ class TestTargetBranchPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
         assert rc == 0
@@ -308,7 +307,7 @@ class TestTargetBranchPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -322,7 +321,7 @@ class TestGuidePassthrough:
         guide = str(tmp_path / "spec.md")
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--guide", guide])
         assert rc == 0
@@ -337,7 +336,7 @@ class TestGuidePassthrough:
         g2 = str(tmp_path / "spec2.md")
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--guide", g1, "--guide", g2])
         assert rc == 0
@@ -350,7 +349,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -365,7 +364,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -376,7 +375,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -387,7 +386,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -510,7 +509,7 @@ class TestDefaultBaseBranch:
         plist = _patches()
         settings = {"worca": {"parallel": {"default_base_branch": "develop"}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
@@ -528,7 +527,7 @@ class TestDefaultBaseBranch:
         plist = _patches()
         settings = {"worca": {"parallel": {}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
@@ -545,7 +544,7 @@ class TestDefaultBaseBranch:
         plist = _patches()
         settings = {"worca": {"parallel": {"default_base_branch": "develop"}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
@@ -569,7 +568,7 @@ class TestDefaultBaseBranch:
         # "master" as the actual repo default.
         settings = {"worca": {"parallel": {"default_base_branch": "main"}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], \
              _patch("worca.scripts.run_worktree.branch_exists", return_value=False), \
              _patch("worca.scripts.run_worktree.detect_default_branch", return_value="master"), \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
@@ -593,7 +592,7 @@ class TestDefaultBaseBranch:
         plist = _patches()
         settings = {"worca": {"parallel": {}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], \
              _patch("worca.scripts.run_worktree.branch_exists", return_value=False), \
              _patch("worca.scripts.run_worktree.detect_default_branch", return_value="master"), \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
@@ -640,29 +639,6 @@ class TestDefaultBaseBranch:
             be.assert_not_called()
 
 
-class TestWorktreePathWrittenToStatus:
-    """worktree_path is written to status.json after worktree creation."""
-
-    def test_worktree_path_written_to_status_json(self):
-        """run_worktree writes worktree_path to status.json via write_status_field."""
-        from unittest.mock import patch as _patch
-        from worca.scripts.run_worktree import main
-
-        plist = _patches()
-        settings = {"worca": {"parallel": {}}}
-        with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6], plist[7], \
-             plist[8] as mock_write, plist[9], plist[10], \
-             _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
-            mock_norm.return_value = _wr("Add auth")
-            rc = main(["--prompt", "Add auth"])
-        assert rc == 0
-        mock_write.assert_called_once()
-        args = mock_write.call_args
-        assert args[0][1] == "worktree_path"
-        assert args[0][2] == _WORKTREE_PATH
-
-
 class TestMissingWorcaRuntime:
     def test_fails_fast_when_runtime_missing(self, capsys):
         from worca.scripts.run_worktree import main
@@ -671,7 +647,7 @@ class TestMissingWorcaRuntime:
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
              plist[3], plist[4] as mock_reg, \
              patch("worca.scripts.run_worktree.os.path.isdir", return_value=False), \
-             plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[6] as mock_popen, plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 1

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4326,3 +4326,47 @@ def test_resolve_project_root_worktree_mode_relative_registry_base():
         registry_base=".worca",
     )
     assert result == cwd
+
+
+def test_wr_dict_includes_plan_path(tmp_path, monkeypatch):
+    """plan_path from WorkRequest must be persisted in status['work_request'].
+
+    runner.py builds wr_dict from WorkRequest fields before calling init_status().
+    If plan_path is omitted from wr_dict, a resumed gh-issue run loses its
+    auto-detected plan link (run_pipeline.py:191 reads wr.get("plan_path")).
+    """
+    from worca.orchestrator.work_request import WorkRequest
+
+    plan_path = "docs/plans/W-042-my-feature.md"
+    plan_file = tmp_path / "W-042-my-feature.md"
+    plan_file.write_text("# Plan\n")
+
+    settings = _make_template_test_settings(tmp_path)
+    worca_dir = tmp_path / ".worca"
+    worca_dir.mkdir()
+    status_path = str(worca_dir / "status.json")
+    monkeypatch.chdir(tmp_path)
+
+    def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                       prompt_override=None, **kwargs):
+        return {"beads_ids": [], "dependency_graph": {}}, {"type": "result"}
+
+    with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
+         patch("worca.orchestrator.runner.create_branch"), \
+         patch("worca.orchestrator.runner._write_pid"), \
+         patch("worca.orchestrator.runner._remove_pid"), \
+         patch("worca.orchestrator.runner.gh_issue_start"), \
+         patch("worca.orchestrator.runner.gh_issue_complete"):
+        result = run_pipeline(
+            WorkRequest(
+                source_type="github_issue",
+                source_ref="gh:42",
+                title="My feature",
+                plan_path=plan_path,
+            ),
+            plan_file=str(plan_file),
+            settings_path=str(settings),
+            status_path=status_path,
+        )
+
+    assert result["work_request"]["plan_path"] == plan_path

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -230,6 +230,12 @@ def test_init_status_has_plan_file():
     assert result["plan_file"] is None
 
 
+def test_init_status_worktree_path_key_absent():
+    wr = {"title": "Task"}
+    result = init_status(wr, "feat/task")
+    assert "worktree_path" not in result
+
+
 # --- start_iteration ---
 
 def test_start_iteration_creates_list():
@@ -379,15 +385,6 @@ def test_resolve_status_passthrough_known_values():
 
 def test_resolve_status_passthrough_unknown():
     assert resolve_status("unknown_val") == "unknown_val"
-
-
-# --- init_status worktree_path ---
-
-def test_init_status_has_worktree_path_none_by_default():
-    wr = {"title": "Task"}
-    result = init_status(wr, "feat/task")
-    assert "worktree_path" in result
-    assert result["worktree_path"] is None
 
 
 # --- write_status_field ---


### PR DESCRIPTION
## Summary

- Replace manual 5-field `wr_dict` construction in `runner.py` with `dataclasses.asdict(work_request)` so `plan_path` (and any future WorkRequest fields) survive persistence and are available on `--resume`
- Remove dead `worktree_path` write from `run_worktree.py` step 3b — consumers (cleanup CLI, UI resolver) read from the registry, not `status.json`
- Drop `worktree_path` from `init_status()` template (no consumer reads it)

Fixes two bugs surfaced during W-050 integration test work:
1. **plan_path dropped on resume** — a resumed gh-issue-sourced run lost its auto-detected plan link and could re-run PLAN
2. **worktree_path overwritten** — step 3b wrote the field, then `_make_initial_status()` immediately overwrote it with `None`

## Test plan

- [x] Unit test: `test_wr_dict_includes_plan_path` — verifies `plan_path` appears in persisted `status['work_request']`
- [x] Unit test: `test_init_status_worktree_path_key_absent` — confirms field removed from template
- [x] Integration test: `test_gh_issue_plan_path_preserved_on_resume` — SIGKILL mid-implement, resume, assert `plan_path` survives and PLAN stays skipped
- [x] Updated integration test: `test_pipeline_with_source_gh_issue_uses_extracted_plan_link` — now asserts `work_request.plan_path` is populated (was previously a known-broken assertion)
- [x] Existing unit tests updated to remove mocked `write_status_field` (dead code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)