### PR TITLE
W-052: Adaptive effort levels for pipeline agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,8 @@ Skills and subagents in this repo split into two scopes:
 
 Agent config in `.claude/settings.json` under the `worca` namespace. Key sections:
 - `worca.stages` — enable/disable stages, override agents
-- `worca.agents` — model and max_turns per agent
+- `worca.agents` — model, max_turns, and effort per agent
+- `worca.effort` — auto_mode, auto_cap for adaptive effort levels (see [`docs/effort.md`](./docs/effort.md))
 - `worca.models` — shorthand→full model ID mapping (supports per-model env vars)
 - `worca.loops` — max iterations for test/review/planning retry loops
 - `worca.circuit_breaker` — error classification and halt thresholds
@@ -133,6 +134,26 @@ Key gotchas:
 - **Reserved keys** matching `WORCA_*`, `PATH`, or `CLAUDECODE` are silently stripped with a stderr warning. Denylist shared between Python (`src/worca/utils/env.py`) and JS (`worca-ui/server/reserved-env-keys.json`).
 - **Worktree materialization:** parent's `settings.local.json` secrets are materialized into the worktree's `settings.json` (gitignored). Same on-disk plaintext exposure model as `~/.aws/credentials`.
 - **`work_request.py` haiku coupling:** `extract_work_request` resolves its hardcoded `--model haiku` through `resolve_model()`, so customizing the `haiku` entry also retargets work-request title generation. Intentional.
+
+### Effort Levels (`worca.effort`)
+
+Per-agent reasoning effort (`low | medium | high | xhigh | max`) is configured via `worca.agents.<agent>.effort` and governed by a pipeline-level `worca.effort` block. Omitted `effort` means "use Claude Code's model default." Full reference: [`docs/effort.md`](./docs/effort.md).
+
+`worca.effort.auto_mode` controls starting point and loopback escalation:
+
+| Mode | Starting point | Escalation on loopbacks |
+|---|---|---|
+| `disabled` | Per-agent value or model default | No |
+| `reactive` | Per-agent value or model default | Yes |
+| `adaptive` (default) | Per-agent value if set, else coordinator's bead label | Yes |
+
+Under `adaptive`, the coordinator classifies each bead's complexity via `worca-effort:<level>` labels during decomposition. The implementer uses that label as its starting point (unless an explicit per-agent value overrides it).
+
+Key points:
+- **`auto_cap`** (default `xhigh`) is the ceiling for runtime-resolved levels.
+- **Model-aware ladders:** effort rungs are model-specific. The shipped models (Opus 4.6, Sonnet 4.6) lack `xhigh` — the 4-rung ladder is `low/medium/high/max`. Resolution collapses requested levels onto the model's ladder.
+- **Env-var seam:** resolved effort passes through `CLAUDE_CODE_EFFORT_LEVEL`. This is the only non-interactive way to set `max`.
+- Set `auto_mode: "disabled"` to reproduce pre-W-052 behavior (no escalation, no bead-label consumption).
 
 ## Code Hosting
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -573,6 +573,66 @@ The UI's settings save handler runs the same migration automatically. The next t
 
 **New reference:** [`docs/governance.md`](./docs/governance.md) — full reference for the three-tier dispatch model.
 
+### 0.33.x → 0.35.0
+
+W-052: Adaptive effort levels for pipeline agents.
+
+**Behavior change (no breaking API changes):**
+
+1. **New default `auto_mode=adaptive`** — Pipelines that previously ran every agent at Claude Code's model default effort now receive explicit per-agent effort values (`planner: xhigh`, `coordinator: medium`, `guardian: high`) and adaptive loopback escalation. The coordinator classifies each bead's complexity via `worca-effort:<level>` labels, and the implementer consumes those labels as its starting effort.
+
+   **One-line opt-out** to restore pre-W-052 behavior (all agents at model default, no escalation):
+
+   ```jsonc
+   // .claude/settings.json
+   { "worca": { "effort": { "auto_mode": "disabled" } } }
+   ```
+
+2. **Shipped models lack `xhigh`** — The default `worca.models` aliases resolve to **Opus 4.6** and **Sonnet 4.6**, whose effort ladders are `low / medium / high / max` (no `xhigh`). The shipped defaults `planner: xhigh` and `auto_cap: xhigh` are collapsed by model-aware resolution:
+   - `planner: xhigh` runs as `high` on Opus 4.6 (base rounds down to the highest supported rung). `status.json` records `level: "high"`, `requested: "xhigh"` so the UI shows the policy-vs-actual divergence.
+   - `auto_cap: xhigh` rounds *up* to `max` on 4-rung models, so the cap does not block loopback escalation.
+
+3. **Aggressive escalation on 4-rung ladders** — On the shipped models, a single loopback takes a `high`-base implementer straight to `max` because the ladder has no `xhigh` rung between them:
+
+   ```
+   Sonnet 4.6 ladder: low(0) → medium(1) → high(2) → max(3)
+                                            ^^^^        ^^^^
+                                            base      base + 1 (test_failure)
+   ```
+
+   The default `auto_cap: xhigh` permits this (rounds up to `max`). This relaxes the "`max` only via explicit opt-in" guarantee to "explicit opt-in **or** loopback escalation on a model lacking `xhigh`."
+
+   **To prevent auto-escalation to `max`**, pin `auto_cap: high`:
+
+   ```jsonc
+   { "worca": { "effort": { "auto_cap": "high" } } }
+   ```
+
+   This creates a deliberate dead-zone: escalation clamps at `high` with `capped_from: "max"` recorded in the iteration.
+
+4. **Restoring the full 5-rung ladder** — Point `worca.models.opus` at Opus 4.7 to get all five rungs (`low / medium / high / xhigh / max`). Escalation becomes gentler: `high + test_failure = xhigh` (not `max`), and `auto_cap: xhigh` is an actual ceiling below `max`.
+
+   ```jsonc
+   { "worca": { "models": { "opus": "claude-opus-4-7-20250219" } } }
+   ```
+
+**New settings (additive):**
+
+```jsonc
+"worca": {
+  "effort": {
+    "auto_mode": "adaptive",   // disabled | reactive | adaptive
+    "auto_cap": "xhigh"        // low | medium | high | xhigh | max
+  }
+}
+```
+
+Per-agent effort values (`worca.agents.<agent>.effort`) accept `low | medium | high | xhigh | max`. Omitted = mode-dependent fallback (model default or bead label).
+
+**No automatic migration required.** The new `worca.effort` block is additive — `worca init --upgrade` merges the defaults into your project's `settings.json` non-destructively. Existing per-agent `model` and `max_turns` values are preserved.
+
+**Full reference:** [`docs/effort.md`](./docs/effort.md).
+
 ## Getting help
 
 - Issues: https://github.com/SinishaDjukic/worca-cc/issues

--- a/docs/effort.md
+++ b/docs/effort.md
@@ -100,6 +100,8 @@ Escalation fires when an agent re-runs on a loopback trigger. Deltas are **index
 
 Deltas stack across iterations: iter 1 = base, iter 2 = base + delta, iter 3 = base + 2*delta, etc. Only the agent re-running on the loopback escalates — the tester does not escalate when re-run after an implementer fix.
 
+Here "iter" counts **escalation loopbacks only**, not total stage iterations. The implementer runs once per bead during Phase-1 implementation (trigger `next_bead`, zero delta); those per-bead iterations do **not** count toward escalation depth. So the first `test_failure` after implementing N beads is escalation loop 1 (+1 rung), not loop N. `escalation_iter_num()` in `effort.py` computes this depth by counting only escalation-relevant prior triggers; the runner passes it to `resolve_effort()`.
+
 ### Aggressive escalation on 4-rung ladders
 
 On the shipped 4-rung models (Opus 4.6, Sonnet 4.6), escalation is coarser than on Opus 4.7's 5-rung ladder. A single `test_failure` (+1 rung) takes a `high`-base implementer straight to `max`:

