### PR TITLE
fix(ui): add stage-key/agent-name contract tests and fix stale fixtures

### DIFF
--- a/src/worca/agents/core/implementer.md
+++ b/src/worca/agents/core/implementer.md
@@ -47,6 +47,8 @@ When your prompt says "Fix All Issues" or "Fix Test Failures" or "Fix Review Iss
 Produce a structured result following the `implement.json` schema.
 In fix mode, set `bead_id` to `"fix"` (sentinel value).
 
+> When reading `status.json`, `stages` is keyed by stage name (`preflight`, `plan`, …, `pr`, `learn`), never by agent name. The `pr` stage is run by the `guardian` agent — `guardian` will never appear as a stage key. Writing `stages.guardian` will silently no-op in production while passing tests.
+
 ## Rules
 
 <!-- governance -->

--- a/src/worca/agents/core/reviewer.md
+++ b/src/worca/agents/core/reviewer.md
@@ -19,10 +19,10 @@ You receive the test results and proof status from the Tester. You have read-onl
    - **Security** — command injection, XSS, SQL injection, exposed secrets, missing auth/authz
    - **Quality** — naming clarity, dead code, unnecessary complexity, violated project conventions
    - **Test coverage** — are the changes adequately tested? Are critical paths covered?
-
-> **Stage-key checklist:** When reviewing code that reads `status.json`, verify all stage comparisons use stage keys (`preflight`, `plan`, `plan_review`, `coordinate`, `implement`, `test`, `review`, `pr`, `learn`), never agent names. The `pr` stage is run by the `guardian` agent — `'guardian'` will never appear as a stage key. Writing `stages.guardian` or `key === 'guardian'` silently no-ops in production while passing tests seeded with the same wrong key.
 4. Categorize issues by severity (see Output section)
 5. Decide outcome based on findings (see Review Outcomes)
+
+> **Stage-key checklist:** When reviewing code that reads `status.json`, verify all stage comparisons use stage keys (`preflight`, `plan`, `plan_review`, `coordinate`, `implement`, `test`, `review`, `pr`, `learn`), never agent names. The `pr` stage is run by the `guardian` agent — `'guardian'` will never appear as a stage key. Writing `stages.guardian` or `key === 'guardian'` silently no-ops in production while passing tests seeded with the same wrong key.
 
 The work request, test results, and files-changed list arrive as a user message.
 

--- a/src/worca/agents/core/reviewer.md
+++ b/src/worca/agents/core/reviewer.md
@@ -19,6 +19,8 @@ You receive the test results and proof status from the Tester. You have read-onl
    - **Security** — command injection, XSS, SQL injection, exposed secrets, missing auth/authz
    - **Quality** — naming clarity, dead code, unnecessary complexity, violated project conventions
    - **Test coverage** — are the changes adequately tested? Are critical paths covered?
+
+> **Stage-key checklist:** When reviewing code that reads `status.json`, verify all stage comparisons use stage keys (`preflight`, `plan`, `plan_review`, `coordinate`, `implement`, `test`, `review`, `pr`, `learn`), never agent names. The `pr` stage is run by the `guardian` agent — `'guardian'` will never appear as a stage key. Writing `stages.guardian` or `key === 'guardian'` silently no-ops in production while passing tests seeded with the same wrong key.
 4. Categorize issues by severity (see Output section)
 5. Decide outcome based on findings (see Review Outcomes)
 

--- a/tests/test_agent_md_refs.py
+++ b/tests/test_agent_md_refs.py
@@ -96,6 +96,13 @@ def test_implementer_has_retry_rules_section():
     assert "## Retry Rules" in content
 
 
+def test_implementer_has_stage_key_nudge():
+    content = _read("implementer.md")
+    assert "stages.guardian" in content, (
+        "implementer.md must warn that stages is keyed by stage name, never agent name"
+    )
+
+
 # ---------------------------------------------------------------------------
 # tester.md
 # ---------------------------------------------------------------------------
