### PR TITLE
feat: generic multi-host PR metadata in guardian output + UI display (W-051)

### DIFF
--- a/src/worca/agents/core/guardian.md
+++ b/src/worca/agents/core/guardian.md
@@ -38,7 +38,12 @@ You receive the review outcome and proof status from the Reviewer. You have acce
    git push -u origin <branch-name>
    ```
 7. Open the PR using the hosting CLI documented in CLAUDE.md (usually `gh pr create` or `glab mr create`). Read `target_branch` from the run's `status.json`; if set, pass it as `--base {target_branch}` so the PR targets the correct branch. If `target_branch` is absent or null, omit `--base` and let the hosting platform use its default. Capture the PR URL and include it in your structured output.
-8. Record the commit SHA (`git rev-parse HEAD`) and the PR URL. Both go into your `pr.json` structured output.
+8. Record all output fields for your `pr.json` structured output:
+   - `commit_sha` — run `git rev-parse HEAD` after committing
+   - `source_branch` — run `git rev-parse --abbrev-ref HEAD` to capture the current branch name
+   - `target_branch` — read from the run's `status.json` (same value used in step 7); fall back to the platform default branch if absent
+   - `provider` (optional) — derive from the PR URL hostname: `github.com` → `github`, `gitlab.com` → `gitlab`, `bitbucket.org` → `bitbucket`, `dev.azure.com` → `azure_devops`, others use the hostname to guess or set `other`
+   - `is_draft` (optional) — `true` if the PR was created as a draft, `false` otherwise
 9. Mark the PR as ready for human review (this is done by `gh pr create` unless `--draft` is passed).
 10. Wait for PRE-PR APPROVAL milestone gate (orchestrator handles this after your structured output is parsed).
 
@@ -61,18 +66,22 @@ Your final response MUST be a single JSON object that matches the `pr.json` sche
 Required fields:
 - `pr_number` (integer) — captured from `gh pr create` / `gh pr view` output
 - `pr_url` (string, URI) — full URL to the PR
+- `source_branch` (string) — current branch name, from `git rev-parse --abbrev-ref HEAD`
+- `target_branch` (string) — branch the PR targets, from `status.json` or platform default
 - `commit_sha` (string, ≥7 chars) — output of `git rev-parse HEAD` after committing (required when `outcome == "success"`)
 
 Optional:
+- `provider` — `"github"` | `"gitlab"` | `"bitbucket"` | `"azure_devops"` | `"gitea"` | `"gerrit"` | `"other"` — derive from the PR URL hostname
+- `is_draft` (boolean) — `true` if the PR was created as a draft
 - `review_status` — `"pending"` | `"approved"` | `"changes_requested"` | `"rejected"`
 
 Example final output (this exact shape, no fences, no prose around it):
 
 ```
-{"pr_number": 42, "pr_url": "https://github.com/owner/repo/pull/42", "commit_sha": "abc1234def5", "review_status": "pending"}
+{"outcome": "success", "pr_number": 42, "pr_url": "https://github.com/owner/repo/pull/42", "commit_sha": "abc1234def5", "source_branch": "feature/my-branch", "target_branch": "main", "provider": "github", "is_draft": false, "review_status": "pending"}
 ```
 
-If the PR couldn't be created (steps 3–7 failed), still emit JSON — set `review_status: "rejected"` and use `0` / empty string for the missing fields, then the orchestrator will treat it as a stage failure.
+If the PR couldn't be created (steps 3–7 failed), still emit JSON — set `review_status: "rejected"` and use `0` / empty string for the missing fields (`pr_number: 0`, `pr_url: ""`, `source_branch: ""`, `target_branch: ""`), then the orchestrator will treat it as a stage failure.
 
 ## Rules
 

--- a/src/worca/agents/core/guardian.md
+++ b/src/worca/agents/core/guardian.md
@@ -38,12 +38,11 @@ You receive the review outcome and proof status from the Reviewer. You have acce
    git push -u origin <branch-name>
    ```
 7. Open the PR using the hosting CLI documented in CLAUDE.md (usually `gh pr create` or `glab mr create`). Read `target_branch` from the run's `status.json`; if set, pass it as `--base {target_branch}` so the PR targets the correct branch. If `target_branch` is absent or null, omit `--base` and let the hosting platform use its default. Capture the PR URL and include it in your structured output.
-8. Record all output fields for your `pr.json` structured output:
-   - `commit_sha` — run `git rev-parse HEAD` after committing
-   - `source_branch` — run `git rev-parse --abbrev-ref HEAD` to capture the current branch name
-   - `target_branch` — read from the run's `status.json` (same value used in step 7); fall back to the platform default branch if absent
-   - `provider` (optional) — derive from the PR URL hostname: `github.com` → `github`, `gitlab.com` → `gitlab`, `bitbucket.org` → `bitbucket`, `dev.azure.com` → `azure_devops`, others use the hostname to guess or set `other`
-   - `is_draft` (optional) — `true` if the PR was created as a draft, `false` otherwise
+8. Record output fields for your `pr.json` structured output:
+   - `commit_sha` — run `git rev-parse HEAD` after committing (required on success)
+   - `source_branch` (optional) — the runner fills this from the run state; only set it explicitly if you committed on a different branch than the run's working branch
+   - `target_branch` (optional) — same: the runner reads it from `status.json`; only set it if you used a different `--base`
+   - `provider` (optional) — the runner derives this from the PR URL; you may emit it but it isn't required
 9. Mark the PR as ready for human review (this is done by `gh pr create` unless `--draft` is passed).
 10. Wait for PRE-PR APPROVAL milestone gate (orchestrator handles this after your structured output is parsed).
 
@@ -66,22 +65,21 @@ Your final response MUST be a single JSON object that matches the `pr.json` sche
 Required fields:
 - `pr_number` (integer) — captured from `gh pr create` / `gh pr view` output
 - `pr_url` (string, URI) — full URL to the PR
-- `source_branch` (string) — current branch name, from `git rev-parse --abbrev-ref HEAD`
-- `target_branch` (string) — branch the PR targets, from `status.json` or platform default
 - `commit_sha` (string, ≥7 chars) — output of `git rev-parse HEAD` after committing (required when `outcome == "success"`)
 
-Optional:
-- `provider` — `"github"` | `"gitlab"` | `"bitbucket"` | `"azure_devops"` | `"gitea"` | `"gerrit"` | `"other"` — derive from the PR URL hostname
-- `is_draft` (boolean) — `true` if the PR was created as a draft
+Optional (the runner fills these from local state if you omit them — only emit them to override):
+- `source_branch` (string) — current branch name; runner default is the run's working branch
+- `target_branch` (string) — branch the PR targets; runner default is `status.json`'s `target_branch`
+- `provider` — `"github"` | `"gitlab"` | `"bitbucket"` | `"azure_devops"` | `"gitea"` | `"gerrit"` | `"other"` — runner derives this from the PR URL
 - `review_status` — `"pending"` | `"approved"` | `"changes_requested"` | `"rejected"`
 
 Example final output (this exact shape, no fences, no prose around it):
 
 ```
-{"outcome": "success", "pr_number": 42, "pr_url": "https://github.com/owner/repo/pull/42", "commit_sha": "abc1234def5", "source_branch": "feature/my-branch", "target_branch": "main", "provider": "github", "is_draft": false, "review_status": "pending"}
+{"outcome": "success", "pr_number": 42, "pr_url": "https://github.com/owner/repo/pull/42", "commit_sha": "abc1234def5", "review_status": "pending"}
 ```
 
-If the PR couldn't be created (steps 3–7 failed), still emit JSON — set `review_status: "rejected"` and use `0` / empty string for the missing fields (`pr_number: 0`, `pr_url: ""`, `source_branch: ""`, `target_branch: ""`), then the orchestrator will treat it as a stage failure.
+If the PR couldn't be created (steps 3–7 failed), still emit JSON — set `outcome: "reject"`, `review_status: "rejected"`, and use `0` / empty string for the missing fields (`pr_number: 0`, `pr_url: ""`), then the orchestrator will treat it as a stage failure.
 
 ## Rules
 

