### PR TITLE
fix: run_parallel.py silently fails when .claude/ is gitignored

### DIFF
--- a/src/worca/scripts/run_parallel.py
+++ b/src/worca/scripts/run_parallel.py
@@ -28,6 +28,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from worca.orchestrator.work_request import normalize
 from worca.utils.claude_cli import _ARG_INLINE_LIMIT
+from worca.utils.runtime import copy_claude_config, validate_runtime
 from worca.utils.settings import load_settings
 
 
@@ -148,6 +149,8 @@ def main():
 
     args = parser.parse_args()
 
+    validate_runtime()
+
     # Build work request list
     if args.prompts:
         items = [(p, normalize("prompt", p)) for p in args.prompts]
@@ -173,6 +176,7 @@ def main():
         slug = _slugify(wr.title)
         branch = f"worca/{slug}"
         worktree_path = _create_worktree(args.worktree_dir, slug, branch)
+        copy_claude_config(".claude", os.path.join(worktree_path, ".claude"))
         worktrees.append((worktree_path, raw_input, wr))
         print(f"  Created: {worktree_path} -> {branch}")
 

--- a/src/worca/scripts/run_worktree.py
+++ b/src/worca/scripts/run_worktree.py
@@ -15,11 +15,9 @@ Usage:
         --fleet-id f_20260426_abc
 """
 import argparse
-import json
 import os
 import re
 import secrets
-import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -35,6 +33,7 @@ from worca.utils.git import (
     detect_default_branch,
     init_worktree_beads,
 )
+from worca.utils.runtime import copy_claude_config, validate_runtime
 from worca.utils.settings import load_settings
 
 
@@ -80,123 +79,6 @@ def _slugify(title: str) -> str:
     name = re.sub(r"[^a-z0-9\-]", "-", name)
     name = re.sub(r"-+", "-", name)
     return name.strip("-")[:30]
-
-
-def _copy_claude_config(src_dir: str, dst_dir: str) -> None:
-    """Copy .claude/ contents into the worktree.
-
-    Most projects gitignore .claude/ (or just don't commit it), so a fresh
-    worktree starts with no .claude/ at all — preflight then fails on the
-    missing settings.json. Copy everything from the project's .claude/ into
-    the worktree, with three rules:
-
-    - Skip settings.local.json (machine-specific; never propagate verbatim).
-    - Never clobber files git has already placed in the worktree (i.e. the
-      project does commit parts of .claude/). Tracked files win.
-    - Narrow exception to the local-skip rule: a small allowlist of
-      worca-namespace runtime keys (webhooks, events) is merged from the
-      parent's settings.local.json into the worktree's settings.json. Without
-      this, the worca-ui's auto-installed loopback webhook (which lives in
-      the parent's settings.local.json) doesn't reach the worktree pipeline,
-      and the UI receives zero pipeline events from worktree runs.
-    """
-    skip_top_level = {"settings.local.json"}
-    if not os.path.isdir(src_dir):
-        return
-    for root, _dirs, files in os.walk(src_dir):
-        rel = os.path.relpath(root, src_dir)
-        if rel == ".":
-            files = [f for f in files if f not in skip_top_level]
-        for f in files:
-            dst_file = os.path.join(dst_dir, rel, f)
-            if os.path.exists(dst_file):
-                continue  # tracked-files-win
-            os.makedirs(os.path.dirname(dst_file), exist_ok=True)
-            shutil.copy2(os.path.join(root, f), dst_file)
-
-    _propagate_runtime_local_keys(src_dir, dst_dir)
-
-
-# Allowlist of worca-namespace keys that are derived from the parent's
-# runtime (host:port of the local UI, etc.) but must follow the run into
-# the worktree. Everything else in settings.local.json stays parent-only.
-_PROPAGATED_LOCAL_WORCA_KEYS = ("webhooks", "events")
-
-
-def _propagate_runtime_local_keys(src_dir: str, dst_dir: str) -> None:
-    """Merge a narrow allowlist of worca-namespace keys from the parent's
-    settings.local.json into the worktree's settings.json.
-
-    No-op when:
-    - The parent has no settings.local.json.
-    - The local file has no worca-namespace runtime keys.
-    - The worktree's settings.json was tracked by git (we never clobber it).
-    """
-    src_local = os.path.join(src_dir, "settings.local.json")
-    dst_settings = os.path.join(dst_dir, "settings.json")
-    if not os.path.exists(src_local) or not os.path.exists(dst_settings):
-        return
-
-    try:
-        with open(src_local) as f:
-            local = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return
-
-    local_worca = (local.get("worca") if isinstance(local, dict) else None) or {}
-    overlay = {
-        k: local_worca[k]
-        for k in _PROPAGATED_LOCAL_WORCA_KEYS
-        if k in local_worca
-    }
-    if not overlay:
-        return
-
-    try:
-        with open(dst_settings) as f:
-            base = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        base = {}
-    if not isinstance(base, dict):
-        base = {}
-
-    base_worca = base.get("worca")
-    if not isinstance(base_worca, dict):
-        base_worca = {}
-
-    # Apply each allowlisted key with deep-merge semantics consistent with
-    # worca.utils.settings.load_settings: dicts merge recursively, lists/
-    # scalars from the overlay replace wholesale.
-    for key, value in overlay.items():
-        if (
-            isinstance(value, dict)
-            and isinstance(base_worca.get(key), dict)
-        ):
-            base_worca[key] = _deep_merge(base_worca[key], value)
-        else:
-            base_worca[key] = value
-
-    base["worca"] = base_worca
-
-    with open(dst_settings, "w") as f:
-        json.dump(base, f, indent=2)
-        f.write("\n")
-
-
-def _deep_merge(base: dict, override: dict) -> dict:
-    """Same semantics as worca.utils.settings.deep_merge — dict-recursive,
-    list/scalar replace. Local copy to keep this script self-contained."""
-    result = dict(base)
-    for k, v in override.items():
-        if (
-            k in result
-            and isinstance(result[k], dict)
-            and isinstance(v, dict)
-        ):
-            result[k] = _deep_merge(result[k], v)
-        else:
-            result[k] = v
-    return result
 
 
 def _build_pipeline_cmd(args: argparse.Namespace, run_id: str = "") -> list:
@@ -332,13 +214,7 @@ def main(argv=None) -> int:
     # Validate the worca runtime exists before any side effects (worktree create,
     # registry write, Popen). Without it the spawned run_pipeline.py crashes
     # under stdout=DEVNULL — UI shows "started" then nothing.
-    src_worca = os.path.join(".claude", "worca")
-    if not os.path.isdir(src_worca):
-        print(
-            f"error: worca runtime not found at {src_worca}/ — run `worca init .` first",
-            file=sys.stderr,
-        )
-        return 1
+    validate_runtime()
 
     # Steps 1-2: generate run_id and derive slug
     run_id = _generate_run_id()
@@ -359,7 +235,7 @@ def main(argv=None) -> int:
     # .claude/, so the worktree starts empty; without this copy preflight
     # fails on missing settings.json. Files git already placed in the
     # worktree are preserved.
-    _copy_claude_config(".claude", os.path.join(worktree_path, ".claude"))
+    copy_claude_config(".claude", os.path.join(worktree_path, ".claude"))
 
     # Step 5: init beads in worktree
     init_worktree_beads(worktree_path)

--- a/src/worca/utils/runtime.py
+++ b/src/worca/utils/runtime.py
@@ -1,0 +1,123 @@
+"""Shared runtime helpers — copy and validate the worca runtime directory.
+
+Used by run_worktree.py and run_parallel.py so both scripts handle the
+gitignored-.claude/ case the same way.
+"""
+import json
+import os
+import shutil
+import sys
+
+# Allowlist of worca-namespace keys that are derived from the parent's
+# runtime (host:port of the local UI, etc.) but must follow the run into
+# the worktree. Everything else in settings.local.json stays parent-only.
+PROPAGATED_LOCAL_WORCA_KEYS = ("webhooks", "events")
+
+
+def deep_merge(base: dict, override: dict) -> dict:
+    """Dict-recursive merge — dicts merge, lists/scalars replace wholesale.
+
+    Same semantics as worca.utils.settings.deep_merge.
+    """
+    result = dict(base)
+    for k, v in override.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
+def propagate_runtime_local_keys(src_dir: str, dst_dir: str) -> None:
+    """Merge a narrow allowlist of worca-namespace keys from the parent's
+    settings.local.json into the worktree's settings.json.
+
+    No-op when:
+    - The parent has no settings.local.json.
+    - The local file has no worca-namespace runtime keys.
+    - The worktree has no settings.json to augment.
+    """
+    src_local = os.path.join(src_dir, "settings.local.json")
+    dst_settings = os.path.join(dst_dir, "settings.json")
+    if not os.path.exists(src_local) or not os.path.exists(dst_settings):
+        return
+
+    try:
+        with open(src_local) as f:
+            local = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+
+    local_worca = (local.get("worca") if isinstance(local, dict) else None) or {}
+    overlay = {k: local_worca[k] for k in PROPAGATED_LOCAL_WORCA_KEYS if k in local_worca}
+    if not overlay:
+        return
+
+    try:
+        with open(dst_settings) as f:
+            base = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        base = {}
+    if not isinstance(base, dict):
+        base = {}
+
+    base_worca = base.get("worca")
+    if not isinstance(base_worca, dict):
+        base_worca = {}
+
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(base_worca.get(key), dict):
+            base_worca[key] = deep_merge(base_worca[key], value)
+        else:
+            base_worca[key] = value
+
+    base["worca"] = base_worca
+
+    with open(dst_settings, "w") as f:
+        json.dump(base, f, indent=2)
+        f.write("\n")
+
+
+def copy_claude_config(src_dir: str, dst_dir: str) -> None:
+    """Copy .claude/ contents into a worktree.
+
+    Most projects gitignore .claude/, so a fresh worktree starts with no
+    .claude/ at all — preflight then fails on missing settings.json. Copy
+    everything from the project's .claude/ into the worktree with three rules:
+
+    - Skip settings.local.json (machine-specific; never propagate verbatim).
+    - Never clobber files git has already placed in the worktree. Tracked
+      files win.
+    - Narrow exception to the local-skip rule: a small allowlist of
+      worca-namespace runtime keys (webhooks, events) is merged from the
+      parent's settings.local.json into the worktree's settings.json.
+    """
+    skip_top_level = {"settings.local.json"}
+    if not os.path.isdir(src_dir):
+        return
+    for root, _dirs, files in os.walk(src_dir):
+        rel = os.path.relpath(root, src_dir)
+        if rel == ".":
+            files = [f for f in files if f not in skip_top_level]
+        for f in files:
+            dst_file = os.path.join(dst_dir, rel, f)
+            if os.path.exists(dst_file):
+                continue  # tracked-files-win
+            os.makedirs(os.path.dirname(dst_file), exist_ok=True)
+            shutil.copy2(os.path.join(root, f), dst_file)
+
+    propagate_runtime_local_keys(src_dir, dst_dir)
+
+
+def validate_runtime(runtime_dir: str = os.path.join(".claude", "worca")) -> None:
+    """Verify the worca runtime directory exists in the current project.
+
+    Raises SystemExit(1) with the canonical error message when the directory
+    is absent so callers get a clear diagnostic before any side effects.
+    """
+    if not os.path.isdir(runtime_dir):
+        print(
+            f"error: worca runtime not found at {runtime_dir}/ — run `worca init .` first",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)

--- a/tests/integration/test_run_parallel.py
+++ b/tests/integration/test_run_parallel.py
@@ -11,34 +11,8 @@ is keyed on agent role, not prompt), so a scenario that succeeds applies
 uniformly and a scenario that fails fails uniformly — which gives us the
 right shape of "all-OK" and "all-failed" tests for the executor's per-task
 result handling.
-
-Setup note: ``run_parallel.py`` does NOT copy ``.claude/`` into the new
-worktrees the way ``run_worktree.py`` does — it relies on the runtime being
-present in tracked files. The fixture-installed ``.claude/`` is untracked by
-default, so each test commits it before running so ``git worktree add`` will
-populate the runtime in the new worktree's working tree.
 """
 from __future__ import annotations
-
-import subprocess
-
-
-
-def _commit_claude_runtime(project) -> None:
-    """Commit .claude/ so `git worktree add` includes the runtime.
-
-    run_parallel.py expects .claude/worca/scripts/run_pipeline.py to exist in
-    each created worktree's cwd, but git worktrees only inherit *tracked*
-    files. The integration fixture installs .claude/ via `worca init` but
-    leaves it untracked (matching real-world projects that gitignore .claude/).
-    Tests that exercise run_parallel.py compensate by committing the runtime
-    once at test setup; tests for run_worktree don't need this because that
-    script copies .claude/ into the new worktree explicitly.
-    """
-    subprocess.run(["git", "add", ".claude"], cwd=str(project),
-                   check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "test: add .claude runtime"],
-                   cwd=str(project), check=True, capture_output=True)
 
 
 _HAPPY = {"default": {"action": "succeed", "delay_s": 0}}