@@ -148,6 +155,13 @@ def test_guardian_example_json_contains_commit_sha():
 def test_reviewer_does_not_embed_block_review():
     content = _read("reviewer.md")
     assert "{{block:review}}" not in content
+
+
+def test_reviewer_has_stage_key_nudge():
+    content = _read("reviewer.md")
+    assert "stages.guardian" in content, (
+        "reviewer.md must warn that stages is keyed by stage name, never agent name"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/worca-ui/app/utils/stage-order.js
+++ b/worca-ui/app/utils/stage-order.js
@@ -14,6 +14,8 @@ export const STAGE_ORDER = [
   'learn',
 ];
 
+export const STAGE_VALUES = new Set(STAGE_ORDER);
+
 /** Stage order with orchestrator prepended (for log display). */
 export const STAGE_ORDER_WITH_ORCHESTRATOR = ['orchestrator', ...STAGE_ORDER];
 

--- a/worca-ui/app/utils/stage-order.test.js
+++ b/worca-ui/app/utils/stage-order.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { STAGE_ORDER, STAGE_VALUES } from './stage-order.js';
+
+describe('STAGE_VALUES', () => {
+  it('is a Set', () => {
+    expect(STAGE_VALUES).toBeInstanceOf(Set);
+  });
+
+  it('contains all entries from STAGE_ORDER', () => {
+    for (const stage of STAGE_ORDER) {
+      expect(STAGE_VALUES.has(stage)).toBe(true);
+    }
+  });
+
+  it('has the same size as STAGE_ORDER', () => {
+    expect(STAGE_VALUES.size).toBe(STAGE_ORDER.length);
+  });
+
+  it('provides O(1) membership check — known stage returns true', () => {
+    expect(STAGE_VALUES.has('pr')).toBe(true);
+  });
+
+  it('returns false for agent names that are not stage keys', () => {
+    expect(STAGE_VALUES.has('guardian')).toBe(false);
+  });
+});

--- a/worca-ui/e2e/fixtures.js
+++ b/worca-ui/e2e/fixtures.js
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import { createApp } from '../server/app.js';
 import { attachWsServer } from '../server/ws.js';
 import { createInbox } from '../server/webhook-inbox.js';
+import { assertStageShape } from '../test/helpers/assert-stage-shape.js';
 
 /**
  * Start an isolated worca-ui server on a random port backed by a temp directory.
@@ -87,6 +88,7 @@ export function seedRun(worcaDir, runId, statusOverrides = {}) {
     stages: { plan: { status: 'in_progress' } },
     ...statusOverrides,
   };
+  assertStageShape(status);
   writeFileSync(join(runDir, 'status.json'), JSON.stringify(status, null, 2) + '\n', 'utf8');
   return status;
 }

--- a/worca-ui/e2e/multi-project.spec.js
+++ b/worca-ui/e2e/multi-project.spec.js
@@ -123,8 +123,8 @@ test.describe('multi-project', () => {
   test('run status endpoint works within project scope', async ({ page }) => {
     seedRun(ctx.worcaDirB, 'status-run-beta', {
       pipeline_status: 'completed',
-      stage: 'guardian',
-      stages: { guardian: { status: 'completed', iteration: 1 } },
+      stage: 'pr',
+      stages: { pr: { status: 'completed', iteration: 1 } },
     });
 
     const statusRes = await page.request.get(
@@ -133,7 +133,7 @@ test.describe('multi-project', () => {
     const body = await statusRes.json();
     expect(body.ok).toBe(true);
     expect(body.pipeline_status).toBe('completed');
-    expect(body.stage).toBe('guardian');
+    expect(body.stage).toBe('pr');
 
     // Same run should NOT be found in alpha
     const notFound = await page.request.get(

--- a/worca-ui/e2e/pr-details-panel.spec.js
+++ b/worca-ui/e2e/pr-details-panel.spec.js
@@ -159,7 +159,7 @@ test.describe('PR details panel — collapsible subsection', () => {
       seedRun(serverCtx.worcaDir, runId, {
         pipeline_status: 'completed',
         stages: {
-          guardian: {
+          pr: {
             status: 'completed',
             iterations: [{ number: 1, status: 'completed', outcome: 'success' }],
           },

--- a/worca-ui/e2e/stage-timeline.spec.js
+++ b/worca-ui/e2e/stage-timeline.spec.js
@@ -25,7 +25,7 @@ test.describe('stage timeline — individual stage statuses', () => {
           coordinate: { status: 'completed' },
           implement: { status: 'completed' },
           test: { status: 'completed' },
-          guardian: { status: 'completed' },
+          pr: { status: 'completed' },
         },
       });
       await openRunDetail(page, ctx.url, runId);
@@ -114,7 +114,7 @@ test.describe('stage timeline — individual stage statuses', () => {
           coordinate: { status: 'in_progress' },
           implement: { status: 'pending' },
           test: { status: 'pending' },
-          guardian: { status: 'pending' },
+          pr: { status: 'pending' },
         },
       });
       await openRunDetail(page, ctx.url, runId);
@@ -164,7 +164,7 @@ test.describe('stage timeline — mixed states', () => {
           coordinate: { status: 'completed' },
           implement: { status: 'running' },
           test: { status: 'pending' },
-          guardian: { status: 'pending' },
+          pr: { status: 'pending' },
           review: { status: 'pending' },
         },
       });

--- a/worca-ui/server/test/multi-project-api.test.js
+++ b/worca-ui/server/test/multi-project-api.test.js
@@ -232,7 +232,7 @@ describe('multi-project API', () => {
       mkdirSync(runDir, { recursive: true });
       writeFileSync(
         join(runDir, 'status.json'),
-        JSON.stringify({ pipeline_status: 'completed', stage: 'guardian' }),
+        JSON.stringify({ pipeline_status: 'completed', stage: 'pr' }),
       );
 
       const app = buildApp();

--- a/worca-ui/test/helpers/assert-stage-shape.js
+++ b/worca-ui/test/helpers/assert-stage-shape.js
@@ -1,0 +1,37 @@
+import { STAGE_VALUES } from '../../app/utils/stage-order.js';
+
+// Inverted from STAGE_AGENT_MAP in settings.js: agent name → stage key
+const AGENT_TO_STAGE = {
+  planner: 'plan',
+  plan_reviewer: 'plan_review',
+  coordinator: 'coordinate',
+  implementer: 'implement',
+  tester: 'test',
+  reviewer: 'review',
+  guardian: 'pr',
+  learner: 'learn',
+};
+
+function assertValidStageKey(value, context) {
+  if (value == null) return;
+  if (!STAGE_VALUES.has(value)) {
+    const hint = AGENT_TO_STAGE[value];
+    const suffix = hint ? `; you probably meant '${hint}'` : '';
+    throw new Error(`'${value}' is not a stage key${suffix} (in ${context})`);
+  }
+}
+
+/**
+ * Asserts that status.stage and all keys of status.stages are valid stage keys.
+ * Throws a descriptive error for agent names mistakenly used as stage keys.
+ * Exported for use in test fixtures.
+ */
+export function assertStageShape(status) {
+  assertValidStageKey(status.stage, 'status.stage');
+
+  if (status.stages != null) {
+    for (const key of Object.keys(status.stages)) {
+      assertValidStageKey(key, 'status.stages');
+    }
+  }
+}

--- a/worca-ui/test/helpers/assert-stage-shape.test.js
+++ b/worca-ui/test/helpers/assert-stage-shape.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { assertStageShape } from './assert-stage-shape.js';
+
+describe('assertStageShape', () => {
+  it('passes for a valid status with no stage fields', () => {
+    expect(() => assertStageShape({})).not.toThrow();
+  });
+
+  it('passes for a valid status.stage', () => {
+    expect(() => assertStageShape({ stage: 'pr' })).not.toThrow();
+    expect(() => assertStageShape({ stage: 'implement' })).not.toThrow();
+    expect(() => assertStageShape({ stage: 'preflight' })).not.toThrow();
+  });
+
+  it('passes for a valid status.stages map', () => {
+    expect(() =>
+      assertStageShape({ stages: { plan: {}, pr: {}, implement: {} } }),
+    ).not.toThrow();
+  });
+
+  it('passes for a full valid status object', () => {
+    expect(() =>
+      assertStageShape({
+        stage: 'implement',
+        stages: { plan: {}, coordinate: {}, implement: {} },
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws for status.stage 'guardian' with 'pr' hint", () => {
+    expect(() => assertStageShape({ stage: 'guardian' })).toThrow(
+      "'guardian' is not a stage key; you probably meant 'pr'",
+    );
+  });
+
+  it("throws for status.stage 'planner' with 'plan' hint", () => {
+    expect(() => assertStageShape({ stage: 'planner' })).toThrow(
+      "'planner' is not a stage key; you probably meant 'plan'",
+    );
+  });
+
+  it("throws for status.stage 'tester' with 'test' hint", () => {
+    expect(() => assertStageShape({ stage: 'tester' })).toThrow(
+      "'tester' is not a stage key; you probably meant 'test'",
+    );
+  });
+
+  it('throws for status.stage with unknown value and no hint', () => {
+    expect(() => assertStageShape({ stage: 'bogus' })).toThrow(
+      "'bogus' is not a stage key",
+    );
+  });
+
+  it("throws for 'guardian' key in status.stages with 'pr' hint", () => {
+    expect(() => assertStageShape({ stages: { guardian: {} } })).toThrow(
+      "'guardian' is not a stage key; you probably meant 'pr'",
+    );
+  });
+
+  it("throws for 'planner' key in status.stages with 'plan' hint", () => {
+    expect(() => assertStageShape({ stages: { planner: {} } })).toThrow(
+      "'planner' is not a stage key; you probably meant 'plan'",
+    );
+  });
+
+  it('throws for unknown key in status.stages with no hint', () => {
+    expect(() => assertStageShape({ stages: { mystery: {} } })).toThrow(
+      "'mystery' is not a stage key",
+    );
+  });
+
+  it('throws for first bad key when stages has multiple invalid keys', () => {
+    expect(() =>
+      assertStageShape({ stages: { guardian: {}, planner: {} } }),
+    ).toThrow("is not a stage key");
+  });
+
+  it('ignores null stage field', () => {
+    expect(() => assertStageShape({ stage: null })).not.toThrow();
+  });
+
+  it('ignores undefined stage field', () => {
+    expect(() => assertStageShape({ stage: undefined })).not.toThrow();
+  });
+
+  it('ignores null stages field', () => {
+    expect(() => assertStageShape({ stages: null })).not.toThrow();
+  });
+
+  it('ignores undefined stages field', () => {
+    expect(() => assertStageShape({ stages: undefined })).not.toThrow();
+  });
+});

--- a/worca-ui/test/stage-contract.test.js
+++ b/worca-ui/test/stage-contract.test.js
@@ -4,7 +4,6 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join, dirname } from 'node:path';
 import { STAGE_ORDER, STAGE_VALUES } from '../app/utils/stage-order.js';
-import { assertStageShape } from './helpers/assert-stage-shape.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..', '..');
@@ -12,11 +11,10 @@ const PROJECT_ROOT = join(__dirname, '..', '..');
 const PYTHON_SCRIPT = `
 import json, sys
 sys.path.insert(0, 'src')
-from worca.orchestrator.stages import Stage, STAGE_AGENT_MAP, STAGE_SCHEMA_MAP
+from worca.orchestrator.stages import Stage, STAGE_AGENT_MAP
 print(json.dumps({
     'stage_values': [s.value for s in Stage],
     'stage_agent_map': {s.value: a for s, a in STAGE_AGENT_MAP.items()},
-    'stage_schema_map': {s.value: sc for s, sc in STAGE_SCHEMA_MAP.items()},
 }))
 `;
 
@@ -25,10 +23,9 @@ function hasPython3() {
   return r.status === 0 && r.error == null;
 }
 
-/**
- * Parse STAGE_AGENT_MAP from settings.js source without importing it.
- * Avoids the lit-html browser dependency in the Node test environment.
- */
+// settings.js can't be imported in Node — it pulls in lit-html which expects a
+// browser. We parse the source instead. The empty-map check below guards
+// against silent regressions if STAGE_AGENT_MAP gets reformatted.
 function readJsStageAgentMap() {
   const src = readFileSync(join(__dirname, '../app/views/settings.js'), 'utf8');
   const match = src.match(/export const STAGE_AGENT_MAP = \{([^}]+)\}/);
@@ -38,10 +35,22 @@ function readJsStageAgentMap() {
     const m = line.match(/^\s+(\w+):\s+'(\w+)',?\s*$/);
     if (m) map[m[1]] = m[2];
   }
+  if (Object.keys(map).length === 0) {
+    throw new Error(
+      'Parsed STAGE_AGENT_MAP is empty — regex in readJsStageAgentMap is out of date with settings.js',
+    );
+  }
   return map;
 }
 
 const python3Available = hasPython3();
+if (!python3Available) {
+  // Skipping silently makes the contract invisible on machines without python3.
+  // CI always has python3, so this is just a local-dev signal.
+  console.warn(
+    '[stage-contract] python3 not on PATH — JS↔Python contract tests skipped',
+  );
+}
 
 describe.skipIf(!python3Available)('stage contract: JS vs Python', () => {
   let py;
@@ -89,27 +98,5 @@ describe.skipIf(!python3Available)('stage contract: JS vs Python', () => {
         `'${stage}' is in JS STAGE_AGENT_MAP but not in Python STAGE_AGENT_MAP`,
       ).toBe(true);
     }
-  });
-});
-
-describe('assertStageShape self-tests', () => {
-  it("rejects 'guardian' as a stage key with 'pr' hint", () => {
-    expect(() => assertStageShape({ stage: 'guardian' })).toThrow(
-      "'guardian' is not a stage key; you probably meant 'pr'",
-    );
-  });
-
-  it("accepts 'pr' as a valid stage key", () => {
-    expect(() => assertStageShape({ stage: 'pr' })).not.toThrow();
-  });
-
-  it("rejects 'guardian' in stages map with 'pr' hint", () => {
-    expect(() => assertStageShape({ stages: { guardian: {} } })).toThrow(
-      "'guardian' is not a stage key; you probably meant 'pr'",
-    );
-  });
-
-  it("accepts 'pr' key in stages map", () => {
-    expect(() => assertStageShape({ stages: { pr: {} } })).not.toThrow();
   });
 });

