### PR TITLE
guardian: verify PR stage with orchestrator post-condition

### DIFF
--- a/src/worca/agents/core/guardian.md
+++ b/src/worca/agents/core/guardian.md
@@ -61,6 +61,7 @@ Your final response MUST be a single JSON object that matches the `pr.json` sche
 Required fields:
 - `pr_number` (integer) — captured from `gh pr create` / `gh pr view` output
 - `pr_url` (string, URI) — full URL to the PR
+- `commit_sha` (string, ≥7 chars) — output of `git rev-parse HEAD` after committing (required when `outcome == "success"`)
 
 Optional:
 - `review_status` — `"pending"` | `"approved"` | `"changes_requested"` | `"rejected"`
@@ -68,7 +69,7 @@ Optional:
 Example final output (this exact shape, no fences, no prose around it):
 
 ```
-{"pr_number": 42, "pr_url": "https://github.com/owner/repo/pull/42", "review_status": "pending"}
+{"pr_number": 42, "pr_url": "https://github.com/owner/repo/pull/42", "commit_sha": "abc1234def5", "review_status": "pending"}
 ```
 
 If the PR couldn't be created (steps 3–7 failed), still emit JSON — set `review_status: "rejected"` and use `0` / empty string for the missing fields, then the orchestrator will treat it as a stage failure.

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -1090,17 +1090,72 @@ def _extract_pr_fields_from_text(text) -> Optional[dict]:
 PRVerification = collections.namedtuple("PRVerification", ["ok", "reason"])
 
 
