### PR TITLE
feat: effort system — reliable labels, unified UI badge, effort-aware defaults

### DIFF
--- a/docs/effort.md
+++ b/docs/effort.md
@@ -4,6 +4,30 @@ Worca surfaces Claude Code's reasoning-effort scale (`low | medium | high | xhig
 
 Configuration lives under `worca.effort` and `worca.agents.<agent>.effort` in `.claude/settings.json`.
 
+## Precedence
+
+Effort values resolve through three layers, each overriding the previous:
+
+**template > project > model default**
+
+1. **Model default** — when no `effort` value is configured, the env var is omitted and Claude Code uses its built-in default.
+2. **Project settings** — `worca.agents.<agent>.effort` in `.claude/settings.json`. Applies to all runs in the project.
+3. **Template override** — the template `config` block is deep-merged over project `worca` settings (`templates.py:deep_merge_config`; template scalars win) into the temp settings file the runner reads end-to-end (`run_pipeline.py:271-294`); worktree runs forward `--template` through (`run_worktree.py:166`). Unspecified keys fall through to the project value.
+
+Under `adaptive` mode, per-bead labels add a fourth dimension: the coordinator's structured-output classification drives the implementer's starting point when no explicit per-agent value is set. This interacts with precedence as follows: an explicit template or project value overrides the bead label (`skip_reason = "explicit_override"`); an unset value lets the label through.
+
+### Design principle
+
+Set explicit effort for:
+- **High-stakes/irreversible work** (guardian — commit/PR is permanent)
+- **Heavy upfront reasoning** (planner — plan quality compounds)
+- **Loop-controlling judgment gates** (reviewer, plan_reviewer, coordinator — review quality drives `review_changes` loop count; coordinator effort determines classification quality)
+
+Leave unset for:
+- **Mechanical/verification work** (tester — deterministic pass/fail)
+- **Adaptive-label-driven work** (implementer — bead label is the intended driver under `adaptive` mode)
+- **Low-stakes/disabled-by-default stages** (learner)
+
 ## Mode semantics
 
 The `worca.effort.auto_mode` field controls two orthogonal axes: **starting point** (where does the effort level come from?) and **escalation** (does loopback bump it?).
@@ -130,11 +154,22 @@ The coordinator classifies effort for every bead during decomposition, regardles
 | `xhigh` | Schema/migration work, concurrency, security-sensitive paths, multi-stage refactors with subtle invariants. |
 | `max` | Never pick autonomously. Reserved for explicit human or template signal. |
 
-Labels are attached via `bd create --labels "run:<run_id>,worca-effort:<level>"` and reasoning is written via `bd update <id> --notes "Effort: <level> -- <reasoning>"`.
+### Reliable labels via structured output
+
+Labels reach beads through two complementary paths (belt-and-suspenders):
+
+1. **`--labels` flag on `bd create`** — the coordinator attaches `worca-effort:<level>` during decomposition. This is best-effort; the model may omit the flag.
+2. **`effort` map in structured output** — the coordinator returns an `effort` object in its `coordinate.json` response, mapping each bead ID to its classified level. The runner applies `worca-effort:<level>` labels programmatically from this map immediately after the existing `run:` label backfill (`runner.py:2970`).
+
+The structured output is the reliable fallback. The runner applies from the map only when no `worca-effort:*` label is already present on the bead, so a coordinator-set or user-set label is never overwritten. Unknown bead IDs and invalid levels are skipped with a stderr warning — the pipeline never halts on label issues.
+
+The `effort` field in `coordinate.json` is optional and validated against a `low|medium|high|xhigh|max` enum. Runs that omit it keep pre-existing behavior (model-default fallback + warning).
+
+Reasoning is written via `bd update <id> --notes "Effort: <level> -- <reasoning>"`.
 
 If a bead already has a `worca-effort:*` label (user-set), the coordinator preserves it. User-set labels are authoritative.
 
-If a bead is missing a label after the coordinator finishes, the runner logs a warning and `resolve_effort()` falls back to model default. The pipeline does not halt.
+If a bead is missing a label after both paths, the runner logs a warning and `resolve_effort()` falls back to model default. The pipeline does not halt.
 
 ## Per-agent override examples
 
@@ -150,16 +185,31 @@ Per-agent `effort` values are set in `worca.agents.<agent>.effort`. They accept 
       "auto_cap": "xhigh"
     },
     "agents": {
-      "planner":     { "effort": "xhigh"  },  // heavy reasoning
-      "coordinator": { "effort": "medium" },  // mechanical decomposition
-      "implementer": { },                     // unset — adaptive path drives base
-      "tester":      { },                     // unset — model default
-      "reviewer":    { },                     // unset — model default
-      "guardian":    { "effort": "high"   }   // high vigilance
+      "planner":      { "effort": "xhigh" },  // heavy upfront reasoning
+      "coordinator":  { "effort": "high"  },   // complexity classification is a judgment call
+      "implementer":  { },                     // unset — adaptive bead label drives base
+      "tester":       { },                     // unset — mechanical verification
+      "reviewer":     { "effort": "high"  },   // review quality controls loop count
+      "plan_reviewer":{ "effort": "high"  },   // judgment gate (disabled by default)
+      "guardian":     { "effort": "high"  },   // irreversible commit/PR work
+      "learner":     { }                      // unset — low stakes, disabled by default
     }
   }
 }
 ```
+
+| Agent | Level | Rationale |
+|---|---|---|
+| planner | `xhigh` | Heavy upfront reasoning; plan quality compounds downstream |
+| coordinator | `high` | Complexity classification is a judgment call, not mechanical decomposition |
+| reviewer | `high` | Review quality directly controls `review_changes` loop count |
+| plan_reviewer | `high` | Judgment gate (only active when `worca.stages.plan_review.enabled`) |
+| guardian | `high` | Irreversible commit and PR creation |
+| implementer | unset | Adaptive bead label drives starting point; explicit value would override classification |
+| tester | unset | Deterministic verification; model default is sufficient |
+| learner | unset | Low stakes, disabled by default |
+
+**Caveat:** the shipped `opus` alias resolves to Opus 4.6, which has a 4-rung ladder (`low/medium/high/max` — no `xhigh`). The planner's `xhigh` collapses to `high` at runtime (`status.json` records `level: "high"`, `requested: "xhigh"`). Pointing `worca.models.opus` at Opus 4.7 activates the full 5-rung ladder.
 
 ### Pin all agents to model defaults (pre-W-052 behavior)
 
@@ -201,6 +251,23 @@ Escalation fires on loopbacks but never exceeds `high`. Bead labels are emitted 
 ```
 
 Under `adaptive` mode, this explicit value overrides the coordinator's bead label. The label is still recorded with `bead_classified.skip_reason = "explicit_override"`.
