### PR TITLE
fix(ui): break beads watcher ↔ client refetch infinite loop

### DIFF
--- a/worca-ui/app/main-beads-update-dedup.test.js
+++ b/worca-ui/app/main-beads-update-dedup.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests that the beads-update WS handler deduplicates unchanged payloads,
+ * skipping rerender + refetch when the incoming data is identical to the
+ * last broadcast, and resets that dedup state on project switch.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function extractHandler(src, eventName) {
+  const marker = `ws.on('${eventName}'`;
+  const start = src.indexOf(marker);
+  if (start === -1) return null;
+  let i = src.indexOf('{', start);
+  if (i === -1) return null;
+  const startBrace = i;
+  let depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    if (src[i] === '}') depth--;
+    if (depth === 0) break;
+  }
+  return src.slice(startBrace, i + 1);
+}
+
+function extractFunctionBody(src, funcName) {
+  const marker = `function ${funcName}`;
+  const start = src.indexOf(marker);
+  if (start === -1) return null;
+  let i = src.indexOf('{', start);
+  if (i === -1) return null;
+  const startBrace = i;
+  let depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    if (src[i] === '}') depth--;
+    if (depth === 0) break;
+  }
+  return src.slice(startBrace, i + 1);
+}
+
+describe('beads-update handler: client-side dedup', () => {
+  const source = readFileSync(join(__dirname, 'main.js'), 'utf8');
+  const handler = extractHandler(source, 'beads-update');
+
+  it('skips rerender when beads-update payload is unchanged', () => {
+    // The handler must compare the incoming payload against a stored previous
+    // value (via JSON.stringify or similar) and return early — skipping
+    // rerender() — when unchanged.
+    expect(handler).not.toBeNull();
+
+    // There should be a serialization/comparison of the payload
+    expect(handler).toMatch(/JSON\.stringify\(payload\)/);
+
+    // There should be an early return when the payload matches the previous
+    const hasEarlyReturn = handler.match(
+      /if\s*\(\s*.*lastBeadsPayload.*\)\s*return/,
+    );
+    expect(hasEarlyReturn).not.toBeNull();
+  });
+
+  it('rerenders when payload changes', () => {
+    // After the dedup check passes (payload is new), the handler must
+    // update the stored previous payload and call rerender().
+    expect(handler).not.toBeNull();
+
+    // The handler must store the new serialized payload for the next comparison
+    expect(handler).toMatch(/lastBeadsPayload\s*=/);
+
+    // rerender() must still be called (it was there before dedup was added)
+    expect(handler).toContain('rerender()');
+  });
+
+  it('resets dedup state on project switch', () => {
+    // resetProjectState() must clear the lastBeadsPayload so that the first
+    // beads-update after switching projects always renders.
+    const resetBody = extractFunctionBody(source, 'resetProjectState');
+    expect(resetBody).not.toBeNull();
+    expect(resetBody).toMatch(/lastBeadsPayload\s*=/);
+  });
+});

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -519,6 +519,7 @@ let beadsStarting = null; // null | issueId
 let beadsStartError = null; // null | string
 const runBeads = new Map(); // runId → issues[]
 let beadsCounts = {}; // { runId: count }
+let lastBeadsPayload = null;
 let beadsRunIssues = []; // issues for the currently viewed run
 let beadsRunLoading = false;
 