--- a/worca-ui/test/stage-contract.test.js
+++ b/worca-ui/test/stage-contract.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+import { STAGE_ORDER, STAGE_VALUES } from '../app/utils/stage-order.js';
+import { assertStageShape } from './helpers/assert-stage-shape.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+
+const PYTHON_SCRIPT = `
+import json, sys
+sys.path.insert(0, 'src')
+from worca.orchestrator.stages import Stage, STAGE_AGENT_MAP, STAGE_SCHEMA_MAP
+print(json.dumps({
+    'stage_values': [s.value for s in Stage],
+    'stage_agent_map': {s.value: a for s, a in STAGE_AGENT_MAP.items()},
+    'stage_schema_map': {s.value: sc for s, sc in STAGE_SCHEMA_MAP.items()},
+}))
+`;
+
+function hasPython3() {
+  const r = spawnSync('python3', ['--version']);
+  return r.status === 0 && r.error == null;
+}
+
+/**
+ * Parse STAGE_AGENT_MAP from settings.js source without importing it.
+ * Avoids the lit-html browser dependency in the Node test environment.
+ */
+function readJsStageAgentMap() {
+  const src = readFileSync(join(__dirname, '../app/views/settings.js'), 'utf8');
+  const match = src.match(/export const STAGE_AGENT_MAP = \{([^}]+)\}/);
+  if (!match) throw new Error('Could not find STAGE_AGENT_MAP in settings.js');
+  const map = {};
+  for (const line of match[1].split('\n')) {
+    const m = line.match(/^\s+(\w+):\s+'(\w+)',?\s*$/);
+    if (m) map[m[1]] = m[2];
+  }
+  return map;
+}
+
+const python3Available = hasPython3();
+
+describe.skipIf(!python3Available)('stage contract: JS vs Python', () => {
+  let py;
+
+  beforeAll(() => {
+    const out = execFileSync('python3', ['-c', PYTHON_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+    });
+    py = JSON.parse(out);
+  });
+
+  it('JS STAGE_ORDER covers all Python Stage enum values', () => {
+    for (const val of py.stage_values) {
+      expect(
+        STAGE_VALUES.has(val),
+        `'${val}' is in Python Stage enum but missing from JS STAGE_ORDER`,
+      ).toBe(true);
+    }
+  });
+
+  it('JS STAGE_ORDER has no extra values beyond Python Stage enum', () => {
+    const pySet = new Set(py.stage_values);
+    for (const val of STAGE_ORDER) {
+      expect(
+        pySet.has(val),
+        `'${val}' is in JS STAGE_ORDER but not in Python Stage enum`,
+      ).toBe(true);
+    }
+  });
+
+  it('JS STAGE_AGENT_MAP entries match Python STAGE_AGENT_MAP', () => {
+    const jsMap = readJsStageAgentMap();
+    for (const [stage, agent] of Object.entries(py.stage_agent_map)) {
+      if (agent === null) continue;
+      expect(jsMap[stage]).toBe(agent);
+    }
+  });
+
+  it('JS STAGE_AGENT_MAP has no entries absent from Python STAGE_AGENT_MAP', () => {
+    const jsMap = readJsStageAgentMap();
+    for (const stage of Object.keys(jsMap)) {
+      expect(
+        stage in py.stage_agent_map,
+        `'${stage}' is in JS STAGE_AGENT_MAP but not in Python STAGE_AGENT_MAP`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('assertStageShape self-tests', () => {
+  it("rejects 'guardian' as a stage key with 'pr' hint", () => {
+    expect(() => assertStageShape({ stage: 'guardian' })).toThrow(
+      "'guardian' is not a stage key; you probably meant 'pr'",
+    );
+  });
+
+  it("accepts 'pr' as a valid stage key", () => {
+    expect(() => assertStageShape({ stage: 'pr' })).not.toThrow();
+  });
+
+  it("rejects 'guardian' in stages map with 'pr' hint", () => {
+    expect(() => assertStageShape({ stages: { guardian: {} } })).toThrow(
+      "'guardian' is not a stage key; you probably meant 'pr'",
+    );
+  });
+
+  it("accepts 'pr' key in stages map", () => {
+    expect(() => assertStageShape({ stages: { pr: {} } })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **Contract test** validates JS `STAGE_ORDER` and `STAGE_AGENT_MAP` against the Python `Stage` enum at test time via `execFileSync` — catches future drift between JS and Python stage constants
- **`STAGE_VALUES` Set** export in `stage-order.js` + **`assertStageShape`** fixture guard helper that rejects agent names used as stage keys with a helpful hint (e.g. `'guardian' is not a stage key; you probably meant 'pr'`)
- **Fixed 3 stale fixtures** in `multi-project-api.test.js` and `multi-project.spec.js` that used `'guardian'` instead of `'pr'` as a stage key — these would silently no-op in production
- **Prompt nudges** in `implementer.md` and `reviewer.md` agent templates warning about the stage-key vs agent-name distinction

## Test plan

- [x] `npx vitest run worca-ui/app/utils/stage-order.test.js` — STAGE_VALUES unit tests
- [x] `npx vitest run worca-ui/test/helpers/assert-stage-shape.test.js` — fixture guard self-tests (14 cases)
- [x] `npx vitest run worca-ui/test/stage-contract.test.js` — JS↔Python contract tests
- [x] `npx vitest run worca-ui/server/test/multi-project-api.test.js` — fixed fixture passes
- [x] `pytest tests/test_agent_md_refs.py` — prompt nudge presence tests
- [x] `cd worca-ui && npx playwright test e2e/multi-project.spec.js --workers=1` — e2e with fixed fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)