### PR TITLE
fix(ui): bulk worktree cleanup freezes UI and under-reports disk

### DIFF
--- a/worca-ui/app/main.bulk-cleanup.test.js
+++ b/worca-ui/app/main.bulk-cleanup.test.js
@@ -1,0 +1,75 @@
+/**
+ * Tests for the bulk worktree cleanup path in main.js.
+ *
+ * Uses source-text inspection to verify structural contracts without
+ * importing main.js (which has browser-side side effects and DOM deps).
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, 'main.js'), 'utf8');
+
+// Extract the confirmWorktreeCleanup function body from source
+function extractFunctionBody(source, fnName) {
+  const marker = `function ${fnName}(`;
+  const start = source.indexOf(marker);
+  if (start === -1) return null;
+  let i = source.indexOf('{', start);
+  if (i === -1) return null;
+  let depth = 0;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    if (source[i] === '}') depth--;
+    if (depth === 0) break;
+  }
+  return source.slice(start, i + 1);
+}
+
+const fnBody = extractFunctionBody(src, 'confirmWorktreeCleanup');
+
+describe('confirmWorktreeCleanup — bulk path structure', () => {
+  it('function exists in main.js', () => {
+    expect(fnBody).not.toBeNull();
+  });
+
+  it('bulk path fires a single POST to /worktrees/cleanup (not N DELETEs)', () => {
+    // Must contain exactly one POST call to the cleanup endpoint
+    expect(fnBody).toContain('POST');
+    expect(fnBody).toContain('/worktrees/cleanup');
+    // Must NOT use a for-of loop that calls deleteWorktree per iteration
+    // (the old loop used "await deleteWorktree" inside a for...of)
+    expect(fnBody).not.toMatch(
+      /for\s*\(.*of\s+completed\b[\s\S]*?deleteWorktree/,
+    );
+  });
+
+  it('bulk path sends force: true in the request body', () => {
+    expect(fnBody).toContain('force: true');
+  });
+
+  it('bulk path optimistically removes completed cards from store before response settles', () => {
+    // The optimistic removal must happen synchronously BEFORE the await on fetch.
+    // We check that setState (removing cards) appears before the await fetch call
+    // in the bulk branch of confirmWorktreeCleanup.
+    const bulkBranchStart = fnBody.indexOf('runId === null');
+    expect(bulkBranchStart).toBeGreaterThan(-1);
+    const bulkBranch = fnBody.slice(bulkBranchStart);
+    const setStateIdx = bulkBranch.indexOf('setState');
+    const awaitFetchIdx = bulkBranch.indexOf('await fetch');
+    expect(setStateIdx).toBeGreaterThan(-1);
+    expect(awaitFetchIdx).toBeGreaterThan(-1);
+    expect(setStateIdx).toBeLessThan(awaitFetchIdx);
+  });
+
+  it('bulk path includes run_ids array in the POST body', () => {
+    expect(fnBody).toContain('run_ids');
+  });
+
+  it('bulk path maps per-id server failures to showActionError toast', () => {
+    expect(fnBody).toContain('showActionError');
+  });
+});

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -1456,21 +1456,40 @@ async function deleteWorktree(runId, force) {
 }
 
 async function confirmWorktreeCleanup(runId, force) {
-  // Bulk path: runId is null, delete every completed worktree.
+  // Bulk path: runId is null, delete every completed worktree via one POST.
   if (runId === null) {
     const completed = (store.getState().worktrees || []).filter(
       (w) => w.status === 'completed',
     );
     closeWorktreeCleanupDialog();
-    const failures = [];
-    for (const wt of completed) {
+    const runIds = completed.map((w) => w.run_id);
+    // Optimistic removal — drop targeted cards from state before response settles
+    // so the UI redraws immediately and the user sees progress.
+    store.setState({
+      worktrees: (store.getState().worktrees || []).filter(
+        (w) => !runIds.includes(w.run_id),
+      ),
+    });
+    const url = projectUrl('/worktrees/cleanup');
+    let data = null;
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ run_ids: runIds, force: true }),
+      });
       try {
-        await deleteWorktree(wt.run_id, false);
-      } catch (err) {
-        failures.push(`${wt.title || wt.run_id}: ${err.message}`);
+        data = await res.json();
+      } catch {
+        /* ignore parse errors */
       }
+    } catch {
+      /* network error — fetchWorktrees will reconcile */
     }
     fetchWorktrees();