@@ -765,6 +766,7 @@ function resetProjectState() {
   beadsStartError = null;
   runBeads.clear();
   beadsCounts = {};
+  lastBeadsPayload = null;
   beadsRunIssues = [];
   beadsRunLoading = false;
   // Stage iteration tabs
@@ -1026,6 +1028,9 @@ ws.on('beads-update', (payload, msg) => {
   const currentProject = store.getState().currentProjectId;
   if (msg?.project && currentProject && msg.project !== currentProject) return;
   if (payload) {
+    const serialized = JSON.stringify(payload);
+    if (serialized === lastBeadsPayload) return;
+    lastBeadsPayload = serialized;
     store.setState({
       beads: {
         issues: payload.issues || [],

--- a/worca-ui/server/ws-beads-watcher.js
+++ b/worca-ui/server/ws-beads-watcher.js
@@ -4,7 +4,7 @@
  * because fs.watch on macOS misses SQLite WAL writes done via mmap.
  */
 
-import { existsSync, unwatchFile, watch, watchFile } from 'node:fs';
+import { existsSync, statSync, unwatchFile, watch, watchFile } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { countIssuesByRunLabel, listIssues } from './beads-reader.js';
 
@@ -20,6 +20,8 @@ export function createBeadsWatcher({ worcaDir, broadcaster, projectId }) {
   const beadsWalPath = `${beadsDbPath}-wal`;
   let fsWatcher = null;
   let BEADS_REFRESH_TIMER = null;
+  let lastPayloadJson = null;
+  let lastSelfReadWalStat = null;
 
   function scheduleBeadsRefresh() {
     if (BEADS_REFRESH_TIMER) clearTimeout(BEADS_REFRESH_TIMER);
@@ -30,6 +32,9 @@ export function createBeadsWatcher({ worcaDir, broadcaster, projectId }) {
           listIssues(beadsDbPath),
           countIssuesByRunLabel(beadsDbPath).catch(() => ({})),
         ]);
+        const payloadJson = JSON.stringify({ issues, counts });
+        if (payloadJson === lastPayloadJson) return;
+        lastPayloadJson = payloadJson;
         broadcaster.broadcast(
           'beads-update',
           {
@@ -40,6 +45,12 @@ export function createBeadsWatcher({ worcaDir, broadcaster, projectId }) {
           },
           projectId,
         );
+        try {
+          const s = statSync(beadsWalPath);
+          lastSelfReadWalStat = { mtimeMs: s.mtimeMs, size: s.size };
+        } catch {
+          lastSelfReadWalStat = null;
+        }
       } catch {
         /* ignore */
       }
@@ -60,6 +71,13 @@ export function createBeadsWatcher({ worcaDir, broadcaster, projectId }) {
     // on macOS. watchFile tolerates a missing file; it starts firing once created.
     watchFile(beadsWalPath, { interval: BEADS_POLL_MS }, (curr, prev) => {
       if (curr.mtimeMs !== prev.mtimeMs || curr.size !== prev.size) {
+        if (
+          lastSelfReadWalStat &&
+          curr.mtimeMs === lastSelfReadWalStat.mtimeMs &&
+          curr.size === lastSelfReadWalStat.size
+        ) {
+          return;
+        }
         scheduleBeadsRefresh();
       }
     });

--- a/worca-ui/server/ws-beads-watcher.test.js
+++ b/worca-ui/server/ws-beads-watcher.test.js
@@ -120,3 +120,225 @@ describe('scheduleBeadsRefresh broadcast payload', () => {
     ]);
   });
 });
+
+describe('payload dedup', () => {
+  let createBeadsWatcher;
+  let mockListIssues;
+  let mockCountIssuesByRunLabel;
+  let watchCallback;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    mockListIssues = vi.fn().mockResolvedValue([
+      { id: '1', title: 'A', status: 'closed' },
+    ]);
+    mockCountIssuesByRunLabel = vi.fn().mockResolvedValue({
+      'run-1': { total: 2, done: 1 },
+    });
+
+    vi.doMock('./beads-reader.js', () => ({
+      listIssues: mockListIssues,
+      countIssuesByRunLabel: mockCountIssuesByRunLabel,
+    }));
+
+    vi.doMock('node:fs', () => ({
+      existsSync: vi.fn(() => true),
+      watch: vi.fn((_path, cb) => {
+        watchCallback = cb;
+        return { close: vi.fn() };
+      }),
+      watchFile: vi.fn(),
+      unwatchFile: vi.fn(),
+      statSync: vi.fn(() => ({ mtimeMs: 100, size: 4096 })),
+    }));
+
+    const mod = await import('./ws-beads-watcher.js');
+    createBeadsWatcher = mod.createBeadsWatcher;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('suppresses broadcast when payload is unchanged', async () => {
+    const broadcasts = [];
+    const broadcaster = {
+      broadcast: (_event, payload) => broadcasts.push(payload),
+    };
+
+    createBeadsWatcher({
+      worcaDir: '/fake/project/.claude/worca',
+      broadcaster,
+      projectId: 'p1',
+    });
+
+    // First change — should broadcast
+    watchCallback('change', 'beads.db');
+    await vi.advanceTimersByTimeAsync(600);
+    expect(broadcasts.length).toBe(1);
+
+    // Second change — identical payload — should NOT broadcast
+    watchCallback('change', 'beads.db');
+    await vi.advanceTimersByTimeAsync(600);
+    expect(broadcasts.length).toBe(1);
+  });
+
+  it('broadcasts when payload changes between events', async () => {
+    const broadcasts = [];
+    const broadcaster = {
+      broadcast: (_event, payload) => broadcasts.push(payload),
+    };
+
+    createBeadsWatcher({
+      worcaDir: '/fake/project/.claude/worca',
+      broadcaster,
+      projectId: 'p1',
+    });
+
+    // First change
+    watchCallback('change', 'beads.db');
+    await vi.advanceTimersByTimeAsync(600);
+    expect(broadcasts.length).toBe(1);
+
+    // Mutate the data so payload differs
+    mockListIssues.mockResolvedValue([
+      { id: '1', title: 'A', status: 'closed' },
+      { id: '3', title: 'C', status: 'open' },
+    ]);
+
+    // Second change — different payload — should broadcast
+    watchCallback('change', 'beads.db');
+    await vi.advanceTimersByTimeAsync(600);
+    expect(broadcasts.length).toBe(2);
+  });
+
+  it('broadcasts the first event with no prior state', async () => {
+    const broadcasts = [];
+    const broadcaster = {
+      broadcast: (_event, payload) => broadcasts.push(payload),
+    };
+
+    createBeadsWatcher({
+      worcaDir: '/fake/project/.claude/worca',
+      broadcaster,
+      projectId: 'p1',
+    });
+
+    // Very first change — no prior payload exists — must broadcast
+    watchCallback('change', 'beads.db');
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(broadcasts.length).toBe(1);
+    expect(broadcasts[0].issues).toEqual([
+      { id: '1', title: 'A', status: 'closed' },
+    ]);
+  });
+});
+
+describe('WAL self-read suppression', () => {
+  let createBeadsWatcher;
+  let mockListIssues;
+  let mockCountIssuesByRunLabel;
+  let watchCallback;
+  let watchFileCallback;
+  let mockStatSync;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    mockListIssues = vi.fn().mockResolvedValue([
+      { id: '1', title: 'A', status: 'closed' },
+    ]);
+    mockCountIssuesByRunLabel = vi.fn().mockResolvedValue({});
+
+    vi.doMock('./beads-reader.js', () => ({
+      listIssues: mockListIssues,
+      countIssuesByRunLabel: mockCountIssuesByRunLabel,
+    }));
+
+    mockStatSync = vi.fn(() => ({ mtimeMs: 1000, size: 8192 }));
+
+    vi.doMock('node:fs', () => ({
+      existsSync: vi.fn(() => true),
+      watch: vi.fn((_path, cb) => {
+        watchCallback = cb;
+        return { close: vi.fn() };
+      }),
+      watchFile: vi.fn((_path, _opts, cb) => {
+        watchFileCallback = cb;
+      }),
+      unwatchFile: vi.fn(),
+      statSync: mockStatSync,
+    }));
+
+    const mod = await import('./ws-beads-watcher.js');
+    createBeadsWatcher = mod.createBeadsWatcher;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('ignores WAL event matching self-read signature', async () => {
+    const broadcasts = [];
+    const broadcaster = {
+      broadcast: (_event, payload) => broadcasts.push(payload),
+    };
+
+    createBeadsWatcher({
+      worcaDir: '/fake/project/.claude/worca',
+      broadcaster,
+      projectId: 'p1',
+    });
+
+    // Trigger an initial refresh so the watcher records post-read WAL stat
+    watchCallback('change', 'beads.db');
+    await vi.advanceTimersByTimeAsync(600);
+    expect(broadcasts.length).toBe(1);
+
+    // statSync returns the same signature the watcher recorded after its own read
+    // so a WAL event with this stat should be suppressed
+    const selfStat = { mtimeMs: 1000, size: 8192 };
+    watchFileCallback(selfStat, { mtimeMs: 900, size: 4096 });
+
+    await vi.advanceTimersByTimeAsync(600);
+    // No new broadcast — the WAL change was from our own read
+    expect(broadcasts.length).toBe(1);
+  });
+
+  it('processes WAL event with different signature', async () => {
+    const broadcasts = [];
+    const broadcaster = {
+      broadcast: (_event, payload) => broadcasts.push(payload),
+    };
+
+    createBeadsWatcher({
+      worcaDir: '/fake/project/.claude/worca',
+      broadcaster,
+      projectId: 'p1',
+    });
+
+    // Trigger initial refresh
+    watchCallback('change', 'beads.db');
+    await vi.advanceTimersByTimeAsync(600);
+    expect(broadcasts.length).toBe(1);
+
+    // Mutate data so payload dedup doesn't suppress
+    mockListIssues.mockResolvedValue([
+      { id: '1', title: 'A', status: 'open' },
+    ]);
+
+    // WAL event with a DIFFERENT stat than what the watcher recorded
+    const externalStat = { mtimeMs: 2000, size: 16384 };
+    watchFileCallback(externalStat, { mtimeMs: 1000, size: 8192 });
+
+    await vi.advanceTimersByTimeAsync(600);
+    // Should broadcast — this WAL change was external
+    expect(broadcasts.length).toBe(2);
+  });
+});

--- a/worca-ui/server/ws-beads-watcher.test.js
+++ b/worca-ui/server/ws-beads-watcher.test.js
@@ -131,9 +131,9 @@ describe('payload dedup', () => {
     vi.useFakeTimers();
     vi.resetModules();
 
-    mockListIssues = vi.fn().mockResolvedValue([
-      { id: '1', title: 'A', status: 'closed' },
-    ]);
+    mockListIssues = vi
+      .fn()
+      .mockResolvedValue([{ id: '1', title: 'A', status: 'closed' }]);
     mockCountIssuesByRunLabel = vi.fn().mockResolvedValue({
       'run-1': { total: 2, done: 1 },
     });
@@ -250,9 +250,9 @@ describe('WAL self-read suppression', () => {
     vi.useFakeTimers();
     vi.resetModules();
 
-    mockListIssues = vi.fn().mockResolvedValue([
-      { id: '1', title: 'A', status: 'closed' },
-    ]);
+    mockListIssues = vi
+      .fn()
+      .mockResolvedValue([{ id: '1', title: 'A', status: 'closed' }]);
     mockCountIssuesByRunLabel = vi.fn().mockResolvedValue({});
 
     vi.doMock('./beads-reader.js', () => ({
@@ -329,9 +329,7 @@ describe('WAL self-read suppression', () => {
     expect(broadcasts.length).toBe(1);
 
     // Mutate data so payload dedup doesn't suppress
-    mockListIssues.mockResolvedValue([
-      { id: '1', title: 'A', status: 'open' },
-    ]);
+    mockListIssues.mockResolvedValue([{ id: '1', title: 'A', status: 'open' }]);
 
     // WAL event with a DIFFERENT stat than what the watcher recorded
     const externalStat = { mtimeMs: 2000, size: 16384 };


### PR DESCRIPTION
## Summary

- **Server-side payload dedup**: suppress `beads-update` broadcast when `{issues, counts}` JSON is byte-identical to the last broadcast
- **Server-side WAL self-read suppression**: after the watcher's own `bd` reads, snapshot the WAL's `{mtimeMs, size}` and ignore subsequent `watchFile` events matching that signature — deterministic regardless of event-delivery latency
- **Client-side dedup**: skip `fetchBeadsRunIssues` + `rerender()` when the incoming `beads-update` payload is unchanged from the previous one; reset dedup state on project switch

Fixes #197 — the 5,575+ `list-beads-by-run` flood observed on completed runs with static beads, caused by a read→watch→refetch→read cycle between the beads watcher and client handler (amplified by PR #195's unconditional `bd show` in `enrichWithDeps`).

## Test plan

- [x] 5 new server tests in `ws-beads-watcher.test.js` — payload dedup (suppress identical, allow changed, first event) + WAL self-read suppression (ignore self-stat, allow external-stat)
- [x] 3 new client tests in `main-beads-update-dedup.test.js` — source-level verification of dedup guard, rerender on change, and reset on project switch
- [ ] Manual: open a completed run's Beads view, confirm no log flood in `~/.worca/worca-ui-global.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)