### PR TITLE
templates: tighten investigate (plan_review) and refactor (pr, learn)

### DIFF
--- a/src/worca/templates/investigate/template.json
+++ b/src/worca/templates/investigate/template.json
@@ -7,11 +7,12 @@
   "tags": ["analysis", "no-code", "plan-pr"],
   "config": {
     "stages": {
-      "coordinate": { "enabled": false },
-      "implement":  { "enabled": false },
-      "test":       { "enabled": false },
-      "review":     { "enabled": false },
-      "pr":         { "enabled": true }
+      "plan_review": { "enabled": true },
+      "coordinate":  { "enabled": false },
+      "implement":   { "enabled": false },
+      "test":        { "enabled": false },
+      "review":      { "enabled": false },
+      "pr":          { "enabled": true }
     },
     "agents": {
       "planner": { "model": "opus", "max_turns": 200 }

--- a/src/worca/templates/refactor/template.json
+++ b/src/worca/templates/refactor/template.json
@@ -1,14 +1,14 @@
 {
   "id": "refactor",
   "name": "Refactor",
-  "description": "Full pipeline without PR, all agents on Opus. Reviewer enforces behavioral preservation. Branch left for manual review.",
+  "description": "Full pipeline with all agents on Opus. Reviewer enforces behavioral preservation. PR opened for human review before merge; learn stage captures invariants surfaced during the refactor.",
   "builtin": true,
   "created_at": "2026-03-10T00:00:00Z",
-  "tags": ["no-pr", "extra-test"],
+  "tags": ["full-pipeline", "all-opus", "plan-review", "learn"],
   "config": {
     "stages": {
-      "pr": { "enabled": false },
-      "plan_review": { "enabled": true }
+      "plan_review": { "enabled": true },
+      "learn":       { "enabled": true }
     },
     "agents": {
       "planner":     { "model": "opus", "max_turns": 100 },

--- a/tests/test_investigate_template.py
+++ b/tests/test_investigate_template.py
@@ -22,7 +22,7 @@ class TestTemplateLoading:
     def test_enabled_stages(self):
         stages = _config()["stages"]
         enabled = {name for name, cfg in stages.items() if cfg.get("enabled", True)}
-        assert enabled == {"pr"}
+        assert enabled == {"plan_review", "pr"}
 
     def test_disabled_stages(self):
         stages = _config()["stages"]
@@ -39,6 +39,9 @@ class TestTemplateLoading:
 
     def test_pr_enabled(self):
         assert _config()["stages"]["pr"]["enabled"] is True
+
+    def test_plan_review_enabled(self):
+        assert _config()["stages"]["plan_review"]["enabled"] is True
 
     def test_milestones_all_disabled(self):
         milestones = _config()["milestones"]

--- a/tests/test_preset_templates.py
+++ b/tests/test_preset_templates.py
@@ -113,8 +113,15 @@ class TestRefactorConfig:
     def _config(self):
         return json.loads((TEMPLATES_DIR / "refactor" / "template.json").read_text())["config"]
 
-    def test_pr_disabled(self):
-        assert self._config()["stages"]["pr"]["enabled"] is False
+    def test_pr_enabled_by_default(self):
+        # `pr` is not overridden in the template, so it inherits the default (enabled).
+        assert self._config()["stages"].get("pr", {}).get("enabled", True) is True
+
+    def test_plan_review_enabled(self):
+        assert self._config()["stages"]["plan_review"]["enabled"] is True
+
+    def test_learn_enabled(self):
+        assert self._config()["stages"]["learn"]["enabled"] is True
 
 
 class TestQuickFixConfig:
@@ -143,6 +150,9 @@ class TestInvestigateConfig:
 
     def test_implement_disabled(self):
         assert self._config()["stages"]["implement"]["enabled"] is False
+
+    def test_plan_review_enabled(self):
+        assert self._config()["stages"]["plan_review"]["enabled"] is True
 
     def test_planner_opus(self):
         assert self._config()["agents"]["planner"]["model"] == "opus"


### PR DESCRIPTION
## Summary

- **`investigate.plan_review` → on** — investigate's deliverable *is* the plan, and there is no downstream test/review/PR backstop to catch a thin analysis. Plan review is the natural quality gate.
- **`refactor.pr` → on** (was off) — the full review chain on Opus already runs. Reviewing a diff on GitHub beats reviewing it in a worktree, and the author still controls the merge button.
- **`refactor.learn` → on** — refactors are precisely where codebase invariants surface; capture them.

Coordinator stays on Opus everywhere — not changed in this PR.

## Files

- `src/worca/templates/investigate/template.json` — add `plan_review: enabled`.
- `src/worca/templates/refactor/template.json` — drop `pr: enabled=false`, add `learn: enabled`, update description + tags.
- `tests/test_investigate_template.py` — flip `enabled` set; add `test_plan_review_enabled`.
- `tests/test_preset_templates.py` — replace `test_pr_disabled` with `test_pr_enabled_by_default`; add `test_plan_review_enabled` and `test_learn_enabled` for refactor; add `test_plan_review_enabled` for investigate.

## Test plan

- [x] `pytest tests/ --ignore=tests/integration` — full unit suite green
- [x] `pytest tests/integration/test_investigate_pr.py` — investigate e2e green (plan_review now runs in addition to plan + pr)
- [x] `pytest tests/test_preset_templates.py tests/test_investigate_template.py` — focused template suites green
- [x] `ruff check` clean
- [ ] Smoke: run a small refactor end-to-end and confirm a PR is opened (manual, post-merge)
- [ ] Smoke: run an investigate end-to-end and confirm plan_review iteration appears in the run (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)