### PR TITLE
fix(ui): keep Beads panel open across transient bd contention (#180)

### DIFF
--- a/worca-ui/app/views/run-detail-beads-panel-identity.test.js
+++ b/worca-ui/app/views/run-detail-beads-panel-identity.test.js
@@ -1,0 +1,67 @@
+/**
+ * Pins GH issue #180: the Beads <sl-details> panel must keep its element
+ * identity (and open state) across beads.length === 0 ↔ > 0 transitions.
+ *
+ * Pre-fix, runBeadsSectionView returned two distinct html`` templates for
+ * the empty and non-empty cases. lit-html tears down the DOM on a template
+ * swap, so the new <sl-details> mounted without ?open and the user's open
+ * panel collapsed on every transient bd contention blip.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { render } from 'lit-html';
+import { describe, expect, it } from 'vitest';
+import { runBeadsSectionView } from './run-detail.js';
+
+function makeBeads(n) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `worca-cc-${i}`,
+    title: `Bead ${i}`,
+    status: 'open',
+    priority: 2,
+    blocked_by: [],
+    depends_on: [],
+  }));
+}
+
+describe('runBeadsSectionView - sl-details identity across empty flip', () => {
+  it('reuses the same <sl-details> node when beads goes 18 -> 0 -> 18', () => {
+    const container = document.createElement('div');
+
+    render(runBeadsSectionView(makeBeads(18)), container);
+    const firstDetails = container.querySelector('sl-details');
+    expect(firstDetails).toBeTruthy();
+
+    // Simulate the user opening the panel (real <sl-details> would handle
+    // the property; in jsdom it's a plain custom element, so we set the
+    // attribute directly — the test cares about node identity, not
+    // shoelace's internal state machine).
+    firstDetails.setAttribute('open', '');
+
+    render(runBeadsSectionView([]), container);
+    const emptyDetails = container.querySelector('sl-details');
+    expect(emptyDetails).toBe(firstDetails);
+
+    render(runBeadsSectionView(makeBeads(18)), container);
+    const finalDetails = container.querySelector('sl-details');
+    expect(finalDetails).toBe(firstDetails);
+    expect(finalDetails.hasAttribute('open')).toBe(true);
+  });
+
+  it('renders empty-state message only when beads is empty', () => {
+    const container = document.createElement('div');
+
+    render(runBeadsSectionView(makeBeads(3)), container);
+    expect(container.querySelector('.run-beads-empty')).toBeNull();
+    expect(container.querySelector('.run-beads-list')).toBeTruthy();
+    expect(container.querySelector('sl-badge')).toBeTruthy();
+
+    render(runBeadsSectionView([]), container);
+    expect(container.querySelector('.run-beads-empty')).toBeTruthy();
+    expect(container.querySelector('.run-beads-list')).toBeNull();
+    // The count badge should be hidden when empty.
+    const summary = container.querySelector('.run-beads-header');
+    expect(summary.querySelector('sl-badge')).toBeNull();
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -831,62 +831,48 @@ export function prApprovalPanelView(run, options = {}) {
 
 export function runBeadsSectionView(beads) {
   if (!beads) return nothing;
-  if (beads.length === 0) {
-    return html`
-      <div class="run-beads-section">
-        <sl-details class="run-beads-panel" @sl-after-show=${scrollOnExpand}>
-          <div slot="summary" class="run-beads-header">
-            <span class="run-beads-icon">${unsafeHTML(iconSvg(List, 16))}</span>
-            <span class="run-beads-title">Beads</span>
-          </div>
-          <div class="run-beads-empty">No linked Beads issues</div>
-        </sl-details>
-      </div>
-    `;
-  }
+  const isEmpty = beads.length === 0;
+  const closed = beads.filter((b) => b.status === 'closed').length;
+  const total = beads.length;
+  const variant =
+    total === 0 ? 'neutral' : closed === total ? 'success' : 'primary';
   return html`
     <div class="run-beads-section">
       <sl-details class="run-beads-panel" @sl-after-show=${scrollOnExpand}>
         <div slot="summary" class="run-beads-header">
           <span class="run-beads-icon">${unsafeHTML(iconSvg(List, 16))}</span>
           <span class="run-beads-title">Beads</span>
-          ${(() => {
-            const closed = beads.filter((b) => b.status === 'closed').length;
-            const total = beads.length;
-            const variant =
-              total === 0
-                ? 'neutral'
-                : closed === total
-                  ? 'success'
-                  : 'primary';
-            return html`<sl-badge variant="${variant}" pill>${closed}/${total}</sl-badge>`;
-          })()}
-        </div>
-        <div class="run-beads-list">
-          ${beads.map(
-            (issue) => html`
-            <sl-tooltip class="bead-tooltip" hoist placement="bottom" distance="4">
-              <div slot="content">${beadTooltipContent(issue)}</div>
-              <div class="run-bead-row">
-                <sl-badge variant="${priorityVariant(issue.priority)}" pill>P${issue.priority}</sl-badge>
-                ${
-                  issue.blocked_by?.length
-                    ? html`<sl-badge variant="warning" pill>blocked</sl-badge>`
-                    : html`<sl-badge variant="${statusVariant(issue.status, issue)}" pill>${issue.status}</sl-badge>`
-                }
-                <span class="run-bead-id">#${issue.id}</span>
-                <span class="run-bead-title">${issue.title}</span>
-              </div>
-            </sl-tooltip>
-          `,
-          )}
+          ${
+            isEmpty
+              ? nothing
+              : html`<sl-badge variant="${variant}" pill>${closed}/${total}</sl-badge>`
+          }
         </div>
         ${
-          beads.length > 1
-            ? html`
-          ${_graphWithTooltips(beads)}
-        `
-            : ''
+          isEmpty
+            ? html`<div class="run-beads-empty">No linked Beads issues</div>`
+            : html`
+              <div class="run-beads-list">
+                ${beads.map(
+                  (issue) => html`
+                  <sl-tooltip class="bead-tooltip" hoist placement="bottom" distance="4">
+                    <div slot="content">${beadTooltipContent(issue)}</div>
+                    <div class="run-bead-row">
+                      <sl-badge variant="${priorityVariant(issue.priority)}" pill>P${issue.priority}</sl-badge>
+                      ${
+                        issue.blocked_by?.length
+                          ? html`<sl-badge variant="warning" pill>blocked</sl-badge>`
+                          : html`<sl-badge variant="${statusVariant(issue.status, issue)}" pill>${issue.status}</sl-badge>`
+                      }
+                      <span class="run-bead-id">#${issue.id}</span>
+                      <span class="run-bead-title">${issue.title}</span>
+                    </div>
+                  </sl-tooltip>
+                `,
+                )}
+              </div>
+              ${beads.length > 1 ? _graphWithTooltips(beads) : nothing}
+            `
         }
       </sl-details>
     </div>

--- a/worca-ui/server/beads-reader.js
+++ b/worca-ui/server/beads-reader.js
@@ -59,14 +59,21 @@ export async function listIssues(beadsDb) {
 }
 
 export async function listIssuesByLabel(beadsDb, label) {
-  try {
+  const attempt = async () => {
     const issues = await runBd(
       ['list', '--label-any', label, '--all', '--limit', '0'],
       beadsDb,
     );
     return await enrichWithDeps(issues, beadsDb);
+  };
+  try {
+    return await attempt();
   } catch {
-    return [];
+    // bd/SQLite contention during active runs is usually sub-second — one
+    // retry covers the observed window. If it still fails, propagate so the
+    // WS handler can return an error rather than masquerading as "no beads."
+    await new Promise((r) => setTimeout(r, 150));
+    return await attempt();
   }
 }
 

--- a/worca-ui/server/beads-reader.test.js
+++ b/worca-ui/server/beads-reader.test.js
@@ -313,9 +313,25 @@ describe('listIssuesByLabel', () => {
     expect(await listIssuesByLabel(DB, 'run:run-999')).toEqual([]);
   });
 
-  it('returns [] when bd fails', async () => {
-    mockBdError('fail');
-    expect(await listIssuesByLabel(DB, 'run:run-1')).toEqual([]);
+  it('retries once on failure and returns the second attempt result', async () => {
+    // First attempt: bd list fails.
+    mockBdError('SIGTERM');
+    // Second attempt: bd list succeeds, no deps needed.
+    mockBdResult([
+      { id: '1', title: 'A', status: 'open', priority: 2, dependency_count: 0 },
+    ]);
+    const issues = await listIssuesByLabel(DB, 'run:run-1');
+    expect(issues.length).toBe(1);
+    expect(issues[0].title).toBe('A');
+  });
+
+  it('throws when both attempts fail (no longer masquerades as empty)', async () => {
+    // Both attempts fail — must propagate so the WS handler can surface
+    // beads_unavailable instead of pretending the run has no beads. See
+    // GH issue #180.
+    mockBdError('SIGTERM');
+    mockBdError('SIGTERM');
+    await expect(listIssuesByLabel(DB, 'run:run-1')).rejects.toThrow('SIGTERM');
   });
 });
 
@@ -516,12 +532,18 @@ describe('enrichWithDeps rejection handling', () => {
     expect(await listIssues(DB)).toEqual([]);
   });
 
-  it('listIssuesByLabel returns [] when bd show (deps) rejects', async () => {
+  it('listIssuesByLabel throws when bd show (deps) rejects on both attempts', async () => {
+    // First attempt: bd list ok, bd show (deps) rejects.
     mockBdResult([
       { id: '1', title: 'A', status: 'open', priority: 2, dependency_count: 1 },
     ]);
     mockBdError('SIGTERM');
-    expect(await listIssuesByLabel(DB, 'run:foo')).toEqual([]);
+    // Retry: same failure mode.
+    mockBdResult([
+      { id: '1', title: 'A', status: 'open', priority: 2, dependency_count: 1 },
+    ]);
+    mockBdError('SIGTERM');
+    await expect(listIssuesByLabel(DB, 'run:foo')).rejects.toThrow('SIGTERM');
   });
 });
 

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -682,14 +682,32 @@ export function createMessageRouter({
         ws.send(JSON.stringify(makeOk(req, { issues: [], runId })));
         return;
       }
-      const issues = await listIssuesByLabel(beadsDbPath, `run:${runId}`);
-      console.log(
-        '[list-beads-by-run] runId=%s count=%d statuses=%o',
-        runId,
-        issues.length,
-        issues.map((i) => i.status),
-      );
-      ws.send(JSON.stringify(makeOk(req, { issues, runId })));
+      try {
+        const issues = await listIssuesByLabel(beadsDbPath, `run:${runId}`);
+        console.log(
+          '[list-beads-by-run] runId=%s count=%d statuses=%o',
+          runId,
+          issues.length,
+          issues.map((i) => i.status),
+        );
+        ws.send(JSON.stringify(makeOk(req, { issues, runId })));
+      } catch (err) {
+        // Don't return empty issues on failure — the UI would treat that as
+        // "all beads deleted" and tear down the open <sl-details> panel. Let
+        // the client keep its last-known-good state until the next poll.
+        console.warn(
+          `[list-beads-by-run] runId=${runId} failed: ${err?.message || err}`,
+        );
+        ws.send(
+          JSON.stringify(
+            makeError(
+              req,
+              'beads_unavailable',
+              `bd query failed: ${err?.message || err}`,
+            ),
+          ),
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #180 — the run-detail Beads `<sl-details>` panel collapsed every few seconds during active runs, scrolling the page up by the panel's height.

Two cooperating bugs, both fixed:

- **Server** (`worca-ui/server/beads-reader.js`): `listIssuesByLabel` swallowed `runBd` failures and returned `[]`, indistinguishable from a genuinely empty result. Under bd/SQLite contention with the implementer agent writing labels, transient errors masqueraded as "all beads deleted." Now retries once after 150 ms; on second failure propagates so the WS handler (`ws-message-router.js`) returns `beads_unavailable`. `fetchRunBeads`'s existing `.catch` leaves the last-known-good `runBeads` value intact.
- **UI** (`worca-ui/app/views/run-detail.js`): `runBeadsSectionView` returned two distinct `html` templates for the empty and non-empty cases. lit-html tore down the DOM on the flip, the new `<sl-details>` mounted without `?open`, and the user's open state was lost. Collapsed into one outer template so `<sl-details>` identity (and open state) survives `length 0 ↔ >0` transitions.

Either fix alone leaves the bug exploitable — server retry avoids most flips, UI refactor makes the remaining ones harmless.

## Test plan

- [x] `npx vitest run worca-ui/app/views/run-detail-beads-panel-identity.test.js` — new test renders 18 beads, opens the panel, re-renders with `[]` then back to 18, asserts same `<sl-details>` node + `open=true`
- [x] `npx vitest run worca-ui/server/beads-reader.test.js` — updated tests cover the new retry/propagate contract (succeeds on retry; throws after both attempts fail)
- [x] `npm run lint` clean (biome)
- [x] Full `npx vitest run` — only pre-existing unrelated flake in `server/ws-pipeline-lifecycle.test.js` (confirmed on clean `master`)
- [ ] Manual: open a live run with active beads activity on `http://127.0.0.1:3400/#/project/<proj>/history/<runId>` — panel should stay open through bd contention blips

🤖 Generated with [Claude Code](https://claude.com/claude-code)