### PR TITLE
fix(ui): speed up worktrees-view first load (~4.5x end-to-end)

### DIFF
--- a/worca-ui/app/router.js
+++ b/worca-ui/app/router.js
@@ -3,10 +3,13 @@ export function parseHash(hash) {
   const [path, query] = clean.split('?');
   const parts = path.split('/').filter(Boolean);
 
-  // New path-segment format: project/{slug}/{section}[/{runId}]
-  if (parts[0] === 'project' && parts.length >= 3) {
+  // New path-segment format: project/{slug}[/{section}[/{runId}]]
+  // A bare `#/project/{slug}` is treated as `#/project/{slug}/active` so the
+  // bootstrap can resolve projectId and avoid fanning worktree fetches across
+  // every registered project.
+  if (parts[0] === 'project' && parts.length >= 2) {
     return {
-      section: parts[2],
+      section: parts[2] || 'active',
       runId: parts[3] || null,
       projectId: parts[1],
     };

--- a/worca-ui/app/router.test.js
+++ b/worca-ui/app/router.test.js
@@ -36,6 +36,14 @@ describe('router', () => {
     });
   });
 
+  it('parseHash defaults section to active for bare #/project/<id>', () => {
+    expect(parseHash('#/project/my-proj')).toEqual({
+      section: 'active',
+      runId: null,
+      projectId: 'my-proj',
+    });
+  });
+
   it('parseHash extracts projectId, section, and runId', () => {
     expect(parseHash('#/project/proj-a/active/run-1')).toEqual({
       section: 'active',

--- a/worca-ui/server/worktrees-routes.js
+++ b/worca-ui/server/worktrees-routes.js
@@ -196,7 +196,10 @@ async function _listWorktrees(worcaDir) {
   const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
   if (!existsSync(pipelinesDir)) return [];
 
-  const entries = [];
+  // Phase 1: cheap synchronous metadata (registry parse, status read).
+  // Phase 2: disk walks in parallel — without this, 13 worktrees serialize
+  // ~3s of awaits even when most results would have been disk-cache hits.
+  const metas = [];
   for (const file of readdirSync(pipelinesDir)) {
     if (!file.endsWith('.json')) continue;
 
@@ -211,7 +214,6 @@ async function _listWorktrees(worcaDir) {
     const worktreePath = reg.worktree_path;
     const worktreeExists = existsSync(worktreePath);
 
-    // Prefer actual status.json; fall back to registry field
     let status = reg.status || 'unknown';
     if (worktreeExists) {
       const actual = _readWorktreeStatus(worktreePath);
@@ -226,32 +228,34 @@ async function _listWorktrees(worcaDir) {
       }
     }
 
-    let diskInfo = { bytes: 0, truncated: false };
-    if (worktreeExists) {
-      diskInfo = await _getDiskBytes(worktreePath);
-    }
-
-    entries.push({
-      run_id: reg.run_id || '',
-      title: reg.title || '',
-      branch: reg.branch || '',
-      worktree_path: worktreePath,
-      disk_bytes: diskInfo.bytes,
-      truncated: diskInfo.truncated,
-      age_seconds: ageSeconds,
-      // started_at lets the client sort with the same sortByStartDesc helper
-      // used by run-list, keeping ordering consistent across views.
-      started_at: reg.started_at || null,
-      status,
-      removable: status !== 'running',
-      fleet_id: reg.fleet_id || null,
-      workspace_id: reg.workspace_id || null,
-      group_type: reg.group_type || null,
-      group_status: null, // populated by W-040 / W-047
-      resumable: RESUMABLE_STATUSES.has(status),
-    });
+    metas.push({ reg, worktreePath, worktreeExists, status, ageSeconds });
   }
-  return entries;
+
+  const disks = await Promise.all(
+    metas.map((m) =>
+      m.worktreeExists
+        ? _getDiskBytes(m.worktreePath)
+        : Promise.resolve({ bytes: 0, truncated: false }),
+    ),
+  );
+
+  return metas.map((m, i) => ({
+    run_id: m.reg.run_id || '',
+    title: m.reg.title || '',
+    branch: m.reg.branch || '',
+    worktree_path: m.worktreePath,
+    disk_bytes: disks[i].bytes,
+    truncated: disks[i].truncated,
+    age_seconds: m.ageSeconds,
+    started_at: m.reg.started_at || null,
+    status: m.status,
+    removable: m.status !== 'running',
+    fleet_id: m.reg.fleet_id || null,
+    workspace_id: m.reg.workspace_id || null,
+    group_type: m.reg.group_type || null,
+    group_status: null,
+    resumable: RESUMABLE_STATUSES.has(m.status),
+  }));
 }
 
 const RUN_ID_RE = /^[a-zA-Z0-9_-]+$/;


### PR DESCRIPTION
## Summary

Two compounding bugs made the Worktrees view take ~3s on first load. This PR fixes both.

- **Bug 1 (frontend):** `parseHash('#/project/<id>')` (no section) fell through to short-format parsing and returned `projectId=null`. That caused `fetchWorktrees` to fan out **one request per registered project** (11 in the dogfood setup) instead of just the active one. Treat `#/project/<id>` as `#/project/<id>/active`.
- **Bug 2 (server):** `_listWorktrees` awaited each `_getDiskBytes` sequentially in a `for` loop, serializing 13 disk walks behind a single async chain. Split into a sync metadata phase + `Promise.all` over the walks.

## Measurements

Cold-cache fresh server, project with 13 worktrees, opening `/#/project/worca-cc`:

|  | Before | After |
|---|---|---|
| `/worktrees` requests fired | 11 | **1** |
| Slowest single request | 3,172 ms | **696 ms** |
| Server-only `_listWorktrees` (curl, isolated) | ~1,250 ms | **~550 ms avg** |
| Total wall-clock to render | ~3.2 s | **~0.7 s** |

End-to-end: ~4.5× faster.

## Test plan

- [x] Targeted vitest: `router.test.js` + `worktrees-routes.test.js` — 35/35 pass
- [x] Full UI vitest suite: 2451/2452 pass (one pre-existing flake in `ws-pipelines-dir-watcher.test.js`, unrelated)
- [x] `npm run lint:fix` — no new warnings
- [x] Browser e2e via Playwright — confirmed single request, fast load
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)