-def _verify_pr_stage(stage_output, baseline_head: str) -> PRVerification:
+def _verify_pr_via_gh(pr_number: int, expected_url: str, timeout: int = 10) -> Optional[PRVerification]:
+    """Best-effort `gh pr view` check.
+
+    Confirms the PR actually exists on the hosting platform and that its URL
+    matches the URL guardian reported — defends against a fabricated `pr_url`
+    that passes structural checks.
+
+    Returns:
+        PRVerification on a definitive answer (PR exists and matches → ok=True;
+        gh ran cleanly but the PR is missing or the URL differs → ok=False).
+        None when gh could not run a meaningful check (binary missing, no auth,
+        no remote, transport error). Callers fall back on local invariants.
+    """
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "url,number"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if r.returncode != 0:
+        stderr_lower = (r.stderr or "").lower()
+        for needle in (
+            "auth", "gh_token", "no such remote", "not a git repo",
+            "no default remote", "no git remote", "could not determine",
+        ):
+            if needle in stderr_lower:
+                return None
+        return PRVerification(
+            ok=False,
+            reason=f"gh pr view #{pr_number} failed: {(r.stderr or '').strip()[:200]}",
+        )
+    try:
+        data = json.loads(r.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    actual_number = data.get("number")
+    actual_url = data.get("url")
+    if actual_number != pr_number:
+        return PRVerification(
+            ok=False,
+            reason=f"gh returned PR #{actual_number}, guardian reported #{pr_number}",
+        )
+    if actual_url and actual_url != expected_url:
+        return PRVerification(
+            ok=False,
+            reason=f"PR URL mismatch: gh has {actual_url!r}, guardian reported {expected_url!r}",
+        )
+    return PRVerification(ok=True, reason="")
+
+
+def _verify_pr_stage(stage_output, baseline_head: str, gh_lookup=None) -> PRVerification:
     """Post-condition check after the PR stage reports success.
 
-    Validates three invariants:
-    1. git HEAD changed from baseline_head (a new commit was made).
-    2. commit_sha, pr_url, and pr_number are present in structured output.
+    Validates four invariants:
+    1. stage_output is a structured dict carrying commit_sha, pr_url, pr_number.
+    2. git HEAD changed from baseline_head (a new commit was made).
     3. The reported commit_sha is a prefix of (or equal to) the actual HEAD SHA.
+    4. (Best-effort) `gh pr view <pr_number>` confirms the PR exists and its
+       URL matches `pr_url`. Skipped silently when gh cannot run.
 
     Args:
         stage_output: Structured output dict from the guardian agent.
         baseline_head: git HEAD SHA captured before the PR stage ran.
+        gh_lookup: Optional callable(pr_number, expected_url) → PRVerification|None.
+            Defaults to _verify_pr_via_gh. Tests inject a stub.
 
     Returns:
         PRVerification(ok=True, reason="") on success, or
@@ -1124,6 +1179,12 @@ def _verify_pr_stage(stage_output, baseline_head: str) -> PRVerification:
             ok=False,
             reason=f"commit sha mismatch: reported {reported_sha!r} but HEAD is {actual_head!r}",
         )
+
+    if gh_lookup is None:
+        gh_lookup = _verify_pr_via_gh
+    gh_result = gh_lookup(stage_output["pr_number"], stage_output["pr_url"])
+    if gh_result is not None and not gh_result.ok:
+        return gh_result
 
     return PRVerification(ok=True, reason="")
 
@@ -1570,6 +1631,10 @@ def run_pipeline(
             loop_counters = restore_loop_counters(status)
         else:
             loop_counters = {}
+        # Captured once on first entry to the PR stage; preserved across
+        # PR-stage retries so iter_2 verification compares against the same
+        # pre-stage HEAD as iter_1.
+        _pr_baseline_head: Optional[str] = None
         max_beads = 0
 
         # Initialize PromptBuilder for context threading across stages
@@ -1957,7 +2022,7 @@ def run_pipeline(
                     # kills it (terminate_current already fired as a no-op).
                     if _shutdown_requested:
                         raise InterruptedError("Pipeline shutdown requested before stage execution")
-                    if current_stage == Stage.PR:
+                    if current_stage == Stage.PR and _pr_baseline_head is None:
                         _pr_baseline_head = get_current_git_head()
                     result, raw_envelope = run_stage(
                         current_stage, context, settings_path,

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -4,6 +4,7 @@ Orchestrates the full pipeline from plan through PR.
 """
 
 import atexit
+import collections
 import dataclasses
 import json
 import os
@@ -1086,6 +1087,47 @@ def _extract_pr_fields_from_text(text) -> Optional[dict]:
     return {"pr_url": m.group(0), "pr_number": int(m.group(1))}
 
 
+PRVerification = collections.namedtuple("PRVerification", ["ok", "reason"])
+
+
+def _verify_pr_stage(stage_output, baseline_head: str) -> PRVerification:
+    """Post-condition check after the PR stage reports success.
+
+    Validates three invariants:
+    1. git HEAD changed from baseline_head (a new commit was made).
+    2. commit_sha, pr_url, and pr_number are present in structured output.
+    3. The reported commit_sha is a prefix of (or equal to) the actual HEAD SHA.
+
+    Args:
+        stage_output: Structured output dict from the guardian agent.
+        baseline_head: git HEAD SHA captured before the PR stage ran.
+
+    Returns:
+        PRVerification(ok=True, reason="") on success, or
+        PRVerification(ok=False, reason=<explanation>) on failure.
+    """
+    if not isinstance(stage_output, dict):
+        return PRVerification(ok=False, reason="stage output is not a structured dict")
+
+    for field in ("commit_sha", "pr_url", "pr_number"):
+        if field not in stage_output:
+            return PRVerification(ok=False, reason=f"missing required field: {field}")
+
+    actual_head = get_current_git_head()
+
+    if actual_head == baseline_head:
+        return PRVerification(ok=False, reason="no new commit on HEAD — git HEAD unchanged from baseline")
+
+    reported_sha = stage_output["commit_sha"]
+    if not actual_head.startswith(reported_sha):
+        return PRVerification(
+            ok=False,
+            reason=f"commit sha mismatch: reported {reported_sha!r} but HEAD is {actual_head!r}",
+        )
+
+    return PRVerification(ok=True, reason="")
+
+
 def run_preflight(
     context: dict,
     settings_path: str = ".claude/settings.json",
@@ -1915,6 +1957,8 @@ def run_pipeline(
                     # kills it (terminate_current already fired as a no-op).
                     if _shutdown_requested:
                         raise InterruptedError("Pipeline shutdown requested before stage execution")
+                    if current_stage == Stage.PR:
+                        _pr_baseline_head = get_current_git_head()
                     result, raw_envelope = run_stage(
                         current_stage, context, settings_path,
                         msize=msize, iteration=iter_num,
@@ -2807,6 +2851,34 @@ def run_pipeline(
                     save_status(status, actual_status_path)
                     return
 
+                # Post-condition verification: only when guardian explicitly
+                # declares outcome=success (prose-fallback and partial outputs
+                # bypass this gate — they already recovered what they can).
+                _pr_verification_passed = False
+                if isinstance(result, dict) and result.get("outcome") == "success":
+                    _vr = _verify_pr_stage(result, _pr_baseline_head)
+                    if not _vr.ok:
+                        _log(f"PR stage verification failed: {_vr.reason}", "warn")
+                        loop_counters["pr_verification_retry"] = (
+                            loop_counters.get("pr_verification_retry", 0) + 1
+                        )
+                        status["loop_counters"] = dict(loop_counters)
+                        iter_extras["outcome"] = "reject"
+                        complete_iteration(status, current_stage.value, **iter_extras)
+                        if loop_counters["pr_verification_retry"] > 1:
+                            set_milestone(status, "pr_verified", False)
+                            if ctx:
+                                emit_event(ctx, MILESTONE_SET, milestone_set_payload(
+                                    milestone="pr_verified", value=False,
+                                    stage=Stage.PR.value,
+                                ))
+                            raise PipelineError(
+                                f"PR verification failed after retry: {_vr.reason}"
+                            )
+                        save_status(status, actual_status_path)
+                        continue
+                    _pr_verification_passed = True
+
                 iter_extras["outcome"] = "success"
                 complete_iteration(status, current_stage.value, **iter_extras)
                 update_stage(status, current_stage.value, **stage_extras)
@@ -2826,6 +2898,14 @@ def run_pipeline(
                             _handle_pause(ctx, f"{current_stage.value} stage.completed")
                         elif _action == "abort":
                             raise PipelineInterrupted("Aborted via control webhook", stop_reason="control_webhook")
+                if _pr_verification_passed:
+                    set_milestone(status, "pr_verified", True)
+                    save_status(status, actual_status_path)
+                    if ctx:
+                        emit_event(ctx, MILESTONE_SET, milestone_set_payload(
+                            milestone="pr_verified", value=True,
+                            stage=Stage.PR.value,
+                        ))
                 if ctx and isinstance(result, dict):
                     _pr_url = result.get("pr_url")
                     _pr_number = result.get("pr_number")

--- a/src/worca/schemas/pr.json
+++ b/src/worca/schemas/pr.json
@@ -14,8 +14,7 @@
     }
   },
   "if": {
-    "properties": { "outcome": { "const": "success" } },
-    "required": ["outcome"]
+    "properties": { "outcome": { "const": "success" } }
   },
   "then": {
     "required": ["commit_sha"]

--- a/src/worca/schemas/pr.json
+++ b/src/worca/schemas/pr.json
@@ -2,13 +2,22 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "PROutput",
   "type": "object",
-  "required": ["pr_number", "pr_url"],
+  "required": ["outcome", "pr_number", "pr_url"],
   "properties": {
+    "outcome": { "type": "string", "enum": ["success", "reject"] },
     "pr_number": { "type": "integer" },
     "pr_url": { "type": "string", "format": "uri" },
+    "commit_sha": { "type": "string", "minLength": 7 },
     "review_status": {
       "type": "string",
       "enum": ["pending", "approved", "changes_requested", "rejected"]
     }
+  },
+  "if": {
+    "properties": { "outcome": { "const": "success" } },
+    "required": ["outcome"]
+  },
+  "then": {
+    "required": ["commit_sha"]
   }
 }

--- a/src/worca/state/status.py
+++ b/src/worca/state/status.py
@@ -238,6 +238,7 @@ def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_
             "plan_approved": None,
             "pr_approved": None,
             "deploy_approved": None,
+            "pr_verified": None,
         },
         "pr_review_outcome": None,
     }

--- a/tests/integration/test_guardian_pr_creation.py
+++ b/tests/integration/test_guardian_pr_creation.py
@@ -166,3 +166,89 @@ def test_pr_stage_iteration_recorded_on_success(pipeline_env):
     assert len(pr_iters) == 1
     assert pr_iters[0]["outcome"] == "success"
     assert result.status["stages"]["pr"]["status"] == "completed"
+
+
+# ===========================================================================
+# 6. Post-condition verification: pr_verified milestone
+# ===========================================================================
+
+def test_pr_verified_milestone_true_when_guardian_commits_and_declares_success(pipeline_env):
+    """When guardian commits and emits outcome=success, pr_verified=True in status."""
+    scenario = {
+        "agents": {
+            "tester": _tester_pass(),
+            "guardian": {
+                "action": "succeed",
+                "run_command": "git commit --allow-empty -m 'guardian: created PR'",
+                "structured_output": {
+                    "outcome": "success",
+                    "pr_url": "https://github.com/example/repo/pull/1",
+                    "pr_number": 1,
+                    "commit_sha": "$HEAD",
+                },
+            },
+        },
+        "default": {"action": "succeed", "delay_s": 0.05},
+    }
+    result = pipeline_env.run(scenario, prompt="pr verify pass", timeout=120)
+    assert result.returncode == 0, f"stderr: {result.stderr[-500:]}"
+    assert result.status.get("milestones", {}).get("pr_verified") is True
+
+
+def test_pr_verification_retries_then_succeeds_on_second_attempt(pipeline_env):
+    """Retry fires when iter_1 fails verification; iter_2 commits and pr_verified=True."""
+    scenario = make_iteration_scenario({
+        "tester": _tester_pass(),
+        "guardian": {
+            "iter_1": {
+                "action": "succeed", "delay_s": 0.05,
+                "structured_output": {
+                    "outcome": "success",
+                    "pr_url": "https://github.com/example/repo/pull/1",
+                    "pr_number": 1,
+                    "commit_sha": "abc1234deadbeef",
+                },
+            },
+            "iter_2": {
+                "action": "succeed", "delay_s": 0.05,
+                "run_command": "git commit --allow-empty -m 'guardian: created PR on retry'",
+                "structured_output": {
+                    "outcome": "success",
+                    "pr_url": "https://github.com/example/repo/pull/1",
+                    "pr_number": 1,
+                    "commit_sha": "$HEAD",
+                },
+            },
+        },
+    })
+    result = pipeline_env.run(scenario, prompt="pr retry success", timeout=120)
+    assert result.returncode == 0, f"stderr: {result.stderr[-500:]}"
+    assert result.status.get("milestones", {}).get("pr_verified") is True
+
+    pr_iters = result.status["stages"]["pr"]["iterations"]
+    assert len(pr_iters) == 2, f"expected 2 pr iterations, got {len(pr_iters)}"
+    assert pr_iters[0]["outcome"] == "reject", "iter_1 should be rejected by verification"
+    assert pr_iters[1]["outcome"] == "success", "iter_2 should succeed"
+
+
+def test_pr_stage_halts_with_pr_verified_false_when_no_new_commit(pipeline_env):
+    """When guardian declares outcome=success but HEAD doesn't change, pipeline halts."""
+    scenario = {
+        "agents": {
+            "tester": _tester_pass(),
+            "guardian": {
+                "action": "succeed", "delay_s": 0.05,
+                "structured_output": {
+                    "outcome": "success",
+                    "pr_url": "https://github.com/example/repo/pull/1",
+                    "pr_number": 1,
+                    "commit_sha": "abc1234deadbeef",
+                },
+            },
+        },
+        "default": {"action": "succeed", "delay_s": 0.05},
+    }
+    result = pipeline_env.run(scenario, prompt="pr verify fail", timeout=120)
+    assert result.returncode != 0, "expected pipeline to fail but it succeeded"
+    assert result.status.get("milestones", {}).get("pr_verified") is False
+    assert result.status.get("pipeline_status") == "failed"

--- a/tests/mock_claude/mock_claude.py
+++ b/tests/mock_claude/mock_claude.py
@@ -23,6 +23,7 @@ import json
 import os
 import re
 import signal
+import subprocess
 import sys
 import time
 
@@ -89,6 +90,18 @@ def _resolve_directive(scenario, agent, iteration):
     return scenario.get("default", {})
 
 
+def _substitute_head_placeholder(obj):
+    """Replace string values that are exactly "$HEAD" with the actual git HEAD SHA."""
+    if isinstance(obj, str) and obj == "$HEAD":
+        r = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True)
+        return r.stdout.strip() if r.returncode == 0 else obj
+    if isinstance(obj, dict):
+        return {k: _substitute_head_placeholder(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_substitute_head_placeholder(item) for item in obj]
+    return obj
+
+
 def main():
     scenario_path = os.environ.get("MOCK_CLAUDE_SCENARIO")
     if not scenario_path:
@@ -127,6 +140,10 @@ def main():
     time.sleep(delay)
 
     if action == "succeed":
+        run_cmd = directive.get("run_command")
+        if run_cmd:
+            subprocess.run(run_cmd, shell=True, check=False)
+
         result_text = directive.get("result_text", "Done.")
         envelope = {
             "type": "result",
@@ -145,6 +162,7 @@ def main():
         # behavior, kept for backward compat.
         structured = directive.get("structured_output")
         if structured is not None:
+            structured = _substitute_head_placeholder(structured)
             envelope["structured_output"] = structured
         print(json.dumps(envelope))
         sys.stdout.flush()

--- a/tests/test_agent_md_refs.py
+++ b/tests/test_agent_md_refs.py
@@ -122,6 +122,24 @@ def test_guardian_no_review_stage_content():
     assert "REVIEW" not in content or "PR" in content  # PR content is fine
 
 
+def test_guardian_output_documents_commit_sha_required():
+    content = _read("guardian.md")
+    assert "commit_sha" in content, (
+        "guardian.md Output section must list commit_sha as a required field"
+    )
+
+
+def test_guardian_example_json_contains_commit_sha():
+    content = _read("guardian.md")
+    # The example JSON block in the Output section must show commit_sha
+    example_start = content.find("Example final output")
+    assert example_start != -1, "guardian.md must contain 'Example final output'"
+    example_section = content[example_start:]
+    assert "commit_sha" in example_section, (
+        "guardian.md example JSON must include commit_sha"
+    )
+
+
 # ---------------------------------------------------------------------------
 # reviewer.md
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_schema.py
+++ b/tests/test_pr_schema.py
@@ -1,0 +1,87 @@
+"""Tests for the pr.json schema — commit_sha required when outcome == success."""
+import json
+import os
+
+import jsonschema
+import pytest
+
+import worca
+
+SCHEMA_PATH = os.path.join(os.path.dirname(worca.__file__), "schemas", "pr.json")
+
+
+@pytest.fixture
+def schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def _success_doc():
+    return {
+        "outcome": "success",
+        "pr_number": 42,
+        "pr_url": "https://github.com/org/repo/pull/42",
+        "commit_sha": "abc1234",
+    }
+
+
+def _reject_doc():
+    return {
+        "outcome": "reject",
+        "pr_number": 0,
+        "pr_url": "https://github.com/org/repo/pull/0",
+    }
+
+
+class TestSchemaStructure:
+    def test_schema_file_exists(self):
+        assert os.path.isfile(SCHEMA_PATH)
+
+    def test_schema_is_valid_json(self, schema):
+        assert isinstance(schema, dict)
+
+    def test_schema_has_commit_sha_property(self, schema):
+        assert "commit_sha" in schema["properties"]
+
+    def test_commit_sha_is_string(self, schema):
+        assert schema["properties"]["commit_sha"]["type"] == "string"
+
+    def test_commit_sha_min_length_7(self, schema):
+        assert schema["properties"]["commit_sha"]["minLength"] == 7
+
+
+class TestSuccessOutcome:
+    def test_success_with_commit_sha_valid(self, schema):
+        jsonschema.validate(_success_doc(), schema)
+
+    def test_success_missing_commit_sha_invalid(self, schema):
+        doc = _success_doc()
+        del doc["commit_sha"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_success_commit_sha_too_short_invalid(self, schema):
+        doc = _success_doc()
+        doc["commit_sha"] = "abc123"  # 6 chars — below minLength 7
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_success_commit_sha_exactly_7_chars_valid(self, schema):
+        doc = _success_doc()
+        doc["commit_sha"] = "abc1234"
+        jsonschema.validate(doc, schema)
+
+    def test_success_commit_sha_full_40_chars_valid(self, schema):
+        doc = _success_doc()
+        doc["commit_sha"] = "a" * 40
+        jsonschema.validate(doc, schema)
+
+
+class TestRejectOutcome:
+    def test_reject_without_commit_sha_valid(self, schema):
+        jsonschema.validate(_reject_doc(), schema)
+
+    def test_reject_with_commit_sha_valid(self, schema):
+        doc = _reject_doc()
+        doc["commit_sha"] = "abc1234"
+        jsonschema.validate(doc, schema)

--- a/tests/test_runner_pr_verification.py
+++ b/tests/test_runner_pr_verification.py
@@ -1,0 +1,174 @@
+"""Unit tests for PRVerification namedtuple and _verify_pr_stage() in runner.py.
+
+Covers:
+- success: HEAD changed, all fields present, sha matches
+- no-commit: HEAD did not change from baseline
+- missing-fields: commit_sha / pr_url / pr_number absent
+- sha-mismatch: reported commit_sha doesn't match actual HEAD
+- non-dict result: stage output is not a dict
+- wiring: _verify_pr_stage is called inside run_pipeline with retry/halt logic
+"""
+import inspect
+
+from unittest.mock import patch
+
+
+from worca.orchestrator.runner import PRVerification, _verify_pr_stage
+from worca.orchestrator import runner as _runner_module
+
+
+SHA_BASELINE = "aaa0000000000000000000000000000000000000"
+SHA_NEW = "bbb1111111111111111111111111111111111111"
+
+
+def _full_output():
+    return {
+        "outcome": "success",
+        "commit_sha": SHA_NEW,
+        "pr_url": "https://github.com/org/repo/pull/42",
+        "pr_number": 42,
+    }
+
+
+class TestPRVerificationNamedtuple:
+    def test_has_ok_field(self):
+        v = PRVerification(ok=True, reason="all good")
+        assert v.ok is True
+
+    def test_has_reason_field(self):
+        v = PRVerification(ok=False, reason="no commit")
+        assert v.reason == "no commit"
+
+    def test_is_namedtuple(self):
+        assert isinstance(PRVerification(True, ""), tuple)
+        assert hasattr(PRVerification, "_fields")
+        assert PRVerification._fields == ("ok", "reason")
+
+
+class TestVerifyPRStageSuccess:
+    def test_returns_ok_true_on_success(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE)
+        assert result.ok is True
+
+    def test_reason_empty_string_on_success(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE)
+        assert result.reason == ""
+
+    def test_returns_prverification_instance(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE)
+        assert isinstance(result, PRVerification)
+
+
+class TestVerifyPRStageNoCommit:
+    def test_ok_false_when_head_unchanged(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_BASELINE):
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE)
+        assert result.ok is False
+
+    def test_reason_mentions_no_new_commit(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_BASELINE):
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE)
+        assert "commit" in result.reason.lower()
+
+
+class TestVerifyPRStageMissingFields:
+    def test_missing_commit_sha(self):
+        output = _full_output()
+        del output["commit_sha"]
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(output, SHA_BASELINE)
+        assert result.ok is False
+        assert "commit_sha" in result.reason
+
+    def test_missing_pr_url(self):
+        output = _full_output()
+        del output["pr_url"]
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(output, SHA_BASELINE)
+        assert result.ok is False
+        assert "pr_url" in result.reason
+
+    def test_missing_pr_number(self):
+        output = _full_output()
+        del output["pr_number"]
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(output, SHA_BASELINE)
+        assert result.ok is False
+        assert "pr_number" in result.reason
+
+    def test_missing_all_required_fields(self):
+        output = {"outcome": "success"}
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(output, SHA_BASELINE)
+        assert result.ok is False
+
+
+class TestVerifyPRStageShaMismatch:
+    def test_ok_false_when_reported_sha_differs_from_head(self):
+        output = _full_output()
+        output["commit_sha"] = "ccc2222222"  # not SHA_NEW
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(output, SHA_BASELINE)
+        assert result.ok is False
+
+    def test_reason_mentions_sha_mismatch(self):
+        output = _full_output()
+        output["commit_sha"] = "ccc2222222"
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(output, SHA_BASELINE)
+        assert "sha" in result.reason.lower() or "commit" in result.reason.lower()
+
+    def test_sha_prefix_match_accepted(self):
+        """Reported SHA may be a 7+ char prefix of the full 40-char HEAD SHA."""
+        output = _full_output()
+        output["commit_sha"] = SHA_NEW[:12]
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(output, SHA_BASELINE)
+        assert result.ok is True
+
+
+class TestVerifyPRStageNonDictResult:
+    def test_ok_false_when_result_is_none(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(None, SHA_BASELINE)
+        assert result.ok is False
+
+    def test_ok_false_when_result_is_string(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage("some prose", SHA_BASELINE)
+        assert result.ok is False
+
+    def test_reason_mentions_structured_output(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage("prose", SHA_BASELINE)
+        assert "structured" in result.reason.lower() or "dict" in result.reason.lower()
+
+    def test_ok_false_when_result_is_list(self):
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage([], SHA_BASELINE)
+        assert result.ok is False
+
+
+class TestPRStageHandlerWiring:
+    """Sentinel tests: fail until _verify_pr_stage is wired into run_pipeline."""
+
+    def _pipeline_source(self):
+        return inspect.getsource(_runner_module.run_pipeline)
+
+    def test_verify_pr_stage_called_inside_run_pipeline(self):
+        assert "_verify_pr_stage(" in self._pipeline_source(), (
+            "_verify_pr_stage is not called inside run_pipeline — wiring missing"
+        )
+
+    def test_pr_verification_retry_counter_in_run_pipeline(self):
+        assert "pr_verification_retry" in self._pipeline_source(), (
+            "Loop counter 'pr_verification_retry' not found in run_pipeline — wiring missing"
+        )
+
+    def test_pr_verified_milestone_set_in_run_pipeline(self):
+        assert '"pr_verified"' in self._pipeline_source(), (
+            "Milestone 'pr_verified' is not set inside run_pipeline — wiring missing"
+        )

--- a/tests/test_runner_pr_verification.py
+++ b/tests/test_runner_pr_verification.py
@@ -6,6 +6,7 @@ Covers:
 - missing-fields: commit_sha / pr_url / pr_number absent
 - sha-mismatch: reported commit_sha doesn't match actual HEAD
 - non-dict result: stage output is not a dict
+- gh lookup: PR existence + URL match via gh pr view
 - wiring: _verify_pr_stage is called inside run_pipeline with retry/halt logic
 """
 import inspect
@@ -13,12 +14,17 @@ import inspect
 from unittest.mock import patch
 
 
-from worca.orchestrator.runner import PRVerification, _verify_pr_stage
+from worca.orchestrator.runner import PRVerification, _verify_pr_stage, _verify_pr_via_gh
 from worca.orchestrator import runner as _runner_module
 
 
 SHA_BASELINE = "aaa0000000000000000000000000000000000000"
 SHA_NEW = "bbb1111111111111111111111111111111111111"
+
+
+def _no_gh(_pr_number, _expected_url):
+    """Stub gh_lookup that opts out of the network check."""
+    return None
 
 
 def _full_output():
@@ -48,17 +54,17 @@ class TestPRVerificationNamedtuple:
 class TestVerifyPRStageSuccess:
     def test_returns_ok_true_on_success(self):
         with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
-            result = _verify_pr_stage(_full_output(), SHA_BASELINE)
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE, gh_lookup=_no_gh)
         assert result.ok is True
 
     def test_reason_empty_string_on_success(self):
         with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
-            result = _verify_pr_stage(_full_output(), SHA_BASELINE)
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE, gh_lookup=_no_gh)
         assert result.reason == ""
 
     def test_returns_prverification_instance(self):
         with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
-            result = _verify_pr_stage(_full_output(), SHA_BASELINE)
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE, gh_lookup=_no_gh)
         assert isinstance(result, PRVerification)
 
 
@@ -126,8 +132,125 @@ class TestVerifyPRStageShaMismatch:
         output = _full_output()
         output["commit_sha"] = SHA_NEW[:12]
         with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
-            result = _verify_pr_stage(output, SHA_BASELINE)
+            result = _verify_pr_stage(output, SHA_BASELINE, gh_lookup=_no_gh)
         assert result.ok is True
+
+
+class TestVerifyPRStageGhLookup:
+    """Defense-in-depth: gh pr view confirms PR exists and URL matches."""
+
+    def test_gh_failure_propagates_as_verification_failure(self):
+        def gh_says_mismatch(_n, _u):
+            return PRVerification(ok=False, reason="PR URL mismatch: gh has 'X', guardian reported 'Y'")
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE, gh_lookup=gh_says_mismatch)
+        assert result.ok is False
+        assert "mismatch" in result.reason.lower()
+
+    def test_gh_success_keeps_overall_ok(self):
+        def gh_ok(_n, _u):
+            return PRVerification(ok=True, reason="")
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE, gh_lookup=gh_ok)
+        assert result.ok is True
+
+    def test_gh_none_means_skip_check(self):
+        """Returning None (transport failure / unavailable) does not fail verification."""
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            result = _verify_pr_stage(_full_output(), SHA_BASELINE, gh_lookup=lambda n, u: None)
+        assert result.ok is True
+
+    def test_gh_lookup_called_with_pr_number_and_url(self):
+        captured = {}
+        def capture(n, u):
+            captured["n"] = n
+            captured["u"] = u
+            return None
+        with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
+            _verify_pr_stage(_full_output(), SHA_BASELINE, gh_lookup=capture)
+        assert captured["n"] == 42
+        assert captured["u"] == "https://github.com/org/repo/pull/42"
+
+
+class TestVerifyPrViaGh:
+    """Direct unit tests for the default gh_lookup implementation."""
+
+    def _stub_run(self, returncode=0, stdout="", stderr=""):
+        class _R:
+            def __init__(self, rc, out, err):
+                self.returncode = rc
+                self.stdout = out
+                self.stderr = err
+        return _R(returncode, stdout, stderr)
+
+    def test_gh_not_installed_returns_none(self):
+        with patch("worca.orchestrator.runner.subprocess.run", side_effect=FileNotFoundError()):
+            assert _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42") is None
+
+    def test_gh_timeout_returns_none(self):
+        import subprocess as _sp
+        with patch(
+            "worca.orchestrator.runner.subprocess.run",
+            side_effect=_sp.TimeoutExpired(cmd="gh", timeout=10),
+        ):
+            assert _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42") is None
+
+    def test_gh_no_auth_returns_none(self):
+        r = self._stub_run(returncode=1, stderr="To authenticate, please run: gh auth login")
+        with patch("worca.orchestrator.runner.subprocess.run", return_value=r):
+            assert _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42") is None
+
+    def test_gh_no_remote_returns_none(self):
+        r = self._stub_run(returncode=1, stderr="no default remote repository is set")
+        with patch("worca.orchestrator.runner.subprocess.run", return_value=r):
+            assert _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42") is None
+
+    def test_gh_returns_matching_pr(self):
+        r = self._stub_run(
+            returncode=0,
+            stdout='{"number": 42, "url": "https://github.com/org/repo/pull/42"}',
+        )
+        with patch("worca.orchestrator.runner.subprocess.run", return_value=r):
+            result = _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42")
+        assert result is not None
+        assert result.ok is True
+
+    def test_gh_returns_url_mismatch(self):
+        r = self._stub_run(
+            returncode=0,
+            stdout='{"number": 42, "url": "https://github.com/org/repo/pull/99"}',
+        )
+        with patch("worca.orchestrator.runner.subprocess.run", return_value=r):
+            result = _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42")
+        assert result is not None
+        assert result.ok is False
+        assert "mismatch" in result.reason.lower()
+
+    def test_gh_returns_different_pr_number(self):
+        r = self._stub_run(
+            returncode=0,
+            stdout='{"number": 7, "url": "https://github.com/org/repo/pull/7"}',
+        )
+        with patch("worca.orchestrator.runner.subprocess.run", return_value=r):
+            result = _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42")
+        assert result is not None
+        assert result.ok is False
+        assert "#7" in result.reason or "#42" in result.reason
+
+    def test_gh_pr_not_found_is_real_failure(self):
+        r = self._stub_run(
+            returncode=1,
+            stderr="GraphQL: Could not resolve to a PullRequest with the number of 42",
+        )
+        with patch("worca.orchestrator.runner.subprocess.run", return_value=r):
+            result = _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42")
+        assert result is not None
+        assert result.ok is False
+
+    def test_gh_invalid_json_returns_none(self):
+        r = self._stub_run(returncode=0, stdout="not json")
+        with patch("worca.orchestrator.runner.subprocess.run", return_value=r):
+            assert _verify_pr_via_gh(42, "https://github.com/org/repo/pull/42") is None
 
 
 class TestVerifyPRStageNonDictResult:
@@ -171,4 +294,15 @@ class TestPRStageHandlerWiring:
     def test_pr_verified_milestone_set_in_run_pipeline(self):
         assert '"pr_verified"' in self._pipeline_source(), (
             "Milestone 'pr_verified' is not set inside run_pipeline — wiring missing"
+        )
+
+    def test_pr_baseline_captured_once_per_stage(self):
+        """Baseline must be captured only when _pr_baseline_head is None.
+
+        Recapturing per-iteration would let a partial commit on iter_1 corrupt
+        the baseline that iter_2 verifies against.
+        """
+        src = self._pipeline_source()
+        assert "_pr_baseline_head is None" in src, (
+            "Baseline guard 'is None' missing — capture would happen every iteration"
         )

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -199,6 +199,13 @@ def test_init_status_has_milestones():
     assert result["milestones"]["deploy_approved"] is None
 
 
+def test_init_status_has_pr_verified_milestone():
+    wr = {"title": "Task"}
+    result = init_status(wr, "feat/task")
+    assert "pr_verified" in result["milestones"]
+    assert result["milestones"]["pr_verified"] is None
+
+
 def test_init_status_has_stage_field():
     wr = {"title": "Task"}
     result = init_status(wr, "feat/task")

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -3415,6 +3415,27 @@ sl-details.learnings-panel::part(content) {
   margin: 8px 0 4px;
 }
 
+.pr-verification-banner {
+  margin: 8px 0 4px;
+}
+
+.pr-verified-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 13px;
+}
+
+.pr-verified-row .meta-label {
+  color: var(--muted);
+}
+
+.pr-verified-badge {
+  display: inline-flex;
+  align-items: center;
+}
+
 .classification-strip {
   margin-top: 10px;
   padding: 8px 10px;

--- a/worca-ui/app/views/run-detail-pr-verification.test.js
+++ b/worca-ui/app/views/run-detail-pr-verification.test.js
@@ -171,4 +171,22 @@ describe('runDetailView pr-verified badge in guardian stage', () => {
     const out = renderToString(runDetailView(run));
     expect(out).not.toContain('pr-verified-badge');
   });
+
+  it('renders pr-verified-badge when guardian has multiple iterations (retry path)', () => {
+    const multiIterGuardian = {
+      status: 'completed',
+      iterations: [
+        { number: 1, status: 'error', outcome: 'reject' },
+        { number: 2, status: 'completed', outcome: 'success' },
+      ],
+    };
+    const run = {
+      pipeline_status: 'completed',
+      milestones: { pr_verified: true },
+      stages: { guardian: multiIterGuardian },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-verified-badge');
+    expect(out).toContain('Verified');
+  });
 });

--- a/worca-ui/app/views/run-detail-pr-verification.test.js
+++ b/worca-ui/app/views/run-detail-pr-verification.test.js
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { prVerificationBannerView, runDetailView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const guardianStage = {
+  status: 'error',
+  iterations: [{ number: 1, status: 'error', outcome: 'reject' }],
+};
+
+const baseRun = {
+  pipeline_status: 'failed',
+  milestones: { pr_verified: false },
+  stages: { guardian: guardianStage },
+};
+
+describe('prVerificationBannerView', () => {
+  it('renders danger sl-alert when pr_verified=false and pipeline_status=failed', () => {
+    const out = renderToString(prVerificationBannerView(baseRun));
+    expect(out).toContain('pr-verification-banner');
+    expect(out).toContain('variant="danger"');
+  });
+
+  it('has class pr-verification-banner', () => {
+    const out = renderToString(prVerificationBannerView(baseRun));
+    expect(out).toContain('pr-verification-banner');
+  });
+
+  it('does not render when pr_verified is null', () => {
+    const run = { ...baseRun, milestones: { pr_verified: null } };
+    const out = renderToString(prVerificationBannerView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('does not render when pr_verified is undefined', () => {
+    const run = { ...baseRun, milestones: {} };
+    const out = renderToString(prVerificationBannerView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('does not render when pr_verified=true', () => {
+    const run = { ...baseRun, milestones: { pr_verified: true } };
+    const out = renderToString(prVerificationBannerView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('does not render when pr_verified=false but pipeline_status=completed', () => {
+    const run = { ...baseRun, pipeline_status: 'completed' };
+    const out = renderToString(prVerificationBannerView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('does not render when pr_verified=false but pipeline_status=running', () => {
+    const run = { ...baseRun, pipeline_status: 'running' };
+    const out = renderToString(prVerificationBannerView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('does not render when pr_verified=false but pipeline_status=paused', () => {
+    const run = { ...baseRun, pipeline_status: 'paused' };
+    const out = renderToString(prVerificationBannerView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('does not render when run is null', () => {
+    const out = renderToString(prVerificationBannerView(null));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('does not render when milestones is absent', () => {
+    const run = { pipeline_status: 'failed', stages: {} };
+    const out = renderToString(prVerificationBannerView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+});
+
+describe('runDetailView pr-verification-banner integration', () => {
+  it('banner appears in overview when pr_verified=false and pipeline_status=failed', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('pr-verification-banner');
+    expect(out).toContain('variant="danger"');
+  });
+
+  it('banner absent when pr_verified=true', () => {
+    const run = { ...baseRun, milestones: { pr_verified: true } };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('banner absent when pr_verified=null', () => {
+    const run = { ...baseRun, milestones: { pr_verified: null } };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+
+  it('banner absent when pipeline_status is not failed', () => {
+    const run = {
+      ...baseRun,
+      pipeline_status: 'completed',
+      milestones: { pr_verified: false },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-verification-banner');
+  });
+});
+
+describe('runDetailView pr-verified badge in guardian stage', () => {
+  it('renders pr-verified-badge with danger variant when pr_verified=false', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('pr-verified-badge');
+    expect(out).toContain('Not Verified');
+  });
+
+  it('renders pr-verified-badge with success variant when pr_verified=true', () => {
+    const run = {
+      pipeline_status: 'completed',
+      milestones: { pr_verified: true },
+      stages: { guardian: guardianStage },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-verified-badge');
+    expect(out).toContain('Verified');
+  });
+
+  it('does not render pr-verified-badge when pr_verified is null', () => {
+    const run = {
+      ...baseRun,
+      milestones: { pr_verified: null },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-verified-badge');
+  });
+
+  it('does not render pr-verified-badge when guardian stage is absent', () => {
+    const run = {
+      pipeline_status: 'failed',
+      milestones: { pr_verified: false },
+      stages: {
+        implement: {
+          status: 'error',
+          iterations: [{ number: 1, status: 'error' }],
+        },
+      },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-verified-badge');
+  });
+
+  it('does not render pr-verified-badge when milestones is absent', () => {
+    const run = {
+      pipeline_status: 'failed',
+      stages: { guardian: guardianStage },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-verified-badge');
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -860,6 +860,7 @@ export function runDetailView(run, settings = {}, options = {}) {
                             ${stageTurns > 0 ? html`<span class="stage-totals-item"><span class="meta-label">Turns:</span> <span class="meta-value">${stageTurns}</span></span>` : nothing}
                           </div>`;
                       })()}
+                      ${key === 'guardian' ? _prVerifiedBadgeView(run) : nothing}
                       <sl-tab-group @sl-tab-show=${(e) => {
                         const panel = e.detail.name;
                         const num = parseInt(panel.split('-').pop(), 10);
@@ -911,7 +912,7 @@ export function runDetailView(run, settings = {}, options = {}) {
                       ${stage.error ? html`<div class="detail-row detail-error"><span class="detail-label">Error:</span> ${stage.error}</div>` : nothing}
                       ${iterations.length === 1 ? _classificationRowView(iterations[0]) : nothing}
                       ${iterations.length === 1 ? _dispatchEventsRowView(iterations[0]) : nothing}
-                      ${key === 'guardian' && iterations.length === 1 ? _prVerifiedBadgeView(run) : nothing}
+                      ${key === 'guardian' ? _prVerifiedBadgeView(run) : nothing}
                       ${key === 'preflight' && iterations.length === 1 ? _preflightChecksView(stage, iterations[0]) : nothing}
                       ${promptData ? _agentPromptSection(key, promptData) : nothing}
                     </div>

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -271,6 +271,35 @@ function _circuitBreakerBannerView(run, settings) {
   return nothing;
 }
 
+export function prVerificationBannerView(run) {
+  if (
+    !(
+      run?.milestones?.pr_verified === false &&
+      run?.pipeline_status === 'failed'
+    )
+  ) {
+    return nothing;
+  }
+  return html`
+    <sl-alert class="pr-verification-banner" variant="danger" open>
+      <strong>PR verification failed:</strong> Guardian reported success but no new commit or PR was detected.
+    </sl-alert>
+  `;
+}
+
+function _prVerifiedBadgeView(run) {
+  const verified = run?.milestones?.pr_verified;
+  if (verified === null || verified === undefined) return nothing;
+  return html`
+    <div class="pr-verified-row">
+      <span class="meta-label">PR Verification:</span>
+      <sl-badge class="pr-verified-badge" variant="${verified ? 'success' : 'danger'}" pill>
+        ${verified ? 'Verified' : 'Not Verified'}
+      </sl-badge>
+    </div>
+  `;
+}
+
 function _preflightCheckBadgeVariant(status) {
   if (status === 'pass') return 'success';
   if (status === 'warn') return 'warning';
@@ -618,6 +647,7 @@ export function runDetailView(run, settings = {}, options = {}) {
     <div class="run-detail-overview">
       ${stageTimelineView(stages, stageUi, run.active)}
       ${_circuitBreakerBannerView(run, settings)}
+      ${prVerificationBannerView(run)}
 
       <div class="run-info-section">
         ${
@@ -881,6 +911,7 @@ export function runDetailView(run, settings = {}, options = {}) {
                       ${stage.error ? html`<div class="detail-row detail-error"><span class="detail-label">Error:</span> ${stage.error}</div>` : nothing}
                       ${iterations.length === 1 ? _classificationRowView(iterations[0]) : nothing}
                       ${iterations.length === 1 ? _dispatchEventsRowView(iterations[0]) : nothing}
+                      ${key === 'guardian' && iterations.length === 1 ? _prVerifiedBadgeView(run) : nothing}
                       ${key === 'preflight' && iterations.length === 1 ? _preflightChecksView(stage, iterations[0]) : nothing}
                       ${promptData ? _agentPromptSection(key, promptData) : nothing}
                     </div>


### PR DESCRIPTION
Closes #98

## Summary

In the 2026-04-13 W-038 pipeline run, the guardian reported `outcome: success` without running any git/gh commands — the orchestrator trusted it, marked the PR stage complete, and silently shipped nothing. Working tree had 10 uncommitted files; no PR was opened. The pipeline appeared successful.

This PR adds defense-in-depth so that prompt drift cannot silently bypass the PR contract.

## Changes

### 1. Orchestrator post-condition (`src/worca/orchestrator/runner.py`)

`_verify_pr_stage(stage_output, baseline_head)` runs after a guardian success and asserts:
- git HEAD differs from a baseline captured **before** the stage ran
- the result carries `commit_sha`, `pr_url`, `pr_number`
- the reported `commit_sha` is a prefix of the actual HEAD SHA

On failure: downgrade outcome to `reject`, increment `pr_verification_retry`, retry once. Second failure halts the pipeline with `pr_verified: false` recorded on the run.

### 2. PR schema (`src/worca/schemas/pr.json`)

- `outcome` (enum `success | reject`) is now required.
- `commit_sha` (≥7 chars) becomes required when `outcome == success` (conditional `if/then`).
- Guardian's prompt and example output (`src/worca/agents/core/guardian.md`) updated to match.

### 3. UI surfacing (`worca-ui/app/views/run-detail.js`)

- `pr_verified: false` renders a red `sl-alert` banner on failed runs.
- A `pr-verified-badge` shows verification state in the run-detail metadata panel.

### 4. Status (`src/worca/state/status.py`)

- New `pr_verified` milestone slot in `init_status()`, defaulting to `null`.

## Test plan

- [x] `pytest tests/ --ignore=tests/integration` — all unit tests green
- [x] `pytest tests/integration/test_guardian_pr_creation.py tests/integration/test_investigate_pr.py` — 18/18 green
- [x] `npx vitest run` (worca-ui) — 2288/2288 green
- [x] `ruff check` — clean
- [x] `npm run lint` (biome) — clean
- [x] New unit tests:
  - `tests/test_pr_schema.py` — schema validation cases for the conditional `commit_sha` requirement
  - `tests/test_runner_pr_verification.py` — `_verify_pr_stage()` covers HEAD-unchanged, missing fields, sha-mismatch, and success cases
  - `worca-ui/app/views/run-detail-pr-verification.test.js` — UI banner + badge rendering for both verified and unverified states
- [ ] Manual smoke (post-merge): run a small feature end-to-end and confirm `pr_verified=true` is recorded on success; force a guardian-no-commit scenario and confirm the run halts with `pr_verified=false`

## Notes

This work was originally produced by an autonomous run (`20260506-104920-909-0814`) that used the `quick-fix` template — which disables `test`, `review`, and `pr`. The implementation completed but never reached a PR. The flow is being completed manually here. Tests/lint were re-run locally before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)