### PR TITLE
fix(governance): self-heal stale dispatch defaults, narrow worca-* denylist, staged Reset buttons

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -633,6 +633,27 @@ Per-agent effort values (`worca.agents.<agent>.effort`) accept `low | medium | h
 
 **Full reference:** [`docs/effort.md`](./docs/effort.md).
 
+### 0.34.x → 0.35.0
+
+W-054 follow-up: dispatch defaults self-heal on upgrade, and the `worca-*` skills denylist is narrowed.
+
+**Behavior changes (no config edits required):**
+
+1. **Stale Explore-only subagent default is auto-adopted to the new wildcard default.** W-054 preserved each project's existing per-agent subagent allow lists verbatim. Projects that were on the *old shipped default* — every pipeline agent capped to `["Explore"]`, from the W-038 era — were therefore left pinned to Explore-only even though the W-054 default had become `_defaults: ["*"]` (any subagent except `general-purpose`). On upgrade, a config whose `governance.dispatch.subagents.per_agent_allow` exactly matches that legacy Explore-only set is collapsed to `{ "_defaults": ["*"] }`, so pipeline agents (planner, implementer, tester, …) can dispatch any subagent again. **Customized configs are not touched** — the match is exact, and a touched `_defaults` (or any added/changed entry) preserves your settings as-is.
+
+2. **The broad `worca-*` skills denylist glob is narrowed.** `governance.dispatch.skills.always_disallowed` previously hard-denied *every* `worca-*` skill via a glob. It now names only the genuinely-dangerous ones individually (`worca-release`, `worca-rc`, `worca-pr-prep`, `worca-install`, `worca-sync`, `worca-sync-commit`, `worca-sync-pr`, `worca-agent-override`, `worca-analyze`, `worca-plan-new`). Useful dev skills (`worca-dev-precommit`, `worca-coverage`, `worca-ui-add-*`, `worca-event-add`, `worca-webhook-test`, `worca-issue`) become dispatchable via the per-agent `"*"` wildcard. As above, this only rewrites an *untouched* denylist (exact set match); a customized denylist is preserved.
+
+**One-time and version-stamped.** Both normalizations are gated by a new `governance.dispatch_migration_version` integer (current value `1`). They run exactly once per config — on `worca init --upgrade` (Python) or on the next Governance-panel save (UI) — then the stamp prevents them from running again, so deliberately re-pinning agents to Explore-only *after* the upgrade sticks.
+
+**To keep the old (restrictive) behavior**, set the per-agent subagent entries (and/or the skills denylist) explicitly to your preferred values. Because the stamp is written on first upgrade, your explicit choices are never re-widened.
+
+**Automatic migration messages via `worca init --upgrade`:**
+
+```
+governance.dispatch.subagents: adopted new default (_defaults: ["*"]) for config pinned to legacy Explore-only set
+governance.dispatch.skills.always_disallowed: narrowed legacy "worca-*" glob to the current must-disallow set
+```
+
 ## Getting help
 
 - Issues: https://github.com/SinishaDjukic/worca-cc/issues

--- a/src/worca/cli/init.py
+++ b/src/worca/cli/init.py
@@ -183,20 +183,29 @@ def _seed_dispatch_defaults(governance_cfg: dict) -> None:
 
 
 def _migrate_dispatch_governance(governance_cfg: dict, changes: list[str]) -> None:
-    """Migrate flat subagent_dispatch -> nested dispatch.subagents (W-054)."""
-    if "subagent_dispatch" not in governance_cfg:
-        return
-    old = governance_cfg.pop("subagent_dispatch")
-    dispatch = governance_cfg.setdefault("dispatch", {})
-    subagents = dispatch.setdefault("subagents", {})
-    per_agent = subagents.setdefault("per_agent_allow", {})
-    per_agent.update(old)
-    _seed_dispatch_defaults(governance_cfg)
-    governance_cfg.pop("_dispatch_legacy", None)
-    changes.append(
-        "  governance.subagent_dispatch -> governance.dispatch.subagents "
-        "(W-054 — tools and skills sections added with defaults)"
-    )
+    """Migrate flat subagent_dispatch -> nested dispatch.subagents (W-054), then
+    apply the one-time dispatch-default normalization (gated by a version stamp).
+
+    The normalization runs even when no legacy shape is present so that configs
+    already on the W-054 nested shape but still pinned to the stale Explore-only
+    subagent default (or the broad ``worca-*`` skills glob) self-heal on upgrade.
+    """
+    from worca.hooks.tracking import normalize_dispatch_defaults
+
+    if "subagent_dispatch" in governance_cfg:
+        old = governance_cfg.pop("subagent_dispatch")
+        dispatch = governance_cfg.setdefault("dispatch", {})
+        subagents = dispatch.setdefault("subagents", {})
+        per_agent = subagents.setdefault("per_agent_allow", {})
+        per_agent.update(old)
+        _seed_dispatch_defaults(governance_cfg)
+        governance_cfg.pop("_dispatch_legacy", None)
+        changes.append(
+            "  governance.subagent_dispatch -> governance.dispatch.subagents "
+            "(W-054 — tools and skills sections added with defaults)"
+        )
+
+    changes.extend(normalize_dispatch_defaults(governance_cfg))
 
 
 def _migrate_settings_paths(settings: dict) -> tuple[dict, list[str]]:

--- a/src/worca/hooks/tracking.py
+++ b/src/worca/hooks/tracking.py
@@ -27,7 +27,22 @@ _DISPATCH_DEFAULTS = {
             "fewer-permission-prompts",
             "loop",
             "schedule",
-            "worca-*",
+            # worca-* dev skills that genuinely must stay off-limits to pipeline
+            # agents: release/publish, PR merges, cross-repo sync, installation,
+            # agent/governance override (privilege escalation), pipeline launch
+            # (recursion), and autonomous issue/plan creation. The rest of the
+            # worca-* dev tooling (precommit, coverage, ui/event scaffolding,
+            # webhook-test, issue read) is allowed via the per-agent "*" wildcard.
+            "worca-release",
+            "worca-rc",
+            "worca-pr-prep",
+            "worca-install",
+            "worca-sync",
+            "worca-sync-commit",
+            "worca-sync-pr",
+            "worca-agent-override",
+            "worca-analyze",
+            "worca-plan-new",
             "update-config",
             "hookify:hookify",
             "hookify:configure",
@@ -63,6 +78,137 @@ _DISPATCH_DEFAULTS = {
         "per_agent_allow": {"_defaults": ["*"]},
     },
 }
+
+# --- One-time dispatch-default normalization (W-054 follow-up) ---------------
+#
+# Version of the dispatch normalization. Stamped onto
+# governance.dispatch_migration_version so the normalization runs exactly once
+# per config; re-runs (and fresh installs already at this version) are no-ops.
+# Bump when adding a new one-time normalization below.
+DISPATCH_MIGRATION_VERSION = 1
+
+# The pre-W-054 (W-038-era) shipped subagent dispatch default: every pipeline
+# agent capped to Explore-only. W-054 changed the default to `_defaults: ["*"]`,
+# but the migration preserved these explicit values verbatim, leaving upgraders
+# pinned to Explore-only. We detect this exact (untouched) shape and adopt the
+# new permissive default. coordinator:[] (and any empty list) is treated as
+# "falls through to _defaults" and ignored in the comparison.
+_LEGACY_EXPLORE_SUBAGENT_DEFAULT = {
+    "planner": ["Explore"],
+    "implementer": ["Explore"],
+    "tester": ["Explore"],
+    "guardian": ["Explore"],
+    "reviewer": ["Explore"],
+    "plan_reviewer": ["Explore"],
+    "learner": ["Explore"],
+}
+
+# The pre-narrowing skills denylist (carried the broad `worca-*` glob). An
+# untouched config matching this set is widened to the current default, which
+# disallows only the genuinely-dangerous worca-* skills.
+_LEGACY_SKILLS_ALWAYS_DISALLOWED = frozenset({
+    "batch",
+    "fewer-permission-prompts",
+    "loop",
+    "schedule",
+    "worca-*",
+    "update-config",
+    "hookify:hookify",
+    "hookify:configure",
+    "hookify:list",
+    "hookify:writing-rules",
+    "init",
+})
+
+
+def _canonical_per_agent(per_agent: dict) -> dict:
+    """Drop _defaults and empty/passthrough entries; sort values for comparison."""
+    out = {}
+    for agent, allow in per_agent.items():
+        if agent == "_defaults":
+            continue
+        if not allow:  # [] or None falls through to _defaults — ignore
+            continue
+        out[agent] = sorted(allow)
+    return out
+
+
+def adopt_stale_subagent_default(subagents_cfg: dict) -> bool:
+    """Collapse a stale Explore-only per_agent_allow to the new default.
+
+    Returns True if the config was the untouched W-038 Explore-only default
+    (and was rewritten to ``{"_defaults": ["*"]}``), else False. Only fires
+    when ``_defaults`` is the new wildcard (or unset) — a customized
+    ``_defaults`` means the operator has touched this section.
+    """
+    if not isinstance(subagents_cfg, dict):
+        return False
+    pa = subagents_cfg.get("per_agent_allow")
+    if not isinstance(pa, dict):
+        return False
+    if pa.get("_defaults") not in (None, ["*"]):
+        return False
+    expected = {a: sorted(v) for a, v in _LEGACY_EXPLORE_SUBAGENT_DEFAULT.items()}
+    if _canonical_per_agent(pa) != expected:
+        return False
+    subagents_cfg["per_agent_allow"] = {"_defaults": ["*"]}
+    return True
+
+
+def adopt_narrowed_skills_denylist(skills_cfg: dict) -> bool:
+    """Widen an untouched skills denylist (broad ``worca-*``) to the current set.
+
+    Returns True if ``always_disallowed`` exactly matched the legacy default
+    (and was replaced with the current narrowed default), else False.
+    """
+    if not isinstance(skills_cfg, dict):
+        return False
+    current = skills_cfg.get("always_disallowed")
+    if not isinstance(current, list):
+        return False
+    if frozenset(current) != _LEGACY_SKILLS_ALWAYS_DISALLOWED:
+        return False
+    skills_cfg["always_disallowed"] = list(
+        _DISPATCH_DEFAULTS["skills"]["always_disallowed"]
+    )
+    return True
+
+
+def normalize_dispatch_defaults(governance_cfg: dict) -> list[str]:
+    """Apply one-time dispatch-default normalizations, gated by a version stamp.
+
+    Brings an *untouched* config up to the current shipped defaults for the two
+    things that changed after W-054:
+      1. subagents.per_agent_allow pinned to the legacy Explore-only set, and
+      2. skills.always_disallowed carrying the broad ``worca-*`` glob.
+
+    Both are exact-match guarded so a customized config is never silently
+    widened. Stamps ``dispatch_migration_version`` so it runs once. Mutates
+    ``governance_cfg`` in place; returns a list of change descriptions.
+    """
+    changes: list[str] = []
+    if not isinstance(governance_cfg, dict):
+        return changes
+    stamp = governance_cfg.get("dispatch_migration_version")
+    if not isinstance(stamp, int):
+        stamp = 0
+    if stamp >= DISPATCH_MIGRATION_VERSION:
+        return changes
+    dispatch = governance_cfg.get("dispatch")
+    if not isinstance(dispatch, dict):
+        return changes
+    if adopt_stale_subagent_default(dispatch.get("subagents")):
+        changes.append(
+            "  governance.dispatch.subagents: adopted new default "
+            '(_defaults: ["*"]) for config pinned to legacy Explore-only set'
+        )
+    if adopt_narrowed_skills_denylist(dispatch.get("skills")):
+        changes.append(
+            "  governance.dispatch.skills.always_disallowed: narrowed legacy "
+            '"worca-*" glob to the current must-disallow set'
+        )
+    governance_cfg["dispatch_migration_version"] = DISPATCH_MIGRATION_VERSION
+    return changes
 
 # In-process cache for resolved dispatch sections. Each entry is keyed by section
 # and stores (resolved_dict, settings_mtime). On every read we re-stat

--- a/src/worca/settings.json
+++ b/src/worca/settings.json
@@ -280,6 +280,7 @@
         "restrict_git_commit": true
       },
       "test_gate_strikes": 2,
+      "dispatch_migration_version": 1,
       "dispatch": {
         "tools": {
           "always_disallowed": ["EnterPlanMode", "EnterWorktree", "TodoWrite"],
@@ -289,7 +290,11 @@
         "skills": {
           "always_disallowed": [
             "batch", "fewer-permission-prompts",
-            "loop", "schedule", "worca-*", "update-config",
+            "loop", "schedule",
+            "worca-release", "worca-rc", "worca-pr-prep", "worca-install",
+            "worca-sync", "worca-sync-commit", "worca-sync-pr",
+            "worca-agent-override", "worca-analyze", "worca-plan-new",
+            "update-config",
             "hookify:hookify", "hookify:configure", "hookify:list",
             "hookify:writing-rules", "init"
           ],

--- a/tests/test_dispatch_default_normalization.py
+++ b/tests/test_dispatch_default_normalization.py
@@ -1,0 +1,218 @@
+"""Tests for the W-054 follow-up dispatch-default normalization.
+
+Covers both the pure helpers in ``worca.hooks.tracking`` and the migration
+entry point ``worca.cli.init._migrate_dispatch_governance``. The fixtures here
+deliberately mirror the JS cases in
+``worca-ui/server/dispatch-migration.test.js`` so the two implementations stay
+in parity (same inputs → same outputs).
+"""
+
+import copy
+
+from worca.cli.init import _migrate_dispatch_governance
+from worca.hooks.tracking import (
+    DISPATCH_MIGRATION_VERSION,
+    _DISPATCH_DEFAULTS,
+    adopt_narrowed_skills_denylist,
+    adopt_stale_subagent_default,
+    normalize_dispatch_defaults,
+)
+
+# The legacy (W-038-era) Explore-only subagent default, as it survives a W-054
+# migration into per_agent_allow (plus the seeded _defaults wildcard).
+_STALE_SUBAGENTS = {
+    "planner": ["Explore"],
+    "coordinator": [],
+    "implementer": ["Explore"],
+    "tester": ["Explore"],
+    "guardian": ["Explore"],
+    "reviewer": ["Explore"],
+    "plan_reviewer": ["Explore"],
+    "learner": ["Explore"],
+    "_defaults": ["*"],
+}
+
+_LEGACY_SKILLS_DENYLIST = [
+    "batch",
+    "fewer-permission-prompts",
+    "loop",
+    "schedule",
+    "worca-*",
+    "update-config",
+    "hookify:hookify",
+    "hookify:configure",
+    "hookify:list",
+    "hookify:writing-rules",
+    "init",
+]
+
+
+def _pop1_config():
+    """A config already on the W-054 nested shape but pinned to the stale
+    Explore-only subagent default + broad worca-* skills glob, no version stamp.
+    """
+    return {
+        "dispatch": {
+            "subagents": {
+                "per_agent_allow": copy.deepcopy(_STALE_SUBAGENTS),
+                "always_disallowed": ["general-purpose"],
+                "default_denied": [],
+            },
+            "skills": {
+                "always_disallowed": list(_LEGACY_SKILLS_DENYLIST),
+                "default_denied": [],
+                "per_agent_allow": {"_defaults": ["*"]},
+            },
+            "tools": {
+                "always_disallowed": [],
+                "default_denied": [],
+                "per_agent_allow": {"_defaults": ["*"]},
+            },
+        }
+    }
+
+
+# --- Default-content guards --------------------------------------------------
+
+
+def test_default_skills_denylist_drops_glob_keeps_dangerous():
+    denylist = _DISPATCH_DEFAULTS["skills"]["always_disallowed"]
+    assert "worca-*" not in denylist
+    for must_deny in (
+        "worca-release",
+        "worca-rc",
+        "worca-pr-prep",
+        "worca-install",
+        "worca-sync",
+        "worca-agent-override",
+        "worca-analyze",
+        "worca-plan-new",
+    ):
+        assert must_deny in denylist
+    # Useful dev skills are NOT hard-denied any more.
+    for allowed in ("worca-dev-precommit", "worca-coverage", "worca-ui-add-card"):
+        assert allowed not in denylist
+
+
+# --- adopt_stale_subagent_default --------------------------------------------
+
+
+def test_adopt_collapses_stale_explore_default():
+    cfg = {"per_agent_allow": copy.deepcopy(_STALE_SUBAGENTS)}
+    assert adopt_stale_subagent_default(cfg) is True
+    assert cfg["per_agent_allow"] == {"_defaults": ["*"]}
+
+
+def test_adopt_preserves_customized_shape():
+    cfg = {
+        "per_agent_allow": {
+            "planner": ["Explore"],
+            "implementer": ["Explore", "feature-dev:code-reviewer"],
+            "_defaults": ["*"],
+        }
+    }
+    assert adopt_stale_subagent_default(cfg) is False
+    assert cfg["per_agent_allow"]["implementer"] == [
+        "Explore",
+        "feature-dev:code-reviewer",
+    ]
+
+
+def test_adopt_preserves_customized_defaults():
+    pa = copy.deepcopy(_STALE_SUBAGENTS)
+    pa["_defaults"] = ["Explore"]  # operator touched _defaults
+    cfg = {"per_agent_allow": pa}
+    assert adopt_stale_subagent_default(cfg) is False
+
+
+# --- adopt_narrowed_skills_denylist ------------------------------------------
+
+
+def test_adopt_narrows_legacy_skills_denylist():
+    cfg = {"always_disallowed": list(_LEGACY_SKILLS_DENYLIST)}
+    assert adopt_narrowed_skills_denylist(cfg) is True
+    assert "worca-*" not in cfg["always_disallowed"]
+    assert "worca-release" in cfg["always_disallowed"]
+
+
+def test_adopt_preserves_customized_skills_denylist():
+    cfg = {"always_disallowed": [*_LEGACY_SKILLS_DENYLIST, "custom-skill"]}
+    assert adopt_narrowed_skills_denylist(cfg) is False
+    assert "worca-*" in cfg["always_disallowed"]
+
+
+# --- normalize_dispatch_defaults (Pop 1) -------------------------------------
+
+
+def test_normalize_pop1_collapses_and_narrows_and_stamps():
+    gov = _pop1_config()
+    changes = normalize_dispatch_defaults(gov)
+    assert len(changes) == 2
+    assert gov["dispatch"]["subagents"]["per_agent_allow"] == {"_defaults": ["*"]}
+    assert "worca-*" not in gov["dispatch"]["skills"]["always_disallowed"]
+    assert "worca-release" in gov["dispatch"]["skills"]["always_disallowed"]
+    assert gov["dispatch_migration_version"] == DISPATCH_MIGRATION_VERSION
+
+
+def test_normalize_is_idempotent():
+    gov = _pop1_config()
+    normalize_dispatch_defaults(gov)
+    snapshot = copy.deepcopy(gov)
+    changes2 = normalize_dispatch_defaults(gov)
+    assert changes2 == []
+    assert gov == snapshot
+
+
+def test_normalize_skips_already_stamped_config():
+    gov = _pop1_config()
+    gov["dispatch_migration_version"] = DISPATCH_MIGRATION_VERSION
+    changes = normalize_dispatch_defaults(gov)
+    assert changes == []
+    # Stamp present → the operator's (stale-looking) values are left intact.
+    assert gov["dispatch"]["subagents"]["per_agent_allow"]["planner"] == ["Explore"]
+    assert "worca-*" in gov["dispatch"]["skills"]["always_disallowed"]
+
+
+def test_normalize_noop_without_dispatch_block():
+    gov = {"guards": {"block_rm_rf": True}}
+    assert normalize_dispatch_defaults(gov) == []
+    assert "dispatch_migration_version" not in gov
+
+
+# --- Pop 2: legacy subagent_dispatch through the migration entry point --------
+
+
+def test_migrate_pop2_subagent_dispatch_collapses_to_new_default():
+    gov = {
+        "subagent_dispatch": {
+            "planner": ["Explore"],
+            "coordinator": [],
+            "implementer": ["Explore"],
+            "tester": ["Explore"],
+            "guardian": ["Explore"],
+            "reviewer": ["Explore"],
+            "plan_reviewer": ["Explore"],
+            "learner": ["Explore"],
+        }
+    }
+    _migrate_dispatch_governance(gov, [])
+    pa = gov["dispatch"]["subagents"]["per_agent_allow"]
+    assert pa == {"_defaults": ["*"]}
+    assert gov["dispatch_migration_version"] == DISPATCH_MIGRATION_VERSION
+
+
+def test_migrate_pop2_preserves_customized_subagent_dispatch():
+    gov = {
+        "subagent_dispatch": {
+            "planner": ["Explore"],
+            "implementer": ["Explore", "feature-dev:code-reviewer"],
+            "tester": ["Explore"],
+            "guardian": ["Explore"],
+            "reviewer": ["Explore"],
+            "plan_reviewer": ["Explore"],
+            "learner": ["Explore"],
+        }
+    }
+    _migrate_dispatch_governance(gov, [])
+    pa = gov["dispatch"]["subagents"]["per_agent_allow"]
+    assert pa["implementer"] == ["Explore", "feature-dev:code-reviewer"]

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -1978,14 +1978,12 @@ sl-input [slot="prefix"] {
 }
 
 .dispatch-chip-locked {
-  text-decoration: line-through;
   opacity: 0.6;
 }
 
-/* Auto-included meta-tool chips (Skill, Agent) — locked but not crossed-out;
- * the line-through reads as "blocked", but these are present-and-required. */
+/* Auto-included meta-tool chips (Skill, Agent) — locked but visually distinct
+ * via the dashed border; present-and-required rather than blocked. */
 .dispatch-chip-auto {
-  text-decoration: none;
   opacity: 0.75;
   font-style: italic;
   border-style: dashed;
@@ -2023,6 +2021,21 @@ sl-input [slot="prefix"] {
 /* Dispatch section layout */
 .dispatch-section {
   margin-bottom: 16px;
+}
+
+/* Header row: optional section title on the left, per-section Reset on the
+ * right. Rendered at the top of each dispatch panel body (visible only when the
+ * sl-details is expanded). */
+.dispatch-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 28px;
+}
+
+.dispatch-section-reset {
+  margin-left: auto;
 }
 
 .dispatch-section-title {

--- a/worca-ui/app/views/dispatch-section.js
+++ b/worca-ui/app/views/dispatch-section.js
@@ -1,6 +1,34 @@
 import { html, nothing } from 'lit-html';
 import { isCustomized } from './dispatch-tag-state.js';
 
+/**
+ * Build the section config to stage when resetting a dispatch section to its
+ * defaults. Returns a deep copy of `defaults`, but ALSO explicitly resets every
+ * per-agent entry currently present in `currentConfig` to its default value.
+ *
+ * This is required because the settings save path deep-merges over the on-disk
+ * config and never deletes keys: simply staging the bare defaults (which omit
+ * customized agents) would leave the customizations on disk. Overwriting each
+ * present agent with its default value (an array, which the merge replaces)
+ * makes the reset actually persist on Save.
+ */
+export function resetSectionConfig(currentConfig, defaults) {
+  const def = structuredClone(defaults || currentConfig || {});
+  const defPerAgent = def.per_agent_allow || {};
+  const merged = { ...defPerAgent };
+  const curPerAgent = currentConfig?.per_agent_allow || {};
+  for (const agent of Object.keys(curPerAgent)) {
+    if (agent === '_defaults') continue;
+    if (!(agent in merged)) {
+      merged[agent] = defPerAgent[agent]
+        ? [...defPerAgent[agent]]
+        : [...(defPerAgent._defaults || ['*'])];
+    }
+  }
+  def.per_agent_allow = merged;
+  return def;
+}
+
 // Follow-up #4: hovering over the `*` chip explains what wildcard means.
 // Hovering a locked chip explains why it's there (e.g. always_disallowed
 // or, in the Tools section, the auto-included Skill/Agent meta-tools).
@@ -341,6 +369,13 @@ export function dispatchSectionView({
     });
   }
 
+  // Per-section reset: replace the whole section config (all three tiers) with
+  // the shipped defaults. Stages in memory only — the user must Save for it to
+  // persist, same as any other dispatch edit.
+  function resetSectionToDefaults() {
+    onChange(resetSectionConfig(config, defaults));
+  }
+
   function _agentDefault(agent) {
     return (
       defaults?.per_agent_allow?.[agent] ||
@@ -423,11 +458,23 @@ export function dispatchSectionView({
 
   return html`
     <div class="dispatch-section">
