### PR TITLE
feat(coverage): --include-unit-tests flag + pipeline_env.run_cli helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ Test naming: `tests/test_<module>.py` mirrors source module names. Pre-existing 
 
 ```bash
 python scripts/coverage.py ci                                     # run + combine + JSON + XML + text
+python scripts/coverage.py ci --include-unit-tests                # include unit tests (wraps pytest with coverage run)
 python scripts/coverage.py run                                    # pytest under WORCA_COVERAGE=1
 python scripts/coverage.py combine                                # merge .coverage.* fragments
 python scripts/coverage.py report --format=text                   # terminal (default)
@@ -154,6 +155,8 @@ python scripts/coverage.py compare --baseline=before.json --current=after.json
 ```
 
 `ci` is the one-shot used locally and in CI: it erases stale state, runs pytest with `WORCA_COVERAGE=1`, combines fragments, and writes `coverage-out/coverage.json` (augmented schema with `summary`, `modules`, `omitted`, `raw`) plus `coverage-out/coverage.xml` (Cobertura-compatible). The pytest exit code is forwarded so CI fails on real test regressions even when coverage upload succeeds.
+
+`--include-unit-tests` wraps the pytest invocation itself with `coverage run --parallel-mode` and targets `tests/` (instead of `tests/integration/` only), so in-process unit test calls are measured alongside subprocess fragments. Default off — doubles wall time but produces accurate per-module numbers for modules exercised only by unit tests. Pass this flag explicitly when a full-coverage baseline is needed.
 
 `compare` diffs a current `coverage.json` against a saved baseline and prints per-module pp deltas — useful for per-phase tracking without bolting in a `--fail-under` gate. Threshold enforcement stays out of scope until baselines stabilize.
 

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -74,10 +74,22 @@ def _count_fragments() -> int:
     return len(list(REPO_ROOT.glob(".coverage.*")))
 
 
-def _run_pytest(target: str, timeout: str, extra: list[str] | None = None) -> int:
+def _run_pytest(
+    target: str,
+    timeout: str,
+    extra: list[str] | None = None,
+    wrap_coverage: bool = False,
+) -> int:
     env = dict(os.environ)
     env["WORCA_COVERAGE"] = "1"
-    cmd = [sys.executable, "-m", "pytest", target, f"--timeout={timeout}"]
+    if wrap_coverage:
+        cmd = [
+            sys.executable, "-m", "coverage", "run",
+            f"--rcfile={COVERAGERC}", "--parallel-mode",
+            "-m", "pytest", target, f"--timeout={timeout}",
+        ]
+    else:
+        cmd = [sys.executable, "-m", "pytest", target, f"--timeout={timeout}"]
     if extra:
         cmd.extend(extra)
     _info(f"running: {' '.join(cmd)}")
@@ -258,7 +270,9 @@ def cmd_ci(args: argparse.Namespace) -> int:
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    rc = _run_pytest(args.target, args.timeout, args.extra)
+    include_unit = getattr(args, "include_unit_tests", False)
+    target = "tests/" if include_unit else args.target
+    rc = _run_pytest(target, args.timeout, args.extra, wrap_coverage=include_unit)
     if rc != 0:
         _info(f"pytest failed (rc={rc}); continuing to combine + report")
 
@@ -319,6 +333,9 @@ def _build_parser() -> argparse.ArgumentParser:
                       help="Glob filter for the final text report only")
     p_ci.add_argument("--extra", nargs=argparse.REMAINDER,
                       help="Extra args forwarded to pytest after `--`")
+    p_ci.add_argument("--include-unit-tests", action="store_true", default=False,
+                      help="Wrap pytest with coverage run --parallel-mode and target tests/ "
+                           "instead of tests/integration/, capturing in-process coverage")
     p_ci.set_defaults(func=cmd_ci)
 
     return parser

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -359,6 +359,35 @@ def pipeline_env(tmp_path):
             capture_output=True, timeout=timeout,
         )
 