+    const failures = (data?.results || [])
+      .filter((r) => !r.ok)
+      .map((r) => `${r.run_id}: ${r.error || 'failed'}`);
     if (failures.length > 0) {
       showActionError(
         `Cleanup completed with ${failures.length} failure(s):\n${failures.join('\n')}`,

--- a/worca-ui/app/views/worktrees.js
+++ b/worca-ui/app/views/worktrees.js
@@ -124,7 +124,7 @@ function _cardView(wt, { onSelectRun, onCleanup } = {}) {
         </span>
         <span class="run-card-meta-item">
           <span class="meta-label">Disk:</span>
-          <span class="meta-value">${_formatBytes(wt.disk_bytes)}</span>
+          <span class="meta-value">${wt.truncated ? html`≥ ${_formatBytes(wt.disk_bytes)}` : _formatBytes(wt.disk_bytes)}</span>
         </span>
         <span class="run-card-meta-item">
           <span class="meta-label">Age:</span>
@@ -269,6 +269,8 @@ function _bulkDialogView(
     ),
   ].filter(Boolean);
 
+  const groupedCount = completed.filter((w) => w.group_type).length;
+
   return html`
     <sl-dialog
       label="Cleanup all completed worktrees"
@@ -287,6 +289,11 @@ function _bulkDialogView(
                 ${groupLines.map((line) => html`<li>${line}</li>`)}
               </ul>
             `
+          : nothing
+      }
+      ${
+        groupedCount > 0
+          ? html`<p class="bulk-grouped-caveat">Includes ${groupedCount} grouped — resume will be unavailable.</p>`
           : nothing
       }
       <div slot="footer" class="dialog-actions">

--- a/worca-ui/app/views/worktrees.test.js
+++ b/worca-ui/app/views/worktrees.test.js
@@ -482,4 +482,57 @@ describe('worktreesView - bulk cleanup', () => {
     const output = renderToString(worktreesView([runningWorktree]));
     expect(output).not.toContain('btn-bulk-cleanup');
   });
+
+  it('bulk dialog shows grouped caveat when grouped completed are included', () => {
+    const groupedCompleted = {
+      ...completedWorktree,
+      run_id: 'run-grouped-c',
+      fleet_id: 'f_abc',
+      group_type: 'fleet',
+    };
+    const output = renderToString(
+      worktreesView([completedWorktree, groupedCompleted], {
+        dialogBulk: true,
+      }),
+    );
+    expect(output).toContain('grouped');
+    expect(output).toContain('resume will be unavailable');
+  });
+
+  it('bulk dialog grouped caveat is absent when no grouped completed worktrees', () => {
+    const output = renderToString(
+      worktreesView([completedWorktree], { dialogBulk: true }),
+    );
+    // completedWorktree has no group_type — no caveat
+    expect(output).not.toContain('resume will be unavailable');
+  });
+});
+
+describe('worktreesView - truncated disk display', () => {
+  it('shows >= prefix for card disk value when truncated flag is set', () => {
+    const truncatedWt = {
+      ...completedWorktree,
+      disk_bytes: 100_000_000,
+      truncated: true,
+    };
+    const output = renderToString(worktreesView([truncatedWt]));
+    expect(output).toContain('≥ 100.0 MB');
+  });
+
+  it('does not show >= prefix when truncated flag is absent', () => {
+    const normalWt = { ...completedWorktree, disk_bytes: 100_000_000 };
+    const output = renderToString(worktreesView([normalWt]));
+    expect(output).toContain('100.0 MB');
+    expect(output).not.toContain('≥');
+  });
+
+  it('does not show >= prefix when truncated is false', () => {
+    const normalWt = {
+      ...completedWorktree,
+      disk_bytes: 100_000_000,
+      truncated: false,
+    };
+    const output = renderToString(worktreesView([normalWt]));
+    expect(output).not.toContain('≥');
+  });
 });

--- a/worca-ui/server/test/process-manager-args.test.js
+++ b/worca-ui/server/test/process-manager-args.test.js
@@ -26,6 +26,7 @@ vi.mock('node:child_process', () => ({
     // Simulate a child that stays alive (timeout resolves the promise)
     return fakeChild;
   }),
+  execFile: vi.fn(),
   execFileSync: vi.fn(),
 }));
 

--- a/worca-ui/server/test/process-manager-worktree-start.test.js
+++ b/worca-ui/server/test/process-manager-worktree-start.test.js
@@ -16,6 +16,7 @@ vi.mock('node:child_process', () => ({
     spawnCalls.push(args);
     return fakeChild;
   }),
+  execFile: vi.fn(),
   execFileSync: vi.fn(),
 }));
 

--- a/worca-ui/server/worktree-ops.js
+++ b/worca-ui/server/worktree-ops.js
@@ -2,33 +2,37 @@
  * Shared worktree operations — single owner of `git worktree remove` shell-out.
  */
 