--- a/docs/effort.md
+++ b/docs/effort.md
@@ -1,0 +1,264 @@
+# Adaptive Effort Levels
+
+Worca surfaces Claude Code's reasoning-effort scale (`low | medium | high | xhigh | max`) as a per-agent, per-iteration configuration lever. Effort controls how much adaptive reasoning the model spends per step — orthogonal to model identity (`--model`) and turn budget (`--max-turns`).
+
+Configuration lives under `worca.effort` and `worca.agents.<agent>.effort` in `.claude/settings.json`.
+
+## Mode semantics
+
+The `worca.effort.auto_mode` field controls two orthogonal axes: **starting point** (where does the effort level come from?) and **escalation** (does loopback bump it?).
+
+| Mode | Starting point | Escalation on loopbacks |
+|---|---|---|
+| `disabled` | Per-agent `effort` value (if set), else model default | No |
+| `reactive` | Per-agent `effort` value (if set), else model default | Yes |
+| `adaptive` | Per-agent `effort` value if explicitly set (wins), else coordinator-set bead label | Yes |
+
+**`adaptive`** is the shipped default. The coordinator classifies each bead's complexity during decomposition and attaches a `worca-effort:<level>` label. The implementer uses that label as its starting point (unless an explicit per-agent value overrides it). Other agents fall back to model default.
+
+**`reactive`** ignores bead labels for resolution (they're still emitted for forensic comparison) and uses the per-agent value or model default as the starting point. Escalation still fires on loopbacks.
+
+**`disabled`** pins every agent to its per-agent value (or model default) with no escalation. Set `auto_mode: "disabled"` to reproduce pre-W-052 behavior exactly.
+
+## Resolution algorithm
+
+`resolve_effort()` in `src/worca/orchestrator/effort.py` runs once per stage invocation, after `get_stage_config()` and before `claude_cli` is called.
+
+**Inputs:** agent name, per-agent `effort` value (or `None`), `auto_mode`, `auto_cap`, iteration trigger, iteration number, assigned bead (implementer only), resolved model id.
+
+**Returns:** `(level, requested, source, base, bead_classified)`.
+
+| Field | Meaning |
+|---|---|
+| `level` | Value sent to `CLAUDE_CODE_EFFORT_LEVEL` after model-ladder collapse. `None` = omit (use model default). |
+| `requested` | Pre-collapse canonical level the policy produced. Differs from `level` only when the model lacks that rung. |
+| `source` | One of: `explicit`, `model_default`, `adaptive:llm`, `reactive`, `disabled`. |
+| `base` | Starting point before escalation. |
+| `bead_classified` | `{level, applied, skip_reason}` or `None` for non-bead stages. |
+
+### Step-by-step
+
+1. **Determine starting point.**
+   - If the agent has an explicit `effort` value in config: use it (`source = "explicit"`). Bead label is recorded but skipped (`skip_reason = "explicit_override"`).
+   - Else if `adaptive` mode, agent is `implementer`, and the bead has a `worca-effort:*` label: use the label (`source = "adaptive:llm"`, `bead_classified.applied = true`).
+   - Otherwise: use model default (`base = None`).
+
+2. **Look up the model's effort ladder** (see [Model-aware ladders](#model-aware-effort-ladders) below).
+
+3. **Under `disabled` mode:** collapse the base down to the nearest supported rung and return. No escalation.
+
+4. **Apply escalation** (see [Escalation deltas](#escalation-deltas)). Deltas are index steps on the model's ladder and saturate at the top rung.
+
+5. **Clamp to `auto_cap`.** The cap is rounded *up* to the nearest supported rung on the model's ladder before comparison. If the resolved level exceeds the cap, it is clamped down and `capped_from` records the pre-clamp level.
+
+6. **Persist** the full `(level, requested, source, base, bead_classified)` tuple in the iteration record in `status.json`.
+
+## Model-aware effort ladders
+
+Effort rungs are model-specific. Not every model supports every rung:
+
+| Model | Supported rungs |
+|---|---|
+| Opus 4.7 | `low`, `medium`, `high`, `xhigh`, `max` |
+| Opus 4.6 / Sonnet 4.6 | `low`, `medium`, `high`, `max` (no `xhigh`) |
+| Sonnet 4.5 / Opus 4.5 / Haiku | Effort not supported (empty ladder) |
+
+The shipped `worca.models` aliases resolve to Opus 4.6 (`opus`) and Sonnet 4.6 (`sonnet`) — **neither supports `xhigh`**. Model-aware resolution is mandatory, not a nicety.
+
+### Rounding rules
+
+| Operation | Direction | Rationale |
+|---|---|---|
+| Base collapse | Round **down** to the highest supported rung <= requested | Mirrors Claude Code's own runtime fallback. The recorded `level` matches what the model actually runs. |
+| `auto_cap` collapse | Round **up** to the nearest supported rung >= configured cap | Prevents the cap from accidentally pinning escalation below what the ladder allows. |
+
+**Example:** `planner: xhigh` on Opus 4.6 (4-rung ladder).
+- Base `xhigh` rounds down to `high` (sent to the model).
+- `status.json` records `level: "high"`, `requested: "xhigh"` so the UI can show "policy wanted xhigh, model ran high."
+
+**Example:** `auto_cap: xhigh` on Sonnet 4.6.
+- Cap `xhigh` rounds up to `max` — escalation to `max` is not blocked.
+
+### Unsupported and unknown models
+
+- **Unsupported models** (Sonnet 4.5, Opus 4.5, Haiku): empty ladder. The `CLAUDE_CODE_EFFORT_LEVEL` env var is omitted entirely and no escalation occurs. No error.
+- **Unknown/unmapped models**: fall back to the canonical 5-rung ladder (`low/medium/high/xhigh/max`) with a logged warning. Claude Code does its own runtime fallback.
+
+## Escalation deltas
+
+Escalation fires when an agent re-runs on a loopback trigger. Deltas are **index steps on the resolved model's ladder**, not fixed canonical rungs, and **saturate at the top rung**.
+
+| Agent | Trigger | Delta per loop |
+|---|---|---|
+| implementer | `initial` / `next_bead` | +0 |
+| implementer | `test_failure` | +1 |
+| implementer | `review_changes` | +2 |
+| planner | `initial` | +0 |
+| planner | `plan_review_revise` | +1 |
+| planner | `restart_planning` | +1 |
+| coordinator, tester, reviewer, guardian | any | +0 (no escalation) |
+
+Deltas stack across iterations: iter 1 = base, iter 2 = base + delta, iter 3 = base + 2*delta, etc. Only the agent re-running on the loopback escalates — the tester does not escalate when re-run after an implementer fix.
+
+### Aggressive escalation on 4-rung ladders
+
+On the shipped 4-rung models (Opus 4.6, Sonnet 4.6), escalation is coarser than on Opus 4.7's 5-rung ladder. A single `test_failure` (+1 rung) takes a `high`-base implementer straight to `max`:
+
+```
+Sonnet 4.6 ladder: low(0) → medium(1) → high(2) → max(3)
+                                         ^^^^        ^^^^
+                                         base      base + 1
+```
+
+The default `auto_cap: xhigh` permits this because `xhigh` rounds up to `max` on the 4-rung ladder. This relaxes the "`max` only via explicit opt-in" guarantee to "explicit opt-in **or** loopback escalation on a model lacking `xhigh`."
+
+**To prevent auto-escalation to `max` on 4-rung models**, pin `auto_cap: high`. This creates a deliberate dead-zone: escalation clamps at `high` with `capped_from: "max"` recorded in the iteration.
+
+Pointing `worca.models.opus` at Opus 4.7 restores the full 5-rung ladder and gentler escalation.
+
+## Coordinator rubric
+
+The coordinator classifies effort for every bead during decomposition, regardless of `auto_mode`. Under `reactive`/`disabled` the labels are informational (forensic comparison); under `adaptive` the implementer consumes them.
+
+| Level | When to pick |
+|---|---|
+| `low` | Typo fixes, comment-only changes, single-line config tweaks, doc updates with no code impact. |
+| `medium` | Localized changes in a single file, mechanical refactors, well-scoped feature toggles. |
+| `high` | Cross-file changes, new abstractions, non-trivial logic, anything touching pipeline state or governance hooks. |
+| `xhigh` | Schema/migration work, concurrency, security-sensitive paths, multi-stage refactors with subtle invariants. |
+| `max` | Never pick autonomously. Reserved for explicit human or template signal. |
+
+Labels are attached via `bd create --labels "run:<run_id>,worca-effort:<level>"` and reasoning is written via `bd update <id> --notes "Effort: <level> -- <reasoning>"`.
+
+If a bead already has a `worca-effort:*` label (user-set), the coordinator preserves it. User-set labels are authoritative.
+
+If a bead is missing a label after the coordinator finishes, the runner logs a warning and `resolve_effort()` falls back to model default. The pipeline does not halt.
+
+## Per-agent override examples
+
+Per-agent `effort` values are set in `worca.agents.<agent>.effort`. They accept literal rungs only: `low | medium | high | xhigh | max`. There is no `auto` value — the mode field controls escalation, the per-agent field is just the starting point.
+
+### Shipped defaults
+
+```jsonc
+{
+  "worca": {
+    "effort": {
+      "auto_mode": "adaptive",
+      "auto_cap": "xhigh"
+    },
+    "agents": {
+      "planner":     { "effort": "xhigh"  },  // heavy reasoning
+      "coordinator": { "effort": "medium" },  // mechanical decomposition
+      "implementer": { },                     // unset — adaptive path drives base
+      "tester":      { },                     // unset — model default
+      "reviewer":    { },                     // unset — model default
+      "guardian":    { "effort": "high"   }   // high vigilance
+    }
+  }
+}
+```
+
+### Pin all agents to model defaults (pre-W-052 behavior)
+
+```jsonc
+{
+  "worca": {
+    "effort": {
+      "auto_mode": "disabled"
+    }
+  }
+}
+```
+
+### Cost-conscious: cap escalation at `high`
+
+```jsonc
+{
+  "worca": {
+    "effort": {
+      "auto_mode": "reactive",
+      "auto_cap": "high"
+    }
+  }
+}
+```
+
+Escalation fires on loopbacks but never exceeds `high`. Bead labels are emitted for forensic comparison but do not drive the implementer's starting point.
+
+### Override a single agent
+
+```jsonc
+{
+  "worca": {
+    "agents": {
+      "implementer": { "effort": "high" }
+    }
+  }
+}
+```
+
+Under `adaptive` mode, this explicit value overrides the coordinator's bead label. The label is still recorded with `bead_classified.skip_reason = "explicit_override"`.
+
+## Output-token truncation at high/max effort
+
+At `high` and `max` effort the model generates more thinking tokens and is more likely to hit `stop_reason: "max_tokens"` (truncated output). Loopback escalation toward `max` can silently truncate the very iteration the escalation was meant to strengthen.
+
+Operators hitting truncation should raise `CLAUDE_CODE_MAX_OUTPUT_TOKENS` via the `worca.models.*.env` path:
+
+```jsonc
+{
+  "worca": {
+    "models": {
+      "sonnet": {
+        "id": "claude-sonnet-4-6-20250514",
+        "env": {
+          "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "32000"
+        }
+      }
+    }
+  }
+}
+```
+
+Per-effort-level `CLAUDE_CODE_MAX_OUTPUT_TOKENS` calibration is a planned follow-up. The workaround above is the supported path today.
+
+## Implementation seam
+
+Resolved effort is injected via `CLAUDE_CODE_EFFORT_LEVEL` on the per-stage env dict, reusing the `worca.models.*.env` merge path in `src/worca/utils/claude_cli.py`. The env var is the only non-interactive way to set `max` (the `effortLevel` settings field rejects it). This seam is load-bearing for `max` support.
+
+## Observability
+
+Each iteration record in `status.json` carries a full effort block:
+
+```jsonc
+{
+  "effort": {
+    "level": "max",                  // sent to CLAUDE_CODE_EFFORT_LEVEL (null = omitted)
+    "requested": "max",              // canonical pre-collapse value
+    "source": "adaptive",            // explicit | model_default | adaptive:llm | reactive | disabled
+    "base": "high",                  // starting point before escalation
+    "escalations": ["test_failure"], // triggers that caused escalation
+    "capped_from": null,             // pre-clamp level if auto_cap fired
+    "bead_classified": {             // null for non-bead stages
+      "level": "high",              // coordinator's verdict
+      "applied": true,              // was this level used as the base?
+      "skip_reason": null           // null | mode_reactive | mode_disabled | explicit_override | non_classified_agent
+    }
+  }
+}
+```
+
+The `requested` vs `level` pair is the model-collapse forensic signal. When they differ, the UI shows "policy wanted X, model ran Y."
+
+Pipeline log lines follow a terse `key=value` format:
+
+| Scenario | Log line |
+|---|---|
+| Adaptive, bead label used | `IMPLEMENT iter 1: effort=high source=adaptive bead=high` |
+| Explicit override, model lacks rung | `IMPLEMENT iter 1: effort=high req=xhigh source=explicit bead=medium(overridden) model-collapsed` |
+| Reactive, bead label informational | `IMPLEMENT iter 1: effort=high source=reactive bead=medium(ignored)` |
+| Loopback escalation (4-rung) | `IMPLEMENT iter 2: effort=max source=adaptive bead=high +test_failure` |
+| Cap fired | `IMPLEMENT iter 3: effort=high source=adaptive bead=high +test_failure capped_from=max` |
+| Non-bead stage, model collapse | `PLAN iter 1: effort=high req=xhigh source=explicit model-collapsed` |
+| Model default fallback | `TEST iter 1: effort=- source=model_default` |

--- a/docs/plans/W-052-adaptive-effort-levels.md
+++ b/docs/plans/W-052-adaptive-effort-levels.md
@@ -70,7 +70,7 @@ The three modes encode two orthogonal axes — **starting point** (template-auth
 
 **The coordinator owns per-bead effort classification.** During its normal `bd create` pass (Opus, full plan + scope in context), it attaches `--labels worca-effort:<level>` and writes a reasoning note via `bd update --notes`. No separate classifier agent. The coordinator emits labels **regardless of `auto_mode`** — under `reactive` / `disabled` the labels are informational and used for forensic comparison ("would `adaptive` have run this differently?").
 
-Implementer loopback escalation: `test_failure` +1 rung, `review_changes` +2 rungs, stacked across iterations. Planner: +1 per `plan_review_changes` bounce. Resolved effort + the coordinator's verdict + a `skip_reason` (when divergent) are persisted per-iteration in `status.json` and surfaced in the UI as tight badges/chips.
+Implementer loopback escalation: `test_failure` +1 rung, `review_changes` +2 rungs, stacked across iterations. Planner: +1 per `plan_review_revise` bounce (plan-review loop) or `restart_planning` bounce (reviewer sends back to planner). Resolved effort + the coordinator's verdict + a `skip_reason` (when divergent) are persisted per-iteration in `status.json` and surfaced in the UI as tight badges/chips.
 
 ## Design
 
@@ -206,7 +206,8 @@ The `(level, requested, source, base, bead_classified)` tuple is persisted in `s
 | implementer | `test_failure` | +1 per loop (stacks across iters) |
 | implementer | `review_changes` | +2 per loop (stacks across iters) |
 | planner | `initial` | +0 |
-| planner | `plan_review_changes` | +1 per re-run (stacks within run) |
+| planner | `plan_review_revise` | +1 per re-run (plan-review loop bounce; stacks within run) |
+| planner | `restart_planning` | +1 per re-run (reviewer sends back to planner; stacks within run) |
 | coordinator / tester / reviewer / guardian | any | +0 (no escalation; non-implementer-non-planner agents do not escalate on loopback) |
 
 Only the agent re-running on a loopback escalates. Tester does not escalate when re-run after an implementer fix; only the implementer does. Reviewer does not escalate when re-run after another loop; only the originating agent does.
@@ -527,8 +528,8 @@ The phases below structure the *order of work within the PR*, not separate PRs.
 
 **Tasks:**
 1. Format-and-emit the effort log line at `runner.py:1887-1889`.
-2. Extend the `STAGE_STARTED` event payload with `effort: {...}` so the UI receives it via SSE.
-3. Update `stage_started_payload()` to accept and forward the effort dict.
+2. Extend `stage_started_payload()` (`src/worca/events/types.py:288-303`) to accept and forward the effort dict as `effort: {...}`. This lets webhook subscribers and the learner see effort on stage start.
+3. **Do not extend `stage_completed_payload()` or `stage_failed_payload()` with effort data.** The effort dict is already persisted in the iteration record in `status.json` (Phase 1, task 6). The UI reads completed iteration data from `status.json` via the WebSocket `status-update` channel (`worca-ui/server/ws-message-router.js`), not from individual event payloads — so the effort block is already available to the UI for completed/failed iterations without duplicating it on the completion event. STAGE_STARTED carries effort for webhook subscribers and in-flight display; status.json is the authoritative source for post-completion rendering (§7.1 badges, §7.3 mini-table).
 
 ### Phase 4: UI — per-iteration badges and tooltips
 
@@ -553,15 +554,18 @@ The phases below structure the *order of work within the PR*, not separate PRs.
 
 ### Phase 6: UI — settings panel
 
-**Files:** `worca-ui/app/views/settings.js`, `worca-ui/server/settings-routes.js` (or equivalent), `worca-ui/app/styles.css`.
+**Files:** `worca-ui/app/views/settings.js`, `worca-ui/server/project-routes.js`, `worca-ui/server/settings-validator.js`, `worca-ui/app/styles.css`.
 
 **Tasks:**
 1. Add "Effort" section to settings.js, between Models and Secrets.
 2. Implement `auto_mode` dropdown, `auto_cap` dropdown, per-agent table.
 3. Per-agent dropdown values: `(unset)`, `low`, `medium`, `high`, `xhigh`, `max`. **No `auto` value.**
-4. Wire writes to `settings.json` via existing settings PUT endpoint.
-5. Implement inheritance placeholder rendering using the models-panel pattern.
-6. Add confirmation modal triggered when selecting `max` (for per-agent fields and `auto_cap`).
+4. Wire writes to `settings.json` via the existing `POST /api/projects/:projectId/settings` endpoint in `project-routes.js:461`. No new route needed — the effort block is a standard `worca.*` section and the existing handler already does read-merge-write on `settings.json`.
+5. Extend `settings-validator.js:validateSettingsPayload()` with effort validation:
+   - Validate `worca.effort` block: `auto_mode` must be one of `disabled | reactive | adaptive`; `auto_cap` must be one of `low | medium | high | xhigh | max`. Reject unknown keys.
+   - Validate `worca.agents.*.effort` (inside the existing agents loop at `settings-validator.js:76-96`): value must be one of `low | medium | high | xhigh | max`. Without this, the UI can write invalid values that the Python runtime silently falls back from.
+6. Implement inheritance placeholder rendering using the models-panel pattern.
+7. Add confirmation modal triggered when selecting `max` (for per-agent fields and `auto_cap`).
 
 ### Phase 7: Documentation
 
@@ -588,7 +592,8 @@ The phases below structure the *order of work within the PR*, not separate PRs.
 | `worca-ui/app/views/beads-panel.js` | Bead detail label (read-only) + `[ignored: <mode>]` chip + per-iteration mini-table |
 | `worca-ui/app/views/settings.js` | "Effort" section (auto_mode, auto_cap, per-agent table); `max`-confirmation modal |
 | `worca-ui/app/styles.css` | Effort-badge color CSS vars if not subsumed by existing variants |
-| `worca-ui/server/settings-routes.js` | Accept `worca.effort.*` writes |
+| `worca-ui/server/settings-validator.js` | Add `worca.effort` block validation (`auto_mode`, `auto_cap` enums) and `worca.agents.*.effort` rung validation inside the existing agents loop |
+| `worca-ui/server/project-routes.js` | (No code change — existing `POST /settings` handler already does read-merge-write for `worca.*` sections) |
 | `CLAUDE.md` | "Effort Levels" section |
 | `MIGRATION.md` | Older-model fallback note |
 | `docs/effort.md` | **New.** Feature documentation |
@@ -625,7 +630,8 @@ The baseline `resolve_effort` rows below pin `model=claude-opus-4-7` (full 5-run
 | Python | `test_resolve_effort_disabled_records_bead_skip_reason` | disabled + bead `worca-effort:medium` → `bead_classified.applied=false`, `skip_reason="mode_disabled"` |
 | Python | `test_resolve_effort_non_implementer_skip_reason` | adaptive + reviewer agent + bead `worca-effort:high` → `bead_classified.applied=false`, `skip_reason="non_classified_agent"` |
 | Python | `test_resolve_effort_review_changes_plus_two` | adaptive + test_failure × 1 then review_changes × 1 → +1+2 = base+3 (clamped to cap) |
-| Python | `test_resolve_effort_planner_stacks_on_replan` | planner + adaptive + 3× plan_review_changes → +3 rungs from model default |
+| Python | `test_resolve_effort_planner_stacks_on_plan_review_revise` | planner + adaptive + 3× `plan_review_revise` → +3 rungs from base |
+| Python | `test_resolve_effort_planner_escalates_on_restart_planning` | planner + adaptive + `restart_planning` trigger → +1 rung from base |
 | Python | `test_resolve_effort_auto_cap_clamps` | escalation past `auto_cap` clamps and sets `capped_from` |
 | Python | `test_resolve_effort_base_collapses_on_model_without_rung` | explicit `xhigh` on `claude-opus-4-6` → `level="high"`, `requested="xhigh"` (base rounds down to model ladder) |
 | Python | `test_resolve_effort_escalation_on_short_ladder_jumps_to_max` | implementer base `high` + `test_failure` on `claude-sonnet-4-6` (4-rung) → `level="max"` in a single rung (delta on model ladder) |
@@ -642,6 +648,7 @@ The baseline `resolve_effort` rows below pin `model=claude-opus-4-7` (full 5-run
 | JS | `effort-badge.test.js` | Level badge + source qualifier chip render correctly; divergence chip appears only when `bead_classified.applied=false` |
 | JS | `effort-tooltip.test.js` | Tooltip text matches the short-line mapping in §7.1 (no prose) |
 | JS | `settings-effort.test.js` | auto_mode + cap dropdowns write to `settings.json`; per-agent table renders inherited placeholders; selecting `max` triggers confirm modal |
+| JS | `settings-validator.test.js` (extend) | `worca.effort.auto_mode` rejects invalid value; `worca.effort.auto_cap` rejects invalid value; `worca.agents.*.effort` rejects invalid rung; valid effort values pass |
 
 ### Integration / E2E Tests
 
@@ -666,9 +673,12 @@ The baseline `resolve_effort` rows below pin `model=claude-opus-4-7` (full 5-run
 |---|---|
 | `tests/test_stages.py::test_get_stage_config_*` | Add assertions for new `effort` field |
 | `tests/test_status.py::test_start_iteration_*` | Verify `effort` kwarg is round-tripped |
-| `tests/integration/test_pipeline_end_to_end.py` | Pin `auto_mode=disabled` in fixtures so existing assertions aren't sensitive to env-var presence |
+| `tests/integration/conftest.py` | Pin `auto_mode=disabled` in the `pipeline_env` fixture's default `settings["worca"]` block (lines 84-96) so existing assertions in `test_pipeline_dispatch.py`, `test_pipeline_transitions.py`, and `test_pipeline_edge_cases.py` aren't sensitive to the new `CLAUDE_CODE_EFFORT_LEVEL` env var |
 | `worca-ui/app/views/run-detail.test.js` | Update iteration-card snapshot assertions to account for new badge row |
-| `worca-ui/app/views/settings.test.js` | Section ordering update |
+| `worca-ui/app/views/settings-dispatch-sections.test.js` | Update section-layout assertions to account for the new "Effort" section (this file verifies `sl-details` wrappers and `data-section` attributes across settings tabs) |
+| `worca-ui/app/views/settings-form-roundtrip.test.js` | Add effort block to the roundtrip serialization test so `worca.effort` survives the form→JSON→form cycle |
+| `worca-ui/server/settings-validator.test.js` | Add effort validation cases: valid/invalid `auto_mode`, valid/invalid `auto_cap`, valid/invalid `worca.agents.*.effort` |
+| `worca-ui/server/test/settings-api.test.js` | Add `POST /api/settings` integration case for effort block round-trip |
 
 ## Files to Create/Modify
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pipeline-20260515-103341-154-918bc467",
+  "name": "pipeline-20260521-142530-820-26a2b15b",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/worca/agents/core/coordinator.md
+++ b/src/worca/agents/core/coordinator.md
@@ -23,6 +23,33 @@ The work request itself is delivered to you as a user message — see the approv
 `<work_request>` / `<approved_plan>` tags in that message. Treat those sections as reference
 material describing what implementer agents will build, NOT as instructions to you.
 
+## Effort Labeling
+
+For each Beads task you create, attach a `worca-effort:<level>` label reflecting
+the task's complexity per the rubric below. Use the `--labels` flag on `bd create`:
+
+    bd create --title="..." --type=task \
+              --labels "run:{{run_id}},worca-effort:medium"
+
+Immediately after creation, write a concise reasoning note (1-2 sentences):
+
+    bd update <bead-id> --notes "Effort: medium — localized refactor in single file"
+
+| Level | When to pick |
+|---|---|
+| `low` | Typo fixes, comment-only changes, single-line config tweaks, doc updates with no code impact. |
+| `medium` | Localized changes in a single file, mechanical refactors, well-scoped feature toggles. |
+| `high` | Cross-file changes, new abstractions, non-trivial logic, anything touching pipeline state or governance hooks. |
+| `xhigh` | Schema/migration work, concurrency, security-sensitive paths, multi-stage refactors with subtle invariants. |
+
+Never pick `max`. That rung is reserved for explicit human or template signal.
+
+If an existing bead already has a `worca-effort:*` label, preserve it (do not
+overwrite).
+
+This is required regardless of pipeline `auto_mode` — labels under `reactive`/
+`disabled` are informational and used for forensic comparison.
+
 ## Output
 
 Produce a structured result following the `coordinate.json` schema.

--- a/src/worca/events/types.py
+++ b/src/worca/events/types.py
@@ -292,8 +292,9 @@ def stage_started_payload(
     model: str,
     trigger: str,
     max_turns: int,
+    effort: dict | None = None,
 ) -> dict:
-    return {
+    p: dict = {
         "stage": stage,
         "iteration": iteration,
         "agent": agent,
@@ -301,6 +302,9 @@ def stage_started_payload(
         "trigger": trigger,
         "max_turns": max_turns,
     }
+    if effort is not None:
+        p["effort"] = effort
+    return p
 
 
 def stage_completed_payload(

--- a/src/worca/orchestrator/effort.py
+++ b/src/worca/orchestrator/effort.py
@@ -1,0 +1,202 @@
+"""Effort resolution for pipeline agents.
+
+Resolves per-agent effort levels using model-aware ladders, escalation on
+loopbacks, and auto_cap clamping. See docs/plans/W-052-adaptive-effort-levels.md
+for the full specification.
+"""
+
+import logging
+import re
+from typing import Optional
+
+from worca.utils.beads import bd_get_effort_label
+
+logger = logging.getLogger(__name__)
+
+EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
+CANONICAL = EFFORT_LEVELS
+
+MODEL_DEFAULT = None
+
+MODEL_EFFORT_LADDERS: dict[str, tuple[str, ...]] = {
+    "opus-4-7": ("low", "medium", "high", "xhigh", "max"),
+    "opus-4-6": ("low", "medium", "high", "max"),
+    "sonnet-4-6": ("low", "medium", "high", "max"),
+}
+
+_UNSUPPORTED_FAMILIES = frozenset({
+    "opus-4-5", "sonnet-4-5", "haiku-4-5", "haiku",
+})
+
+_FAMILY_RE = re.compile(
+    r"claude-(?P<family>(?:opus|sonnet|haiku)-\d+-\d+)"
+)
+
+
+def _extract_family(model_id: str) -> Optional[str]:
+    m = _FAMILY_RE.match(model_id)
+    if not m:
+        return None
+    return m.group("family")
+
+
+def model_ladder(model_id: str) -> tuple[str, ...]:
+    family = _extract_family(model_id)
+    if family and family in MODEL_EFFORT_LADDERS:
+        return MODEL_EFFORT_LADDERS[family]
+    if family:
+        for prefix in _UNSUPPORTED_FAMILIES:
+            if family.startswith(prefix):
+                return ()
+    if model_id in MODEL_EFFORT_LADDERS:
+        return MODEL_EFFORT_LADDERS[model_id]
+    logger.warning("Unmapped/unknown model %r — using canonical 5-rung ladder; escalation may be inexact", model_id)
+    return CANONICAL
+
+
+def collapse_down(level: Optional[str], ladder: tuple[str, ...]) -> Optional[str]:
+    if level is None:
+        return None
+    if not ladder:
+        return None
+    if level in ladder:
+        return level
+    idx = CANONICAL.index(level) if level in CANONICAL else -1
+    for i in range(idx - 1, -1, -1):
+        if CANONICAL[i] in ladder:
+            return CANONICAL[i]
+    return None
+
+
+def round_up(level: Optional[str], ladder: tuple[str, ...]) -> Optional[str]:
+    if level is None:
+        return None
+    if not ladder:
+        return None
+    if level in ladder:
+        return level
+    idx = CANONICAL.index(level) if level in CANONICAL else -1
+    for i in range(idx + 1, len(CANONICAL)):
+        if CANONICAL[i] in ladder:
+            return CANONICAL[i]
+    return ladder[-1] if ladder else None
+
+
+_ESCALATION_DELTAS: dict[str, dict[str, int]] = {
+    "implementer": {
+        "test_failure": 1,
+        "review_changes": 2,
+    },
+    "planner": {
+        "plan_review_revise": 1,
+        "restart_planning": 1,
+    },
+}
+
+
+def apply_escalation(
+    base: Optional[str],
+    agent: str,
+    trigger: str,
+    iter_num: int,
+    ladder: tuple[str, ...],
+) -> Optional[str]:
+    if base is None:
+        return None
+    if not ladder:
+        return None
+
+    delta_per_loop = _ESCALATION_DELTAS.get(agent, {}).get(trigger, 0)
+    if delta_per_loop == 0:
+        return base
+
+    loops = max(iter_num - 1, 0)
+    total_delta = delta_per_loop * loops
+
+    if base not in ladder:
+        base = collapse_down(base, ladder)
+        if base is None:
+            return None
+
+    idx = ladder.index(base)
+    new_idx = min(idx + total_delta, len(ladder) - 1)
+    return ladder[new_idx]
+
+
+def clamp(
+    level: Optional[str], cap: Optional[str]
+) -> tuple[Optional[str], Optional[str]]:
+    if level is None or cap is None:
+        return (level, None)
+    level_idx = CANONICAL.index(level) if level in CANONICAL else -1
+    cap_idx = CANONICAL.index(cap) if cap in CANONICAL else -1
+    if level_idx <= cap_idx or level_idx < 0 or cap_idx < 0:
+        return (level, None)
+    return (cap, level)
+
+
+def resolve_effort(
+    *,
+    agent: str,
+    agent_effort: Optional[str],
+    auto_mode: str,
+    auto_cap: Optional[str],
+    trigger: str,
+    iter_num: int,
+    bead: Optional[str],
+    model: str,
+) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[dict], Optional[str]]:
+    """Resolve the effort level for a stage invocation.
+
+    Returns (level, requested, source, base, bead_classified, capped_from).
+    """
+    bead_label = bd_get_effort_label(bead) if bead else None
+    bead_classified = None
+    if bead is not None:
+        bead_classified = {
+            "level": bead_label,
+            "applied": False,
+            "skip_reason": None,
+        }
+
+    if agent_effort is not None:
+        base = agent_effort
+        source_base = "explicit"
+        if bead_classified is not None:
+            bead_classified["skip_reason"] = "explicit_override"
+    elif auto_mode == "adaptive" and agent == "implementer" and bead_label:
+        base = bead_label
+        source_base = "adaptive:llm"
+        bead_classified["applied"] = True
+    else:
+        base = MODEL_DEFAULT
+        source_base = "model_default"
+        if bead_classified is not None:
+            if auto_mode == "disabled":
+                bead_classified["skip_reason"] = "mode_disabled"
+            elif auto_mode == "reactive":
+                bead_classified["skip_reason"] = "mode_reactive"
+            elif agent != "implementer":
+                bead_classified["skip_reason"] = "non_classified_agent"
+
+    ladder = model_ladder(model)
+
+    if auto_mode == "disabled":
+        level = collapse_down(base, ladder)
+        source = "disabled" if source_base == "explicit" else source_base
+        return (level, base, source, base, bead_classified, None)
+
+    requested = apply_escalation(base, agent, trigger, iter_num, CANONICAL)
+    collapsed_base = collapse_down(base, ladder)
+    level = apply_escalation(collapsed_base, agent, trigger, iter_num, ladder)
+    cap_on_ladder = round_up(auto_cap, ladder)
+    level, capped_from = clamp(level, cap_on_ladder)
+
+    if auto_mode == "reactive":
+        source = "reactive"
+    elif source_base == "adaptive:llm":
+        source = "adaptive:llm"
+    else:
+        source = source_base
+
+    return (level, requested, source, base, bead_classified, capped_from)

--- a/src/worca/orchestrator/effort.py
+++ b/src/worca/orchestrator/effort.py
@@ -123,6 +123,32 @@ def apply_escalation(
     return ladder[new_idx]
 
 
+def escalation_iter_num(
+    agent: str, trigger: str, prev_triggers: Optional[list]
+) -> int:
+    """Logical escalation iteration number to pass to ``resolve_effort``.
+
+    ``apply_escalation`` derives ``loops = iter_num - 1`` and multiplies the
+    per-loop delta by ``loops``. That multiplier must reflect the number of
+    *escalation loopbacks* the stage has taken — NOT its total iteration count.
+
+    For the implementer the total count is dominated by per-bead Phase-1
+    iterations (trigger ``"next_bead"``, zero delta). Passing
+    ``len(prev_iterations) + 1`` therefore over-escalated: the first real
+    ``test_failure``/``review_changes`` loopback in an N-bead run jumped N
+    rungs (straight to the ladder top) instead of the intended +1/+2.
+
+    This counts only escalation-relevant triggers for ``agent`` (those carrying
+    a non-zero delta in ``_ESCALATION_DELTAS``), including the current one, and
+    returns ``count + 1`` so that ``loops`` equals the number of escalation
+    loopbacks. Non-escalating agents/triggers always return 1 (no escalation).
+    """
+    deltas = _ESCALATION_DELTAS.get(agent, {})
+    prior = sum(1 for t in (prev_triggers or []) if t in deltas)
+    current = 1 if trigger in deltas else 0
+    return prior + current + 1
+
+
 def clamp(
     level: Optional[str], cap: Optional[str]
 ) -> tuple[Optional[str], Optional[str]]:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -26,7 +26,7 @@ from worca.orchestrator.registry import update_pipeline
 from worca.orchestrator.control import read_control, delete_control
 from worca.orchestrator.overlay import OverlayResolver, resolve_agent
 from worca.orchestrator.prompt_builder import PromptBuilder
-from worca.orchestrator.effort import resolve_effort
+from worca.orchestrator.effort import resolve_effort, escalation_iter_num
 from worca.orchestrator.stages import (
     Stage, get_stage_config, get_enabled_stages, STAGE_AGENT_MAP,
     is_learn_enabled,
@@ -2029,13 +2029,21 @@ def run_pipeline(
                     _bead_ids = prompt_builder.get_context("beads_ids") or []
                     if _bead_ids:
                         _assigned_bead = _bead_ids[0]
+                # Escalation depth counts only escalation-relevant loopbacks,
+                # NOT total stage iterations (per-bead Phase-1 fan-out would
+                # otherwise inflate the multiplier — see escalation_iter_num).
+                _eff_iter_num = escalation_iter_num(
+                    stage_config["agent"] or "",
+                    trigger,
+                    [it.get("trigger") for it in prev_iterations],
+                )
                 _eff_level, _eff_requested, _eff_source, _eff_base, _eff_bc, _eff_capped = resolve_effort(
                     agent=stage_config["agent"],
                     agent_effort=stage_config["effort"],
                     auto_mode=_effort_auto_mode,
                     auto_cap=_effort_auto_cap,
                     trigger=trigger,
-                    iter_num=len(prev_iterations) + 1,
+                    iter_num=_eff_iter_num,
                     bead=_assigned_bead,
                     model=stage_config["model"] or "",
                 )

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -26,6 +26,7 @@ from worca.orchestrator.registry import update_pipeline
 from worca.orchestrator.control import read_control, delete_control
 from worca.orchestrator.overlay import OverlayResolver, resolve_agent
 from worca.orchestrator.prompt_builder import PromptBuilder
+from worca.orchestrator.effort import resolve_effort
 from worca.orchestrator.stages import (
     Stage, get_stage_config, get_enabled_stages, STAGE_AGENT_MAP,
     is_learn_enabled,
@@ -36,7 +37,7 @@ from worca.state.status import (
     start_iteration, complete_iteration,
     PipelineStatus, PIPELINE_TERMINAL,
 )
-from worca.utils.beads import bd_ready, bd_show, bd_update, bd_close, bd_label_add, bd_daemon_stop
+from worca.utils.beads import bd_ready, bd_show, bd_update, bd_close, bd_label_add, bd_daemon_stop, bd_get_effort_label
 from worca.utils.gh_issues import gh_issue_start, gh_issue_complete
 from worca.utils.claude_cli import run_agent, terminate_current, AgentSubprocessError
 from worca.utils.git import create_branch, current_branch, get_current_git_head
@@ -703,6 +704,58 @@ def _format_duration(seconds: float) -> str:
     return f"{h}h {m}m {s}s"
 
 
+_ESCALATION_TRIGGERS = frozenset({
+    "test_failure", "review_changes", "plan_review_revise", "restart_planning",
+})
+
+
+def format_effort_log_line(
+    stage_label: str, iter_num: int, effort: dict | None, *, trigger: str = "initial",
+) -> str | None:
+    """Format a terse key=value effort log line per §6 of the W-052 plan.
+
+    Returns None when effort is None (e.g. preflight).
+    """
+    if effort is None:
+        return None
+
+    level = effort.get("level")
+    requested = effort.get("requested")
+    source = effort.get("source", "model_default")
+    capped_from = effort.get("capped_from")
+    bc = effort.get("bead_classified")
+
+    parts = [f"{stage_label} iter {iter_num}:"]
+
+    parts.append(f"effort={level or '-'}")
+
+    if requested and requested != level:
+        parts.append(f"req={requested}")
+
+    source_display = source.replace("adaptive:llm", "adaptive") if source else "model_default"
+    parts.append(f"source={source_display}")
+
+    if bc and bc.get("level") is not None:
+        bead_level = bc["level"]
+        if bc.get("applied"):
+            parts.append(f"bead={bead_level}")
+        elif bc.get("skip_reason") == "explicit_override":
+            parts.append(f"bead={bead_level}(overridden)")
+        else:
+            parts.append(f"bead={bead_level}(ignored)")
+
+    if iter_num > 1 and trigger in _ESCALATION_TRIGGERS:
+        parts.append(f"+{trigger}")
+
+    if capped_from:
+        parts.append(f"capped_from={capped_from}")
+
+    if requested and requested != level and source != "adaptive:llm":
+        parts.append("model-collapsed")
+
+    return " ".join(parts)
+
+
 def _log_stage_metrics(stage_label: str, result: dict, raw_envelope: dict) -> None:
     """Log detailed metrics from a completed stage."""
     parts = []
@@ -1058,6 +1111,7 @@ def run_stage(
     prompt_override: str = None,
     agent_override: str = None,
     ctx: Optional[EventContext] = None,
+    env_overrides: Optional[dict] = None,
 ) -> tuple[dict, dict]:
     """Run a single pipeline stage.
 
@@ -1072,6 +1126,8 @@ def run_stage(
         agent_override: When provided, used as the --agent path instead of the
             default _agent_path(). Allows per-stage resolved templates to be
             passed directly to the claude CLI.
+        env_overrides: Extra env vars merged into model_env before passing to
+            run_agent(). Used for CLAUDE_CODE_EFFORT_LEVEL injection.
 
     Returns (structured_output, raw_envelope) tuple. The structured_output
     is the schema-conforming result used by pipeline logic. The raw_envelope
@@ -1094,6 +1150,9 @@ def run_stage(
     log_path = os.path.join(log_dir, f"iter-{iteration}.log")
     on_event = _make_agent_event_handler(ctx, stage, iteration, settings_path)
     agent = agent_override if agent_override is not None else _agent_path(config["agent"], run_dir=run_dir)
+    merged_env = dict(config.get("model_env") or {})
+    if env_overrides:
+        merged_env.update(env_overrides)
     raw = run_agent(
         prompt=prompt,
         agent=agent,
@@ -1101,7 +1160,7 @@ def run_stage(
         output_format="stream-json",
         json_schema=_schema_path(config["schema"]),
         model=config.get("model"),
-        model_env=config.get("model_env"),
+        model_env=merged_env,
         log_path=log_path,
         on_event=on_event,
     )
@@ -1795,6 +1854,12 @@ def run_pipeline(
             except Exception:
                 pass
 
+        # Read effort settings once at pipeline start
+        _effort_settings = load_settings(settings_path).get("worca", {}).get("effort", {})
+        _effort_auto_mode = _effort_settings.get("auto_mode", "adaptive")
+        _effort_auto_cap = _effort_settings.get("auto_cap", "xhigh")
+        _log(f"Effort: auto_mode={_effort_auto_mode}, auto_cap={_effort_auto_cap}")
+
         stage_order = get_enabled_stages(settings_path)
 
         # Handle plan file
@@ -1952,12 +2017,52 @@ def run_pipeline(
             if prev_iteration_count:
                 status["stages"][current_stage.value]["iteration"] = prev_iteration_count
 
+            # Resolve effort level for non-preflight stages
+            _effort_env_overrides = {}
+            _effort_dict = None
+            if current_stage != Stage.PREFLIGHT and stage_config["agent"]:
+                _assigned_bead = (
+                    prompt_builder.get_context("assigned_bead_id")
+                    if current_stage == Stage.IMPLEMENT else None
+                )
+                if _assigned_bead is None and current_stage == Stage.IMPLEMENT:
+                    _bead_ids = prompt_builder.get_context("beads_ids") or []
+                    if _bead_ids:
+                        _assigned_bead = _bead_ids[0]
+                _eff_level, _eff_requested, _eff_source, _eff_base, _eff_bc, _eff_capped = resolve_effort(
+                    agent=stage_config["agent"],
+                    agent_effort=stage_config["effort"],
+                    auto_mode=_effort_auto_mode,
+                    auto_cap=_effort_auto_cap,
+                    trigger=trigger,
+                    iter_num=len(prev_iterations) + 1,
+                    bead=_assigned_bead,
+                    model=stage_config["model"] or "",
+                )
+                _iter_num = len(prev_iterations) + 1
+                _escalations = (
+                    [trigger] if trigger in _ESCALATION_TRIGGERS and _iter_num > 1
+                    else []
+                )
+                _effort_dict = {
+                    "level": _eff_level,
+                    "requested": _eff_requested,
+                    "source": _eff_source,
+                    "base": _eff_base,
+                    "escalations": _escalations,
+                    "capped_from": _eff_capped,
+                    "bead_classified": _eff_bc,
+                }
+                if _eff_level is not None:
+                    _effort_env_overrides["CLAUDE_CODE_EFFORT_LEVEL"] = _eff_level
+
             # Start a new iteration record
             iter_record = start_iteration(
                 status, current_stage.value,
                 agent=stage_config["agent"],
                 model=stage_config["model"],
                 trigger=trigger,
+                effort=_effort_dict,
             )
             iter_num = iter_record["number"]
             save_status(status, actual_status_path)
@@ -1969,6 +2074,7 @@ def run_pipeline(
                     model=stage_config.get("model", ""),
                     trigger=trigger,
                     max_turns=(stage_config.get("max_turns") or 0) * msize,
+                    effort=_effort_dict,
                 ))
                 if current_stage == Stage.TEST:
                     emit_event(ctx, TEST_SUITE_STARTED, test_suite_started_payload(
@@ -1984,7 +2090,11 @@ def run_pipeline(
 
             stage_label = current_stage.value.upper()
             iter_label = f" (iter {iter_num})" if iter_num > 1 else ""
-            _log(f"{stage_label}{iter_label} starting...")
+            _effort_line = format_effort_log_line(stage_label, iter_num, _effort_dict, trigger=trigger)
+            if _effort_line:
+                _log(_effort_line)
+            else:
+                _log(f"{stage_label}{iter_label} starting...")
             t0 = time.time()
 
             # Check shutdown flag between stages
@@ -2002,8 +2112,7 @@ def run_pipeline(
 
             # --- Phase 1 bead assignment (IMPLEMENT only) ---
             if current_stage == Stage.IMPLEMENT:
-                impl_trigger = _next_trigger.get(Stage.IMPLEMENT.value, "initial")
-                if impl_trigger in ("initial", "next_bead"):
+                if trigger in ("initial", "next_bead"):
                     # Phase 1: implement all beads sequentially
                     run_bead_ids = prompt_builder.get_context("beads_ids")
                     bead = _query_ready_bead(allowed_ids=run_bead_ids, run_id=status.get("run_id"))
@@ -2023,9 +2132,7 @@ def run_pipeline(
                             prompt_builder.update_context("assigned_bead_description", details.get("description", ""))
                         except Exception:
                             prompt_builder.update_context("assigned_bead_description", "")
-                elif impl_trigger in ("test_failure", "review_changes"):
-                    # Phase 3: fix mode — no bead assignment
-                    prompt_builder.update_context("assigned_bead_id", None)
+                elif trigger in ("test_failure", "review_changes"):
                     prompt_builder.update_context("assigned_bead_title", None)
                     prompt_builder.update_context("assigned_bead_description", None)
 
@@ -2163,6 +2270,7 @@ def run_pipeline(
                         prompt_override=rendered_prompt,
                         agent_override=_agent_override,
                         ctx=ctx,
+                        env_overrides=_effort_env_overrides,
                     )
             except InterruptedError:
                 stage_completed = datetime.now(timezone.utc).isoformat()
@@ -2673,6 +2781,11 @@ def run_pipeline(
                             ))
                     else:
                         _log(f"Failed to label beads with {run_label}", "warn")
+                # Best-effort check: warn about beads missing worca-effort:* labels
+                if beads_ids:
+                    _unlabeled = [bid for bid in beads_ids if not bd_get_effort_label(bid)]
+                    if _unlabeled:
+                        _log(f"{len(_unlabeled)} bead(s) missing worca-effort label: {', '.join(_unlabeled)}", "warn")
 
             # Handle implement results — batch-then-test flow
             elif current_stage == Stage.IMPLEMENT:

--- a/src/worca/orchestrator/stages.py
+++ b/src/worca/orchestrator/stages.py
@@ -106,7 +106,7 @@ def get_stage_config(stage: Stage, settings_path: str = ".claude/settings.json")
     agent_name = stage_entry.get("agent") or STAGE_AGENT_MAP.get(stage)
 
     if agent_name is None:
-        return {"agent": None, "model": None, "model_env": {}, "max_turns": None, "schema": None}
+        return {"agent": None, "model": None, "model_env": {}, "max_turns": None, "effort": None, "schema": None}
 
     agent_config = worca.get("agents", {}).get(agent_name, {})
     model_map = worca.get("models", {})
@@ -117,6 +117,7 @@ def get_stage_config(stage: Stage, settings_path: str = ".claude/settings.json")
         "model": model_id,
         "model_env": model_env,
         "max_turns": agent_config.get("max_turns", 30),
+        "effort": agent_config.get("effort"),
         "schema": STAGE_SCHEMA_MAP.get(stage, f"{stage.value}.json"),
     }
 

--- a/src/worca/settings.json
+++ b/src/worca/settings.json
@@ -162,14 +162,20 @@
         "enabled": false
       }
     },
+    "effort": {
+      "auto_mode": "adaptive",
+      "auto_cap": "xhigh"
+    },
     "agents": {
       "planner": {
         "model": "opus",
-        "max_turns": 100
+        "max_turns": 100,
+        "effort": "xhigh"
       },
       "coordinator": {
         "model": "opus",
-        "max_turns": 300
+        "max_turns": 300,
+        "effort": "medium"
       },
       "implementer": {
         "model": "sonnet",
@@ -185,7 +191,8 @@
       },
       "guardian": {
         "model": "opus",
-        "max_turns": 50
+        "max_turns": 50,
+        "effort": "high"
       },
       "learner": {
         "model": "opus",

--- a/src/worca/state/status.py
+++ b/src/worca/state/status.py
@@ -131,12 +131,17 @@ def set_milestone(status: dict, milestone: str, value: bool) -> dict:
     return status
 
 
-def start_iteration(pipeline_status: dict, stage: str, **kwargs) -> dict:
+def start_iteration(pipeline_status: dict, stage: str, *, effort: dict | None = None, **kwargs) -> dict:
     """Start a new iteration for a stage.
 
     Appends a new entry to pipeline_status['stages'][stage]['iterations'].
     Creates the 'iterations' list if absent. Sets number, status, started_at,
     and any extra kwargs (agent, model, trigger).
+
+    Args:
+        effort: Optional effort resolution dict with keys: level, requested,
+            source, base, escalations, capped_from, bead_classified. Only
+            persisted when non-None.
 
     Returns the new iteration dict.
     """
@@ -149,7 +154,6 @@ def start_iteration(pipeline_status: dict, stage: str, **kwargs) -> dict:
     if "iterations" not in stage_data:
         stage_data["iterations"] = []
 
-    # Mark any stale in_progress iterations as interrupted (crash/stop residue)
     for it in stage_data["iterations"]:
         if it.get("status") == "in_progress":
             it["status"] = "interrupted"
@@ -163,6 +167,8 @@ def start_iteration(pipeline_status: dict, stage: str, **kwargs) -> dict:
         "started_at": datetime.now(timezone.utc).isoformat(),
         **kwargs,
     }
+    if effort is not None:
+        iteration["effort"] = effort
     stage_data["iterations"].append(iteration)
     stage_data["iteration"] = iteration_num
     return iteration

--- a/src/worca/utils/beads.py
+++ b/src/worca/utils/beads.py
@@ -348,6 +348,30 @@ def bd_daemon_ensure(beads_dir: str) -> bool:
     return bd_daemon_start(beads_dir)
 
 
+_EFFORT_LEVELS = frozenset({"low", "medium", "high", "xhigh", "max"})
+_EFFORT_LABEL_PREFIX = "worca-effort:"
+
+
+def bd_get_effort_label(bead_id: str) -> Optional[str]:
+    """Extract the effort level from a bead's worca-effort:* label.
+
+    Returns the level string (e.g. "high") or None if missing/invalid.
+    """
+    result = _run_bd("show", bead_id)
+    if result.returncode != 0:
+        return None
+    label_match = re.search(r'^LABELS:\s*(.+)$', result.stdout, re.MULTILINE)
+    if not label_match:
+        return None
+    for label in label_match.group(1).split(","):
+        label = label.strip()
+        if label.startswith(_EFFORT_LABEL_PREFIX):
+            level = label[len(_EFFORT_LABEL_PREFIX):]
+            if level in _EFFORT_LEVELS:
+                return level
+    return None
+
+
 def bd_init(cwd: Optional[str] = None) -> bool:
     """Initialize beads in a directory via bd init.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,6 +94,7 @@ def pipeline_env(tmp_path):
         "reviewer": {"max_turns": 5},
         "guardian": {"max_turns": 5},
     }
+    settings["worca"]["effort"] = {"auto_mode": "disabled"}
     settings_path.write_text(json.dumps(settings, indent=2))
 
     worca_dir = project / ".worca"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -429,7 +429,9 @@ def pipeline_env(tmp_path):
         """
         _overrides["WORCA_AGENT"] = name
 
-    def enable_beads(response_file: Path | None = None) -> None:
+    def enable_beads(
+        response_file: Path | None = None, beads_file: Path | None = None
+    ) -> None:
         """Activate the bd stub and clear ``WORCA_SKIP_BEADS`` for the next run.
 
         The stubs directory is prepended to ``PATH`` only inside the next
@@ -439,6 +441,11 @@ def pipeline_env(tmp_path):
             response_file: Optional path to a JSON file with canned bd
                 responses. See ``tests/integration/stubs/_stub_lib.py`` for
                 the schema.
+            beads_file: Optional path to a JSON file describing a stateful bead
+                pool (``{"beads": [{"id", "title", "effort", ...}]}``). When
+                set, the stub serves ``bd ready``/``show``/``close`` from the
+                pool, tracking closures across calls — exercising multi-bead
+                Phase-1 fan-out. See ``stubs/_stub_lib.py``.
         """
         existing_path = _overrides.get("PATH", os.environ.get("PATH", ""))
         if str(STUBS_DIR) not in existing_path.split(os.pathsep):
@@ -448,6 +455,8 @@ def pipeline_env(tmp_path):
         if response_file is not None:
             _overrides["WORCA_STUB_BD_RESPONSE_FILE"] = str(response_file)
             _stub_response_files["bd"] = Path(response_file)
+        if beads_file is not None:
+            _overrides["WORCA_STUB_BEADS_FILE"] = str(beads_file)
 
     yield PipelineEnv(
         project=project,

--- a/tests/integration/stubs/_stub_lib.py
+++ b/tests/integration/stubs/_stub_lib.py
@@ -94,14 +94,8 @@ def _pick_response(responses: dict, argv_tail: list[str]) -> dict:
     return responses.get("default", {})
 
 
-def run_stub(binary: str, response_env_var: str) -> int:
-    """Execute the stub: log the call, emit a canned response, exit."""
-    argv = sys.argv[1:]
-    _log_invocation(binary, argv)
-
-    responses = _load_responses(response_env_var)
-    response = _pick_response(responses, argv)
-
+def _emit(response: dict) -> int:
+    """Write a response dict's stdout/stderr and return its exit code."""
     stdout = response.get("stdout", "")
     stderr = response.get("stderr", "")
     exit_code = int(response.get("exit", 0))
@@ -115,3 +109,106 @@ def run_stub(binary: str, response_env_var: str) -> int:
         if not stderr.endswith("\n"):
             sys.stderr.write("\n")
     return exit_code
+
+
+# ---------------------------------------------------------------------------
+# Stateful bead pool (opt-in via $WORCA_STUB_BEADS_FILE)
+# ---------------------------------------------------------------------------
+#
+# Unlike the canned-response mechanism, this serves a *sequence* of beads:
+# ``bd ready`` lists only beads not yet closed, ``bd close <id>`` records the
+# closure to a sibling state file, and ``bd show <id>`` emits the bead with its
+# ``worca-effort:`` label. This lets integration tests exercise multi-bead
+# Phase-1 fan-out (one IMPLEMENT iteration per bead) — see W-052. When the env
+# var is unset the stub falls through to the stateless canned responses, so
+# existing tests are unaffected.
+
+
+def _bead_state_path(beads_file: str) -> str:
+    return beads_file + ".closed"
+
+
+def _load_bead_pool() -> list | None:
+    path = os.environ.get("WORCA_STUB_BEADS_FILE")
+    if not path or not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f).get("beads", [])
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _load_closed(beads_file: str) -> set:
+    path = _bead_state_path(beads_file)
+    if not os.path.exists(path):
+        return set()
+    try:
+        with open(path) as f:
+            return set(json.load(f))
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+
+def _save_closed(beads_file: str, closed: set) -> None:
+    with open(_bead_state_path(beads_file), "w") as f:
+        json.dump(sorted(closed), f)
+
+
+def _render_ready(open_beads: list) -> str:
+    lines = [f"\U0001f4cb Ready work ({len(open_beads)} issues with no blockers):", ""]
+    for i, b in enumerate(open_beads, 1):
+        pri = b.get("priority", "P2")
+        typ = b.get("type", "task")
+        lines.append(f"{i}. [● {pri}] [{typ}] {b['id']}: {b.get('title', '')}")
+    return "\n".join(lines) + "\n"
+
+
+def _render_show(bead: dict) -> str:
+    pri = bead.get("priority", "P2")
+    out = f"○ {bead['id']} · {bead.get('title', '')}   [● {pri} · OPEN]\n"
+    effort = bead.get("effort")
+    if effort:
+        out += f"LABELS: worca-effort:{effort}\n"
+    return out
+
+
+def _handle_bd_beads(argv: list) -> dict | None:
+    """Serve ready/show/close from a stateful bead pool, or None to fall through."""
+    beads_file = os.environ.get("WORCA_STUB_BEADS_FILE")
+    if not beads_file:
+        return None
+    beads = _load_bead_pool()
+    if beads is None or not argv:
+        return None
+
+    sub = argv[0]
+    closed = _load_closed(beads_file)
+
+    if sub == "ready":
+        open_beads = [b for b in beads if b["id"] not in closed]
+        return {"stdout": _render_ready(open_beads), "exit": 0}
+    if sub == "show" and len(argv) >= 2:
+        for b in beads:
+            if b["id"] == argv[1]:
+                return {"stdout": _render_show(b), "exit": 0}
+        return None  # unknown bead — let canned/default handle it
+    if sub == "close" and len(argv) >= 2:
+        closed.add(argv[1])
+        _save_closed(beads_file, closed)
+        return {"stdout": f"Closed {argv[1]}", "exit": 0}
+    return None  # update / label / etc. fall through to canned responses
+
+
+def run_stub(binary: str, response_env_var: str) -> int:
+    """Execute the stub: log the call, emit a canned response, exit."""
+    argv = sys.argv[1:]
+    _log_invocation(binary, argv)
+
+    if binary == "bd":
+        bead_response = _handle_bd_beads(argv)
+        if bead_response is not None:
+            return _emit(bead_response)
+
+    responses = _load_responses(response_env_var)
+    return _emit(_pick_response(responses, argv))

--- a/tests/integration/test_effort_integration.py
+++ b/tests/integration/test_effort_integration.py
@@ -1,0 +1,590 @@
+"""Integration tests for effort mode scenarios (W-052 Phase 18).
+
+Exercises the full pipeline with effort configuration, verifying that
+effort levels propagate correctly through settings → runner → env var →
+status.json iteration records. Uses the bd stub to serve bead labels.
+"""
+import json
+
+import pytest
+
+pytestmark = pytest.mark.allow_worca_writes
+
+from tests.integration.helpers import make_iteration_scenario  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BEAD_ID = "bd-test-effort-1"
+
+
+def _configure_effort(pipeline_env, *, auto_mode="adaptive", auto_cap="xhigh",
+                       agents=None, models=None):
+    """Patch worca.effort and optionally worca.agents / worca.models."""
+    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings = json.loads(settings_path.read_text())
+    settings["worca"]["effort"] = {"auto_mode": auto_mode, "auto_cap": auto_cap}
+    if agents:
+        for k, v in agents.items():
+            settings["worca"]["agents"].setdefault(k, {}).update(v)
+    if models:
+        settings["worca"]["models"] = models
+    settings_path.write_text(json.dumps(settings, indent=2))
+
+
+def _bd_responses(bead_id=BEAD_ID, effort_label=None):
+    """Build canned bd stub responses for a bead with an optional effort label."""
+    labels_parts = []
+    if effort_label:
+        labels_parts.append(f"worca-effort:{effort_label}")
+    labels_line = f"\nLABELS: {','.join(labels_parts)}" if labels_parts else ""
+    show_stdout = (
+        f"○ {bead_id} · Test bead   [● P2 · OPEN]"
+        f"{labels_line}\n"
+    )
+    ready_stdout = (
+        "📋 Ready work (1 issues with no blockers):\n"
+        f"1. [● P2] [task] {bead_id}: Test bead\n"
+    )
+    return {
+        f"show {bead_id}": {"stdout": show_stdout, "exit": 0},
+        "ready": {"stdout": ready_stdout, "exit": 0},
+        "default": {"stdout": "", "exit": 0},
+    }
+
+
+def _setup_beads(pipeline_env, effort_label=None, bead_id=BEAD_ID):
+    """Enable the bd stub and write response file with effort label."""
+    response_file = pipeline_env.tmp_path / "bd_effort_responses.json"
+    response_file.write_text(json.dumps(_bd_responses(bead_id, effort_label)))
+    pipeline_env.enable_beads(response_file=response_file)
+    return response_file
+
+
+def _happy_scenario(*, coord_beads=None, tester_per_iter=None,
+                    impl_run_cmd=None, impl_per_iter=None):
+    """Build a full-pipeline scenario with coordinator beads and tester outcome.
+
+    All agents succeed. Coordinator returns beads_ids in structured output.
+    Tester returns passed=True by default (override via tester_per_iter for
+    test-failure loopback tests).
+    """
+    agents = {}
+
+    # Coordinator
+    coord_so = {"beads_ids": coord_beads or []}
+    agents["coordinator"] = {
+        "action": "succeed",
+        "structured_output": coord_so,
+    }
+
+    # Implementer
+    if impl_per_iter:
+        agents["implementer"] = impl_per_iter
+    else:
+        impl_directive = {
+            "action": "succeed",
+            "structured_output": {
+                "files_changed": ["src/foo.py"],
+                "tests_added": ["tests/test_foo.py"],
+            },
+        }
+        if impl_run_cmd:
+            impl_directive["run_command"] = impl_run_cmd
+        agents["implementer"] = impl_directive
+
+    # Tester
+    if tester_per_iter:
+        agents["tester"] = tester_per_iter
+    else:
+        agents["tester"] = {
+            "action": "succeed",
+            "structured_output": {"passed": True},
+        }
+
+    # Reviewer
+    agents["reviewer"] = {
+        "action": "succeed",
+        "structured_output": {"outcome": "approve"},
+    }
+
+    # Guardian (PR)
+    agents["guardian"] = {
+        "action": "succeed",
+        "structured_output": {
+            "pr_url": "https://github.com/test/test/pull/1",
+            "pr_number": 1,
+        },
+    }
+
+    return make_iteration_scenario(agents, default={"action": "succeed", "delay_s": 0})
+
+
+def _get_iteration_effort(status, stage, iteration_num):
+    """Extract effort dict from a specific iteration record in status.json."""
+    stage_data = status.get("stages", {}).get(stage, {})
+    iterations = stage_data.get("iterations", [])
+    for it in iterations:
+        if it.get("number") == iteration_num:
+            return it.get("effort")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# (a) Adaptive mode — bead label applied to IMPLEMENT
+# ---------------------------------------------------------------------------
+
+
+def test_adaptive_bead_label_applied(pipeline_env):
+    """Adaptive mode: coordinator-labeled bead sets implementer effort."""
+    _configure_effort(pipeline_env, auto_mode="adaptive", auto_cap="xhigh")
+    _setup_beads(pipeline_env, effort_label="high")
+    capture_dir = pipeline_env.tmp_path / "effort_capture"
+    capture_dir.mkdir()
+
+    scenario = _happy_scenario(
+        coord_beads=[BEAD_ID],
+        impl_run_cmd=f"echo $CLAUDE_CODE_EFFORT_LEVEL > {capture_dir}/impl_1.txt",
+    )
+    result = pipeline_env.run(scenario, prompt="adaptive effort test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    eff = _get_iteration_effort(result.status, "implement", 1)
+    assert eff is not None, "Effort dict missing from implement iter 1"
+    assert eff["level"] == "high"
+    assert eff["source"] == "adaptive:llm"
+    assert eff["base"] == "high"
+    assert eff["bead_classified"]["applied"] is True
+    assert eff["bead_classified"]["level"] == "high"
+    assert eff["bead_classified"]["skip_reason"] is None
+    assert eff["capped_from"] is None
+
+    captured = (capture_dir / "impl_1.txt").read_text().strip()
+    assert captured == "high"
+
+
+# ---------------------------------------------------------------------------
+# (b) Adaptive test_failure loopback — escalation
+# ---------------------------------------------------------------------------
+
+
+def test_adaptive_test_failure_escalation(pipeline_env):
+    """Adaptive mode: test failure bumps implement effort by +1 rung."""
+    _configure_effort(pipeline_env, auto_mode="adaptive", auto_cap="xhigh")
+    _setup_beads(pipeline_env, effort_label="high")
+    capture_dir = pipeline_env.tmp_path / "effort_capture"
+    capture_dir.mkdir()
+
+    scenario = _happy_scenario(
+        coord_beads=[BEAD_ID],
+        impl_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "run_command": f"echo $CLAUDE_CODE_EFFORT_LEVEL > {capture_dir}/impl_1.txt",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+            "iter_2": {
+                "action": "succeed",
+                "run_command": f"echo $CLAUDE_CODE_EFFORT_LEVEL > {capture_dir}/impl_2.txt",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+            "default": {
+                "action": "succeed",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+        },
+        tester_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "structured_output": {"passed": False, "failures": [{"test": "test_x"}]},
+            },
+            "iter_2": {
+                "action": "succeed",
+                "structured_output": {"passed": True},
+            },
+        },
+    )
+    result = pipeline_env.run(scenario, prompt="escalation test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    # Iter 1: base effort from bead label
+    eff1 = _get_iteration_effort(result.status, "implement", 1)
+    assert eff1 is not None
+    assert eff1["level"] == "high"
+    assert eff1["source"] == "adaptive:llm"
+
+    # Iter 2: escalated by +1 on Sonnet 4.6 ladder (high → max)
+    eff2 = _get_iteration_effort(result.status, "implement", 2)
+    assert eff2 is not None
+    assert eff2["level"] == "max"
+    assert eff2["base"] == "high"
+    # Requested is canonical escalation: high +1 = xhigh
+    assert eff2["requested"] == "xhigh"
+
+    # Verify env var was set on each iteration
+    captured_1 = (capture_dir / "impl_1.txt").read_text().strip()
+    assert captured_1 == "high"
+    captured_2 = (capture_dir / "impl_2.txt").read_text().strip()
+    assert captured_2 == "max"
+
+
+# ---------------------------------------------------------------------------
+# (c) Adaptive with explicit per-agent override — explicit wins
+# ---------------------------------------------------------------------------
+
+
+def test_adaptive_explicit_override(pipeline_env):
+    """Explicit per-agent effort overrides bead label in adaptive mode."""
+    _configure_effort(
+        pipeline_env,
+        auto_mode="adaptive", auto_cap="xhigh",
+        agents={"implementer": {"effort": "medium"}},
+    )
+    _setup_beads(pipeline_env, effort_label="high")
+
+    scenario = _happy_scenario(coord_beads=[BEAD_ID])
+    result = pipeline_env.run(scenario, prompt="explicit override test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    eff = _get_iteration_effort(result.status, "implement", 1)
+    assert eff is not None
+    assert eff["level"] == "medium"
+    assert eff["source"] == "explicit"
+    assert eff["bead_classified"]["applied"] is False
+    assert eff["bead_classified"]["skip_reason"] == "explicit_override"
+    assert eff["bead_classified"]["level"] == "high"
+
+
+# ---------------------------------------------------------------------------
+# (d) Reactive mode — explicit start, escalation, bead not applied
+# ---------------------------------------------------------------------------
+
+
+def test_reactive_mode_escalation(pipeline_env):
+    """Reactive mode: explicit effort as base, escalation on loopback,
+    bead label present but not applied."""
+    _configure_effort(
+        pipeline_env,
+        auto_mode="reactive", auto_cap="xhigh",
+        agents={"implementer": {"effort": "medium"}},
+    )
+    _setup_beads(pipeline_env, effort_label="high")
+    capture_dir = pipeline_env.tmp_path / "effort_capture"
+    capture_dir.mkdir()
+
+    scenario = _happy_scenario(
+        coord_beads=[BEAD_ID],
+        impl_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "run_command": f"echo $CLAUDE_CODE_EFFORT_LEVEL > {capture_dir}/impl_1.txt",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+            "iter_2": {
+                "action": "succeed",
+                "run_command": f"echo $CLAUDE_CODE_EFFORT_LEVEL > {capture_dir}/impl_2.txt",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+            "default": {
+                "action": "succeed",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+        },
+        tester_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "structured_output": {"passed": False, "failures": [{"test": "test_y"}]},
+            },
+            "iter_2": {
+                "action": "succeed",
+                "structured_output": {"passed": True},
+            },
+        },
+    )
+    result = pipeline_env.run(scenario, prompt="reactive mode test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    # Iter 1: explicit effort, bead not applied
+    eff1 = _get_iteration_effort(result.status, "implement", 1)
+    assert eff1 is not None
+    assert eff1["level"] == "medium"
+    assert eff1["source"] == "reactive"
+    assert eff1["bead_classified"]["applied"] is False
+
+    # Iter 2: escalated from medium +1 = high
+    eff2 = _get_iteration_effort(result.status, "implement", 2)
+    assert eff2 is not None
+    assert eff2["level"] == "high"
+    assert eff2["source"] == "reactive"
+
+    captured_1 = (capture_dir / "impl_1.txt").read_text().strip()
+    assert captured_1 == "medium"
+    captured_2 = (capture_dir / "impl_2.txt").read_text().strip()
+    assert captured_2 == "high"
+
+
+# ---------------------------------------------------------------------------
+# (e) Disabled mode — no escalation
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_mode_no_escalation(pipeline_env):
+    """Disabled mode: explicit effort in env, no escalation on loopback."""
+    _configure_effort(
+        pipeline_env,
+        auto_mode="disabled", auto_cap="xhigh",
+        agents={"implementer": {"effort": "high"}},
+    )
+    _setup_beads(pipeline_env, effort_label="high")
+    capture_dir = pipeline_env.tmp_path / "effort_capture"
+    capture_dir.mkdir()
+
+    scenario = _happy_scenario(
+        coord_beads=[BEAD_ID],
+        impl_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "run_command": f"echo $CLAUDE_CODE_EFFORT_LEVEL > {capture_dir}/impl_1.txt",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+            "iter_2": {
+                "action": "succeed",
+                "run_command": f"echo $CLAUDE_CODE_EFFORT_LEVEL > {capture_dir}/impl_2.txt",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+            "default": {
+                "action": "succeed",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+        },
+        tester_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "structured_output": {"passed": False, "failures": [{"test": "test_z"}]},
+            },
+            "iter_2": {
+                "action": "succeed",
+                "structured_output": {"passed": True},
+            },
+        },
+    )
+    result = pipeline_env.run(scenario, prompt="disabled mode test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    eff1 = _get_iteration_effort(result.status, "implement", 1)
+    assert eff1 is not None
+    assert eff1["level"] == "high"
+    assert eff1["source"] == "disabled"
+
+    # Iter 2: same effort, NO escalation
+    eff2 = _get_iteration_effort(result.status, "implement", 2)
+    assert eff2 is not None
+    assert eff2["level"] == "high"
+    assert eff2["source"] == "disabled"
+
+    captured_1 = (capture_dir / "impl_1.txt").read_text().strip()
+    assert captured_1 == "high"
+    captured_2 = (capture_dir / "impl_2.txt").read_text().strip()
+    assert captured_2 == "high"
+
+
+# ---------------------------------------------------------------------------
+# (f) Coordinator emits labels under all modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["adaptive", "reactive", "disabled"])
+def test_coordinator_emits_labels_all_modes(mode, pipeline_env):
+    """Post-COORDINATE unlabeled bead warning absent when label is present."""
+    _configure_effort(pipeline_env, auto_mode=mode)
+    _setup_beads(pipeline_env, effort_label="medium")
+
+    scenario = _happy_scenario(coord_beads=[BEAD_ID])
+    result = pipeline_env.run(scenario, prompt=f"labels-{mode}", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    # No "missing worca-effort label" warning when label is present
+    assert "missing worca-effort label" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# (g) Pre-set bead label preserved by coordinator
+# ---------------------------------------------------------------------------
+
+
+def test_preset_bead_label_preserved(pipeline_env):
+    """A bead that already has a worca-effort label keeps it through the run."""
+    _configure_effort(pipeline_env, auto_mode="adaptive", auto_cap="xhigh")
+    _setup_beads(pipeline_env, effort_label="low")
+
+    scenario = _happy_scenario(coord_beads=[BEAD_ID])
+    result = pipeline_env.run(scenario, prompt="preset label test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    eff = _get_iteration_effort(result.status, "implement", 1)
+    assert eff is not None
+    assert eff["level"] == "low"
+    assert eff["source"] == "adaptive:llm"
+    assert eff["bead_classified"]["level"] == "low"
+    assert eff["bead_classified"]["applied"] is True
+
+
+# ---------------------------------------------------------------------------
+# (h) Auto_cap clamping
+# ---------------------------------------------------------------------------
+
+
+def test_auto_cap_clamping(pipeline_env):
+    """auto_cap clamps effort at the configured ceiling."""
+    _configure_effort(
+        pipeline_env,
+        auto_mode="adaptive", auto_cap="medium",
+    )
+    _setup_beads(pipeline_env, effort_label="high")
+
+    scenario = _happy_scenario(coord_beads=[BEAD_ID])
+    result = pipeline_env.run(scenario, prompt="cap clamp test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    eff = _get_iteration_effort(result.status, "implement", 1)
+    assert eff is not None
+    assert eff["level"] == "medium"
+    assert eff["capped_from"] == "high"
+    assert eff["bead_classified"]["level"] == "high"
+    assert eff["bead_classified"]["applied"] is True
+
+
+# ---------------------------------------------------------------------------
+# (i) Missing bead label warning (pipeline continues)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_bead_label_warning(pipeline_env):
+    """Missing worca-effort label emits warning, pipeline still completes."""
+    _configure_effort(pipeline_env, auto_mode="adaptive")
+    # Bead WITHOUT effort label
+    _setup_beads(pipeline_env, effort_label=None)
+
+    scenario = _happy_scenario(coord_beads=[BEAD_ID])
+    result = pipeline_env.run(scenario, prompt="missing label test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    assert "missing worca-effort label" in result.stderr
+
+    # Effort falls back to model_default (level=None → env var not set)
+    eff = _get_iteration_effort(result.status, "implement", 1)
+    assert eff is not None
+    assert eff["source"] == "model_default"
+
+
+# ---------------------------------------------------------------------------
+# (j) Model collapse — planner xhigh on Opus 4.6
+# ---------------------------------------------------------------------------
+
+
+def test_model_collapse_planner_opus46(pipeline_env):
+    """Planner with effort=xhigh on Opus 4.6 collapses to high."""
+    _configure_effort(
+        pipeline_env,
+        auto_mode="adaptive", auto_cap="xhigh",
+        agents={"planner": {"effort": "xhigh", "model": "opus"}},
+        models={"opus": "claude-opus-4-6"},
+    )
+
+    scenario = _happy_scenario()
+    result = pipeline_env.run(scenario, prompt="model collapse test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    eff = _get_iteration_effort(result.status, "plan", 1)
+    assert eff is not None
+    assert eff["level"] == "high"
+    assert eff["requested"] == "xhigh"
+
+
+# ---------------------------------------------------------------------------
+# (k) Sonnet 4.6 test_failure escalation high → max (one rung)
+# ---------------------------------------------------------------------------
+
+
+def test_sonnet46_high_to_max_escalation(pipeline_env):
+    """On Sonnet 4.6 (4-rung ladder), high +1 escalation jumps to max."""
+    _configure_effort(pipeline_env, auto_mode="adaptive", auto_cap="xhigh")
+    _setup_beads(pipeline_env, effort_label="high")
+
+    scenario = _happy_scenario(
+        coord_beads=[BEAD_ID],
+        impl_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+            "iter_2": {
+                "action": "succeed",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+            "default": {
+                "action": "succeed",
+                "structured_output": {
+                    "files_changed": ["src/foo.py"],
+                    "tests_added": ["tests/test_foo.py"],
+                },
+            },
+        },
+        tester_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "structured_output": {"passed": False, "failures": [{"test": "t1"}]},
+            },
+            "iter_2": {
+                "action": "succeed",
+                "structured_output": {"passed": True},
+            },
+        },
+    )
+    result = pipeline_env.run(scenario, prompt="sonnet escalation test", timeout=60)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    eff2 = _get_iteration_effort(result.status, "implement", 2)
+    assert eff2 is not None
+    # Sonnet 4.6 ladder: low, medium, high, max — high +1 = max
+    assert eff2["level"] == "max"
+    # Canonical requested: high +1 = xhigh
+    assert eff2["requested"] == "xhigh"
+    assert eff2["base"] == "high"
+    # auto_cap xhigh rounds up to max on Sonnet 4.6, so no clamping
+    assert eff2["capped_from"] is None

--- a/tests/integration/test_effort_integration.py
+++ b/tests/integration/test_effort_integration.py
@@ -63,6 +63,23 @@ def _setup_beads(pipeline_env, effort_label=None, bead_id=BEAD_ID):
     return response_file
 
 
+def _setup_bead_pool(pipeline_env, bead_ids, effort_label=None):
+    """Enable the stateful bd stub with a pool of beads (one IMPLEMENT iter each).
+
+    ``bd ready`` serves the beads in order and drops each as it is closed, so
+    the runner's Phase-1 loop produces one IMPLEMENT iteration per bead.
+    """
+    beads_file = pipeline_env.tmp_path / "bd_pool.json"
+    beads_file.write_text(json.dumps({
+        "beads": [
+            {"id": bid, "title": f"Bead {bid}", "effort": effort_label}
+            for bid in bead_ids
+        ],
+    }))
+    pipeline_env.enable_beads(beads_file=beads_file)
+    return beads_file
+
+
 def _happy_scenario(*, coord_beads=None, tester_per_iter=None,
                     impl_run_cmd=None, impl_per_iter=None):
     """Build a full-pipeline scenario with coordinator beads and tester outcome.
@@ -237,6 +254,60 @@ def test_adaptive_test_failure_escalation(pipeline_env):
     assert captured_1 == "high"
     captured_2 = (capture_dir / "impl_2.txt").read_text().strip()
     assert captured_2 == "max"
+
+
+# ---------------------------------------------------------------------------
+# (b2) Multi-bead test_failure loopback — escalation depth excludes Phase-1 fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_adaptive_test_failure_escalation_multibead(pipeline_env):
+    """W-052 regression: per-bead Phase-1 iterations must NOT inflate escalation.
+
+    With 3 beads, Phase 1 produces 3 IMPLEMENT iterations (trigger next_bead,
+    zero delta). The first test_failure loopback (IMPLEMENT iter 4) must
+    escalate by exactly +1 rung (low -> medium on the Sonnet 4.6 ladder), NOT
+    by the total iteration count. The pre-fix runner passed
+    iter_num = len(prev_iterations) + 1 = 4, escalating low +3 rungs straight
+    to max.
+    """
+    bead_ids = ["bd-eff-a", "bd-eff-b", "bd-eff-c"]
+    _configure_effort(pipeline_env, auto_mode="adaptive", auto_cap="xhigh")
+    _setup_bead_pool(pipeline_env, bead_ids, effort_label="low")
+
+    scenario = _happy_scenario(
+        coord_beads=bead_ids,
+        tester_per_iter={
+            "iter_1": {
+                "action": "succeed",
+                "structured_output": {"passed": False, "failures": [{"test": "test_x"}]},
+            },
+            "iter_2": {
+                "action": "succeed",
+                "structured_output": {"passed": True},
+            },
+        },
+    )
+    result = pipeline_env.run(scenario, prompt="multibead escalation", timeout=120)
+    assert result.returncode == 0, f"Pipeline failed: {result.stderr[:500]}"
+
+    # Phase 1: one IMPLEMENT iteration per bead, all at the bead-label base.
+    for n in (1, 2, 3):
+        eff = _get_iteration_effort(result.status, "implement", n)
+        assert eff is not None, f"missing implement iter {n}"
+        assert eff["level"] == "low", f"iter {n}: {eff}"
+        assert eff["source"] == "adaptive:llm"
+        assert eff["escalations"] == []
+
+    # IMPLEMENT iter 4 = first test_failure loopback. Escalation depth is 1
+    # (one loopback), so low + 1 rung = "medium" — NOT "max".
+    eff4 = _get_iteration_effort(result.status, "implement", 4)
+    assert eff4 is not None, "expected a 4th implement iteration (test_failure loopback)"
+    assert eff4["base"] == "low"
+    assert eff4["level"] == "medium", f"over-escalation regression: {eff4}"
+    assert eff4["requested"] == "medium"
+    assert eff4["escalations"] == ["test_failure"]
+    assert eff4["capped_from"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_fixture_smoke.py
+++ b/tests/integration/test_fixture_smoke.py
@@ -38,6 +38,13 @@ def test_pipeline_env_settings_overridden(pipeline_env):
     assert stages.get("learn", {}).get("enabled") is False
 
 
+def test_pipeline_env_effort_pinned_disabled(pipeline_env):
+    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings = json.loads(settings_path.read_text())
+    effort = settings.get("worca", {}).get("effort", {})
+    assert effort.get("auto_mode") == "disabled"
+
+
 def test_webhook_server_url_is_localhost(webhook_server):
     assert webhook_server.url.startswith("http://localhost:")
 

--- a/tests/test_agent_md_refs.py
+++ b/tests/test_agent_md_refs.py
@@ -82,6 +82,63 @@ def test_coordinator_no_single_brace_run_id():
 
 
 # ---------------------------------------------------------------------------
+# coordinator.md — Effort Labeling (W-052 Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_has_effort_labeling_section():
+    content = _read("coordinator.md")
+    assert "## Effort Labeling" in content
+
+
+def test_coordinator_effort_rubric_has_all_levels():
+    content = _read("coordinator.md")
+    for level in ("low", "medium", "high", "xhigh"):
+        assert f"| `{level}`" in content, (
+            f"coordinator.md effort rubric must include the `{level}` level"
+        )
+
+
+def test_coordinator_effort_rubric_never_pick_max():
+    content = _read("coordinator.md")
+    lower = content.lower()
+    assert "never pick" in lower and "max" in lower, (
+        "coordinator.md effort rubric must instruct never to pick `max` autonomously"
+    )
+
+
+def test_coordinator_effort_bd_create_labels_instruction():
+    content = _read("coordinator.md")
+    assert "worca-effort:" in content, (
+        "coordinator.md must instruct bd create --labels worca-effort:<level>"
+    )
+    assert "--labels" in content
+
+
+def test_coordinator_effort_bd_update_notes_instruction():
+    content = _read("coordinator.md")
+    assert "bd update" in content and "--notes" in content, (
+        "coordinator.md must instruct bd update <id> --notes for effort reasoning"
+    )
+
+
+def test_coordinator_effort_preserve_existing_label():
+    content = _read("coordinator.md")
+    lower = content.lower()
+    assert "preserve" in lower or "do not overwrite" in lower, (
+        "coordinator.md must instruct preserving existing worca-effort:* labels"
+    )
+
+
+def test_coordinator_effort_mode_independent_emission():
+    content = _read("coordinator.md")
+    lower = content.lower()
+    assert ("regardless" in lower and "auto_mode" in lower) or "mode-independent" in lower, (
+        "coordinator.md must note that effort labels are emitted regardless of auto_mode"
+    )
+
+
+# ---------------------------------------------------------------------------
 # implementer.md
 # ---------------------------------------------------------------------------
 

--- a/tests/test_beads.py
+++ b/tests/test_beads.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, MagicMock, mock_open
 from worca.utils.beads import (
     bd_create, bd_ready, bd_show, bd_close, bd_update, bd_dep_add,
     bd_daemon_stop, bd_daemon_status, bd_daemon_start, bd_daemon_ensure,
+    bd_get_effort_label,
     _wait_for_pid_exit, _DAEMON_STOPPED_SENTINEL,
 )
 
@@ -645,3 +646,94 @@ def test_bd_daemon_start_after_stop_reenables_ensure(tmp_path):
     with patch("worca.utils.beads.bd_daemon_status", return_value=False), \
          patch("worca.utils.beads.bd_daemon_start", return_value=True):
         assert bd_daemon_ensure(beads_dir) is True
+
+
+# --- bd_get_effort_label ---
+
+
+def _bd_show_output_with_labels(labels_str: str) -> str:
+    return (
+        "○ worca-cc-xyz · Implement feature   [● P2 · OPEN]\n"
+        "\n"
+        "DESCRIPTION\n"
+        "Some description.\n"
+        "\n"
+        f"LABELS: {labels_str}\n"
+        "\n"
+        "DEPENDENCIES\n"
+        "  (none)\n"
+    )
+
+
+def test_bd_get_effort_label_parses_label():
+    """Returns the effort level for a bead with a valid worca-effort label."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = _bd_show_output_with_labels("run:abc123, worca-effort:high")
+    with patch("worca.utils.beads.subprocess.run", return_value=mock_result):
+        assert bd_get_effort_label("worca-cc-xyz") == "high"
+
+
+def test_bd_get_effort_label_all_valid_levels():
+    """Every canonical effort level is accepted."""
+    for level in ("low", "medium", "high", "xhigh", "max"):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = _bd_show_output_with_labels(f"worca-effort:{level}")
+        with patch("worca.utils.beads.subprocess.run", return_value=mock_result):
+            assert bd_get_effort_label("bead-1") == level
+
+
+def test_bd_get_effort_label_invalid_returns_none():
+    """Returns None when the worca-effort label has an unrecognized level."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = _bd_show_output_with_labels("worca-effort:bogus")
+    with patch("worca.utils.beads.subprocess.run", return_value=mock_result):
+        assert bd_get_effort_label("bead-1") is None
+
+
+def test_bd_get_effort_label_missing_returns_none():
+    """Returns None when no worca-effort label exists."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = _bd_show_output_with_labels("run:abc123, area:cc")
+    with patch("worca.utils.beads.subprocess.run", return_value=mock_result):
+        assert bd_get_effort_label("bead-1") is None
+
+
+def test_bd_get_effort_label_no_labels_section():
+    """Returns None when bd show output has no LABELS line."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = (
+        "○ worca-cc-xyz · Task   [● P2 · OPEN]\n"
+        "\n"
+        "DESCRIPTION\n"
+        "No labels here.\n"
+        "\n"
+        "DEPENDENCIES\n"
+        "  (none)\n"
+    )
+    with patch("worca.utils.beads.subprocess.run", return_value=mock_result):
+        assert bd_get_effort_label("worca-cc-xyz") is None
+
+
+def test_bd_get_effort_label_bd_show_fails():
+    """Returns None when bd show fails (non-zero exit)."""
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stderr = "Error: not found"
+    with patch("worca.utils.beads.subprocess.run", return_value=mock_result):
+        assert bd_get_effort_label("nonexistent") is None
+
+
+def test_bd_get_effort_label_only_first_effort_label():
+    """When multiple worca-effort labels exist, returns the first valid one."""
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = _bd_show_output_with_labels(
+        "worca-effort:medium, worca-effort:high"
+    )
+    with patch("worca.utils.beads.subprocess.run", return_value=mock_result):
+        assert bd_get_effort_label("bead-1") == "medium"

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -578,3 +578,92 @@ class TestResolveEffortCappedFrom:
             trigger="test_failure", iter_num=3, bead=None, model=self.MODEL,
         )
         assert capped is None
+
+
+# ---------------------------------------------------------------------------
+# escalation_iter_num() — escalation depth excludes per-bead Phase-1 fan-out
+# ---------------------------------------------------------------------------
+#
+# Regression guard for the W-052 over-escalation bug: the runner used to pass
+# iter_num = len(prev_iterations) + 1 (TOTAL stage iterations) to
+# resolve_effort. For the implementer, that count is dominated by per-bead
+# Phase-1 iterations (trigger "next_bead", zero delta), so the FIRST real
+# loopback escalated by N rungs (N = beads implemented) instead of +1,
+# jumping straight to the ladder top on any multi-bead run.
+#
+# escalation_iter_num() returns the logical escalation iteration number:
+# loops = iter_num - 1 must equal the number of escalation loopbacks taken
+# (including the current one), NOT the total iteration count.
+
+
+class TestEscalationIterNum:
+    def test_implementer_first_test_failure_ignores_fanout(self):
+        """A single test_failure after N per-bead Phase-1 iters is still loop 1."""
+        from worca.orchestrator.effort import escalation_iter_num
+        prev = ["initial", "next_bead", "next_bead", "next_bead"]  # 4-bead Phase 1
+        assert escalation_iter_num("implementer", "test_failure", prev) == 2
+
+    def test_implementer_second_failure_stacks(self):
+        from worca.orchestrator.effort import escalation_iter_num
+        prev = ["initial", "next_bead", "next_bead", "test_failure"]
+        assert escalation_iter_num("implementer", "test_failure", prev) == 3
+
+    def test_implementer_review_changes_after_fanout(self):
+        from worca.orchestrator.effort import escalation_iter_num
+        prev = ["initial", "next_bead", "next_bead"]
+        assert escalation_iter_num("implementer", "review_changes", prev) == 2
+
+    def test_phase1_next_bead_never_escalates(self):
+        from worca.orchestrator.effort import escalation_iter_num
+        prev = ["initial", "next_bead"]
+        assert escalation_iter_num("implementer", "next_bead", prev) == 1
+
+    def test_initial_no_history(self):
+        from worca.orchestrator.effort import escalation_iter_num
+        assert escalation_iter_num("implementer", "initial", []) == 1
+
+    def test_planner_first_plan_review(self):
+        from worca.orchestrator.effort import escalation_iter_num
+        assert escalation_iter_num("planner", "plan_review_revise", ["initial"]) == 2
+
+    def test_planner_stacks(self):
+        from worca.orchestrator.effort import escalation_iter_num
+        prev = ["initial", "plan_review_revise"]
+        assert escalation_iter_num("planner", "restart_planning", prev) == 3
+
+    def test_non_escalating_agent_always_one(self):
+        from worca.orchestrator.effort import escalation_iter_num
+        prev = ["initial", "next_bead", "test_failure", "review_changes"]
+        assert escalation_iter_num("coordinator", "review_changes", prev) == 1
+
+    def test_none_prev_triggers(self):
+        from worca.orchestrator.effort import escalation_iter_num
+        assert escalation_iter_num("implementer", "test_failure", None) == 2
+
+
+class TestMultiBeadEscalationBehavior:
+    """End-to-end demonstration of the bug fix on the Sonnet 4.6 (default) ladder."""
+
+    def test_first_failure_after_multibead_escalates_one_rung(self):
+        from worca.orchestrator.effort import (
+            apply_escalation,
+            escalation_iter_num,
+            model_ladder,
+        )
+        ladder = model_ladder("claude-sonnet-4-6")  # (low, medium, high, max)
+        prev = ["initial", "next_bead", "next_bead"]  # 3-bead Phase 1
+        itn = escalation_iter_num("implementer", "test_failure", prev)
+        # base "low" + 1 rung = "medium"; the buggy total-count path gave "max".
+        assert apply_escalation("low", "implementer", "test_failure", itn, ladder) == "medium"
+
+    def test_single_bead_unchanged(self):
+        """Single-bead runs (the only case the old code got right) still +1."""
+        from worca.orchestrator.effort import (
+            apply_escalation,
+            escalation_iter_num,
+            model_ladder,
+        )
+        ladder = model_ladder("claude-sonnet-4-6")
+        prev = ["initial"]
+        itn = escalation_iter_num("implementer", "test_failure", prev)
+        assert apply_escalation("medium", "implementer", "test_failure", itn, ladder) == "high"

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -1,0 +1,580 @@
+"""Tests for worca.orchestrator.effort — effort resolution, model-aware ladders, escalation."""
+
+import logging
+from unittest.mock import patch
+
+
+from worca.orchestrator.effort import (
+    CANONICAL,
+    EFFORT_LEVELS,
+    MODEL_DEFAULT,
+    MODEL_EFFORT_LADDERS,
+    apply_escalation,
+    clamp,
+    collapse_down,
+    model_ladder,
+    resolve_effort,
+    round_up,
+)
+
+
+# ---------------------------------------------------------------------------
+# EFFORT_LEVELS and MODEL_EFFORT_LADDERS
+# ---------------------------------------------------------------------------
+
+
+class TestEffortLevels:
+    def test_canonical_order(self):
+        assert EFFORT_LEVELS == ("low", "medium", "high", "xhigh", "max")
+
+    def test_canonical_is_effort_levels(self):
+        assert CANONICAL is EFFORT_LEVELS
+
+    def test_model_default_is_none(self):
+        assert MODEL_DEFAULT is None
+
+
+class TestModelEffortLadders:
+    def test_opus_4_7_five_rung(self):
+        assert MODEL_EFFORT_LADDERS["opus-4-7"] == ("low", "medium", "high", "xhigh", "max")
+
+    def test_opus_4_6_four_rung(self):
+        assert MODEL_EFFORT_LADDERS["opus-4-6"] == ("low", "medium", "high", "max")
+
+    def test_sonnet_4_6_four_rung(self):
+        assert MODEL_EFFORT_LADDERS["sonnet-4-6"] == ("low", "medium", "high", "max")
+
+    def test_haiku_empty(self):
+        ladder = model_ladder("claude-haiku-4-5-20251001")
+        assert ladder == ()
+
+    def test_sonnet_4_5_empty(self):
+        ladder = model_ladder("claude-sonnet-4-5-20251014")
+        assert ladder == ()
+
+
+# ---------------------------------------------------------------------------
+# model_ladder()
+# ---------------------------------------------------------------------------
+
+
+class TestModelLadder:
+    def test_opus_4_7_full_id(self):
+        assert model_ladder("claude-opus-4-7-20250506") == MODEL_EFFORT_LADDERS["opus-4-7"]
+
+    def test_opus_4_6_full_id(self):
+        assert model_ladder("claude-opus-4-6-20250501") == MODEL_EFFORT_LADDERS["opus-4-6"]
+
+    def test_sonnet_4_6_full_id(self):
+        assert model_ladder("claude-sonnet-4-6-20250514") == MODEL_EFFORT_LADDERS["sonnet-4-6"]
+
+    def test_bare_family_name(self):
+        assert model_ladder("claude-opus-4-7") == MODEL_EFFORT_LADDERS["opus-4-7"]
+
+    def test_unknown_model_returns_canonical(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            ladder = model_ladder("some-unknown-model-v99")
+        assert ladder == CANONICAL
+        assert any("unmapped" in r.message.lower() or "unknown" in r.message.lower() for r in caplog.records)
+
+    def test_empty_ladder_for_unsupported(self):
+        assert model_ladder("claude-haiku-4-5-20251001") == ()
+
+
+# ---------------------------------------------------------------------------
+# collapse_down()
+# ---------------------------------------------------------------------------
+
+
+class TestCollapseDown:
+    def test_none_stays_none(self):
+        assert collapse_down(None, CANONICAL) is None
+
+    def test_level_on_ladder(self):
+        assert collapse_down("high", CANONICAL) == "high"
+
+    def test_xhigh_on_4_rung_collapses_to_high(self):
+        ladder = MODEL_EFFORT_LADDERS["opus-4-6"]
+        assert collapse_down("xhigh", ladder) == "high"
+
+    def test_max_on_4_rung_stays_max(self):
+        ladder = MODEL_EFFORT_LADDERS["opus-4-6"]
+        assert collapse_down("max", ladder) == "max"
+
+    def test_empty_ladder_returns_none(self):
+        assert collapse_down("high", ()) is None
+
+    def test_low_stays_on_any_ladder(self):
+        for key in MODEL_EFFORT_LADDERS:
+            ladder = MODEL_EFFORT_LADDERS[key]
+            if ladder:
+                assert collapse_down("low", ladder) == "low"
+
+
+# ---------------------------------------------------------------------------
+# round_up()
+# ---------------------------------------------------------------------------
+
+
+class TestRoundUp:
+    def test_level_on_ladder(self):
+        assert round_up("high", CANONICAL) == "high"
+
+    def test_xhigh_on_4_rung_rounds_up_to_max(self):
+        ladder = MODEL_EFFORT_LADDERS["opus-4-6"]
+        assert round_up("xhigh", ladder) == "max"
+
+    def test_none_stays_none(self):
+        assert round_up(None, CANONICAL) is None
+
+    def test_max_stays_max(self):
+        assert round_up("max", MODEL_EFFORT_LADDERS["opus-4-6"]) == "max"
+
+    def test_empty_ladder_returns_none(self):
+        assert round_up("high", ()) is None
+
+
+# ---------------------------------------------------------------------------
+# apply_escalation()
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEscalation:
+    def test_initial_no_escalation(self):
+        assert apply_escalation("high", "implementer", "initial", 1, CANONICAL) == "high"
+
+    def test_next_bead_no_escalation(self):
+        assert apply_escalation("high", "implementer", "next_bead", 1, CANONICAL) == "high"
+
+    def test_test_failure_plus_one(self):
+        assert apply_escalation("high", "implementer", "test_failure", 2, CANONICAL) == "xhigh"
+
+    def test_review_changes_plus_two(self):
+        assert apply_escalation("high", "implementer", "review_changes", 2, CANONICAL) == "max"
+
+    def test_test_failure_stacks(self):
+        # iter 3 means 2 escalation-eligible iterations: +1 + +1 = +2
+        assert apply_escalation("medium", "implementer", "test_failure", 3, CANONICAL) == "xhigh"
+
+    def test_review_changes_stacks(self):
+        # iter 3: +2 + +2 = +4, saturates at max
+        assert apply_escalation("low", "implementer", "review_changes", 3, CANONICAL) == "max"
+
+    def test_planner_plan_review_revise_plus_one(self):
+        assert apply_escalation("high", "planner", "plan_review_revise", 2, CANONICAL) == "xhigh"
+
+    def test_planner_restart_planning_plus_one(self):
+        assert apply_escalation("high", "planner", "restart_planning", 2, CANONICAL) == "xhigh"
+
+    def test_planner_initial_no_escalation(self):
+        assert apply_escalation("high", "planner", "initial", 1, CANONICAL) == "high"
+
+    def test_coordinator_no_escalation_on_any_trigger(self):
+        for trigger in ("initial", "test_failure", "review_changes"):
+            assert apply_escalation("medium", "coordinator", trigger, 3, CANONICAL) == "medium"
+
+    def test_tester_no_escalation(self):
+        assert apply_escalation("high", "tester", "test_failure", 3, CANONICAL) == "high"
+
+    def test_reviewer_no_escalation(self):
+        assert apply_escalation("high", "reviewer", "review_changes", 3, CANONICAL) == "high"
+
+    def test_guardian_no_escalation(self):
+        assert apply_escalation("high", "guardian", "review_changes", 3, CANONICAL) == "high"
+
+    def test_saturates_at_top(self):
+        assert apply_escalation("xhigh", "implementer", "review_changes", 5, CANONICAL) == "max"
+
+    def test_none_base_returns_none(self):
+        assert apply_escalation(None, "implementer", "test_failure", 2, CANONICAL) is None
+
+    def test_short_ladder_test_failure_jumps_to_max(self):
+        ladder = MODEL_EFFORT_LADDERS["sonnet-4-6"]
+        assert apply_escalation("high", "implementer", "test_failure", 2, ladder) == "max"
+
+    def test_short_ladder_planner_escalation(self):
+        ladder = MODEL_EFFORT_LADDERS["opus-4-6"]
+        assert apply_escalation("high", "planner", "plan_review_revise", 2, ladder) == "max"
+
+
+# ---------------------------------------------------------------------------
+# clamp()
+# ---------------------------------------------------------------------------
+
+
+class TestClamp:
+    def test_below_cap_unchanged(self):
+        assert clamp("high", "xhigh") == ("high", None)
+
+    def test_equal_to_cap_unchanged(self):
+        assert clamp("xhigh", "xhigh") == ("xhigh", None)
+
+    def test_above_cap_clamped(self):
+        assert clamp("max", "xhigh") == ("xhigh", "max")
+
+    def test_none_level_returns_none(self):
+        assert clamp(None, "xhigh") == (None, None)
+
+    def test_none_cap_no_clamping(self):
+        assert clamp("max", None) == ("max", None)
+
+
+# ---------------------------------------------------------------------------
+# resolve_effort() — baseline (Opus 4.7 / full 5-rung ladder)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEffortBaseline:
+    MODEL = "claude-opus-4-7-20250506"
+
+    def test_omitted_disabled_returns_model_default(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="implementer", agent_effort=None,
+            auto_mode="disabled", auto_cap="xhigh",
+            trigger="initial", iter_num=1, bead=None, model=self.MODEL,
+        )
+        assert level is None
+        assert source == "model_default"
+        assert base is None
+
+    def test_explicit_disabled_no_escalation(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="implementer", agent_effort="high",
+            auto_mode="disabled", auto_cap="xhigh",
+            trigger="test_failure", iter_num=3, bead=None, model=self.MODEL,
+        )
+        assert level == "high"
+        assert source == "disabled"
+
+    def test_reactive_explicit_escalates(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="implementer", agent_effort="high",
+            auto_mode="reactive", auto_cap="max",
+            trigger="test_failure", iter_num=2, bead=None, model=self.MODEL,
+        )
+        assert level == "xhigh"
+        assert source == "reactive"
+        assert base == "high"
+
+    def test_reactive_omitted_starts_at_model_default(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="implementer", agent_effort=None,
+            auto_mode="reactive", auto_cap="xhigh",
+            trigger="initial", iter_num=1, bead=None, model=self.MODEL,
+        )
+        assert level is None
+        assert source == "reactive"
+        assert base is None
+
+    def test_adaptive_reads_bead_label(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="initial", iter_num=1, bead="bead-123", model=self.MODEL,
+            )
+        assert level == "high"
+        assert source == "adaptive:llm"
+        assert bc["applied"] is True
+        assert bc["skip_reason"] is None
+
+    def test_adaptive_explicit_overrides_bead(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="medium"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort="xhigh",
+                auto_mode="adaptive", auto_cap="max",
+                trigger="initial", iter_num=1, bead="bead-123", model=self.MODEL,
+            )
+        assert level == "xhigh"
+        assert source == "explicit"
+        assert bc["applied"] is False
+        assert bc["skip_reason"] == "explicit_override"
+
+    def test_reactive_records_bead_skip_reason(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="medium"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="reactive", auto_cap="xhigh",
+                trigger="initial", iter_num=1, bead="bead-123", model=self.MODEL,
+            )
+        assert bc["applied"] is False
+        assert bc["skip_reason"] == "mode_reactive"
+
+    def test_disabled_records_bead_skip_reason(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="medium"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="disabled", auto_cap="xhigh",
+                trigger="initial", iter_num=1, bead="bead-123", model=self.MODEL,
+            )
+        assert bc["applied"] is False
+        assert bc["skip_reason"] == "mode_disabled"
+
+    def test_non_implementer_skip_reason(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="reviewer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="initial", iter_num=1, bead="bead-123", model=self.MODEL,
+            )
+        assert bc["applied"] is False
+        assert bc["skip_reason"] == "non_classified_agent"
+
+    def test_review_changes_plus_two(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="medium"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="review_changes", iter_num=2, bead="bead-123", model=self.MODEL,
+            )
+        assert level == "xhigh"
+        assert base == "medium"
+
+    def test_planner_stacks_on_plan_review_revise(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="planner", agent_effort="medium",
+            auto_mode="adaptive", auto_cap="max",
+            trigger="plan_review_revise", iter_num=4, bead=None, model=self.MODEL,
+        )
+        assert level == "max"
+        assert base == "medium"
+
+    def test_planner_escalates_on_restart_planning(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="planner", agent_effort="high",
+            auto_mode="adaptive", auto_cap="max",
+            trigger="restart_planning", iter_num=2, bead=None, model=self.MODEL,
+        )
+        assert level == "xhigh"
+
+    def test_auto_cap_clamps(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="implementer", agent_effort="high",
+            auto_mode="reactive", auto_cap="xhigh",
+            trigger="review_changes", iter_num=2, bead=None, model=self.MODEL,
+        )
+        assert level == "xhigh"
+
+    def test_no_bead_no_bead_classified(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="planner", agent_effort="high",
+            auto_mode="adaptive", auto_cap="max",
+            trigger="initial", iter_num=1, bead=None, model=self.MODEL,
+        )
+        assert bc is None
+
+    def test_bead_no_label_falls_back_to_model_default(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value=None):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="initial", iter_num=1, bead="bead-no-label", model=self.MODEL,
+            )
+        assert level is None
+        assert source == "model_default"
+        assert bc["level"] is None
+        assert bc["applied"] is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_effort() — model-aware (4-rung ladders)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEffortModelAware:
+    def test_base_collapses_on_model_without_rung(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="planner", agent_effort="xhigh",
+            auto_mode="disabled", auto_cap="xhigh",
+            trigger="initial", iter_num=1, bead=None, model="claude-opus-4-6",
+        )
+        assert level == "high"
+        assert requested == "xhigh"
+
+    def test_escalation_on_short_ladder_jumps_to_max(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="test_failure", iter_num=2, bead="bead-1", model="claude-sonnet-4-6",
+            )
+        assert level == "max"
+
+    def test_cap_rounds_up_on_short_ladder(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="xhigh",
+                trigger="test_failure", iter_num=2, bead="bead-1", model="claude-sonnet-4-6",
+            )
+        assert level == "max"
+
+    def test_cap_pinned_high_freezes_escalation(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="high",
+                trigger="test_failure", iter_num=2, bead="bead-1", model="claude-sonnet-4-6",
+            )
+        assert level == "high"
+
+    def test_unsupported_model_omits_env(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="implementer", agent_effort="high",
+            auto_mode="adaptive", auto_cap="max",
+            trigger="initial", iter_num=1, bead=None, model="claude-sonnet-4-5-20251014",
+        )
+        assert level is None
+
+    def test_unknown_model_uses_canonical_with_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="planner", agent_effort="xhigh",
+                auto_mode="disabled", auto_cap="max",
+                trigger="initial", iter_num=1, bead=None, model="totally-unknown-model",
+            )
+        assert level == "xhigh"
+        assert any("unmapped" in r.message.lower() or "unknown" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# resolve_effort() — escalation stacking
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEffortEscalation:
+    MODEL = "claude-opus-4-7-20250506"
+
+    def test_test_failure_then_review_changes_stacks(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="low"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="review_changes", iter_num=3, bead="bead-1", model=self.MODEL,
+            )
+        assert level == "max"
+        assert base == "low"
+
+    def test_planner_three_plan_review_revise_bounces(self):
+        level, requested, source, base, bc, _ = resolve_effort(
+            agent="planner", agent_effort="medium",
+            auto_mode="adaptive", auto_cap="max",
+            trigger="plan_review_revise", iter_num=4, bead=None, model=self.MODEL,
+        )
+        assert level == "max"
+
+    def test_implementer_multiple_test_failures(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="low"):
+            level, requested, source, base, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="test_failure", iter_num=4, bead="bead-1", model=self.MODEL,
+            )
+        assert level == "xhigh"
+
+
+# ---------------------------------------------------------------------------
+# resolve_effort() — bead_classified detail
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEffortBeadClassified:
+    MODEL = "claude-opus-4-7-20250506"
+
+    def test_adaptive_applied_has_no_skip_reason(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            _, _, _, _, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="initial", iter_num=1, bead="b-1", model=self.MODEL,
+            )
+        assert bc["applied"] is True
+        assert bc["skip_reason"] is None
+        assert bc["level"] == "high"
+
+    def test_explicit_override_populates_skip_reason(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="low"):
+            _, _, _, _, bc, _ = resolve_effort(
+                agent="implementer", agent_effort="max",
+                auto_mode="adaptive", auto_cap="max",
+                trigger="initial", iter_num=1, bead="b-1", model=self.MODEL,
+            )
+        assert bc["level"] == "low"
+        assert bc["applied"] is False
+        assert bc["skip_reason"] == "explicit_override"
+
+    def test_mode_disabled_skip_reason(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            _, _, _, _, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="disabled", auto_cap="max",
+                trigger="initial", iter_num=1, bead="b-1", model=self.MODEL,
+            )
+        assert bc["skip_reason"] == "mode_disabled"
+
+    def test_mode_reactive_skip_reason(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            _, _, _, _, bc, _ = resolve_effort(
+                agent="implementer", agent_effort=None,
+                auto_mode="reactive", auto_cap="max",
+                trigger="initial", iter_num=1, bead="b-1", model=self.MODEL,
+            )
+        assert bc["skip_reason"] == "mode_reactive"
+
+    def test_non_classified_agent_skip_reason(self):
+        with patch("worca.orchestrator.effort.bd_get_effort_label", return_value="high"):
+            _, _, _, _, bc, _ = resolve_effort(
+                agent="tester", agent_effort=None,
+                auto_mode="adaptive", auto_cap="max",
+                trigger="initial", iter_num=1, bead="b-1", model=self.MODEL,
+            )
+        assert bc["skip_reason"] == "non_classified_agent"
+
+    def test_bead_none_gives_bead_classified_none(self):
+        _, _, _, _, bc, _ = resolve_effort(
+            agent="planner", agent_effort="high",
+            auto_mode="adaptive", auto_cap="max",
+            trigger="initial", iter_num=1, bead=None, model=self.MODEL,
+        )
+        assert bc is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_effort() — capped_from return value
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEffortCappedFrom:
+    MODEL = "claude-opus-4-7-20250506"
+
+    def test_no_cap_returns_none(self):
+        _, _, _, _, _, capped = resolve_effort(
+            agent="implementer", agent_effort="high",
+            auto_mode="reactive", auto_cap="max",
+            trigger="initial", iter_num=1, bead=None, model=self.MODEL,
+        )
+        assert capped is None
+
+    def test_cap_fires_returns_original(self):
+        _, _, _, _, _, capped = resolve_effort(
+            agent="implementer", agent_effort="high",
+            auto_mode="reactive", auto_cap="high",
+            trigger="test_failure", iter_num=2, bead=None, model=self.MODEL,
+        )
+        assert capped == "xhigh"
+
+    def test_cap_not_fired_when_level_below(self):
+        _, _, _, _, _, capped = resolve_effort(
+            agent="implementer", agent_effort="low",
+            auto_mode="reactive", auto_cap="xhigh",
+            trigger="initial", iter_num=1, bead=None, model=self.MODEL,
+        )
+        assert capped is None
+
+    def test_disabled_mode_no_cap(self):
+        _, _, _, _, _, capped = resolve_effort(
+            agent="implementer", agent_effort="high",
+            auto_mode="disabled", auto_cap="high",
+            trigger="test_failure", iter_num=3, bead=None, model=self.MODEL,
+        )
+        assert capped is None

--- a/tests/test_event_types.py
+++ b/tests/test_event_types.py
@@ -350,6 +350,34 @@ def test_stage_started_payload_required_fields():
     assert p["max_turns"] == 50
 
 
+def test_stage_started_payload_with_effort():
+    from worca.events.types import stage_started_payload
+    effort = {
+        "level": "high",
+        "source": "adaptive",
+        "base": "medium",
+        "escalations": 1,
+        "bead_classified": "medium",
+    }
+    p = stage_started_payload(
+        stage="IMPLEMENT", iteration=2,
+        agent="implementer", model="claude-sonnet-4-6",
+        trigger="test_failure", max_turns=50,
+        effort=effort,
+    )
+    assert p["effort"] == effort
+
+
+def test_stage_started_payload_effort_omitted_when_none():
+    from worca.events.types import stage_started_payload
+    p = stage_started_payload(
+        stage="PLAN", iteration=1,
+        agent="planner", model="claude-opus-4-6",
+        trigger="initial", max_turns=30,
+    )
+    assert "effort" not in p
+
+
 def test_stage_completed_payload_required_fields():
     from worca.events.types import stage_completed_payload
     p = stage_completed_payload(

--- a/tests/test_runner_effort.py
+++ b/tests/test_runner_effort.py
@@ -1,0 +1,925 @@
+"""Tests for effort resolution wiring in the pipeline runner."""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+from worca.orchestrator.runner import run_stage, run_pipeline
+from worca.orchestrator.stages import Stage
+from worca.orchestrator.work_request import WorkRequest
+
+# Pipeline tests trigger run_pipeline which takes non-trivial wall time;
+# a background worca-ui server writing to ~/.worca/worca-ui-global.log
+# during that window is falsely attributed to the test by the leak detector.
+pytestmark = pytest.mark.allow_worca_writes
+
+
+@pytest.fixture(autouse=True)
+def _mock_beads_init():
+    with patch("worca.orchestrator.runner._ensure_beads_initialized"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_signal_event_flag():
+    import worca.orchestrator.runner as runner_mod
+    runner_mod._signal_event_emitted = False
+    runner_mod._pending_signal_event = None
+    yield
+    runner_mod._signal_event_emitted = False
+    runner_mod._pending_signal_event = None
+
+
+# ---------------------------------------------------------------------------
+# run_stage: env_overrides parameter
+# ---------------------------------------------------------------------------
+
+
+class TestRunStageEnvOverrides:
+    _BASE_CONFIG = {
+        "agent": "planner",
+        "model": "claude-opus-4-6",
+        "model_env": {"SOME_VAR": "original"},
+        "max_turns": 40,
+        "effort": None,
+        "schema": "plan.json",
+    }
+
+    def test_env_overrides_merged_into_model_env(self):
+        with patch("worca.orchestrator.runner.get_stage_config", return_value=dict(self._BASE_CONFIG)):
+            with patch("worca.orchestrator.runner.run_agent", return_value={"ok": True}) as mock_run:
+                run_stage(
+                    Stage.PLAN, {"prompt": "test"},
+                    env_overrides={"CLAUDE_CODE_EFFORT_LEVEL": "high"},
+                )
+        kw = mock_run.call_args.kwargs
+        assert kw["model_env"]["CLAUDE_CODE_EFFORT_LEVEL"] == "high"
+        assert kw["model_env"]["SOME_VAR"] == "original"
+
+    def test_env_overrides_none_passes_original_model_env(self):
+        with patch("worca.orchestrator.runner.get_stage_config", return_value=dict(self._BASE_CONFIG)):
+            with patch("worca.orchestrator.runner.run_agent", return_value={"ok": True}) as mock_run:
+                run_stage(Stage.PLAN, {"prompt": "test"})
+        kw = mock_run.call_args.kwargs
+        assert kw["model_env"] == {"SOME_VAR": "original"}
+
+    def test_env_overrides_empty_dict_passes_original(self):
+        with patch("worca.orchestrator.runner.get_stage_config", return_value=dict(self._BASE_CONFIG)):
+            with patch("worca.orchestrator.runner.run_agent", return_value={"ok": True}) as mock_run:
+                run_stage(Stage.PLAN, {"prompt": "test"}, env_overrides={})
+        kw = mock_run.call_args.kwargs
+        assert kw["model_env"] == {"SOME_VAR": "original"}
+
+    def test_env_overrides_none_effort_omitted_from_env(self):
+        """When resolve_effort returns None level, CLAUDE_CODE_EFFORT_LEVEL should not be set."""
+        with patch("worca.orchestrator.runner.get_stage_config", return_value=dict(self._BASE_CONFIG)):
+            with patch("worca.orchestrator.runner.run_agent", return_value={"ok": True}) as mock_run:
+                run_stage(Stage.PLAN, {"prompt": "test"}, env_overrides={})
+        kw = mock_run.call_args.kwargs
+        assert "CLAUDE_CODE_EFFORT_LEVEL" not in kw["model_env"]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: effort settings read at start
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineEffortSettingsLog:
+    """Verify worca.effort is read at pipeline start and logged."""
+
+    def _make_settings(self, tmp_path, effort=None):
+        settings = {"worca": {"stages": {}, "agents": {}, "models": {}}}
+        if effort is not None:
+            settings["worca"]["effort"] = effort
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump(settings, f)
+        return path
+
+    def _make_wr(self):
+        return WorkRequest(source_type="prompt", title="test", description="test desc")
+
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_logs_effort_settings_at_start(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create, mock_stage, tmp_path
+    ):
+        settings_path = self._make_settings(tmp_path, effort={
+            "auto_mode": "reactive",
+            "auto_cap": "high",
+        })
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        mock_stage.side_effect = Exception("stop early")
+
+        with pytest.raises(Exception, match="stop early"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        effort_log = [m for m in log_messages if "effort" in m.lower() and ("reactive" in m.lower() or "auto_mode" in m.lower())]
+        assert effort_log, f"Expected effort settings log line, got: {log_messages}"
+
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_logs_default_effort_when_not_configured(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create, mock_stage, tmp_path
+    ):
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        mock_stage.side_effect = Exception("stop early")
+
+        with pytest.raises(Exception, match="stop early"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        effort_log = [m for m in log_messages if "effort" in m.lower() and "adaptive" in m.lower()]
+        assert effort_log, f"Expected default effort log (adaptive), got: {log_messages}"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: resolve_effort called at stage invocation
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineResolveEffortCall:
+    """Verify resolve_effort() is invoked at stage invocation with correct args."""
+
+    def _make_settings(self, tmp_path, effort=None, agents=None):
+        settings = {
+            "worca": {
+                "stages": {},
+                "agents": agents or {},
+                "models": {},
+            },
+        }
+        if effort is not None:
+            settings["worca"]["effort"] = effort
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump(settings, f)
+        return path
+
+    def _make_wr(self):
+        return WorkRequest(source_type="prompt", title="test", description="test desc")
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    def test_resolve_effort_called_for_non_preflight_stage(
+        self, mock_bead, mock_head, mock_branch, mock_create, mock_stage,
+        mock_resolve, tmp_path,
+    ):
+        mock_resolve.return_value = ("high", "high", "explicit", "high", None, None)
+
+        settings_path = self._make_settings(tmp_path, effort={
+            "auto_mode": "reactive",
+            "auto_cap": "xhigh",
+        })
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        # Plan stage is the first non-preflight stage
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "test", "tasks_outline": []}, {})
+            raise Exception("stop after plan")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop after plan"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        assert mock_resolve.called, "resolve_effort should have been called"
+        kw = mock_resolve.call_args.kwargs
+        assert kw["auto_mode"] == "reactive"
+        assert kw["auto_cap"] == "xhigh"
+        assert kw["trigger"] == "initial"
+        assert kw["iter_num"] == 1
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    def test_resolve_effort_not_called_for_preflight(
+        self, mock_bead, mock_head, mock_branch, mock_create, mock_stage,
+        mock_resolve, tmp_path,
+    ):
+        """Preflight runs its own code path — resolve_effort should not be called for it."""
+        mock_resolve.return_value = ("high", "high", "explicit", "high", None, None)
+
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        # Make preflight pass then stop at PLAN
+        def stage_side_effect(*args, **kwargs):
+            raise Exception("stop at plan")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with patch("worca.orchestrator.runner.run_preflight", return_value={"status": "ok", "checks": []}):
+            with pytest.raises(Exception, match="stop at plan"):
+                run_pipeline(
+                    self._make_wr(),
+                    settings_path=settings_path,
+                    status_path=status_path,
+                )
+
+        # resolve_effort should be called for PLAN (the stage_side_effect raises before
+        # run_stage completes, but resolve_effort happens before run_stage)
+        # The key point is: PREFLIGHT itself does NOT call resolve_effort.
+        # Any calls are for stages after PREFLIGHT.
+        if mock_resolve.called:
+            for c in mock_resolve.call_args_list:
+                assert c.kwargs.get("agent") != "preflight"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: effort level passed as CLAUDE_CODE_EFFORT_LEVEL env var
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineEffortEnvVar:
+    """Verify resolved effort is passed to run_stage as CLAUDE_CODE_EFFORT_LEVEL."""
+
+    def _make_settings(self, tmp_path, effort=None):
+        settings = {"worca": {"stages": {}, "agents": {}, "models": {}}}
+        if effort is not None:
+            settings["worca"]["effort"] = effort
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump(settings, f)
+        return path
+
+    def _make_wr(self):
+        return WorkRequest(source_type="prompt", title="test", description="test desc")
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    def test_effort_level_in_env_overrides(
+        self, mock_bead, mock_head, mock_branch, mock_create, mock_stage,
+        mock_resolve, tmp_path,
+    ):
+        mock_resolve.return_value = ("high", "high", "explicit", "high", None, None)
+
+        settings_path = self._make_settings(tmp_path, effort={
+            "auto_mode": "reactive",
+            "auto_cap": "xhigh",
+        })
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        # First call to run_stage should have env_overrides with effort level
+        first_call = mock_stage.call_args_list[0]
+        env_overrides = first_call.kwargs.get("env_overrides", {})
+        assert env_overrides.get("CLAUDE_CODE_EFFORT_LEVEL") == "high"
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    def test_none_effort_level_omits_env_var(
+        self, mock_bead, mock_head, mock_branch, mock_create, mock_stage,
+        mock_resolve, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        first_call = mock_stage.call_args_list[0]
+        env_overrides = first_call.kwargs.get("env_overrides", {})
+        assert "CLAUDE_CODE_EFFORT_LEVEL" not in env_overrides
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: effort dict persisted in start_iteration
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineEffortPersistence:
+    """Verify effort dict is passed to start_iteration for status.json persistence."""
+
+    def _make_settings(self, tmp_path, effort=None):
+        settings = {"worca": {"stages": {}, "agents": {}, "models": {}}}
+        if effort is not None:
+            settings["worca"]["effort"] = effort
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump(settings, f)
+        return path
+
+    def _make_wr(self):
+        return WorkRequest(source_type="prompt", title="test", description="test desc")
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.start_iteration", wraps=__import__("worca.state.status", fromlist=["start_iteration"]).start_iteration)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    def test_effort_dict_passed_to_start_iteration(
+        self, mock_bead, mock_head, mock_branch, mock_create, mock_stage,
+        mock_start_iter, mock_resolve, tmp_path,
+    ):
+        mock_resolve.return_value = ("high", "high", "explicit", "high", None, None)
+
+        settings_path = self._make_settings(tmp_path, effort={
+            "auto_mode": "adaptive",
+            "auto_cap": "xhigh",
+        })
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        # Find the start_iteration call for the plan stage (first non-preflight)
+        plan_calls = [
+            c for c in mock_start_iter.call_args_list
+            if len(c.args) >= 2 and c.args[1] == "plan"
+        ]
+        assert plan_calls, "start_iteration should have been called for plan stage"
+        kw = plan_calls[0].kwargs
+        assert "effort" in kw, f"effort kwarg missing from start_iteration call: {kw}"
+        effort = kw["effort"]
+        assert effort["level"] == "high"
+        assert effort["source"] == "explicit"
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.start_iteration", wraps=__import__("worca.state.status", fromlist=["start_iteration"]).start_iteration)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    def test_none_effort_still_persists_structure(
+        self, mock_bead, mock_head, mock_branch, mock_create, mock_stage,
+        mock_start_iter, mock_resolve, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        plan_calls = [
+            c for c in mock_start_iter.call_args_list
+            if len(c.args) >= 2 and c.args[1] == "plan"
+        ]
+        assert plan_calls
+        kw = plan_calls[0].kwargs
+        assert "effort" in kw
+        effort = kw["effort"]
+        assert effort["level"] is None
+        assert effort["source"] == "model_default"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: implementer receives bead ID in resolve_effort
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineEffortBeadArg:
+    """Verify assigned bead is passed for implementer, None for others."""
+
+    def _make_settings(self, tmp_path):
+        settings = {"worca": {"stages": {}, "agents": {}, "models": {}}}
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump(settings, f)
+        return path
+
+    def _make_wr(self):
+        return WorkRequest(source_type="prompt", title="test", description="test desc")
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    def test_non_implementer_passes_none_bead(
+        self, mock_bead, mock_head, mock_branch, mock_create, mock_stage,
+        mock_resolve, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        # Plan stage — should pass bead=None
+        plan_calls = [
+            c for c in mock_resolve.call_args_list
+            if c.kwargs.get("agent") == "planner"
+        ]
+        assert plan_calls
+        assert plan_calls[0].kwargs["bead"] is None
+
+
+# ---------------------------------------------------------------------------
+# format_effort_log_line
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEffortLogLine:
+    """Unit tests for the terse key=value effort log formatter."""
+
+    def test_import(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        assert callable(format_effort_log_line)
+
+    def test_model_default_shows_dash(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": None, "requested": None, "source": "model_default",
+            "base": None, "capped_from": None, "bead_classified": None,
+        }
+        line = format_effort_log_line("IMPLEMENT", 1, effort, trigger="initial")
+        assert "effort=- source=model_default" in line
+        assert "IMPLEMENT iter 1:" in line
+
+    def test_adaptive_bead_label_used(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "high", "requested": "high", "source": "adaptive:llm",
+            "base": "high", "capped_from": None,
+            "bead_classified": {"level": "high", "applied": True, "skip_reason": None},
+        }
+        line = format_effort_log_line("IMPLEMENT", 1, effort, trigger="initial")
+        assert "effort=high source=adaptive bead=high" in line
+        assert "model-collapsed" not in line
+        assert "req=" not in line
+
+    def test_explicit_override_model_collapsed(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "high", "requested": "xhigh", "source": "explicit",
+            "base": "xhigh", "capped_from": None,
+            "bead_classified": {"level": "medium", "applied": False, "skip_reason": "explicit_override"},
+        }
+        line = format_effort_log_line("IMPLEMENT", 1, effort, trigger="initial")
+        assert "effort=high" in line
+        assert "req=xhigh" in line
+        assert "source=explicit" in line
+        assert "bead=medium(overridden)" in line
+        assert "model-collapsed" in line
+
+    def test_reactive_bead_ignored(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "high", "requested": "high", "source": "reactive",
+            "base": "high", "capped_from": None,
+            "bead_classified": {"level": "medium", "applied": False, "skip_reason": "mode_reactive"},
+        }
+        line = format_effort_log_line("IMPLEMENT", 1, effort, trigger="initial")
+        assert "source=reactive" in line
+        assert "bead=medium(ignored)" in line
+
+    def test_disabled_bead_ignored(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "high", "requested": "high", "source": "disabled",
+            "base": "high", "capped_from": None,
+            "bead_classified": {"level": "medium", "applied": False, "skip_reason": "mode_disabled"},
+        }
+        line = format_effort_log_line("IMPLEMENT", 1, effort, trigger="initial")
+        assert "source=disabled" in line
+        assert "bead=medium(ignored)" in line
+
+    def test_escalation_trigger(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "max", "requested": "max", "source": "adaptive:llm",
+            "base": "high", "capped_from": None,
+            "bead_classified": {"level": "high", "applied": True, "skip_reason": None},
+        }
+        line = format_effort_log_line("IMPLEMENT", 2, effort, trigger="test_failure")
+        assert "effort=max source=adaptive bead=high" in line
+        assert "+test_failure" in line
+
+    def test_cap_fired(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "high", "requested": "high", "source": "adaptive:llm",
+            "base": "high", "capped_from": "max",
+            "bead_classified": {"level": "high", "applied": True, "skip_reason": None},
+        }
+        line = format_effort_log_line("IMPLEMENT", 3, effort, trigger="test_failure")
+        assert "capped_from=max" in line
+
+    def test_non_bead_stage_no_bead_field(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "high", "requested": "xhigh", "source": "explicit",
+            "base": "xhigh", "capped_from": None, "bead_classified": None,
+        }
+        line = format_effort_log_line("PLAN", 1, effort, trigger="initial")
+        assert "effort=high" in line
+        assert "req=xhigh" in line
+        assert "model-collapsed" in line
+        assert "bead=" not in line
+
+    def test_none_effort_dict_returns_none(self):
+        from worca.orchestrator.runner import format_effort_log_line
+        result = format_effort_log_line("PLAN", 1, None, trigger="initial")
+        assert result is None
+
+    def test_no_escalation_on_initial_iter2(self):
+        """iter_num > 1 but trigger is 'initial' — no +trigger suffix."""
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "high", "requested": "high", "source": "explicit",
+            "base": "high", "capped_from": None, "bead_classified": None,
+        }
+        line = format_effort_log_line("PLAN", 2, effort, trigger="initial")
+        assert "+initial" not in line
+
+    def test_escalation_trigger_next_bead_no_suffix(self):
+        """next_bead is not an escalation trigger — no +next_bead suffix."""
+        from worca.orchestrator.runner import format_effort_log_line
+        effort = {
+            "level": "high", "requested": "high", "source": "adaptive:llm",
+            "base": "high", "capped_from": None,
+            "bead_classified": {"level": "high", "applied": True, "skip_reason": None},
+        }
+        line = format_effort_log_line("IMPLEMENT", 2, effort, trigger="next_bead")
+        assert "+next_bead" not in line
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: effort log line emitted at stage start
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineEffortLogLine:
+    """Verify the effort log line is emitted at stage start."""
+
+    def _make_settings(self, tmp_path, effort=None):
+        settings = {"worca": {"stages": {}, "agents": {}, "models": {}}}
+        if effort is not None:
+            settings["worca"]["effort"] = effort
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump(settings, f)
+        return path
+
+    def _make_wr(self):
+        return WorkRequest(source_type="prompt", title="test", description="test desc")
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_effort_log_line_emitted(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_resolve, tmp_path,
+    ):
+        mock_resolve.return_value = ("high", "high", "explicit", "high", None, None)
+
+        settings_path = self._make_settings(tmp_path, effort={
+            "auto_mode": "reactive",
+            "auto_cap": "xhigh",
+        })
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        effort_lines = [m for m in log_messages if "effort=" in m and "source=" in m]
+        assert effort_lines, f"Expected effort log line, got: {log_messages}"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline: post-COORDINATE unlabeled bead warning
+# ---------------------------------------------------------------------------
+
+
+class TestPostCoordinateUnlabeledBeadWarning:
+    """Verify warning is logged when beads lack worca-effort:* labels after COORDINATE."""
+
+    def _make_settings(self, tmp_path):
+        settings = {"worca": {"stages": {}, "agents": {}, "models": {}}}
+        path = str(tmp_path / "settings.json")
+        with open(path, "w") as f:
+            json.dump(settings, f)
+        return path
+
+    def _make_wr(self):
+        return WorkRequest(source_type="prompt", title="test", description="test desc")
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_warns_on_unlabeled_beads(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None  # no effort label
+
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # PLAN
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            elif call_count[0] == 2:
+                # COORDINATE
+                return ({"beads_ids": ["bead-1", "bead-2"], "dependency_graph": {}}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        warn_lines = [m for m in log_messages if "unlabeled" in m.lower() or "missing" in m.lower() and "effort" in m.lower()]
+        assert warn_lines, f"Expected unlabeled-bead warning, got: {log_messages}"
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_no_warning_when_all_beads_labeled(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = "high"  # all beads have labels
+
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            elif call_count[0] == 2:
+                return ({"beads_ids": ["bead-1", "bead-2"], "dependency_graph": {}}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        warn_lines = [m for m in log_messages if "unlabeled" in m.lower()]
+        assert not warn_lines, f"No warning expected when all beads labeled, got: {warn_lines}"
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_warning_lists_unlabeled_bead_ids(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.side_effect = lambda bid: "high" if bid == "bead-1" else None
+
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            elif call_count[0] == 2:
+                return ({"beads_ids": ["bead-1", "bead-2"], "dependency_graph": {}}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        warn_lines = [m for m in log_messages if "bead-2" in m and ("unlabeled" in m.lower() or "missing" in m.lower())]
+        assert warn_lines, f"Expected warning mentioning bead-2, got: {log_messages}"
+
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_no_warning_when_no_beads(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+
+        settings_path = self._make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "ok", "tasks_outline": []}, {})
+            elif call_count[0] == 2:
+                return ({"beads_ids": [], "dependency_graph": {}}, {})
+            raise Exception("stop")
+
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        warn_lines = [m for m in log_messages if "unlabeled" in m.lower()]
+        assert not warn_lines, "No warning expected with empty beads list"

--- a/tests/test_runner_effort.py
+++ b/tests/test_runner_effort.py
@@ -229,6 +229,57 @@ class TestPipelineResolveEffortCall:
         assert kw["iter_num"] == 1
 
     @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.escalation_iter_num")
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    def test_iter_num_routed_through_escalation_depth(
+        self, mock_bead, mock_head, mock_branch, mock_create, mock_stage,
+        mock_iter_num, mock_resolve, tmp_path,
+    ):
+        """resolve_effort's iter_num must come from escalation_iter_num()
+        (escalation depth), NOT len(prev_iterations) + 1. This is the W-052
+        multi-bead over-escalation regression guard: per-bead Phase-1 fan-out
+        must not inflate the escalation multiplier."""
+        mock_iter_num.return_value = 99  # sentinel distinct from any real count
+        mock_resolve.return_value = ("high", "high", "explicit", "high", None, None)
+
+        settings_path = self._make_settings(tmp_path, effort={
+            "auto_mode": "reactive",
+            "auto_cap": "xhigh",
+        })
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        call_count = [0]
+        def stage_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ({"approach": "test", "tasks_outline": []}, {})
+            raise Exception("stop after plan")
+        mock_stage.side_effect = stage_side_effect
+
+        with pytest.raises(Exception, match="stop after plan"):
+            run_pipeline(
+                self._make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        assert mock_iter_num.called, "runner should compute iter_num via escalation_iter_num()"
+        # First non-preflight stage is PLAN: planner agent, initial trigger,
+        # no prior iterations.
+        assert mock_iter_num.call_args_list[0].args == ("planner", "initial", [])
+        # resolve_effort must receive the helper's return value verbatim
+        # (every stage, not the raw len(prev_iterations) + 1).
+        assert all(
+            c.kwargs["iter_num"] == 99 for c in mock_resolve.call_args_list
+        )
+
+    @patch("worca.orchestrator.runner.resolve_effort")
     @patch("worca.orchestrator.runner.run_stage")
     @patch("worca.orchestrator.runner.create_branch")
     @patch("worca.orchestrator.runner.current_branch", return_value="main")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -471,3 +471,155 @@ class TestWorkspaceSettings:
         assert result["worca"]["workspace"]["max_parallel"] == 3
         assert result["worca"]["fleet"]["max_parallel"] == 5
         assert result["worca"]["fleet"]["failure_threshold"] == 0.30
+
+
+# ---------------------------------------------------------------------------
+# TestEffortSettings (W-052 Phase 1)
+# ---------------------------------------------------------------------------
+
+
+class TestEffortSettings:
+    """Tests for the worca.effort settings block and per-agent effort defaults."""
+
+    def test_real_settings_has_effort_section(self):
+        """src/worca/settings.json contains the worca.effort block."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert "effort" in result.get("worca", {}), \
+            "worca.effort section missing from src/worca/settings.json"
+
+    def test_effort_auto_mode_default(self):
+        """Default auto_mode is 'adaptive'."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert result["worca"]["effort"]["auto_mode"] == "adaptive"
+
+    def test_effort_auto_cap_default(self):
+        """Default auto_cap is 'xhigh'."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert result["worca"]["effort"]["auto_cap"] == "xhigh"
+
+    def test_effort_block_has_exactly_two_keys(self):
+        """The effort block contains only auto_mode and auto_cap."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert set(result["worca"]["effort"].keys()) == {"auto_mode", "auto_cap"}
+
+    def test_planner_effort_xhigh(self):
+        """Planner has effort 'xhigh' (heavy reasoning)."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert result["worca"]["agents"]["planner"]["effort"] == "xhigh"
+
+    def test_coordinator_effort_medium(self):
+        """Coordinator has effort 'medium' (mechanical decomposition)."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert result["worca"]["agents"]["coordinator"]["effort"] == "medium"
+
+    def test_guardian_effort_high(self):
+        """Guardian has effort 'high' (high vigilance)."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert result["worca"]["agents"]["guardian"]["effort"] == "high"
+
+    def test_implementer_effort_unset(self):
+        """Implementer has no effort field (adaptive path drives base)."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert "effort" not in result["worca"]["agents"]["implementer"]
+
+    def test_tester_effort_unset(self):
+        """Tester has no effort field (model default)."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert "effort" not in result["worca"]["agents"]["tester"]
+
+    def test_reviewer_effort_unset(self):
+        """Reviewer has no effort field (model default)."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert "effort" not in result["worca"]["agents"]["reviewer"]
+
+    def test_local_override_auto_mode(self, tmp_path):
+        """Local override can change auto_mode."""
+        base = {
+            "worca": {
+                "effort": {"auto_mode": "adaptive", "auto_cap": "xhigh"}
+            }
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(base))
+        local_file = tmp_path / "settings.local.json"
+        local_file.write_text(json.dumps({
+            "worca": {"effort": {"auto_mode": "disabled"}}
+        }))
+
+        result = load_settings(str(settings_file))
+        assert result["worca"]["effort"]["auto_mode"] == "disabled"
+        assert result["worca"]["effort"]["auto_cap"] == "xhigh"
+
+    def test_local_override_agent_effort(self, tmp_path):
+        """Local override can add effort to an agent that lacks it."""
+        base = {
+            "worca": {
+                "agents": {
+                    "implementer": {"model": "sonnet", "max_turns": 300}
+                }
+            }
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(base))
+        local_file = tmp_path / "settings.local.json"
+        local_file.write_text(json.dumps({
+            "worca": {"agents": {"implementer": {"effort": "high"}}}
+        }))
+
+        result = load_settings(str(settings_file))
+        impl = result["worca"]["agents"]["implementer"]
+        assert impl["effort"] == "high"
+        assert impl["model"] == "sonnet"
+        assert impl["max_turns"] == 300
+
+    def test_effort_merge_preserves_siblings(self, tmp_path):
+        """Overriding effort keys does not affect sibling worca sections."""
+        base = {
+            "worca": {
+                "effort": {"auto_mode": "adaptive", "auto_cap": "xhigh"},
+                "fleet": {"max_parallel": 5, "failure_threshold": 0.30},
+            }
+        }
+        local = {
+            "worca": {"effort": {"auto_cap": "high"}}
+        }
+
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(base))
+        local_file = tmp_path / "settings.local.json"
+        local_file.write_text(json.dumps(local))
+
+        result = load_settings(str(settings_file))
+        assert result["worca"]["effort"]["auto_cap"] == "high"
+        assert result["worca"]["effort"]["auto_mode"] == "adaptive"
+        assert result["worca"]["fleet"]["max_parallel"] == 5

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -199,6 +199,7 @@ class TestGetStageConfig:
         assert config["model"] == "claude-sonnet-4-6"  # default "sonnet" resolved
         assert config["max_turns"] == 30
         assert config["schema"] == "plan.json"
+        assert config["effort"] is None
 
     def test_reads_agent_config_from_settings(self, tmp_path):
         settings = {
@@ -230,6 +231,7 @@ class TestGetStageConfig:
         assert config["model"] == "claude-sonnet-4-6"  # default "sonnet" resolved
         assert config["max_turns"] == 30
         assert config["schema"] == "implement.json"
+        assert config["effort"] is None
 
     def test_schema_matches_stage_map(self, tmp_path):
         from worca.orchestrator.stages import STAGE_SCHEMA_MAP
@@ -265,6 +267,73 @@ class TestGetStageConfig:
         assert config["model"] is None
         assert config["max_turns"] is None
         assert config["schema"] is None
+        assert config["effort"] is None
+
+
+class TestGetStageConfigEffort:
+    """Tests for effort field in get_stage_config return value."""
+
+    def test_effort_none_when_not_set(self, tmp_path):
+        settings = {
+            "worca": {
+                "agents": {
+                    "planner": {"model": "opus", "max_turns": 10}
+                }
+            }
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+        config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
+        assert config["effort"] is None
+
+    def test_effort_returned_when_set(self, tmp_path):
+        settings = {
+            "worca": {
+                "agents": {
+                    "planner": {"model": "opus", "max_turns": 10, "effort": "xhigh"}
+                }
+            }
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+        config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
+        assert config["effort"] == "xhigh"
+
+    def test_effort_medium(self, tmp_path):
+        settings = {
+            "worca": {
+                "agents": {
+                    "coordinator": {"model": "opus", "effort": "medium"}
+                }
+            }
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+        config = get_stage_config(Stage.COORDINATE, settings_path=str(settings_file))
+        assert config["effort"] == "medium"
+
+    def test_effort_none_for_empty_settings(self, tmp_path):
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({}))
+        config = get_stage_config(Stage.REVIEW, settings_path=str(settings_file))
+        assert config["effort"] is None
+
+    def test_effort_preserved_with_stage_agent_override(self, tmp_path):
+        settings = {
+            "worca": {
+                "stages": {
+                    "plan": {"agent": "guardian"}
+                },
+                "agents": {
+                    "guardian": {"model": "opus", "effort": "high"}
+                }
+            }
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+        config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
+        assert config["agent"] == "guardian"
+        assert config["effort"] == "high"
 
 
 class TestGetStageConfigWithStages:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -285,6 +285,100 @@ def test_start_iteration_passes_kwargs():
     assert iteration["trigger"] == "human"
 
 
+def test_start_iteration_persists_effort_dict():
+    status = {"stages": {"implement": {}}}
+    effort = {
+        "level": "high",
+        "requested": "xhigh",
+        "source": "adaptive:llm",
+        "base": "high",
+        "escalations": [],
+        "capped_from": None,
+        "bead_classified": {
+            "level": "high",
+            "applied": True,
+            "skip_reason": None,
+        },
+    }
+    iteration = start_iteration(status, "implement", effort=effort)
+    assert iteration["effort"] == effort
+    assert iteration["effort"]["bead_classified"]["level"] == "high"
+    assert iteration["effort"]["bead_classified"]["applied"] is True
+
+
+def test_start_iteration_effort_roundtrips_through_json(tmp_path):
+    status = {"stages": {"implement": {}}}
+    effort = {
+        "level": "max",
+        "requested": "max",
+        "source": "reactive",
+        "base": "high",
+        "escalations": ["test_failure"],
+        "capped_from": None,
+        "bead_classified": {
+            "level": "medium",
+            "applied": False,
+            "skip_reason": "mode_reactive",
+        },
+    }
+    start_iteration(status, "implement", agent="implementer", model="claude-sonnet-4-6", trigger="test_failure", effort=effort)
+    path = str(tmp_path / "status.json")
+    save_status(status, path)
+    loaded = load_status(path)
+    roundtripped = loaded["stages"]["implement"]["iterations"][0]["effort"]
+    assert roundtripped == effort
+    assert roundtripped["escalations"] == ["test_failure"]
+    assert roundtripped["bead_classified"]["skip_reason"] == "mode_reactive"
+
+
+def test_start_iteration_effort_none_omits_key():
+    status = {"stages": {"plan": {}}}
+    iteration = start_iteration(status, "plan", agent="planner")
+    assert "effort" not in iteration
+
+
+def test_start_iteration_effort_explicit_none_omits_key():
+    status = {"stages": {"plan": {}}}
+    iteration = start_iteration(status, "plan", effort=None)
+    assert "effort" not in iteration
+
+
+def test_start_iteration_effort_with_capped_from():
+    status = {"stages": {"implement": {}}}
+    effort = {
+        "level": "high",
+        "requested": "xhigh",
+        "source": "adaptive:llm",
+        "base": "high",
+        "escalations": ["test_failure"],
+        "capped_from": "max",
+        "bead_classified": {
+            "level": "high",
+            "applied": True,
+            "skip_reason": None,
+        },
+    }
+    iteration = start_iteration(status, "implement", effort=effort)
+    assert iteration["effort"]["capped_from"] == "max"
+    assert iteration["effort"]["level"] == "high"
+
+
+def test_start_iteration_effort_non_bead_stage():
+    status = {"stages": {"plan": {}}}
+    effort = {
+        "level": "high",
+        "requested": "xhigh",
+        "source": "explicit",
+        "base": "xhigh",
+        "escalations": [],
+        "capped_from": None,
+        "bead_classified": None,
+    }
+    iteration = start_iteration(status, "plan", effort=effort)
+    assert iteration["effort"]["bead_classified"] is None
+    assert iteration["effort"]["source"] == "explicit"
+
+
 # --- complete_iteration ---
 
 def test_complete_iteration_sets_fields():

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -48,8 +48,16 @@ def test_blocks_implementer_dispatching_planner_under_narrow_default():
 def test_implementer_dispatching_planner_allowed_under_wildcard_default():
     """PR B: wildcard default allows the implementer to dispatch any
     non-denied subagent — including a project-defined `planner` subagent."""
-    code, _ = check_dispatch("implementer", "planner")
-    assert code == 0
+    cfg = {"worca": {"governance": {"dispatch": {"subagents": {
+        "always_disallowed": ["general-purpose"],
+        "default_denied": [],
+        "per_agent_allow": {"_defaults": ["*"]},
+    }}}}}
+    allowed, reason, _ = check_allowed(
+        "subagents", "implementer", "planner", settings_override=cfg,
+    )
+    assert allowed is True
+    assert reason == "ok"
 
 
 def test_allows_planner_dispatching_explore():

--- a/worca-ui/app/views/beads-panel-effort.test.js
+++ b/worca-ui/app/views/beads-panel-effort.test.js
@@ -1,0 +1,301 @@
+import { nothing } from 'lit-html';
+import { describe, expect, it } from 'vitest';
+import {
+  beadEffortBadgeView,
+  beadIterationMiniTable,
+  beadNotesView,
+  effortLevelVariant,
+  effortSourceLabel,
+  extractEffortLabel,
+} from './beads-panel.js';
+
+function renderToString(template) {
+  if (!template || template === nothing) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+describe('extractEffortLabel', () => {
+  it('extracts effort level from labels array', () => {
+    expect(extractEffortLabel(['area:cc', 'worca-effort:high', 'P2'])).toBe(
+      'high',
+    );
+  });
+
+  it('returns first effort label when multiple exist', () => {
+    expect(extractEffortLabel(['worca-effort:low', 'worca-effort:high'])).toBe(
+      'low',
+    );
+  });
+
+  it('returns null when no effort label', () => {
+    expect(extractEffortLabel(['area:cc', 'P2'])).toBeNull();
+  });
+
+  it('returns null for empty labels', () => {
+    expect(extractEffortLabel([])).toBeNull();
+  });
+
+  it('returns null for undefined labels', () => {
+    expect(extractEffortLabel(undefined)).toBeNull();
+  });
+});
+
+describe('effortLevelVariant — §7.1 color scale', () => {
+  it('maps low to neutral', () => {
+    expect(effortLevelVariant('low')).toBe('neutral');
+  });
+
+  it('maps medium to neutral', () => {
+    expect(effortLevelVariant('medium')).toBe('neutral');
+  });
+
+  it('maps high to primary', () => {
+    expect(effortLevelVariant('high')).toBe('primary');
+  });
+
+  it('maps xhigh to warning', () => {
+    expect(effortLevelVariant('xhigh')).toBe('warning');
+  });
+
+  it('maps max to danger', () => {
+    expect(effortLevelVariant('max')).toBe('danger');
+  });
+
+  it('defaults to neutral for unknown levels', () => {
+    expect(effortLevelVariant('unknown')).toBe('neutral');
+  });
+});
+
+describe('effortSourceLabel', () => {
+  it('maps adaptive:llm to adaptive', () => {
+    expect(effortSourceLabel('adaptive:llm')).toBe('adaptive');
+  });
+
+  it('maps model_default to model default', () => {
+    expect(effortSourceLabel('model_default')).toBe('model default');
+  });
+
+  it('passes through explicit', () => {
+    expect(effortSourceLabel('explicit')).toBe('explicit');
+  });
+
+  it('passes through reactive', () => {
+    expect(effortSourceLabel('reactive')).toBe('reactive');
+  });
+
+  it('returns empty string for falsy source', () => {
+    expect(effortSourceLabel(undefined)).toBe('');
+  });
+});
+
+describe('beadEffortBadgeView — effort label badge', () => {
+  it('renders badge with effort level from labels', () => {
+    const issue = { labels: ['worca-effort:high'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
+    expect(html).toContain('bead-effort-badge');
+    expect(html).toContain('high');
+  });
+
+  it('renders low with neutral variant', () => {
+    const issue = { labels: ['worca-effort:low'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
+    expect(html).toMatch(/variant="neutral"[^>]*>low/s);
+  });
+
+  it('renders high with primary variant', () => {
+    const issue = { labels: ['worca-effort:high'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
+    expect(html).toMatch(/variant="primary"[^>]*>high/s);
+  });
+
+  it('renders xhigh with warning variant', () => {
+    const issue = { labels: ['worca-effort:xhigh'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
+    expect(html).toMatch(/variant="warning"[^>]*>xhigh/s);
+  });
+
+  it('renders max with danger variant', () => {
+    const issue = { labels: ['worca-effort:max'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
+    expect(html).toMatch(/variant="danger"[^>]*>max/s);
+  });
+
+  it('renders "ignored: reactive" chip when auto_mode is reactive', () => {
+    const issue = { labels: ['worca-effort:high'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'reactive'));
+    expect(html).toContain('ignored: reactive');
+    expect(html).toContain('bead-effort-ignored');
+  });
+
+  it('renders "ignored: disabled" chip when auto_mode is disabled', () => {
+    const issue = { labels: ['worca-effort:high'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'disabled'));
+    expect(html).toContain('ignored: disabled');
+    expect(html).toContain('bead-effort-ignored');
+  });
+
+  it('does not render ignored chip when auto_mode is adaptive', () => {
+    const issue = { labels: ['worca-effort:high'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
+    expect(html).not.toContain('ignored');
+  });
+
+  it('returns nothing when no effort label present', () => {
+    const issue = { labels: ['area:cc'] };
+    const result = beadEffortBadgeView(issue, 'adaptive');
+    expect(result).toBe(nothing);
+  });
+
+  it('returns nothing when labels are undefined', () => {
+    const issue = {};
+    const result = beadEffortBadgeView(issue, 'adaptive');
+    expect(result).toBe(nothing);
+  });
+});
+
+describe('beadNotesView — coordinator reasoning notes', () => {
+  it('renders notes content in a dedicated section', () => {
+    const issue = {
+      notes: 'Coordinator reasoning: straightforward CRUD, low complexity',
+    };
+    const html = renderToString(beadNotesView(issue));
+    expect(html).toContain('bead-notes-section');
+    expect(html).toContain('straightforward CRUD, low complexity');
+  });
+
+  it('renders "Notes" label', () => {
+    const issue = { notes: 'Some reasoning note' };
+    const html = renderToString(beadNotesView(issue));
+    expect(html).toContain('Notes');
+  });
+
+  it('returns nothing when notes is empty', () => {
+    expect(beadNotesView({ notes: '' })).toBe(nothing);
+  });
+
+  it('returns nothing when notes is undefined', () => {
+    expect(beadNotesView({})).toBe(nothing);
+  });
+
+  it('returns nothing when issue is null', () => {
+    expect(beadNotesView(null)).toBe(nothing);
+  });
+});
+
+describe('beadIterationMiniTable — per-iteration effort rows', () => {
+  const iterations = [
+    {
+      number: 1,
+      effort: {
+        level: 'high',
+        source: 'explicit',
+        base: 'high',
+      },
+    },
+    {
+      number: 2,
+      effort: {
+        level: 'max',
+        source: 'reactive',
+        base: 'high',
+        escalations: ['test_failure'],
+        capped_from: 'max',
+      },
+    },
+    {
+      number: 3,
+      effort: {
+        level: 'high',
+        source: 'adaptive:llm',
+        base: 'high',
+      },
+    },
+  ];
+
+  it('renders a row per iteration with effort data', () => {
+    const html = renderToString(beadIterationMiniTable(iterations));
+    expect(html).toContain('iter 1');
+    expect(html).toContain('iter 2');
+    expect(html).toContain('iter 3');
+  });
+
+  it('uses bead-iter-table CSS class', () => {
+    const html = renderToString(beadIterationMiniTable(iterations));
+    expect(html).toContain('bead-iter-table');
+  });
+
+  it('renders level badge with correct variant per §7.1', () => {
+    const html = renderToString(beadIterationMiniTable(iterations));
+    expect(html).toMatch(/variant="primary"[^>]*>high/s);
+    expect(html).toMatch(/variant="danger"[^>]*>max/s);
+  });
+
+  it('renders source qualifier for each iteration', () => {
+    const html = renderToString(beadIterationMiniTable(iterations));
+    expect(html).toContain('explicit');
+    expect(html).toContain('reactive');
+    expect(html).toContain('adaptive');
+  });
+
+  it('renders escalation chips', () => {
+    const html = renderToString(beadIterationMiniTable(iterations));
+    expect(html).toContain('+test_failure');
+  });
+
+  it('renders capped chip when capped_from is set', () => {
+    const html = renderToString(beadIterationMiniTable(iterations));
+    expect(html).toContain('capped');
+  });
+
+  it('skips iterations without effort data', () => {
+    const mixed = [
+      { number: 1 },
+      {
+        number: 2,
+        effort: { level: 'high', source: 'explicit', base: 'high' },
+      },
+    ];
+    const html = renderToString(beadIterationMiniTable(mixed));
+    expect(html).not.toContain('iter 1');
+    expect(html).toContain('iter 2');
+  });
+
+  it('returns nothing when no iterations provided', () => {
+    expect(beadIterationMiniTable([])).toBe(nothing);
+  });
+
+  it('returns nothing when undefined', () => {
+    expect(beadIterationMiniTable(undefined)).toBe(nothing);
+  });
+
+  it('returns nothing when all iterations lack effort', () => {
+    const noEffort = [{ number: 1 }, { number: 2 }];
+    expect(beadIterationMiniTable(noEffort)).toBe(nothing);
+  });
+
+  it('renders model default as dash badge with neutral variant', () => {
+    const iters = [
+      {
+        number: 1,
+        effort: { level: null, source: 'model_default', base: null },
+      },
+    ];
+    const html = renderToString(beadIterationMiniTable(iters));
+    expect(html).toContain('iter 1');
+    expect(html).toMatch(/variant="neutral"[^>]*>-/s);
+    expect(html).toContain('model default');
+  });
+});

--- a/worca-ui/app/views/beads-panel.js
+++ b/worca-ui/app/views/beads-panel.js
@@ -13,6 +13,86 @@ import {
 import { sortByStartDesc } from '../utils/sort-runs.js';
 import { runCardView } from './run-card.js';
 
+export function extractEffortLabel(labels) {
+  if (!labels) return null;
+  for (const label of labels) {
+    if (typeof label === 'string' && label.startsWith('worca-effort:')) {
+      return label.slice('worca-effort:'.length);
+    }
+  }
+  return null;
+}
+
+export function effortLevelVariant(level) {
+  if (level === 'high') return 'primary';
+  if (level === 'xhigh') return 'warning';
+  if (level === 'max') return 'danger';
+  return 'neutral';
+}
+
+export function effortSourceLabel(source) {
+  if (source === 'adaptive:llm') return 'adaptive';
+  if (source === 'model_default') return 'model default';
+  return source || '';
+}
+
+export function beadEffortBadgeView(issue, autoMode) {
+  const level = extractEffortLabel(issue?.labels);
+  if (!level) return nothing;
+  const variant = effortLevelVariant(level);
+  const showIgnored = autoMode === 'reactive' || autoMode === 'disabled';
+  return html`
+    <span class="bead-effort-badge">
+      <sl-badge variant="${variant}" pill>${level}</sl-badge>
+      ${showIgnored ? html`<sl-badge class="bead-effort-ignored" variant="warning" pill>ignored: ${autoMode}</sl-badge>` : nothing}
+    </span>
+  `;
+}
+
+export function beadNotesView(issue) {
+  if (!issue?.notes) return nothing;
+  return html`
+    <div class="bead-notes-section">
+      <div class="meta-label">Notes</div>
+      <div class="bead-notes-content">${issue.notes}</div>
+    </div>
+  `;
+}
+
+export function beadIterationMiniTable(iterations) {
+  if (!iterations?.length) return nothing;
+  const withEffort = iterations.filter((iter) => iter.effort);
+  if (withEffort.length === 0) return nothing;
+  return html`
+    <div class="bead-iter-table">
+      ${withEffort.map((iter) => {
+        const e = iter.effort;
+        const levelText = e.level ?? '-';
+        const variant = e.level ? effortLevelVariant(e.level) : 'neutral';
+        const sourceText = effortSourceLabel(e.source);
+        const escalationChips = e.escalations?.length
+          ? e.escalations.map(
+              (esc) =>
+                html`<sl-badge variant="neutral" pill>+${esc}</sl-badge>`,
+            )
+          : nothing;
+        const cappedChip = e.capped_from
+          ? html`<sl-badge variant="neutral" pill>capped</sl-badge>`
+          : nothing;
+        return html`
+          <div class="bead-iter-row">
+            <span class="bead-iter-label">iter ${iter.number}</span>
+            <sl-badge variant="${variant}" pill>${levelText}</sl-badge>
+            <sl-badge variant="neutral" pill>${sourceText}</sl-badge>
+            ${escalationChips}
+            ${cappedChip}
+          </div>
+        `;
+      })}
+    </div>
+  `;
+}
+
 export function priorityVariant(priority) {
   if (priority === 0 || priority === 1) return 'danger';
   if (priority === 2) return 'warning';

--- a/worca-ui/app/views/effort-badge.test.js
+++ b/worca-ui/app/views/effort-badge.test.js
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest';
+import { runDetailView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+function makeRun(effortOverride, stageKey = 'implement') {
+  return {
+    stages: {
+      [stageKey]: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            outcome: 'success',
+            effort: effortOverride,
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe('effort level badge variant mapping', () => {
+  it('renders low effort with neutral variant', () => {
+    const html = renderToString(
+      runDetailView(makeRun({ level: 'low', source: 'explicit', base: 'low' })),
+    );
+    expect(html).toContain('Effort:');
+    expect(html).toContain('low');
+  });
+
+  it('renders medium effort with neutral variant', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'medium', source: 'explicit', base: 'medium' }),
+      ),
+    );
+    expect(html).toContain('effort-level-badge');
+    expect(html).toMatch(/variant="neutral"[^>]*>medium/s);
+  });
+
+  it('renders high effort with primary variant', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'high', source: 'adaptive:llm', base: 'high' }),
+      ),
+    );
+    expect(html).toContain('effort-level-badge');
+    expect(html).toMatch(/variant="primary"[^>]*>high/s);
+  });
+
+  it('renders xhigh effort with warning variant', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'xhigh', source: 'explicit', base: 'xhigh' }),
+      ),
+    );
+    expect(html).toContain('effort-level-badge');
+    expect(html).toMatch(/variant="warning"[^>]*>xhigh/s);
+  });
+
+  it('renders max effort with danger variant', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'max', source: 'reactive', base: 'high' }),
+      ),
+    );
+    expect(html).toContain('effort-level-badge');
+    expect(html).toMatch(/variant="danger"[^>]*>max/s);
+  });
+
+  it('renders model default as neutral dash badge', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: null, source: 'model_default', base: null }),
+      ),
+    );
+    expect(html).toContain('Effort:');
+    expect(html).toContain('effort-level-badge');
+    expect(html).toMatch(/variant="neutral"[^>]*>-/s);
+  });
+});
+
+describe('effort source qualifier chip', () => {
+  it('renders explicit source as neutral chip', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'high', source: 'explicit', base: 'high' }),
+      ),
+    );
+    expect(html).toContain('effort-source-chip');
+    expect(html).toContain('explicit');
+  });
+
+  it('renders adaptive:llm source as adaptive chip', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'high', source: 'adaptive:llm', base: 'high' }),
+      ),
+    );
+    expect(html).toContain('effort-source-chip');
+    expect(html).toContain('adaptive');
+  });
+
+  it('renders reactive source chip', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'high', source: 'reactive', base: 'high' }),
+      ),
+    );
+    expect(html).toContain('effort-source-chip');
+    expect(html).toContain('reactive');
+  });
+
+  it('renders model_default source as "model default" chip', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: null, source: 'model_default', base: null }),
+      ),
+    );
+    expect(html).toContain('effort-source-chip');
+    expect(html).toContain('model default');
+  });
+
+  it('renders escalation trigger as source chip', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'max',
+          source: 'reactive',
+          base: 'high',
+          escalations: ['test_failure'],
+        }),
+      ),
+    );
+    expect(html).toContain('effort-source-chip');
+    expect(html).toContain('+test_failure');
+  });
+
+  it('renders capped chip when capped_from is set', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'reactive',
+          base: 'medium',
+          capped_from: 'max',
+        }),
+      ),
+    );
+    expect(html).toContain('effort-source-chip');
+    expect(html).toContain('capped');
+  });
+});
+
+describe('effort bead classified row', () => {
+  it('renders bead row when bead_classified exists and applied is false', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'explicit',
+          base: 'high',
+          bead_classified: {
+            level: 'medium',
+            applied: false,
+            skip_reason: 'explicit_override',
+          },
+        }),
+      ),
+    );
+    expect(html).toContain('Bead:');
+    expect(html).toContain('effort-bead-level');
+    expect(html).toContain('medium');
+    expect(html).toContain('overridden');
+  });
+
+  it('renders ignored divergence chip for mode_reactive skip_reason', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'reactive',
+          base: 'high',
+          bead_classified: {
+            level: 'medium',
+            applied: false,
+            skip_reason: 'mode_reactive',
+          },
+        }),
+      ),
+    );
+    expect(html).toContain('Bead:');
+    expect(html).toContain('ignored');
+    expect(html).toMatch(/variant="warning"/);
+  });
+
+  it('renders ignored divergence chip for mode_disabled skip_reason', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'disabled',
+          base: 'high',
+          bead_classified: {
+            level: 'medium',
+            applied: false,
+            skip_reason: 'mode_disabled',
+          },
+        }),
+      ),
+    );
+    expect(html).toContain('Bead:');
+    expect(html).toContain('ignored');
+  });
+
+  it('does not render bead row when bead_classified is absent', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'high', source: 'explicit', base: 'high' }),
+      ),
+    );
+    expect(html).not.toContain('effort-bead-level');
+  });
+
+  it('does not render bead row when applied is true and levels match', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'adaptive:llm',
+          base: 'high',
+          bead_classified: {
+            level: 'high',
+            applied: true,
+            skip_reason: null,
+          },
+        }),
+      ),
+    );
+    // When applied=true and level matches, no divergence to show
+    expect(html).not.toContain('overridden');
+    expect(html).not.toContain('ignored');
+  });
+
+  it('does not render bead row when bead_classified level is null', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'explicit',
+          base: 'high',
+          bead_classified: {
+            level: null,
+            applied: false,
+            skip_reason: 'explicit_override',
+          },
+        }),
+      ),
+    );
+    expect(html).not.toContain('effort-bead-level');
+  });
+});
+
+describe('effort row absent when no effort data', () => {
+  it('does not render effort row when iteration has no effort field', () => {
+    const run = {
+      stages: {
+        implement: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed', outcome: 'success' }],
+        },
+      },
+    };
+    const html = renderToString(runDetailView(run));
+    expect(html).not.toContain('effort-level-badge');
+    expect(html).not.toContain('effort-source-chip');
+  });
+});
+
+describe('run-header effort chip', () => {
+  it('renders effort mode and cap chip in overview', () => {
+    const settings = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+    };
+    const run = {
+      id: 'r1',
+      stages: {
+        implement: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed' }],
+        },
+      },
+    };
+    const result = runDetailView(run, settings);
+    const html = renderToString(result.overview);
+    expect(html).toContain('effort-header-chip');
+    expect(html).toContain('adaptive');
+    expect(html).toContain('cap xhigh');
+  });
+
+  it('renders disabled mode in header chip', () => {
+    const settings = {
+      effort: { auto_mode: 'disabled', auto_cap: 'high' },
+    };
+    const run = {
+      id: 'r1',
+      stages: {
+        implement: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed' }],
+        },
+      },
+    };
+    const result = runDetailView(run, settings);
+    const html = renderToString(result.overview);
+    expect(html).toContain('effort-header-chip');
+    expect(html).toContain('disabled');
+    expect(html).toContain('cap high');
+  });
+
+  it('does not render header chip when effort settings are absent', () => {
+    const run = {
+      id: 'r1',
+      stages: {
+        implement: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed' }],
+        },
+      },
+    };
+    const result = runDetailView(run, {});
+    const html = renderToString(result.overview);
+    expect(html).not.toContain('effort-header-chip');
+  });
+});

--- a/worca-ui/app/views/effort-tooltip.test.js
+++ b/worca-ui/app/views/effort-tooltip.test.js
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { runDetailView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+function makeRun(effortOverride) {
+  return {
+    stages: {
+      implement: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            outcome: 'success',
+            effort: effortOverride,
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe('effort tooltip content', () => {
+  it('shows "template value" tooltip for explicit source', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'high', source: 'explicit', base: 'high' }),
+      ),
+    );
+    expect(html).toMatch(/title="template value"/);
+  });
+
+  it('shows "Claude Code default for this model" for model_default source', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: null, source: 'model_default', base: null }),
+      ),
+    );
+    expect(html).toMatch(/title="Claude Code default for this model"/);
+  });
+
+  it('shows "coordinator label: <level>" for adaptive:llm source', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'adaptive:llm',
+          base: 'high',
+          bead_classified: { level: 'high', applied: true, skip_reason: null },
+        }),
+      ),
+    );
+    expect(html).toMatch(/title="coordinator label: high"/);
+  });
+
+  it('shows not-applied tooltip for reactive mode with bead', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'reactive',
+          base: 'high',
+          bead_classified: {
+            level: 'medium',
+            applied: false,
+            skip_reason: 'mode_reactive',
+          },
+        }),
+      ),
+    );
+    expect(html).toMatch(
+      /coordinator labeled medium; not applied under reactive/,
+    );
+  });
+
+  it('shows not-applied tooltip for disabled mode with bead', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'disabled',
+          base: 'high',
+          bead_classified: {
+            level: 'medium',
+            applied: false,
+            skip_reason: 'mode_disabled',
+          },
+        }),
+      ),
+    );
+    expect(html).toMatch(
+      /coordinator labeled medium; not applied under disabled/,
+    );
+  });
+
+  it('appends capped-from info to tooltip', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'reactive',
+          base: 'medium',
+          capped_from: 'max',
+        }),
+      ),
+    );
+    expect(html).toContain('capped from max');
+  });
+
+  it('appends escalation info to tooltip', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'max',
+          source: 'reactive',
+          base: 'high',
+          escalations: ['test_failure'],
+        }),
+      ),
+    );
+    expect(html).toContain('escalated from high');
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -368,6 +368,93 @@ function _outcomeBadge(outcome) {
   return html`<sl-badge variant="${_outcomeVariant(outcome)}" pill>${outcome.replace(/_/g, ' ')}</sl-badge>`;
 }
 
+function _effortLevelVariant(level) {
+  if (level === 'high') return 'primary';
+  if (level === 'xhigh') return 'warning';
+  if (level === 'max') return 'danger';
+  return 'neutral';
+}
+
+function _effortSourceLabel(source) {
+  if (source === 'adaptive:llm') return 'adaptive';
+  if (source === 'model_default') return 'model default';
+  return source || '';
+}
+
+function _effortTooltip(effort) {
+  const parts = [];
+  if (effort.source === 'explicit') {
+    parts.push('template value');
+  } else if (effort.source === 'model_default') {
+    parts.push('Claude Code default for this model');
+  } else if (effort.source === 'adaptive:llm') {
+    const beadLevel = effort.bead_classified?.level;
+    parts.push(`coordinator label: ${beadLevel || effort.base}`);
+  } else if (
+    (effort.source === 'reactive' || effort.source === 'disabled') &&
+    effort.bead_classified &&
+    !effort.bead_classified.applied &&
+    effort.bead_classified.level
+  ) {
+    parts.push(
+      `coordinator labeled ${effort.bead_classified.level}; not applied under ${effort.source}`,
+    );
+  }
+  if (effort.capped_from) {
+    parts.push(`capped from ${effort.capped_from}`);
+  }
+  if (effort.escalations?.length && effort.base) {
+    parts.push(`escalated from ${effort.base}`);
+  }
+  return parts.join(' · ');
+}
+
+function _effortRowView(iter) {
+  const e = iter.effort;
+  if (!e) return nothing;
+  const levelText = e.level ?? '-';
+  const variant = e.level ? _effortLevelVariant(e.level) : 'neutral';
+  const sourceLabel = _effortSourceLabel(e.source);
+  const tooltip = _effortTooltip(e);
+
+  const escalationChips = e.escalations?.length
+    ? e.escalations.map(
+        (esc) =>
+          html`<sl-badge class="effort-source-chip" variant="neutral" pill>+${esc}</sl-badge>`,
+      )
+    : nothing;
+
+  const cappedChip = e.capped_from
+    ? html`<sl-badge class="effort-source-chip" variant="neutral" pill>capped</sl-badge>`
+    : nothing;
+
+  const bc = e.bead_classified;
+  const showBeadRow = bc && bc.level != null && bc.applied === false;
+  const divergenceLabel =
+    bc?.skip_reason === 'explicit_override' ? 'overridden' : 'ignored';
+
+  return html`
+    <div class="iteration-tags-row" title="${tooltip}">
+      <span class="meta-label">Effort:</span>
+      <sl-badge class="effort-level-badge" variant="${variant}" pill>${levelText}</sl-badge>
+      <sl-badge class="effort-source-chip" variant="neutral" pill>${sourceLabel}</sl-badge>
+      ${escalationChips}
+      ${cappedChip}
+    </div>
+    ${
+      showBeadRow
+        ? html`
+      <div class="iteration-tags-row">
+        <span class="meta-label">Bead:</span>
+        <sl-badge class="effort-bead-level" variant="${_effortLevelVariant(bc.level)}" pill>${bc.level}</sl-badge>
+        <sl-badge class="effort-divergence-chip" variant="warning" pill>${divergenceLabel}</sl-badge>
+      </div>
+    `
+        : nothing
+    }
+  `;
+}
+
 function _classificationVariant(category) {
   if (category === 'infra_transient') return 'warning';
   if (
@@ -794,6 +881,7 @@ function _iterationDetailView(iter, stageKey, stageAgent, promptData) {
       `
           : nothing
       }
+      ${_effortRowView(iter)}
       ${_classificationRowView(iter)}
       ${_dispatchEventsRowsView(iter)}
       ${_agentPromptSection(stageKey, iterPromptData)}
@@ -1082,6 +1170,15 @@ export function runDetailView(run, settings = {}, options = {}) {
         `
             : nothing
         }
+        ${(() => {
+          const effortCfg = settings.effort;
+          if (!effortCfg?.auto_mode) return nothing;
+          return html`
+          <div class="run-effort-header">
+            <sl-badge class="effort-header-chip" variant="neutral" pill>Effort: ${effortCfg.auto_mode} · cap ${effortCfg.auto_cap || 'xhigh'}</sl-badge>
+          </div>
+        `;
+        })()}
         ${timingStripView(run.started_at, endTime)}
         ${(() => {
           const allIters = Object.values(stages).flatMap(
@@ -1314,6 +1411,7 @@ export function runDetailView(run, settings = {}, options = {}) {
                       }
                       ${stage.task_progress ? html`<div class="detail-row"><span class="detail-label">Progress:</span> ${stage.task_progress}</div>` : nothing}
                       ${stage.error ? html`<div class="detail-row detail-error"><span class="detail-label">Error:</span> ${stage.error}</div>` : nothing}
+                      ${iterations.length === 1 ? _effortRowView(iterations[0]) : nothing}
                       ${iterations.length === 1 ? _classificationRowView(iterations[0]) : nothing}
                       ${iterations.length === 1 ? _dispatchEventsRowsView(iterations[0]) : nothing}
                       ${key === 'pr' ? _prVerifiedBadgeView(run) : nothing}

--- a/worca-ui/app/views/settings-dispatch-sections.test.js
+++ b/worca-ui/app/views/settings-dispatch-sections.test.js
@@ -157,4 +157,56 @@ describe('settings.js dispatch sections (W-054)', () => {
       expect(html).toContain('dispatch-section-details');
     });
   });
+
+  describe('effortTab section layout', () => {
+    it('renders Effort Mode section title', async () => {
+      const { effortTab } = await import('./settings.js');
+      const worca = {
+        effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+        agents: {},
+      };
+      const html = renderToString(effortTab(worca, vi.fn()));
+      expect(html).toContain('Effort Mode');
+    });
+
+    it('renders Per-Agent Effort section title', async () => {
+      const { effortTab } = await import('./settings.js');
+      const worca = {
+        effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+        agents: {},
+      };
+      const html = renderToString(effortTab(worca, vi.fn()));
+      expect(html).toContain('Per-Agent Effort');
+    });
+
+    it('renders auto_mode and auto_cap controls with correct IDs', async () => {
+      const { effortTab } = await import('./settings.js');
+      const worca = {
+        effort: { auto_mode: 'reactive', auto_cap: 'high' },
+        agents: {},
+      };
+      const html = renderToString(effortTab(worca, vi.fn()));
+      expect(html).toContain('effort-auto-mode');
+      expect(html).toContain('effort-auto-cap');
+    });
+
+    it('renders per-agent effort selects for all agents', async () => {
+      const { effortTab, AGENT_NAMES } = await import('./settings.js');
+      const worca = {
+        effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+        agents: {},
+      };
+      const html = renderToString(effortTab(worca, vi.fn()));
+      for (const name of AGENT_NAMES) {
+        expect(html).toContain(`effort-agent-${name}`);
+      }
+    });
+
+    it('wraps content in settings-tab-content', async () => {
+      const { effortTab } = await import('./settings.js');
+      const worca = { effort: {}, agents: {} };
+      const html = renderToString(effortTab(worca, vi.fn()));
+      expect(html).toContain('settings-tab-content');
+    });
+  });
 });

--- a/worca-ui/app/views/settings-effort.test.js
+++ b/worca-ui/app/views/settings-effort.test.js
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+describe('Effort settings constants', () => {
+  it('exports EFFORT_LEVELS with 5 levels and no auto', async () => {
+    const { EFFORT_LEVELS } = await import('./settings.js');
+    expect(EFFORT_LEVELS).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    expect(EFFORT_LEVELS).not.toContain('auto');
+  });
+
+  it('exports AUTO_MODES with 3 modes', async () => {
+    const { AUTO_MODES } = await import('./settings.js');
+    expect(AUTO_MODES).toEqual(['disabled', 'reactive', 'adaptive']);
+  });
+});
+
+describe('effortTab rendering', () => {
+  it('renders auto_mode dropdown with all 3 modes', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+      agents: {},
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('effort-auto-mode');
+    expect(html).toContain('>disabled<');
+    expect(html).toContain('>reactive<');
+    expect(html).toContain('>adaptive<');
+  });
+
+  it('renders auto_cap dropdown with 5 effort levels', async () => {
+    const { effortTab, EFFORT_LEVELS } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+      agents: {},
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('effort-auto-cap');
+    for (const level of EFFORT_LEVELS) {
+      expect(html).toContain(`value="${level}"`);
+    }
+  });
+
+  it('does not include auto value in any dropdown', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+      agents: {},
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).not.toContain('value="auto"');
+  });
+
+  it('renders per-agent effort table with all agents', async () => {
+    const { effortTab, AGENT_NAMES } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+      agents: {},
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    for (const name of AGENT_NAMES) {
+      expect(html).toContain(`effort-agent-${name}`);
+    }
+  });
+
+  it('renders (unset) option for per-agent dropdowns', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+      agents: {},
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('(unset)');
+  });
+
+  it('renders Save and Reset buttons', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+      agents: {},
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('Save');
+    expect(html).toContain('Reset');
+  });
+
+  it('shows inheritance hint for agents without explicit effort', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+      agents: {
+        planner: { model: 'opus', max_turns: 100 },
+      },
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('effort-inherit-hint');
+  });
+
+  it('does not show inheritance hint for agents with explicit effort', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' },
+      agents: {
+        planner: { model: 'opus', max_turns: 100, effort: 'high' },
+      },
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    const plannerSection = html
+      .split('effort-agent-planner')[1]
+      .split('effort-agent-')[0];
+    expect(plannerSection).not.toContain('effort-inherit-hint');
+  });
+
+  it('renders auto_mode description hints', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = {
+      effort: { auto_mode: 'reactive', auto_cap: 'high' },
+      agents: {},
+    };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('settings-field-hint');
+  });
+
+  it('defaults auto_mode to adaptive when missing', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = { effort: {}, agents: {} };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('effort-auto-mode');
+  });
+
+  it('defaults auto_cap to xhigh when missing', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = { effort: {}, agents: {} };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('effort-auto-cap');
+  });
+
+  it('handles missing effort block gracefully', async () => {
+    const { effortTab } = await import('./settings.js');
+    const worca = { agents: {} };
+    const html = renderToString(effortTab(worca, () => {}));
+    expect(html).toContain('effort-auto-mode');
+    expect(html).toContain('effort-auto-cap');
+  });
+});
+
+describe('readEffortFromDom', () => {
+  it('is exported as a function', async () => {
+    const { readEffortFromDom } = await import('./settings.js');
+    expect(typeof readEffortFromDom).toBe('function');
+  });
+});
+
+describe('Effort tab in projectSettingsView', () => {
+  it('projectSettingsView includes effort tab panel', async () => {
+    const mod = await import('./settings.js');
+    expect(typeof mod.effortTab).toBe('function');
+  });
+});

--- a/worca-ui/app/views/settings-form-roundtrip.test.js
+++ b/worca-ui/app/views/settings-form-roundtrip.test.js
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { loadSettings, readPipelineFromDom } from './settings.js';
+import {
+  loadSettings,
+  readEffortFromDom,
+  readPipelineFromDom,
+} from './settings.js';
 
 describe('Form round-trip: pr_approval stays absent on no-op Save', () => {
   let origDocument;
@@ -57,5 +61,80 @@ describe('Form round-trip: pr_approval stays absent on no-op Save', () => {
 
     expect(result.milestones.plan_approval).toBe(true);
     expect(result.milestones).not.toHaveProperty('pr_approval');
+  });
+});
+
+describe('Form round-trip: effort block survives form -> JSON -> form cycle', () => {
+  let origDocument;
+  let origFetch;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    origFetch = globalThis.fetch;
+    globalThis.document = {
+      querySelectorAll: () => [],
+      getElementById: () => null,
+    };
+  });
+
+  afterEach(() => {
+    globalThis.document = origDocument;
+    globalThis.fetch = origFetch;
+  });
+
+  it('readEffortFromDom returns auto_mode, auto_cap, and per-agent effort', async () => {
+    const serverResponse = {
+      worca: {
+        effort: { auto_mode: 'reactive', auto_cap: 'high' },
+        agents: {
+          planner: { model: 'opus', max_turns: 100, effort: 'xhigh' },
+          implementer: { model: 'sonnet', max_turns: 300 },
+        },
+      },
+    };
+
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes('/api/subagents')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, subagents: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(serverResponse),
+      });
+    });
+
+    await loadSettings('test-project');
+
+    const elements = {
+      'effort-auto-mode': { value: 'reactive' },
+      'effort-auto-cap': { value: 'high' },
+      'effort-agent-planner': { value: 'xhigh' },
+      'effort-agent-implementer': { value: '' },
+      'effort-agent-coordinator': { value: '' },
+      'effort-agent-tester': { value: '' },
+      'effort-agent-reviewer': { value: '' },
+      'effort-agent-guardian': { value: '' },
+      'effort-agent-plan_reviewer': { value: '' },
+      'effort-agent-learner': { value: '' },
+      'effort-agent-workspace_planner': { value: '' },
+    };
+    globalThis.document.getElementById = (id) => elements[id] || null;
+
+    const result = readEffortFromDom();
+
+    expect(result.auto_mode).toBe('reactive');
+    expect(result.auto_cap).toBe('high');
+    expect(result.agents.planner).toEqual({ effort: 'xhigh' });
+    expect(result.agents.implementer).toEqual({ effort: null });
+  });
+
+  it('readEffortFromDom defaults to adaptive/xhigh when DOM elements are missing', () => {
+    const result = readEffortFromDom();
+
+    expect(result.auto_mode).toBe('adaptive');
+    expect(result.auto_cap).toBe('xhigh');
   });
 });

--- a/worca-ui/app/views/settings.js
+++ b/worca-ui/app/views/settings.js
@@ -8,6 +8,7 @@ import {
   showInfo,
 } from '../utils/confirm-dialog.js';
 import {
+  Activity,
   Bell,
   ClipboardCopy,
   ClipboardPaste,
@@ -59,6 +60,9 @@ export const CONFIGURABLE_STAGES = STAGE_ORDER.filter((s) => s !== 'preflight');
 export { AGENT_NAMES } from './agent-names.js';
 
 const DEFAULT_MODEL_KEYS = ['opus', 'sonnet', 'haiku'];
+
+export const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'];
+export const AUTO_MODES = ['disabled', 'reactive', 'adaptive'];
 
 export function getModelKeys(worca) {
   const models = worca?.models || {};
@@ -827,6 +831,25 @@ export function readPricingFromDom() {
     currency: settingsData?.worca?.pricing?.currency || 'USD',
     last_updated: new Date().toISOString().slice(0, 10),
   };
+}
+
+export function readEffortFromDom() {
+  const auto_mode =
+    document.getElementById('effort-auto-mode')?.value || 'adaptive';
+  const auto_cap = document.getElementById('effort-auto-cap')?.value || 'xhigh';
+
+  const agents = {};
+  for (const name of AGENT_NAMES) {
+    const el = document.getElementById(`effort-agent-${name}`);
+    const val = el?.value;
+    if (val && val !== '') {
+      agents[name] = { effort: val };
+    } else {
+      agents[name] = { effort: null };
+    }
+  }
+
+  return { auto_mode, auto_cap, agents };
 }
 
 export function getDefaults() {
@@ -2448,6 +2471,171 @@ export function modelsTab(worca, rerender) {
   `;
 }
 
+const _AUTO_MODE_HINTS = {
+  disabled: 'Per-agent effort only; no runtime escalation on loopbacks.',
+  reactive:
+    'Per-agent effort as starting point; escalates on test failures and review bounces.',
+  adaptive:
+    'Coordinator classifies per-bead effort; escalates on loopbacks. Explicit per-agent values override.',
+};
+
+function _confirmMaxEffort(selectEl, previousValue, rerender) {
+  showConfirm(
+    {
+      label: 'Confirm max effort',
+      message: html`Setting effort to <strong>max</strong> significantly
+        increases token consumption and cost. Continue?`,
+      confirmLabel: 'Use max',
+      confirmVariant: 'warning',
+      onConfirm: () => {},
+      onCancel: () => {
+        selectEl.value = previousValue;
+      },
+    },
+    rerender,
+  );
+}
+
+export function effortTab(worca, rerender) {
+  const effort = worca.effort || {};
+  const agents = worca.agents || {};
+  const autoMode = effort.auto_mode || 'adaptive';
+  const autoCap = effort.auto_cap || 'xhigh';
+
+  return html`
+    <div class="settings-tab-content">
+      <h3 class="settings-section-title">Effort Mode</h3>
+      <div class="settings-grid">
+        <div class="settings-field">
+          <label class="settings-label">Auto Mode</label>
+          <sl-select
+            id="effort-auto-mode"
+            .value="${autoMode}"
+            size="small"
+            hoist
+          >
+            ${AUTO_MODES.map(
+              (m) => html`<sl-option value="${m}">${m}</sl-option>`,
+            )}
+          </sl-select>
+          <span class="settings-field-hint"
+            >${_AUTO_MODE_HINTS[autoMode] || ''}</span
+          >
+        </div>
+        <div class="settings-field">
+          <label class="settings-label">Auto Cap</label>
+          <sl-select
+            id="effort-auto-cap"
+            .value="${autoCap}"
+            size="small"
+            hoist
+            @sl-change=${(e) => {
+              if (e.target.value === 'max') {
+                _confirmMaxEffort(e.target, autoCap, rerender);
+              }
+            }}
+          >
+            ${EFFORT_LEVELS.map(
+              (l) => html`<sl-option value="${l}">${l}</sl-option>`,
+            )}
+          </sl-select>
+          <span class="settings-field-hint"
+            >Ceiling for runtime-resolved effort levels</span
+          >
+        </div>
+      </div>
+
+      <h3 class="settings-section-title">Per-Agent Effort</h3>
+      <div class="effort-agent-table">
+        <table class="effort-table">
+          <thead>
+            <tr>
+              <th>Agent</th>
+              <th>Effort</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${AGENT_NAMES.map((name) => {
+              const agentCfg = agents[name] || {};
+              const currentEffort = agentCfg.effort || '';
+              const hasExplicit = Boolean(agentCfg.effort);
+              return html`
+                <tr>
+                  <td class="effort-agent-name">${name}</td>
+                  <td>
+                    <sl-select
+                      id="effort-agent-${name}"
+                      .value="${currentEffort}"
+                      size="small"
+                      hoist
+                      @sl-change=${(e) => {
+                        if (e.target.value === 'max') {
+                          _confirmMaxEffort(e.target, currentEffort, rerender);
+                        }
+                      }}
+                    >
+                      <sl-option value="">(unset)</sl-option>
+                      ${EFFORT_LEVELS.map(
+                        (l) => html`<sl-option value="${l}">${l}</sl-option>`,
+                      )}
+                    </sl-select>
+                  </td>
+                  <td>
+                    ${
+                      !hasExplicit
+                        ? html`<span
+                            class="effort-inherit-hint settings-muted-small"
+                            >inherits from auto mode</span
+                          >`
+                        : nothing
+                    }
+                  </td>
+                </tr>
+              `;
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div class="settings-tab-actions">
+        <sl-button
+          variant="primary"
+          size="small"
+          @click=${() => {
+            const {
+              auto_mode,
+              auto_cap,
+              agents: agentEfforts,
+            } = readEffortFromDom();
+            saveSettings(
+              {
+                worca: {
+                  effort: { auto_mode, auto_cap },
+                  agents: agentEfforts,
+                },
+              },
+              rerender,
+            );
+          }}
+        >
+          ${unsafeHTML(iconSvg(Save, 14))}
+          Save
+        </sl-button>
+        <sl-button
+          variant="default"
+          size="small"
+          outline
+          @click=${() => confirmReset('effort', rerender)}
+        >
+          ${unsafeHTML(iconSvg(RefreshCw, 14))}
+          Reset
+        </sl-button>
+      </div>
+    </div>
+  `;
+}
+
 function pricingTab(worca, rerender) {
   const pricing = worca.pricing || {};
   const models = pricing.models || {};
@@ -3232,6 +3420,10 @@ export function projectSettingsView(
           ${unsafeHTML(iconSvg(Cpu, 14))}
           Models
         </sl-tab>
+        <sl-tab slot="nav" panel="effort">
+          ${unsafeHTML(iconSvg(Activity, 14))}
+          Effort
+        </sl-tab>
         <sl-tab slot="nav" panel="pipeline">
           ${unsafeHTML(iconSvg(Workflow, 14))}
           Pipeline
@@ -3251,6 +3443,7 @@ export function projectSettingsView(
 
         <sl-tab-panel name="agents">${agentsTab(worca, rerender)}</sl-tab-panel>
         <sl-tab-panel name="models">${modelsTab(worca, rerender)}</sl-tab-panel>
+        <sl-tab-panel name="effort">${effortTab(worca, rerender)}</sl-tab-panel>
         <sl-tab-panel name="pipeline">${pipelineTab(worca, rerender)}</sl-tab-panel>
         <sl-tab-panel name="governance">${governanceTab(worca, permissions, rerender)}</sl-tab-panel>
         <sl-tab-panel name="pricing">${pricingTab(worca, rerender)}</sl-tab-panel>

--- a/worca-ui/server/settings-validator.js
+++ b/worca-ui/server/settings-validator.js
@@ -21,6 +21,9 @@ const VALID_LOOPS = [
   'restart_planning',
   'plan_review',
 ];
+const VALID_EFFORT_RUNGS = ['low', 'medium', 'high', 'xhigh', 'max'];
+const VALID_AUTO_MODES = ['disabled', 'reactive', 'adaptive'];
+const VALID_EFFORT_KEYS = ['auto_mode', 'auto_cap'];
 const VALID_MILESTONES = ['plan_approval', 'pr_approval', 'deploy_approval'];
 const VALID_GUARDS = [
   'block_rm_rf',
@@ -92,6 +95,52 @@ export function validateSettingsPayload(body, options = {}) {
               );
             }
           }
+          if (cfg.effort !== undefined) {
+            if (
+              typeof cfg.effort !== 'string' ||
+              !VALID_EFFORT_RUNGS.includes(cfg.effort)
+            ) {
+              details.push(
+                `Invalid effort "${cfg.effort}" for agent "${name}". Must be one of: ${VALID_EFFORT_RUNGS.join(', ')}`,
+              );
+            }
+          }
+        }
+      }
+    }
+
+    // effort
+    if (w.effort !== undefined) {
+      if (
+        typeof w.effort !== 'object' ||
+        w.effort === null ||
+        Array.isArray(w.effort)
+      ) {
+        details.push('effort must be an object');
+      } else {
+        const ef = w.effort;
+        for (const key of Object.keys(ef)) {
+          if (!VALID_EFFORT_KEYS.includes(key)) {
+            details.push(`Unknown effort key: "${key}"`);
+          }
+        }
+        if (
+          ef.auto_mode !== undefined &&
+          (typeof ef.auto_mode !== 'string' ||
+            !VALID_AUTO_MODES.includes(ef.auto_mode))
+        ) {
+          details.push(
+            `effort.auto_mode must be one of: ${VALID_AUTO_MODES.join(', ')}`,
+          );
+        }
+        if (
+          ef.auto_cap !== undefined &&
+          (typeof ef.auto_cap !== 'string' ||
+            !VALID_EFFORT_RUNGS.includes(ef.auto_cap))
+        ) {
+          details.push(
+            `effort.auto_cap must be one of: ${VALID_EFFORT_RUNGS.join(', ')}`,
+          );
         }
       }
     }

--- a/worca-ui/server/settings-validator.test.js
+++ b/worca-ui/server/settings-validator.test.js
@@ -1254,3 +1254,130 @@ describe('validateGlobalSettings — dynamic model validation', () => {
     }
   });
 });
