### PR TITLE
Fix flaky test_fleet_pause_resume (control.json consume-delete race)

### DIFF
--- a/tests/integration/test_fleet_lifecycle_e2e.py
+++ b/tests/integration/test_fleet_lifecycle_e2e.py
@@ -481,10 +481,13 @@ def test_fleet_pause_resume(tmp_path):
         m = read_fleet_manifest(fleet_id)
         assert m["status"] == "paused", f"manifest not paused: {m['status']!r}"
 
-        for child, (_, wt) in zip(children, cleanup_pairs):
-            ctl = Path(wt) / ".worca" / "runs" / child["run_id"] / "control.json"
-            assert ctl.exists(), f"missing control.json for {child['run_id']}"
-            assert json.loads(ctl.read_text())["action"] == "pause"
+        # NOTE: do not assert control.json exists here. The live child consumes
+        # and deletes it at the top of its next iteration (runner's
+        # _check_control_file), so checking the file is a consume-delete race.
+        # The pause is verified below by each child reaching pipeline_status
+        # "paused"; the control file's worktree targeting + "pause" action are
+        # covered deterministically (no live consumer) by
+        # tests/test_fleet_lifecycle.py::TestPauseFleet.
 
         # Sticky-paused invariant: poll must NOT flip back to running.
         derived = poll_and_update_fleet_manifest(fleet_id)


### PR DESCRIPTION
## Summary
- `test_fleet_pause_resume` intermittently failed in CI with `AssertionError: missing control.json`.
- Root cause: a **consume-delete race**. The test asserts `control.json` exists immediately after `pause_fleet`, but the live child pipeline reads and **deletes** the control file at the top of its next iteration (`runner._check_control_file`, `runner.py:210`). When the child wins the race, the file is gone before the assertion.
- The `count == 2` + manifest-`paused` asserts still pass because `count` reflects intent (incremented after `cmd_pause` returns), not whether the file survived.

## Fix
- Remove the transient `control.json` existence/action assertion. No coverage is lost:
  - The pause is already verified by the subsequent `pipeline_status == "paused"` poll — which would time out if the control file had been written to the wrong place.
  - The control file's worktree targeting + `action == "pause"` are covered deterministically (no live consumer) by `tests/test_fleet_lifecycle.py::TestPauseFleet`.

## Audit
Swept the suite for the same pattern — this was the only instance. Other `control.json` assertions are in unit tests with no live consumer; the sibling e2e lifecycle tests (`test_fleet_stop_then_resume`, `test_fleet_interrupted_child_does_not_trip_breaker`) already use the correct write-then-poll pattern.

## Test plan
- [x] `ruff check` passes on the changed file
- [x] `test_fleet_pause_resume` run locally 3/3 green
- [ ] CI green on the PR