+
+## Shipped template effort divergences
+
+Templates override the project defaults via deep-merge (see [Precedence](#precedence)). Unspecified keys fall through to the baseline. Only templates that diverge from the default `adaptive` + shipped agent values are listed:
+
+| Template | Divergence | Why |
+|---|---|---|
+| `quick-fix` | `effort.auto_mode: disabled`; planner `medium`, coordinator `low`, implementer `low` | Trivial work — deterministic and cheap; intentional disable prevents wasted escalation |
+| `bugfix` | `effort.auto_cap: high` | Clamp escalation cost on focused fixes; prevents auto-escalation to `max` |
+| `feature` | none (baseline + adaptive) | Complex beads get `high`/`xhigh` naturally via the coordinator's classification |
+| `investigate` | none (baseline + adaptive) | Same as feature |
+| `refactor` | none (baseline + adaptive) | Same as feature |
+| `test-only` | none (baseline + adaptive) | Same as feature |
+
+The `quick-fix` template is the only one that disables `auto_mode`. This is intentional: for trivial one-liner changes, adaptive classification adds overhead with no benefit — the work is known-simple at template selection time. All agent efforts are pinned low, and no escalation fires.
+
+The `bugfix` template keeps `auto_mode: adaptive` (labels still drive the implementer) but caps escalation at `high` to bound cost. On the shipped 4-rung models this prevents the `high → max` jump on the first `test_failure` loopback.
 
 ## Output-token truncation at high/max effort
 

--- a/src/worca/agents/core/coordinator.md
+++ b/src/worca/agents/core/coordinator.md
@@ -54,6 +54,26 @@ This is required regardless of pipeline `auto_mode` — labels under `reactive`/
 
 Produce a structured result following the `coordinate.json` schema.
 
+Include the `effort` map in your output: an object mapping each bead ID to its
+complexity level (`low`, `medium`, `high`, or `xhigh`). Every bead you created
+must have an entry. Use the same rubric as the `--labels` classification above.
+
+Example (partial):
+
+```json
+{
+  "beads_ids": ["beads-abc", "beads-def"],
+  "effort": {
+    "beads-abc": "medium",
+    "beads-def": "high"
+  }
+}
+```
+
+The runner uses this map as the reliable, programmatic source for per-bead
+effort labels. The `--labels` flag on `bd create` is the best-effort
+first pass; the structured `effort` map is the authoritative fallback.
+
 ## Rules
 
 <!-- governance -->

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -27,7 +27,7 @@ from worca.orchestrator.registry import update_pipeline
 from worca.orchestrator.control import read_control, delete_control
 from worca.orchestrator.overlay import OverlayResolver, resolve_agent
 from worca.orchestrator.prompt_builder import PromptBuilder
-from worca.orchestrator.effort import resolve_effort, escalation_iter_num
+from worca.orchestrator.effort import resolve_effort, escalation_iter_num, EFFORT_LEVELS
 from worca.orchestrator.stages import (
     Stage, get_stage_config, get_enabled_stages, STAGE_AGENT_MAP,
     is_learn_enabled,
@@ -2967,9 +2967,30 @@ def run_pipeline(
                             ))
                     else:
                         _log(f"Failed to label beads with {run_label}", "warn")
+                # Effort label backfill from structured output
+                _effort_backfilled = set()
+                effort_map = result.get("effort", {})
+                if beads_ids and effort_map:
+                    beads_set = set(beads_ids)
+                    for bid, level in effort_map.items():
+                        if bid not in beads_set:
+                            _log(f"Effort backfill: skip unknown bead {bid}", "warn")
+                            continue
+                        if level not in EFFORT_LEVELS:
+                            _log(f"Effort backfill: skip invalid level '{level}' for {bid}", "warn")
+                            continue
+                        if bd_get_effort_label(bid):
+                            continue
+                        if bd_label_add([bid], f"worca-effort:{level}"):
+                            _effort_backfilled.add(bid)
+                    if _effort_backfilled:
+                        _log(f"Effort backfill: labeled {len(_effort_backfilled)} bead(s) from structured output", "ok")
                 # Best-effort check: warn about beads missing worca-effort:* labels
                 if beads_ids:
-                    _unlabeled = [bid for bid in beads_ids if not bd_get_effort_label(bid)]
+                    _unlabeled = [
+                        bid for bid in beads_ids
+                        if bid not in _effort_backfilled and not bd_get_effort_label(bid)
+                    ]
                     if _unlabeled:
                         _log(f"{len(_unlabeled)} bead(s) missing worca-effort label: {', '.join(_unlabeled)}", "warn")
 

--- a/src/worca/schemas/coordinate.json
+++ b/src/worca/schemas/coordinate.json
@@ -21,6 +21,13 @@
         "type": "array",
         "items": { "type": "string" }
       }
+    },
+    "effort": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["low", "medium", "high", "xhigh", "max"]
+      }
     }
   }
 }