@@ -58,7 +32,6 @@ def test_run_parallel_completes_two_prompts(pipeline_env):
     """Two parallel prompts both run to completion and return rc=0 from
     run_parallel.py. The summary contains one entry per prompt with the
     worktree path and the inner pipeline's returncode."""
-    _commit_claude_runtime(pipeline_env.project)
     result = pipeline_env.run_parallel(_HAPPY, prompts=["task one", "task two"])
 
     assert result.returncode == 0, (
@@ -80,7 +53,6 @@ def test_run_parallel_aggregates_per_prompt_failures(pipeline_env):
     — i.e. one task's failure does NOT abort the others. This exercises the
     executor's ``except Exception`` / non-zero-rc handling at runner.py line
     197 onward."""
-    _commit_claude_runtime(pipeline_env.project)
     result = pipeline_env.run_parallel(
         _TESTER_FAILS, prompts=["fail one", "fail two"],
     )
@@ -107,7 +79,6 @@ def test_run_parallel_summary_json_shape(pipeline_env):
     """The summary file at ``.worktrees/parallel-results.json`` is a list of
     dicts with stable keys (worktree, prompt, returncode, stdout, stderr).
     Downstream tooling (run reports, fleet UI) depends on this shape."""
-    _commit_claude_runtime(pipeline_env.project)
     result = pipeline_env.run_parallel(_HAPPY, prompts=["shape test"])
 
     assert result.returncode == 0

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -3,7 +3,7 @@
 import os
 import re
 import sys
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 import pytest
 

--- a/tests/test_run_parallel.py
+++ b/tests/test_run_parallel.py
@@ -2,7 +2,10 @@
 
 import os
 import re
-from unittest.mock import patch, MagicMock
+import sys
+from unittest.mock import patch, MagicMock, call
+
+import pytest
 
 from worca.scripts.run_parallel import _slugify, _run_pipeline_in_worktree
 from worca.utils.claude_cli import _ARG_INLINE_LIMIT
@@ -81,3 +84,134 @@ class TestRunPipelineLargePrompt:
         mock_run.side_effect = capture_run
         _run_pipeline_in_worktree("/tmp/wt", large_prompt, 1, 1, "settings.json")
         assert written_content == large_prompt
+
+
+# --- main() — validate_runtime and copy_claude_config integration ---
+
+class TestMainValidateRuntime:
+    """main() must call validate_runtime() before creating any worktrees."""
+
+    def test_validate_runtime_called_before_worktrees(self, monkeypatch, tmp_path):
+        # Use ThreadPoolExecutor so mock functions can be called without cross-process serialization.
+        from concurrent.futures import ThreadPoolExecutor
+        wt_dir = tmp_path / "worktrees"
+        wt_dir.mkdir()
+        wt_path = str(wt_dir / "add-auth")
+        monkeypatch.setattr(sys, "argv", [
+            "run_parallel.py", "--prompts", "Add auth",
+            "--worktree-dir", str(wt_dir),
+        ])
+        call_order = []
+
+        def fake_validate():
+            call_order.append("validate")
+
+        def fake_create(base_dir, slug, branch):
+            call_order.append("create")
+            return wt_path
+
+        def fake_run(worktree_path, prompt, msize, mloops, settings):
+            return {"worktree": worktree_path, "prompt": prompt,
+                    "returncode": 0, "stdout": "", "stderr": ""}
+
+        with patch("worca.scripts.run_parallel.validate_runtime", side_effect=fake_validate), \
+             patch("worca.scripts.run_parallel.copy_claude_config"), \
+             patch("worca.scripts.run_parallel._create_worktree", side_effect=fake_create), \
+             patch("worca.scripts.run_parallel._run_pipeline_in_worktree", side_effect=fake_run), \
+             patch("worca.scripts.run_parallel.ProcessPoolExecutor", ThreadPoolExecutor), \
+             pytest.raises(SystemExit):
+            from worca.scripts.run_parallel import main
+            main()
+
+        assert call_order.index("validate") < call_order.index("create")
+
+    def test_validate_runtime_failure_exits_before_worktree_creation(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["run_parallel.py", "--prompts", "Add auth"])
+        create_called = []
+
+        def fake_validate():
+            raise SystemExit(1)
+
+        def fake_create(*args, **kwargs):
+            create_called.append(True)
+            return "/tmp/wt/add-auth"
+
+        with patch("worca.scripts.run_parallel.validate_runtime", side_effect=fake_validate), \
+             patch("worca.scripts.run_parallel._create_worktree", side_effect=fake_create), \
+             pytest.raises(SystemExit) as exc_info:
+            from worca.scripts.run_parallel import main
+            main()
+
+        assert exc_info.value.code == 1
+        assert create_called == [], "worktree creation must not run when validation fails"
+
+
+class TestMainCopyClaudeConfig:
+    """main() must call copy_claude_config after each worktree is created."""
+
+    def test_copy_called_for_each_worktree(self, monkeypatch, tmp_path):
+        from concurrent.futures import ThreadPoolExecutor
+        wt_dir = tmp_path / "worktrees"
+        wt_dir.mkdir()
+        wt_paths = [str(wt_dir / "add-auth"), str(wt_dir / "fix-bug")]
+        monkeypatch.setattr(sys, "argv", [
+            "run_parallel.py", "--prompts", "Add auth", "Fix bug",
+            "--worktree-dir", str(wt_dir),
+        ])
+        create_iter = iter(wt_paths)
+        copy_calls = []
+
+        def fake_create(base_dir, slug, branch):
+            return next(create_iter)
+
+        def fake_copy(src, dst):
+            copy_calls.append((src, dst))
+
+        result_map = {p: {"worktree": p, "prompt": p, "returncode": 0, "stdout": "", "stderr": ""}
+                      for p in wt_paths}
+
+        def fake_run(worktree_path, prompt, msize, mloops, settings):
+            return result_map[worktree_path]
+
+        with patch("worca.scripts.run_parallel.validate_runtime"), \
+             patch("worca.scripts.run_parallel.copy_claude_config", side_effect=fake_copy), \
+             patch("worca.scripts.run_parallel._create_worktree", side_effect=fake_create), \
+             patch("worca.scripts.run_parallel._run_pipeline_in_worktree", side_effect=fake_run), \
+             patch("worca.scripts.run_parallel.ProcessPoolExecutor", ThreadPoolExecutor), \
+             pytest.raises(SystemExit):
+            from worca.scripts.run_parallel import main
+            main()
+
+        assert len(copy_calls) == 2
+        assert copy_calls[0] == (".claude", wt_paths[0] + "/.claude")
+        assert copy_calls[1] == (".claude", wt_paths[1] + "/.claude")
+
+    def test_copy_dst_is_dot_claude_inside_worktree(self, monkeypatch, tmp_path):
+        from concurrent.futures import ThreadPoolExecutor
+        wt_dir = tmp_path / "worktrees"
+        wt_dir.mkdir()
+        wt_path = str(wt_dir / "my-worktree")
+        monkeypatch.setattr(sys, "argv", [
+            "run_parallel.py", "--prompts", "Do work",
+            "--worktree-dir", str(wt_dir),
+        ])
+        copy_calls = []
+
+        def fake_run(worktree_path, prompt, msize, mloops, settings):
+            return {"worktree": worktree_path, "prompt": prompt,
+                    "returncode": 0, "stdout": "", "stderr": ""}
+
+        with patch("worca.scripts.run_parallel.validate_runtime"), \
+             patch("worca.scripts.run_parallel.copy_claude_config",
+                   side_effect=lambda src, dst: copy_calls.append((src, dst))), \
+             patch("worca.scripts.run_parallel._create_worktree", return_value=wt_path), \
+             patch("worca.scripts.run_parallel._run_pipeline_in_worktree", side_effect=fake_run), \
+             patch("worca.scripts.run_parallel.ProcessPoolExecutor", ThreadPoolExecutor), \
+             pytest.raises(SystemExit):
+            from worca.scripts.run_parallel import main
+            main()
+
+        assert len(copy_calls) == 1
+        src, dst = copy_calls[0]
+        assert src == ".claude"
+        assert dst == wt_path + "/.claude"

--- a/tests/test_run_worktree.py
+++ b/tests/test_run_worktree.py
@@ -184,9 +184,9 @@ def _patches(worktree_path=_WORKTREE_PATH):
         patch("worca.scripts.run_worktree.create_pipeline_worktree", return_value=worktree_path),
         patch("worca.scripts.run_worktree.init_worktree_beads", return_value=True),
         patch("worca.scripts.run_worktree.register_pipeline"),
-        patch("worca.scripts.run_worktree.os.path.isdir", return_value=True),
+        patch("worca.utils.runtime.os.path.isdir", return_value=True),
         patch("worca.scripts.run_worktree.subprocess.Popen"),
-        patch("worca.scripts.run_worktree._copy_claude_config"),
+        patch("worca.scripts.run_worktree.copy_claude_config"),
         patch("worca.scripts.run_worktree.branch_exists", return_value=True),
         patch("worca.scripts.run_worktree.detect_default_branch", return_value="main"),
     ]
@@ -407,7 +407,7 @@ class TestCopyClaudeConfig:
     """_copy_claude_config: project's .claude/ → worktree, no-clobber."""
 
     def test_copies_settings_and_subdirs(self, tmp_path):
-        from worca.scripts.run_worktree import _copy_claude_config
+        from worca.utils.runtime import copy_claude_config
 
         src = tmp_path / "project" / ".claude"
         dst = tmp_path / "worktree" / ".claude"
@@ -417,14 +417,14 @@ class TestCopyClaudeConfig:
         (src / "agents" / "planner.md").write_text("plan")
         (src / "hooks" / "pre.py").write_text("h")
 
-        _copy_claude_config(str(src), str(dst))
+        copy_claude_config(str(src), str(dst))
 
         assert (dst / "settings.json").read_text() == '{"a": 1}'
         assert (dst / "agents" / "planner.md").read_text() == "plan"
         assert (dst / "hooks" / "pre.py").read_text() == "h"
 
     def test_skips_settings_local_json(self, tmp_path):
-        from worca.scripts.run_worktree import _copy_claude_config
+        from worca.utils.runtime import copy_claude_config
 
         src = tmp_path / "project" / ".claude"
         dst = tmp_path / "worktree" / ".claude"
@@ -432,7 +432,7 @@ class TestCopyClaudeConfig:
         (src / "settings.json").write_text("{}")
         (src / "settings.local.json").write_text('{"machine": "local"}')
 
-        _copy_claude_config(str(src), str(dst))
+        copy_claude_config(str(src), str(dst))
 
         assert (dst / "settings.json").exists()
         assert not (dst / "settings.local.json").exists()
@@ -440,7 +440,7 @@ class TestCopyClaudeConfig:
     def test_no_clobber_preserves_tracked_files(self, tmp_path):
         """When git already populated the worktree (committed .claude/),
         the copy must not overwrite those files."""
-        from worca.scripts.run_worktree import _copy_claude_config
+        from worca.utils.runtime import copy_claude_config
 
         src = tmp_path / "project" / ".claude"
         dst = tmp_path / "worktree" / ".claude"
@@ -451,13 +451,13 @@ class TestCopyClaudeConfig:
         # Project's untracked-on-master version (newer)
         (src / "settings.json").write_text('{"version": "uncommitted"}')
 
-        _copy_claude_config(str(src), str(dst))
+        copy_claude_config(str(src), str(dst))
 
         # Tracked file wins
         assert (dst / "settings.json").read_text() == '{"version": "tracked"}'
 
     def test_no_clobber_within_subdirs(self, tmp_path):
-        from worca.scripts.run_worktree import _copy_claude_config
+        from worca.utils.runtime import copy_claude_config
 
         src = tmp_path / "project" / ".claude"
         dst = tmp_path / "worktree" / ".claude"
@@ -467,7 +467,7 @@ class TestCopyClaudeConfig:
         (src / "agents" / "planner.md").write_text("uncommitted")
         (src / "agents" / "tester.md").write_text("new")
 
-        _copy_claude_config(str(src), str(dst))
+        copy_claude_config(str(src), str(dst))
 
         assert (dst / "agents" / "planner.md").read_text() == "tracked"
         # Files only in src still get copied through
@@ -475,24 +475,24 @@ class TestCopyClaudeConfig:
 
     def test_no_op_when_src_missing(self, tmp_path):
         """If the project has no .claude/ at all (edge case), don't crash."""
-        from worca.scripts.run_worktree import _copy_claude_config
+        from worca.utils.runtime import copy_claude_config
 
         src = tmp_path / "project" / ".claude"  # never created
         dst = tmp_path / "worktree" / ".claude"
 
-        _copy_claude_config(str(src), str(dst))  # must not raise
+        copy_claude_config(str(src), str(dst))  # must not raise
         assert not dst.exists()
 
     def test_includes_worca_runtime(self, tmp_path):
         """worca/ subdir must come along — that's the whole runtime."""
-        from worca.scripts.run_worktree import _copy_claude_config
+        from worca.utils.runtime import copy_claude_config
 
         src = tmp_path / "project" / ".claude"
         dst = tmp_path / "worktree" / ".claude"
         (src / "worca" / "scripts").mkdir(parents=True)
         (src / "worca" / "scripts" / "run_pipeline.py").write_text("py")
 
-        _copy_claude_config(str(src), str(dst))
+        copy_claude_config(str(src), str(dst))
 
         assert (dst / "worca" / "scripts" / "run_pipeline.py").read_text() == "py"
 
@@ -641,16 +641,18 @@ class TestDefaultBaseBranch:
 
 class TestMissingWorcaRuntime:
     def test_fails_fast_when_runtime_missing(self, capsys):
+        import pytest
         from worca.scripts.run_worktree import main
         plist = _patches()
         # Override isdir to return False — simulates missing .claude/worca/.
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
              plist[3], plist[4] as mock_reg, \
-             patch("worca.scripts.run_worktree.os.path.isdir", return_value=False), \
+             patch("worca.utils.runtime.os.path.isdir", return_value=False), \
              plist[6] as mock_popen, plist[7], plist[8], plist[9]:
             mock_norm.return_value = _wr("Add auth")
-            rc = main(["--prompt", "Add auth"])
-        assert rc == 1
+            with pytest.raises(SystemExit) as exc_info:
+                main(["--prompt", "Add auth"])
+        assert exc_info.value.code == 1
         err = capsys.readouterr().err
         assert "worca runtime not found" in err
         # Validation must run before any side effects.

--- a/tests/test_run_worktree_copy_config.py
+++ b/tests/test_run_worktree_copy_config.py
@@ -12,7 +12,7 @@ settings.local.json (permissions, hooks, mcpServers, etc.) stays parent-only.
 
 import json
 
-from worca.scripts.run_worktree import _copy_claude_config
+from worca.utils.runtime import copy_claude_config
 
 
 def _read_json(path: str) -> dict:
@@ -30,7 +30,7 @@ def test_skips_settings_local_json_top_level(tmp_path):
         json.dumps({"permissions": {"allow": ["Bash"]}})
     )
 
