### PR TITLE
fix(ui): exclude vendored dirs from worktree disk walk

### DIFF
--- a/worca-ui/app/views/worktrees.js
+++ b/worca-ui/app/views/worktrees.js
@@ -55,6 +55,10 @@ function _diskSummaryView(worktrees, diskWarningBytes = 2_000_000_000) {
   const resumableBytes = resumable.reduce((s, w) => s + (w.disk_bytes || 0), 0);
   const over2gb = total > diskWarningBytes;
 
+  // Documents the server-side WALK_SKIP_DIRS exclusion so users aren't
+  // surprised when `du -sh` reports a larger number.
+  const caveat = html`<div class="worktrees-disk-caveat">Excludes node_modules, .git, and build/cache dirs</div>`;
+
   // Warning banner only when over the threshold; otherwise a quiet meta line.
   if (over2gb) {
     return html`
@@ -68,6 +72,7 @@ function _diskSummaryView(worktrees, diskWarningBytes = 2_000_000_000) {
             : nothing
         }).
       </sl-alert>
+      ${caveat}
     `;
   }
 
@@ -88,6 +93,7 @@ function _diskSummaryView(worktrees, diskWarningBytes = 2_000_000_000) {
           : nothing
       }
     </div>
+    ${caveat}
   `;
 }
 

--- a/worca-ui/app/views/worktrees.test.js
+++ b/worca-ui/app/views/worktrees.test.js
@@ -279,6 +279,25 @@ describe('worktreesView - disk summary', () => {
     );
     expect(output).not.toContain('worktrees-disk-alert');
   });
+
+  it('shows disk caveat in normal summary path', () => {
+    const output = renderToString(worktreesView([completedWorktree]));
+    expect(output).toContain('worktrees-disk-caveat');
+    expect(output).toContain(
+      'Excludes node_modules, .git, and build/cache dirs',
+    );
+  });
+
+  it('shows disk caveat in warning-banner path', () => {
+    const big = {
+      ...completedWorktree,
+      run_id: 'r2',
+      disk_bytes: 1_200_000_000,
+    };
+    const output = renderToString(worktreesView([completedWorktree, big]));
+    expect(output).toContain('worktrees-disk-alert');
+    expect(output).toContain('worktrees-disk-caveat');
+  });
 });
 
 describe('worktreesView - cleanup button disabled when running', () => {

--- a/worca-ui/server/worktrees-routes.js
+++ b/worca-ui/server/worktrees-routes.js
@@ -6,6 +6,14 @@
  * POST /worktrees/cleanup  — batch remove (always returns 200 with `{ok, results, failed_count}`)
  *
  * Expects req.project.worcaDir to be set by projectResolver middleware.
+ *
+ * NOTE on disk semantics: `disk_bytes` reflects project files only — vendored
+ * and derived directories listed in WALK_SKIP_DIRS (node_modules, .git, .venv,
+ * dist, build, .next, etc.) are skipped during the walk. This answers "how
+ * much project disk would I free?" rather than raw on-disk bytes, and makes
+ * cold first loads ~10× faster on node_modules-heavy worktrees. The route
+ * surfaces `disk_walk_skip_dirs` in the GET response so clients can document
+ * the discrepancy with `du -sh`.
  */
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
@@ -53,11 +61,36 @@ const _diskCache = new Map();
 const DISK_CACHE_TTL_MS = 30_000;
 
 /**
+ * Directory names skipped during the disk walk. These are vendored or derived
+ * trees that dominate file count without changing the user's mental model of
+ * "project disk". Excluding them drops the walked file count by ~10–20× on
+ * typical worktrees and keeps `disk_bytes` focused on the project's own
+ * source files — closing the gap between "raw on-disk bytes" and "bytes I
+ * would actually free by cleaning up this worktree".
+ */
+export const WALK_SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.venv',
+  'venv',
+  '__pycache__',
+  '.pytest_cache',
+  '.mypy_cache',
+  '.ruff_cache',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  '.cache',
+]);
+
+/**
  * Sum file sizes under a directory tree. Cross-platform: prior `du -sb`
  * relied on GNU coreutils and silently returned 0 on macOS / BSD du,
  * which is why the Worktrees view always showed "0 B".
  *
- * Skips symlinks (don't follow into other trees) and is bounded by
+ * Skips symlinks (don't follow into other trees), skips directory names in
+ * WALK_SKIP_DIRS (node_modules, .git, build/cache dirs), and is bounded by
  * MAX_WALK_FILES so a runaway directory can't hang the request.
  * Override the cap with WORCA_DISK_WALK_MAX (positive integer); the
  * raised default of 1M handles node_modules-heavy worktrees, but very
@@ -92,7 +125,7 @@ export async function walkDirSize(rootPath, maxFiles = MAX_WALK_FILES) {
       const child = join(cur, e.name);
       if (e.isSymbolicLink()) continue;
       if (e.isDirectory()) {
-        stack.push(child);
+        if (!WALK_SKIP_DIRS.has(e.name)) stack.push(child);
       } else if (e.isFile()) {
         try {
           const st = await fsp.stat(child);
@@ -248,7 +281,13 @@ export function createWorktreesRouter() {
     }
     try {
       const worktrees = await _listWorktrees(worcaDir);
-      res.json({ ok: true, worktrees });
+      res.json({
+        ok: true,
+        worktrees,
+        // Documents the semantics shift in `disk_bytes` (project files only).
+        // Clients can render this as a caveat next to disk totals.
+        disk_walk_skip_dirs: [...WALK_SKIP_DIRS],
+      });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-ui/server/worktrees-routes.test.js
+++ b/worca-ui/server/worktrees-routes.test.js
@@ -49,7 +49,7 @@ vi.mock('./process-manager.js', () => {
 });
 
 const { createApp } = await import('./app.js');
-const { walkDirSize } = await import('./worktrees-routes.js');
+const { walkDirSize, WALK_SKIP_DIRS } = await import('./worktrees-routes.js');
 
 // Default mock behaviour: mirror the registry-file deletion that real removeWorktree does.
 // Tests that need different behaviour override mockImplementation inline.
@@ -234,6 +234,38 @@ describe('GET /api/worktrees', () => {
     const res = await fetch(`${base}/api/worktrees`);
     const data = await res.json();
     expect(data.worktrees).toHaveLength(0);
+  });
+
+  it('GET_disk_bytes_excludes_vendored: route-level disk_bytes excludes node_modules subtrees and response surfaces disk_walk_skip_dirs', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'wt-excl-'));
+    const projectFileSize = 123;
+    writeFileSync(join(worktreePath, 'app.js'), 'x'.repeat(projectFileSize));
+    const nmDir = join(worktreePath, 'node_modules');
+    mkdirSync(nmDir);
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(join(nmDir, `pkg${i}.js`), 'x'.repeat(5_000));
+    }
+    writePipelineEntry(tmpDir, 'run-excl', {
+      run_id: 'run-excl',
+      worktree_path: worktreePath,
+    });
+
+    try {
+      const res = await fetch(`${base}/api/worktrees`);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      const wt = data.worktrees.find((w) => w.run_id === 'run-excl');
+      expect(wt).toBeDefined();
+      // node_modules (20 × 5 000 = 100 000 B) must not be counted
+      expect(wt.disk_bytes).toBe(projectFileSize);
+      // Response must surface the skip-dirs list so clients can document the
+      // semantics shift in `disk_bytes` next to disk totals.
+      expect(Array.isArray(data.disk_walk_skip_dirs)).toBe(true);
+      expect(data.disk_walk_skip_dirs).toContain('node_modules');
+      expect(data.disk_walk_skip_dirs).toContain('.git');
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true });
+    }
   });
 });
 
@@ -588,6 +620,61 @@ describe('walkDirSize (async walker)', () => {
     try {
       const result = await walkDirSize(dir, 5);
       expect(result.truncated).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('WALK_SKIP_DIRS_constant: exported Set contains expected vendored/derived dirs', () => {
+    expect(WALK_SKIP_DIRS).toBeInstanceOf(Set);
+    for (const name of [
+      'node_modules',
+      '.git',
+      '.venv',
+      'venv',
+      '__pycache__',
+      '.pytest_cache',
+      '.mypy_cache',
+      '.ruff_cache',
+      'dist',
+      'build',
+      '.next',
+      '.turbo',
+      '.cache',
+    ]) {
+      expect(WALK_SKIP_DIRS.has(name)).toBe(true);
+    }
+  });
+
+  it('WALKER_skips_node_modules: excludes files inside node_modules', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wt-walker-nm-'));
+    const projectFileSize = 50;
+    writeFileSync(join(dir, 'src.js'), 'x'.repeat(projectFileSize));
+    const nm = join(dir, 'node_modules');
+    mkdirSync(nm);
+    for (let i = 0; i < 20; i++) {
+      writeFileSync(join(nm, `pkg${i}.js`), 'x'.repeat(5_000));
+    }
+    try {
+      const result = await walkDirSize(dir);
+      expect(result.bytes).toBe(projectFileSize);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('WALKER_skips_all_vendored: every entry in WALK_SKIP_DIRS is skipped', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wt-walker-skipall-'));
+    const rootSize = 10;
+    writeFileSync(join(dir, 'root.txt'), 'x'.repeat(rootSize));
+    for (const name of WALK_SKIP_DIRS) {
+      const skipPath = join(dir, name);
+      mkdirSync(skipPath, { recursive: true });
+      writeFileSync(join(skipPath, 'hidden.txt'), 'x'.repeat(1_000));
+    }
+    try {
+      const result = await walkDirSize(dir);
+      expect(result.bytes).toBe(rootSize);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

**Rebased on master after #156 merged** — the original PR's async walker, bounded concurrency limiter, and walk-cap logic are now redundant (shipped in #156). This commit keeps only the missing piece: **directory exclusions during the walk**.

- **`WALK_SKIP_DIRS`**: exported `Set` listing vendored/derived trees (`node_modules`, `.git`, `.venv`, `venv`, `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `dist`, `build`, `.next`, `.turbo`, `.cache`). Single-line skip check inside `walkDirSize` (now in master).
- **API contract**: `GET /worktrees` response surfaces `disk_walk_skip_dirs: [...]` so API clients can explain why `disk_bytes` is smaller than `du -sh`.
- **UI caveat**: `_diskSummaryView` renders "Excludes node_modules, .git, and build/cache dirs" under both the warning-banner and quiet-summary states.