--- a/src/worca/events/types.py
+++ b/src/worca/events/types.py
@@ -467,7 +467,6 @@ def git_pr_created_payload(
     source_branch: str = None,
     target_branch: str = None,
     provider: str = None,
-    is_draft: bool = None,
 ) -> dict:
     return {
         "pr_url": pr_url,
@@ -477,7 +476,6 @@ def git_pr_created_payload(
         "source_branch": source_branch,
         "target_branch": target_branch,
         "provider": provider,
-        "is_draft": is_draft,
     }
 
 

--- a/src/worca/events/types.py
+++ b/src/worca/events/types.py
@@ -459,8 +459,26 @@ def git_commit_payload(
     }
 
 
-def git_pr_created_payload(pr_url: str, pr_number: int, title: str) -> dict:
-    return {"pr_url": pr_url, "pr_number": pr_number, "title": title}
+def git_pr_created_payload(
+    pr_url: str,
+    pr_number: int,
+    title: str,
+    commit_sha: str = None,
+    source_branch: str = None,
+    target_branch: str = None,
+    provider: str = None,
+    is_draft: bool = None,
+) -> dict:
+    return {
+        "pr_url": pr_url,
+        "pr_number": pr_number,
+        "title": title,
+        "commit_sha": commit_sha,
+        "source_branch": source_branch,
+        "target_branch": target_branch,
+        "provider": provider,
+        "is_draft": is_draft,
+    }
 
 
 def git_pr_merged_payload(pr_url: str, pr_number: int) -> dict:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -38,6 +38,7 @@ from worca.utils.beads import bd_ready, bd_show, bd_update, bd_close, bd_label_a
 from worca.utils.gh_issues import gh_issue_start, gh_issue_complete
 from worca.utils.claude_cli import run_agent, terminate_current, AgentSubprocessError
 from worca.utils.git import create_branch, current_branch, get_current_git_head
+from worca.utils.pr_url import parse_pr_url
 from worca.utils.settings import load_settings
 from worca.utils.token_usage import extract_token_usage, aggregate_token_usage, aggregate_by_model
 from worca.utils.stats import update_cumulative_stats
@@ -2976,10 +2977,25 @@ def run_pipeline(
                     _pr_number = result.get("pr_number")
                     if _pr_url and _pr_number is not None:
                         _commit_sha = result.get("commit_sha")
-                        _source_branch = result.get("source_branch")
-                        _target_branch = result.get("target_branch")
+                        # Branches: prefer agent value, fall back to runner state.
+                        # The orchestrator already knows both — no reason to
+                        # require the agent to re-emit them.
+                        _source_branch = (
+                            result.get("source_branch")
+                            or status.get("branch")
+                        )
+                        _target_branch = (
+                            result.get("target_branch")
+                            or status.get("target_branch")
+                        )
+                        # Provider: agent may emit it, but verify/fill from URL.
                         _provider = result.get("provider")
-                        _is_draft = result.get("is_draft")
+                        if not _provider or _provider == "other":
+                            _parsed = parse_pr_url(_pr_url)
+                            if _parsed["provider"] != "other":
+                                _provider = _parsed["provider"]
+                            elif not _provider:
+                                _provider = "other"
                         _review_status = result.get("review_status")
                         status["pr"] = {
                             "url": _pr_url,
@@ -2988,7 +3004,6 @@ def run_pipeline(
                             "source_branch": _source_branch,
                             "target_branch": _target_branch,
                             "provider": _provider,
-                            "is_draft": _is_draft,
                             "review_status": _review_status,
                         }
                         save_status(status, actual_status_path)
@@ -3001,7 +3016,6 @@ def run_pipeline(
                                 source_branch=_source_branch,
                                 target_branch=_target_branch,
                                 provider=_provider,
-                                is_draft=_is_draft,
                             ))
 
             # Default: complete iteration for stages without special handling

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -2971,15 +2971,38 @@ def run_pipeline(
                             milestone="pr_verified", value=True,
                             stage=Stage.PR.value,
                         ))
-                if ctx and isinstance(result, dict):
+                if isinstance(result, dict):
                     _pr_url = result.get("pr_url")
                     _pr_number = result.get("pr_number")
                     if _pr_url and _pr_number is not None:
-                        emit_event(ctx, GIT_PR_CREATED, git_pr_created_payload(
-                            pr_url=_pr_url,
-                            pr_number=_pr_number,
-                            title=work_request.title,
-                        ))
+                        _commit_sha = result.get("commit_sha")
+                        _source_branch = result.get("source_branch")
+                        _target_branch = result.get("target_branch")
+                        _provider = result.get("provider")
+                        _is_draft = result.get("is_draft")
+                        _review_status = result.get("review_status")
+                        status["pr"] = {
+                            "url": _pr_url,
+                            "number": _pr_number,
+                            "commit_sha": _commit_sha,
+                            "source_branch": _source_branch,
+                            "target_branch": _target_branch,
+                            "provider": _provider,
+                            "is_draft": _is_draft,
+                            "review_status": _review_status,
+                        }
+                        save_status(status, actual_status_path)
+                        if ctx:
+                            emit_event(ctx, GIT_PR_CREATED, git_pr_created_payload(
+                                pr_url=_pr_url,
+                                pr_number=_pr_number,
+                                title=work_request.title,
+                                commit_sha=_commit_sha,
+                                source_branch=_source_branch,
+                                target_branch=_target_branch,
+                                provider=_provider,
+                                is_draft=_is_draft,
+                            ))
 
             # Default: complete iteration for stages without special handling
             else:

--- a/src/worca/schemas/pr.json
+++ b/src/worca/schemas/pr.json
@@ -2,12 +2,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "PROutput",
   "type": "object",
-  "required": ["outcome", "pr_number", "pr_url"],
+  "required": ["outcome", "pr_number", "pr_url", "source_branch", "target_branch"],
   "properties": {
     "outcome": { "type": "string", "enum": ["success", "reject"] },
     "pr_number": { "type": "integer" },
     "pr_url": { "type": "string", "format": "uri" },
     "commit_sha": { "type": "string", "minLength": 7 },
+    "source_branch": { "type": "string" },
+    "target_branch": { "type": "string" },
+    "provider": {
+      "type": "string",
+      "enum": ["github", "gitlab", "bitbucket", "azure_devops", "gitea", "gerrit", "other"]
+    },
+    "is_draft": { "type": "boolean" },
     "review_status": {
       "type": "string",
       "enum": ["pending", "approved", "changes_requested", "rejected"]

--- a/src/worca/schemas/pr.json
+++ b/src/worca/schemas/pr.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "PROutput",
   "type": "object",
-  "required": ["outcome", "pr_number", "pr_url", "source_branch", "target_branch"],
+  "required": ["outcome", "pr_number", "pr_url"],
   "properties": {
     "outcome": { "type": "string", "enum": ["success", "reject"] },
     "pr_number": { "type": "integer" },
@@ -14,7 +14,6 @@
       "type": "string",
       "enum": ["github", "gitlab", "bitbucket", "azure_devops", "gitea", "gerrit", "other"]
     },
-    "is_draft": { "type": "boolean" },
     "review_status": {
       "type": "string",
       "enum": ["pending", "approved", "changes_requested", "rejected"]

--- a/src/worca/state/status.py
+++ b/src/worca/state/status.py
@@ -241,6 +241,7 @@ def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_
             "pr_verified": None,
         },
         "pr_review_outcome": None,
+        "pr": None,
     }
     return status
 

--- a/src/worca/utils/pr_url.py
+++ b/src/worca/utils/pr_url.py
@@ -1,0 +1,76 @@
+"""PR URL parser — maps a PR/MR URL to {provider, host, repo_path}."""
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+
+def parse_pr_url(url: str | None) -> dict[str, str]:
+    """Return ``{provider, host, repo_path}`` for *url*.
+
+    Never raises. Defaults to ``provider="other"`` for unrecognised URLs.
+    """
+    empty = {"provider": "other", "host": "", "repo_path": ""}
+
+    if not url:
+        return empty
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return empty
+
+    host = parsed.hostname or ""
+    if not host:
+        return empty
+
+    path = parsed.path.rstrip("/")
+
+    # --- Azure DevOps ---
+    # https://dev.azure.com/{org}/{project}/_git/{repo}/pullrequest/{n}
+    if host == "dev.azure.com":
+        m = re.match(r"^/([^/]+)/([^/]+)/_git/([^/]+)/pullrequest/\d+", path)
+        if m:
+            repo_path = f"{m.group(1)}/{m.group(2)}/{m.group(3)}"
+            return {"provider": "azure_devops", "host": host, "repo_path": repo_path}
+        return {"provider": "azure_devops", "host": host, "repo_path": ""}
+
+    # --- GitLab (cloud + self-hosted) ---
+    # https://{host}/{group...}/{repo}/-/merge_requests/{n}
+    if host == "gitlab.com" or "gitlab" in host:
+        m = re.match(r"^/(.+)/-/merge_requests/\d+", path)
+        if m:
+            return {"provider": "gitlab", "host": host, "repo_path": m.group(1)}
+        return {"provider": "other", "host": host, "repo_path": ""}
+
+    # --- Bitbucket Cloud ---
+    # https://bitbucket.org/{owner}/{repo}/pull-requests/{n}
+    if host == "bitbucket.org":
+        m = re.match(r"^/([^/]+)/([^/]+)/pull-requests/\d+", path)
+        if m:
+            return {"provider": "bitbucket", "host": host, "repo_path": f"{m.group(1)}/{m.group(2)}"}
+        return {"provider": "other", "host": host, "repo_path": ""}
+
+    # --- Bitbucket Server / Data Center ---
+    # https://{host}/projects/{KEY}/repos/{repo}/pull-requests/{n}
+    m = re.match(r"^/projects/([^/]+)/repos/([^/]+)/pull-requests/\d+", path)
+    if m:
+        return {"provider": "bitbucket", "host": host, "repo_path": f"{m.group(1)}/{m.group(2)}"}
+
+    # --- Gitea (cloud + self-hosted) ---
+    # https://{host}/{owner}/{repo}/pulls/{n}
+    # Gitea cloud domains: gitea.io, try.gitea.io; self-hosted often has "gitea" in the host
+    if host in ("gitea.io", "try.gitea.io") or "gitea" in host:
+        m = re.match(r"^/([^/]+)/([^/]+)/pulls/\d+", path)
+        if m:
+            return {"provider": "gitea", "host": host, "repo_path": f"{m.group(1)}/{m.group(2)}"}
+        return {"provider": "other", "host": host, "repo_path": ""}
+
+    # --- GitHub Cloud + Enterprise ---
+    # https://{host}/{owner}/{repo}/pull/{n}
+    # Covers github.com and any Enterprise GitHub host (e.g. github.mycompany.com, git.internal.corp)
+    m = re.match(r"^/([^/]+)/([^/]+)/pull/\d+", path)
+    if m:
+        return {"provider": "github", "host": host, "repo_path": f"{m.group(1)}/{m.group(2)}"}
+
+    return {"provider": "other", "host": host, "repo_path": ""}

--- a/tests/integration/test_guardian_pr_creation.py
+++ b/tests/integration/test_guardian_pr_creation.py
@@ -44,6 +44,11 @@ def test_guardian_structured_pr_fields_emit_pr_created_event(pipeline_env):
                 "structured_output": {
                     "pr_url": "https://github.com/example/repo/pull/42",
                     "pr_number": 42,
+                    "commit_sha": "abc1234567890def",
+                    "source_branch": "feature/test-branch",
+                    "target_branch": "main",
+                    "provider": "github",
+                    "is_draft": False,
                 },
             },
         },
@@ -57,6 +62,11 @@ def test_guardian_structured_pr_fields_emit_pr_created_event(pipeline_env):
     payload = pr_created[0]["payload"]
     assert payload["pr_url"] == "https://github.com/example/repo/pull/42"
     assert payload["pr_number"] == 42
+    assert payload["commit_sha"] == "abc1234567890def"
+    assert payload["source_branch"] == "feature/test-branch"
+    assert payload["target_branch"] == "main"
+    assert payload["provider"] == "github"
+    assert payload["is_draft"] is False
 
 
 # ===========================================================================
@@ -155,6 +165,11 @@ def test_pr_stage_iteration_recorded_on_success(pipeline_env):
                 "structured_output": {
                     "pr_url": "https://github.com/example/repo/pull/1",
                     "pr_number": 1,
+                    "commit_sha": "deadbeef00000001",
+                    "source_branch": "feature/iter-test",
+                    "target_branch": "main",
+                    "provider": "github",
+                    "is_draft": False,
                 },
             },
         },
@@ -252,3 +267,41 @@ def test_pr_stage_halts_with_pr_verified_false_when_no_new_commit(pipeline_env):
     assert result.returncode != 0, "expected pipeline to fail but it succeeded"
     assert result.status.get("milestones", {}).get("pr_verified") is False
     assert result.status.get("pipeline_status") == "failed"
+
+
+# ===========================================================================
+# 9. All PR metadata fields are persisted to status["pr"]
+# ===========================================================================
+
+def test_guardian_pr_metadata_persisted_in_status(pipeline_env):
+    """All new PR metadata fields from structured_output are written to status['pr']."""
+    scenario = {
+        "agents": {
+            "tester": _tester_pass(),
+            "guardian": {
+                "action": "succeed", "delay_s": 0.05,
+                "structured_output": {
+                    "pr_url": "https://github.com/example/repo/pull/99",
+                    "pr_number": 99,
+                    "commit_sha": "cafebabe12345678",
+                    "source_branch": "feature/my-feature",
+                    "target_branch": "main",
+                    "provider": "github",
+                    "is_draft": False,
+                },
+            },
+        },
+        "default": {"action": "succeed", "delay_s": 0.05},
+    }
+    result = pipeline_env.run(scenario, prompt="pr metadata persistence", timeout=120)
+    assert result.returncode == 0, f"stderr: {result.stderr[-500:]}"
+
+    pr = result.status.get("pr")
+    assert pr is not None, "status['pr'] should be populated after successful PR stage"
+    assert pr["url"] == "https://github.com/example/repo/pull/99"
+    assert pr["number"] == 99
+    assert pr["commit_sha"] == "cafebabe12345678"
+    assert pr["source_branch"] == "feature/my-feature"
+    assert pr["target_branch"] == "main"
+    assert pr["provider"] == "github"
+    assert pr["is_draft"] is False

--- a/tests/integration/test_guardian_pr_creation.py
+++ b/tests/integration/test_guardian_pr_creation.py
@@ -48,7 +48,6 @@ def test_guardian_structured_pr_fields_emit_pr_created_event(pipeline_env):
                     "source_branch": "feature/test-branch",
                     "target_branch": "main",
                     "provider": "github",
-                    "is_draft": False,
                 },
             },
         },
@@ -66,7 +65,6 @@ def test_guardian_structured_pr_fields_emit_pr_created_event(pipeline_env):
     assert payload["source_branch"] == "feature/test-branch"
     assert payload["target_branch"] == "main"
     assert payload["provider"] == "github"
-    assert payload["is_draft"] is False
 
 
 # ===========================================================================
@@ -169,7 +167,6 @@ def test_pr_stage_iteration_recorded_on_success(pipeline_env):
                     "source_branch": "feature/iter-test",
                     "target_branch": "main",
                     "provider": "github",
-                    "is_draft": False,
                 },
             },
         },
@@ -274,7 +271,7 @@ def test_pr_stage_halts_with_pr_verified_false_when_no_new_commit(pipeline_env):
 # ===========================================================================
 
 def test_guardian_pr_metadata_persisted_in_status(pipeline_env):
-    """All new PR metadata fields from structured_output are written to status['pr']."""
+    """All PR metadata fields from structured_output are written to status['pr']."""
     scenario = {
         "agents": {
             "tester": _tester_pass(),
@@ -287,7 +284,6 @@ def test_guardian_pr_metadata_persisted_in_status(pipeline_env):
                     "source_branch": "feature/my-feature",
                     "target_branch": "main",
                     "provider": "github",
-                    "is_draft": False,
                 },
             },
         },
@@ -304,4 +300,3 @@ def test_guardian_pr_metadata_persisted_in_status(pipeline_env):
     assert pr["source_branch"] == "feature/my-feature"
     assert pr["target_branch"] == "main"
     assert pr["provider"] == "github"
-    assert pr["is_draft"] is False

--- a/tests/test_audit_fixes_121_122.py
+++ b/tests/test_audit_fixes_121_122.py
@@ -66,9 +66,10 @@ def test_runner_keeps_legacy_flat_status_path(tmp_path):
 
 # ─── #122.1: Guardian PR fallback ────────────────────────────────────────────
 # NOTE: The prose fallback (_extract_pr_fields_from_text) only recovers
-# pr_url and pr_number. Extended fields (commit_sha, source_branch,
-# target_branch, provider, is_draft) are NOT recoverable from prose — agents
-# must emit structured JSON output for those fields to be persisted.
+# pr_url and pr_number from free-form agent output. The runner's PR-stage
+# persistence layer fills the rest from local state: source_branch and
+# target_branch from status.json, provider from parse_pr_url(pr_url).
+# commit_sha is the only field that still requires structured JSON output.
 
 
 def test_extract_pr_fields_from_text_github():

--- a/tests/test_audit_fixes_121_122.py
+++ b/tests/test_audit_fixes_121_122.py
@@ -65,6 +65,10 @@ def test_runner_keeps_legacy_flat_status_path(tmp_path):
 
 
 # ─── #122.1: Guardian PR fallback ────────────────────────────────────────────