-    _copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
+    copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
 
     assert (dst / ".claude" / "settings.json").exists()
     assert not (dst / ".claude" / "settings.local.json").exists()
@@ -60,7 +60,7 @@ def test_propagates_worca_webhooks_from_parent_local(tmp_path):
         )
     )
 
-    _copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
+    copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
 
     merged = _read_json(str(dst / ".claude" / "settings.json"))
     assert merged["worca"]["webhooks"] == [
@@ -109,7 +109,7 @@ def test_local_webhooks_replace_base_webhooks_wholesale(tmp_path):
         )
     )
 
-    _copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
+    copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
 
     merged = _read_json(str(dst / ".claude" / "settings.json"))
     # Local replaces base wholesale (not concatenation, not dedup).
@@ -130,7 +130,7 @@ def test_no_op_when_no_parent_local_settings(tmp_path):
     base = {"worca": {"agents": {"implementer": {"model": "opus"}}}}
     (src / ".claude" / "settings.json").write_text(json.dumps(base))
 
-    _copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
+    copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
 
     merged = _read_json(str(dst / ".claude" / "settings.json"))
     assert merged == base
@@ -154,7 +154,7 @@ def test_no_op_when_local_has_no_worca_runtime_keys(tmp_path):
         )
     )
 