+
+describe('validateSettingsPayload — worca.effort', () => {
+  it('accepts valid effort block with all fields', () => {
+    const result = validateSettingsPayload({
+      worca: { effort: { auto_mode: 'adaptive', auto_cap: 'xhigh' } },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts each valid auto_mode value', () => {
+    for (const mode of ['disabled', 'reactive', 'adaptive']) {
+      const result = validateSettingsPayload({
+        worca: { effort: { auto_mode: mode } },
+      });
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  it('rejects invalid auto_mode value', () => {
+    const result = validateSettingsPayload({
+      worca: { effort: { auto_mode: 'turbo' } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(expect.stringContaining('auto_mode'));
+  });
+
+  it('rejects non-string auto_mode', () => {
+    const result = validateSettingsPayload({
+      worca: { effort: { auto_mode: true } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(expect.stringContaining('auto_mode'));
+  });
+
+  it('accepts each valid auto_cap value', () => {
+    for (const cap of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      const result = validateSettingsPayload({
+        worca: { effort: { auto_cap: cap } },
+      });
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  it('rejects invalid auto_cap value', () => {
+    const result = validateSettingsPayload({
+      worca: { effort: { auto_cap: 'ultra' } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(expect.stringContaining('auto_cap'));
+  });
+
+  it('rejects non-string auto_cap', () => {
+    const result = validateSettingsPayload({
+      worca: { effort: { auto_cap: 5 } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(expect.stringContaining('auto_cap'));
+  });
+
+  it('rejects unknown keys in effort block', () => {
+    const result = validateSettingsPayload({
+      worca: { effort: { auto_mode: 'adaptive', unknown_key: true } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('Unknown effort key'),
+    );
+  });
+
+  it('rejects non-object effort', () => {
+    const result = validateSettingsPayload({ worca: { effort: 'high' } });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('effort must be an object'),
+    );
+  });
+
+  it('rejects array effort', () => {
+    const result = validateSettingsPayload({ worca: { effort: [] } });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(
+      expect.stringContaining('effort must be an object'),
+    );
+  });
+
+  it('accepts empty effort object', () => {
+    const result = validateSettingsPayload({ worca: { effort: {} } });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateSettingsPayload — per-agent effort', () => {
+  it('accepts valid per-agent effort rung', () => {
+    for (const level of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      const result = validateSettingsPayload({
+        worca: { agents: { implementer: { effort: level } } },
+      });
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  it('rejects invalid per-agent effort rung', () => {
+    const result = validateSettingsPayload({
+      worca: { agents: { implementer: { effort: 'turbo' } } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(expect.stringContaining('effort'));
+    expect(result.details).toContainEqual(
+      expect.stringContaining('implementer'),
+    );
+  });
+
+  it('rejects non-string per-agent effort', () => {
+    const result = validateSettingsPayload({
+      worca: { agents: { planner: { effort: 3 } } },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.details).toContainEqual(expect.stringContaining('effort'));
+  });
+
+  it('accepts agent config without effort field', () => {
+    const result = validateSettingsPayload({
+      worca: { agents: { implementer: { model: 'sonnet', max_turns: 200 } } },
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/worca-ui/server/test/settings-api.test.js
+++ b/worca-ui/server/test/settings-api.test.js
@@ -330,6 +330,37 @@ describe('POST /api/settings', () => {
     });
   });
 
+  it('merges worca.effort correctly -- returns merged view', async () => {
+    const effort = { auto_mode: 'reactive', auto_cap: 'high' };
+    const res = await post({ worca: { effort } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.worca.effort).toEqual(effort);
+    expect(data.worca.loops).toEqual(SAMPLE_SETTINGS.worca.loops);
+  });
+
+  it('merges per-agent effort alongside model and max_turns', async () => {
+    const res = await post({
+      worca: {
+        agents: { planner: { model: 'opus', max_turns: 100, effort: 'xhigh' } },
+      },
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.worca.agents.planner).toEqual({
+      model: 'opus',
+      max_turns: 100,
+      effort: 'xhigh',
+    });
+  });
+
+  it('persists effort block to disk and re-reads correctly', async () => {
+    const effort = { auto_mode: 'adaptive', auto_cap: 'xhigh' };
+    await post({ worca: { effort } });
+    const saved = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    expect(saved.worca.effort).toEqual(effort);
+  });
+
   it('migrates subagent_dispatch to dispatch.subagents on save', async () => {
     const res = await post({
       worca: {


### PR DESCRIPTION
## Summary

- Add per-agent `effort` field (`low|medium|high|xhigh|max`) to `worca.agents.<agent>` — passes through via `CLAUDE_CODE_EFFORT_LEVEL` on the per-stage env dict.
- New `worca.effort` block with three auto modes (`disabled`/`reactive`/`adaptive`) and `auto_cap` ceiling. Under `adaptive` (default), the coordinator classifies bead complexity via `worca-effort:<level>` labels during decomposition.
- Loopback escalation: `test_failure` bumps effort +1 rung, `review_changes` bumps +2 rungs, stacking across iterations. Model-aware ladders collapse requested levels onto the model's supported rungs.
- Effort data persisted per-iteration in `status.json` (`effort.source`, `effort.base`, `effort.escalations`, `effort.resolved`, `effort.bead_classified`). UI surfaces effort badges in beads panel, run-detail iteration table, and settings form.
- New `src/worca/orchestrator/effort.py` module with `resolve_effort()`, model ladder definitions, and escalation logic.
- Settings validation extended for `worca.effort` and per-agent `effort` fields. Full docs at `docs/effort.md`, migration notes in `MIGRATION.md`.

## Test plan

- [x] `tests/test_effort.py` — unit tests for `resolve_effort()`, model-aware ladders, escalation, cap enforcement
- [x] `tests/test_runner_effort.py` — runner integration: effort env var injection, loopback escalation, status.json persistence
- [x] `tests/test_stages.py` — `Stage.effort` field parsing from settings
- [x] `tests/test_status.py` — effort dict in iteration records
- [x] `tests/test_beads.py` — `extract_effort_label()` from bead labels
- [x] `tests/test_settings.py` — `worca.effort` block and per-agent effort validation
- [x] `tests/test_event_types.py` — STAGE_STARTED effort payload extension
- [x] `tests/test_agent_md_refs.py` — coordinator.md effort labeling section refs
- [x] `tests/test_tracking.py` — governance dispatch with effort config
- [x] `tests/integration/test_effort_integration.py` — end-to-end effort flow via integration fixture
- [x] `worca-ui/app/views/beads-panel-effort.test.js` — effort badge/tooltip rendering
- [x] `worca-ui/app/views/effort-badge.test.js` — effort badge variant mapping
- [x] `worca-ui/app/views/effort-tooltip.test.js` — effort tooltip content
- [x] `worca-ui/app/views/settings-effort.test.js` — settings form effort section
- [x] `worca-ui/server/settings-validator.test.js` — server-side effort validation
- [x] `worca-ui/app/views/settings-form-roundtrip.test.js` — effort fields round-trip
- [x] `worca-ui/app/views/settings-dispatch-sections.test.js` — dispatch sections with effort config

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)