### PR TITLE
feat(ui): server-side cleanup status + sidebar loading spinners + always-show Worktrees

### DIFF
--- a/worca-ui/app/main.bulk-cleanup.test.js
+++ b/worca-ui/app/main.bulk-cleanup.test.js
@@ -51,18 +51,23 @@ describe('confirmWorktreeCleanup — bulk path structure', () => {
     expect(fnBody).toContain('force: true');
   });
 
-  it('bulk path optimistically removes completed cards from store before response settles', () => {
-    // The optimistic removal must happen synchronously BEFORE the await on fetch.
-    // We check that setState (removing cards) appears before the await fetch call
-    // in the bulk branch of confirmWorktreeCleanup.
+  it('bulk path does NOT optimistically remove cards (server-side cleanup_state drives UX)', () => {
+    // The previous behaviour cleared the local worktrees list before the
+    // POST returned. That caused a UX glitch where a page reload mid-
+    // cleanup showed partial state. The server now stamps `cleanup_state`
+    // per registry entry, so the bulk branch should NOT touch local state
+    // before the POST — the only state-write in the bulk branch should
+    // be the closeWorktreeCleanupDialog call (which sets dialog-only state).
     const bulkBranchStart = fnBody.indexOf('runId === null');
     expect(bulkBranchStart).toBeGreaterThan(-1);
-    const bulkBranch = fnBody.slice(bulkBranchStart);
-    const setStateIdx = bulkBranch.indexOf('setState');
-    const awaitFetchIdx = bulkBranch.indexOf('await fetch');
-    expect(setStateIdx).toBeGreaterThan(-1);
-    expect(awaitFetchIdx).toBeGreaterThan(-1);
-    expect(setStateIdx).toBeLessThan(awaitFetchIdx);
+    const fetchIdx = fnBody.indexOf('await fetch');
+    const bulkBranch = fnBody.slice(bulkBranchStart, fetchIdx);
+    expect(bulkBranch).not.toContain('store.setState');
+    expect(bulkBranch).not.toContain('worktrees: (store.getState');
+  });
+
+  it('bulk path starts cleanup polling after kicking off the POST', () => {
+    expect(fnBody).toContain('startCleanupPolling');
   });
 
   it('bulk path includes run_ids array in the POST body', () => {

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -847,7 +847,7 @@ function fetchWorktrees() {
       : [];
 
   if (targets.length === 0) {
-    store.setState({ worktrees: [] });
+    store.setState({ worktrees: [], worktreesLoaded: true });
     return;
   }
 
@@ -861,7 +861,10 @@ function fetchWorktrees() {
   );
 
   Promise.all(requests).then((lists) => {
-    store.setState({ worktrees: lists.flat() });
+    store.setState({ worktrees: lists.flat(), worktreesLoaded: true });
+    // Reload during cleanup or a freshly-stamped pending — keep polling
+    // until the server confirms everything has settled.
+    if (anyCleanupInFlight()) startCleanupPolling();
   });
 }
 
@@ -949,6 +952,7 @@ function handleProjectSwitch(newProjectId) {
     activeRunId: null,
     runsLoaded: false,
     worktrees: [],
+    worktreesLoaded: false,
   });
   worktreesFilter = '';
   worktreesDialogItem = null;
@@ -1416,6 +1420,36 @@ const { archiveRun, unarchiveRun } = createArchiveActions({
   rerender,
 });
 
+// --- Worktrees: cleanup polling ---
+//
+// While any worktree carries cleanup_state ('pending' or 'cleaning'), poll
+// GET /worktrees every 2s so the spinner cards reflect server-side progress
+// across reloads and multiple tabs. Stops when no worktree is mid-cleanup.
+
+let _cleanupPollTimer = null;
+const CLEANUP_POLL_MS = 2000;
+
+function anyCleanupInFlight() {
+  return (store.getState().worktrees || []).some(
+    (w) => w.cleanup_state === 'pending' || w.cleanup_state === 'cleaning',
+  );
+}
+
+function startCleanupPolling() {
+  if (_cleanupPollTimer) return;
+  const tick = () => {
+    _cleanupPollTimer = null;
+    fetchWorktrees();
+    // fetchWorktrees mutates state asynchronously; re-check on next tick.
+    setTimeout(() => {
+      if (anyCleanupInFlight()) {
+        _cleanupPollTimer = setTimeout(tick, CLEANUP_POLL_MS);
+      }
+    }, 50);
+  };
+  _cleanupPollTimer = setTimeout(tick, CLEANUP_POLL_MS);
+}
+
 // --- Worktrees: cleanup actions ---
 
 function openWorktreeCleanupDialog(wt) {
@@ -1457,19 +1491,16 @@ async function deleteWorktree(runId, force) {
 
 async function confirmWorktreeCleanup(runId, force) {
   // Bulk path: runId is null, delete every completed worktree via one POST.
+  // No optimistic removal — the server stamps `cleanup_state: 'pending'` on
+  // each registry entry; we surface that via a spinner per card and poll
+  // GET /worktrees until everything settles. A page reload during cleanup
+  // sees the same intermediate state.
   if (runId === null) {
     const completed = (store.getState().worktrees || []).filter(
       (w) => w.status === 'completed',
     );
     closeWorktreeCleanupDialog();
     const runIds = completed.map((w) => w.run_id);
-    // Optimistic removal — drop targeted cards from state before response settles
-    // so the UI redraws immediately and the user sees progress.
-    store.setState({
-      worktrees: (store.getState().worktrees || []).filter(
-        (w) => !runIds.includes(w.run_id),
-      ),
-    });
     const url = projectUrl('/worktrees/cleanup');
     let data = null;
     try {
@@ -1484,21 +1515,23 @@ async function confirmWorktreeCleanup(runId, force) {
         /* ignore parse errors */
       }
     } catch {
-      /* network error — fetchWorktrees will reconcile */
+      /* network error — startCleanupPolling will reconcile on next tick */
     }
     fetchWorktrees();
-    const failures = (data?.results || [])
-      .filter((r) => !r.ok)
-      .map((r) => `${r.run_id}: ${r.error || 'failed'}`);
-    if (failures.length > 0) {
+    startCleanupPolling();
+    const rejected = data?.rejected || [];
+    if (rejected.length > 0) {
       showActionError(
-        `Cleanup completed with ${failures.length} failure(s):\n${failures.join('\n')}`,
+        `Cleanup rejected ${rejected.length} item(s):\n${rejected
+          .map((r) => `${r.run_id}: ${r.error || 'failed'}`)
+          .join('\n')}`,
       );
     }
     return;
   }
 
-  // Single-row path
+  // Single-row path — server-side single-target DELETE is still synchronous,
+  // so this path doesn't go through cleanup_state; just refresh.
   closeWorktreeCleanupDialog();
   try {
     await deleteWorktree(runId, !!force);

--- a/worca-ui/app/state.js
+++ b/worca-ui/app/state.js
@@ -43,6 +43,7 @@ export function createStore(initial = {}) {
     runsLoaded: initial.runsLoaded ?? false,
     addProjectDialogOpen: initial.addProjectDialogOpen ?? false,
     worktrees: initial.worktrees ?? [],
+    worktreesLoaded: initial.worktreesLoaded ?? false,
     worktreeDiskWarningBytes: initial.worktreeDiskWarningBytes ?? 2_000_000_000,
     classifierModel: initial.classifierModel ?? 'haiku',
     cleanupPolicy: initial.cleanupPolicy ?? 'never',

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -221,6 +221,19 @@ h1, h2, h3, h4, h5, h6 {
   opacity: 1;
 }
 
+/* Loading spinner shown in sidebar nav items while underlying data is still
+   being fetched. Delayed fade-in avoids a noisy flash on fast loads. */
+.sidebar-loading-spinner {
+  font-size: 14px;
+  --indicator-color: var(--text-secondary, currentColor);
+  opacity: 0;
+  animation: sidebar-spinner-fade 200ms ease-out 150ms forwards;
+}
+
+@keyframes sidebar-spinner-fade {
+  to { opacity: 0.7; }
+}
+
 .sidebar-item.active sl-badge {
   --sl-color-primary-600: #ffffff;
   --sl-color-neutral-600: #ffffff;
@@ -4635,6 +4648,33 @@ sl-tooltip.bead-tooltip::part(body) {
   color: var(--muted);
   word-break: break-all;
 }
+/* Worktree card mid-cleanup state — surfaces server-side cleanup_state
+   so a reload during a long bulk cleanup shows the same progress. */
+.worktree-card-cleaning {
+  opacity: 0.72;
+  pointer-events: none;
+}
+.worktree-card-cleaning .btn-cleanup {
+  pointer-events: none;
+}
+.status-badge-cleaning {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.badge-spinner,
+.btn-cleanup-spinner {
+  font-size: 12px;
+}
+.worktree-card-cleanup-error {
+  margin-top: 6px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--sl-color-danger-50, #fef2f2);
+  color: var(--sl-color-danger-700, #b91c1c);
+  font-size: 12px;
+}
+
 .worktrees-bulk-groups {
   margin: 8px 0 0;
   padding-left: 18px;

--- a/worca-ui/app/views/sidebar.js
+++ b/worca-ui/app/views/sidebar.js
@@ -82,6 +82,8 @@ export function sidebarView(
     worktreeDiskWarningBytes = 2_000_000_000,
     totalRunning = 0,
     maxConcurrentPipelines = 10,
+    runsLoaded = false,
+    worktreesLoaded = false,
   } = state;
   const atCapacity = totalRunning >= maxConcurrentPipelines;
   const allRunList = Object.values(runs);
@@ -191,7 +193,13 @@ export function sidebarView(
             ${unsafeHTML(iconSvg(Activity, 16))}
             <span>Running</span>
           </span>
-          ${activeCount > 0 ? html`<sl-badge variant="primary" pill>${activeCount}</sl-badge>` : ''}
+          ${
+            !runsLoaded
+              ? html`<sl-spinner class="sidebar-loading-spinner" data-testid="sidebar-running-loading"></sl-spinner>`
+              : activeCount > 0
+                ? html`<sl-badge variant="primary" pill>${activeCount}</sl-badge>`
+                : ''
+          }
         </div>
         <div class="sidebar-item ${route.section === 'history' ? 'active' : ''}"
              @click=${() => onNavigate('history')}>
@@ -199,21 +207,28 @@ export function sidebarView(
             ${unsafeHTML(iconSvg(Archive, 16))}
             <span>History</span>
           </span>
-          ${historyCount > 0 ? html`<sl-badge variant="neutral" pill>${historyCount}</sl-badge>` : ''}
+          ${
+            !runsLoaded
+              ? html`<sl-spinner class="sidebar-loading-spinner" data-testid="sidebar-history-loading"></sl-spinner>`
+              : historyCount > 0
+                ? html`<sl-badge variant="neutral" pill>${historyCount}</sl-badge>`
+                : ''
+          }
         </div>
-        ${
-          worktreeCount > 0
-            ? html`
         <div class="sidebar-item ${route.section === 'worktrees' ? 'active' : ''}"
              @click=${() => onNavigate('worktrees')}>
           <span class="sidebar-item-left">
             ${unsafeHTML(iconSvg(GitBranch, 16))}
             <span>Worktrees</span>
           </span>
-          <sl-badge variant="${worktreeDiskWarning ? 'warning' : 'neutral'}" pill class="worktrees-count-badge">${worktreeCount}</sl-badge>
-        </div>`
-            : ''
-        }
+          ${
+            !worktreesLoaded
+              ? html`<sl-spinner class="sidebar-loading-spinner" data-testid="sidebar-worktrees-loading"></sl-spinner>`
+              : worktreeCount > 0
+                ? html`<sl-badge variant="${worktreeDiskWarning ? 'warning' : 'neutral'}" pill class="worktrees-count-badge">${worktreeCount}</sl-badge>`
+                : ''
+          }
+        </div>
       </div>
 
       <div class="sidebar-section">

--- a/worca-ui/app/views/sidebar.test.js
+++ b/worca-ui/app/views/sidebar.test.js
@@ -42,13 +42,15 @@ const route = { section: 'active' };
 const defaultOpts = () => ({ onNavigate: vi.fn() });
 
 describe('sidebar - Worktrees nav entry visibility', () => {
-  it('hides Worktrees entry when worktrees is empty', async () => {
+  it('shows Worktrees entry with no badge when loaded and empty', async () => {
     const { sidebarView } = await import('./sidebar.js');
-    const state = makeState({ worktrees: [] });
+    const state = makeState({ worktrees: [], worktreesLoaded: true });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),
     );
-    expect(output).not.toContain('>Worktrees<');
+    expect(output).toContain('>Worktrees<');
+    expect(output).not.toContain('worktrees-count-badge');
+    expect(output).not.toContain('sidebar-worktrees-loading');
   });
 
   it('shows Worktrees entry when worktrees array is non-empty', async () => {
@@ -57,6 +59,7 @@ describe('sidebar - Worktrees nav entry visibility', () => {
       worktrees: [
         { run_id: 'r1', disk_bytes: 100_000_000, status: 'completed' },
       ],
+      worktreesLoaded: true,
     });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),
@@ -71,6 +74,7 @@ describe('sidebar - Worktrees nav entry visibility', () => {
         { run_id: 'r1', disk_bytes: 100_000_000, status: 'completed' },
         { run_id: 'r2', disk_bytes: 200_000_000, status: 'running' },
       ],
+      worktreesLoaded: true,
     });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),
@@ -83,12 +87,55 @@ describe('sidebar - Worktrees nav entry visibility', () => {
     const { sidebarView } = await import('./sidebar.js');
     const state = makeState({
       worktrees: [{ run_id: 'r1', disk_bytes: 100_000_000, status: 'running' }],
+      worktreesLoaded: true,
     });
     const activeRoute = { section: 'worktrees' };
     const output = renderToString(
       sidebarView(state, activeRoute, 'open', defaultOpts()),
     );
     expect(output).toContain('sidebar-item active');
+  });
+});
+
+describe('sidebar - loading spinners', () => {
+  it('shows spinner for Running/History when runs not yet loaded', async () => {
+    const { sidebarView } = await import('./sidebar.js');
+    const state = makeState({
+      runsLoaded: false,
+      worktreesLoaded: true,
+    });
+    const output = renderToString(
+      sidebarView(state, route, 'open', defaultOpts()),
+    );
+    expect(output).toContain('sidebar-running-loading');
+    expect(output).toContain('sidebar-history-loading');
+    expect(output).not.toContain('sidebar-worktrees-loading');
+  });
+
+  it('shows spinner for Worktrees when worktrees not yet loaded', async () => {
+    const { sidebarView } = await import('./sidebar.js');
+    const state = makeState({
+      runsLoaded: true,
+      worktreesLoaded: false,
+    });
+    const output = renderToString(
+      sidebarView(state, route, 'open', defaultOpts()),
+    );
+    expect(output).not.toContain('sidebar-running-loading');
+    expect(output).not.toContain('sidebar-history-loading');
+    expect(output).toContain('sidebar-worktrees-loading');
+  });
+
+  it('shows no spinners once everything is loaded', async () => {
+    const { sidebarView } = await import('./sidebar.js');
+    const state = makeState({
+      runsLoaded: true,
+      worktreesLoaded: true,
+    });
+    const output = renderToString(
+      sidebarView(state, route, 'open', defaultOpts()),
+    );
+    expect(output).not.toContain('sidebar-loading');
   });
 });
 
@@ -100,6 +147,7 @@ describe('sidebar - Worktrees badge disk-pressure threshold', () => {
       worktrees: [
         { run_id: 'r1', disk_bytes: 1_000_000_000, status: 'completed' },
       ],
+      worktreesLoaded: true,
     });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),
@@ -117,6 +165,7 @@ describe('sidebar - Worktrees badge disk-pressure threshold', () => {
         { run_id: 'r1', disk_bytes: 1_500_000_000, status: 'completed' },
         { run_id: 'r2', disk_bytes: 700_000_000, status: 'running' },
       ],
+      worktreesLoaded: true,
     });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),
@@ -132,6 +181,7 @@ describe('sidebar - Worktrees badge disk-pressure threshold', () => {
         { run_id: 'r1', disk_bytes: 500_000_000, status: 'completed' },
       ],
       worktreeDiskWarningBytes: 400_000_000,
+      worktreesLoaded: true,
     });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),
@@ -147,6 +197,7 @@ describe('sidebar - Worktrees badge disk-pressure threshold', () => {
         { run_id: 'r1', disk_bytes: 300_000_000, status: 'completed' },
       ],
       worktreeDiskWarningBytes: 400_000_000,
+      worktreesLoaded: true,
     });
     const output = renderToString(
       sidebarView(state, route, 'open', defaultOpts()),

--- a/worca-ui/app/views/worktrees.js
+++ b/worca-ui/app/views/worktrees.js
@@ -99,15 +99,19 @@ function _diskSummaryView(worktrees, diskWarningBytes = 2_000_000_000) {
 
 function _cardView(wt, { onSelectRun, onCleanup } = {}) {
   const isRunning = wt.status === 'running';
+  const cleanupState = wt.cleanup_state || null; // 'pending' | 'cleaning' | null
+  const isCleaning = !!cleanupState;
+  const cleanupError = wt.cleanup_error || null;
   const groupLabel = _groupLabel(wt);
   const status = wt.status || 'unknown';
   // Whole card is the click target — matches run-card behaviour. The
   // Cleanup button stops propagation so it doesn't trigger navigation.
   const cardClick = onSelectRun ? () => onSelectRun(wt.run_id) : null;
+  const cleanupDisabled = isRunning || isCleaning;
 
   return html`
     <div
-      class="run-card worktree-card ${statusClass(status)}"
+      class="run-card worktree-card ${statusClass(status)}${isCleaning ? ' worktree-card-cleaning' : ''}"
       @click=${cardClick}
     >
       <div class="run-card-top">
@@ -115,13 +119,17 @@ function _cardView(wt, { onSelectRun, onCleanup } = {}) {
           ${unsafeHTML(statusIcon(status, 16))}
         </span>
         <span class="run-card-title">${wt.title || wt.run_id}</span>
-        <sl-badge
-          variant="${_statusBadgeVariant(status)}"
-          pill
-          class="status-badge-${status}"
-        >
-          ${status}
-        </sl-badge>
+        ${
+          isCleaning
+            ? html`<sl-badge variant="warning" pill class="status-badge-cleaning"><sl-spinner class="badge-spinner"></sl-spinner> ${cleanupState}</sl-badge>`
+            : html`<sl-badge
+                variant="${_statusBadgeVariant(status)}"
+                pill
+                class="status-badge-${status}"
+              >
+                ${status}
+              </sl-badge>`
+        }
       </div>
       <div class="run-card-meta">
         <span class="run-card-meta-item">
@@ -151,20 +159,37 @@ function _cardView(wt, { onSelectRun, onCleanup } = {}) {
         <span class="meta-label">Path:</span>
         <code class="worktree-path-mono">${wt.worktree_path}</code>
       </div>
+      ${
+        cleanupError
+          ? html`<div class="worktree-card-cleanup-error">
+              <strong>Cleanup failed:</strong> ${cleanupError}
+            </div>`
+          : nothing
+      }
       <div class="run-card-actions">
         <sl-button
           size="small"
           variant="danger"
           outline
-          class="btn-cleanup${isRunning ? ' btn-cleanup-disabled' : ''}"
-          ?disabled=${isRunning}
-          title=${isRunning ? 'Cannot cleanup a running worktree' : nothing}
+          class="btn-cleanup${cleanupDisabled ? ' btn-cleanup-disabled' : ''}"
+          ?disabled=${cleanupDisabled}
+          title=${
+            isRunning
+              ? 'Cannot cleanup a running worktree'
+              : isCleaning
+                ? 'Cleanup already in progress'
+                : nothing
+          }
           @click=${(e) => {
             e.stopPropagation();
-            if (!isRunning && onCleanup) onCleanup(wt);
+            if (!cleanupDisabled && onCleanup) onCleanup(wt);
           }}
         >
-          ${unsafeHTML(iconSvg(Trash2, 12))} Cleanup
+          ${
+            isCleaning
+              ? html`<sl-spinner class="btn-cleanup-spinner"></sl-spinner> ${cleanupState}`
+              : html`${unsafeHTML(iconSvg(Trash2, 12))} Cleanup`
+          }
         </sl-button>
       </div>
     </div>

--- a/worca-ui/app/views/worktrees.test.js
+++ b/worca-ui/app/views/worktrees.test.js
@@ -322,6 +322,58 @@ describe('worktreesView - cleanup button disabled when running', () => {
   });
 });
 
+describe('worktreesView - cleanup_state rendering', () => {
+  const cleaningWorktree = {
+    run_id: 'r-cleaning',
+    title: 'Mid-cleanup',
+    branch: 'cleanup',
+    worktree_path: '/p/x',
+    disk_bytes: 1_000_000,
+    age_seconds: 60,
+    started_at: '2026-05-01T00:00:00Z',
+    status: 'completed',
+    cleanup_state: 'cleaning',
+  };
+  const pendingWorktree = {
+    ...cleaningWorktree,
+    run_id: 'r-pending',
+    cleanup_state: 'pending',
+  };
+  const erroredWorktree = {
+    ...cleaningWorktree,
+    run_id: 'r-error',
+    cleanup_state: null,
+    cleanup_error: 'permission denied',
+  };
+
+  it('disables Cleanup button while cleanup_state is set', () => {
+    const output = renderToString(worktreesView([cleaningWorktree]));
+    expect(output).toContain('btn-cleanup-disabled');
+  });
+
+  it('disables Cleanup button while cleanup_state is pending', () => {
+    const output = renderToString(worktreesView([pendingWorktree]));
+    expect(output).toContain('btn-cleanup-disabled');
+  });
+
+  it('shows the worktree-card-cleaning class on the card', () => {
+    const output = renderToString(worktreesView([cleaningWorktree]));
+    expect(output).toContain('worktree-card-cleaning');
+  });
+
+  it('renders cleanup error banner when cleanup_error is set', () => {
+    const output = renderToString(worktreesView([erroredWorktree]));
+    expect(output).toContain('worktree-card-cleanup-error');
+    expect(output).toContain('permission denied');
+  });
+
+  it('does not show cleaning class or disable button when cleanup_state is null', () => {
+    const output = renderToString(worktreesView([completedWorktree]));
+    expect(output).not.toContain('worktree-card-cleaning');
+    expect(output).not.toContain('btn-cleanup-disabled');
+  });
+});
+
 describe('worktreesView - filter input narrows rows', () => {
   it('shows all rows when filter is empty', () => {
     const worktrees = [completedWorktree, runningWorktree, failedWorktree];

--- a/worca-ui/server/worktrees-routes.js
+++ b/worca-ui/server/worktrees-routes.js
@@ -16,7 +16,7 @@
  * the discrepancy with `du -sh`.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import { join } from 'node:path';
 import { Router } from 'express';
@@ -192,6 +192,76 @@ function _readWorktreeStatus(worktreePath) {
   return null;
 }
 
+/**
+ * Run a pre-validated cleanup batch in the background. Each task stamps
+ * `cleanup_state: 'cleaning'`, calls `removeWorktree` (which deletes the
+ * registry entry on success), and on failure stamps `cleanup_error` while
+ * clearing `cleanup_state` so the UI can render the error and let the user
+ * retry. Concurrency is bounded by `CLEANUP_CONCURRENCY`.
+ */
+async function _runCleanupBatch(worcaDir, accepted) {
+  const tasks = accepted.map(({ run_id, reg }) => ({
+    run_id,
+    fn: async () => {
+      _patchRegistry(worcaDir, run_id, { cleanup_state: 'cleaning' });
+      try {
+        await removeWorktree(worcaDir, run_id, { skipPrune: true });
+        if (reg.worktree_path) _diskCache.delete(reg.worktree_path);
+        return { run_id, ok: true };
+      } catch (err) {
+        _patchRegistry(worcaDir, run_id, {
+          cleanup_state: undefined,
+          cleanup_error: err?.message || String(err),
+        });
+        return { run_id, ok: false, error: err?.message || String(err) };
+      }
+    },
+  }));
+
+  try {
+    await runWithConcurrencyLimit(tasks, CLEANUP_CONCURRENCY);
+  } catch {
+    /* per-task failures already persisted into the registry */
+  }
+
+  try {
+    await pruneWorktrees(worcaDir);
+  } catch {
+    /* non-fatal */
+  }
+}
+
+/**
+ * Atomically patch fields on a pipelines.d/<run>.json entry.
+ * Set a field to `undefined` to delete it. Returns `false` if the file is
+ * gone (the worktree was already cleaned up) or unreadable.
+ *
+ * Note: write is not strictly atomic — for a single-writer-per-id model
+ * (the cleanup background task owns its registry entry for the lifetime
+ * of the cleanup), read-modify-write is fine. A multi-writer scenario
+ * would need rename-into-place; we don't have that here.
+ */
+function _patchRegistry(worcaDir, runId, patch) {
+  const regFile = join(worcaDir, 'multi', 'pipelines.d', `${runId}.json`);
+  if (!existsSync(regFile)) return false;
+  let reg;
+  try {
+    reg = JSON.parse(readFileSync(regFile, 'utf8'));
+  } catch {
+    return false;
+  }
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) delete reg[k];
+    else reg[k] = v;
+  }
+  try {
+    writeFileSync(regFile, JSON.stringify(reg, null, 2), 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function _listWorktrees(worcaDir) {
   const pipelinesDir = join(worcaDir, 'multi', 'pipelines.d');
   if (!existsSync(pipelinesDir)) return [];
@@ -228,7 +298,15 @@ async function _listWorktrees(worcaDir) {
       }
     }
 
-    metas.push({ reg, worktreePath, worktreeExists, status, ageSeconds });
+    metas.push({
+      reg,
+      worktreePath,
+      worktreeExists,
+      status,
+      ageSeconds,
+      cleanup_state: reg.cleanup_state || null,
+      cleanup_error: reg.cleanup_error || null,
+    });
   }
 
   const disks = await Promise.all(
@@ -255,6 +333,8 @@ async function _listWorktrees(worcaDir) {
     group_type: m.reg.group_type || null,
     group_status: null,
     resumable: RESUMABLE_STATUSES.has(m.status),
+    cleanup_state: m.cleanup_state,
+    cleanup_error: m.cleanup_error,
   }));
 }
 
@@ -371,13 +451,19 @@ export function createWorktreesRouter() {
 
   // POST /worktrees/cleanup
   //
-  // Batch worktree removal. Always responds with HTTP 200 and a JSON body of
-  // shape `{ ok, results, failed_count }`, where `ok` is the AND of per-id
-  // outcomes and `failed_count` is the number of entries with `ok: false`.
-  // Per-entry errors carry a `code` field (`running`, `resumable_or_grouped`)
-  // when actionable. Clients must inspect `results[]` — a single bad id never
-  // aborts the batch, and partial failures are not signalled via HTTP status.
-  router.post('/cleanup', async (req, res) => {
+  // Batch worktree removal — async. Synchronously validates each id and
+  // stamps `cleanup_state: 'pending'` on the registry entries that pass
+  // pre-flight checks, then returns 202. The actual removal happens in
+  // the background with bounded concurrency. Clients poll GET /worktrees
+  // and observe `cleanup_state` per entry; on success the entry vanishes,
+  // on failure `cleanup_error` is set and `cleanup_state` is cleared.
+  //
+  // Response shape `{ ok, accepted, rejected }` where `rejected[]` carries
+  // entries that failed pre-flight (running, resumable without force, etc).
+  // A single bad id never blocks the rest of the batch; this stays
+  // compatible with the legacy synchronous shape's promise that partial
+  // failures are not signalled via HTTP status.
+  router.post('/cleanup', (req, res) => {
     const worcaDir = req.project?.worcaDir;
     if (!worcaDir) {
       return res
@@ -399,86 +485,82 @@ export function createWorktreesRouter() {
       }
     }
 
-    const tasks = run_ids.map((run_id) => ({
-      run_id,
-      fn: async () => {
-        const regFile = join(
-          worcaDir,
-          'multi',
-          'pipelines.d',
-          `${run_id}.json`,
-        );
-        if (!existsSync(regFile)) {
-          return {
-            run_id,
-            ok: false,
-            error: `Worktree "${run_id}" not found`,
-          };
-        }
+    // Pre-flight: read each registry entry, decide pending vs reject. We do
+    // this synchronously so the HTTP response can carry the rejection list
+    // — clients shouldn't have to poll to learn that a 'running' worktree
+    // was refused.
+    const accepted = [];
+    const rejected = [];
+    for (const run_id of run_ids) {
+      const regFile = join(worcaDir, 'multi', 'pipelines.d', `${run_id}.json`);
+      if (!existsSync(regFile)) {
+        rejected.push({
+          run_id,
+          ok: false,
+          error: `Worktree "${run_id}" not found`,
+        });
+        continue;
+      }
+      let reg;
+      try {
+        reg = JSON.parse(readFileSync(regFile, 'utf8'));
+      } catch {
+        rejected.push({
+          run_id,
+          ok: false,
+          error: 'Failed to read registry entry',
+        });
+        continue;
+      }
 
-        let reg;
-        try {
-          reg = JSON.parse(readFileSync(regFile, 'utf8'));
-        } catch {
-          return {
-            run_id,
-            ok: false,
-            error: 'Failed to read registry entry',
-          };
-        }
+      let status = reg.status || 'unknown';
+      if (reg.worktree_path && existsSync(reg.worktree_path)) {
+        const actual = _readWorktreeStatus(reg.worktree_path);
+        if (actual) status = actual;
+      }
 
-        let status = reg.status || 'unknown';
-        if (reg.worktree_path && existsSync(reg.worktree_path)) {
-          const actual = _readWorktreeStatus(reg.worktree_path);
-          if (actual) status = actual;
-        }
+      if (status === 'running') {
+        rejected.push({
+          run_id,
+          ok: false,
+          error: 'Cannot remove a running worktree',
+          code: 'running',
+        });
+        continue;
+      }
 
-        if (status === 'running') {
-          return {
-            run_id,
-            ok: false,
-            error: 'Cannot remove a running worktree',
-            code: 'running',
-          };
-        }
+      const isResumable = RESUMABLE_STATUSES.has(status);
+      const isGrouped = !!(reg.fleet_id || reg.workspace_id);
+      if (!force && (isResumable || isGrouped)) {
+        rejected.push({
+          run_id,
+          ok: false,
+          error:
+            'Removing this worktree prevents resuming the run. Pass force=true to confirm.',
+          code: 'resumable_or_grouped',
+        });
+        continue;
+      }
 
-        const isResumable = RESUMABLE_STATUSES.has(status);
-        const isGrouped = !!(reg.fleet_id || reg.workspace_id);
-        if (!force && (isResumable || isGrouped)) {
-          return {
-            run_id,
-            ok: false,
-            error:
-              'Removing this worktree prevents resuming the run. Pass force=true to confirm.',
-            code: 'resumable_or_grouped',
-          };
-        }
-
-        try {
-          await removeWorktree(worcaDir, run_id, { skipPrune: true });
-          if (reg.worktree_path) _diskCache.delete(reg.worktree_path);
-          return { run_id, ok: true };
-        } catch (err) {
-          return { run_id, ok: false, error: err.message };
-        }
-      },
-    }));
-
-    let results;
-    try {
-      results = await runWithConcurrencyLimit(tasks, CLEANUP_CONCURRENCY);
-    } catch (err) {
-      return res.status(500).json({ ok: false, error: err.message });
+      // Stamp pending so a reload mid-cleanup shows the same state.
+      _patchRegistry(worcaDir, run_id, {
+        cleanup_state: 'pending',
+        cleanup_error: undefined,
+      });
+      accepted.push({ run_id, reg });
     }
 
-    try {
-      await pruneWorktrees(worcaDir);
-    } catch {
-      /* non-fatal */
-    }
+    // Respond immediately — the client polls GET /worktrees to observe progress.
+    res.status(202).json({
+      ok: rejected.length === 0,
+      accepted: accepted.map((a) => a.run_id),
+      rejected,
+    });
 
-    const failed_count = results.reduce((n, r) => (r.ok ? n : n + 1), 0);
-    res.json({ ok: failed_count === 0, failed_count, results });
+    // Fire-and-forget background removal. Errors are persisted into the
+    // registry so the client can render them; nothing here is awaited by
+    // the HTTP request.
+    void _runCleanupBatch(worcaDir, accepted);
   });
 
   return router;

--- a/worca-ui/server/worktrees-routes.test.js
+++ b/worca-ui/server/worktrees-routes.test.js
@@ -2,6 +2,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   unlinkSync,
   writeFileSync,
@@ -163,6 +164,38 @@ describe('GET /api/worktrees', () => {
       // started_at is needed by the client to sort newest-first.
       expect(typeof wt.started_at).toBe('string');
       expect(wt.started_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    } finally {
+      rmSync(worktreePath, { recursive: true, force: true });
+    }
+  });
+
+  it('GET_surfaces_cleanup_state_and_error: registry cleanup_state and cleanup_error appear on the response entry', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'wt-cleanup-state-'));
+    writeWorktreeStatus(worktreePath, 'completed');
+    writePipelineEntry(tmpDir, 'run-mid-cleanup', {
+      run_id: 'run-mid-cleanup',
+      worktree_path: worktreePath,
+      cleanup_state: 'cleaning',
+    });
+    writePipelineEntry(tmpDir, 'run-failed-cleanup', {
+      run_id: 'run-failed-cleanup',
+      worktree_path: '/nonexistent/failed',
+      cleanup_error: 'disk on fire',
+    });
+
+    try {
+      const res = await fetch(`${base}/api/worktrees`);
+      const data = await res.json();
+
+      const mid = data.worktrees.find((w) => w.run_id === 'run-mid-cleanup');
+      expect(mid.cleanup_state).toBe('cleaning');
+      expect(mid.cleanup_error).toBeNull();
+
+      const failed = data.worktrees.find(
+        (w) => w.run_id === 'run-failed-cleanup',
+      );
+      expect(failed.cleanup_state).toBeNull();
+      expect(failed.cleanup_error).toBe('disk on fire');
     } finally {
       rmSync(worktreePath, { recursive: true, force: true });
     }
@@ -428,6 +461,34 @@ describe('POST /api/worktrees/cleanup', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  // Wait until no registry file for the given run_ids has a `cleanup_state` set
+  // — either the file is gone (success) or the field has been cleared after a
+  // recorded failure. Polls every 5 ms up to `timeoutMs`.
+  async function waitForCleanupToSettle(worcaDir, runIds, timeoutMs = 2000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      let pending = false;
+      for (const id of runIds) {
+        const f = join(worcaDir, 'multi', 'pipelines.d', `${id}.json`);
+        if (!existsSync(f)) continue;
+        try {
+          const reg = JSON.parse(readFileSync(f, 'utf8'));
+          if (reg.cleanup_state) {
+            pending = true;
+            break;
+          }
+        } catch {
+          /* unreadable mid-write — treat as pending */
+          pending = true;
+          break;
+        }
+      }
+      if (!pending) return;
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    throw new Error('cleanup did not settle within timeout');
+  }
+
   it('POST_cleanup_parallelises_prune_once: runs ≤4 concurrent removes and prunes exactly once', async () => {
     for (let i = 1; i <= 6; i++) {
       writePipelineEntry(tmpDir, `run-bulk-${i}`, {
@@ -440,40 +501,46 @@ describe('POST /api/worktrees/cleanup', () => {
     let concurrent = 0;
     let maxConcurrent = 0;
 
-    mockRemoveWorktree.mockImplementation(async () => {
+    mockRemoveWorktree.mockImplementation(async (worcaDir, runId) => {
       concurrent++;
       maxConcurrent = Math.max(maxConcurrent, concurrent);
       await new Promise((r) => setTimeout(r, 20));
       concurrent--;
+      // Match real removeWorktree: delete the registry entry on success
+      try {
+        unlinkSync(join(worcaDir, 'multi', 'pipelines.d', `${runId}.json`));
+      } catch {
+        /* ignore */
+      }
     });
 
+    const runIds = [
+      'run-bulk-1',
+      'run-bulk-2',
+      'run-bulk-3',
+      'run-bulk-4',
+      'run-bulk-5',
+      'run-bulk-6',
+    ];
     const res = await fetch(`${base}/api/worktrees/cleanup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        run_ids: [
-          'run-bulk-1',
-          'run-bulk-2',
-          'run-bulk-3',
-          'run-bulk-4',
-          'run-bulk-5',
-          'run-bulk-6',
-        ],
-      }),
+      body: JSON.stringify({ run_ids: runIds }),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(202);
     const data = await res.json();
     expect(data.ok).toBe(true);
-    expect(data.failed_count).toBe(0);
-    expect(data.results).toHaveLength(6);
-    expect(data.results.every((r) => r.ok)).toBe(true);
+    expect(data.accepted).toHaveLength(6);
+    expect(data.rejected).toHaveLength(0);
+
+    await waitForCleanupToSettle(tmpDir, runIds);
     expect(maxConcurrent).toBeGreaterThan(1);
     expect(maxConcurrent).toBeLessThanOrEqual(4);
     expect(mockPruneWorktrees).toHaveBeenCalledTimes(1);
   });
 
-  it('POST_cleanup_per_id_success_failure: returns per-id error for missing/running, ok for completed', async () => {
+  it('POST_cleanup_per_id_success_failure: rejects missing/running synchronously, processes completed in background', async () => {
     const worktreeRunning = mkdtempSync(join(tmpdir(), 'wt-cleanup-running-'));
     writeWorktreeStatus(worktreeRunning, 'running');
     writePipelineEntry(tmpDir, 'run-running-c', {
@@ -495,22 +562,26 @@ describe('POST /api/worktrees/cleanup', () => {
         }),
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202);
       const data = await res.json();
-      expect(data.results).toHaveLength(3);
       expect(data.ok).toBe(false);
-      expect(data.failed_count).toBe(2);
+      expect(data.accepted).toEqual(['run-ok-c']);
+      expect(data.rejected).toHaveLength(2);
 
-      const missing = data.results.find((r) => r.run_id === 'run-missing-c');
+      const missing = data.rejected.find((r) => r.run_id === 'run-missing-c');
       expect(missing.ok).toBe(false);
       expect(missing.error).toMatch(/not found/i);
 
-      const running = data.results.find((r) => r.run_id === 'run-running-c');
+      const running = data.rejected.find((r) => r.run_id === 'run-running-c');
       expect(running.ok).toBe(false);
       expect(running.code).toBe('running');
 
-      const ok = data.results.find((r) => r.run_id === 'run-ok-c');
-      expect(ok.ok).toBe(true);
+      // The accepted entry is processed in the background — the registry
+      // entry should be gone once that finishes.
+      await waitForCleanupToSettle(tmpDir, ['run-ok-c']);
+      expect(
+        existsSync(join(tmpDir, 'multi', 'pipelines.d', 'run-ok-c.json')),
+      ).toBe(false);
     } finally {
       rmSync(worktreeRunning, { recursive: true, force: true });
     }
@@ -537,15 +608,54 @@ describe('POST /api/worktrees/cleanup', () => {
         body: JSON.stringify({ run_ids: ['run-fleet-c'], force: true }),
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202);
       const data = await res.json();
       expect(data.ok).toBe(true);
-      expect(data.results[0].run_id).toBe('run-fleet-c');
-      expect(data.results[0].ok).toBe(true);
+      expect(data.accepted).toEqual(['run-fleet-c']);
+      await waitForCleanupToSettle(tmpDir, ['run-fleet-c']);
       expect(existsSync(regFile)).toBe(false);
     } finally {
       rmSync(worktreePath, { recursive: true, force: true });
     }
+  });
+
+  it('POST_cleanup_stamps_pending_and_persists_error: pending visible mid-cleanup, error visible on failure', async () => {
+    writePipelineEntry(tmpDir, 'run-fail-c', {
+      run_id: 'run-fail-c',
+      worktree_path: '/nonexistent/fail',
+      status: 'completed',
+    });
+
+    let pendingObservedDuringRemoval = false;
+    mockRemoveWorktree.mockImplementation(async () => {
+      const reg = JSON.parse(
+        readFileSync(
+          join(tmpDir, 'multi', 'pipelines.d', 'run-fail-c.json'),
+          'utf8',
+        ),
+      );
+      pendingObservedDuringRemoval =
+        reg.cleanup_state === 'pending' || reg.cleanup_state === 'cleaning';
+      throw new Error('disk on fire');
+    });
+
+    const res = await fetch(`${base}/api/worktrees/cleanup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ run_ids: ['run-fail-c'] }),
+    });
+    expect(res.status).toBe(202);
+    await waitForCleanupToSettle(tmpDir, ['run-fail-c']);
+
+    expect(pendingObservedDuringRemoval).toBe(true);
+    const reg = JSON.parse(
+      readFileSync(
+        join(tmpDir, 'multi', 'pipelines.d', 'run-fail-c.json'),
+        'utf8',
+      ),
+    );
+    expect(reg.cleanup_state).toBeUndefined();
+    expect(reg.cleanup_error).toMatch(/disk on fire/);
   });
 
   it('DELETE_cache_evicted_on_delete: stale disk cache is cleared after single DELETE', async () => {


### PR DESCRIPTION
## Summary

Three coupled UX improvements to the Worktrees view and sidebar.

### 1. Server-side worktree cleanup status

The bulk cleanup flow was misleading: clicking "Cleanup all completed" optimistically wiped the local list, but the actual removal took minutes. A page reload mid-cleanup revealed partial truth — and each subsequent refresh showed fewer remaining — so the state appeared to vary at random.

Now:

- `POST /worktrees/cleanup` validates synchronously, stamps `cleanup_state: 'pending'` on each accepted registry entry, and returns **202** with `{ok, accepted, rejected}`. Removal runs in the background with bounded concurrency.
- `GET /worktrees` surfaces `cleanup_state` (`'pending' | 'cleaning' | null`) and `cleanup_error` per entry. On success the entry vanishes; on failure `cleanup_state` clears and `cleanup_error` persists for the user to see.
- Frontend drops the optimistic clear, renders a per-card spinner while `cleanup_state` is set, and polls `/worktrees` every 2s until everything settles. A reload mid-cleanup now sees the same intermediate state across all tabs.

**Breaking response shape:** POST /worktrees/cleanup now returns `{ok, accepted, rejected}` with HTTP 202, instead of `{ok, results, failed_count}` with 200. Single-row DELETE is unchanged.

### 2. Sidebar loading spinners

Running, History, and Worktrees badges showed an empty space until their respective fetches landed — indistinguishable from "0". Now a small inline spinner appears in that window, with a 150ms CSS fade-in to keep fast loads quiet.

### 3. Sidebar always shows Worktrees

Previously hidden when count was 0, which made the item vanish after cleaning everything and left no obvious way back. Matches History now: item always present, badge hidden at 0.

## Test plan

- [x] Targeted vitest (sidebar / worktrees / router / worktrees-routes): 109/109 pass
- [x] Full UI vitest suite: 2463/2463 pass
- [x] `npm run lint` — only 3 pre-existing warnings in `settings.js`
- [x] Playwright on `/#/project/worca-cc/worktrees` (empty state) and `/#/project/test-multi-01/worktrees` (5 worktrees): sidebar Worktrees item always visible; badge appears when populated
- [x] Stamped `cleanup_state: 'cleaning'` and `cleanup_error: '...'` on registry entries directly — UI rendered cleaning-spinner badge, disabled cleanup button, and the red error banner as expected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)