+    def run_cli(
+        name: str,
+        *args: str,
+        env_overrides: dict | None = None,
+        timeout: int = 30,
+    ) -> subprocess.CompletedProcess:
+        """Invoke a worca CLI subcommand as a coverage-tracked subprocess.
+
+        Spawns ``python -m worca.cli.main <name> <args>`` via
+        ``_wrap_with_coverage`` with ``COVERAGE_FILE`` pointing to
+        ``REPO_ROOT/.coverage`` so fragments land where ``coverage combine``
+        can find them (not in the per-test tmpdir). Mirrors ``run_hook``.
+
+        Args:
+            name: CLI subcommand name, e.g. ``"cleanup"``.
+            *args: Additional arguments forwarded to the subcommand.
+            env_overrides: per-call env additions, applied after fixture overrides.
+            timeout: subprocess timeout in seconds.
+        """
+        cmd = [sys.executable, "-m", "worca.cli.main", name, *args]
+        cmd = _wrap_with_coverage(cmd)
+        env = _base_env_common()
+        if env_overrides:
+            env.update(env_overrides)
+        return subprocess.run(
+            cmd, cwd=str(project), env=env,
+            capture_output=True, text=True, timeout=timeout,
+        )
+
     def add_webhook(url: str) -> None:
         """Add a webhook URL to settings for event dispatch testing.
 
@@ -419,6 +448,7 @@ def pipeline_env(tmp_path):
         run_hook=run_hook,
         run_worktree=run_worktree,
         run_parallel=run_parallel,
+        run_cli=run_cli,
         add_webhook=add_webhook,
         enable_stages=enable_stages,
         set_governance_agent=set_governance_agent,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -68,6 +68,8 @@ class PipelineEnv:
     # W-050 Phase 3 helpers — drive run_worktree.py / run_parallel.py.
     run_worktree: Callable = None  # type: ignore[assignment]
     run_parallel: Callable = None  # type: ignore[assignment]
+    # W-050 coverage helper — drives a worca.cli.main subcommand as a subprocess.
+    run_cli: Callable = None  # type: ignore[assignment]
     stubs_dir: Optional[Path] = None
     stub_log_path: Optional[Path] = None
     stub_response_files: dict = field(default_factory=dict)

--- a/tests/integration/test_run_cli.py
+++ b/tests/integration/test_run_cli.py
@@ -1,0 +1,54 @@
+"""Integration tests for pipeline_env.run_cli helper (W-050 coverage improvement).
+
+Validates that run_cli:
+- spawns ``python -m worca.cli.main <name> <args>`` via _wrap_with_coverage
+- captures stdout and stderr
+- returns the subprocess exit code faithfully
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.timeout(120)
+
+
+def test_run_cli_cleanup_dry_run_returns_zero_and_captures_stdout(pipeline_env):
+    """``run_cli('cleanup', '--dry-run')`` exits 0 and stdout is captured.
+
+    With no completed worktrees present the dry-run listing is empty, but the
+    command must succeed and the caller must be able to read stdout — verifying
+    the subprocess wiring (cwd, coverage wrapping, capture_output=True).
+    """
+    result = pipeline_env.run_cli("cleanup", "--dry-run")
+    assert result.returncode == 0, (
+        f"expected rc=0, got {result.returncode}\n"
+        f"stdout: {result.stdout[:500]}\n"
+        f"stderr: {result.stderr[:500]}"
+    )
+    # stdout is a string (capture_output=True, text=True); may be empty but must exist
+    assert isinstance(result.stdout, str)
+
+
+def test_run_cli_captures_stderr_from_failing_command(pipeline_env):
+    """``run_cli`` with an unrecognised flag returns nonzero and populates stderr.
+
+    argparse writes its usage/error messages to stderr when it rejects a flag,
+    so this exercises the stderr-capture path without needing a real failure.
+    """
+    result = pipeline_env.run_cli("cleanup", "--no-such-flag-xyz")
+    assert result.returncode != 0, (
+        "expected nonzero exit from invalid flag, got 0"
+    )
+    assert result.stderr, (
+        f"expected stderr output from argparse, got empty string\n"
+        f"stdout: {result.stdout[:300]}"
+    )
+
+
+def test_run_cli_result_has_stdout_and_stderr_attributes(pipeline_env):
+    """The returned CompletedProcess always exposes .stdout and .stderr as strings."""
+    result = pipeline_env.run_cli("cleanup", "--dry-run")
+    assert hasattr(result, "stdout")
+    assert hasattr(result, "stderr")
+    assert isinstance(result.stdout, str)
+    assert isinstance(result.stderr, str)

