### PR TITLE
fix: honor $WORCA_HOME + add ~/.worca/ leak detector (#162)

### DIFF
--- a/src/worca/cli/cleanup.py
+++ b/src/worca/cli/cleanup.py
@@ -212,7 +212,8 @@ class FleetSource:
     def __init__(self, fleet_runs_dir: str = None):
         if fleet_runs_dir is None:
             from worca.orchestrator.fleet_manifest import _FLEET_RUNS_DIR
-            fleet_runs_dir = _FLEET_RUNS_DIR
+            from worca.utils.paths import fleet_runs_dir as resolve_fleet_runs_dir
+            fleet_runs_dir = resolve_fleet_runs_dir(_FLEET_RUNS_DIR)
         self.fleet_runs_dir = fleet_runs_dir
 
     def list_eligible(self, filters: dict) -> list[dict]:

--- a/src/worca/events/fleet_emitter.py
+++ b/src/worca/events/fleet_emitter.py
@@ -32,15 +32,19 @@ import uuid
 from datetime import datetime, timezone
 
 from worca.orchestrator.events import dispatch_shell_hooks
+from worca.utils.paths import fleet_runs_dir as resolve_fleet_runs_dir
 from worca.utils.settings import load_settings
 
-_DEFAULT_FLEET_RUNS_DIR = os.path.expanduser("~/.worca/fleet-runs")
+# Module-level override slot.  See worca.utils.paths.fleet_runs_dir for
+# resolution precedence.  Defaulted to None and resolved lazily so tests
+# can set $WORCA_HOME (or patch this attribute) after import (issue #162).
+_DEFAULT_FLEET_RUNS_DIR: str | None = None
 
 
 def fleet_events_path(fleet_id: str, base_dir: str | None = None) -> str:
     """Return the absolute path to a fleet's event log."""
     if base_dir is None:
-        base_dir = _DEFAULT_FLEET_RUNS_DIR
+        base_dir = resolve_fleet_runs_dir(_DEFAULT_FLEET_RUNS_DIR)
     return os.path.join(base_dir, f"{fleet_id}.events.jsonl")
 
 

--- a/src/worca/events/workspace_emitter.py
+++ b/src/worca/events/workspace_emitter.py
@@ -27,9 +27,13 @@ import uuid
 from datetime import datetime, timezone
 
 from worca.orchestrator.events import dispatch_shell_hooks
+from worca.utils.paths import workspace_runs_dir as resolve_workspace_runs_dir
 from worca.utils.settings import load_settings
 
-_DEFAULT_WORKSPACE_RUNS_DIR = os.path.expanduser("~/.worca/workspace-runs")
+# Module-level override slot.  See worca.utils.paths.workspace_runs_dir for
+# resolution precedence.  Defaulted to None and resolved lazily so tests
+# can set $WORCA_HOME (or patch this attribute) after import (issue #162).
+_DEFAULT_WORKSPACE_RUNS_DIR: str | None = None
 
 
 def workspace_events_path(
@@ -37,7 +41,7 @@ def workspace_events_path(
 ) -> str:
     """Return the absolute path to a workspace's event log."""
     if base_dir is None:
-        base_dir = _DEFAULT_WORKSPACE_RUNS_DIR
+        base_dir = resolve_workspace_runs_dir(_DEFAULT_WORKSPACE_RUNS_DIR)
     return os.path.join(base_dir, f"{workspace_id}.events.jsonl")
 
 

--- a/src/worca/orchestrator/fleet_manifest.py
+++ b/src/worca/orchestrator/fleet_manifest.py
@@ -14,9 +14,17 @@ from worca.state.status import (
     PipelineStatus, FleetStatus, FLEET_STICKY,
     PIPELINE_ACTIVE, PIPELINE_FAILURE, PIPELINE_ALL_TERMINAL,
 )
+from worca.utils.paths import fleet_runs_dir
 
 
-_FLEET_RUNS_DIR = os.path.expanduser("~/.worca/fleet-runs")
+# Module-level override slot.  Resolution precedence (see paths.fleet_runs_dir):
+#   1. _FLEET_RUNS_DIR if set (typically via ``mock.patch`` in tests)
+#   2. $WORCA_HOME/fleet-runs
+#   3. ~/.worca/fleet-runs
+# Defaulting to None — and resolving lazily inside the helpers below — avoids
+# the module-load-time capture that leaked test state into the real home
+# directory (issue #162).
+_FLEET_RUNS_DIR: str | None = None
 
 _RUNNING_STATES = PIPELINE_ACTIVE
 _FAILURE_STATES = PIPELINE_FAILURE
@@ -40,7 +48,7 @@ def generate_fleet_id(*, now=None) -> tuple:
 def fleet_manifest_path(fleet_id: str, base_dir: str = None) -> str:
     """Return absolute path to the fleet manifest JSON file."""
     if base_dir is None:
-        base_dir = _FLEET_RUNS_DIR
+        base_dir = fleet_runs_dir(_FLEET_RUNS_DIR)
     return os.path.join(base_dir, f"{fleet_id}.json")
 
 

--- a/src/worca/scripts/run_fleet.py
+++ b/src/worca/scripts/run_fleet.py
@@ -21,6 +21,7 @@ from worca.orchestrator.fleet_manifest import (
     update_fleet_status,
 )
 from worca.state.status import PipelineStatus, FleetStatus
+from worca.utils.paths import fleet_runs_dir as resolve_fleet_runs_dir
 
 # Per W-040 §5: the fleet scrub list is fleet-specific. It is NOT the same as
 # `worca.utils.env.RESERVED_ENV_KEYS` (which is the denylist for per-model env
@@ -36,7 +37,10 @@ _FLEET_SCRUB_KEYS = frozenset({
 })
 _FLEET_SCRUB_PREFIXES = ("WORCA_",)
 
-_FLEET_RUNS_DEFAULT = os.path.expanduser("~/.worca/fleet-runs")
+# Module-level override slot.  Resolves lazily via
+# worca.utils.paths.fleet_runs_dir — None means "use $WORCA_HOME or ~/.worca"
+# (issue #162).
+_FLEET_RUNS_DEFAULT: str | None = None
 
 
 _BRANCH_REJECTION_MSG = (
@@ -268,7 +272,7 @@ def run_plan_first(
         return None
 
     if fleet_runs_base is None:
-        fleet_runs_base = _FLEET_RUNS_DEFAULT
+        fleet_runs_base = resolve_fleet_runs_dir(_FLEET_RUNS_DEFAULT)
     fleet_dir = os.path.join(fleet_runs_base, fleet_id)
     os.makedirs(fleet_dir, exist_ok=True)
     shared_plan = os.path.join(fleet_dir, "shared-plan.md")

--- a/src/worca/scripts/run_workspace.py
+++ b/src/worca/scripts/run_workspace.py
@@ -24,6 +24,7 @@ from worca.events import types as event_types
 from worca.events.workspace_emitter import emit_workspace_event
 from worca.state.status import WorkspaceStatus
 from worca.utils.claude_cli import run_agent
+from worca.utils.paths import workspace_runs_dir as resolve_workspace_runs_dir
 from worca.workspace.manifest import Workspace
 
 
@@ -180,7 +181,10 @@ _AGENTS_DIR = os.path.join(os.path.dirname(worca.__file__), "agents", "core")
 _SCHEMAS_DIR = os.path.join(os.path.dirname(worca.__file__), "schemas")
 
 
-_POINTER_DIR_DEFAULT = os.path.expanduser("~/.worca/workspace-runs")
+# Module-level override slot.  Resolves lazily via
+# worca.utils.paths.workspace_runs_dir — None means "use $WORCA_HOME or
+# ~/.worca" (issue #162).
+_POINTER_DIR_DEFAULT: str | None = None
 
 
 def generate_workspace_id(*, now=None) -> tuple:
@@ -212,7 +216,7 @@ def write_pointer_file(
     every project directory.
     """
     if pointer_dir is None:
-        pointer_dir = _POINTER_DIR_DEFAULT
+        pointer_dir = resolve_workspace_runs_dir(_POINTER_DIR_DEFAULT)
     os.makedirs(pointer_dir, exist_ok=True)
 
     pointer_path = os.path.join(pointer_dir, f"{workspace_id}.json")
@@ -517,7 +521,7 @@ def load_workspace_manifest(
     file is missing/corrupt.
     """
     if pointer_dir is None:
-        pointer_dir = _POINTER_DIR_DEFAULT
+        pointer_dir = resolve_workspace_runs_dir(_POINTER_DIR_DEFAULT)
 
     pointer_path = os.path.join(pointer_dir, f"{workspace_id}.json")
     try:

--- a/src/worca/utils/paths.py
+++ b/src/worca/utils/paths.py
@@ -1,0 +1,57 @@
+"""Lazy resolvers for ~/.worca/ subdirectories.
+
+Why these helpers exist: many call sites used to capture
+``os.path.expanduser("~/.worca/...")`` into a module-level constant at
+import time. That makes the path impossible to override from a test
+(or from a different ``WORCA_HOME``) after the module is imported —
+which leaked temp-test state into the developer's real home directory
+(issue #162).
+
+Every helper here re-reads the environment on each call. Each
+resolver accepts an optional ``override`` arg so legacy module-level
+constants set to non-None (typically by ``unittest.mock.patch``) win
+over the env-var lookup. This preserves backwards compatibility with
+the dozens of tests that patch the per-module constants directly.
+
+Resolution order:
+
+    1. ``override`` arg (e.g. a module-level constant set by tests)
+    2. ``$WORCA_HOME/<subdir>``
+    3. ``~/.worca/<subdir>``
+"""
+
+import os
+
+
+def worca_home() -> str:
+    """Return the worca state directory.
+
+    Honors ``$WORCA_HOME`` if set, else falls back to ``~/.worca``.
+    Resolved on every call so tests can set the env var after import.
+    """
+    override = os.environ.get("WORCA_HOME")
+    if override:
+        return os.path.expanduser(override)
+    return os.path.expanduser("~/.worca")
+
+
+def fleet_runs_dir(override: str | None = None) -> str:
+    """Return the fleet-runs directory.
+
+    Pass ``override`` to honor a module-level constant set by tests
+    (via ``mock.patch``). Otherwise resolves to ``<worca_home>/fleet-runs``.
+    """
+    if override:
+        return override
+    return os.path.join(worca_home(), "fleet-runs")
+
+
+def workspace_runs_dir(override: str | None = None) -> str:
+    """Return the workspace-runs directory.
+
+    Pass ``override`` to honor a module-level constant set by tests
+    (via ``mock.patch``). Otherwise resolves to ``<worca_home>/workspace-runs``.
+    """
+    if override:
+        return override
+    return os.path.join(worca_home(), "workspace-runs")

--- a/src/worca/utils/project_registry.py
+++ b/src/worca/utils/project_registry.py
@@ -6,6 +6,8 @@ import os
 import re
 import tempfile
 
+from worca.utils.paths import worca_home
+
 logger = logging.getLogger(__name__)
 
 _SLUG_RE = re.compile(r"^[a-z0-9_-]{1,64}$", re.IGNORECASE)
@@ -18,13 +20,21 @@ def slugify(name: str) -> str:
     return slug[:64]
 
 
-def auto_register_project(project_root: str, prefs_dir: str = "~/.worca") -> None:
+def auto_register_project(project_root: str, prefs_dir: str | None = None) -> None:
     """Register the current project in ~/.worca/projects.d/ if not already registered.
+
+    ``prefs_dir`` defaults to ``$WORCA_HOME`` (falling back to ``~/.worca``)
+    via the lazy resolver in ``worca.utils.paths``.  Honoring the env var
+    keeps subprocess-spawned pipelines from writing into the developer's
+    real home directory during test runs (issue #162).
 
     Non-fatal — catches and logs all errors.
     """
     try:
-        prefs_dir = os.path.expanduser(prefs_dir)
+        if prefs_dir is None:
+            prefs_dir = worca_home()
+        else:
+            prefs_dir = os.path.expanduser(prefs_dir)
         projects_dir = os.path.join(prefs_dir, "projects.d")
         os.makedirs(projects_dir, exist_ok=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,38 @@ import os
 import pytest
 
 
+_WORCA_HOME = os.path.expanduser("~/.worca")
+_leak_baseline: dict | None = None
+
+
+def _snapshot_worca_home() -> dict:
+    """Return {relative_path: (size, mtime_ns)} for every file under ~/.worca/.
+
+    Cheap stat-only scan — does not read file contents. Returns {} when the
+    directory does not exist.
+    """
+    if not os.path.isdir(_WORCA_HOME):
+        return {}
+    snap: dict = {}
+    for dirpath, _, filenames in os.walk(_WORCA_HOME):
+        for name in filenames:
+            full = os.path.join(dirpath, name)
+            try:
+                st = os.stat(full)
+            except FileNotFoundError:
+                continue
+            snap[os.path.relpath(full, _WORCA_HOME)] = (st.st_size, st.st_mtime_ns)
+    return snap
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "allow_worca_writes: opt out of the ~/.worca/ leak detector for "
+        "tests that intentionally exercise the real home directory",
+    )
+
+
 def pytest_load_initial_conftests(early_config, parser, args):
     """Disable pytest-cov when WORCA_COVERAGE=1.
 
@@ -29,6 +61,64 @@ def pytest_load_initial_conftests(early_config, parser, args):
     if os.environ.get("WORCA_COVERAGE") == "1":
         if not any(a == "no:cov" or a.endswith("no:cov") for a in args):
             args[:0] = ["-p", "no:cov"]
+
+
+@pytest.fixture(autouse=True)
+def _detect_worca_home_leaks(request):
+    """Fail any test that writes into the real ~/.worca/ directory.
+
+    Why: hardcoded module-load-time defaults like ``_FLEET_RUNS_DIR =
+    os.path.expanduser("~/.worca/fleet-runs")`` (issue #162) silently
+    leak temp-test state into the developer's real home directory,
+    where it then surfaces as phantom fleets/workspaces in the UI.
+    This guard catches *any* such leak — including future ones — by
+    snapshotting ~/.worca/ around each test and asserting nothing was
+    added or modified.
+
+    Opt out for tests that intentionally write to the real home:
+
+        @pytest.mark.allow_worca_writes
+        def test_something(...): ...
+
+    Set WORCA_DISABLE_LEAK_DETECTOR=1 to disable globally (escape
+    hatch for emergencies — do not use in CI).
+    """
+    if os.environ.get("WORCA_DISABLE_LEAK_DETECTOR") == "1":
+        yield
+        return
+    if request.node.get_closest_marker("allow_worca_writes"):
+        yield
+        return
+
+    global _leak_baseline
+    if _leak_baseline is None:
+        _leak_baseline = _snapshot_worca_home()
+
+    yield
+
+    current = _snapshot_worca_home()
+    added = set(current) - set(_leak_baseline)
+    modified = {
+        p for p in set(current) & set(_leak_baseline)
+        if current[p] != _leak_baseline[p]
+    }
+    leaks = added | modified
+
+    # Reset baseline so a single leak does not cascade across every
+    # subsequent test in the session.
+    _leak_baseline = current
+
+    if leaks:
+        listing = "\n".join(f"  - ~/.worca/{p}" for p in sorted(leaks))
+        pytest.fail(
+            f"Test '{request.node.nodeid}' wrote to the real ~/.worca/:\n"
+            f"{listing}\n"
+            "\n"
+            "Fix the test to redirect writes to a tmp directory (e.g. set "
+            "WORCA_HOME, pass base_dir=, or monkeypatch the module-level "
+            "constant). If the write is intentional, add the "
+            "@pytest.mark.allow_worca_writes marker."
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,32 +3,56 @@
 Prevents test runs from polluting ~/.worca/projects.d/ with temporary project
 entries that would then show up in the global worca-ui.
 """
+import atexit
 import os
+import shutil
+import tempfile
 
 import pytest
 
 
-_WORCA_HOME = os.path.expanduser("~/.worca")
+# Snapshot the *real* ~/.worca/ root for the leak detector before we
+# redirect the env var.  The detector compares against this path; the
+# WORCA_HOME redirect protects the tests that use the lazy resolvers
+# in worca.utils.paths.
+_REAL_WORCA_HOME = os.path.expanduser("~/.worca")
+
+# Redirect $WORCA_HOME to a session-scoped tmp dir so any code path that
+# resolves through worca.utils.paths.worca_home() (including the lazy
+# fleet_runs_dir / workspace_runs_dir helpers) writes into the tmp dir
+# instead of the developer's real ~/.worca/.  Set unconditionally at
+# conftest import time — before any test module is collected — so that
+# even tests that read the env var at module load see the override.
+# Honors a caller-supplied WORCA_HOME (e.g. CI) instead of overriding it.
+if "WORCA_HOME" not in os.environ:
+    _session_worca_home = tempfile.mkdtemp(prefix="worca-test-home-")
+    os.environ["WORCA_HOME"] = _session_worca_home
+    atexit.register(shutil.rmtree, _session_worca_home, ignore_errors=True)
+
+
 _leak_baseline: dict | None = None
 
 
 def _snapshot_worca_home() -> dict:
-    """Return {relative_path: (size, mtime_ns)} for every file under ~/.worca/.
+    """Return {relative_path: (size, mtime_ns)} for every file under the
+    real ~/.worca/.
 
     Cheap stat-only scan — does not read file contents. Returns {} when the
     directory does not exist.
     """
-    if not os.path.isdir(_WORCA_HOME):
+    if not os.path.isdir(_REAL_WORCA_HOME):
         return {}
     snap: dict = {}
-    for dirpath, _, filenames in os.walk(_WORCA_HOME):
+    for dirpath, _, filenames in os.walk(_REAL_WORCA_HOME):
         for name in filenames:
             full = os.path.join(dirpath, name)
             try:
                 st = os.stat(full)
             except FileNotFoundError:
                 continue
-            snap[os.path.relpath(full, _WORCA_HOME)] = (st.st_size, st.st_mtime_ns)
+            snap[os.path.relpath(full, _REAL_WORCA_HOME)] = (
+                st.st_size, st.st_mtime_ns
+            )
     return snap
 
 

--- a/tests/integration/test_fleet_lifecycle_e2e.py
+++ b/tests/integration/test_fleet_lifecycle_e2e.py
@@ -456,7 +456,11 @@ def test_fleet_pause_resume(tmp_path):
     env = _build_child_env(scenario)
 
     fleet_id, fleet_id_short = generate_fleet_id()
-    fleet_runs_dir = Path.home() / ".worca" / "fleet-runs"
+    # Resolve via the same lazy helper subprocesses use, so $WORCA_HOME
+    # (set by tests/conftest.py to a session tmp dir) keeps writes out
+    # of the developer's real ~/.worca/ (issue #162).
+    from worca.utils.paths import fleet_runs_dir as _resolve_fleet_runs_dir
+    fleet_runs_dir = Path(_resolve_fleet_runs_dir())
     manifest = _write_initial_manifest(fleet_runs_dir, fleet_id, fleet_id_short)
 
     children = []
@@ -545,7 +549,11 @@ def test_fleet_stop_then_resume(tmp_path):
     env = _build_child_env(scenario)
 
     fleet_id, fleet_id_short = generate_fleet_id()
-    fleet_runs_dir = Path.home() / ".worca" / "fleet-runs"
+    # Resolve via the same lazy helper subprocesses use, so $WORCA_HOME
+    # (set by tests/conftest.py to a session tmp dir) keeps writes out
+    # of the developer's real ~/.worca/ (issue #162).
+    from worca.utils.paths import fleet_runs_dir as _resolve_fleet_runs_dir
+    fleet_runs_dir = Path(_resolve_fleet_runs_dir())
     manifest = _write_initial_manifest(fleet_runs_dir, fleet_id, fleet_id_short)
 
     children = []
@@ -659,7 +667,11 @@ def test_fleet_circuit_breaker_trips_with_running_children(tmp_path):
     )
 
     fleet_id, fleet_id_short = generate_fleet_id()
-    fleet_runs_dir = Path.home() / ".worca" / "fleet-runs"
+    # Resolve via the same lazy helper subprocesses use, so $WORCA_HOME
+    # (set by tests/conftest.py to a session tmp dir) keeps writes out
+    # of the developer's real ~/.worca/ (issue #162).
+    from worca.utils.paths import fleet_runs_dir as _resolve_fleet_runs_dir
+    fleet_runs_dir = Path(_resolve_fleet_runs_dir())
     manifest = _write_initial_manifest(
         fleet_runs_dir, fleet_id, fleet_id_short, threshold=0.30, max_parallel=5
     )
@@ -745,7 +757,11 @@ def test_fleet_circuit_breaker_does_not_trip_below_threshold(tmp_path):
     )
 
     fleet_id, fleet_id_short = generate_fleet_id()
-    fleet_runs_dir = Path.home() / ".worca" / "fleet-runs"
+    # Resolve via the same lazy helper subprocesses use, so $WORCA_HOME
+    # (set by tests/conftest.py to a session tmp dir) keeps writes out
+    # of the developer's real ~/.worca/ (issue #162).
+    from worca.utils.paths import fleet_runs_dir as _resolve_fleet_runs_dir
+    fleet_runs_dir = Path(_resolve_fleet_runs_dir())
     manifest = _write_initial_manifest(
         fleet_runs_dir, fleet_id, fleet_id_short, threshold=0.30, max_parallel=5
     )
@@ -807,7 +823,11 @@ def test_fleet_interrupted_child_does_not_trip_breaker(tmp_path):
     env = _build_child_env(scenario)
 
     fleet_id, fleet_id_short = generate_fleet_id()
-    fleet_runs_dir = Path.home() / ".worca" / "fleet-runs"
+    # Resolve via the same lazy helper subprocesses use, so $WORCA_HOME
+    # (set by tests/conftest.py to a session tmp dir) keeps writes out
+    # of the developer's real ~/.worca/ (issue #162).
+    from worca.utils.paths import fleet_runs_dir as _resolve_fleet_runs_dir
+    fleet_runs_dir = Path(_resolve_fleet_runs_dir())
     manifest = _write_initial_manifest(
         fleet_runs_dir, fleet_id, fleet_id_short, threshold=0.30, max_parallel=3
     )
@@ -998,7 +1018,11 @@ def test_fleet_plan_propagates_to_children(tmp_path):
     env = _build_child_env(scenario)
 
     fleet_id, fleet_id_short = generate_fleet_id()
-    fleet_runs_dir = Path.home() / ".worca" / "fleet-runs"
+    # Resolve via the same lazy helper subprocesses use, so $WORCA_HOME
+    # (set by tests/conftest.py to a session tmp dir) keeps writes out
+    # of the developer's real ~/.worca/ (issue #162).
+    from worca.utils.paths import fleet_runs_dir as _resolve_fleet_runs_dir
+    fleet_runs_dir = Path(_resolve_fleet_runs_dir())
     manifest = _write_initial_manifest(fleet_runs_dir, fleet_id, fleet_id_short)
 
     children = []
@@ -1058,7 +1082,11 @@ def test_fleet_guide_injected_into_every_child(tmp_path):
     env = _build_child_env(scenario)
 
     fleet_id, fleet_id_short = generate_fleet_id()
-    fleet_runs_dir = Path.home() / ".worca" / "fleet-runs"
+    # Resolve via the same lazy helper subprocesses use, so $WORCA_HOME
+    # (set by tests/conftest.py to a session tmp dir) keeps writes out
+    # of the developer's real ~/.worca/ (issue #162).
+    from worca.utils.paths import fleet_runs_dir as _resolve_fleet_runs_dir
+    fleet_runs_dir = Path(_resolve_fleet_runs_dir())
     manifest = _write_initial_manifest(
         fleet_runs_dir, fleet_id, fleet_id_short, guide_paths=[str(guide)]
     )
@@ -1146,7 +1174,11 @@ def test_fleet_stale_pid_regression(tmp_path):
     env = _build_child_env(scenario)
 
     fleet_id, fleet_id_short = generate_fleet_id()
-    fleet_runs_dir = Path.home() / ".worca" / "fleet-runs"
+    # Resolve via the same lazy helper subprocesses use, so $WORCA_HOME
+    # (set by tests/conftest.py to a session tmp dir) keeps writes out
+    # of the developer's real ~/.worca/ (issue #162).
+    from worca.utils.paths import fleet_runs_dir as _resolve_fleet_runs_dir
+    fleet_runs_dir = Path(_resolve_fleet_runs_dir())
     manifest = _write_initial_manifest(fleet_runs_dir, fleet_id, fleet_id_short)
 
     run_id = None

--- a/tests/integration/test_ui_server_against_live_run.py
+++ b/tests/integration/test_ui_server_against_live_run.py
@@ -191,13 +191,20 @@ def ui_server_single_project(ui_project, tmp_path):
     # Spawn server/index.js directly (rather than via bin/worca-ui.js, which
     # double-spawns + detaches and would leave us without a child PID to
     # cleanly kill in the finalizer).
+    # WORCA_HOME pins the prefs root to <fake_home>/.worca so the server
+    # honors the fake home in addition to HOME (issue #162).
     proc = subprocess.Popen(
         [_NODE_BIN, str(_UI_SERVER_SCRIPT),
          "--project", str(project),
          "--port", str(port),
          "--host", "127.0.0.1"],
         cwd=str(project),
-        env={**os.environ, "HOME": str(home_dir), "WORCA_NO_OPEN": "1"},
+        env={
+            **os.environ,
+            "HOME": str(home_dir),
+            "WORCA_HOME": str(home_dir / ".worca"),
+            "WORCA_NO_OPEN": "1",
+        },
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
     )
     base_url = f"http://127.0.0.1:{port}"
@@ -233,13 +240,21 @@ def ui_server_global(ui_project, tmp_path):
         json.dumps(project_entry)
     )
 
+    # WORCA_HOME pins the prefs root to <fake_home>/.worca so the server
+    # reads projects.d/ from the fake home, not the session tmp dir set
+    # by tests/conftest.py (issue #162).
     proc = subprocess.Popen(
         [_NODE_BIN, str(_UI_SERVER_SCRIPT),
          "--global",
          "--port", str(port),
          "--host", "127.0.0.1"],
         cwd=str(home_dir),
-        env={**os.environ, "HOME": str(home_dir), "WORCA_NO_OPEN": "1"},
+        env={
+            **os.environ,
+            "HOME": str(home_dir),
+            "WORCA_HOME": str(home_dir / ".worca"),
+            "WORCA_NO_OPEN": "1",
+        },
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
     )
     base_url = f"http://127.0.0.1:{port}"

--- a/tests/test_fleet_manifest.py
+++ b/tests/test_fleet_manifest.py
@@ -84,16 +84,20 @@ class TestFleetManifestPath:
         path = fleet_manifest_path("f_202605120809_abc123", base_dir=str(tmp_path))
         assert path.startswith(str(tmp_path))
 
-    def test_default_base_dir_expands_home(self):
+    def test_default_base_dir_falls_back_to_real_home(self, monkeypatch):
+        """When $WORCA_HOME is unset, the default resolves to ~/.worca/fleet-runs."""
+        monkeypatch.delenv("WORCA_HOME", raising=False)
         from worca.orchestrator.fleet_manifest import fleet_manifest_path
         path = fleet_manifest_path("f_202605120809_abc123")
-        expanded_home = os.path.expanduser("~")
-        assert path.startswith(expanded_home)
+        expected = os.path.expanduser("~/.worca/fleet-runs")
+        assert path.startswith(expected)
 
-    def test_default_base_dir_is_worca_fleet_runs(self):
+    def test_default_base_dir_honors_worca_home(self, monkeypatch, tmp_path):
+        """$WORCA_HOME redirects the default base dir at call time."""
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path))
         from worca.orchestrator.fleet_manifest import fleet_manifest_path
         path = fleet_manifest_path("f_202605120809_abc123")
-        assert ".worca/fleet-runs" in path
+        assert path.startswith(str(tmp_path / "fleet-runs"))
 
 
 # ---------------------------------------------------------------------------

--- a/worca-ui/bin/worca-ui.js
+++ b/worca-ui/bin/worca-ui.js
@@ -12,9 +12,9 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { connect, createServer } from 'node:net';
-import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { worcaHome } from '../server/paths.js';
 import {
   readProjects,
   removeProject,
@@ -37,7 +37,7 @@ function findProjectRoot(startDir) {
   return startDir;
 }
 
-const PREFS_DIR = join(homedir(), '.worca');
+const PREFS_DIR = worcaHome();
 const SERVER_SCRIPT = join(__dirname, '..', 'server', 'index.js');
 
 /** Exported for testing */

--- a/worca-ui/server/app.js
+++ b/worca-ui/server/app.js
@@ -13,6 +13,7 @@ import { createFleetRouter } from './fleet-routes.js';
 import { RAW_BODY } from './integrations/index.js';
 import { verify } from './integrations/verify.js';
 import { LaunchLock } from './launch-lock.js';
+import { fleetRunsDir, workspaceRunsDir, workspacesDir } from './paths.js';
 import { createPreferencesRouter } from './preferences-routes.js';
 import { ProcessManager } from './process-manager.js';
 import { scanDirectory } from './project-registry.js';
@@ -578,7 +579,7 @@ export function createApp(options = {}) {
     app.use(
       '/api/fleet-runs',
       createFleetRouter({
-        fleetRunsDir: join(homedir(), '.worca', 'fleet-runs'),
+        fleetRunsDir: fleetRunsDir(),
         prefsDir,
         runCleanup: (id) => runWorcaCleanupSubprocess('--fleet-id', id),
         // Spawn run_fleet.py in a detached subprocess so the route can return
@@ -646,8 +647,8 @@ export function createApp(options = {}) {
     // Workspace routers — both definitions (/api/workspaces) and runs
     // (/api/workspace-runs). The router factory exposes them as a pair.
     const workspaceRouters = createWorkspaceRouter({
-      workspaceRunsDir: join(homedir(), '.worca', 'workspace-runs'),
-      workspacesDir: join(homedir(), '.worca', 'workspaces.d'),
+      workspaceRunsDir: workspaceRunsDir(),
+      workspacesDir: workspacesDir(),
       runCleanup: (id) => runWorcaCleanupSubprocess('--workspace-id', id),
       // Spawn run_workspace.py in a detached subprocess, mirroring the fleet
       // dispatcher. We pass --workspace-id so the script reuses the manifest

--- a/worca-ui/server/fleet-routes.js
+++ b/worca-ui/server/fleet-routes.js
@@ -15,11 +15,10 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import { Router } from 'express';
+import { fleetRunsDir as resolveFleetRunsDir } from './paths.js';
 
-const DEFAULT_FLEET_RUNS_DIR = join(homedir(), '.worca', 'fleet-runs');
 const GUIDE_CAP_BYTES_DEFAULT = 64 * 1024; // 64 KB
 
 // Fleet IDs have the form f_<12 digits>_<hex>  — enforces no path traversal.
@@ -513,7 +512,7 @@ function defaultStopFleet(fleetId) {
  * entries that reference the fleet_id and includes them in the response.
  */
 export function createFleetRouter({
-  fleetRunsDir = DEFAULT_FLEET_RUNS_DIR,
+  fleetRunsDir: fleetRunsDirArg,
   prefsDir = null,
   dispatchFleet = null,
   runCleanup = defaultRunCleanup,
@@ -522,6 +521,9 @@ export function createFleetRouter({
   validateBaseBranch = defaultValidateBaseBranch,
   guideCapBytes = GUIDE_CAP_BYTES_DEFAULT,
 } = {}) {
+  // Lazy resolution honors $WORCA_HOME at router-construction time, falling
+  // back to ~/.worca/fleet-runs.  Issue #162.
+  const fleetRunsDir = resolveFleetRunsDir(fleetRunsDirArg);
   const router = Router();
 
   // ── GET /api/fleet-runs ─────────────────────────────────────────────────

--- a/worca-ui/server/index.js
+++ b/worca-ui/server/index.js
@@ -1,11 +1,12 @@
 // server/index.js
 import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { homedir, platform } from 'node:os';
+import { platform } from 'node:os';
 import { join } from 'node:path';
 import { createApp } from './app.js';
 import { parseServerArgv } from './argv-parser.js';
 import { createIntegrations } from './integrations/index.js';
+import { preferencesPath, prefsDir as resolvePrefsDir } from './paths.js';
 import { attachWsServer } from './ws.js';
 
 // Parse argv (env vars provide defaults; argv flags take precedence)
@@ -49,7 +50,7 @@ if (isGlobal) {
   settingsPath = join(projectRoot, '.claude', 'settings.json');
 }
 
-const prefsDir = join(homedir(), '.worca');
+const prefsDir = resolvePrefsDir();
 const webhookInbox = createInbox();
 const app = createApp({
   settingsPath,
@@ -94,7 +95,7 @@ const { broadcast, scheduleRefresh, resolveRunProject } = attachWsServer(
   {
     worcaDir,
     settingsPath,
-    prefsPath: join(homedir(), '.worca', 'preferences.json'),
+    prefsPath: preferencesPath(),
     prefsDir,
     webhookInbox,
     projectRoot,

--- a/worca-ui/server/paths.js
+++ b/worca-ui/server/paths.js
@@ -1,0 +1,78 @@
+/**
+ * Lazy resolvers for ~/.worca/ subdirectories.
+ *
+ * Mirror of src/worca/utils/paths.py — every helper re-reads the
+ * environment on each call so $WORCA_HOME is honored consistently by
+ * both halves of the system. See issue #162.
+ *
+ * Resolution order for every subdir helper:
+ *   1. `override` arg (e.g. a constant set by the caller / tests)
+ *   2. $WORCA_HOME/<subdir>
+ *   3. ~/.worca/<subdir>
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * @returns {string} The worca state directory.  Honors $WORCA_HOME, else ~/.worca.
+ */
+export function worcaHome() {
+  const override = process.env.WORCA_HOME;
+  if (override) return override;
+  return join(homedir(), '.worca');
+}
+
+/**
+ * @param {string=} override Caller-supplied path that wins over $WORCA_HOME.
+ * @returns {string} Absolute path to the fleet-runs directory.
+ */
+export function fleetRunsDir(override) {
+  if (override) return override;
+  return join(worcaHome(), 'fleet-runs');
+}
+
+/**
+ * @param {string=} override
+ * @returns {string} Absolute path to the workspace-runs directory.
+ */
+export function workspaceRunsDir(override) {
+  if (override) return override;
+  return join(worcaHome(), 'workspace-runs');
+}
+
+/**
+ * @param {string=} override
+ * @returns {string} Absolute path to the workspaces.d directory.
+ */
+export function workspacesDir(override) {
+  if (override) return override;
+  return join(worcaHome(), 'workspaces.d');
+}
+
+/**
+ * @param {string=} override
+ * @returns {string} Absolute path to the preferences/prefs root (= worca home).
+ */
+export function prefsDir(override) {
+  if (override) return override;
+  return worcaHome();
+}
+
+/**
+ * @param {string=} override
+ * @returns {string} Absolute path to the user templates directory.
+ */
+export function templatesDir(override) {
+  if (override) return override;
+  return join(worcaHome(), 'templates');
+}
+
+/**
+ * @param {string=} override
+ * @returns {string} Absolute path to preferences.json.
+ */
+export function preferencesPath(override) {
+  if (override) return override;
+  return join(worcaHome(), 'preferences.json');
+}

--- a/worca-ui/server/paths.test.js
+++ b/worca-ui/server/paths.test.js
@@ -1,0 +1,91 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  fleetRunsDir,
+  preferencesPath,
+  prefsDir,
+  templatesDir,
+  worcaHome,
+  workspaceRunsDir,
+  workspacesDir,
+} from './paths.js';
+
+describe('worca-ui server paths helper', () => {
+  let originalHome;
+
+  beforeEach(() => {
+    originalHome = process.env.WORCA_HOME;
+    delete process.env.WORCA_HOME;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.WORCA_HOME;
+    } else {
+      process.env.WORCA_HOME = originalHome;
+    }
+  });
+
+  describe('worcaHome()', () => {
+    it('falls back to ~/.worca when WORCA_HOME is unset', () => {
+      expect(worcaHome()).toBe(join(homedir(), '.worca'));
+    });
+
+    it('honors WORCA_HOME when set', () => {
+      process.env.WORCA_HOME = '/tmp/custom-worca';
+      expect(worcaHome()).toBe('/tmp/custom-worca');
+    });
+
+    it('is resolved lazily — env set after import takes effect', () => {
+      expect(worcaHome()).toBe(join(homedir(), '.worca'));
+      process.env.WORCA_HOME = '/tmp/late-binding';
+      expect(worcaHome()).toBe('/tmp/late-binding');
+    });
+  });
+
+  describe('subdir helpers honor WORCA_HOME', () => {
+    beforeEach(() => {
+      process.env.WORCA_HOME = '/tmp/wh';
+    });
+
+    it('fleetRunsDir()', () => {
+      expect(fleetRunsDir()).toBe('/tmp/wh/fleet-runs');
+    });
+
+    it('workspaceRunsDir()', () => {
+      expect(workspaceRunsDir()).toBe('/tmp/wh/workspace-runs');
+    });
+
+    it('workspacesDir()', () => {
+      expect(workspacesDir()).toBe('/tmp/wh/workspaces.d');
+    });
+
+    it('templatesDir()', () => {
+      expect(templatesDir()).toBe('/tmp/wh/templates');
+    });
+
+    it('prefsDir()', () => {
+      expect(prefsDir()).toBe('/tmp/wh');
+    });
+
+    it('preferencesPath()', () => {
+      expect(preferencesPath()).toBe('/tmp/wh/preferences.json');
+    });
+  });
+
+  describe('explicit override beats WORCA_HOME', () => {
+    beforeEach(() => {
+      process.env.WORCA_HOME = '/tmp/wh';
+    });
+
+    it('fleetRunsDir(override) returns override unchanged', () => {
+      expect(fleetRunsDir('/explicit/path')).toBe('/explicit/path');
+    });
+
+    it('workspaceRunsDir(override) returns override unchanged', () => {
+      expect(workspaceRunsDir('/explicit/ws')).toBe('/explicit/ws');
+    });
+  });
+});

--- a/worca-ui/server/project-routes.js
+++ b/worca-ui/server/project-routes.js
@@ -16,7 +16,6 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { Router } from 'express';
 import lockfile from 'proper-lockfile';
@@ -28,6 +27,7 @@ import { ensureWebhookForUi } from './ensure-webhook.js';
 import { extractAndStripGlobalKeys } from './global-keys.js';
 import { LaunchLock } from './launch-lock.js';
 import { createModelEnvRouter } from './model-env-routes.js';
+import { preferencesPath, templatesDir } from './paths.js';
 import { readPreferences } from './preferences.js';
 import { ProcessManager } from './process-manager.js';
 import { countRunningPipelinesAcrossProjects } from './process-registry.js';
@@ -1532,7 +1532,7 @@ export function createProjectScopedRoutes({
     const tiers = [
       { tier: 'worca', dir: join(root, '.claude', 'worca', 'templates') },
       { tier: 'project', dir: join(root, '.claude', 'templates') },
-      { tier: 'user', dir: join(homedir(), '.worca', 'templates') },
+      { tier: 'user', dir: templatesDir() },
     ];
 
     const templates = [];
@@ -1604,9 +1604,7 @@ export function createProjectScopedRoutes({
     // Fall back to source_repo from global preferences
     if (!source) {
       try {
-        const prefs = readPreferences(
-          join(homedir(), '.worca', 'preferences.json'),
-        );
+        const prefs = readPreferences(preferencesPath());
         source = prefs.source_repo || undefined;
       } catch {
         /* ignore — worca init will use its own resolution chain */

--- a/worca-ui/server/workspace-routes.js
+++ b/worca-ui/server/workspace-routes.js
@@ -20,13 +20,14 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import { Router } from 'express';
 import { WORKSPACE_TERMINAL } from '../app/utils/status-constants.js';
+import {
+  workspaceRunsDir as resolveWorkspaceRunsDir,
+  workspacesDir as resolveWorkspacesDir,
+} from './paths.js';
 
-const DEFAULT_WS_RUNS_DIR = join(homedir(), '.worca', 'workspace-runs');
-const DEFAULT_WORKSPACES_DIR = join(homedir(), '.worca', 'workspaces.d');
 const GUIDE_CAP_BYTES_DEFAULT = 64 * 1024;
 
 const WS_ID_RE = /^ws_\d{12}_[0-9a-f]{1,32}$/;
@@ -594,8 +595,8 @@ function defaultRunIntegrationTest(_manifest) {
 // ─── router factory ────────────────────────────────────────────────────────
 
 export function createWorkspaceRouter({
-  workspaceRunsDir = DEFAULT_WS_RUNS_DIR,
-  workspacesDir = DEFAULT_WORKSPACES_DIR,
+  workspaceRunsDir: workspaceRunsDirArg,
+  workspacesDir: workspacesDirArg,
   dispatchWorkspace = null,
   haltWorkspace = defaultHaltWorkspace,
   runCleanup = defaultRunCleanup,
@@ -604,6 +605,10 @@ export function createWorkspaceRouter({
   runIntegrationTest = defaultRunIntegrationTest,
   guideCapBytes = GUIDE_CAP_BYTES_DEFAULT,
 } = {}) {
+  // Lazy resolution honors $WORCA_HOME (issue #162).
+  const workspaceRunsDir = resolveWorkspaceRunsDir(workspaceRunsDirArg);
+  const workspacesDir = resolveWorkspacesDir(workspacesDirArg);
+
   const workspaces = Router();
   const workspaceRuns = Router();
 

--- a/worca-ui/server/ws-fleet-manifest-watcher.js
+++ b/worca-ui/server/ws-fleet-manifest-watcher.js
@@ -4,12 +4,11 @@
  */
 
 import { existsSync, readFileSync, watch } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { effectiveFleetStatus } from './fleet-routes.js';
+import { fleetRunsDir as resolveFleetRunsDir } from './paths.js';
 
 const FLEET_DEBOUNCE_MS = 200;
-const DEFAULT_FLEET_RUNS_DIR = join(homedir(), '.worca', 'fleet-runs');
 
 const FAILURE_STATES = new Set(['failed', 'setup_failed', 'unrecoverable']);
 
@@ -40,8 +39,10 @@ function resolveChildStatus(child) {
  */
 export function createFleetManifestWatcher({
   broadcaster,
-  fleetRunsDir = DEFAULT_FLEET_RUNS_DIR,
+  fleetRunsDir: fleetRunsDirArg,
 }) {
+  // Lazy resolution honors $WORCA_HOME (issue #162).
+  const fleetRunsDir = resolveFleetRunsDir(fleetRunsDirArg);
   let fsWatcher = null;
   /** @type {Map<string, ReturnType<typeof setTimeout>>} */
   const debounceTimers = new Map();

--- a/worca-ui/server/ws-modular.js
+++ b/worca-ui/server/ws-modular.js
@@ -7,9 +7,9 @@
  */
 
 import { existsSync, watch } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { WebSocketServer } from 'ws';
+import { fleetRunsDir, workspaceRunsDir } from './paths.js';
 import { readProjects, synthesizeDefaultProject } from './project-registry.js';
 import { TIER_FULL, TIER_POLLING, WatcherSet } from './watcher-set.js';
 import { readProjectWorcaVersion } from './worca-setup.js';
@@ -51,13 +51,13 @@ export function attachWsServer(httpServer, config) {
   // 3a. Fleet manifest watcher — global, not per-project (§13.5)
   const fleetManifestWatcher = createFleetManifestWatcher({
     broadcaster,
-    fleetRunsDir: join(homedir(), '.worca', 'fleet-runs'),
+    fleetRunsDir: fleetRunsDir(),
   });
 
   // 3a-ws. Workspace manifest watcher — global, separate from fleet (W-047 §13.5)
   const workspaceManifestWatcher = createWorkspaceManifestWatcher({
     broadcaster,
-    workspaceRunsDir: join(homedir(), '.worca', 'workspace-runs'),
+    workspaceRunsDir: workspaceRunsDir(),
   });
 
   // 3b. Create WatcherSet(s) — one per project

--- a/worca-ui/server/ws-workspace-manifest-watcher.js
+++ b/worca-ui/server/ws-workspace-manifest-watcher.js
@@ -7,11 +7,10 @@
  */
 
 import { existsSync, readFileSync, watch } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { workspaceRunsDir as resolveWorkspaceRunsDir } from './paths.js';
 
 const WS_DEBOUNCE_MS = 200;
-const DEFAULT_WS_RUNS_DIR = join(homedir(), '.worca', 'workspace-runs');
 
 function readJson(path) {
   try {
@@ -39,8 +38,11 @@ function readManifestFromPointer(wsRunsDir, wsId) {
  */
 export function createWorkspaceManifestWatcher({
   broadcaster,
-  workspaceRunsDir = DEFAULT_WS_RUNS_DIR,
+  workspaceRunsDir: workspaceRunsDirArg,
 }) {
+  // Lazy resolution honors $WORCA_HOME (issue #162).
+  const workspaceRunsDir = resolveWorkspaceRunsDir(workspaceRunsDirArg);
+
   let fsWatcher = null;
   /** @type {Map<string, ReturnType<typeof setTimeout>>} */
   const debounceTimers = new Map();


### PR DESCRIPTION
## Summary

Closes #162.  Honors `$WORCA_HOME` consistently across both Python and JS halves, with a leak detector to prevent regression.

- **Leak detector** (commit `baf8634`) — autouse pytest fixture in `tests/conftest.py` that snapshots `~/.worca/` around every test and fails teardown if any file is added or modified.  Surfaces the bug in this issue and any future leaks.  Opt out with `@pytest.mark.allow_worca_writes`; escape hatch `WORCA_DISABLE_LEAK_DETECTOR=1`.

- **Python lazy `$WORCA_HOME` resolver** (commit `6628cb6`) — new `worca.utils.paths` with `worca_home()` / `fleet_runs_dir()` / `workspace_runs_dir()` that re-read the env on every call.  Five module-load constants now default to `None` and resolve through the helper:

  | File | Constant |
  |---|---|
  | `orchestrator/fleet_manifest.py` | `_FLEET_RUNS_DIR` |
  | `events/fleet_emitter.py` | `_DEFAULT_FLEET_RUNS_DIR` |
  | `events/workspace_emitter.py` | `_DEFAULT_WORKSPACE_RUNS_DIR` |
  | `scripts/run_fleet.py` | `_FLEET_RUNS_DEFAULT` |
  | `scripts/run_workspace.py` | `_POINTER_DIR_DEFAULT` |

  Resolution: `module override > $WORCA_HOME/<subdir> > ~/.worca/<subdir>`.  The `None`-defaulted override slot preserves the 40+ existing tests that `patch("..._FLEET_RUNS_DIR", str)` without touching them.

- **JS-side mirror** (commit `dc703bd`) — `worca-ui/server/paths.js` exports the same surface: `worcaHome()` / `fleetRunsDir()` / `workspaceRunsDir()` / `workspacesDir()` / `prefsDir()` / `templatesDir()` / `preferencesPath()`, each re-reading `process.env.WORCA_HOME` on every call.  Wired into 9 modules:

  | Tier | File |
  |---|---|
  | HIGH | `server/fleet-routes.js`, `server/ws-fleet-manifest-watcher.js`, `server/workspace-routes.js`, `server/ws-workspace-manifest-watcher.js` |
  | MEDIUM | `server/ws-modular.js`, `server/app.js`, `server/index.js`, `server/project-routes.js`, `bin/worca-ui.js` |

  Vitest coverage in `server/paths.test.js` validates lazy resolution, default fallback, and override precedence.  Verified `paths.js` ships in the npm tarball.

- **`auto_register_project` lazy resolver** (commit `94e0834`) — pipeline subprocesses that auto-register their tmp project at `~/.worca/projects.d/` were leaking on CI.  Switched the `prefs_dir` default to `None` and resolved via `worca_home()`, so subprocess inherits `$WORCA_HOME` from the parent and writes to the session tmp dir.

- **Integration-test fixes** (commits `f0eff39`, `fd18501`) — six `test_fleet_lifecycle_e2e.py` tests had hardcoded `Path.home() / ".worca" / "fleet-runs"` for manifest read/write; two `test_ui_server_against_live_run.py` fixtures redirected only `HOME` and not `WORCA_HOME`, so the inherited session WORCA_HOME shadowed the fake home.  Both now go through the lazy helpers.

- **`tests/conftest.py` session redirect** — sets `$WORCA_HOME` to a session tmp dir at conftest import (unless the caller already set it, e.g. CI).  Combined with the lazy resolvers, this isolates the entire Python test suite without per-test changes.

## Impact

| Before | After |
|---|---|
| 4281 passed, 123 teardown errors (all real-`~/.worca/` leaks) | **4281 passed, 0 errors** |
| Backlog: 3357 orphan event logs accumulated over weeks | Already cleaned (audit found and wiped them during this PR) |
| Phantom fleets in UI from leaked manifests | Cannot recur — tests can't reach the real dir |
| Setting `$WORCA_HOME` partially worked: Python wrote there, UI still read from `~/.worca/` | Both halves agree on the env var |

## Test plan

- [x] Python unit suite: `pytest tests/ --ignore=tests/integration` → 4281 passed, 0 errors
- [x] Python integration suite: `pytest tests/integration` → green via CI
- [x] JS vitest suite: `npx vitest run server/` → 118 files / 1647 tests passed
- [x] biome lint: `npm run lint` — clean
- [x] ruff lint: `ruff check .` — clean
- [x] Verified previously-leaking `tests/test_run_fleet.py::TestMainStub::test_main_returns_int` now stays inside the tmp dir
- [x] Verified `~/.worca/fleet-runs/` and `~/.worca/workspace-runs/` unchanged after a full suite run
- [x] Verified `paths.js` is included by `worca-ui/package.json`'s `files` allowlist (`npm pack --dry-run`)
- [x] CI green on `fd18501`: Tests + E2E Tests both passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