-    _copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
+    copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
 
     merged = _read_json(str(dst / ".claude" / "settings.json"))
     # Only webhooks/events propagate from local; agents stays as-is from base
@@ -173,7 +173,7 @@ def test_propagates_only_worca_events_when_webhooks_absent(tmp_path):
         json.dumps({"worca": {"events": {"enabled": False}}})
     )
 
-    _copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
+    copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
 
     merged = _read_json(str(dst / ".claude" / "settings.json"))
     assert merged["worca"]["events"] == {"enabled": False}
@@ -204,7 +204,7 @@ def test_augments_tracked_settings_json_with_runtime_keys(tmp_path):
     tracked = {"worca": {"agents": {"implementer": {"model": "opus"}}}}
     (dst / ".claude" / "settings.json").write_text(json.dumps(tracked))
 
-    _copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
+    copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
 
     merged = _read_json(str(dst / ".claude" / "settings.json"))
     # The tracked agents config is preserved.
@@ -234,7 +234,7 @@ def test_propagated_settings_json_is_pretty_printed(tmp_path):
         )
     )
 
-    _copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
+    copy_claude_config(str(src / ".claude"), str(dst / ".claude"))
 
     content = (dst / ".claude" / "settings.json").read_text()
     assert content.endswith("\n")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,38 @@