+# NOTE: The prose fallback (_extract_pr_fields_from_text) only recovers
+# pr_url and pr_number. Extended fields (commit_sha, source_branch,
+# target_branch, provider, is_draft) are NOT recoverable from prose — agents
+# must emit structured JSON output for those fields to be persisted.
 
 
 def test_extract_pr_fields_from_text_github():

--- a/tests/test_event_types.py
+++ b/tests/test_event_types.py
@@ -526,13 +526,11 @@ def test_git_pr_created_payload_extended_fields():
         source_branch="feature/x",
         target_branch="main",
         provider="github",
-        is_draft=False,
     )
     assert p["commit_sha"] == "abc1234567"
     assert p["source_branch"] == "feature/x"
     assert p["target_branch"] == "main"
     assert p["provider"] == "github"
-    assert p["is_draft"] is False
 
 
 def test_git_pr_created_payload_backwards_compat_no_extended_fields():
@@ -546,7 +544,6 @@ def test_git_pr_created_payload_backwards_compat_no_extended_fields():
     assert p["source_branch"] is None
     assert p["target_branch"] is None
     assert p["provider"] is None
-    assert p["is_draft"] is None
 
 
 def test_git_pr_merged_payload_required_fields():

--- a/tests/test_event_types.py
+++ b/tests/test_event_types.py
@@ -516,6 +516,39 @@ def test_git_pr_created_payload_required_fields():
     assert p["title"] == "Add events module"
 
 
