### PR TITLE
fix(ui): Lockdown chip only fires on ["none"] sentinel, not on empty []

### DIFF
--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -2005,6 +2005,16 @@ sl-input [slot="prefix"] {
   font-size: 10px;
 }
 
+/* Inherits-defaults placeholder — shown when per-agent entry is an empty
+ * list, which the resolver treats as fall-through to _defaults. Visually
+ * lighter than lockdown so the two states are easy to distinguish. */
+.dispatch-chip-inherits {
+  text-decoration: none;
+  opacity: 0.6;
+  font-style: italic;
+  font-size: 10px;
+}
+
 .dispatch-chip-warn {
   --sl-color-neutral-200: var(--sl-color-warning-200);
   background: var(--sl-color-warning-100);

--- a/worca-ui/app/views/dispatch-section.js
+++ b/worca-ui/app/views/dispatch-section.js
@@ -100,22 +100,50 @@ function _autoIncludedMetaChips(section, tags) {
   );
 }
 
+// Must match LOCKDOWN_SENTINEL in src/worca/hooks/tracking.py. An entry of
+// exactly ["none"] means "lock this agent out — allow nothing"; any other
+// combination (including bare []) falls through to _defaults at resolve time.
+const LOCKDOWN_SENTINEL = 'none';
+
+function _isLockdownEntry(entry) {
+  return (
+    Array.isArray(entry) && entry.length === 1 && entry[0] === LOCKDOWN_SENTINEL
+  );
+}
+
+function _isEmptyExplicit(entry) {
+  return Array.isArray(entry) && entry.length === 0;
+}
+
 function _lockdownChip(section, agent, perAgentAllow) {
-  // Follow-up #4: show a "Lockdown" placeholder when a non-_defaults row
-  // has an *explicit* empty per_agent_allow entry. Distinguishes "I removed
-  // every chip" (lockdown) from "I never customized this agent" (inherits
-  // _defaults).
+  // True lockdown is the singleton sentinel ["none"] — matching the
+  // resolver in src/worca/hooks/tracking.py. An empty list [] is NOT
+  // lockdown; it falls through to _defaults (see _inheritsDefaultsChip).
   if (agent === '_defaults') return null;
-  const explicit = perAgentAllow?.[agent];
-  if (!Array.isArray(explicit) || explicit.length !== 0) return null;
+  if (!_isLockdownEntry(perAgentAllow?.[agent])) return null;
   const noun = section.slice(0, -1); // "tools" -> "tool"
   return html`<sl-tag
     size="small"
     class="dispatch-chip dispatch-chip-locked dispatch-chip-lockdown"
-    data-value=""
+    data-value="${LOCKDOWN_SENTINEL}"
     data-lockdown="true"
     title="Explicit lockdown — no ${noun} available to this agent"
     >Lockdown</sl-tag
+  >`;
+}
+
+function _inheritsDefaultsChip(_section, agent, perAgentAllow) {
+  // Explicit empty per_agent_allow entry falls through to _defaults at
+  // resolve time. The placeholder makes that explicit so users don't
+  // misread an empty chip row as a hard block.
+  if (agent === '_defaults') return null;
+  if (!_isEmptyExplicit(perAgentAllow?.[agent])) return null;
+  return html`<sl-tag
+    size="small"
+    class="dispatch-chip dispatch-chip-inherits"
+    data-inherits="true"
+    title="Empty list — falls through to _defaults at dispatch time"
+    >Inherits defaults</sl-tag
   >`;
 }
 