+"""Tests for worca.utils.runtime — validate_runtime helper."""
+import pytest
+
+
+def test_validate_runtime_success(tmp_path, monkeypatch):
+    """validate_runtime is a no-op when .claude/worca/ exists."""
+    (tmp_path / ".claude" / "worca").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    from worca.utils.runtime import validate_runtime
+
+    validate_runtime()  # must not raise
+
+
+def test_validate_runtime_missing_raises_systemexit(tmp_path, monkeypatch):
+    """validate_runtime raises SystemExit(1) when .claude/worca/ is absent."""
+    monkeypatch.chdir(tmp_path)
+
+    from worca.utils.runtime import validate_runtime
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_runtime()
+    assert exc_info.value.code == 1
+
+
+def test_validate_runtime_error_message_on_stderr(tmp_path, monkeypatch, capsys):
+    """The error message names the missing path and the fix command."""
+    monkeypatch.chdir(tmp_path)
+
+    from worca.utils.runtime import validate_runtime
+
+    with pytest.raises(SystemExit):
+        validate_runtime()
+
+    err = capsys.readouterr().err
+    assert "worca runtime not found" in err
+    assert ".claude/worca" in err
+    assert "worca init" in err


### PR DESCRIPTION
## Summary

- Extracts `_copy_claude_config`, `_propagate_runtime_local_keys`, and `_deep_merge` from `run_worktree.py` into a shared `worca.utils.runtime` module
- `run_parallel.py` now validates the worca runtime up front (`validate_runtime()`) and copies `.claude/` into each worktree (`copy_claude_config()`) — matching `run_worktree.py` behavior
- Removes the `_commit_claude_runtime` workaround in integration tests that compensated for the missing copy

## Test plan

- [x] 75 unit tests pass across `test_runtime.py`, `test_run_parallel.py`, `test_run_worktree.py`, `test_run_worktree_copy_config.py`
- [x] CI green on all platforms
- [x] Integration tests (`tests/integration/test_run_parallel.py`) pass without the `_commit_claude_runtime` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)