-      ${
-        showTitle
-          ? html`<h4 class="dispatch-section-title">${capitalize(section)}</h4>`
-          : nothing
-      }
+      <div class="dispatch-section-header">
+        ${
+          showTitle
+            ? html`<h4 class="dispatch-section-title">${capitalize(section)}</h4>`
+            : html`<span></span>`
+        }
+        <sl-button
+          size="small"
+          variant="text"
+          class="dispatch-section-reset"
+          data-section="${section}"
+          title="Reset ${capitalize(section)} to defaults (applies on Save)"
+          @click=${resetSectionToDefaults}
+        >
+          Reset
+        </sl-button>
+      </div>
       ${
         sectionHint
           ? html`<p class="dispatch-section-hint">${sectionHint}</p>`

--- a/worca-ui/app/views/dispatch-section.test.js
+++ b/worca-ui/app/views/dispatch-section.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DISPATCH_DEFAULTS } from '../../server/dispatch-defaults.js';
-import { dispatchSectionView } from './dispatch-section.js';
+import { dispatchSectionView, resetSectionConfig } from './dispatch-section.js';
 
 function renderToString(template) {
   if (!template) return '';
@@ -632,6 +632,110 @@ describe('dispatch-section', () => {
         ['review'],
       );
       expect(html).not.toContain('dispatch-wildcard-deny-warning');
+    });
+  });
+
+  describe('per-section reset', () => {
+    // Collect every function value (event handler) reachable in the template
+    // tree so we can invoke the section-reset handler directly — renderToString
+    // skips functions.
+    function collectHandlers(template, out = []) {
+      if (!template || !template.values) return out;
+      for (const v of template.values) {
+        if (typeof v === 'function') out.push(v);
+        else if (Array.isArray(v)) {
+          for (const item of v) collectHandlers(item, out);
+        } else if (v?.strings) collectHandlers(v, out);
+      }
+      return out;
+    }
+
+    for (const section of ['tools', 'skills', 'subagents']) {
+      it(`renders a per-section Reset button for ${section}`, () => {
+        const html = renderToString(
+          dispatchSectionView({
+            section,
+            config: {
+              always_disallowed: [],
+              default_denied: [],
+              per_agent_allow: { _defaults: ['*'] },
+            },
+            knownItems: [],
+            agentRoles: AGENT_ROLES,
+            defaults: DISPATCH_DEFAULTS[section],
+            onChange: vi.fn(),
+          }),
+        );
+        expect(html).toContain('dispatch-section-reset');
+        expect(html).toContain(`data-section="${section}"`);
+      });
+    }
+
+    it('reset handler emits onChange with the reset section config', () => {
+      const onChange = vi.fn();
+      // A customized config (planner pinned) that differs from defaults.
+      const config = {
+        always_disallowed: ['general-purpose'],
+        default_denied: [],
+        per_agent_allow: { planner: ['Explore'], _defaults: ['*'] },
+      };
+      const template = dispatchSectionView({
+        section: 'subagents',
+        config,
+        knownItems: KNOWN_SUBAGENTS,
+        agentRoles: AGENT_ROLES,
+        defaults: DISPATCH_DEFAULTS.subagents,
+        onChange,
+      });
+      for (const fn of collectHandlers(template)) {
+        try {
+          fn();
+        } catch {
+          /* per-agent input handlers expect a DOM event — ignore */
+        }
+      }
+      const expected = resetSectionConfig(config, DISPATCH_DEFAULTS.subagents);
+      const resetCall = onChange.mock.calls.find(
+        ([arg]) => JSON.stringify(arg) === JSON.stringify(expected),
+      );
+      expect(resetCall).toBeTruthy();
+      // planner is reset away from the customization, back to the wildcard.
+      expect(resetCall[0].per_agent_allow.planner).toEqual(['*']);
+    });
+  });
+
+  describe('resetSectionConfig (deep-merge-safe reset)', () => {
+    it('returns a deep copy of the defaults (no shared reference)', () => {
+      const out = resetSectionConfig(
+        { per_agent_allow: { _defaults: ['*'] } },
+        DISPATCH_DEFAULTS.skills,
+      );
+      expect(out).not.toBe(DISPATCH_DEFAULTS.skills);
+      expect(out.always_disallowed).toEqual(
+        DISPATCH_DEFAULTS.skills.always_disallowed,
+      );
+    });
+
+    it('overwrites a customized agent with its default value so save can clear it', () => {
+      // subagents defaults have no per-agent entries → planner falls back to the
+      // wildcard default rather than being silently dropped.
+      const out = resetSectionConfig(
+        { per_agent_allow: { planner: ['Explore', 'Plan'], _defaults: ['*'] } },
+        DISPATCH_DEFAULTS.subagents,
+      );
+      expect(out.per_agent_allow.planner).toEqual(['*']);
+    });
+
+    it('restores a section-default agent value (skills implementer)', () => {
+      const out = resetSectionConfig(
+        {
+          per_agent_allow: { implementer: ['custom-skill'], _defaults: ['*'] },
+        },
+        DISPATCH_DEFAULTS.skills,
+      );
+      expect(out.per_agent_allow.implementer).toEqual(
+        DISPATCH_DEFAULTS.skills.per_agent_allow.implementer,
+      );
     });
   });
 });