@@ -145,8 +173,16 @@ function perAgentRowView({
     ? filterSuggestions(rowState.input, knownItems, tags, deniedSet, warnSet)
     : [];
 
-  const autoIncludedChips = _autoIncludedMetaChips(section, tags);
+  // When lockdown is active, the sentinel ("none") lives in `tags` but we
+  // surface it as the Lockdown placeholder instead of a raw chip.
+  const lockdownActive = isAgent && _isLockdownEntry(perAgentAllow?.[agent]);
+  const visibleTags = lockdownActive
+    ? tags.filter((t) => t !== LOCKDOWN_SENTINEL)
+    : tags;
+
+  const autoIncludedChips = _autoIncludedMetaChips(section, visibleTags);
   const lockdownChip = _lockdownChip(section, agent, perAgentAllow);
+  const inheritsChip = _inheritsDefaultsChip(section, agent, perAgentAllow);
 
   return html`
     <div
@@ -167,7 +203,7 @@ function perAgentRowView({
             if (input && e.target !== input) input.focus();
           }}
         >
-          ${tags.map((tag) =>
+          ${visibleTags.map((tag) =>
             chipView(tag, {
               locked: false,
               warn: false,
@@ -177,11 +213,12 @@ function perAgentRowView({
           )}
           ${autoIncludedChips ?? nothing}
           ${lockdownChip ?? nothing}
+          ${inheritsChip ?? nothing}
           <input
             class="dispatch-tag-input-field"
             type="text"
             .value=${rowState.input || ''}
-            placeholder=${tags.length === 0 ? `Add ${section.slice(0, -1)}…` : ''}
+            placeholder=${visibleTags.length === 0 && !lockdownChip && !inheritsChip ? `Add ${section.slice(0, -1)}…` : ''}
             @input=${onInput}
             @focus=${onFocus}
             @blur=${onBlur}

--- a/worca-ui/app/views/dispatch-section.test.js
+++ b/worca-ui/app/views/dispatch-section.test.js
@@ -348,7 +348,17 @@ describe('dispatch-section', () => {
       expect(html).not.toContain('data-auto-included="true"');
     });
 
-    it('does NOT render auto-included chips when tools per-agent is empty (lockdown)', () => {
+    it('does NOT render auto-included chips when tools per-agent is the lockdown sentinel', () => {
+      const html = render({ _defaults: ['*'], planner: ['none'] }, 'tools');
+      const plannerRow =
+        html.split('data-agent="planner"')[1]?.split('data-agent="')[0] || '';
+      expect(plannerRow).not.toContain('data-auto-included="true"');
+    });
+
+    it('does NOT render auto-included chips when tools per-agent is empty (inherits defaults)', () => {
+      // Empty [] falls through to _defaults at resolve time, so no named-list
+      // restriction is in effect — the auto-included meta-tools are
+      // unnecessary here.
       const html = render({ _defaults: ['*'], planner: [] }, 'tools');
       const plannerRow =
         html.split('data-agent="planner"')[1]?.split('data-agent="')[0] || '';
@@ -380,7 +390,7 @@ describe('dispatch-section', () => {
     });
   });
 
-  describe('Lockdown chip for explicit empty lists', () => {
+  describe('Lockdown chip — only the ["none"] sentinel triggers it', () => {
     function render(perAgent, section) {
       return renderToString(
         dispatchSectionView({
@@ -398,8 +408,8 @@ describe('dispatch-section', () => {
       );
     }
 
-    it('renders Lockdown chip when per-agent list is explicitly empty', () => {
-      const html = render({ _defaults: ['*'], planner: [] }, 'skills');
+    it('renders Lockdown chip when per-agent list is the ["none"] sentinel', () => {
+      const html = render({ _defaults: ['*'], planner: ['none'] }, 'skills');
       const plannerRow =
         html.split('data-agent="planner"')[1]?.split('data-agent="')[0] || '';
       expect(plannerRow).toContain('data-lockdown="true"');
@@ -407,28 +417,96 @@ describe('dispatch-section', () => {
       expect(plannerRow).toContain('dispatch-chip-lockdown');
     });
 
+    it('hides the raw "none" sentinel chip when lockdown is active', () => {
+      const html = render({ _defaults: ['*'], planner: ['none'] }, 'skills');
+      const plannerRow =
+        html.split('data-agent="planner"')[1]?.split('data-agent="')[0] || '';
+      // The Lockdown chip uses data-value="none"; assert there is NOT a
+      // separate raw chip rendering the bare sentinel.
+      const removableNoneChips = plannerRow.match(
+        /data-value="none"[^>]*removable/g,
+      );
+      expect(removableNoneChips).toBeNull();
+    });
+
+    it('does NOT render Lockdown when per-agent list is empty []', () => {
+      // Empty [] falls through to _defaults at resolve time — that's
+      // "inherits defaults", not lockdown.
+      const html = render({ _defaults: ['*'], planner: [] }, 'skills');
+      const plannerRow =
+        html.split('data-agent="planner"')[1]?.split('data-agent="')[0] || '';
+      expect(plannerRow).not.toContain('data-lockdown="true"');
+      expect(plannerRow).not.toContain('dispatch-chip-lockdown');
+    });
+
     it('does NOT render Lockdown when row inherits non-empty defaults', () => {
       const html = render({ _defaults: ['*'] }, 'skills');
-      // No agent has an explicit empty list, so no lockdown anywhere.
       expect(html).not.toContain('data-lockdown="true"');
     });
 
     it('does NOT render Lockdown for the _defaults row itself', () => {
-      // Even when _defaults is explicitly [], that's "inherit nothing", not
-      // a per-agent lockdown — the placeholder would be confusing.
-      const html = render({ _defaults: [] }, 'skills');
+      const html = render({ _defaults: ['none'] }, 'skills');
       const defaultsRow =
         html.split('data-agent="_defaults"')[1]?.split('data-agent="')[0] || '';
       expect(defaultsRow).not.toContain('data-lockdown="true"');
     });
 
-    it('renders Lockdown across all three sections when applicable', () => {
+    it('renders Lockdown across all three sections when ["none"] is used', () => {
       for (const section of ['tools', 'skills', 'subagents']) {
-        const html = render({ _defaults: ['*'], planner: [] }, section);
+        const html = render({ _defaults: ['*'], planner: ['none'] }, section);
         const plannerRow =
           html.split('data-agent="planner"')[1]?.split('data-agent="')[0] || '';
         expect(plannerRow).toContain('data-lockdown="true"');
       }
+    });
+  });
+
+  describe('Inherits-defaults chip for empty per-agent lists', () => {
+    function render(perAgent, section) {
+      return renderToString(
+        dispatchSectionView({
+          section,
+          config: {
+            always_disallowed: [],
+            default_denied: [],
+            per_agent_allow: perAgent,
+          },
+          knownItems: [],
+          agentRoles: AGENT_ROLES,
+          defaults: DISPATCH_DEFAULTS[section],
+          onChange: vi.fn(),
+        }),
+      );
+    }
+
+    it('renders Inherits-defaults chip when per-agent list is empty []', () => {
+      const html = render({ _defaults: ['*'], planner: [] }, 'subagents');
+      const plannerRow =
+        html.split('data-agent="planner"')[1]?.split('data-agent="')[0] || '';
+      expect(plannerRow).toContain('data-inherits="true"');
+      expect(plannerRow).toContain('Inherits defaults');
+      expect(plannerRow).toContain('dispatch-chip-inherits');
+    });
+
+    it('does NOT render Inherits chip when per-agent list is ["none"]', () => {
+      const html = render({ _defaults: ['*'], planner: ['none'] }, 'subagents');
+      const plannerRow =
+        html.split('data-agent="planner"')[1]?.split('data-agent="')[0] || '';
+      expect(plannerRow).not.toContain('data-inherits="true"');
+    });
+
+    it('does NOT render Inherits chip for an uncustomized agent', () => {
+      // When the agent has no explicit key, _effectiveTags falls back to
+      // _defaults visually — no placeholder needed.
+      const html = render({ _defaults: ['*'] }, 'subagents');
+      expect(html).not.toContain('data-inherits="true"');
+    });
+
+    it('does NOT render Inherits chip for the _defaults row itself', () => {
+      const html = render({ _defaults: [] }, 'subagents');
+      const defaultsRow =
+        html.split('data-agent="_defaults"')[1]?.split('data-agent="')[0] || '';
+      expect(defaultsRow).not.toContain('data-inherits="true"');
     });
   });
 


### PR DESCRIPTION
## Summary

- The dispatch section misrendered an empty per-agent allow list `[]` as **Lockdown**, contradicting the resolver in `src/worca/hooks/tracking.py` (which treats `[]` as fall-through to `_defaults`) and `docs/governance.md:164-177`.
- True lockdown only fires on the singleton sentinel `["none"]`. The Lockdown chip now matches that, and the raw `"none"` chip is hidden when lockdown is active.
- Empty `[]` now shows a distinct **Inherits defaults** placeholder so the row reads correctly.

Visible symptom: on `/project/worca-cc/project-settings`, the **coordinator → subagents** row was labeled "Lockdown" even though `subagents.per_agent_allow.coordinator = []` actually inherits `_defaults: ["*"]` at dispatch time.

## Test plan

- [x] `worca-ui` unit tests (`npx vitest run app/views/dispatch-section.test.js`) — 38/38 pass, including new Inherits-defaults suite + updated Lockdown semantics.
- [x] Lint (`npm run lint`) — clean.
- [x] Manual verification at http://127.0.0.1:3400/#/project/worca-cc/project-settings — coordinator → subagents now shows "Inherits defaults" instead of "Lockdown".

🤖 Generated with [Claude Code](https://claude.com/claude-code)