--- a/tests/integration/test_worktree_cleanup.py
+++ b/tests/integration/test_worktree_cleanup.py
@@ -13,42 +13,10 @@ the four documented modes — ``--dry-run``, ``--all``, ``--run-id``,
 from __future__ import annotations
 
 import json
-import os
-import subprocess
-import sys
 from pathlib import Path
 
 
-
 _HAPPY = {"default": {"action": "succeed", "delay_s": 0}}
-
-
-_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-
-
-def _run_cleanup(project: Path, *args: str, timeout: int = 30) -> subprocess.CompletedProcess:
-    """Invoke ``python -m worca.cli.main cleanup <args>`` from the project.
-
-    Inherits the parent process env (no MOCK_CLAUDE_SCENARIO needed — cleanup
-    doesn't spawn pipelines). When WORCA_COVERAGE=1, wraps via ``coverage run
-    --parallel-mode`` AND points ``COVERAGE_FILE`` at REPO_ROOT/.coverage so
-    the fragment lands where ``coverage combine`` will find it (without this
-    the fragment writes next to ``cwd`` — a per-test tmpdir — and is lost
-    when the test exits).
-    """
-    env = os.environ.copy()
-    if env.get("WORCA_COVERAGE") == "1":
-        env["COVERAGE_FILE"] = str(_REPO_ROOT / ".coverage")
-        cmd = [sys.executable, "-m", "coverage", "run",
-               f"--rcfile={_REPO_ROOT / '.coveragerc'}",
-               "--parallel-mode",
-               "-m", "worca.cli.main", "cleanup", *args]
-    else:
-        cmd = [sys.executable, "-m", "worca.cli.main", "cleanup", *args]
-    return subprocess.run(
-        cmd, cwd=str(project), capture_output=True, text=True,
-        timeout=timeout, env=env,
-    )
 
 
 def _registry_entries(project: Path) -> list[dict]:
@@ -78,7 +46,7 @@ def test_cleanup_dry_run_lists_without_removing(pipeline_env):
     wt_path = Path(result.worktree_path)
     assert wt_path.is_dir()
 
