### PR TITLE
fix: split pr.json so neither schema uses top-level allOf

### DIFF
--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -16,7 +16,7 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
-from worca.orchestrator.guardian_context import build_guardian_context
+from worca.orchestrator.guardian_context import build_guardian_context, compute_defer_pr
 from worca.orchestrator.error_classifier import (
     classify_error, record_failure, record_success,
     should_halt, get_retry_delay, get_circuit_breaker_state,
@@ -1078,6 +1078,12 @@ def run_stage(
     is the full claude CLI JSON response for logging.
     """
     config = get_stage_config(stage, settings_path=settings_path)
+    # PR stage uses a different schema when the run defers PR creation to a
+    # parent orchestrator (workspace child). Two schemas instead of one
+    # conditional schema keeps each flat — the Claude API rejects custom
+    # tools whose input_schema has top-level allOf/oneOf/anyOf.
+    if stage == Stage.PR and compute_defer_pr(os.environ):
+        config = {**config, "schema": "pr-deferred.json"}
     max_turns = config["max_turns"] * msize
     raw_prompt = context.get("prompt", "")
     prompt = prompt_override if prompt_override is not None else raw_prompt

--- a/src/worca/schemas/pr-deferred.json
+++ b/src/worca/schemas/pr-deferred.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PRDeferredOutput",
+  "description": "Schema for the PR stage when the run defers PR creation to a parent orchestrator (workspace child with WORCA_DEFER_PR=1). Selected by the orchestrator instead of pr.json. Two-schema split keeps each schema flat (no top-level allOf/oneOf/anyOf) so the Claude API accepts it as a custom-tool input_schema.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["outcome"],
+  "properties": {
+    "outcome": { "type": "string", "enum": ["success", "reject"] },
+    "deferred": {
+      "type": "boolean",
+      "const": true,
+      "description": "Must be true on this schema — the discriminator that selects this branch. The orchestrator chose this schema because WORCA_DEFER_PR=1; the agent must echo deferred:true to confirm it understood the deferral contract."
+    },
+    "commit_sha": { "type": "string", "minLength": 7 },
+    "source_branch": { "type": "string" },
+    "target_branch": { "type": "string" },
+    "provider": {
+      "type": "string",
+      "enum": ["github", "gitlab", "bitbucket", "azure_devops", "gitea", "gerrit", "other"]
+    },
+    "review_status": {
+      "type": "string",
+      "enum": ["pending", "approved", "changes_requested", "rejected"]
+    }
+  },
+  "if": {
+    "properties": { "outcome": { "const": "success" } }
+  },
+  "then": {
+    "required": ["deferred", "commit_sha"]
+  }
+}

--- a/src/worca/schemas/pr.json
+++ b/src/worca/schemas/pr.json
@@ -2,13 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "PROutput",
   "type": "object",
-  "required": ["outcome"],
+  "required": ["outcome", "pr_number", "pr_url"],
   "properties": {
     "outcome": { "type": "string", "enum": ["success", "reject"] },
-    "deferred": {
-      "type": "boolean",
-      "description": "True when the run defers PR creation to a parent orchestrator (workspace child with WORCA_DEFER_PR=1). When true, pr_number and pr_url are not produced by this run."
-    },
     "pr_number": { "type": "integer" },
     "pr_url": { "type": "string" },
     "commit_sha": { "type": "string", "minLength": 7 },
@@ -23,41 +19,10 @@
       "enum": ["pending", "approved", "changes_requested", "rejected"]
     }
   },
-  "allOf": [
-    {
-      "if": {
-        "properties": { "outcome": { "const": "success" } },
-        "required": ["outcome"]
-      },
-      "then": {
-        "required": ["commit_sha"]
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "outcome": { "const": "success" },
-          "deferred": { "const": true }
-        },
-        "required": ["outcome", "deferred"]
-      },
-      "then": {
-        "not": {
-          "anyOf": [
-            { "required": ["pr_number"] },
-            { "required": ["pr_url"] }
-          ]
-        }
-      },
-      "else": {
-        "if": {
-          "properties": { "outcome": { "const": "success" } },
-          "required": ["outcome"]
-        },
-        "then": {
-          "required": ["pr_number", "pr_url"]
-        }
-      }
-    }
-  ]
+  "if": {
+    "properties": { "outcome": { "const": "success" } }
+  },
+  "then": {
+    "required": ["commit_sha"]
+  }
 }

--- a/tests/test_pr_schema.py
+++ b/tests/test_pr_schema.py
@@ -8,13 +8,25 @@ import pytest
 import worca
 
 SCHEMA_PATH = os.path.join(os.path.dirname(worca.__file__), "schemas", "pr.json")
+DEFERRED_SCHEMA_PATH = os.path.join(os.path.dirname(worca.__file__), "schemas", "pr-deferred.json")
 
 PROVIDER_ENUM = ["github", "gitlab", "bitbucket", "azure_devops", "gitea", "gerrit", "other"]
+
+# The Claude API rejects custom-tool input_schemas with top-level allOf/oneOf/anyOf.
+# Both pr.json and pr-deferred.json are sent to the API as structured-output tools,
+# so neither may use these keywords at the root.
+FORBIDDEN_TOP_LEVEL_COMBINATORS = ("allOf", "oneOf", "anyOf")
 
 
 @pytest.fixture
 def schema():
     with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def deferred_schema():
+    with open(DEFERRED_SCHEMA_PATH) as f:
         return json.load(f)
 
 
@@ -146,11 +158,25 @@ class TestSuccessOutcome:
         jsonschema.validate(doc, schema)
 
 
+class TestNonDeferredSuccessOnDefaultSchema:
+    """pr.json is the standalone/fleet schema. It must still require
+    pr_number+pr_url on success even when the deferred field is absent or
+    explicitly false — those runs were never deferred."""
+
+    def test_non_deferred_success_still_requires_pr_fields(self, schema):
+        doc = {
+            "outcome": "success",
+            "commit_sha": "abc1234",
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+
 class TestDeferredOutcome:
     """Workspace child guardian short-circuits PR creation (WORCA_DEFER_PR=1).
-    Schema must accept `deferred: true` outputs that have commit_sha but no
-    pr_number/pr_url, while still rejecting non-deferred success outputs
-    that are missing those fields."""
+    The orchestrator selects pr-deferred.json instead of pr.json for these
+    runs — the two-schema split keeps each schema flat so the Claude API
+    accepts both as custom-tool input_schemas."""
 
     def _deferred_doc(self):
         return {
@@ -159,55 +185,64 @@ class TestDeferredOutcome:
             "commit_sha": "abc1234",
         }
 
-    def test_deferred_success_without_pr_fields_valid(self, schema):
-        jsonschema.validate(self._deferred_doc(), schema)
+    def test_deferred_success_without_pr_fields_valid(self, deferred_schema):
+        jsonschema.validate(self._deferred_doc(), deferred_schema)
 
-    def test_deferred_success_still_requires_commit_sha(self, schema):
+    def test_deferred_success_still_requires_commit_sha(self, deferred_schema):
         doc = self._deferred_doc()
         del doc["commit_sha"]
         with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
+            jsonschema.validate(doc, deferred_schema)
 
-    def test_deferred_success_must_not_include_pr_number(self, schema):
-        """Belt-and-suspenders: `deferred: true` semantically means no PR
-        was created here. Including pr_number would contradict the
-        discriminator. Schema enforces 'not' to catch a misbehaving agent."""
+    def test_deferred_success_must_not_include_pr_number(self, deferred_schema):
+        """`deferred: true` semantically means no PR was created here.
+        Including pr_number would contradict the discriminator. Enforced
+        via additionalProperties:false — pr_number/pr_url aren't declared
+        on this schema, so any extra field is rejected."""
         doc = self._deferred_doc()
         doc["pr_number"] = 7
         with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
+            jsonschema.validate(doc, deferred_schema)
 
-    def test_deferred_success_must_not_include_pr_url(self, schema):
+    def test_deferred_success_must_not_include_pr_url(self, deferred_schema):
         doc = self._deferred_doc()
         doc["pr_url"] = "https://github.com/org/repo/pull/7"
         with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
+            jsonschema.validate(doc, deferred_schema)
 
-    def test_deferred_false_requires_pr_fields_like_normal_success(self, schema):
-        """`deferred: false` must NOT relax the contract — only `true` opts
-        in. Catches a misconfigured guardian that emits the flag without
-        actually deferring."""
+    def test_deferred_must_be_true_not_false(self, deferred_schema):
+        """`deferred: false` is rejected by the deferred schema — the
+        orchestrator only routes a run here when it intends to defer, and
+        the discriminator must echo that. Catches a misbehaving agent that
+        emits the wrong flag on this branch."""
         doc = {
             "outcome": "success",
             "deferred": False,
             "commit_sha": "abc1234",
         }
         with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
+            jsonschema.validate(doc, deferred_schema)
 
-    def test_non_deferred_success_still_requires_pr_fields(self, schema):
-        """Regression: dropping deferred entirely must still require
-        pr_number + pr_url for outcome=success."""
-        doc = {
-            "outcome": "success",
-            "commit_sha": "abc1234",
-        }
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(doc, schema)
+    def test_deferred_property_required_const_true(self, deferred_schema):
+        assert "deferred" in deferred_schema["properties"]
+        assert deferred_schema["properties"]["deferred"]["type"] == "boolean"
+        assert deferred_schema["properties"]["deferred"]["const"] is True
 
-    def test_deferred_property_documented(self, schema):
-        assert "deferred" in schema["properties"]
-        assert schema["properties"]["deferred"]["type"] == "boolean"
+
+class TestAPICompatibility:
+    """Both schemas must be acceptable as custom-tool input_schemas for the
+    Claude API. The API rejects any top-level allOf/oneOf/anyOf — regression
+    guard against re-introducing them."""
+
+    @pytest.mark.parametrize("path", [SCHEMA_PATH, DEFERRED_SCHEMA_PATH])
+    def test_no_top_level_forbidden_combinators(self, path):
+        with open(path) as f:
+            doc = json.load(f)
+        for kw in FORBIDDEN_TOP_LEVEL_COMBINATORS:
+            assert kw not in doc, (
+                f"{os.path.basename(path)} has top-level '{kw}', which the "
+                f"Claude API rejects on custom-tool input_schemas"
+            )
 
 
 class TestRejectOutcome:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -95,6 +95,51 @@ def test_run_stage_passes_none_model_when_missing():
     assert mock_run.call_args.kwargs.get("model") is None
 
 
+class TestPRSchemaSelection:
+    """PR stage picks pr-deferred.json when WORCA_DEFER_PR=1, else pr.json.
+    Two schemas keep each flat so the Claude API accepts both as
+    custom-tool input_schemas (top-level allOf/oneOf/anyOf is rejected)."""
+
+    _PR_CONFIG = {"agent": "guardian", "model": "claude-opus-4-6", "max_turns": 40, "schema": "pr.json"}
+
+    def _invoke(self, env):
+        with patch.dict(os.environ, env, clear=False):
+            with patch("worca.orchestrator.runner.get_stage_config", return_value=dict(self._PR_CONFIG)):
+                with patch("worca.orchestrator.runner.run_agent", return_value={"ok": True}) as mock_run:
+                    run_stage(Stage.PR, {"prompt": "ship it"})
+        return str(mock_run.call_args)
+
+    def test_pr_stage_uses_default_schema_when_defer_pr_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "WORCA_DEFER_PR"}
+        with patch.dict(os.environ, env, clear=True):
+            call_str = self._invoke({})
+        assert ".claude/worca/schemas/pr.json" in call_str
+        assert "pr-deferred.json" not in call_str
+
+    def test_pr_stage_uses_deferred_schema_when_defer_pr_is_one(self):
+        call_str = self._invoke({"WORCA_DEFER_PR": "1"})
+        assert ".claude/worca/schemas/pr-deferred.json" in call_str
+
+    def test_pr_stage_uses_default_schema_when_defer_pr_is_zero(self):
+        """Only the exact string "1" opts in — matches compute_defer_pr's
+        contract that "0", "true", or any other value does not defer."""
+        call_str = self._invoke({"WORCA_DEFER_PR": "0"})
+        assert ".claude/worca/schemas/pr.json" in call_str
+        assert "pr-deferred.json" not in call_str
+
+    def test_non_pr_stage_never_uses_deferred_schema(self):
+        """Defensive: even if WORCA_DEFER_PR is set, non-PR stages must use
+        their own schema. The override is gated on stage == Stage.PR."""
+        plan_config = {"agent": "planner", "model": "claude-opus-4-6", "max_turns": 40, "schema": "plan.json"}
+        with patch.dict(os.environ, {"WORCA_DEFER_PR": "1"}, clear=False):
+            with patch("worca.orchestrator.runner.get_stage_config", return_value=plan_config):
+                with patch("worca.orchestrator.runner.run_agent", return_value={"ok": True}) as mock_run:
+                    run_stage(Stage.PLAN, {"prompt": "plan it"})
+        call_str = str(mock_run.call_args)
+        assert ".claude/worca/schemas/plan.json" in call_str
+        assert "pr-deferred.json" not in call_str
+
+
 def test_check_loop_limit_within_limit(tmp_path):
     settings = tmp_path / "settings.json"
     settings.write_text(json.dumps({"worca": {"loops": {"implement_test": 10}}}))


### PR DESCRIPTION
## Summary
- Restore `pr.json` to its pre-d7fa5eb shape (flat, top-level `if`/`then` only) for standalone/fleet runs.
- Add `pr-deferred.json` for workspace-child runs (`WORCA_DEFER_PR=1`); enforces `deferred:true` + `commit_sha` and uses `additionalProperties:false` to forbid `pr_number`/`pr_url` leaks.
- `runner.run_stage` swaps to `pr-deferred.json` when `stage==PR` and `compute_defer_pr(os.environ)` is true.

## Why
The Claude API rejects custom-tool `input_schema` values that contain top-level `allOf`/`oneOf`/`anyOf`. `d7fa5eb` introduced a top-level `allOf` in `pr.json` to express the deferred-PR contract conditionally. The PR stage now fails on every run:

```
API Error: 400 tools.9.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

Two flat schemas keep each contract independently expressible without conditional combinators at the root. The schema split is invisible to the agent — the orchestrator picks based on the env var it already owns.

## Test plan
- [x] `pytest tests/` → 4290 passed (full unit suite, excluding integration)
- [x] `ruff check .` → clean
- [x] `TestPRSchemaSelection` (4 new tests) covers: `WORCA_DEFER_PR` unset → `pr.json`, `=0` → `pr.json`, `=1` → `pr-deferred.json`, non-PR stages always use their own schema
- [x] `TestAPICompatibility` regression-guards both schemas against re-introducing top-level `allOf`/`oneOf`/`anyOf`
- [x] `TestDeferredOutcome` invariants preserved (now against `pr-deferred.json`): deferred without pr fields valid, commit_sha required, pr_number/pr_url rejected, deferred:false rejected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)