--- a/src/worca/settings.json
+++ b/src/worca/settings.json
@@ -175,7 +175,7 @@
       "coordinator": {
         "model": "opus",
         "max_turns": 300,
-        "effort": "medium"
+        "effort": "high"
       },
       "implementer": {
         "model": "sonnet",
@@ -187,7 +187,8 @@
       },
       "reviewer": {
         "model": "opus",
-        "max_turns": 50
+        "max_turns": 50,
+        "effort": "high"
       },
       "guardian": {
         "model": "opus",
@@ -200,7 +201,8 @@
       },
       "plan_reviewer": {
         "model": "opus",
-        "max_turns": 50
+        "max_turns": 50,
+        "effort": "high"
       }
     },
     "models": {

--- a/src/worca/templates/bugfix/template.json
+++ b/src/worca/templates/bugfix/template.json
@@ -6,6 +6,9 @@
   "created_at": "2026-03-10T00:00:00Z",
   "tags": ["fast", "focused"],
   "config": {
+    "effort": {
+      "auto_cap": "high"
+    },
     "agents": {
       "planner":     { "model": "opus", "max_turns": 50 },
       "coordinator": { "model": "opus", "max_turns": 50 },

--- a/src/worca/templates/quick-fix/template.json
+++ b/src/worca/templates/quick-fix/template.json
@@ -11,10 +11,13 @@
       "review": { "enabled": false },
       "pr":     { "enabled": false }
     },
+    "effort": {
+      "auto_mode": "disabled"
+    },
     "agents": {
-      "planner":     { "model": "opus", "max_turns": 50 },
-      "coordinator": { "model": "opus", "max_turns": 50 },
-      "implementer": { "model": "sonnet", "max_turns": 100 }
+      "planner":     { "model": "opus", "max_turns": 50, "effort": "medium" },
+      "coordinator": { "model": "opus", "max_turns": 50, "effort": "low" },
+      "implementer": { "model": "sonnet", "max_turns": 100, "effort": "low" }
     },
     "loops": {
       "implement_test": 0

--- a/tests/test_agent_md_refs.py
+++ b/tests/test_agent_md_refs.py
@@ -139,6 +139,42 @@ def test_coordinator_effort_mode_independent_emission():
 
 
 # ---------------------------------------------------------------------------
+# coordinator.md — Structured effort map (effort-system-reliable-labels)
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_effort_map_in_structured_output():
+    """The coordinator must be told to populate the `effort` field in its output."""
+    content = _read("coordinator.md")
+    assert '"effort"' in content or "`effort`" in content, (
+        "coordinator.md must reference the `effort` field for structured output"
+    )
+    lower = content.lower()
+    assert "map" in lower or "mapping" in lower, (
+        "coordinator.md must describe effort as a map/mapping of bead IDs to levels"
+    )
+
+
+def test_coordinator_effort_map_documents_bead_id_key():
+    """The effort map instruction must explain that keys are bead IDs."""
+    content = _read("coordinator.md")
+    assert "bead_id" in content or "bead ID" in content or "bead id" in content.lower(), (
+        "coordinator.md must document that effort map keys are bead IDs"
+    )
+
+
+def test_coordinator_effort_map_belt_and_suspenders():
+    """Both --labels instruction AND structured effort map must coexist."""
+    content = _read("coordinator.md")
+    assert "--labels" in content, (
+        "coordinator.md must retain --labels instruction (belt-and-suspenders)"
+    )
+    assert ('"effort"' in content or "`effort`" in content), (
+        "coordinator.md must also instruct structured effort map output"
+    )
+
+
+# ---------------------------------------------------------------------------
 # implementer.md
 # ---------------------------------------------------------------------------
 

--- a/tests/test_coordinate_schema.py
+++ b/tests/test_coordinate_schema.py
@@ -1,0 +1,94 @@
+"""Tests for the coordinate JSON schema (src/worca/schemas/coordinate.json)."""
+import json
+import os
+
+import jsonschema
+import pytest
+
+import worca
+
+SCHEMA_PATH = os.path.join(
+    os.path.dirname(worca.__file__), "schemas", "coordinate.json",
+)
+
+
+@pytest.fixture
+def schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def _minimal_doc():
+    return {
+        "beads_ids": ["beads-abc", "beads-def"],
+        "dependency_graph": {"beads-def": ["beads-abc"]},
+    }
+
+
+class TestEffortPropertyExists:
+    def test_effort_absent_is_valid(self, schema):
+        doc = _minimal_doc()
+        jsonschema.validate(doc, schema)
+
+    def test_effort_empty_object_is_valid(self, schema):
+        doc = _minimal_doc()
+        doc["effort"] = {}
+        jsonschema.validate(doc, schema)
+
+    def test_effort_with_valid_levels(self, schema):
+        doc = _minimal_doc()
+        doc["effort"] = {
+            "beads-abc": "low",
+            "beads-def": "high",
+        }
+        jsonschema.validate(doc, schema)
+
+
+class TestEffortEnumValues:
+    VALID_LEVELS = ["low", "medium", "high", "xhigh", "max"]
+
+    @pytest.mark.parametrize("level", VALID_LEVELS)
+    def test_valid_effort_level(self, schema, level):
+        doc = _minimal_doc()
+        doc["effort"] = {"beads-abc": level}
+        jsonschema.validate(doc, schema)
+
+    def test_invalid_effort_level_rejected(self, schema):
+        doc = _minimal_doc()
+        doc["effort"] = {"beads-abc": "ultra"}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_numeric_effort_level_rejected(self, schema):
+        doc = _minimal_doc()
+        doc["effort"] = {"beads-abc": 3}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_null_effort_level_rejected(self, schema):
+        doc = _minimal_doc()
+        doc["effort"] = {"beads-abc": None}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+
+class TestEffortMapStructure:
+    def test_effort_must_be_object(self, schema):
+        doc = _minimal_doc()
+        doc["effort"] = ["low", "high"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_effort_string_rejected(self, schema):
+        doc = _minimal_doc()
+        doc["effort"] = "high"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(doc, schema)
+
+    def test_multiple_beads_with_different_levels(self, schema):
+        doc = _minimal_doc()
+        doc["effort"] = {
+            "beads-abc": "low",
+            "beads-def": "max",
+        }
+        jsonschema.validate(doc, schema)

--- a/tests/test_preset_templates.py
+++ b/tests/test_preset_templates.py
@@ -97,6 +97,9 @@ class TestBugfixConfig:
     def test_coordinator_model_opus(self):
         assert self._config()["agents"]["coordinator"]["model"] == "opus"
 
+    def test_effort_auto_cap_high(self):
+        assert self._config()["effort"]["auto_cap"] == "high"
+
 
 class TestFeatureConfig:
     def _config(self):
@@ -107,6 +110,9 @@ class TestFeatureConfig:
 
     def test_learn_enabled(self):
         assert self._config()["stages"]["learn"]["enabled"] is True
+
+    def test_no_effort_override(self):
+        assert "effort" not in self._config()
 
 
 class TestRefactorConfig:
@@ -139,6 +145,18 @@ class TestQuickFixConfig:
 
     def test_review_stage_disabled(self):
         assert self._config()["stages"]["review"]["enabled"] is False
+
+    def test_effort_auto_mode_disabled(self):
+        assert self._config()["effort"]["auto_mode"] == "disabled"
+
+    def test_planner_effort_medium(self):
+        assert self._config()["agents"]["planner"]["effort"] == "medium"
+
+    def test_coordinator_effort_low(self):
+        assert self._config()["agents"]["coordinator"]["effort"] == "low"
+
+    def test_implementer_effort_low(self):
+        assert self._config()["agents"]["implementer"]["effort"] == "low"
 
 
 class TestInvestigateConfig:

--- a/tests/test_runner_effort_backfill.py
+++ b/tests/test_runner_effort_backfill.py
@@ -1,0 +1,436 @@
+"""Tests for effort label backfill from coordinate structured output."""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from worca.orchestrator.runner import run_pipeline
+from worca.orchestrator.work_request import WorkRequest
+
+pytestmark = pytest.mark.allow_worca_writes
+
+
+@pytest.fixture(autouse=True)
+def _mock_beads_init():
+    with patch("worca.orchestrator.runner._ensure_beads_initialized"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_signal_event_flag():
+    import worca.orchestrator.runner as runner_mod
+    runner_mod._signal_event_emitted = False
+    runner_mod._pending_signal_event = None
+    yield
+    runner_mod._signal_event_emitted = False
+    runner_mod._pending_signal_event = None
+
+
+def _make_settings(tmp_path, effort=None):
+    settings = {"worca": {"stages": {}, "agents": {}, "models": {}}}
+    if effort is not None:
+        settings["worca"]["effort"] = effort
+    path = str(tmp_path / "settings.json")
+    with open(path, "w") as f:
+        json.dump(settings, f)
+    return path
+
+
+def _make_wr():
+    return WorkRequest(source_type="prompt", title="test", description="test desc")
+
+
+def _coordinate_result(beads, effort=None):
+    r = {"beads_ids": beads, "dependency_graph": {}}
+    if effort is not None:
+        r["effort"] = effort
+    return r
+
+
+def _make_stage_side_effect(coordinate_result):
+    call_count = [0]
+    def stage_side_effect(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return ({"approach": "ok", "tasks_outline": []}, {})
+        elif call_count[0] == 2:
+            return (coordinate_result, {})
+        raise Exception("stop")
+    return stage_side_effect
+
+
+class TestEffortBackfillFromStructuredOutput:
+    """Effort labels are applied programmatically from coordinate's effort map."""
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_applies_effort_labels_from_map(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(
+            ["bead-1", "bead-2"],
+            effort={"bead-1": "high", "bead-2": "low"},
+        )
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        label_calls = mock_label.call_args_list
+        effort_labels = [
+            c for c in label_calls
+            if len(c.args) >= 2 and "worca-effort:" in str(c.args[1])
+        ]
+        assert len(effort_labels) == 2, f"Expected 2 effort label calls, got: {label_calls}"
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_skips_unknown_bead_id_with_warning(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(
+            ["bead-1"],
+            effort={"bead-1": "high", "bead-unknown": "low"},
+        )
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        skip_warnings = [m for m in log_messages if "bead-unknown" in m and "skip" in m.lower()]
+        assert skip_warnings, f"Expected skip warning for unknown bead, got: {log_messages}"
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_skips_invalid_level_with_warning(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(
+            ["bead-1"],
+            effort={"bead-1": "ultra"},
+        )
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        skip_warnings = [m for m in log_messages if "ultra" in m and "skip" in m.lower()]
+        assert skip_warnings, f"Expected skip warning for invalid level, got: {log_messages}"
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_preserves_existing_effort_label(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.side_effect = lambda bid: "medium" if bid == "bead-1" else None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(
+            ["bead-1", "bead-2"],
+            effort={"bead-1": "high", "bead-2": "low"},
+        )
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        label_calls = mock_label.call_args_list
+        effort_labels = [
+            c for c in label_calls
+            if len(c.args) >= 2 and "worca-effort:" in str(c.args[1])
+        ]
+        assert len(effort_labels) == 1, (
+            f"Expected 1 effort label call (bead-2 only; bead-1 preserved), got: {effort_labels}"
+        )
+        assert effort_labels[0].args[1] == "worca-effort:low"
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_backfilled_beads_excluded_from_unlabeled_warning(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(
+            ["bead-1", "bead-2", "bead-3"],
+            effort={"bead-1": "high", "bead-2": "low"},
+        )
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        unlabeled_warnings = [
+            m for m in log_messages
+            if "missing worca-effort" in m.lower() or "unlabeled" in m.lower()
+        ]
+        assert unlabeled_warnings, "Expected unlabeled warning for bead-3"
+        for w in unlabeled_warnings:
+            assert "bead-1" not in w, f"bead-1 was backfilled, should not be in warning: {w}"
+            assert "bead-2" not in w, f"bead-2 was backfilled, should not be in warning: {w}"
+            assert "bead-3" in w, f"bead-3 was not backfilled, should be in warning: {w}"
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_no_unlabeled_warning_when_all_backfilled(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(
+            ["bead-1", "bead-2"],
+            effort={"bead-1": "high", "bead-2": "low"},
+        )
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        unlabeled_warnings = [
+            m for m in log_messages
+            if "missing worca-effort" in m.lower()
+        ]
+        assert not unlabeled_warnings, (
+            f"No unlabeled warning expected when all beads backfilled, got: {unlabeled_warnings}"
+        )
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_empty_effort_map_no_crash(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(["bead-1"], effort={})
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        label_calls = mock_label.call_args_list
+        effort_labels = [
+            c for c in label_calls
+            if len(c.args) >= 2 and "worca-effort:" in str(c.args[1])
+        ]
+        assert len(effort_labels) == 0, f"No effort labels expected from empty map, got: {effort_labels}"
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        unlabeled_warnings = [
+            m for m in log_messages if "missing worca-effort" in m.lower()
+        ]
+        assert unlabeled_warnings, "Expected unlabeled warning with empty effort map"
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_no_effort_map_falls_through_to_original_warning(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(["bead-1", "bead-2"])
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        unlabeled_warnings = [
+            m for m in log_messages
+            if "missing worca-effort" in m.lower()
+        ]
+        assert unlabeled_warnings, "Expected original unlabeled warning when no effort map"
+        assert "bead-1" in unlabeled_warnings[0]
+        assert "bead-2" in unlabeled_warnings[0]
+
+    @patch("worca.orchestrator.runner.bd_get_effort_label")
+    @patch("worca.orchestrator.runner.resolve_effort")
+    @patch("worca.orchestrator.runner.bd_label_add", return_value=True)
+    @patch("worca.orchestrator.runner.run_stage")
+    @patch("worca.orchestrator.runner.create_branch")
+    @patch("worca.orchestrator.runner.current_branch", return_value="main")
+    @patch("worca.orchestrator.runner.get_current_git_head", return_value="abc123")
+    @patch("worca.orchestrator.runner._query_ready_bead", return_value=None)
+    @patch("worca.orchestrator.runner._log")
+    def test_logs_backfill_count(
+        self, mock_log, mock_bead, mock_head, mock_branch, mock_create,
+        mock_stage, mock_label, mock_resolve, mock_get_effort, tmp_path,
+    ):
+        mock_resolve.return_value = (None, None, "model_default", None, None, None)
+        mock_get_effort.return_value = None
+
+        settings_path = _make_settings(tmp_path)
+        status_path = str(tmp_path / "status.json")
+        os.makedirs(tmp_path / "runs", exist_ok=True)
+
+        result = _coordinate_result(
+            ["bead-1", "bead-2"],
+            effort={"bead-1": "high", "bead-2": "low"},
+        )
+        mock_stage.side_effect = _make_stage_side_effect(result)
+
+        with pytest.raises(Exception, match="stop"):
+            run_pipeline(
+                _make_wr(),
+                settings_path=settings_path,
+                status_path=status_path,
+                skip_preflight=True,
+            )
+
+        log_messages = [c.args[0] for c in mock_log.call_args_list]
+        backfill_logs = [m for m in log_messages if "effort" in m.lower() and "backfill" in m.lower()]
+        assert backfill_logs, f"Expected backfill log line, got: {log_messages}"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -522,13 +522,13 @@ class TestEffortSettings:
         result = load_settings(settings_path)
         assert result["worca"]["agents"]["planner"]["effort"] == "xhigh"
 
-    def test_coordinator_effort_medium(self):
-        """Coordinator has effort 'medium' (mechanical decomposition)."""
+    def test_coordinator_effort_high(self):
+        """Coordinator has effort 'high' (complexity classification is judgment)."""
         settings_path = os.path.join(
             os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
         )
         result = load_settings(settings_path)
-        assert result["worca"]["agents"]["coordinator"]["effort"] == "medium"
+        assert result["worca"]["agents"]["coordinator"]["effort"] == "high"
 
     def test_guardian_effort_high(self):
         """Guardian has effort 'high' (high vigilance)."""
@@ -554,13 +554,29 @@ class TestEffortSettings:
         result = load_settings(settings_path)
         assert "effort" not in result["worca"]["agents"]["tester"]
 
-    def test_reviewer_effort_unset(self):
-        """Reviewer has no effort field (model default)."""
+    def test_reviewer_effort_high(self):
+        """Reviewer has effort 'high' (loop-controlling judgment gate)."""
         settings_path = os.path.join(
             os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
         )
         result = load_settings(settings_path)
-        assert "effort" not in result["worca"]["agents"]["reviewer"]
+        assert result["worca"]["agents"]["reviewer"]["effort"] == "high"
+
+    def test_plan_reviewer_effort_high(self):
+        """Plan reviewer has effort 'high' (judgment gate, only active when enabled)."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert result["worca"]["agents"]["plan_reviewer"]["effort"] == "high"
+
+    def test_learner_effort_unset(self):
+        """Learner has no effort field (low stakes, disabled by default)."""
+        settings_path = os.path.join(
+            os.path.dirname(__file__), '..', 'src', 'worca', 'settings.json'
+        )
+        result = load_settings(settings_path)
+        assert "effort" not in result["worca"]["agents"]["learner"]
 
     def test_local_override_auto_mode(self, tmp_path):
         """Local override can change auto_mode."""

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -766,6 +766,13 @@ h1, h2, h3, h4, h5, h6 {
   to { transform: rotate(360deg); }
 }
 
+.effort-zap-icon {
+  width: 12px;
+  height: 12px;
+  vertical-align: -1px;
+  margin-right: 2px;
+}
+
 /* --- 13. Stage Connector --- */
 .stage-connector {
   width: 36px;

--- a/worca-ui/app/utils/effort-badge.js
+++ b/worca-ui/app/utils/effort-badge.js
@@ -1,0 +1,18 @@
+import { iconSvg, Zap } from './icons.js';
+
+const VARIANT_MAP = {
+  high: 'primary',
+  xhigh: 'warning',
+  max: 'danger',
+};
+
+export function effortLevelVariant(level) {
+  return VARIANT_MAP[level] || 'neutral';
+}
+
+export function effortLevelBadge(level) {
+  const text = level ?? '-';
+  const variant = effortLevelVariant(level);
+  const icon = iconSvg(Zap, 12, 'effort-zap-icon');
+  return `<sl-badge variant="${variant}" pill>${icon}${text}</sl-badge>`;
+}

--- a/worca-ui/app/utils/effort-badge.test.js
+++ b/worca-ui/app/utils/effort-badge.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { effortLevelBadge, effortLevelVariant } from './effort-badge.js';
+
+describe('effortLevelVariant', () => {
+  it('returns neutral for low', () => {
+    expect(effortLevelVariant('low')).toBe('neutral');
+  });
+  it('returns neutral for medium', () => {
+    expect(effortLevelVariant('medium')).toBe('neutral');
+  });
+  it('returns primary for high', () => {
+    expect(effortLevelVariant('high')).toBe('primary');
+  });
+  it('returns warning for xhigh', () => {
+    expect(effortLevelVariant('xhigh')).toBe('warning');
+  });
+  it('returns danger for max', () => {
+    expect(effortLevelVariant('max')).toBe('danger');
+  });
+  it('returns neutral for null', () => {
+    expect(effortLevelVariant(null)).toBe('neutral');
+  });
+  it('returns neutral for undefined', () => {
+    expect(effortLevelVariant(undefined)).toBe('neutral');
+  });
+  it('returns neutral for unknown string', () => {
+    expect(effortLevelVariant('turbo')).toBe('neutral');
+  });
+});
+
+describe('effortLevelBadge', () => {
+  it('renders Zap SVG icon', () => {
+    const result = effortLevelBadge('high');
+    expect(result).toContain('<svg');
+    expect(result).toContain('class="effort-zap-icon"');
+  });
+  it('renders the level text for a known level', () => {
+    expect(effortLevelBadge('high')).toContain('high');
+  });
+  it('renders dash when level is null', () => {
+    expect(effortLevelBadge(null)).toContain('-');
+  });
+  it('renders dash when level is undefined', () => {
+    expect(effortLevelBadge(undefined)).toContain('-');
+  });
+  it('uses correct variant for high', () => {
+    expect(effortLevelBadge('high')).toContain('variant="primary"');
+  });
+  it('uses neutral variant for null', () => {
+    expect(effortLevelBadge(null)).toContain('variant="neutral"');
+  });
+  it('uses danger variant for max', () => {
+    expect(effortLevelBadge('max')).toContain('variant="danger"');
+  });
+  it('renders each known level text', () => {
+    for (const level of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      expect(effortLevelBadge(level)).toContain(level);
+    }
+  });
+});

--- a/worca-ui/app/views/beads-panel-effort.test.js
+++ b/worca-ui/app/views/beads-panel-effort.test.js
@@ -1,10 +1,10 @@
 import { nothing } from 'lit-html';
 import { describe, expect, it } from 'vitest';
+import { effortLevelVariant } from '../utils/effort-badge.js';
 import {
   beadEffortBadgeView,
   beadIterationMiniTable,
   beadNotesView,
-  effortLevelVariant,
   effortSourceLabel,
   extractEffortLabel,
 } from './beads-panel.js';
@@ -12,6 +12,8 @@ import {
 function renderToString(template) {
   if (!template || template === nothing) return '';
   if (typeof template === 'string') return template;
+  if (template._$litDirective$ && template.values)
+    return template.values[0] || '';
   if (!template.strings) return String(template);
   let result = '';
   template.strings.forEach((s, i) => {
@@ -22,6 +24,7 @@ function renderToString(template) {
       else if (typeof v === 'number') result += String(v);
       else if (Array.isArray(v)) result += v.map(renderToString).join('');
       else if (v?.strings) result += renderToString(v);
+      else if (v?._$litDirective$ && v?.values) result += v.values[0] || '';
     }
   });
   return result;
@@ -109,28 +112,38 @@ describe('beadEffortBadgeView — effort label badge', () => {
     expect(html).toContain('high');
   });
 
+  it('renders Zap icon via shared effortLevelBadge', () => {
+    const issue = { labels: ['worca-effort:high'] };
+    const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
+    expect(html).toContain('effort-zap-icon');
+  });
+
   it('renders low with neutral variant', () => {
     const issue = { labels: ['worca-effort:low'] };
     const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
-    expect(html).toMatch(/variant="neutral"[^>]*>low/s);
+    expect(html).toContain('variant="neutral"');
+    expect(html).toContain('low</sl-badge>');
   });
 
   it('renders high with primary variant', () => {
     const issue = { labels: ['worca-effort:high'] };
     const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
-    expect(html).toMatch(/variant="primary"[^>]*>high/s);
+    expect(html).toContain('variant="primary"');
+    expect(html).toContain('high</sl-badge>');
   });
 
   it('renders xhigh with warning variant', () => {
     const issue = { labels: ['worca-effort:xhigh'] };
     const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
-    expect(html).toMatch(/variant="warning"[^>]*>xhigh/s);
+    expect(html).toContain('variant="warning"');
+    expect(html).toContain('xhigh</sl-badge>');
   });
 
   it('renders max with danger variant', () => {
     const issue = { labels: ['worca-effort:max'] };
     const html = renderToString(beadEffortBadgeView(issue, 'adaptive'));
-    expect(html).toMatch(/variant="danger"[^>]*>max/s);
+    expect(html).toContain('variant="danger"');
+    expect(html).toContain('max</sl-badge>');
   });
 
   it('renders "ignored: reactive" chip when auto_mode is reactive', () => {

--- a/worca-ui/app/views/beads-panel.js
+++ b/worca-ui/app/views/beads-panel.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { effortLevelBadge, effortLevelVariant } from '../utils/effort-badge.js';
 import {
   Circle,
   CircleCheck,
@@ -23,12 +24,7 @@ export function extractEffortLabel(labels) {
   return null;
 }
 
-export function effortLevelVariant(level) {
-  if (level === 'high') return 'primary';
-  if (level === 'xhigh') return 'warning';
-  if (level === 'max') return 'danger';
-  return 'neutral';
-}
+export { effortLevelVariant };
 
 export function effortSourceLabel(source) {
   if (source === 'adaptive:llm') return 'adaptive';
@@ -39,11 +35,10 @@ export function effortSourceLabel(source) {
 export function beadEffortBadgeView(issue, autoMode) {
   const level = extractEffortLabel(issue?.labels);
   if (!level) return nothing;
-  const variant = effortLevelVariant(level);
   const showIgnored = autoMode === 'reactive' || autoMode === 'disabled';
   return html`
     <span class="bead-effort-badge">
-      <sl-badge variant="${variant}" pill>${level}</sl-badge>
+      ${unsafeHTML(effortLevelBadge(level))}
       ${showIgnored ? html`<sl-badge class="bead-effort-ignored" variant="warning" pill>ignored: ${autoMode}</sl-badge>` : nothing}
     </span>
   `;
@@ -282,6 +277,7 @@ export function beadTooltipContent(issue) {
           }
         </span>
       </div>
+      ${'effort' in issue ? html`<span class="bead-tooltip-effort">${unsafeHTML(effortLevelBadge(issue.effort))}</span>` : nothing}
       <hr class="bead-tooltip-separator">
       <div class="bead-tooltip-label">Title:</div>
       <div class="bead-tooltip-title">${issue.title}</div>

--- a/worca-ui/app/views/beads-panel.test.js
+++ b/worca-ui/app/views/beads-panel.test.js
@@ -11,6 +11,8 @@ import {
 function renderToString(template) {
   if (!template) return '';
   if (typeof template === 'string') return template;
+  if (template._$litDirective$ && template.values)
+    return template.values[0] || '';
   if (!template.strings) return String(template);
   let result = '';
   template.strings.forEach((s, i) => {
@@ -21,7 +23,7 @@ function renderToString(template) {
       else if (typeof v === 'number') result += String(v);
       else if (Array.isArray(v)) result += v.map(renderToString).join('');
       else if (v?.strings) result += renderToString(v);
-      // unsafeHTML directives / functions — skip
+      else if (v?._$litDirective$ && v?.values) result += v.values[0] || '';
     }
   });
   return result;
@@ -395,6 +397,28 @@ describe('beadTooltipContent', () => {
     const out = renderToString(beadTooltipContent(issue));
     expect(out).toContain('bead-tooltip-copy');
     expect(out).toContain('Copy');
+  });
+
+  it('shows effort badge when issue.effort is set', () => {
+    const issueWithEffort = { ...issue, effort: 'high' };
+    const out = renderToString(beadTooltipContent(issueWithEffort));
+    expect(out).toContain('bead-tooltip-effort');
+    expect(out).toContain('effort-zap-icon');
+    expect(out).toContain('high');
+  });
+
+  it('shows dash effort badge when issue.effort is null', () => {
+    const issueNoEffort = { ...issue, effort: null };
+    const out = renderToString(beadTooltipContent(issueNoEffort));
+    expect(out).toContain('bead-tooltip-effort');
+    expect(out).toContain('effort-zap-icon');
+    expect(out).toContain('-');
+  });
+
+  it('omits effort badge when issue has no effort field', () => {
+    const out = renderToString(beadTooltipContent(issue));
+    expect(out).not.toContain('bead-tooltip-effort');
+    expect(out).not.toContain('effort-zap-icon');
   });
 });
 

--- a/worca-ui/app/views/effort-badge.test.js
+++ b/worca-ui/app/views/effort-badge.test.js
@@ -6,6 +6,8 @@ function renderToString(template) {
   if (template.overview)
     return renderToString(template.overview) + renderToString(template.stages);
   if (typeof template === 'string') return template;
+  if (template._$litDirective$ && template.values)
+    return template.values[0] || '';
   if (!template.strings) return String(template);
   let result = '';
   template.strings.forEach((s, i) => {
@@ -15,6 +17,7 @@ function renderToString(template) {
       if (typeof v === 'string') result += v;
       else if (Array.isArray(v)) result += v.map(renderToString).join('');
       else if (v?.strings) result += renderToString(v);
+      else if (v?._$litDirective$ && v?.values) result += v.values[0] || '';
     }
   });
   return result;
@@ -53,8 +56,8 @@ describe('effort level badge variant mapping', () => {
         makeRun({ level: 'medium', source: 'explicit', base: 'medium' }),
       ),
     );
-    expect(html).toContain('effort-level-badge');
-    expect(html).toMatch(/variant="neutral"[^>]*>medium/s);
+    expect(html).toContain('effort-zap-icon');
+    expect(html).toMatch(/variant="neutral"[^>]*>.*medium/s);
   });
 
   it('renders high effort with primary variant', () => {
@@ -63,8 +66,8 @@ describe('effort level badge variant mapping', () => {
         makeRun({ level: 'high', source: 'adaptive:llm', base: 'high' }),
       ),
     );
-    expect(html).toContain('effort-level-badge');
-    expect(html).toMatch(/variant="primary"[^>]*>high/s);
+    expect(html).toContain('effort-zap-icon');
+    expect(html).toMatch(/variant="primary"[^>]*>.*high/s);
   });
 
   it('renders xhigh effort with warning variant', () => {
@@ -73,8 +76,8 @@ describe('effort level badge variant mapping', () => {
         makeRun({ level: 'xhigh', source: 'explicit', base: 'xhigh' }),
       ),
     );
-    expect(html).toContain('effort-level-badge');
-    expect(html).toMatch(/variant="warning"[^>]*>xhigh/s);
+    expect(html).toContain('effort-zap-icon');
+    expect(html).toMatch(/variant="warning"[^>]*>.*xhigh/s);
   });
 
   it('renders max effort with danger variant', () => {
@@ -83,8 +86,8 @@ describe('effort level badge variant mapping', () => {
         makeRun({ level: 'max', source: 'reactive', base: 'high' }),
       ),
     );
-    expect(html).toContain('effort-level-badge');
-    expect(html).toMatch(/variant="danger"[^>]*>max/s);
+    expect(html).toContain('effort-zap-icon');
+    expect(html).toMatch(/variant="danger"[^>]*>.*max/s);
   });
 
   it('renders model default as neutral dash badge', () => {
@@ -94,8 +97,8 @@ describe('effort level badge variant mapping', () => {
       ),
     );
     expect(html).toContain('Effort:');
-    expect(html).toContain('effort-level-badge');
-    expect(html).toMatch(/variant="neutral"[^>]*>-/s);
+    expect(html).toContain('effort-zap-icon');
+    expect(html).toMatch(/variant="neutral"[^>]*>.*-/s);
   });
 });
 
@@ -188,7 +191,8 @@ describe('effort bead classified row', () => {
       ),
     );
     expect(html).toContain('Bead:');
-    expect(html).toContain('effort-bead-level');
+    const beadSection = html.split('Bead:')[1];
+    expect(beadSection).toContain('effort-zap-icon');
     expect(html).toContain('medium');
     expect(html).toContain('overridden');
   });
@@ -238,7 +242,7 @@ describe('effort bead classified row', () => {
         makeRun({ level: 'high', source: 'explicit', base: 'high' }),
       ),
     );
-    expect(html).not.toContain('effort-bead-level');
+    expect(html).not.toContain('Bead:');
   });
 
   it('does not render bead row when applied is true and levels match', () => {
@@ -276,7 +280,50 @@ describe('effort bead classified row', () => {
         }),
       ),
     );
-    expect(html).not.toContain('effort-bead-level');
+    expect(html).not.toContain('Bead:');
+  });
+});
+
+describe('effort row uses shared effortLevelBadge (Zap icon)', () => {
+  it('renders Zap icon in the effort level badge', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ level: 'high', source: 'explicit', base: 'high' }),
+      ),
+    );
+    expect(html).toContain('effort-zap-icon');
+  });
+
+  it('renders Zap icon in the bead divergence badge', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'explicit',
+          base: 'high',
+          bead_classified: {
+            level: 'medium',
+            applied: false,
+            skip_reason: 'explicit_override',
+          },
+        }),
+      ),
+    );
+    const beadSection = html.split('Bead:')[1];
+    expect(beadSection).toContain('effort-zap-icon');
+  });
+
+  it('does not render Zap icon when effort data is absent', () => {
+    const run = {
+      stages: {
+        implement: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed', outcome: 'success' }],
+        },
+      },
+    };
+    const html = renderToString(runDetailView(run));
+    expect(html).not.toContain('effort-zap-icon');
   });
 });
 
@@ -291,7 +338,7 @@ describe('effort row absent when no effort data', () => {
       },
     };
     const html = renderToString(runDetailView(run));
-    expect(html).not.toContain('effort-level-badge');
+    expect(html).not.toContain('effort-zap-icon');
     expect(html).not.toContain('effort-source-chip');
   });
 });

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -2,6 +2,7 @@ import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { marked } from 'marked';
 import { elapsed, formatDuration, formatTimestamp } from '../utils/duration.js';
+import { effortLevelBadge } from '../utils/effort-badge.js';
 import {
   AlertTriangle,
   CircleCheck,
@@ -368,13 +369,6 @@ function _outcomeBadge(outcome) {
   return html`<sl-badge variant="${_outcomeVariant(outcome)}" pill>${outcome.replace(/_/g, ' ')}</sl-badge>`;
 }
 
-function _effortLevelVariant(level) {
-  if (level === 'high') return 'primary';
-  if (level === 'xhigh') return 'warning';
-  if (level === 'max') return 'danger';
-  return 'neutral';
-}
-
 function _effortSourceLabel(source) {
   if (source === 'adaptive:llm') return 'adaptive';
   if (source === 'model_default') return 'model default';
@@ -434,8 +428,6 @@ function _effortRowView(iter, graphifyEnabled) {
       ? nothing
       : html`<div class="iteration-tags-row">${gfx}</div>`;
   }
-  const levelText = e.level ?? '-';
-  const variant = e.level ? _effortLevelVariant(e.level) : 'neutral';
   const sourceLabel = _effortSourceLabel(e.source);
   const tooltip = _effortTooltip(e);
 
@@ -458,7 +450,7 @@ function _effortRowView(iter, graphifyEnabled) {
   return html`
     <div class="iteration-tags-row" title="${tooltip}">
       <span class="meta-label">Effort:</span>
-      <sl-badge class="effort-level-badge" variant="${variant}" pill>${levelText}</sl-badge>
+      ${unsafeHTML(effortLevelBadge(e.level))}
       <sl-badge class="effort-source-chip" variant="neutral" pill>${sourceLabel}</sl-badge>
       ${escalationChips}
       ${cappedChip}
@@ -469,7 +461,7 @@ function _effortRowView(iter, graphifyEnabled) {
         ? html`
       <div class="iteration-tags-row">
         <span class="meta-label">Bead:</span>
-        <sl-badge class="effort-bead-level" variant="${_effortLevelVariant(bc.level)}" pill>${bc.level}</sl-badge>
+        ${unsafeHTML(effortLevelBadge(bc.level))}
         <sl-badge class="effort-divergence-chip" variant="warning" pill>${divergenceLabel}</sl-badge>
       </div>
     `

--- a/worca-ui/package-lock.json
+++ b/worca-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worca/ui",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worca/ui",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.20.1",

--- a/worca-ui/server/beads-reader.js
+++ b/worca-ui/server/beads-reader.js
@@ -14,6 +14,13 @@ async function runBd(args, dbPath) {
   return JSON.parse(stdout);
 }
 
+export function extractEffortFromLabels(labels) {
+  if (!labels || labels.length === 0) return null;
+  const match = labels.find((l) => l.startsWith('worca-effort:'));
+  if (!match) return null;
+  return match.slice('worca-effort:'.length);
+}
+
 function transformIssue(issue, deps) {
   const depends_on = (deps || []).map((d) => d.id);
   const blocked_by = (deps || [])
@@ -29,17 +36,18 @@ function transformIssue(issue, deps) {
     external_ref: issue.external_ref || null,
     depends_on,
     blocked_by,
+    effort: extractEffortFromLabels(issue.labels),
   };
 }
 
 async function enrichWithDeps(issues, dbPath) {
-  const needDeps = issues.filter((i) => i.dependency_count > 0);
-  if (needDeps.length === 0) {
-    return issues.map((i) => transformIssue(i, []));
-  }
-  const detailed = await runBd(['show', ...needDeps.map((i) => i.id)], dbPath);
-  const depMap = new Map(detailed.map((d) => [d.id, d.dependencies || []]));
-  return issues.map((i) => transformIssue(i, depMap.get(i.id) || []));
+  if (issues.length === 0) return [];
+  const detailed = await runBd(['show', ...issues.map((i) => i.id)], dbPath);
+  const detailMap = new Map(detailed.map((d) => [d.id, d]));
+  return issues.map((i) => {
+    const d = detailMap.get(i.id);
+    return transformIssue(d || i, d?.dependencies || []);
+  });
 }
 
 export function dbExists(beadsDb) {
@@ -89,10 +97,9 @@ export async function listUnlinkedIssues(beadsDb) {
       const labels = d?.labels || [];
       return !labels.some((l) => l.startsWith('run:'));
     });
-    // detailed already has dependencies, use them directly
     return unlinked.map((i) => {
       const d = detailMap.get(i.id);
-      return transformIssue(i, d?.dependencies || []);
+      return transformIssue(d || i, d?.dependencies || []);
     });
   } catch {
     return [];

--- a/worca-ui/server/beads-reader.test.js
+++ b/worca-ui/server/beads-reader.test.js
@@ -29,6 +29,7 @@ const { execFile } = await import('node:child_process');
 const { existsSync } = await import('node:fs');
 const {
   dbExists,
+  extractEffortFromLabels,
   getIssue,
   listDistinctRunLabels,
   listIssues,
@@ -78,6 +79,7 @@ describe('listIssues', () => {
   });
 
   it('returns transformed issues without deps', async () => {
+    // bd list
     mockBdResult([
       {
         id: '1',
@@ -88,6 +90,19 @@ describe('listIssues', () => {
         created_at: '2026-01-01',
         dependency_count: 0,
         dependent_count: 0,
+      },
+    ]);
+    // bd show (enrichWithDeps always calls it)
+    mockBdResult([
+      {
+        id: '1',
+        title: 'Open',
+        description: 'body text',
+        status: 'open',
+        priority: 2,
+        created_at: '2026-01-01',
+        labels: [],
+        dependencies: [],
       },
     ]);
     const issues = await listIssues(DB);
@@ -102,6 +117,7 @@ describe('listIssues', () => {
         external_ref: null,
         depends_on: [],
         blocked_by: [],
+        effort: null,
       },
     ]);
   });
@@ -126,8 +142,18 @@ describe('listIssues', () => {
         dependency_count: 1,
       },
     ]);
-    // Second call: bd show for issues with deps
+    // Second call: bd show for all issues
     mockBdResult([
+      {
+        id: '1',
+        title: 'Dep',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: [],
+        dependencies: [],
+      },
       {
         id: '2',
         title: 'B',
@@ -135,6 +161,7 @@ describe('listIssues', () => {
         status: 'open',
         priority: 2,
         created_at: '',
+        labels: [],
         dependencies: [
           {
             id: '1',
@@ -278,6 +305,7 @@ describe('getIssue', () => {
 
 describe('listIssuesByLabel', () => {
   it('returns issues matching the given label', async () => {
+    // bd list
     mockBdResult([
       {
         id: '1',
@@ -298,6 +326,29 @@ describe('listIssuesByLabel', () => {
         dependency_count: 0,
       },
     ]);
+    // bd show (enrichWithDeps always calls it)
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: [],
+        dependencies: [],
+      },
+      {
+        id: '2',
+        title: 'B',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: [],
+        dependencies: [],
+      },
+    ]);
     const issues = await listIssuesByLabel(DB, 'run:run-1');
     expect(issues.length).toBe(2);
     expect(issues.map((i) => i.title).sort()).toEqual(['A', 'B']);
@@ -316,9 +367,22 @@ describe('listIssuesByLabel', () => {
   it('retries once on failure and returns the second attempt result', async () => {
     // First attempt: bd list fails.
     mockBdError('SIGTERM');
-    // Second attempt: bd list succeeds, no deps needed.
+    // Second attempt: bd list succeeds.
     mockBdResult([
       { id: '1', title: 'A', status: 'open', priority: 2, dependency_count: 0 },
+    ]);
+    // bd show (enrichWithDeps always calls it)
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: [],
+        dependencies: [],
+      },
     ]);
     const issues = await listIssuesByLabel(DB, 'run:run-1');
     expect(issues.length).toBe(1);
@@ -557,5 +621,157 @@ describe('countIssuesByRunLabel observability', () => {
     expect(warn).toHaveBeenCalled();
     expect(warn.mock.calls[0][0]).toMatch(/countIssuesByRunLabel/);
     warn.mockRestore();
+  });
+});
+
+describe('extractEffortFromLabels', () => {
+  it('returns null for undefined labels', () => {
+    expect(extractEffortFromLabels(undefined)).toBeNull();
+  });
+
+  it('returns null for empty labels', () => {
+    expect(extractEffortFromLabels([])).toBeNull();
+  });
+
+  it('returns null when no worca-effort label present', () => {
+    expect(extractEffortFromLabels(['run:abc', 'component:auth'])).toBeNull();
+  });
+
+  it('extracts effort level from worca-effort label', () => {
+    expect(extractEffortFromLabels(['run:abc', 'worca-effort:high'])).toBe(
+      'high',
+    );
+  });
+
+  it('handles all valid effort levels', () => {
+    for (const level of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      expect(extractEffortFromLabels([`worca-effort:${level}`])).toBe(level);
+    }
+  });
+});
+
+describe('effort field in output', () => {
+  it('getIssue includes effort from worca-effort label', async () => {
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: ['worca-effort:high'],
+        dependencies: [],
+      },
+    ]);
+    const issue = await getIssue(DB, '1');
+    expect(issue.effort).toBe('high');
+  });
+
+  it('getIssue effort is null when no worca-effort label', async () => {
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: ['run:abc'],
+        dependencies: [],
+      },
+    ]);
+    const issue = await getIssue(DB, '1');
+    expect(issue.effort).toBeNull();
+  });
+
+  it('listIssues includes effort via enrichWithDeps bd show', async () => {
+    // bd list
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        dependency_count: 0,
+      },
+    ]);
+    // bd show (enrichWithDeps always calls it now)
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: ['worca-effort:medium'],
+        dependencies: [],
+      },
+    ]);
+    const issues = await listIssues(DB);
+    expect(issues[0].effort).toBe('medium');
+  });
+
+  it('listUnlinkedIssues includes effort from bd show labels', async () => {
+    // bd list
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        dependency_count: 0,
+      },
+    ]);
+    // bd show
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: ['worca-effort:low'],
+        dependencies: [],
+      },
+    ]);
+    const issues = await listUnlinkedIssues(DB);
+    expect(issues[0].effort).toBe('low');
+  });
+
+  it('enrichWithDeps calls bd show even when no issues have deps', async () => {
+    // bd list — no issues have dependency_count > 0
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        dependency_count: 0,
+      },
+    ]);
+    // bd show (always called now)
+    mockBdResult([
+      {
+        id: '1',
+        title: 'A',
+        description: '',
+        status: 'open',
+        priority: 2,
+        created_at: '',
+        labels: ['worca-effort:high'],
+        dependencies: [],
+      },
+    ]);
+    await listIssues(DB);
+    expect(execFile).toHaveBeenCalledTimes(2);
+    const showArgs = execFile.mock.calls[1][1];
+    expect(showArgs).toContain('show');
+    expect(showArgs).toContain('1');
   });
 });


### PR DESCRIPTION
## Summary

- **Reliable labels (keystone):** Add optional `effort` map to `coordinate.json` schema — coordinator returns per-bead complexity classification as structured output. Runner backfills `worca-effort:<level>` labels programmatically from this map immediately after the `run:` label backfill, never overwriting existing labels. Closes the reliability gap where models omit `--labels` on `bd create`.
- **Unified UI badge:** New shared `app/utils/effort-badge.js` (Zap icon + level text) replaces duplicated rendering in `run-detail.js` and `beads-panel.js`. Server-side `beads-reader.js` now surfaces `effort` field from labels into bead tooltips.
- **Effort-aware defaults:** Bump coordinator/reviewer/plan_reviewer to `high` effort. Add effort overrides to `quick-fix` (disabled adaptive, all agents pinned low) and `bugfix` (auto_cap: high) templates.
- **Docs:** Document precedence (template > project > model default), design principles, and template divergences in `docs/effort.md`.

Addresses issue #194.

## Test plan

- [x] `pytest tests/test_coordinate_schema.py` — schema validation (effort map enum, optional field)
- [x] `pytest tests/test_runner_effort_backfill.py` — runner backfill logic (skip unknown bead, skip invalid level, skip pre-existing label, apply from map)
- [x] `pytest tests/test_settings.py` — coordinator/reviewer/plan_reviewer effort values in project settings
- [x] `pytest tests/test_preset_templates.py` — quick-fix and bugfix template effort overrides
- [x] `npx vitest run worca-ui/app/utils/effort-badge.test.js` — shared badge module
- [x] `npx vitest run worca-ui/app/views/effort-badge.test.js` — run-detail integration
- [x] `npx vitest run worca-ui/app/views/beads-panel-effort.test.js` — beads panel Zap icon
- [x] `npx vitest run worca-ui/app/views/beads-panel.test.js` — tooltip effort field
- [x] `npx vitest run worca-ui/server/beads-reader.test.js` — extractEffortFromLabels + transformIssue effort field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