-    proc = _run_cleanup(pipeline_env.project, "--dry-run")
+    proc = pipeline_env.run_cli("cleanup", "--dry-run")
     assert proc.returncode == 0, f"cleanup --dry-run rc={proc.returncode}\n{proc.stderr}"
     assert result.run_id in proc.stdout, (
         f"dry-run listing should mention run_id {result.run_id}; "
@@ -107,7 +75,7 @@ def test_cleanup_all_removes_completed_worktrees(pipeline_env):
     wt_path = Path(result.worktree_path)
     assert wt_path.is_dir()
 
-    proc = _run_cleanup(pipeline_env.project, "--all")
+    proc = pipeline_env.run_cli("cleanup", "--all")
     assert proc.returncode == 0, f"cleanup --all rc={proc.returncode}\n{proc.stderr}"
     assert "Removed" in proc.stdout, f"unexpected stdout: {proc.stdout[:500]}"
 
@@ -135,7 +103,7 @@ def test_cleanup_run_id_targets_only_specified_worktree(pipeline_env):
     wt_a, wt_b = Path(result_a.worktree_path), Path(result_b.worktree_path)
     assert wt_a.is_dir() and wt_b.is_dir()
 
-    proc = _run_cleanup(pipeline_env.project, "--run-id", result_b.run_id)
+    proc = pipeline_env.run_cli("cleanup", "--run-id", result_b.run_id)
     assert proc.returncode == 0, (
         f"cleanup --run-id rc={proc.returncode}\n{proc.stderr}"
     )
@@ -162,7 +130,7 @@ def test_cleanup_older_than_skips_recent_worktrees(pipeline_env):
     wt_path = Path(result.worktree_path)
     assert wt_path.is_dir()
 
-    proc = _run_cleanup(pipeline_env.project, "--all", "--older-than", "1h")
+    proc = pipeline_env.run_cli("cleanup", "--all", "--older-than", "1h")
     assert proc.returncode == 0, (
         f"cleanup --older-than rc={proc.returncode}\n{proc.stderr}"
     )

--- a/tests/test_coverage_script.py
+++ b/tests/test_coverage_script.py
@@ -1,0 +1,246 @@
+"""Tests for scripts/coverage.py — _run_pytest wrapping and --include-unit-tests flag."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the standalone script (not a package module)
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "coverage.py"
+
+
+def _load_coverage_script():
+    spec = importlib.util.spec_from_file_location("coverage_script", _SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def cov():
+    return _load_coverage_script()
+
+
+# ---------------------------------------------------------------------------
+# _run_pytest — command construction
+# ---------------------------------------------------------------------------
+
+
+class TestRunPytestCommand:
+    def test_no_wrap_builds_plain_pytest(self, cov):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cov._run_pytest("tests/integration/", "120", wrap_coverage=False)
+
+        assert len(captured) == 1
+        cmd = captured[0]
+        assert cmd[1] == "-m"
+        assert cmd[2] == "pytest"
+        assert "coverage" not in cmd
+
+    def test_no_wrap_is_default(self, cov):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cov._run_pytest("tests/integration/", "120")
+
+        cmd = captured[0]
+        assert cmd[2] == "pytest"
+        assert "coverage" not in cmd
+
+    def test_wrap_true_builds_coverage_run_command(self, cov):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cov._run_pytest("tests/", "120", wrap_coverage=True)
+
+        assert len(captured) == 1
+        cmd = captured[0]
+        # Must invoke coverage run, not pytest directly
+        assert cmd[1] == "-m"
+        assert cmd[2] == "coverage"
+        assert "run" in cmd
+        assert "--parallel-mode" in cmd
+        assert "-m" in cmd[cmd.index("--parallel-mode") + 1 :]
+        # pytest must appear after the -m flag
+        m_idx = cmd.index("--parallel-mode")
+        rest = cmd[m_idx + 1 :]
+        assert "-m" in rest
+        assert rest[rest.index("-m") + 1] == "pytest"
+
+    def test_wrap_true_includes_target(self, cov):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cov._run_pytest("tests/", "120", wrap_coverage=True)
+
+        cmd = captured[0]
+        assert "tests/" in cmd
+
+    def test_wrap_true_includes_rcfile(self, cov):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cov._run_pytest("tests/", "120", wrap_coverage=True)
+
+        cmd = captured[0]
+        assert any("--rcfile=" in arg for arg in cmd)
+
+    def test_wrap_false_includes_target_and_timeout(self, cov):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cov._run_pytest("tests/integration/", "999", wrap_coverage=False)
+
+        cmd = captured[0]
+        assert "tests/integration/" in cmd
+        assert "--timeout=999" in cmd
+
+    def test_extra_args_forwarded_with_wrap_false(self, cov):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cov._run_pytest("tests/", "60", extra=["-x", "-v"], wrap_coverage=False)
+
+        cmd = captured[0]
+        assert "-x" in cmd
+        assert "-v" in cmd
+
+    def test_extra_args_forwarded_with_wrap_true(self, cov):
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            cov._run_pytest("tests/", "60", extra=["-x"], wrap_coverage=True)
+
+        cmd = captured[0]
+        assert "-x" in cmd
+
+
+# ---------------------------------------------------------------------------
+# cmd_ci — --include-unit-tests flag
+# ---------------------------------------------------------------------------
+
+
+class TestCmdCiIncludeUnitTests:
+    def _make_ci_args(self, cov, include_unit_tests=False, target="tests/integration/"):
+        """Build a Namespace that matches what argparse would produce for cmd_ci."""
+        import argparse
+
+        return argparse.Namespace(
+            target=target,
+            timeout="180",
+            out_dir="/tmp/cov-out",
+            include=None,
+            extra=None,
+            include_unit_tests=include_unit_tests,
+        )
+
+    def test_default_ci_uses_integration_target_no_wrap(self, cov):
+        """cmd_ci without --include-unit-tests must call _run_pytest with wrap_coverage=False."""
+        calls = []
+
+        def fake_run_pytest(target, timeout, extra=None, wrap_coverage=False):
+            calls.append({"target": target, "wrap": wrap_coverage})
+            return 0
+
+        args = self._make_ci_args(cov, include_unit_tests=False)
+        with patch.object(cov, "_run_pytest", side_effect=fake_run_pytest), \
+             patch.object(cov, "_combine", return_value=0), \
+             patch.object(cov, "_report_json", return_value=0), \
+             patch.object(cov, "_report_xml", return_value=0), \
+             patch.object(cov, "_report_text", return_value=0), \
+             patch("os.makedirs"):
+            cov.cmd_ci(args)
+
+        assert len(calls) == 1
+        assert calls[0]["wrap"] is False
+        assert calls[0]["target"] == "tests/integration/"
+
+    def test_include_unit_tests_sets_tests_root_target(self, cov):
+        """--include-unit-tests must switch target to tests/."""
+        calls = []
+
+        def fake_run_pytest(target, timeout, extra=None, wrap_coverage=False):
+            calls.append({"target": target, "wrap": wrap_coverage})
+            return 0
+
+        args = self._make_ci_args(cov, include_unit_tests=True)
+        with patch.object(cov, "_run_pytest", side_effect=fake_run_pytest), \
+             patch.object(cov, "_combine", return_value=0), \
+             patch.object(cov, "_report_json", return_value=0), \
+             patch.object(cov, "_report_xml", return_value=0), \
+             patch.object(cov, "_report_text", return_value=0), \
+             patch("os.makedirs"):
+            cov.cmd_ci(args)
+
+        assert len(calls) == 1
+        assert calls[0]["target"] == "tests/"
+
+    def test_include_unit_tests_enables_wrap(self, cov):
+        """--include-unit-tests must set wrap_coverage=True."""
+        calls = []
+
+        def fake_run_pytest(target, timeout, extra=None, wrap_coverage=False):
+            calls.append({"target": target, "wrap": wrap_coverage})
+            return 0
+
+        args = self._make_ci_args(cov, include_unit_tests=True)
+        with patch.object(cov, "_run_pytest", side_effect=fake_run_pytest), \
+             patch.object(cov, "_combine", return_value=0), \
+             patch.object(cov, "_report_json", return_value=0), \
+             patch.object(cov, "_report_xml", return_value=0), \
+             patch.object(cov, "_report_text", return_value=0), \
+             patch("os.makedirs"):
+            cov.cmd_ci(args)
+
+        assert calls[0]["wrap"] is True
+
+    def test_parser_accepts_include_unit_tests_flag(self, cov):
+        """The argparse parser must accept --include-unit-tests for the ci subcommand."""
+        parser = cov._build_parser()
+        args = parser.parse_args(["ci", "--include-unit-tests"])
+        assert args.include_unit_tests is True
+
+    def test_parser_default_include_unit_tests_is_false(self, cov):
+        parser = cov._build_parser()
+        args = parser.parse_args(["ci"])
+        assert args.include_unit_tests is False


### PR DESCRIPTION
## Summary

- Add `--include-unit-tests` flag to `scripts/coverage.py ci` that wraps the pytest invocation with `coverage run --parallel-mode` and targets `tests/` (instead of `tests/integration/`), capturing in-process unit test coverage alongside subprocess fragments. Default off to preserve fast CI path.
- Add `pipeline_env.run_cli(name, *args)` helper in `tests/integration/conftest.py` that spawns worca CLI subcommands via `_wrap_with_coverage` with correct `COVERAGE_FILE` targeting — symmetric with existing `run_hook`/`run_worktree`/`run_parallel` helpers.
- Refactor `test_worktree_cleanup.py` to use `run_cli`, removing ~30 lines of duplicated coverage plumbing (`_run_cleanup` + `_REPO_ROOT`).
- Update CLAUDE.md with `--include-unit-tests` documentation.

## Test plan

- [x] 13 unit tests in `tests/test_coverage_script.py` — validates `_run_pytest` command construction (wrap vs no-wrap) and `cmd_ci` flag routing
- [x] 3 integration tests in `tests/integration/test_run_cli.py` — validates `run_cli` subprocess wiring (exit code, stdout/stderr capture)
- [x] Existing `test_worktree_cleanup.py` tests pass with refactored `run_cli` usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)