Combined with the async walker already in master, cold first loads on `node_modules`-heavy worktrees drop another ~10–20× in walked file count — `disk_bytes` now reflects "how much project disk would I free?" rather than raw on-disk bytes. The 1M walk cap and `truncated` flag (shipped in #156) are preserved.

## What changed vs. the original PR

The original PR was opened against pre-#156 master and re-implemented the async walker, a parallel `pLimit` helper, and a 100k walk cap. After #156 merged, ~85% of that diff was duplicate — and the 100k cap was a regression against master's 1M (env-tunable via `WORCA_DISK_WALK_MAX`). Rebasing kept only the genuinely new contribution.

| Aspect | Original PR | This PR |
|---|---|---|
| Diff size | +846 / −76 | +155 / −4 |
| Conflict state | CONFLICTING | MERGEABLE |
| Async walker | re-implemented (duplicate) | inherited from master |
| Walk cap | 100k (regression) | 1M (env-tunable, from master) |
| `truncated` flag | dropped | preserved |
| Concurrency limiter | inline `pLimit` (duplicate) | `runWithConcurrencyLimit` (from master) |
| `WALK_SKIP_DIRS` | new | new |
| UI caveat | new | new |
| API surfaces skip-dirs | — | new (`disk_walk_skip_dirs` in GET response) |

## Test plan

- [x] `worktrees-routes.test.js` (23 passed) — new tests:
  - `WALK_SKIP_DIRS_constant`: exported `Set` contains every expected entry.
  - `WALKER_skips_node_modules`: `walkDirSize` ignores files inside `node_modules`.
  - `WALKER_skips_all_vendored`: parametrised over every `WALK_SKIP_DIRS` entry — only the root file is counted.
  - `GET_disk_bytes_excludes_vendored`: route-level `disk_bytes` excludes `node_modules` AND response surfaces `disk_walk_skip_dirs`.
- [x] `worktrees.test.js` (62 passed) — caveat rendered in both warning-banner and quiet-summary states.
- [x] Biome lint clean.
- [x] Pre-existing flaky `ws-pipeline-lifecycle.test.js` failure under full-suite contention reproduces on clean master without these changes — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