--- a/worca-ui/app/views/settings.js
+++ b/worca-ui/app/views/settings.js
@@ -36,7 +36,7 @@ import {
 import { STAGE_ORDER } from '../utils/stage-order.js';
 import { isVersionBehind } from '../utils/version-compare.js';
 import { AGENT_NAMES } from './agent-names.js';
-import { dispatchSectionView } from './dispatch-section.js';
+import { dispatchSectionView, resetSectionConfig } from './dispatch-section.js';
 import { KNOWN_TYPES } from './dispatch-tag-state.js';
 import { integrationsTab } from './integrations.js';
 
@@ -160,6 +160,7 @@ export const DEFAULT_GOVERNANCE = {
     restrict_git_commit: true,
   },
   test_gate_strikes: 2,
+  dispatch_migration_version: 1,
   dispatch: {
     tools: { ...DISPATCH_DEFAULTS.tools },
     skills: { ...DISPATCH_DEFAULTS.skills },
@@ -590,6 +591,46 @@ function confirmReset(section, rerender) {
       confirmLabel: 'Reset',
       confirmVariant: 'danger',
       onConfirm: () => resetSection(section, rerender),
+    },
+    rerender,
+  );
+}
+
+// Governance-tab reset is staged in memory (NOT an immediate server reset like
+// confirmReset/resetSection): it restores DEFAULT_GOVERNANCE in settingsData so
+// the form re-renders to defaults, and the user must click Save to persist —
+// matching the per-section Reset behaviour in the dispatch panels.
+function resetGovernanceTabInMemory(rerender) {
+  if (!settingsData?.worca) return;
+  const current = settingsData.worca.governance || {};
+  const reset = structuredClone(DEFAULT_GOVERNANCE);
+  // The save path deep-merges and never deletes keys, so reset each dispatch
+  // section through resetSectionConfig — that explicitly overwrites every
+  // currently-customized per-agent entry with its default value so the reset
+  // actually persists on Save (see resetSectionConfig).
+  for (const section of ['tools', 'skills', 'subagents']) {
+    reset.dispatch[section] = resetSectionConfig(
+      current.dispatch?.[section],
+      DISPATCH_DEFAULTS[section],
+    );
+  }
+  settingsData.worca.governance = reset;
+  resetDispatchEditState();
+  saveStatus = null;
+  saveMessage = '';
+  rerender();
+}
+
+function confirmResetGovernance(rerender) {
+  showConfirm(
+    {
+      label: 'Reset Governance',
+      message: html`Reset all <strong>Governance</strong> settings (guard rules,
+        test gate, and dispatch rules) to their defaults? Changes apply when you
+        click <strong>Save</strong>.`,
+      confirmLabel: 'Reset',
+      confirmVariant: 'danger',
+      onConfirm: () => resetGovernanceTabInMemory(rerender),
     },
     rerender,
   );
@@ -1252,7 +1293,7 @@ export function governanceTab(worca, permissions, rerender) {
           ${unsafeHTML(iconSvg(Save, 14))}
           Save
         </sl-button>
-        <sl-button variant="default" size="small" outline @click=${() => confirmReset('governance', rerender)}>
+        <sl-button variant="default" size="small" outline @click=${() => confirmResetGovernance(rerender)}>
           ${unsafeHTML(iconSvg(RefreshCw, 14))}
           Reset
         </sl-button>

--- a/worca-ui/e2e/settings-dispatch-sections.spec.js
+++ b/worca-ui/e2e/settings-dispatch-sections.spec.js
@@ -574,3 +574,126 @@ test('Esc clears input and dismisses suggestions popup', async ({ page }) => {
     await ctx.close();
   }
 });
+
+// ─── W-054 follow-up: strikethrough removal + per-section / per-tab reset ─────
+
+test('always_disallowed chips are not struck through', async ({ page }) => {
+  const ctx = await startServer();
+  try {
+    await goToGovernance(page, ctx, {});
+    await expandDispatchSection(page, 'tools');
+
+    const lockedChip = page.locator(
+      'sl-tag.dispatch-chip-locked[data-value="EnterPlanMode"]',
+    );
+    await expect(lockedChip).toBeVisible();
+    const decoration = await lockedChip.evaluate(
+      (el) => getComputedStyle(el).textDecorationLine,
+    );
+    expect(decoration).not.toBe('line-through');
+  } finally {
+    await ctx.close();
+  }
+});
+
+test('per-section Reset stages defaults and persists on Save', async ({
+  page,
+}) => {
+  const ctx = await startServer();
+  try {
+    await goToGovernance(page, ctx, {
+      worca: {
+        governance: {
+          dispatch: {
+            subagents: {
+              always_disallowed: ['general-purpose'],
+              default_denied: [],
+              per_agent_allow: {
+                planner: ['Explore', 'Plan'],
+                _defaults: ['*'],
+              },
+            },
+          },
+        },
+      },
+    });
+    await expandDispatchSection(page, 'subagents');
+
+    const planChip = page.locator(
+      '#dispatch-subagents-planner sl-tag[data-value="Plan"]',
+    );
+    await expect(planChip).toBeVisible();
+
+    // Per-section Reset (top-right of the expanded panel) stages defaults.
+    await page
+      .locator('.dispatch-section-reset[data-section="subagents"]')
+      .click();
+    await expect(planChip).not.toBeAttached();
+
+    // Persist and round-trip.
+    await saveGovernanceTab(page);
+    await page.reload(GOTO_OPTS);
+    await page.locator('sl-tab[panel="governance"]').click();
+    await expandDispatchSection(page, 'subagents');
+    await expect(
+      page.locator('#dispatch-subagents-planner sl-tag[data-value="Plan"]'),
+    ).not.toBeAttached();
+  } finally {
+    await ctx.close();
+  }
+});
+
+test('bottom Reset stages tab defaults in memory and requires Save to persist', async ({
+  page,
+}) => {
+  const ctx = await startServer();
+  try {
+    await goToGovernance(page, ctx, {
+      worca: {
+        governance: {
+          dispatch: {
+            subagents: {
+              always_disallowed: ['general-purpose'],
+              default_denied: [],
+              per_agent_allow: {
+                planner: ['Explore', 'Plan'],
+                _defaults: ['*'],
+              },
+            },
+          },
+        },
+      },
+    });
+    await expandDispatchSection(page, 'subagents');
+    const planChip = page.locator(
+      '#dispatch-subagents-planner sl-tag[data-value="Plan"]',
+    );
+    await expect(planChip).toBeVisible();
+
+    // Bottom Reset (whole tab) → confirm dialog → reset staged in memory.
+    await page
+      .locator(
+        'sl-tab-panel[name="governance"] .settings-tab-actions sl-button[variant="default"]',
+      )
+      .click();
+    // showConfirm() opens the dialog via getElementById().show(); when more than
+    // one #global-confirm-dialog is mounted (app shell + settings view) only the
+    // opened one carries the [open] attribute.
+    const dialog = page.locator('#global-confirm-dialog[open]');
+    await expect(dialog).toBeVisible();
+    await dialog.locator('sl-button[variant="danger"]').click();
+
+    // Staged in memory — custom chip gone without a Save.
+    await expect(planChip).not.toBeAttached();
+
+    // Not persisted: reload (no Save) restores the on-disk customization.
+    await page.reload(GOTO_OPTS);
+    await page.locator('sl-tab[panel="governance"]').click();
+    await expandDispatchSection(page, 'subagents');
+    await expect(
+      page.locator('#dispatch-subagents-planner sl-tag[data-value="Plan"]'),
+    ).toBeVisible();
+  } finally {
+    await ctx.close();
+  }
+});

--- a/worca-ui/server/dispatch-defaults.js
+++ b/worca-ui/server/dispatch-defaults.js
@@ -18,7 +18,22 @@ export const DISPATCH_DEFAULTS = {
       'fewer-permission-prompts',
       'loop',
       'schedule',
-      'worca-*',
+      // worca-* dev skills that genuinely must stay off-limits to pipeline
+      // agents: release/publish, PR merges, cross-repo sync, installation,
+      // agent/governance override (privilege escalation), pipeline launch
+      // (recursion), and autonomous issue/plan creation. The rest of the
+      // worca-* dev tooling (precommit, coverage, ui/event scaffolding,
+      // webhook-test, issue read) is allowed via the per-agent '*' wildcard.
+      'worca-release',
+      'worca-rc',
+      'worca-pr-prep',
+      'worca-install',
+      'worca-sync',
+      'worca-sync-commit',
+      'worca-sync-pr',
+      'worca-agent-override',
+      'worca-analyze',
+      'worca-plan-new',
       'update-config',
       'hookify:hookify',
       'hookify:configure',

--- a/worca-ui/server/dispatch-defaults.test.js
+++ b/worca-ui/server/dispatch-defaults.test.js
@@ -32,7 +32,26 @@ describe('DISPATCH_DEFAULTS', () => {
 
   it('skills always_disallowed includes pipeline-recursion skills', () => {
     expect(DISPATCH_DEFAULTS.skills.always_disallowed).toEqual(
-      expect.arrayContaining(['loop', 'schedule', 'worca-*', 'init']),
+      expect.arrayContaining(['loop', 'schedule', 'init']),
+    );
+  });
+
+  it('skills always_disallowed names dangerous worca-* skills individually, not via a glob', () => {
+    // The broad `worca-*` glob was narrowed so useful dev skills (precommit,
+    // coverage, ui/event scaffolding) are dispatchable; only genuinely
+    // dangerous worca-* skills (release/sync/override/launch) stay hard-denied.
+    expect(DISPATCH_DEFAULTS.skills.always_disallowed).not.toContain('worca-*');
+    expect(DISPATCH_DEFAULTS.skills.always_disallowed).toEqual(
+      expect.arrayContaining([
+        'worca-release',
+        'worca-rc',
+        'worca-pr-prep',
+        'worca-install',
+        'worca-sync',
+        'worca-agent-override',
+        'worca-analyze',
+        'worca-plan-new',
+      ]),
     );
   });
 

--- a/worca-ui/server/dispatch-migration.js
+++ b/worca-ui/server/dispatch-migration.js
@@ -55,12 +55,141 @@ function _absorbFlatDispatchKeys(dispatch) {
   return true;
 }
 
+// --- One-time dispatch-default normalization (W-054 follow-up) -------------
+//
+// Mirror of normalize_dispatch_defaults() in src/worca/hooks/tracking.py.
+// Bumped when a new one-time normalization is added; stamped onto
+// governance.dispatch_migration_version so it runs exactly once per config.
+export const DISPATCH_MIGRATION_VERSION = 1;
+
+// Pre-W-054 (W-038-era) shipped subagent default: every pipeline agent capped
+// to Explore-only. coordinator:[] / empty lists fall through to _defaults and
+// are ignored in the comparison.
+const _LEGACY_EXPLORE_SUBAGENT_DEFAULT = {
+  planner: ['Explore'],
+  implementer: ['Explore'],
+  tester: ['Explore'],
+  guardian: ['Explore'],
+  reviewer: ['Explore'],
+  plan_reviewer: ['Explore'],
+  learner: ['Explore'],
+};
+
+// Pre-narrowing skills denylist (carried the broad `worca-*` glob).
+const _LEGACY_SKILLS_ALWAYS_DISALLOWED = new Set([
+  'batch',
+  'fewer-permission-prompts',
+  'loop',
+  'schedule',
+  'worca-*',
+  'update-config',
+  'hookify:hookify',
+  'hookify:configure',
+  'hookify:list',
+  'hookify:writing-rules',
+  'init',
+]);
+
+function _canonicalPerAgent(perAgent) {
+  const out = {};
+  for (const [agent, allow] of Object.entries(perAgent)) {
+    if (agent === '_defaults') continue;
+    if (!Array.isArray(allow) || allow.length === 0) continue;
+    out[agent] = [...allow].sort();
+  }
+  return out;
+}
+
+function _sameStringMap(a, b) {
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) {
+    const av = a[k];
+    const bv = b[k];
+    if (!Array.isArray(bv) || av.length !== bv.length) return false;
+    for (let i = 0; i < av.length; i++) {
+      if (av[i] !== bv[i]) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Collapse a stale Explore-only per_agent_allow to the new `_defaults: ["*"]`
+ * default. Only fires on the untouched W-038 shape with an unset/wildcard
+ * _defaults. Returns true if changed.
+ */
+export function adoptStaleSubagentDefault(subagentsCfg) {
+  if (!subagentsCfg || typeof subagentsCfg !== 'object') return false;
+  const pa = subagentsCfg.per_agent_allow;
+  if (!pa || typeof pa !== 'object' || Array.isArray(pa)) return false;
+  const def = pa._defaults;
+  const defOk =
+    def === undefined ||
+    (Array.isArray(def) && def.length === 1 && def[0] === '*');
+  if (!defOk) return false;
+  const expected = _canonicalPerAgent(_LEGACY_EXPLORE_SUBAGENT_DEFAULT);
+  if (!_sameStringMap(_canonicalPerAgent(pa), expected)) return false;
+  subagentsCfg.per_agent_allow = { _defaults: ['*'] };
+  return true;
+}
+
+/**
+ * Widen an untouched skills denylist (broad `worca-*`) to the current set.
+ * Exact-match (set) guarded. Returns true if changed.
+ */
+export function adoptNarrowedSkillsDenylist(skillsCfg) {
+  if (!skillsCfg || typeof skillsCfg !== 'object') return false;
+  const current = skillsCfg.always_disallowed;
+  if (!Array.isArray(current)) return false;
+  if (current.length !== _LEGACY_SKILLS_ALWAYS_DISALLOWED.size) return false;
+  for (const item of current) {
+    if (!_LEGACY_SKILLS_ALWAYS_DISALLOWED.has(item)) return false;
+  }
+  skillsCfg.always_disallowed = [...DISPATCH_DEFAULTS.skills.always_disallowed];
+  return true;
+}
+
+/**
+ * Apply one-time dispatch-default normalizations, gated by a version stamp.
+ * Brings an *untouched* config up to current shipped defaults for the two
+ * things that changed after W-054 (subagent per_agent_allow, skills denylist).
+ * Mutates governanceCfg; returns change descriptions.
+ */
+export function normalizeDispatchDefaults(governanceCfg) {
+  const changes = [];
+  if (!governanceCfg || typeof governanceCfg !== 'object') return changes;
+  let stamp = governanceCfg.dispatch_migration_version;
+  if (!Number.isInteger(stamp)) stamp = 0;
+  if (stamp >= DISPATCH_MIGRATION_VERSION) return changes;
+  const dispatch = governanceCfg.dispatch;
+  if (!dispatch || typeof dispatch !== 'object' || Array.isArray(dispatch)) {
+    return changes;
+  }
+  if (adoptStaleSubagentDefault(dispatch.subagents)) {
+    changes.push(
+      'governance.dispatch.subagents: adopted new default (_defaults:["*"]) for config pinned to legacy Explore-only set',
+    );
+  }
+  if (adoptNarrowedSkillsDenylist(dispatch.skills)) {
+    changes.push(
+      'governance.dispatch.skills.always_disallowed: narrowed legacy "worca-*" glob to the current must-disallow set',
+    );
+  }
+  governanceCfg.dispatch_migration_version = DISPATCH_MIGRATION_VERSION;
+  return changes;
+}
+
 /**
  * Migrate legacy governance.subagent_dispatch and/or legacy flat
- * governance.dispatch (agent-keyed) → governance.dispatch.subagents.per_agent_allow.
+ * governance.dispatch (agent-keyed) → governance.dispatch.subagents.per_agent_allow,
+ * then apply the one-time dispatch-default normalization.
  *
- * Seeds _defaults, adds tools/skills defaults, drops _dispatch_legacy.
- * Idempotent — returns [] on already-migrated configs.
+ * Seeds _defaults, adds tools/skills defaults, drops _dispatch_legacy. The
+ * normalization runs even with no legacy shape so already-migrated configs
+ * pinned to the stale Explore-only subagent default (or the broad `worca-*`
+ * skills glob) self-heal on next save. Gated by a version stamp → idempotent.
  *
  * @param {object} worcaConfig — the `worca` object from settings (mutated)
  * @returns {string[]} list of change descriptions (empty = no-op)
@@ -73,60 +202,64 @@ export function migrateDispatchGovernance(worcaConfig) {
   const hasSubagentDispatch = 'subagent_dispatch' in gov;
   const hasLegacyFlatDispatch = _isLegacyFlatDispatch(gov.dispatch);
 
-  if (!hasSubagentDispatch && !hasLegacyFlatDispatch) return changes;
+  if (hasSubagentDispatch || hasLegacyFlatDispatch) {
+    if (!gov.dispatch || Array.isArray(gov.dispatch)) gov.dispatch = {};
+    const dispatch = gov.dispatch;
 
-  if (!gov.dispatch || Array.isArray(gov.dispatch)) gov.dispatch = {};
-  const dispatch = gov.dispatch;
-
-  // Absorb legacy flat shape (pre-W-038) first so subagent_dispatch values
-  // take precedence below.
-  if (hasLegacyFlatDispatch) {
-    _absorbFlatDispatchKeys(dispatch);
-    changes.push(
-      'governance.dispatch (flat agent-keyed) -> governance.dispatch.subagents (W-054)',
-    );
-  }
-
-  if (hasSubagentDispatch) {
-    const old = gov.subagent_dispatch;
-    delete gov.subagent_dispatch;
-    if (!dispatch.subagents) dispatch.subagents = {};
-    if (!dispatch.subagents.per_agent_allow) {
-      dispatch.subagents.per_agent_allow = {};
+    // Absorb legacy flat shape (pre-W-038) first so subagent_dispatch values
+    // take precedence below.
+    if (hasLegacyFlatDispatch) {
+      _absorbFlatDispatchKeys(dispatch);
+      changes.push(
+        'governance.dispatch (flat agent-keyed) -> governance.dispatch.subagents (W-054)',
+      );
     }
-    Object.assign(dispatch.subagents.per_agent_allow, old);
-    changes.push(
-      'governance.subagent_dispatch -> governance.dispatch.subagents (W-054)',
-    );
+
+    if (hasSubagentDispatch) {
+      const old = gov.subagent_dispatch;
+      delete gov.subagent_dispatch;
+      if (!dispatch.subagents) dispatch.subagents = {};
+      if (!dispatch.subagents.per_agent_allow) {
+        dispatch.subagents.per_agent_allow = {};
+      }
+      Object.assign(dispatch.subagents.per_agent_allow, old);
+      changes.push(
+        'governance.subagent_dispatch -> governance.dispatch.subagents (W-054)',
+      );
+    }
+
+    if (!dispatch.subagents) dispatch.subagents = {};
+    const subagents = dispatch.subagents;
+
+    if (!subagents.per_agent_allow) subagents.per_agent_allow = {};
+    if (!('_defaults' in subagents.per_agent_allow)) {
+      subagents.per_agent_allow._defaults = [
+        ...DISPATCH_DEFAULTS.subagents.per_agent_allow._defaults,
+      ];
+    }
+
+    if (!subagents.always_disallowed) {
+      subagents.always_disallowed = [
+        ...DISPATCH_DEFAULTS.subagents.always_disallowed,
+      ];
+    }
+    if (!subagents.default_denied) {
+      subagents.default_denied = [
+        ...DISPATCH_DEFAULTS.subagents.default_denied,
+      ];
+    }
+
+    if (!dispatch.tools) {
+      dispatch.tools = structuredClone(DISPATCH_DEFAULTS.tools);
+    }
+    if (!dispatch.skills) {
+      dispatch.skills = structuredClone(DISPATCH_DEFAULTS.skills);
+    }
+
+    delete gov._dispatch_legacy;
   }
 
-  if (!dispatch.subagents) dispatch.subagents = {};
-  const subagents = dispatch.subagents;
-
-  if (!subagents.per_agent_allow) subagents.per_agent_allow = {};
-  if (!('_defaults' in subagents.per_agent_allow)) {
-    subagents.per_agent_allow._defaults = [
-      ...DISPATCH_DEFAULTS.subagents.per_agent_allow._defaults,
-    ];
-  }
-
-  if (!subagents.always_disallowed) {
-    subagents.always_disallowed = [
-      ...DISPATCH_DEFAULTS.subagents.always_disallowed,
-    ];
-  }
-  if (!subagents.default_denied) {
-    subagents.default_denied = [...DISPATCH_DEFAULTS.subagents.default_denied];
-  }
-
-  if (!dispatch.tools) {
-    dispatch.tools = structuredClone(DISPATCH_DEFAULTS.tools);
-  }
-  if (!dispatch.skills) {
-    dispatch.skills = structuredClone(DISPATCH_DEFAULTS.skills);
-  }
-
-  delete gov._dispatch_legacy;
+  changes.push(...normalizeDispatchDefaults(gov));
 
   return changes;
 }

--- a/worca-ui/server/dispatch-migration.test.js
+++ b/worca-ui/server/dispatch-migration.test.js
@@ -165,7 +165,10 @@ describe('migrateDispatchGovernance', () => {
     );
   });
 
-  it('preserves full eight-agent enumerated shape', () => {
+  it('collapses the legacy Explore-only default to the new wildcard default', () => {
+    // The full eight-agent Explore-only enumeration is the untouched W-038
+    // default. The W-054 follow-up adopts the new permissive `_defaults: ["*"]`
+    // default for it instead of preserving the per-agent Explore caps.
     const worca = {
       governance: {
         subagent_dispatch: {
@@ -182,11 +185,124 @@ describe('migrateDispatchGovernance', () => {
     };
     migrateDispatchGovernance(worca);
     const pa = worca.governance.dispatch.subagents.per_agent_allow;
+    expect(pa).toEqual({ _defaults: ['*'] });
+    expect(worca.governance.dispatch_migration_version).toBe(1);
+  });
+
+  it('preserves a genuinely customized subagent shape', () => {
+    // A shape that differs from the untouched W-038 default (here: an extra
+    // allowed subagent) is a deliberate operator choice and must survive.
+    const worca = {
+      governance: {
+        subagent_dispatch: {
+          planner: ['Explore'],
+          implementer: ['Explore', 'feature-dev:code-reviewer'],
+          tester: ['Explore'],
+          guardian: ['Explore'],
+          reviewer: ['Explore'],
+          plan_reviewer: ['Explore'],
+          learner: ['Explore'],
+        },
+      },
+    };
+    migrateDispatchGovernance(worca);
+    const pa = worca.governance.dispatch.subagents.per_agent_allow;
+    expect(pa.implementer).toEqual(['Explore', 'feature-dev:code-reviewer']);
     expect(pa.planner).toEqual(['Explore']);
-    expect(pa.coordinator).toEqual([]);
-    expect(pa.implementer).toEqual(['Explore']);
-    // PR B: subagents _defaults is now ['*']; the migration seeds the new
-    // default for projects that didn't have an explicit _defaults entry.
-    expect(pa._defaults).toEqual(['*']);
+  });
+});
+
+describe('normalizeDispatchDefaults (W-054 follow-up)', () => {
+  // Pop-1 fixture: already on the W-054 nested shape (no legacy keys) but still
+  // pinned to the stale Explore-only subagent default + broad worca-* skills
+  // glob, with no version stamp.
+  function pop1Config() {
+    return {
+      governance: {
+        dispatch: {
+          subagents: {
+            per_agent_allow: {
+              planner: ['Explore'],
+              coordinator: [],
+              implementer: ['Explore'],
+              tester: ['Explore'],
+              guardian: ['Explore'],
+              reviewer: ['Explore'],
+              plan_reviewer: ['Explore'],
+              learner: ['Explore'],
+              _defaults: ['*'],
+            },
+            always_disallowed: ['general-purpose'],
+            default_denied: [],
+          },
+          skills: {
+            always_disallowed: [
+              'batch',
+              'fewer-permission-prompts',
+              'loop',
+              'schedule',
+              'worca-*',
+              'update-config',
+              'hookify:hookify',
+              'hookify:configure',
+              'hookify:list',
+              'hookify:writing-rules',
+              'init',
+            ],
+            default_denied: [],
+            per_agent_allow: { _defaults: ['*'] },
+          },
+          tools: {
+            always_disallowed: [],
+            default_denied: [],
+            per_agent_allow: { _defaults: ['*'] },
+          },
+        },
+      },
+    };
+  }
+
+  it('collapses stale Pop-1 subagent default and narrows the skills glob', () => {
+    const worca = pop1Config();
+    const changes = migrateDispatchGovernance(worca);
+    const d = worca.governance.dispatch;
+    expect(d.subagents.per_agent_allow).toEqual({ _defaults: ['*'] });
+    expect(d.skills.always_disallowed).not.toContain('worca-*');
+    expect(d.skills.always_disallowed).toContain('worca-release');
+    expect(worca.governance.dispatch_migration_version).toBe(1);
+    expect(changes.length).toBeGreaterThan(0);
+  });
+
+  it('is idempotent — a second pass makes no changes', () => {
+    const worca = pop1Config();
+    migrateDispatchGovernance(worca);
+    const snapshot = JSON.stringify(worca);
+    const changes = migrateDispatchGovernance(worca);
+    expect(changes).toEqual([]);
+    expect(JSON.stringify(worca)).toBe(snapshot);
+  });
+
+  it('does not touch a config already stamped at the current version', () => {
+    const worca = pop1Config();
+    worca.governance.dispatch_migration_version = 1;
+    const changes = migrateDispatchGovernance(worca);
+    // Stamp present → stale shapes are left exactly as the operator left them.
+    expect(changes).toEqual([]);
+    expect(worca.governance.dispatch.subagents.per_agent_allow.planner).toEqual(
+      ['Explore'],
+    );
+    expect(worca.governance.dispatch.skills.always_disallowed).toContain(
+      'worca-*',
+    );
+  });
+
+  it('preserves a Pop-1 config with a customized _defaults', () => {
+    const worca = pop1Config();
+    worca.governance.dispatch.subagents.per_agent_allow._defaults = ['Explore'];
+    migrateDispatchGovernance(worca);
+    // Customized _defaults means the operator touched it → not collapsed.
+    expect(worca.governance.dispatch.subagents.per_agent_allow.planner).toEqual(
+      ['Explore'],
+    );
   });
 });

--- a/worca-ui/server/settings-validator.js
+++ b/worca-ui/server/settings-validator.js
@@ -437,6 +437,16 @@ export function validateSettingsPayload(body, options = {}) {
             );
           }
         }
+        if (g.dispatch_migration_version !== undefined) {
+          if (
+            !Number.isInteger(g.dispatch_migration_version) ||
+            g.dispatch_migration_version < 0
+          ) {
+            details.push(
+              'dispatch_migration_version must be a non-negative integer',
+            );
+          }
+        }
         if (g.dispatch !== undefined) {
           if (
             typeof g.dispatch !== 'object' ||


### PR DESCRIPTION
## Summary

W-054 follow-up. Fixes the upgrade path that left projects pinned to the old Explore-only subagent dispatch default, narrows the over-broad `worca-*` skills denylist, and improves the Governance settings UI.

Motivation: after upgrading to the W-054 three-tier dispatch model, projects that were on the **old shipped default** (every pipeline agent capped to `["Explore"]`) stayed locked to Explore-only — the migration preserved their values verbatim, but those values *were* the stale default, not a deliberate choice. Meanwhile the `worca-*` glob hard-denied every dev skill, including harmless ones.

## What's in it

**Migration (Python + JS parity, version-stamped)**
- Detects the untouched W-038 Explore-only subagent default in **both** populations — the pre-migration `subagent_dispatch` (not-yet-upgraded) and the already-migrated `dispatch.subagents.per_agent_allow` — and collapses it to `{_defaults:["*"]}`. The already-migrated case is handled **silently** (no banner/notice).
- Narrows `skills.always_disallowed` from the `worca-*` glob to the genuinely dangerous skills only: `worca-release`, `worca-rc`, `worca-pr-prep`, `worca-install`, `worca-sync`, `worca-sync-commit`, `worca-sync-pr`, `worca-agent-override`, `worca-analyze`, `worca-plan-new`. Useful dev skills (`worca-dev-precommit`, `worca-coverage`, `worca-ui-add-*`, `worca-event-add`, `worca-webhook-test`, `worca-issue`) become dispatchable.
- Both are **exact-match guarded** (a customized config is never silently widened) and **gated by a new `governance.dispatch_migration_version` stamp** so they run exactly once and are idempotent. Logic mirrored in `src/worca/hooks/tracking.py` and `worca-ui/server/dispatch-migration.js`.

**UI**
- Removed the strikethrough on always-disallowed dispatch badges.
- Added a per-section **Reset** button to each tools/skills/subagents panel, and converted the Governance bottom Reset to **stage defaults in memory (requires Save)** rather than resetting on the server immediately. `resetSectionConfig` works around deep-merge-on-save (which can't delete keys) by overwriting each customized agent with its default value.

## Test plan

- **Python:** new `tests/test_dispatch_default_normalization.py` (Pop-1/Pop-2 collapse, idempotency, stamp gating, customization preservation, narrowed-denylist content). Mirrors the JS fixtures for cross-language parity.
- **JS unit:** extended `dispatch-migration.test.js` + `dispatch-section.test.js` (reset helper, per-section reset button); updated `dispatch-defaults.test.js` for the narrowed denylist.
- **Playwright:** 3 new e2e in `settings-dispatch-sections.spec.js` — always-disallowed badges not struck through, per-section reset round-trips through Save, bottom reset stages in memory and requires Save to persist.
- Gauntlet: ruff ✅, biome ✅, vitest ✅ (one pre-existing flaky WS timing test, passes in isolation), governance Playwright specs ✅ (28).

## Migration note

`MIGRATION.md` gains a `0.34.x → 0.35.0` entry documenting both auto-normalizations, the version stamp, the exact-match-preserves-customizations guarantee, and the keep-old-behavior opt-out.

## Reviewer notes

- Gitignored files were intentionally **not** committed: `.claude/settings.json` (the dogfooding config was fixed locally) and `worca-ui/app/main.bundle.js` (CI rebuilds it).
- The shipped default lives in four places, all updated: `tracking.py` `_DISPATCH_DEFAULTS`, `worca-ui/server/dispatch-defaults.js`, and `src/worca/settings.json` (plus the local `.claude/settings.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)