+def test_git_pr_created_payload_extended_fields():
+    from worca.events.types import git_pr_created_payload
+    p = git_pr_created_payload(
+        pr_url="https://github.com/org/repo/pull/42",
+        pr_number=42,
+        title="Add events module",
+        commit_sha="abc1234567",
+        source_branch="feature/x",
+        target_branch="main",
+        provider="github",
+        is_draft=False,
+    )
+    assert p["commit_sha"] == "abc1234567"
+    assert p["source_branch"] == "feature/x"
+    assert p["target_branch"] == "main"
+    assert p["provider"] == "github"
+    assert p["is_draft"] is False
+
+
+def test_git_pr_created_payload_backwards_compat_no_extended_fields():
+    from worca.events.types import git_pr_created_payload
+    p = git_pr_created_payload(
+        pr_url="https://github.com/org/repo/pull/42",
+        pr_number=42,
+        title="Old call",
+    )
+    assert p["commit_sha"] is None
+    assert p["source_branch"] is None
+    assert p["target_branch"] is None
+    assert p["provider"] is None
+    assert p["is_draft"] is None
+
+
 def test_git_pr_merged_payload_required_fields():
     from worca.events.types import git_pr_merged_payload
     p = git_pr_merged_payload(

--- a/tests/test_guardian_template.py
+++ b/tests/test_guardian_template.py
@@ -1,0 +1,100 @@
+"""Tests for the base guardian agent template content — verifies schema alignment.
+
+These tests verify that guardian.md documents all fields the orchestrator
+expects in the pr.json output, including new required and optional fields
+added in W-051.
+"""
+
+from pathlib import Path
+
+GUARDIAN_PATH = (
+    Path(__file__).parent.parent
+    / "src"
+    / "worca"
+    / "agents"
+    / "core"
+    / "guardian.md"
+)
+
+
+def _guardian():
+    return GUARDIAN_PATH.read_text()
+
+
+class TestGuardianRequired:
+    def test_documents_source_branch_field(self):
+        assert "source_branch" in _guardian()
+
+    def test_documents_target_branch_field(self):
+        assert "target_branch" in _guardian()
+
+    def test_documents_commit_sha_field(self):
+        assert "commit_sha" in _guardian()
+
+    def test_documents_pr_number_field(self):
+        assert "pr_number" in _guardian()
+
+    def test_documents_pr_url_field(self):
+        assert "pr_url" in _guardian()
+
+
+class TestGuardianOptional:
+    def test_documents_provider_field(self):
+        assert "provider" in _guardian()
+
+    def test_documents_is_draft_field(self):
+        assert "is_draft" in _guardian()
+
+    def test_documents_review_status_field(self):
+        assert "review_status" in _guardian()
+
+
+class TestGuardianCaptureInstructions:
+    def test_source_branch_capture_command(self):
+        # Must instruct agent to run: git rev-parse --abbrev-ref HEAD
+        assert "git rev-parse --abbrev-ref HEAD" in _guardian()
+
+    def test_target_branch_from_status_json(self):
+        # Must instruct agent to read target_branch from status.json
+        assert "status.json" in _guardian()
+
+    def test_provider_heuristic_from_url(self):
+        # Must mention deriving provider from PR URL hostname
+        content = _guardian()
+        assert "hostname" in content or "provider" in content and "URL" in content
+
+    def test_provider_heuristic_mentions_url_derivation(self):
+        # The provider instruction must mention using the PR URL
+        content = _guardian()
+        # Should mention provider determination from URL
+        assert "pr_url" in content or "PR URL" in content
+
+
+class TestGuardianJsonExample:
+    def test_json_example_contains_source_branch(self):
+        assert '"source_branch"' in _guardian()
+
+    def test_json_example_contains_target_branch(self):
+        assert '"target_branch"' in _guardian()
+
+    def test_json_example_contains_provider(self):
+        assert '"provider"' in _guardian()
+
+    def test_json_example_contains_is_draft(self):
+        assert '"is_draft"' in _guardian()
+
+    def test_json_example_contains_commit_sha(self):
+        assert '"commit_sha"' in _guardian()
+
+
+class TestGuardianFailurePath:
+    def test_failure_path_mentions_empty_string_for_missing_fields(self):
+        content = _guardian()
+        # Failure path must explain that missing fields can be empty string or 0
+        assert 'empty string' in content or '""' in content
+
+    def test_failure_path_mentions_new_fields(self):
+        content = _guardian()
+        # The failure path section should cover new fields too
+        # Check that the section at the bottom references the overall missing-fields pattern
+        assert "missing" in content.lower() or "0" in content

--- a/tests/test_guardian_template.py
+++ b/tests/test_guardian_template.py
@@ -1,100 +1,67 @@
-"""Tests for the base guardian agent template content — verifies schema alignment.
+"""Schema-alignment tests for the guardian agent template.
 
-These tests verify that guardian.md documents all fields the orchestrator
-expects in the pr.json output, including new required and optional fields
-added in W-051.
+Rather than asserting individual strings are present in guardian.md (which
+breaks on every reword), we extract the JSON example block from the template
+and validate it against pr.json. This catches real drift (missing required
+field, wrong enum, type mismatch) and ignores prose changes.
 """
 
+import json
+import re
 from pathlib import Path
 
-GUARDIAN_PATH = (
-    Path(__file__).parent.parent
-    / "src"
-    / "worca"
-    / "agents"
-    / "core"
-    / "guardian.md"
-)
+import jsonschema
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+GUARDIAN_PATH = REPO_ROOT / "src" / "worca" / "agents" / "core" / "guardian.md"
+SCHEMA_PATH = REPO_ROOT / "src" / "worca" / "schemas" / "pr.json"
 
 
-def _guardian():
+@pytest.fixture
+def guardian_md() -> str:
     return GUARDIAN_PATH.read_text()
 
 
-class TestGuardianRequired:
-    def test_documents_source_branch_field(self):
-        assert "source_branch" in _guardian()
-
-    def test_documents_target_branch_field(self):
-        assert "target_branch" in _guardian()
-
-    def test_documents_commit_sha_field(self):
-        assert "commit_sha" in _guardian()
-
-    def test_documents_pr_number_field(self):
-        assert "pr_number" in _guardian()
-
-    def test_documents_pr_url_field(self):
-        assert "pr_url" in _guardian()
+@pytest.fixture
+def pr_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
 
 
-class TestGuardianOptional:
-    def test_documents_provider_field(self):
-        assert "provider" in _guardian()
-
-    def test_documents_is_draft_field(self):
-        assert "is_draft" in _guardian()
-
-    def test_documents_review_status_field(self):
-        assert "review_status" in _guardian()
-
-
-class TestGuardianCaptureInstructions:
-    def test_source_branch_capture_command(self):
-        # Must instruct agent to run: git rev-parse --abbrev-ref HEAD
-        assert "git rev-parse --abbrev-ref HEAD" in _guardian()
-
-    def test_target_branch_from_status_json(self):
-        # Must instruct agent to read target_branch from status.json
-        assert "status.json" in _guardian()
-
-    def test_provider_heuristic_from_url(self):
-        # Must mention deriving provider from PR URL hostname
-        content = _guardian()
-        assert "hostname" in content or "provider" in content and "URL" in content
-
-    def test_provider_heuristic_mentions_url_derivation(self):
-        # The provider instruction must mention using the PR URL
-        content = _guardian()
-        # Should mention provider determination from URL
-        assert "pr_url" in content or "PR URL" in content
+def _extract_json_blocks(md: str) -> list:
+    """Pull all fenced JSON-object blocks out of guardian.md."""
+    blocks = []
+    for match in re.finditer(r"```\s*\n(\{.*?\})\s*\n```", md, re.DOTALL):
+        try:
+            blocks.append(json.loads(match.group(1)))
+        except json.JSONDecodeError:
+            continue
+    return blocks
 
 
-class TestGuardianJsonExample:
-    def test_json_example_contains_source_branch(self):
-        assert '"source_branch"' in _guardian()
-
-    def test_json_example_contains_target_branch(self):
-        assert '"target_branch"' in _guardian()
-
-    def test_json_example_contains_provider(self):
-        assert '"provider"' in _guardian()
-
-    def test_json_example_contains_is_draft(self):
-        assert '"is_draft"' in _guardian()
-
-    def test_json_example_contains_commit_sha(self):
-        assert '"commit_sha"' in _guardian()
+def test_guardian_md_exists(guardian_md):
+    assert guardian_md.strip(), "guardian.md must not be empty"
 
 
-class TestGuardianFailurePath:
-    def test_failure_path_mentions_empty_string_for_missing_fields(self):
-        content = _guardian()
-        # Failure path must explain that missing fields can be empty string or 0
-        assert 'empty string' in content or '""' in content
+def test_guardian_md_contains_at_least_one_json_example(guardian_md):
+    blocks = _extract_json_blocks(guardian_md)
+    assert blocks, "guardian.md must contain at least one fenced JSON example"
 
-    def test_failure_path_mentions_new_fields(self):
-        content = _guardian()
-        # The failure path section should cover new fields too
-        # Check that the section at the bottom references the overall missing-fields pattern
-        assert "missing" in content.lower() or "0" in content
+
+def test_guardian_json_example_validates_against_schema(guardian_md, pr_schema):
+    """The example output in guardian.md must validate against pr.json.
+
+    This is the only test that catches drift between the schema and the
+    documented example, and it survives prompt rewordings.
+    """
+    blocks = _extract_json_blocks(guardian_md)
+    for block in blocks:
+        jsonschema.validate(block, pr_schema)
+
+
+def test_guardian_json_example_has_outcome_success(guardian_md):
+    """The primary example should show a successful PR (the happy path)."""
+    blocks = _extract_json_blocks(guardian_md)
+    assert any(b.get("outcome") == "success" for b in blocks), (
+        "guardian.md should include at least one outcome=success example"
+    )

--- a/tests/test_pr_schema.py
+++ b/tests/test_pr_schema.py
@@ -24,8 +24,6 @@ def _success_doc():
         "pr_number": 42,
         "pr_url": "https://github.com/org/repo/pull/42",
         "commit_sha": "abc1234",
-        "source_branch": "feature/my-branch",
-        "target_branch": "main",
     }
 
 
@@ -34,8 +32,6 @@ def _reject_doc():
         "outcome": "reject",
         "pr_number": 0,
         "pr_url": "https://github.com/org/repo/pull/0",
-        "source_branch": "feature/my-branch",
-        "target_branch": "main",
     }
 
 
@@ -61,8 +57,9 @@ class TestSchemaStructure:
     def test_source_branch_is_string(self, schema):
         assert schema["properties"]["source_branch"]["type"] == "string"
 
-    def test_source_branch_in_required(self, schema):
-        assert "source_branch" in schema["required"]
+    def test_source_branch_not_in_required(self, schema):
+        # Branches are runner-derived; agents may omit them.
+        assert "source_branch" not in schema["required"]
 
     def test_schema_has_target_branch_property(self, schema):
         assert "target_branch" in schema["properties"]
@@ -70,8 +67,8 @@ class TestSchemaStructure:
     def test_target_branch_is_string(self, schema):
         assert schema["properties"]["target_branch"]["type"] == "string"
 
-    def test_target_branch_in_required(self, schema):
-        assert "target_branch" in schema["required"]
+    def test_target_branch_not_in_required(self, schema):
+        assert "target_branch" not in schema["required"]
 
     def test_schema_has_provider_property(self, schema):
         assert "provider" in schema["properties"]
@@ -87,14 +84,9 @@ class TestSchemaStructure:
     def test_provider_not_in_required(self, schema):
         assert "provider" not in schema["required"]
 
-    def test_schema_has_is_draft_property(self, schema):
-        assert "is_draft" in schema["properties"]
-
-    def test_is_draft_is_boolean(self, schema):
-        assert schema["properties"]["is_draft"]["type"] == "boolean"
-
-    def test_is_draft_not_in_required(self, schema):
-        assert "is_draft" not in schema["required"]
+    def test_is_draft_not_present(self, schema):
+        # is_draft was removed; reintroduce only when there's a producer.
+        assert "is_draft" not in schema["properties"]
 
 
 class TestSuccessOutcome:
@@ -123,17 +115,16 @@ class TestSuccessOutcome:
         doc["commit_sha"] = "a" * 40
         jsonschema.validate(doc, schema)
 
-    def test_success_missing_source_branch_invalid(self, schema):
+    def test_success_without_branches_valid(self, schema):
+        # Branches are optional — runner fills them.
         doc = _success_doc()
-        del doc["source_branch"]
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
+        jsonschema.validate(doc, schema)
 
-    def test_success_missing_target_branch_invalid(self, schema):
+    def test_success_with_branches_valid(self, schema):
         doc = _success_doc()
-        del doc["target_branch"]
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
+        doc["source_branch"] = "feature/x"
+        doc["target_branch"] = "main"
+        jsonschema.validate(doc, schema)
 
     def test_success_with_valid_provider_valid(self, schema):
         doc = _success_doc()
@@ -146,26 +137,11 @@ class TestSuccessOutcome:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(doc, schema)
 
-    def test_success_with_is_draft_true_valid(self, schema):
-        doc = _success_doc()
-        doc["is_draft"] = True
-        jsonschema.validate(doc, schema)
-
-    def test_success_with_is_draft_false_valid(self, schema):
-        doc = _success_doc()
-        doc["is_draft"] = False
-        jsonschema.validate(doc, schema)
-
-    def test_success_with_is_draft_non_boolean_invalid(self, schema):
-        doc = _success_doc()
-        doc["is_draft"] = "true"
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
-
     def test_success_all_optional_fields_valid(self, schema):
         doc = _success_doc()
+        doc["source_branch"] = "feature/x"
+        doc["target_branch"] = "main"
         doc["provider"] = "gitlab"
-        doc["is_draft"] = False
         doc["review_status"] = "pending"
         jsonschema.validate(doc, schema)
 
@@ -179,17 +155,9 @@ class TestRejectOutcome:
         doc["commit_sha"] = "abc1234"
         jsonschema.validate(doc, schema)
 
-    def test_reject_missing_source_branch_invalid(self, schema):
-        doc = _reject_doc()
-        del doc["source_branch"]
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
-
-    def test_reject_missing_target_branch_invalid(self, schema):
-        doc = _reject_doc()
-        del doc["target_branch"]
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
+    def test_reject_without_branches_valid(self, schema):
+        # Reject path: agent typically can't compute branches anyway.
+        jsonschema.validate(_reject_doc(), schema)
 
 
 class TestProviderEnum:

--- a/tests/test_pr_schema.py
+++ b/tests/test_pr_schema.py
@@ -1,4 +1,4 @@
-"""Tests for the pr.json schema — commit_sha required when outcome == success."""
+"""Tests for the pr.json schema — required fields and optional fields."""
 import json
 import os
 
@@ -8,6 +8,8 @@ import pytest
 import worca
 
 SCHEMA_PATH = os.path.join(os.path.dirname(worca.__file__), "schemas", "pr.json")
+
+PROVIDER_ENUM = ["github", "gitlab", "bitbucket", "azure_devops", "gitea", "gerrit", "other"]
 
 
 @pytest.fixture
@@ -22,6 +24,8 @@ def _success_doc():
         "pr_number": 42,
         "pr_url": "https://github.com/org/repo/pull/42",
         "commit_sha": "abc1234",
+        "source_branch": "feature/my-branch",
+        "target_branch": "main",
     }
 
 
@@ -30,6 +34,8 @@ def _reject_doc():
         "outcome": "reject",
         "pr_number": 0,
         "pr_url": "https://github.com/org/repo/pull/0",
+        "source_branch": "feature/my-branch",
+        "target_branch": "main",
     }
 
 
@@ -48,6 +54,47 @@ class TestSchemaStructure:
 
     def test_commit_sha_min_length_7(self, schema):
         assert schema["properties"]["commit_sha"]["minLength"] == 7
+
+    def test_schema_has_source_branch_property(self, schema):
+        assert "source_branch" in schema["properties"]
+
+    def test_source_branch_is_string(self, schema):
+        assert schema["properties"]["source_branch"]["type"] == "string"
+
+    def test_source_branch_in_required(self, schema):
+        assert "source_branch" in schema["required"]
+
+    def test_schema_has_target_branch_property(self, schema):
+        assert "target_branch" in schema["properties"]
+
+    def test_target_branch_is_string(self, schema):
+        assert schema["properties"]["target_branch"]["type"] == "string"
+
+    def test_target_branch_in_required(self, schema):
+        assert "target_branch" in schema["required"]
+
+    def test_schema_has_provider_property(self, schema):
+        assert "provider" in schema["properties"]
+
+    def test_provider_is_string_enum(self, schema):
+        prop = schema["properties"]["provider"]
+        assert prop["type"] == "string"
+        assert "enum" in prop
+
+    def test_provider_enum_values(self, schema):
+        assert schema["properties"]["provider"]["enum"] == PROVIDER_ENUM
+
+    def test_provider_not_in_required(self, schema):
+        assert "provider" not in schema["required"]
+
+    def test_schema_has_is_draft_property(self, schema):
+        assert "is_draft" in schema["properties"]
+
+    def test_is_draft_is_boolean(self, schema):
+        assert schema["properties"]["is_draft"]["type"] == "boolean"
+
+    def test_is_draft_not_in_required(self, schema):
+        assert "is_draft" not in schema["required"]
 
 
 class TestSuccessOutcome:
@@ -76,6 +123,52 @@ class TestSuccessOutcome:
         doc["commit_sha"] = "a" * 40
         jsonschema.validate(doc, schema)
 
+    def test_success_missing_source_branch_invalid(self, schema):
+        doc = _success_doc()
+        del doc["source_branch"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_success_missing_target_branch_invalid(self, schema):
+        doc = _success_doc()
+        del doc["target_branch"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_success_with_valid_provider_valid(self, schema):
+        doc = _success_doc()
+        doc["provider"] = "github"
+        jsonschema.validate(doc, schema)
+
+    def test_success_with_invalid_provider_rejected(self, schema):
+        doc = _success_doc()
+        doc["provider"] = "unknown_host"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_success_with_is_draft_true_valid(self, schema):
+        doc = _success_doc()
+        doc["is_draft"] = True
+        jsonschema.validate(doc, schema)
+
+    def test_success_with_is_draft_false_valid(self, schema):
+        doc = _success_doc()
+        doc["is_draft"] = False
+        jsonschema.validate(doc, schema)
+
+    def test_success_with_is_draft_non_boolean_invalid(self, schema):
+        doc = _success_doc()
+        doc["is_draft"] = "true"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_success_all_optional_fields_valid(self, schema):
+        doc = _success_doc()
+        doc["provider"] = "gitlab"
+        doc["is_draft"] = False
+        doc["review_status"] = "pending"
+        jsonschema.validate(doc, schema)
+
 
 class TestRejectOutcome:
     def test_reject_without_commit_sha_valid(self, schema):
@@ -85,3 +178,35 @@ class TestRejectOutcome:
         doc = _reject_doc()
         doc["commit_sha"] = "abc1234"
         jsonschema.validate(doc, schema)
+
+    def test_reject_missing_source_branch_invalid(self, schema):
+        doc = _reject_doc()
+        del doc["source_branch"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_reject_missing_target_branch_invalid(self, schema):
+        doc = _reject_doc()
+        del doc["target_branch"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+
+class TestProviderEnum:
+    @pytest.mark.parametrize("provider", PROVIDER_ENUM)
+    def test_each_valid_provider_accepted(self, schema, provider):
+        doc = _success_doc()
+        doc["provider"] = provider
+        jsonschema.validate(doc, schema)
+
+    def test_empty_string_provider_rejected(self, schema):
+        doc = _success_doc()
+        doc["provider"] = ""
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_numeric_provider_rejected(self, schema):
+        doc = _success_doc()
+        doc["provider"] = 1
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)

--- a/tests/test_pr_url_parser.py
+++ b/tests/test_pr_url_parser.py
@@ -1,0 +1,206 @@
+"""Table-driven tests for src/worca/utils/pr_url.py — parse_pr_url()."""
+import pytest
+
+from worca.utils.pr_url import parse_pr_url
+
+
+# ---------------------------------------------------------------------------
+# Table entries: (url, expected_provider, expected_host, expected_repo_path)
+# ---------------------------------------------------------------------------
+CASES = [
+    # --- GitHub cloud ---
+    (
+        "https://github.com/owner/repo/pull/42",
+        "github",
+        "github.com",
+        "owner/repo",
+    ),
+    (
+        "https://github.com/my-org/my-repo/pull/1",
+        "github",
+        "github.com",
+        "my-org/my-repo",
+    ),
+    # --- GitHub Enterprise (self-hosted) ---
+    (
+        "https://github.mycompany.com/owner/repo/pull/7",
+        "github",
+        "github.mycompany.com",
+        "owner/repo",
+    ),
+    (
+        "https://git.internal.corp/owner/repo/pull/99",
+        "github",
+        "git.internal.corp",
+        "owner/repo",
+    ),
+    # --- GitLab cloud ---
+    (
+        "https://gitlab.com/group/project/-/merge_requests/5",
+        "gitlab",
+        "gitlab.com",
+        "group/project",
+    ),
+    (
+        "https://gitlab.com/top-group/sub-group/project/-/merge_requests/12",
+        "gitlab",
+        "gitlab.com",
+        "top-group/sub-group/project",
+    ),
+    # --- GitLab self-hosted ---
+    (
+        "https://gitlab.mycompany.com/group/repo/-/merge_requests/3",
+        "gitlab",
+        "gitlab.mycompany.com",
+        "group/repo",
+    ),
+    # --- Bitbucket Cloud ---
+    (
+        "https://bitbucket.org/owner/repo/pull-requests/10",
+        "bitbucket",
+        "bitbucket.org",
+        "owner/repo",
+    ),
+    # --- Bitbucket Server / Data Center ---
+    (
+        "https://bitbucket.mycompany.com/projects/PROJ/repos/myrepo/pull-requests/4",
+        "bitbucket",
+        "bitbucket.mycompany.com",
+        "PROJ/myrepo",
+    ),
+    (
+        "https://stash.myorg.net/projects/KEY/repos/service/pull-requests/8",
+        "bitbucket",
+        "stash.myorg.net",
+        "KEY/service",
+    ),
+    # --- Azure DevOps ---
+    (
+        "https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/15",
+        "azure_devops",
+        "dev.azure.com",
+        "myorg/myproject/myrepo",
+    ),
+    (
+        "https://dev.azure.com/contoso/WebApp/_git/Frontend/pullrequest/200",
+        "azure_devops",
+        "dev.azure.com",
+        "contoso/WebApp/Frontend",
+    ),
+    # --- Gitea ---
+    (
+        "https://gitea.io/owner/repo/pulls/6",
+        "gitea",
+        "gitea.io",
+        "owner/repo",
+    ),
+    (
+        "https://try.gitea.io/owner/repo/pulls/6",
+        "gitea",
+        "try.gitea.io",
+        "owner/repo",
+    ),
+    (
+        "https://gitea.mycompany.com/team/project/pulls/22",
+        "gitea",
+        "gitea.mycompany.com",
+        "team/project",
+    ),
+    # --- "other" fallback ---
+    (
+        "https://unknown.host.com/owner/repo/pr/5",
+        "other",
+        "unknown.host.com",
+        "",
+    ),
+    (
+        "https://phabricator.example.com/D42",
+        "other",
+        "phabricator.example.com",
+        "",
+    ),
+]
+
+
+@pytest.mark.parametrize("url,provider,host,repo_path", CASES)
+def test_parse_pr_url(url, provider, host, repo_path):
+    result = parse_pr_url(url)
+    assert result["provider"] == provider, f"provider mismatch for {url}"
+    assert result["host"] == host, f"host mismatch for {url}"
+    assert result["repo_path"] == repo_path, f"repo_path mismatch for {url}"
+
+
+# ---------------------------------------------------------------------------
+# Edge-case tests (individual, not parametrized)
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_url_with_query_string(self):
+        url = "https://github.com/owner/repo/pull/42?token=secret&ref=main"
+        result = parse_pr_url(url)
+        assert result["provider"] == "github"
+        assert result["host"] == "github.com"
+        assert result["repo_path"] == "owner/repo"
+
+    def test_url_with_fragment(self):
+        url = "https://github.com/owner/repo/pull/42#issuecomment-123"
+        result = parse_pr_url(url)
+        assert result["provider"] == "github"
+        assert result["repo_path"] == "owner/repo"
+
+    def test_url_with_trailing_slash(self):
+        url = "https://github.com/owner/repo/pull/42/"
+        result = parse_pr_url(url)
+        assert result["provider"] == "github"
+        assert result["repo_path"] == "owner/repo"
+
+    def test_empty_string_returns_other(self):
+        result = parse_pr_url("")
+        assert result["provider"] == "other"
+        assert result["host"] == ""
+        assert result["repo_path"] == ""
+
+    def test_none_returns_other(self):
+        result = parse_pr_url(None)
+        assert result["provider"] == "other"
+        assert result["host"] == ""
+        assert result["repo_path"] == ""
+
+    def test_non_url_string_returns_other(self):
+        result = parse_pr_url("not-a-url-at-all")
+        assert result["provider"] == "other"
+        assert result["host"] == ""
+        assert result["repo_path"] == ""
+
+    def test_http_not_https_github(self):
+        url = "http://github.com/owner/repo/pull/42"
+        result = parse_pr_url(url)
+        assert result["provider"] == "github"
+        assert result["host"] == "github.com"
+
+    def test_typo_in_path_returns_other_for_unknown_host(self):
+        # Valid-looking URL but host is completely unknown and path doesn't match any pattern
+        url = "https://notgit.randomservice.example/owner/repo/merge/42"
+        result = parse_pr_url(url)
+        assert result["provider"] == "other"
+
+    def test_gitlab_missing_merge_requests_segment_returns_other(self):
+        # gitlab.com host but path doesn't match /-/merge_requests/
+        url = "https://gitlab.com/group/repo/issues/5"
+        result = parse_pr_url(url)
+        assert result["provider"] == "other"
+
+    def test_returns_dict_with_all_keys(self):
+        result = parse_pr_url("https://github.com/a/b/pull/1")
+        assert set(result.keys()) == {"provider", "host", "repo_path"}
+
+    def test_azure_devops_repo_path_includes_org_project_repo(self):
+        url = "https://dev.azure.com/org/proj/_git/repo/pullrequest/1"
+        result = parse_pr_url(url)
+        assert result["repo_path"] == "org/proj/repo"
+
+    def test_bitbucket_server_repo_path_is_project_key_slash_repo(self):
+        url = "https://bitbucket.internal.net/projects/AB/repos/my-service/pull-requests/7"
+        result = parse_pr_url(url)
+        assert result["provider"] == "bitbucket"
+        assert result["repo_path"] == "AB/my-service"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2770,8 +2770,7 @@ def test_git_pr_created_payload_fields(tmp_path):
                 "commit_sha": "abc1234567",
                 "source_branch": "feature/x",
                 "target_branch": "main",
-                "provider": "github",
-                "is_draft": False}, {"type": "result"}
+                "provider": "github"}, {"type": "result"}
 
     with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage):
         with patch("worca.orchestrator.runner.create_branch"):
@@ -2794,11 +2793,10 @@ def test_git_pr_created_payload_fields(tmp_path):
     assert p["source_branch"] == "feature/x"
     assert p["target_branch"] == "main"
     assert p["provider"] == "github"
-    assert p["is_draft"] is False
 
 
 def test_pr_metadata_persisted_without_ctx(tmp_path):
-    """PR metadata is written to status['pr'] even in headless runs (no event ctx)."""
+    """PR metadata is written to status['pr'] even when EventContext is unavailable."""
     from worca.orchestrator.work_request import WorkRequest
 
     plan = tmp_path / "plan.md"
@@ -2828,22 +2826,16 @@ def test_pr_metadata_persisted_without_ctx(tmp_path):
                 "commit_sha": "deadbeef1",
                 "source_branch": "feat/headless",
                 "target_branch": "main",
-                "provider": "github",
-                "is_draft": True}, {"type": "result"}
+                "provider": "github"}, {"type": "result"}
 
-    import os.path as osp
-    _orig_join = osp.join
-
-    def null_events_join(*args):
-        if len(args) >= 2 and args[-1] == "events.jsonl":
-            return None
-        return _orig_join(*args)
-
+    # Suppress event emission to exercise the persistence path that doesn't
+    # depend on ctx — status['pr'] is written and saved unconditionally,
+    # only the GIT_PR_CREATED event is gated on `if ctx`.
     with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
          patch("worca.orchestrator.runner.create_branch"), \
          patch("worca.orchestrator.runner._write_pid"), \
          patch("worca.orchestrator.runner._remove_pid"), \
-         patch("os.path.join", side_effect=null_events_join):
+         patch("worca.orchestrator.runner.emit_event", return_value=None):
         final_status = run_pipeline(
             wr, plan_file=str(plan),
             settings_path=settings_path,
@@ -2851,14 +2843,119 @@ def test_pr_metadata_persisted_without_ctx(tmp_path):
         )
 
     pr = final_status.get("pr")
-    assert pr is not None, "status['pr'] must be set even in headless runs"
+    assert pr is not None, "status['pr'] must be set even when ctx is None"
     assert pr["url"] == "https://github.com/org/repo/pull/7"
     assert pr["number"] == 7
     assert pr["commit_sha"] == "deadbeef1"
     assert pr["source_branch"] == "feat/headless"
     assert pr["target_branch"] == "main"
     assert pr["provider"] == "github"
-    assert pr["is_draft"] is True
+
+
+def test_pr_metadata_runner_fills_branches_and_provider(tmp_path):
+    """When agent omits source/target branch and provider, runner fills them.
+
+    source_branch ← status['branch'] (the run's working branch)
+    target_branch ← status['target_branch']
+    provider      ← parse_pr_url(pr_url)
+    """
+    from worca.orchestrator.work_request import WorkRequest
+
+    plan = tmp_path / "plan.md"
+    plan.write_text("# Plan\n")
+    settings_path = _make_minimal_settings(tmp_path, extra={
+        "stages": {
+            "plan": {"agent": "planner", "enabled": False},
+            "coordinate": {"agent": "coordinator", "enabled": False},
+            "implement": {"agent": "implementer", "enabled": False},
+            "test": {"agent": "tester", "enabled": False},
+            "review": {"agent": "guardian", "enabled": False},
+            "pr": {"agent": "guardian", "enabled": True},
+        },
+        "agents": {
+            "guardian": {"model": "opus", "max_turns": 10},
+        },
+    })
+    worca_dir = tmp_path / ".worca"
+    worca_dir.mkdir(exist_ok=True)
+    status_path = str(worca_dir / "status.json")
+    wr = WorkRequest(source_type="prompt", title="Runner-derived PR fields")
+
+    def mock_run_stage(stage, context, sp, msize=1, iteration=1,
+                       prompt_override=None, **kwargs):
+        # Agent emits only the minimal required fields — no branches, no provider.
+        return {"pr_url": "https://gitlab.com/group/proj/-/merge_requests/3",
+                "pr_number": 3,
+                "commit_sha": "feedface1"}, {"type": "result"}
+
+    import os
+    os.environ["WORCA_TARGET_BRANCH"] = "develop"
+    try:
+        with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
+             patch("worca.orchestrator.runner.create_branch"), \
+             patch("worca.orchestrator.runner._write_pid"), \
+             patch("worca.orchestrator.runner._remove_pid"):
+            final_status = run_pipeline(
+                wr, plan_file=str(plan),
+                settings_path=settings_path,
+                status_path=status_path,
+            )
+    finally:
+        del os.environ["WORCA_TARGET_BRANCH"]
+
+    pr = final_status.get("pr")
+    assert pr is not None
+    # Branches: runner-derived from status, since agent omitted them.
+    assert pr["source_branch"] == final_status["branch"]
+    assert pr["target_branch"] == "develop"
+    # Provider: parsed from the gitlab.com URL.
+    assert pr["provider"] == "gitlab"
+
+
+def test_pr_metadata_runner_overrides_other_provider(tmp_path):
+    """When agent emits provider='other' but URL is recognisable, runner upgrades it."""
+    from worca.orchestrator.work_request import WorkRequest
+
+    plan = tmp_path / "plan.md"
+    plan.write_text("# Plan\n")
+    settings_path = _make_minimal_settings(tmp_path, extra={
+        "stages": {
+            "plan": {"agent": "planner", "enabled": False},
+            "coordinate": {"agent": "coordinator", "enabled": False},
+            "implement": {"agent": "implementer", "enabled": False},
+            "test": {"agent": "tester", "enabled": False},
+            "review": {"agent": "guardian", "enabled": False},
+            "pr": {"agent": "guardian", "enabled": True},
+        },
+        "agents": {
+            "guardian": {"model": "opus", "max_turns": 10},
+        },
+    })
+    worca_dir = tmp_path / ".worca"
+    worca_dir.mkdir(exist_ok=True)
+    status_path = str(worca_dir / "status.json")
+    wr = WorkRequest(source_type="prompt", title="Provider override test")
+
+    def mock_run_stage(stage, context, sp, msize=1, iteration=1,
+                       prompt_override=None, **kwargs):
+        return {"pr_url": "https://github.com/owner/repo/pull/5",
+                "pr_number": 5,
+                "commit_sha": "deadbeef1",
+                "provider": "other"}, {"type": "result"}
+
+    with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
+         patch("worca.orchestrator.runner.create_branch"), \
+         patch("worca.orchestrator.runner._write_pid"), \
+         patch("worca.orchestrator.runner._remove_pid"):
+        final_status = run_pipeline(
+            wr, plan_file=str(plan),
+            settings_path=settings_path,
+            status_path=status_path,
+        )
+
+    pr = final_status.get("pr")
+    assert pr is not None
+    assert pr["provider"] == "github"  # upgraded from "other"
 
 
 def test_git_pr_created_not_emitted_without_pr_url(tmp_path):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2766,7 +2766,12 @@ def test_git_pr_created_payload_fields(tmp_path):
     def mock_run_stage(stage, context, sp, msize=1, iteration=1,
                        prompt_override=None, **kwargs):
         return {"pr_url": "https://github.com/org/repo/pull/99",
-                "pr_number": 99}, {"type": "result"}
+                "pr_number": 99,
+                "commit_sha": "abc1234567",
+                "source_branch": "feature/x",
+                "target_branch": "main",
+                "provider": "github",
+                "is_draft": False}, {"type": "result"}
 
     with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage):
         with patch("worca.orchestrator.runner.create_branch"):
@@ -2785,6 +2790,75 @@ def test_git_pr_created_payload_fields(tmp_path):
     assert p["pr_url"] == "https://github.com/org/repo/pull/99"
     assert p["pr_number"] == 99
     assert "title" in p
+    assert p["commit_sha"] == "abc1234567"
+    assert p["source_branch"] == "feature/x"
+    assert p["target_branch"] == "main"
+    assert p["provider"] == "github"
+    assert p["is_draft"] is False
+
+
+def test_pr_metadata_persisted_without_ctx(tmp_path):
+    """PR metadata is written to status['pr'] even in headless runs (no event ctx)."""
+    from worca.orchestrator.work_request import WorkRequest
+
+    plan = tmp_path / "plan.md"
+    plan.write_text("# Plan\n")
+    settings_path = _make_minimal_settings(tmp_path, extra={
+        "stages": {
+            "plan": {"agent": "planner", "enabled": False},
+            "coordinate": {"agent": "coordinator", "enabled": False},
+            "implement": {"agent": "implementer", "enabled": False},
+            "test": {"agent": "tester", "enabled": False},
+            "review": {"agent": "guardian", "enabled": False},
+            "pr": {"agent": "guardian", "enabled": True},
+        },
+        "agents": {
+            "guardian": {"model": "opus", "max_turns": 10},
+        },
+    })
+    worca_dir = tmp_path / ".worca"
+    worca_dir.mkdir(exist_ok=True)
+    status_path = str(worca_dir / "status.json")
+    wr = WorkRequest(source_type="prompt", title="Headless PR test")
+
+    def mock_run_stage(stage, context, sp, msize=1, iteration=1,
+                       prompt_override=None, **kwargs):
+        return {"pr_url": "https://github.com/org/repo/pull/7",
+                "pr_number": 7,
+                "commit_sha": "deadbeef1",
+                "source_branch": "feat/headless",
+                "target_branch": "main",
+                "provider": "github",
+                "is_draft": True}, {"type": "result"}
+
+    import os.path as osp
+    _orig_join = osp.join
+
+    def null_events_join(*args):
+        if len(args) >= 2 and args[-1] == "events.jsonl":
+            return None
+        return _orig_join(*args)
+
+    with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
+         patch("worca.orchestrator.runner.create_branch"), \
+         patch("worca.orchestrator.runner._write_pid"), \
+         patch("worca.orchestrator.runner._remove_pid"), \
+         patch("os.path.join", side_effect=null_events_join):
+        final_status = run_pipeline(
+            wr, plan_file=str(plan),
+            settings_path=settings_path,
+            status_path=status_path,
+        )
+
+    pr = final_status.get("pr")
+    assert pr is not None, "status['pr'] must be set even in headless runs"
+    assert pr["url"] == "https://github.com/org/repo/pull/7"
+    assert pr["number"] == 7
+    assert pr["commit_sha"] == "deadbeef1"
+    assert pr["source_branch"] == "feat/headless"
+    assert pr["target_branch"] == "main"
+    assert pr["provider"] == "github"
+    assert pr["is_draft"] is True
 
 
 def test_git_pr_created_not_emitted_without_pr_url(tmp_path):

--- a/tests/test_runner_pr_approval.py
+++ b/tests/test_runner_pr_approval.py
@@ -109,7 +109,13 @@ def _run_pr_pipeline(tmp_path, pr_approval=None, timeout_seconds=None,
 
     def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
                        prompt_override=None, **kwargs):
-        return _mock_stage(stage, {"pr_url": "https://github.com/test/1", "pr_number": 1})
+        return _mock_stage(stage, {
+            "pr_url": "https://github.com/test/repo/pull/1",
+            "pr_number": 1,
+            "commit_sha": "abc1234567",
+            "source_branch": "feature/test",
+            "target_branch": "main",
+        })
 
     patches = [
         patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage),
@@ -186,7 +192,13 @@ class TestPrApprovalReject:
 
         def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
                            prompt_override=None, **kwargs):
-            return _mock_stage(stage, {"pr_url": "https://github.com/test/1", "pr_number": 1})
+            return _mock_stage(stage, {
+                "pr_url": "https://github.com/test/repo/pull/1",
+                "pr_number": 1,
+                "commit_sha": "abc1234567",
+                "source_branch": "feature/test",
+                "target_branch": "main",
+            })
 
         with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
              patch("worca.orchestrator.runner.create_branch"), \
@@ -215,7 +227,13 @@ class TestPrApprovalNoCtx:
 
         def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
                            prompt_override=None, **kwargs):
-            return _mock_stage(stage, {"pr_url": "https://github.com/test/1", "pr_number": 1})
+            return _mock_stage(stage, {
+                "pr_url": "https://github.com/test/repo/pull/1",
+                "pr_number": 1,
+                "commit_sha": "abc1234567",
+                "source_branch": "feature/test",
+                "target_branch": "main",
+            })
 
         # Prevent ctx from being created by making EventContext raise.
         # runner.py wraps EventContext construction in `if events_path:` and

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -77,6 +77,7 @@ import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/copy-button/copy-button.js';
 
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/divider/divider.js';

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -3436,6 +3436,51 @@ sl-details.learnings-panel::part(content) {
   align-items: center;
 }
 
+.pr-details-section {
+  margin-top: 8px;
+}
+
+.pr-details-table {
+  border-collapse: collapse;
+  font-size: 13px;
+  width: 100%;
+}
+
+.pr-details-table td {
+  padding: 3px 8px 3px 0;
+  vertical-align: middle;
+}
+
+.pr-details-table td.meta-label {
+  white-space: nowrap;
+  width: 1%;
+  padding-right: 10px;
+}
+
+.pr-commit-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pr-commit-sha {
+  font-family: monospace;
+  font-size: 12px;
+  background: var(--bg-secondary);
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--border-subtle);
+}
+
+.pr-branch-flow {
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.pr-title-badge {
+  margin-left: 6px;
+}
+
 .classification-strip {
   margin-top: 10px;
   padding: 8px 10px;

--- a/worca-ui/app/views/beads-panel.js
+++ b/worca-ui/app/views/beads-panel.js
@@ -431,7 +431,9 @@ export function beadsPanelView(
 
   const branch = run?.branch || run?.work_request?.branch || '';
   const displayRunId = runId || run?.run_id || '';
-  const pr = run?.pr_url || null;
+  const prUrl = run?.pr?.url || run?.pr_url || null;
+  const prNumber = run?.pr?.number ?? null;
+  const prLabel = prNumber != null ? `PR #${prNumber}` : 'View PR';
 
   const metaStripView =
     branch || displayRunId
@@ -453,7 +455,7 @@ export function beadsPanelView(
         <div class="run-branch">
           <span class="stage-meta-icon">${unsafeHTML(iconSvg(GitBranch, 14))}</span>
           <span>${branch}</span>
-          ${pr ? html`<a class="run-pr-link" href="${pr}" target="_blank">View PR</a>` : nothing}
+          ${prUrl ? html`<a class="run-pr-link" href="${prUrl}" target="_blank">${prLabel}</a>` : nothing}
         </div>
       `
           : nothing

--- a/worca-ui/app/views/beads-panel.test.js
+++ b/worca-ui/app/views/beads-panel.test.js
@@ -224,6 +224,51 @@ describe('beadsPanelView - run/branch metadata strip', () => {
     expect(output).not.toContain('View PR');
   });
 
+  it('uses run.pr.url with "PR #N" label when run.pr is set', () => {
+    const run = {
+      branch: 'worca/feature',
+      pr: {
+        url: 'https://github.com/owner/repo/pull/42',
+        number: 42,
+      },
+    };
+    const output = renderToString(
+      beadsPanelView([], {
+        ...baseOptions,
+        run,
+      }),
+    );
+    expect(output).toContain('https://github.com/owner/repo/pull/42');
+    expect(output).toContain('PR #42');
+  });
+
+  it('falls back to run.pr_url with "View PR" label when run.pr is absent', () => {
+    const run = {
+      branch: 'worca/feature',
+      pr_url: 'https://github.com/owner/repo/pull/7',
+    };
+    const output = renderToString(
+      beadsPanelView([], {
+        ...baseOptions,
+        run,
+      }),
+    );
+    expect(output).toContain('https://github.com/owner/repo/pull/7');
+    expect(output).toContain('View PR');
+  });
+
+  it('hides PR link when neither run.pr nor run.pr_url is set', () => {
+    const run = { branch: 'worca/feature' };
+    const output = renderToString(
+      beadsPanelView([], {
+        ...baseOptions,
+        run,
+      }),
+    );
+    expect(output).not.toContain('PR #');
+    expect(output).not.toContain('View PR');
+  });
+
   it('shows both run ID and branch when both present', () => {
     const run = { branch: 'worca/feature-xyz' };
     const output = renderToString(

--- a/worca-ui/app/views/run-detail-pr-details.test.js
+++ b/worca-ui/app/views/run-detail-pr-details.test.js
@@ -1,0 +1,317 @@
+import { describe, expect, it } from 'vitest';
+import { beadsPanelView } from './beads-panel.js';
+import { runDetailView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const guardianStage = {
+  status: 'completed',
+  iterations: [{ number: 1, status: 'completed', outcome: 'success' }],
+};
+
+const prObject = {
+  url: 'https://github.com/owner/repo/pull/42',
+  number: 42,
+  commit_sha: 'abc1234567890',
+  source_branch: 'feature/my-feature',
+  target_branch: 'main',
+  provider: 'github',
+  is_draft: false,
+};
+
+const baseRun = {
+  pipeline_status: 'completed',
+  milestones: { pr_verified: true },
+  stages: { pr: guardianStage },
+  pr: prObject,
+};
+
+const baseOptions = {
+  runId: 'test-run-001',
+  run: null,
+  statusFilter: 'all',
+  priorityFilter: 'all',
+  onStatusFilter: () => {},
+  onPriorityFilter: () => {},
+};
+
+describe('_prDetailsView via runDetailView — pr stage', () => {
+  it('renders pr-details-section when run.pr is set', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('pr-details-section');
+  });
+
+  it('renders PR link as "#42 ↗" with target=_blank', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('#42');
+    expect(out).toContain('↗');
+    expect(out).toContain('target="_blank"');
+    expect(out).toContain('rel="noopener noreferrer"');
+    expect(out).toContain('https://github.com/owner/repo/pull/42');
+  });
+
+  it('renders provider badge with neutral variant', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('pr-provider-badge');
+    expect(out).toContain('github');
+  });
+
+  it('renders short commit SHA (7 chars) in code element', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('pr-commit-sha');
+    expect(out).toContain('abc1234');
+    // full SHA in sl-copy-button value; short SHA in code display
+    expect(out).toContain('abc1234567890');
+  });
+
+  it('renders copy button for commit SHA', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('sl-copy-button');
+  });
+
+  it('renders source → target branch', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('feature/my-feature');
+    expect(out).toContain('main');
+    expect(out).toContain('→');
+    expect(out).toContain('pr-branch-flow');
+  });
+
+  it('does not render Draft badge when is_draft=false', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).not.toContain('pr-draft-badge');
+    expect(out).not.toContain('Draft');
+  });
+
+  it('renders Draft badge with warning variant when is_draft=true', () => {
+    const run = { ...baseRun, pr: { ...prObject, is_draft: true } };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-draft-badge');
+    expect(out).toContain('Draft');
+    expect(out).toContain('variant="warning"');
+  });
+
+  it('renders review_status badge when is_draft=false and review_status set', () => {
+    const run = {
+      ...baseRun,
+      pr: { ...prObject, is_draft: false, review_status: 'approved' },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-review-status-badge');
+    expect(out).toContain('approved');
+    expect(out).toContain('variant="success"');
+  });
+
+  it('renders review_status=changes_requested with warning variant', () => {
+    const run = {
+      ...baseRun,
+      pr: { ...prObject, is_draft: false, review_status: 'changes_requested' },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-review-status-badge');
+    expect(out).toContain('variant="warning"');
+  });
+
+  it('renders review_status=rejected with danger variant', () => {
+    const run = {
+      ...baseRun,
+      pr: { ...prObject, is_draft: false, review_status: 'rejected' },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-review-status-badge');
+    expect(out).toContain('variant="danger"');
+  });
+
+  it('prefers is_draft=true over review_status', () => {
+    const run = {
+      ...baseRun,
+      pr: { ...prObject, is_draft: true, review_status: 'approved' },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-draft-badge');
+    expect(out).not.toContain('pr-review-status-badge');
+  });
+
+  it('renders nothing for status row when is_draft=false and no review_status', () => {
+    const run = { ...baseRun, pr: { ...prObject, is_draft: false } };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-draft-badge');
+    expect(out).not.toContain('pr-review-status-badge');
+  });
+
+  it('skips provider row when provider is absent', () => {
+    const run = { ...baseRun, pr: { ...prObject, provider: undefined } };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-provider-badge');
+  });
+
+  it('skips commit row when commit_sha is absent', () => {
+    const run = { ...baseRun, pr: { ...prObject, commit_sha: undefined } };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-commit-sha');
+  });
+
+  it('skips branch row when source or target branch is absent', () => {
+    const run = {
+      ...baseRun,
+      pr: { ...prObject, source_branch: undefined },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-branch-flow');
+  });
+
+  it('does not render pr-details-section when run.pr is null', () => {
+    const run = { ...baseRun, pr: null };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-details-section');
+  });
+
+  it('does not render pr-details-section when run has neither pr nor pr_url', () => {
+    const run = {
+      pipeline_status: 'completed',
+      stages: { pr: guardianStage },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-details-section');
+  });
+
+  it('renders pr-details-section using run.pr_url fallback (legacy)', () => {
+    const run = {
+      pipeline_status: 'completed',
+      stages: { pr: guardianStage },
+      pr_url: 'https://github.com/owner/repo/pull/7',
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-details-section');
+    expect(out).toContain('https://github.com/owner/repo/pull/7');
+  });
+
+  it('renders pr-details-section only in pr stage, not other stages', () => {
+    const run = {
+      ...baseRun,
+      stages: {
+        pr: guardianStage,
+        implement: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed' }],
+        },
+      },
+    };
+    const out = renderToString(runDetailView(run));
+    const count = (out.match(/pr-details-section/g) || []).length;
+    expect(count).toBe(1);
+  });
+});
+
+describe('PR stage title badge', () => {
+  it('renders pr-title-badge in pr stage header when PR present', () => {
+    const out = renderToString(runDetailView(baseRun));
+    expect(out).toContain('pr-title-badge');
+    expect(out).toContain('PR #42');
+  });
+
+  it('shows "· draft" suffix in title badge when is_draft=true', () => {
+    const run = { ...baseRun, pr: { ...prObject, is_draft: true } };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('PR #42');
+    expect(out).toContain('draft');
+  });
+
+  it('uses warning variant for draft title badge', () => {
+    const run = { ...baseRun, pr: { ...prObject, is_draft: true } };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('pr-title-badge');
+  });
+
+  it('does not render pr-title-badge when no PR data', () => {
+    const run = {
+      pipeline_status: 'completed',
+      stages: { pr: guardianStage },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('pr-title-badge');
+  });
+});
+
+describe('overview PR link uses richer data', () => {
+  it('shows pr_url from run.pr.url in overview when branch is set', () => {
+    const run = { ...baseRun, branch: 'feature/my-feature' };
+    const out = renderToString(runDetailView(run).overview);
+    expect(out).toContain('https://github.com/owner/repo/pull/42');
+  });
+
+  it('falls back to run.pr_url in overview when run.pr absent', () => {
+    const run = {
+      pipeline_status: 'completed',
+      branch: 'feature/x',
+      stages: {},
+      pr_url: 'https://github.com/owner/repo/pull/5',
+    };
+    const out = renderToString(runDetailView(run).overview);
+    expect(out).toContain('https://github.com/owner/repo/pull/5');
+  });
+});
+
+describe('beadsPanelView — PR link uses run.pr.url', () => {
+  it('shows PR link using run.pr.url when run.pr is set', () => {
+    const run = {
+      branch: 'worca/feature',
+      pr: {
+        url: 'https://github.com/owner/repo/pull/42',
+        number: 42,
+      },
+    };
+    const out = renderToString(
+      beadsPanelView([], {
+        ...baseOptions,
+        run,
+      }),
+    );
+    expect(out).toContain('https://github.com/owner/repo/pull/42');
+    expect(out).toContain('PR #42');
+  });
+
+  it('falls back to run.pr_url when run.pr is absent', () => {
+    const run = {
+      branch: 'worca/feature',
+      pr_url: 'https://github.com/owner/repo/pull/7',
+    };
+    const out = renderToString(
+      beadsPanelView([], {
+        ...baseOptions,
+        run,
+      }),
+    );
+    expect(out).toContain('https://github.com/owner/repo/pull/7');
+    expect(out).toContain('View PR');
+  });
+
+  it('hides PR link when neither run.pr nor run.pr_url is set', () => {
+    const run = { branch: 'worca/feature' };
+    const out = renderToString(
+      beadsPanelView([], {
+        ...baseOptions,
+        run,
+      }),
+    );
+    expect(out).not.toContain('View PR');
+    expect(out).not.toContain('PR #');
+  });
+});

--- a/worca-ui/app/views/run-detail-pr-details.test.js
+++ b/worca-ui/app/views/run-detail-pr-details.test.js
@@ -33,7 +33,6 @@ const prObject = {
   source_branch: 'feature/my-feature',
   target_branch: 'main',
   provider: 'github',
-  is_draft: false,
 };
 
 const baseRun = {
@@ -94,24 +93,10 @@ describe('_prDetailsView via runDetailView — pr stage', () => {
     expect(out).toContain('pr-branch-flow');
   });
 
-  it('does not render Draft badge when is_draft=false', () => {
-    const out = renderToString(runDetailView(baseRun));
-    expect(out).not.toContain('pr-draft-badge');
-    expect(out).not.toContain('Draft');
-  });
-
-  it('renders Draft badge with warning variant when is_draft=true', () => {
-    const run = { ...baseRun, pr: { ...prObject, is_draft: true } };
-    const out = renderToString(runDetailView(run));
-    expect(out).toContain('pr-draft-badge');
-    expect(out).toContain('Draft');
-    expect(out).toContain('variant="warning"');
-  });
-
-  it('renders review_status badge when is_draft=false and review_status set', () => {
+  it('renders review_status badge when review_status set', () => {
     const run = {
       ...baseRun,
-      pr: { ...prObject, is_draft: false, review_status: 'approved' },
+      pr: { ...prObject, review_status: 'approved' },
     };
     const out = renderToString(runDetailView(run));
     expect(out).toContain('pr-review-status-badge');
@@ -122,7 +107,7 @@ describe('_prDetailsView via runDetailView — pr stage', () => {
   it('renders review_status=changes_requested with warning variant', () => {
     const run = {
       ...baseRun,
-      pr: { ...prObject, is_draft: false, review_status: 'changes_requested' },
+      pr: { ...prObject, review_status: 'changes_requested' },
     };
     const out = renderToString(runDetailView(run));
     expect(out).toContain('pr-review-status-badge');
@@ -132,27 +117,15 @@ describe('_prDetailsView via runDetailView — pr stage', () => {
   it('renders review_status=rejected with danger variant', () => {
     const run = {
       ...baseRun,
-      pr: { ...prObject, is_draft: false, review_status: 'rejected' },
+      pr: { ...prObject, review_status: 'rejected' },
     };
     const out = renderToString(runDetailView(run));
     expect(out).toContain('pr-review-status-badge');
     expect(out).toContain('variant="danger"');
   });
 
-  it('prefers is_draft=true over review_status', () => {
-    const run = {
-      ...baseRun,
-      pr: { ...prObject, is_draft: true, review_status: 'approved' },
-    };
-    const out = renderToString(runDetailView(run));
-    expect(out).toContain('pr-draft-badge');
-    expect(out).not.toContain('pr-review-status-badge');
-  });
-
-  it('renders nothing for status row when is_draft=false and no review_status', () => {
-    const run = { ...baseRun, pr: { ...prObject, is_draft: false } };
-    const out = renderToString(runDetailView(run));
-    expect(out).not.toContain('pr-draft-badge');
+  it('renders nothing for status row when review_status is absent', () => {
+    const out = renderToString(runDetailView(baseRun));
     expect(out).not.toContain('pr-review-status-badge');
   });
 
@@ -225,19 +198,6 @@ describe('PR stage title badge', () => {
     const out = renderToString(runDetailView(baseRun));
     expect(out).toContain('pr-title-badge');
     expect(out).toContain('PR #42');
-  });
-
-  it('shows "· draft" suffix in title badge when is_draft=true', () => {
-    const run = { ...baseRun, pr: { ...prObject, is_draft: true } };
-    const out = renderToString(runDetailView(run));
-    expect(out).toContain('PR #42');
-    expect(out).toContain('draft');
-  });
-
-  it('uses warning variant for draft title badge', () => {
-    const run = { ...baseRun, pr: { ...prObject, is_draft: true } };
-    const out = renderToString(runDetailView(run));
-    expect(out).toContain('pr-title-badge');
   });
 
   it('does not render pr-title-badge when no PR data', () => {

--- a/worca-ui/app/views/run-detail-pr-verification.test.js
+++ b/worca-ui/app/views/run-detail-pr-verification.test.js
@@ -28,7 +28,7 @@ const guardianStage = {
 const baseRun = {
   pipeline_status: 'failed',
   milestones: { pr_verified: false },
-  stages: { guardian: guardianStage },
+  stages: { pr: guardianStage },
 };
 
 describe('prVerificationBannerView', () => {
@@ -132,7 +132,7 @@ describe('runDetailView pr-verified badge in guardian stage', () => {
     const run = {
       pipeline_status: 'completed',
       milestones: { pr_verified: true },
-      stages: { guardian: guardianStage },
+      stages: { pr: guardianStage },
     };
     const out = renderToString(runDetailView(run));
     expect(out).toContain('pr-verified-badge');
@@ -166,7 +166,7 @@ describe('runDetailView pr-verified badge in guardian stage', () => {
   it('does not render pr-verified-badge when milestones is absent', () => {
     const run = {
       pipeline_status: 'failed',
-      stages: { guardian: guardianStage },
+      stages: { pr: guardianStage },
     };
     const out = renderToString(runDetailView(run));
     expect(out).not.toContain('pr-verified-badge');
@@ -183,7 +183,7 @@ describe('runDetailView pr-verified badge in guardian stage', () => {
     const run = {
       pipeline_status: 'completed',
       milestones: { pr_verified: true },
-      stages: { guardian: multiIterGuardian },
+      stages: { pr: multiIterGuardian },
     };
     const out = renderToString(runDetailView(run));
     expect(out).toContain('pr-verified-badge');

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -313,12 +313,12 @@ function _prDetailsView(run) {
   if (!prUrl) return nothing;
 
   const number = pr?.number;
+  const numberLabel = number != null ? `#${number} ↗` : '↗';
   const commitSha = pr?.commit_sha;
   const shortSha = commitSha ? commitSha.slice(0, 7) : null;
   const source = pr?.source_branch;
   const target = pr?.target_branch;
   const provider = pr?.provider;
-  const isDraft = pr?.is_draft;
   const reviewStatus = pr?.review_status;
 
   return html`
@@ -327,7 +327,7 @@ function _prDetailsView(run) {
         <tbody>
           <tr>
             <td class="meta-label">PR</td>
-            <td><a class="run-pr-link" href="${prUrl}" target="_blank" rel="noopener noreferrer">#${number} ↗</a></td>
+            <td><a class="run-pr-link" href="${prUrl}" target="_blank" rel="noopener noreferrer">${numberLabel}</a></td>
           </tr>
           ${
             provider
@@ -357,17 +357,12 @@ function _prDetailsView(run) {
               : nothing
           }
           ${
-            isDraft
+            reviewStatus
               ? html`<tr>
-            <td class="meta-label">Status</td>
-            <td><sl-badge class="pr-draft-badge" variant="warning" pill>Draft</sl-badge></td>
-          </tr>`
-              : reviewStatus
-                ? html`<tr>
             <td class="meta-label">Status</td>
             <td><sl-badge class="pr-review-status-badge" variant="${_prReviewStatusVariant(reviewStatus)}" pill>${reviewStatus.replace(/_/g, ' ')}</sl-badge></td>
           </tr>`
-                : nothing
+              : nothing
           }
         </tbody>
       </table>
@@ -380,9 +375,8 @@ function _prTitleBadge(run) {
   const prUrl = pr?.url || run?.pr_url;
   if (!prUrl) return nothing;
   const number = pr?.number;
-  const isDraft = pr?.is_draft;
-  const label = isDraft ? `PR #${number} · draft` : `PR #${number}`;
-  return html`<sl-badge class="pr-title-badge" variant="${isDraft ? 'warning' : 'success'}" pill>${label}</sl-badge>`;
+  const label = `PR #${number}`;
+  return html`<sl-badge class="pr-title-badge" variant="success" pill>${label}</sl-badge>`;
 }
 
 function _preflightCheckBadgeVariant(status) {

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -300,6 +300,91 @@ function _prVerifiedBadgeView(run) {
   `;
 }
 
+function _prReviewStatusVariant(status) {
+  if (status === 'approved') return 'success';
+  if (status === 'changes_requested') return 'warning';
+  if (status === 'rejected') return 'danger';
+  return 'neutral';
+}
+
+function _prDetailsView(run) {
+  const pr = run?.pr;
+  const prUrl = pr?.url || run?.pr_url;
+  if (!prUrl) return nothing;
+
+  const number = pr?.number;
+  const commitSha = pr?.commit_sha;
+  const shortSha = commitSha ? commitSha.slice(0, 7) : null;
+  const source = pr?.source_branch;
+  const target = pr?.target_branch;
+  const provider = pr?.provider;
+  const isDraft = pr?.is_draft;
+  const reviewStatus = pr?.review_status;
+
+  return html`
+    <sl-details class="pr-details-section" summary="PR details">
+      <table class="pr-details-table">
+        <tbody>
+          <tr>
+            <td class="meta-label">PR</td>
+            <td><a class="run-pr-link" href="${prUrl}" target="_blank" rel="noopener noreferrer">#${number} ↗</a></td>
+          </tr>
+          ${
+            provider
+              ? html`<tr>
+            <td class="meta-label">Provider</td>
+            <td><sl-badge class="pr-provider-badge" variant="neutral" pill>${provider.replace(/_/g, ' ')}</sl-badge></td>
+          </tr>`
+              : nothing
+          }
+          ${
+            shortSha
+              ? html`<tr>
+            <td class="meta-label">Commit</td>
+            <td class="pr-commit-cell">
+              <code class="pr-commit-sha">${shortSha}</code>
+              <sl-copy-button value="${commitSha}"></sl-copy-button>
+            </td>
+          </tr>`
+              : nothing
+          }
+          ${
+            source && target
+              ? html`<tr>
+            <td class="meta-label">Branch</td>
+            <td><code class="pr-branch-flow">${source} → ${target}</code></td>
+          </tr>`
+              : nothing
+          }
+          ${
+            isDraft
+              ? html`<tr>
+            <td class="meta-label">Status</td>
+            <td><sl-badge class="pr-draft-badge" variant="warning" pill>Draft</sl-badge></td>
+          </tr>`
+              : reviewStatus
+                ? html`<tr>
+            <td class="meta-label">Status</td>
+            <td><sl-badge class="pr-review-status-badge" variant="${_prReviewStatusVariant(reviewStatus)}" pill>${reviewStatus.replace(/_/g, ' ')}</sl-badge></td>
+          </tr>`
+                : nothing
+          }
+        </tbody>
+      </table>
+    </sl-details>
+  `;
+}
+
+function _prTitleBadge(run) {
+  const pr = run?.pr;
+  const prUrl = pr?.url || run?.pr_url;
+  if (!prUrl) return nothing;
+  const number = pr?.number;
+  const isDraft = pr?.is_draft;
+  const label = isDraft ? `PR #${number} · draft` : `PR #${number}`;
+  return html`<sl-badge class="pr-title-badge" variant="${isDraft ? 'warning' : 'success'}" pill>${label}</sl-badge>`;
+}
+
 function _preflightCheckBadgeVariant(status) {
   if (status === 'pass') return 'success';
   if (status === 'warn') return 'warning';
@@ -631,7 +716,7 @@ export function runDetailView(run, settings = {}, options = {}) {
 
   const branch = run.branch || run.work_request?.branch || '';
   const pipelineTemplate = formatPipelineTemplate(run.pipeline_template);
-  const pr = run.pr_url || null;
+  const pr = run.pr?.url || run.pr_url || null;
   const endTime =
     run.completed_at || (run.active ? null : _lastStageEnd(run.stages));
   const rawStages = run.stages || {};
@@ -810,6 +895,7 @@ export function runDetailView(run, settings = {}, options = {}) {
                 <sl-badge variant="${_badgeVariant(stageStatus)}" pill>
                   ${stageStatus.replace(/_/g, ' ')}
                 </sl-badge>
+                ${key === 'pr' ? _prTitleBadge(run) : nothing}
               </div>
               ${(() => {
                 const promptData =
@@ -860,7 +946,8 @@ export function runDetailView(run, settings = {}, options = {}) {
                             ${stageTurns > 0 ? html`<span class="stage-totals-item"><span class="meta-label">Turns:</span> <span class="meta-value">${stageTurns}</span></span>` : nothing}
                           </div>`;
                       })()}
-                      ${key === 'guardian' ? _prVerifiedBadgeView(run) : nothing}
+                      ${key === 'pr' ? _prVerifiedBadgeView(run) : nothing}
+                      ${key === 'pr' ? _prDetailsView(run) : nothing}
                       <sl-tab-group @sl-tab-show=${(e) => {
                         const panel = e.detail.name;
                         const num = parseInt(panel.split('-').pop(), 10);
@@ -912,7 +999,8 @@ export function runDetailView(run, settings = {}, options = {}) {
                       ${stage.error ? html`<div class="detail-row detail-error"><span class="detail-label">Error:</span> ${stage.error}</div>` : nothing}
                       ${iterations.length === 1 ? _classificationRowView(iterations[0]) : nothing}
                       ${iterations.length === 1 ? _dispatchEventsRowView(iterations[0]) : nothing}
-                      ${key === 'guardian' ? _prVerifiedBadgeView(run) : nothing}
+                      ${key === 'pr' ? _prVerifiedBadgeView(run) : nothing}
+                      ${key === 'pr' ? _prDetailsView(run) : nothing}
                       ${key === 'preflight' && iterations.length === 1 ? _preflightChecksView(stage, iterations[0]) : nothing}
                       ${promptData ? _agentPromptSection(key, promptData) : nothing}
                     </div>

--- a/worca-ui/e2e/pr-details-panel.spec.js
+++ b/worca-ui/e2e/pr-details-panel.spec.js
@@ -10,7 +10,6 @@ const PR_DATA = {
   source_branch: 'feature/my-feature',
   target_branch: 'main',
   provider: 'github',
-  is_draft: false,
 };
 
 async function openRunDetail(page, baseUrl, runId) {

--- a/worca-ui/e2e/pr-details-panel.spec.js
+++ b/worca-ui/e2e/pr-details-panel.spec.js
@@ -1,0 +1,176 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+const PR_DATA = {
+  url: 'https://github.com/owner/repo/pull/42',
+  number: 42,
+  commit_sha: 'abc1234567890',
+  source_branch: 'feature/my-feature',
+  target_branch: 'main',
+  provider: 'github',
+  is_draft: false,
+};
+
+async function openRunDetail(page, baseUrl, runId) {
+  await page.goto(`${baseUrl}/#/history?run=${runId}`, GOTO_OPTS);
+  await expect(page.locator('.run-detail .stage-panels')).toBeVisible({ timeout: 8000 });
+}
+
+/**
+ * Open an sl-details element and wait for its animation to finish
+ * (sl-after-show fires once content is fully visible).
+ */
+async function expandDetails(detailsLocator) {
+  await detailsLocator.evaluate((el) => {
+    return new Promise((resolve) => {
+      el.addEventListener('sl-after-show', resolve, { once: true });
+      el.show();
+    });
+  });
+}
+
+function seedWithPR(worcaDir, runId, prOverrides = {}) {
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'completed',
+    milestones: { pr_verified: true },
+    stages: {
+      pr: {
+        status: 'completed',
+        iterations: [{ number: 1, status: 'completed', outcome: 'success' }],
+      },
+    },
+    pr: { ...PR_DATA, ...prOverrides },
+  });
+}
+
+test.describe('PR details panel — collapsible subsection', () => {
+  test('section is collapsed by default', async ({ page }) => {
+    const serverCtx = await startServer();
+    try {
+      const runId = '20260101-pr-closed-default';
+      seedWithPR(serverCtx.worcaDir, runId);
+      await openRunDetail(page, serverCtx.url, runId);
+
+      const details = page.locator('sl-details.pr-details-section');
+      await expect(details).toBeAttached({ timeout: 5000 });
+      await expect(details).not.toHaveAttribute('open');
+    } finally {
+      await serverCtx.close();
+    }
+  });
+
+  test('section expands and collapses', async ({ page }) => {
+    const serverCtx = await startServer();
+    try {
+      const runId = '20260101-pr-toggle';
+      seedWithPR(serverCtx.worcaDir, runId);
+      await openRunDetail(page, serverCtx.url, runId);
+
+      const details = page.locator('sl-details.pr-details-section');
+      await expect(details).not.toHaveAttribute('open');
+
+      await expandDetails(details);
+      await expect(details).toHaveAttribute('open');
+
+      await details.evaluate((el) => el.hide());
+      await expect(details).not.toHaveAttribute('open', { timeout: 3000 });
+    } finally {
+      await serverCtx.close();
+    }
+  });
+
+  test('PR link has correct href and opens in new tab', async ({ page }) => {
+    const serverCtx = await startServer();
+    try {
+      const runId = '20260101-pr-link-attrs';
+      seedWithPR(serverCtx.worcaDir, runId);
+      await openRunDetail(page, serverCtx.url, runId);
+
+      const details = page.locator('sl-details.pr-details-section');
+      await expandDetails(details);
+
+      // The link exists in the DOM inside the expanded section.
+      // toHaveAttribute works regardless of visibility state.
+      const prLink = details.locator('.run-pr-link').first();
+      await expect(prLink).toHaveAttribute('href', PR_DATA.url, { timeout: 5000 });
+      await expect(prLink).toHaveAttribute('target', '_blank');
+      await expect(prLink).toHaveAttribute('rel', 'noopener noreferrer');
+    } finally {
+      await serverCtx.close();
+    }
+  });
+
+  test('copy button carries full commit SHA as value', async ({ page }) => {
+    const serverCtx = await startServer();
+    try {
+      const runId = '20260101-pr-copy-value';
+      seedWithPR(serverCtx.worcaDir, runId);
+      await openRunDetail(page, serverCtx.url, runId);
+
+      const details = page.locator('sl-details.pr-details-section');
+      await expandDetails(details);
+
+      const copyButton = details.locator('sl-copy-button');
+      await expect(copyButton).toBeAttached();
+      await expect(copyButton).toHaveAttribute('value', PR_DATA.commit_sha);
+    } finally {
+      await serverCtx.close();
+    }
+  });
+
+  test('copy button copies commit SHA to clipboard', async ({ page }) => {
+    const serverCtx = await startServer();
+    try {
+      const runId = '20260101-pr-clipboard';
+      seedWithPR(serverCtx.worcaDir, runId);
+
+      // Mock clipboard.writeText before navigation so Shoelace's component
+      // uses our spy when handleCopy() is invoked.
+      await page.addInitScript(() => {
+        window.__lastClipboardWrite = null;
+        navigator.clipboard.writeText = (text) => {
+          window.__lastClipboardWrite = text;
+          return Promise.resolve();
+        };
+      });
+
+      await openRunDetail(page, serverCtx.url, runId);
+      const details = page.locator('sl-details.pr-details-section');
+      await expandDetails(details);
+
+      // Call handleCopy() directly — it's a public method on the Shoelace
+      // component and calls navigator.clipboard.writeText(this.value).
+      await details.evaluate((el) => {
+        el.querySelector('sl-copy-button')?.handleCopy();
+      });
+
+      const written = await page.evaluate(() => window.__lastClipboardWrite);
+      expect(written).toBe(PR_DATA.commit_sha);
+    } finally {
+      await serverCtx.close();
+    }
+  });
+
+  test('section absent when run has no PR data', async ({ page }) => {
+    const serverCtx = await startServer();
+    try {
+      const runId = '20260101-pr-no-data';
+      seedRun(serverCtx.worcaDir, runId, {
+        pipeline_status: 'completed',
+        stages: {
+          guardian: {
+            status: 'completed',
+            iterations: [{ number: 1, status: 'completed', outcome: 'success' }],
+          },
+        },
+      });
+      await openRunDetail(page, serverCtx.url, runId);
+
+      await expect(page.locator('sl-details.pr-details-section')).not.toBeAttached();
+    } finally {
+      await serverCtx.close();
+    }
+  });
+});

--- a/worca-ui/package-lock.json
+++ b/worca-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worca/ui",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worca/ui",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.20.1",


### PR DESCRIPTION
## Summary

- **Extended `pr.json` schema** with `commit_sha`, `source_branch`, `target_branch`, `provider` (enum: github/gitlab/bitbucket/azure_devops/gitea/gerrit/other) — all threaded through event payloads (`GIT_PR_CREATED`), `status.json`'s new `pr` object, and the runner's PR-stage handler.
- **Added `src/worca/utils/pr_url.py`** — host-agnostic URL parser supporting GitHub (cloud + Enterprise), GitLab (cloud + self-hosted), Bitbucket (cloud + Server/DC), Azure DevOps, Gitea, with `other` fallback. Wired into the runner: when guardian omits `provider` or emits `"other"`, the runner fills it from the URL.
- **Branches are runner-derived.** `source_branch`/`target_branch` are optional in the schema — the runner reads them from `status['branch']` and `status['target_branch']` respectively. Agents only need to override them when targeting a different branch.
- **New collapsible "PR details" subsection** in worca-ui's PR stage card: provider badge, copyable short SHA (full SHA in `sl-copy-button`), source→target branch flow, review status. `beads-panel.js` now uses the richer `run.pr` object with `run.pr_url` fallback.

## Incidental fix

This PR also corrects a latent bug from #98: `_prVerifiedBadgeView` and the new PR-stage badges were gated on `key === 'guardian'`, but the actual stage key is `pr` (per `PIPELINE_STAGES`), so the verified badge from #98 never rendered in production. Both production code in `run-detail.js` and the matching test in `run-detail-pr-verification.test.js` are updated to use `key === 'pr'`.

## Files changed

**Python core:** `pr.json` schema, `guardian.md` prompt, `runner.py` (parse_pr_url wiring + branch fallback), `events/types.py`, `state/status.py`, new `utils/pr_url.py`

**Python tests:** `test_pr_url_parser.py` (new), `test_guardian_template.py` (rewritten — extracts JSON example block from `guardian.md` and validates against schema, replacing brittle substring assertions), `test_pr_schema.py`, `test_event_types.py`, `test_runner.py` (new tests for runner-derived branches and provider auto-detect; dropped global `os.path.join` patch in favour of a scoped `emit_event` patch), `test_runner_pr_approval.py`, `test_audit_fixes_121_122.py`, `test_guardian_pr_creation.py` (integration)

**UI:** `run-detail.js`, `beads-panel.js`, `main.js`, `styles.css`, `run-detail-pr-details.test.js` (new), `beads-panel.test.js`, `run-detail-pr-verification.test.js`, `pr-details-panel.spec.js` (new e2e)

## Test plan

- [x] 2991 Python unit tests pass
- [x] 254 schema/event/template tests pass
- [x] 167 runner tests pass (including new runner-derived branch + provider tests)
- [x] 9 integration tests pass (`pytest tests/integration/test_guardian_pr_creation.py`)
- [x] 2316 vitest tests pass
- [x] Biome lint clean (289 files)
- [x] esbuild bundle rebuilt
- [x] CI green (python 3.10/3.12, ui-unit-tests, ui-e2e-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)