### PR TITLE
fix(ui): stack bead tooltip header so badges don't overflow

### DIFF
--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -4786,9 +4786,9 @@ sl-details.learnings-panel::part(content) {
 
 .bead-tooltip-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
 }
 
 sl-tooltip.bead-tooltip::part(body) {
@@ -4797,6 +4797,7 @@ sl-tooltip.bead-tooltip::part(body) {
 
 .bead-tooltip-badges {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 4px;
 }

--- a/worca-ui/app/views/bead-tooltip-styles.test.js
+++ b/worca-ui/app/views/bead-tooltip-styles.test.js
@@ -34,6 +34,20 @@ describe('bead tooltip CSS styles', () => {
       expect(match).not.toBeNull();
       expect(match[1]).toContain('display: flex');
     });
+
+    it('uses column direction to stack ID above badges', () => {
+      const match = css.match(/\.bead-tooltip-header\s*\{([^}]+)\}/);
+      expect(match).not.toBeNull();
+      expect(match[1]).toContain('flex-direction: column');
+    });
+  });
+
+  describe('.bead-tooltip-badges', () => {
+    it('uses flex-wrap so badges wrap at narrow widths', () => {
+      const match = css.match(/\.bead-tooltip-badges\s*\{([^}]+)\}/);
+      expect(match).not.toBeNull();
+      expect(match[1]).toContain('flex-wrap: wrap');
+    });
   });
 
   describe('.bead-tooltip-label', () => {

--- a/worca-ui/app/views/beads-panel.js
+++ b/worca-ui/app/views/beads-panel.js
@@ -275,9 +275,9 @@ export function beadTooltipContent(issue) {
               ? html`<sl-badge variant="warning" pill>blocked</sl-badge>`
               : html`<sl-badge variant="${statusVariant(issue.status, issue)}" pill>${issue.status}</sl-badge>`
           }
+          ${'effort' in issue ? unsafeHTML(effortLevelBadge(issue.effort)) : nothing}
         </span>
       </div>
-      ${'effort' in issue ? html`<span class="bead-tooltip-effort">${unsafeHTML(effortLevelBadge(issue.effort))}</span>` : nothing}
       <hr class="bead-tooltip-separator">
       <div class="bead-tooltip-label">Title:</div>
       <div class="bead-tooltip-title">${issue.title}</div>

--- a/worca-ui/app/views/beads-panel.test.js
+++ b/worca-ui/app/views/beads-panel.test.js
@@ -399,25 +399,29 @@ describe('beadTooltipContent', () => {
     expect(out).toContain('Copy');
   });
 
-  it('shows effort badge when issue.effort is set', () => {
+  it('shows effort badge inside bead-tooltip-badges when issue.effort is set', () => {
     const issueWithEffort = { ...issue, effort: 'high' };
     const out = renderToString(beadTooltipContent(issueWithEffort));
-    expect(out).toContain('bead-tooltip-effort');
     expect(out).toContain('effort-zap-icon');
     expect(out).toContain('high');
+    const badgesStart = out.indexOf('bead-tooltip-badges');
+    const effortIdx = out.indexOf('effort-zap-icon');
+    expect(badgesStart).toBeGreaterThan(-1);
+    expect(effortIdx).toBeGreaterThan(badgesStart);
   });
 
-  it('shows dash effort badge when issue.effort is null', () => {
+  it('shows dash effort badge inside bead-tooltip-badges when issue.effort is null', () => {
     const issueNoEffort = { ...issue, effort: null };
     const out = renderToString(beadTooltipContent(issueNoEffort));
-    expect(out).toContain('bead-tooltip-effort');
     expect(out).toContain('effort-zap-icon');
     expect(out).toContain('-');
+    const badgesStart = out.indexOf('bead-tooltip-badges');
+    const effortIdx = out.indexOf('effort-zap-icon');
+    expect(effortIdx).toBeGreaterThan(badgesStart);
   });
 
   it('omits effort badge when issue has no effort field', () => {
     const out = renderToString(beadTooltipContent(issue));
-    expect(out).not.toContain('bead-tooltip-effort');
     expect(out).not.toContain('effort-zap-icon');
   });
 });


### PR DESCRIPTION
## Summary

- Moves the effort badge from a standalone element below the header into the `.bead-tooltip-badges` container, consolidating all badges (priority, status, effort) on one row
- Switches `.bead-tooltip-header` from horizontal `space-between` to vertical column layout — bead ID on line 1, all badges on line 2
- Adds `flex-wrap: wrap` on `.bead-tooltip-badges` as a safety net for narrow widths

## Test plan

- [x] Biome lint passes
- [x] 62 vitest tests pass (bead-tooltip-styles + beads-panel)
- [x] Visual check: hover a bead with effort label — ID on first line, all 3 badges on second line, no wrapping at 540px width — verified via Playwright against test-multi-01 run `20260524-093139-039-7d2d67e2`: ID on line 1, `P2`/`closed`/`⚡ low` on line 2 sharing one row, no overflow at default width and at a 540px viewport (tooltip body 283px)

Addresses #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