-import { execFileSync } from 'node:child_process';
-import {
-  existsSync,
-  lstatSync,
-  readFileSync,
-  rmSync,
-  unlinkSync,
-} from 'node:fs';
+import { execFile } from 'node:child_process';
+import { existsSync, lstatSync } from 'node:fs';
+import { readFile, rm, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Remove a worktree and its registry entry.
  * Mirrors WorktreeSource.remove from src/worca/cli/cleanup.py:
  *   1. Attempt `git worktree remove --force <path>` from the project root
- *   2. On failure (e.g. non-worktree temp dir in tests), fall back to rmSync
+ *   2. On failure (e.g. non-worktree temp dir in tests), fall back to rm (async)
  *   3. Run `git worktree prune` so git's metadata (`.git/worktrees/<id>/`)
  *      drops the entry even when the directory was removed manually
+ *      (skipped when skipPrune is true — caller is responsible for pruning later)
  *   4. Delete the registry file
  */
-export function removeWorktree(worcaDir, runId) {
+export async function removeWorktree(
+  worcaDir,
+  runId,
+  { skipPrune = false } = {},
+) {
   const regFile = join(worcaDir, 'multi', 'pipelines.d', `${runId}.json`);
   const projectRoot = join(worcaDir, '..');
   let worktreePath = null;
 
   if (existsSync(regFile)) {
     try {
-      const reg = JSON.parse(readFileSync(regFile, 'utf8'));
+      const content = await readFile(regFile, 'utf8');
+      const reg = JSON.parse(content);
       worktreePath = reg.worktree_path || null;
     } catch {
       /* ignore */
@@ -37,11 +41,15 @@ export function removeWorktree(worcaDir, runId) {
 
   if (worktreePath && existsSync(worktreePath)) {
     try {
-      execFileSync('git', ['worktree', 'remove', '--force', worktreePath], {
-        cwd: projectRoot,
-        stdio: 'pipe',
-        timeout: 30_000,
-      });
+      await execFileAsync(
+        'git',
+        ['worktree', 'remove', '--force', worktreePath],
+        {
+          cwd: projectRoot,
+          stdio: 'pipe',
+          timeout: 30_000,
+        },
+      );
     } catch {
       let isRealDir = false;
       try {
@@ -51,22 +59,41 @@ export function removeWorktree(worcaDir, runId) {
         /* ignore */
       }
       if (isRealDir) {
-        rmSync(worktreePath, { recursive: true, force: true });
+        await rm(worktreePath, { recursive: true, force: true });
       }
     }
   }
 
+  if (!skipPrune) {
+    try {
+      await execFileAsync('git', ['worktree', 'prune'], {
+        cwd: projectRoot,
+        stdio: 'pipe',
+        timeout: 30_000,
+      });
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  if (existsSync(regFile)) {
+    await unlink(regFile);
+  }
+}
+
+/**
+ * Run `git worktree prune` once for the project at worcaDir.
+ * Use after a batch of removeWorktree({ skipPrune: true }) calls.
+ */
+export async function pruneWorktrees(worcaDir) {
+  const projectRoot = join(worcaDir, '..');
   try {
-    execFileSync('git', ['worktree', 'prune'], {
+    await execFileAsync('git', ['worktree', 'prune'], {
       cwd: projectRoot,
       stdio: 'pipe',
       timeout: 30_000,
     });
   } catch {
     /* non-fatal */
-  }
-
-  if (existsSync(regFile)) {
-    unlinkSync(regFile);
   }
 }

--- a/worca-ui/server/worktree-ops.test.js
+++ b/worca-ui/server/worktree-ops.test.js
@@ -46,6 +46,15 @@ describe('worktree-ops', () => {
   }
 
   it('event loop is unblocked during parallel removeWorktree calls', async () => {
+    // Make the mocked git invocation deliberately slow so the test actually
+    // exercises liveness — a sync execFileSync impl would block the timer
+    // and ticks would stay near zero. With async execFile the ticker should
+    // accumulate well into the double digits over the ~100ms total.
+    mockExecFile.mockImplementation((...args) => {
+      const cb = args[args.length - 1];
+      setTimeout(() => cb(null, '', ''), 50);
+    });
+
     let ticks = 0;
     let running = true;
     function ticker() {
@@ -69,7 +78,11 @@ describe('worktree-ops', () => {
     // Flush one more round so the last ticker setImmediate can fire
     await new Promise((r) => setImmediate(r));
 
-    expect(ticks).toBeGreaterThan(0);
+    // Each remove issues 2 sequential git calls (remove + prune), each 50ms.
+    // Two parallel removes ⇒ ~100ms of awaiting, which is plenty of headroom
+    // for setImmediate to fire many times. Anything below 10 means the loop
+    // was being blocked.
+    expect(ticks).toBeGreaterThanOrEqual(10);
   });
 
   it('skipPrune=true skips git worktree prune', async () => {

--- a/worca-ui/server/worktree-ops.test.js
+++ b/worca-ui/server/worktree-ops.test.js
@@ -1,0 +1,104 @@
+/**
+ * Tests: worktree-ops async API
+ * TDD: written before implementation.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFile = vi.fn();
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, execFile: (...args) => mockExecFile(...args) };
+});
+
+const { removeWorktree, pruneWorktrees } = await import('./worktree-ops.js');
+
+describe('worktree-ops', () => {
+  let tmpDir;
+  let worcaDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'worca-ops-'));
+    worcaDir = join(tmpDir, '.worca');
+    mkdirSync(join(worcaDir, 'multi', 'pipelines.d'), { recursive: true });
+
+    // Default mock: succeed via setImmediate (yields to event loop)
+    mockExecFile.mockImplementation((...args) => {
+      const cb = args[args.length - 1];
+      setImmediate(() => cb(null, '', ''));
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    mockExecFile.mockReset();
+  });
+
+  function writeReg(runId, data = {}) {
+    writeFileSync(
+      join(worcaDir, 'multi', 'pipelines.d', `${runId}.json`),
+      JSON.stringify(data),
+    );
+  }
+
+  it('event loop is unblocked during parallel removeWorktree calls', async () => {
+    let ticks = 0;
+    let running = true;
+    function ticker() {
+      if (running)
+        setImmediate(() => {
+          ticks++;
+          ticker();
+        });
+    }
+    ticker();
+
+    writeReg('run-a');
+    writeReg('run-b');
+
+    await Promise.all([
+      removeWorktree(worcaDir, 'run-a'),
+      removeWorktree(worcaDir, 'run-b'),
+    ]);
+
+    running = false;
+    // Flush one more round so the last ticker setImmediate can fire
+    await new Promise((r) => setImmediate(r));
+
+    expect(ticks).toBeGreaterThan(0);
+  });
+
+  it('skipPrune=true skips git worktree prune', async () => {
+    writeReg('run-skip');
+    await removeWorktree(worcaDir, 'run-skip', { skipPrune: true });
+
+    const pruneCalls = mockExecFile.mock.calls.filter(
+      (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1].includes('prune'),
+    );
+    expect(pruneCalls).toHaveLength(0);
+  });
+
+  it('pruneWorktrees runs once after N skipPrune removes', async () => {
+    writeReg('run-1');
+    writeReg('run-2');
+    writeReg('run-3');
+
+    await Promise.all([
+      removeWorktree(worcaDir, 'run-1', { skipPrune: true }),
+      removeWorktree(worcaDir, 'run-2', { skipPrune: true }),
+      removeWorktree(worcaDir, 'run-3', { skipPrune: true }),
+    ]);
+
+    mockExecFile.mockClear();
+    await pruneWorktrees(worcaDir);
+
+    const pruneCalls = mockExecFile.mock.calls.filter(
+      (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1].includes('prune'),
+    );
+    expect(pruneCalls).toHaveLength(1);
+  });
+});

--- a/worca-ui/server/worktrees-routes.js
+++ b/worca-ui/server/worktrees-routes.js
@@ -3,6 +3,7 @@
  *
  * GET  /worktrees          — list worktree entries enriched with disk/age/group data
  * DELETE /worktrees/:run_id — remove a worktree (409 if running, 412 if resumable/grouped without ?force=1)
+ * POST /worktrees/cleanup  — batch remove (always returns 200 with `{ok, results, failed_count}`)
  *
  * Expects req.project.worcaDir to be set by projectResolver middleware.
  */
@@ -15,13 +16,28 @@ import { pruneWorktrees, removeWorktree } from './worktree-ops.js';
 
 const CLEANUP_CONCURRENCY = 4;
 
+/**
+ * Run an array of `{run_id, fn}` tasks with bounded concurrency.
+ * Tasks are expected to return a result object — but if one throws,
+ * the limiter converts the throw into an attributable failure result
+ * so a single bad task can't halt the rest of the batch.
+ */
 async function runWithConcurrencyLimit(tasks, limit) {
   const results = new Array(tasks.length);
   let nextIdx = 0;
   async function worker() {
     while (nextIdx < tasks.length) {
       const idx = nextIdx++;
-      results[idx] = await tasks[idx]();
+      const { run_id, fn } = tasks[idx];
+      try {
+        results[idx] = await fn();
+      } catch (err) {
+        results[idx] = {
+          run_id,
+          ok: false,
+          error: err?.message || String(err),
+        };
+      }
     }
   }
   await Promise.all(
@@ -43,11 +59,22 @@ const DISK_CACHE_TTL_MS = 30_000;
  *
  * Skips symlinks (don't follow into other trees) and is bounded by
  * MAX_WALK_FILES so a runaway directory can't hang the request.
+ * Override the cap with WORCA_DISK_WALK_MAX (positive integer); the
+ * raised default of 1M handles node_modules-heavy worktrees, but very
+ * large monorepos may still want a higher ceiling.
  * Errors on individual entries are swallowed so a transiently-locked
  * file doesn't poison the whole sum.
  */
-const MAX_WALK_FILES = 1_000_000;
-export async function _walkDirSize(rootPath, maxFiles = MAX_WALK_FILES) {
+function _resolveWalkCap() {
+  const raw = process.env.WORCA_DISK_WALK_MAX;
+  if (raw) {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return 1_000_000;
+}
+const MAX_WALK_FILES = _resolveWalkCap();
+export async function walkDirSize(rootPath, maxFiles = MAX_WALK_FILES) {
   let bytes = 0;
   let count = 0;
   const stack = [rootPath];
@@ -87,7 +114,7 @@ async function _getDiskBytes(worktreePath) {
 
   let result = { bytes: 0, truncated: false };
   try {
-    result = await _walkDirSize(worktreePath);
+    result = await walkDirSize(worktreePath);
   } catch {
     result = { bytes: 0, truncated: false };
   }
@@ -300,6 +327,13 @@ export function createWorktreesRouter() {
   });
 
   // POST /worktrees/cleanup
+  //
+  // Batch worktree removal. Always responds with HTTP 200 and a JSON body of
+  // shape `{ ok, results, failed_count }`, where `ok` is the AND of per-id
+  // outcomes and `failed_count` is the number of entries with `ok: false`.
+  // Per-entry errors carry a `code` field (`running`, `resumable_or_grouped`)
+  // when actionable. Clients must inspect `results[]` — a single bad id never
+  // aborts the batch, and partial failures are not signalled via HTTP status.
   router.post('/cleanup', async (req, res) => {
     const worcaDir = req.project?.worcaDir;
     if (!worcaDir) {
@@ -322,54 +356,70 @@ export function createWorktreesRouter() {
       }
     }
 
-    const tasks = run_ids.map((run_id) => async () => {
-      const regFile = join(worcaDir, 'multi', 'pipelines.d', `${run_id}.json`);
-      if (!existsSync(regFile)) {
-        return { run_id, ok: false, error: `Worktree "${run_id}" not found` };
-      }
+    const tasks = run_ids.map((run_id) => ({
+      run_id,
+      fn: async () => {
+        const regFile = join(
+          worcaDir,
+          'multi',
+          'pipelines.d',
+          `${run_id}.json`,
+        );
+        if (!existsSync(regFile)) {
+          return {
+            run_id,
+            ok: false,
+            error: `Worktree "${run_id}" not found`,
+          };
+        }
 
-      let reg;
-      try {
-        reg = JSON.parse(readFileSync(regFile, 'utf8'));
-      } catch {
-        return { run_id, ok: false, error: 'Failed to read registry entry' };
-      }
+        let reg;
+        try {
+          reg = JSON.parse(readFileSync(regFile, 'utf8'));
+        } catch {
+          return {
+            run_id,
+            ok: false,
+            error: 'Failed to read registry entry',
+          };
+        }
 
-      let status = reg.status || 'unknown';
-      if (reg.worktree_path && existsSync(reg.worktree_path)) {
-        const actual = _readWorktreeStatus(reg.worktree_path);
-        if (actual) status = actual;
-      }
+        let status = reg.status || 'unknown';
+        if (reg.worktree_path && existsSync(reg.worktree_path)) {
+          const actual = _readWorktreeStatus(reg.worktree_path);
+          if (actual) status = actual;
+        }
 
-      if (status === 'running') {
-        return {
-          run_id,
-          ok: false,
-          error: 'Cannot remove a running worktree',
-          code: 'running',
-        };
-      }
+        if (status === 'running') {
+          return {
+            run_id,
+            ok: false,
+            error: 'Cannot remove a running worktree',
+            code: 'running',
+          };
+        }
 
-      const isResumable = RESUMABLE_STATUSES.has(status);
-      const isGrouped = !!(reg.fleet_id || reg.workspace_id);
-      if (!force && (isResumable || isGrouped)) {
-        return {
-          run_id,
-          ok: false,
-          error:
-            'Removing this worktree prevents resuming the run. Pass force=true to confirm.',
-          code: 'resumable_or_grouped',
-        };
-      }
+        const isResumable = RESUMABLE_STATUSES.has(status);
+        const isGrouped = !!(reg.fleet_id || reg.workspace_id);
+        if (!force && (isResumable || isGrouped)) {
+          return {
+            run_id,
+            ok: false,
+            error:
+              'Removing this worktree prevents resuming the run. Pass force=true to confirm.',
+            code: 'resumable_or_grouped',
+          };
+        }
 
-      try {
-        await removeWorktree(worcaDir, run_id, { skipPrune: true });
-        if (reg.worktree_path) _diskCache.delete(reg.worktree_path);
-        return { run_id, ok: true };
-      } catch (err) {
-        return { run_id, ok: false, error: err.message };
-      }
-    });
+        try {
+          await removeWorktree(worcaDir, run_id, { skipPrune: true });
+          if (reg.worktree_path) _diskCache.delete(reg.worktree_path);
+          return { run_id, ok: true };
+        } catch (err) {
+          return { run_id, ok: false, error: err.message };
+        }
+      },
+    }));
 
     let results;
     try {
@@ -384,7 +434,8 @@ export function createWorktreesRouter() {
       /* non-fatal */
     }
 
-    res.json({ ok: results.every((r) => r.ok), results });
+    const failed_count = results.reduce((n, r) => (r.ok ? n : n + 1), 0);
+    res.json({ ok: failed_count === 0, failed_count, results });
   });
 
   return router;

--- a/worca-ui/server/worktrees-routes.js
+++ b/worca-ui/server/worktrees-routes.js
@@ -7,10 +7,28 @@
  * Expects req.project.worcaDir to be set by projectResolver middleware.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import { join } from 'node:path';
 import { Router } from 'express';
-import { removeWorktree } from './worktree-ops.js';
+import { pruneWorktrees, removeWorktree } from './worktree-ops.js';
+
+const CLEANUP_CONCURRENCY = 4;
+
+async function runWithConcurrencyLimit(tasks, limit) {
+  const results = new Array(tasks.length);
+  let nextIdx = 0;
+  async function worker() {
+    while (nextIdx < tasks.length) {
+      const idx = nextIdx++;
+      results[idx] = await tasks[idx]();
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, tasks.length) }, worker),
+  );
+  return results;
+}
 
 const RESUMABLE_STATUSES = new Set(['failed', 'paused', 'cancelled']);
 
@@ -28,51 +46,57 @@ const DISK_CACHE_TTL_MS = 30_000;
  * Errors on individual entries are swallowed so a transiently-locked
  * file doesn't poison the whole sum.
  */
-const MAX_WALK_FILES = 100_000;
-function _walkDirSize(rootPath) {
-  let total = 0;
+const MAX_WALK_FILES = 1_000_000;
+export async function _walkDirSize(rootPath, maxFiles = MAX_WALK_FILES) {
+  let bytes = 0;
   let count = 0;
   const stack = [rootPath];
-  while (stack.length > 0 && count < MAX_WALK_FILES) {
+  while (stack.length > 0 && count < maxFiles) {
     const cur = stack.pop();
-    let entries;
+    let dir;
     try {
-      entries = readdirSync(cur, { withFileTypes: true });
+      dir = await fsp.opendir(cur);
     } catch {
       continue;
     }
-    for (const e of entries) {
+    for await (const e of dir) {
       count++;
-      if (count >= MAX_WALK_FILES) break;
+      if (count >= maxFiles) break;
       const child = join(cur, e.name);
       if (e.isSymbolicLink()) continue;
       if (e.isDirectory()) {
         stack.push(child);
       } else if (e.isFile()) {
         try {
-          total += statSync(child).size;
+          const st = await fsp.stat(child);
+          bytes += st.size;
         } catch {
           /* ignore — file vanished mid-walk */
         }
       }
     }
   }
-  return total;
+  return { bytes, truncated: count >= maxFiles };
 }
 
-function _getDiskBytes(worktreePath) {
+async function _getDiskBytes(worktreePath) {
   const now = Date.now();
   const hit = _diskCache.get(worktreePath);
-  if (hit && hit.expiry > now) return hit.bytes;
+  if (hit && hit.expiry > now)
+    return { bytes: hit.bytes, truncated: hit.truncated };
 
-  let bytes = 0;
+  let result = { bytes: 0, truncated: false };
   try {
-    bytes = _walkDirSize(worktreePath);
+    result = await _walkDirSize(worktreePath);
   } catch {
-    bytes = 0;
+    result = { bytes: 0, truncated: false };
   }
-  _diskCache.set(worktreePath, { bytes, expiry: now + DISK_CACHE_TTL_MS });
-  return bytes;
+  _diskCache.set(worktreePath, {
+    bytes: result.bytes,
+    truncated: result.truncated,
+    expiry: now + DISK_CACHE_TTL_MS,
+  });
+  return result;
 }
 
 /**
@@ -108,7 +132,7 @@ function _readWorktreeStatus(worktreePath) {
   return null;
 }
 
-function _listWorktrees(worcaDir) {
+async function _listWorktrees(worcaDir) {
   const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
   if (!existsSync(pipelinesDir)) return [];
 
@@ -142,12 +166,18 @@ function _listWorktrees(worcaDir) {
       }
     }
 
+    let diskInfo = { bytes: 0, truncated: false };
+    if (worktreeExists) {
+      diskInfo = await _getDiskBytes(worktreePath);
+    }
+
     entries.push({
       run_id: reg.run_id || '',
       title: reg.title || '',
       branch: reg.branch || '',
       worktree_path: worktreePath,
-      disk_bytes: worktreeExists ? _getDiskBytes(worktreePath) : 0,
+      disk_bytes: diskInfo.bytes,
+      truncated: diskInfo.truncated,
       age_seconds: ageSeconds,
       // started_at lets the client sort with the same sortByStartDesc helper
       // used by run-list, keeping ordering consistent across views.
@@ -182,7 +212,7 @@ export function createWorktreesRouter() {
   const router = Router({ mergeParams: true });
 
   // GET /worktrees
-  router.get('/', (req, res) => {
+  router.get('/', async (req, res) => {
     const worcaDir = req.project?.worcaDir;
     if (!worcaDir) {
       return res
@@ -190,7 +220,7 @@ export function createWorktreesRouter() {
         .json({ ok: false, error: 'worcaDir not configured' });
     }
     try {
-      const worktrees = _listWorktrees(worcaDir);
+      const worktrees = await _listWorktrees(worcaDir);
       res.json({ ok: true, worktrees });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
@@ -198,7 +228,7 @@ export function createWorktreesRouter() {
   });
 
   // DELETE /worktrees/:run_id
-  router.delete('/:run_id', (req, res) => {
+  router.delete('/:run_id', async (req, res) => {
     const worcaDir = req.project?.worcaDir;
     if (!worcaDir) {
       return res
@@ -261,11 +291,100 @@ export function createWorktreesRouter() {
         });
       }
 
-      removeWorktree(worcaDir, run_id);
+      await removeWorktree(worcaDir, run_id);
+      if (reg.worktree_path) _diskCache.delete(reg.worktree_path);
       res.json({ ok: true, run_id });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }
+  });
+
+  // POST /worktrees/cleanup
+  router.post('/cleanup', async (req, res) => {
+    const worcaDir = req.project?.worcaDir;
+    if (!worcaDir) {
+      return res
+        .status(501)
+        .json({ ok: false, error: 'worcaDir not configured' });
+    }
+
+    const { run_ids, force = false } = req.body || {};
+    if (!Array.isArray(run_ids) || run_ids.length === 0) {
+      return res
+        .status(400)
+        .json({ ok: false, error: 'run_ids must be a non-empty array' });
+    }
+    for (const id of run_ids) {
+      if (!_validateRunId(id)) {
+        return res
+          .status(400)
+          .json({ ok: false, error: `Invalid run ID: ${id}` });
+      }
+    }
+
+    const tasks = run_ids.map((run_id) => async () => {
+      const regFile = join(worcaDir, 'multi', 'pipelines.d', `${run_id}.json`);
+      if (!existsSync(regFile)) {
+        return { run_id, ok: false, error: `Worktree "${run_id}" not found` };
+      }
+
+      let reg;
+      try {
+        reg = JSON.parse(readFileSync(regFile, 'utf8'));
+      } catch {
+        return { run_id, ok: false, error: 'Failed to read registry entry' };
+      }
+
+      let status = reg.status || 'unknown';
+      if (reg.worktree_path && existsSync(reg.worktree_path)) {
+        const actual = _readWorktreeStatus(reg.worktree_path);
+        if (actual) status = actual;
+      }
+
+      if (status === 'running') {
+        return {
+          run_id,
+          ok: false,
+          error: 'Cannot remove a running worktree',
+          code: 'running',
+        };
+      }
+
+      const isResumable = RESUMABLE_STATUSES.has(status);
+      const isGrouped = !!(reg.fleet_id || reg.workspace_id);
+      if (!force && (isResumable || isGrouped)) {
+        return {
+          run_id,
+          ok: false,
+          error:
+            'Removing this worktree prevents resuming the run. Pass force=true to confirm.',
+          code: 'resumable_or_grouped',
+        };
+      }
+
+      try {
+        await removeWorktree(worcaDir, run_id, { skipPrune: true });
+        if (reg.worktree_path) _diskCache.delete(reg.worktree_path);
+        return { run_id, ok: true };
+      } catch (err) {
+        return { run_id, ok: false, error: err.message };
+      }
+    });
+
+    let results;
+    try {
+      results = await runWithConcurrencyLimit(tasks, CLEANUP_CONCURRENCY);
+    } catch (err) {
+      return res.status(500).json({ ok: false, error: err.message });
+    }
+
+    try {
+      await pruneWorktrees(worcaDir);
+    } catch {
+      /* non-fatal */
+    }
+
+    res.json({ ok: results.every((r) => r.ok), results });
   });
 
   return router;

--- a/worca-ui/server/worktrees-routes.test.js
+++ b/worca-ui/server/worktrees-routes.test.js
@@ -3,12 +3,21 @@ import {
   mkdirSync,
   mkdtempSync,
   rmSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRemoveWorktree = vi.fn();
+const mockPruneWorktrees = vi.fn();
+
+vi.mock('./worktree-ops.js', () => ({
+  removeWorktree: (...args) => mockRemoveWorktree(...args),
+  pruneWorktrees: (...args) => mockPruneWorktrees(...args),
+}));
 
 vi.mock('./process-manager.js', () => {
   class ProcessManager {
@@ -40,6 +49,26 @@ vi.mock('./process-manager.js', () => {
 });
 
 const { createApp } = await import('./app.js');
+const { _walkDirSize } = await import('./worktrees-routes.js');
+
+// Default mock behaviour: mirror the registry-file deletion that real removeWorktree does.
+// Tests that need different behaviour override mockImplementation inline.
+beforeEach(() => {
+  mockRemoveWorktree.mockImplementation(async (worcaDir, runId) => {
+    const regPath = join(worcaDir, 'multi', 'pipelines.d', `${runId}.json`);
+    try {
+      unlinkSync(regPath);
+    } catch {
+      /* ignore */
+    }
+  });
+  mockPruneWorktrees.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  mockRemoveWorktree.mockReset();
+  mockPruneWorktrees.mockReset();
+});
 
 function startServer(worcaDir) {
   const app = createApp({ worcaDir });
@@ -349,5 +378,215 @@ describe('DELETE /api/worktrees/:run_id', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.ok).toBe(false);
+  });
+});
+
+// ─── POST /api/worktrees/cleanup ─────────────────────────────────────────────
+
+describe('POST /api/worktrees/cleanup', () => {
+  let tmpDir, server, base;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'wt-routes-cleanup-'));
+    ({ server, base } = await startServer(tmpDir));
+  });
+
+  afterEach(async () => {
+    await stopServer(server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('POST_cleanup_parallelises_prune_once: runs ≤4 concurrent removes and prunes exactly once', async () => {
+    for (let i = 1; i <= 6; i++) {
+      writePipelineEntry(tmpDir, `run-bulk-${i}`, {
+        run_id: `run-bulk-${i}`,
+        worktree_path: `/nonexistent/fake-${i}`,
+        status: 'completed',
+      });
+    }
+
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    mockRemoveWorktree.mockImplementation(async () => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((r) => setTimeout(r, 20));
+      concurrent--;
+    });
+
+    const res = await fetch(`${base}/api/worktrees/cleanup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        run_ids: [
+          'run-bulk-1',
+          'run-bulk-2',
+          'run-bulk-3',
+          'run-bulk-4',
+          'run-bulk-5',
+          'run-bulk-6',
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(data.results).toHaveLength(6);
+    expect(data.results.every((r) => r.ok)).toBe(true);
+    expect(maxConcurrent).toBeGreaterThan(1);
+    expect(maxConcurrent).toBeLessThanOrEqual(4);
+    expect(mockPruneWorktrees).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST_cleanup_per_id_success_failure: returns per-id error for missing/running, ok for completed', async () => {
+    const worktreeRunning = mkdtempSync(join(tmpdir(), 'wt-cleanup-running-'));
+    writeWorktreeStatus(worktreeRunning, 'running');
+    writePipelineEntry(tmpDir, 'run-running-c', {
+      run_id: 'run-running-c',
+      worktree_path: worktreeRunning,
+    });
+    writePipelineEntry(tmpDir, 'run-ok-c', {
+      run_id: 'run-ok-c',
+      worktree_path: '/nonexistent/ok',
+      status: 'completed',
+    });
+
+    try {
+      const res = await fetch(`${base}/api/worktrees/cleanup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          run_ids: ['run-missing-c', 'run-running-c', 'run-ok-c'],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.results).toHaveLength(3);
+
+      const missing = data.results.find((r) => r.run_id === 'run-missing-c');
+      expect(missing.ok).toBe(false);
+      expect(missing.error).toMatch(/not found/i);
+
+      const running = data.results.find((r) => r.run_id === 'run-running-c');
+      expect(running.ok).toBe(false);
+      expect(running.code).toBe('running');
+
+      const ok = data.results.find((r) => r.run_id === 'run-ok-c');
+      expect(ok.ok).toBe(true);
+    } finally {
+      rmSync(worktreeRunning, { recursive: true, force: true });
+    }
+  });
+
+  it('POST_cleanup_force_removes_grouped_completed: force=true bypasses 412 and removes fleet member', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'wt-fleet-cleanup-'));
+    writeWorktreeStatus(worktreePath, 'completed');
+    writePipelineEntry(tmpDir, 'run-fleet-c', {
+      run_id: 'run-fleet-c',
+      worktree_path: worktreePath,
+      fleet_id: 'fleet-xyz',
+      group_type: 'fleet',
+      status: 'completed',
+    });
+
+    const regFile = join(tmpDir, 'multi', 'pipelines.d', 'run-fleet-c.json');
+    expect(existsSync(regFile)).toBe(true);
+
+    try {
+      const res = await fetch(`${base}/api/worktrees/cleanup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ run_ids: ['run-fleet-c'], force: true }),
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.ok).toBe(true);
+      expect(data.results[0].run_id).toBe('run-fleet-c');
+      expect(data.results[0].ok).toBe(true);
+      expect(existsSync(regFile)).toBe(false);
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true });
+    }
+  });
+
+  it('DELETE_cache_evicted_on_delete: stale disk cache is cleared after single DELETE', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'wt-cache-evict-'));
+    writeWorktreeStatus(worktreePath, 'completed');
+    const bigFilePath = join(worktreePath, 'bigfile.bin');
+    writeFileSync(bigFilePath, 'x'.repeat(1_000_000));
+    writePipelineEntry(tmpDir, 'run-cache-evict', {
+      run_id: 'run-cache-evict',
+      worktree_path: worktreePath,
+      status: 'completed',
+    });
+
+    try {
+      // Populate the cache via GET
+      const res1 = await fetch(`${base}/api/worktrees`);
+      const data1 = await res1.json();
+      const wt1 = data1.worktrees.find((w) => w.run_id === 'run-cache-evict');
+      expect(wt1).toBeDefined();
+      expect(wt1.disk_bytes).toBeGreaterThanOrEqual(1_000_000);
+
+      // Remove the big file so a fresh walk would return a much smaller number
+      unlinkSync(bigFilePath);
+
+      // DELETE — should evict the cache entry for worktreePath
+      const delRes = await fetch(`${base}/api/worktrees/run-cache-evict`, {
+        method: 'DELETE',
+      });
+      expect(delRes.status).toBe(200);
+
+      // Re-register the same worktree path under a new run_id
+      writePipelineEntry(tmpDir, 'run-cache-evict-2', {
+        run_id: 'run-cache-evict-2',
+        worktree_path: worktreePath,
+        status: 'completed',
+      });
+
+      // GET again — must do a fresh walk (not return stale cached bytes)
+      const res2 = await fetch(`${base}/api/worktrees`);
+      const data2 = await res2.json();
+      const wt2 = data2.worktrees.find((w) => w.run_id === 'run-cache-evict-2');
+      expect(wt2).toBeDefined();
+      expect(wt2.disk_bytes).toBeLessThan(1_000_000);
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Async disk walker ────────────────────────────────────────────────────────
+
+describe('_walkDirSize (async walker)', () => {
+  it('WALKER_accurate_bytes: returns accurate bytes and truncated=false for normal trees', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wt-walker-bytes-'));
+    writeFileSync(join(dir, 'a.bin'), Buffer.alloc(10_000));
+    writeFileSync(join(dir, 'b.bin'), Buffer.alloc(20_000));
+    try {
+      const result = await _walkDirSize(dir);
+      expect(result.bytes).toBeGreaterThanOrEqual(30_000);
+      expect(result.truncated).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('WALKER_truncated: reports truncated=true when entry count exceeds cap', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wt-walker-trunc-'));
+    // Create 6 files so that walking with cap=5 triggers truncation
+    for (let i = 0; i < 6; i++) {
+      writeFileSync(join(dir, `f${i}.txt`), 'x');
+    }
+    try {
+      const result = await _walkDirSize(dir, 5);
+      expect(result.truncated).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/worca-ui/server/worktrees-routes.test.js
+++ b/worca-ui/server/worktrees-routes.test.js
@@ -49,7 +49,7 @@ vi.mock('./process-manager.js', () => {
 });
 
 const { createApp } = await import('./app.js');
-const { _walkDirSize } = await import('./worktrees-routes.js');
+const { walkDirSize } = await import('./worktrees-routes.js');
 
 // Default mock behaviour: mirror the registry-file deletion that real removeWorktree does.
 // Tests that need different behaviour override mockImplementation inline.
@@ -433,6 +433,7 @@ describe('POST /api/worktrees/cleanup', () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.ok).toBe(true);
+    expect(data.failed_count).toBe(0);
     expect(data.results).toHaveLength(6);
     expect(data.results.every((r) => r.ok)).toBe(true);
     expect(maxConcurrent).toBeGreaterThan(1);
@@ -465,6 +466,8 @@ describe('POST /api/worktrees/cleanup', () => {
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.results).toHaveLength(3);
+      expect(data.ok).toBe(false);
+      expect(data.failed_count).toBe(2);
 
       const missing = data.results.find((r) => r.run_id === 'run-missing-c');
       expect(missing.ok).toBe(false);
@@ -562,13 +565,13 @@ describe('POST /api/worktrees/cleanup', () => {
 
 // ─── Async disk walker ────────────────────────────────────────────────────────
 
-describe('_walkDirSize (async walker)', () => {
+describe('walkDirSize (async walker)', () => {
   it('WALKER_accurate_bytes: returns accurate bytes and truncated=false for normal trees', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'wt-walker-bytes-'));
     writeFileSync(join(dir, 'a.bin'), Buffer.alloc(10_000));
     writeFileSync(join(dir, 'b.bin'), Buffer.alloc(20_000));
     try {
-      const result = await _walkDirSize(dir);
+      const result = await walkDirSize(dir);
       expect(result.bytes).toBeGreaterThanOrEqual(30_000);
       expect(result.truncated).toBe(false);
     } finally {
@@ -583,7 +586,7 @@ describe('_walkDirSize (async walker)', () => {
       writeFileSync(join(dir, `f${i}.txt`), 'x');
     }
     try {
-      const result = await _walkDirSize(dir, 5);
+      const result = await walkDirSize(dir, 5);
       expect(result.truncated).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- **Async server-side delete**: Replace `execFileSync` with promisified `execFile` in `worktree-ops.js` so `git worktree remove`/`prune` no longer block the Node event loop. Add `skipPrune` option and standalone `pruneWorktrees()` for batch callers.
- **Bulk cleanup endpoint**: Add `POST /worktrees/cleanup` with bounded concurrency (4 parallel removes, 1 prune at end), per-id results. Client fires a single POST with `force=true` instead of N sequential DELETEs, optimistically removes cards from state before response settles.
- **Honest disk accounting**: Replace sync `_walkDirSize` with async `opendir`+`stat` walker, raise entry cap to 1M, surface `truncated` flag. Cards show "≥ X" when truncated. Bulk dialog warns when grouped completed worktrees are included. Cache eviction on delete across all paths.

## Test plan

- [x] `worktree-ops.test.js` — event loop unblocked during parallel removes, skipPrune skips prune, pruneWorktrees runs once after N skipPrune removes
- [x] `worktrees-routes.test.js` — POST cleanup parallelises + prunes once, per-id success/failure, force removes grouped completed, cache eviction on delete, walker truncation
- [x] `main.bulk-cleanup.test.js` — bulk path fires one POST (not N DELETEs), optimistic card removal, force=true in body, run_ids in body, failures mapped to toast
- [x] `worktrees.test.js` — bulk dialog grouped caveat, truncated disk display (≥ prefix)
- [x] Existing DELETE route tests (409/412 paths) remain green
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)