### PR TITLE
W-005: Cross-bead design notes for implementer consistency

### DIFF
--- a/docs/plans/W-005-agent-memory-context-sharing.md
+++ b/docs/plans/W-005-agent-memory-context-sharing.md
@@ -64,20 +64,41 @@ all_files.extend(new_files)
 prompt_builder.update_context("all_files_changed", all_files)
 ```
 
-- **Resolution:** `design_notes` slots into the identical spot, one idiom over. Read it from the same `result` dict that yields `new_files` (`runner.py:2982`):
+- **Resolution:** `design_notes` is read **unconditionally** from `result` — alongside `files_changed`/`tests_added` at `runner.py:3002-3006`, outside the `if impl_trigger in ("initial", "next_bead")` guard. This ensures retries (`test_failure`, `review_changes`) can surface or revise design notes.
 
 ```python
-# alongside runner.py:2982-2985
+# alongside runner.py:3003-3004 (unconditional, all trigger types)
 new_note = (result.get("design_notes") or "").strip()
+```
 
-# alongside the accumulation block at runner.py:3007-3013
+Accumulation into `all_design_notes` differs by trigger:
+
+- **`initial` / `next_bead`** (first implementation of a bead): append `{bead_id, note}` if non-empty.
+- **`test_failure` / `review_changes`** (retry of the same bead): if the retry emits a note, **replace** the existing entry for this `bead_id` in `all_design_notes`. If the retry emits no note, leave the original entry unchanged. Rationale: a retry may change the design decision (e.g., switching from exceptions to Result types after a test failure), and the stale original note would mislead subsequent beads.
+
+```python
+# inside the bead-close block at runner.py:3028 (initial/next_bead only)
 all_notes = prompt_builder.get_context("all_design_notes") or []
 if new_note:
     all_notes.append({"bead_id": claimed_bead, "note": new_note})
 prompt_builder.update_context("all_design_notes", all_notes)
+
+# outside the bead-close guard, for retry triggers (test_failure/review_changes)
+if impl_trigger not in ("initial", "next_bead") and new_note:
+    all_notes = prompt_builder.get_context("all_design_notes") or []
+    claimed_bead = prompt_builder.get_context("assigned_bead_id")
+    replaced = False
+    for i, entry in enumerate(all_notes):
+        if entry.get("bead_id") == claimed_bead:
+            all_notes[i] = {"bead_id": claimed_bead, "note": new_note}
+            replaced = True
+            break
+    if not replaced:
+        all_notes.append({"bead_id": claimed_bead, "note": new_note})
+    prompt_builder.update_context("all_design_notes", all_notes)
 ```
 
-The accumulated structure is a list of `{bead_id, note}` so each rendered bullet can be attributed (attribution also lets a reader discount a note whose bead was later redone).
+The accumulated structure is a list of `{bead_id, note}` so each rendered bullet can be attributed (attribution also lets a reader discount a note whose bead was later redone). At most one entry exists per `bead_id` — retries replace, they do not append a second entry for the same bead.
 
 ### 3. Rendering — `PromptBuilder` + `implement.block.md`
 
@@ -85,15 +106,17 @@ The accumulated structure is a list of `{bead_id, note}` so each rendered bullet
 - **Resolution:** add two keys in the same place:
 
 ```python
+_DESIGN_NOTES_CAP = 2000  # chars — ~5 full notes; <2% of _MAX_CONTEXT_BYTES (100KB)
+
 # build_context(), alongside prompt_builder.py:167-169
 notes = self._context.get("all_design_notes") or []
 current = ctx.get("assigned_bead_id")
 siblings = [n for n in notes if n.get("bead_id") != current]   # self-exclusion
-ctx["accumulated_design_notes"] = _render_notes(siblings)       # bullet list, drop-oldest cap
+ctx["accumulated_design_notes"] = _render_notes(siblings, cap=_DESIGN_NOTES_CAP)
 ctx["has_design_notes"] = bool(siblings)
 ```
 
-`_render_notes` emits an attributed bullet list and applies a block-level character cap (drop-oldest — recent beads' decisions are likeliest to bear on current work) on top of the per-note `maxLength`:
+`_render_notes` emits an attributed bullet list and applies a **block-level character cap of 2000 characters** (constant `_DESIGN_NOTES_CAP = 2000` in `prompt_builder.py`), using drop-oldest semantics — recent beads' decisions are likeliest to bear on current work. The cap sits on top of the per-note `maxLength: 400`. Sizing rationale: 2000 chars ≈ 5 full-length notes, which covers typical sequential runs (3-8 beads) while consuming <2% of the 100KB `prompt_context.json` cap (`_MAX_CONTEXT_BYTES`) and staying small relative to plan/guide content that occupies the higher-authority prompt space. When notes exceed the cap, the oldest entries (earliest `bead_id`s) are dropped first until the rendered block fits:
 
 ```markdown
 ## Accumulated design notes (advisory)
@@ -149,14 +172,17 @@ Within one pipeline, beads are sequential (`runner.py:2266`), so bead *N* determ
 ### Phase 2: Accumulation
 **Files:** `src/worca/orchestrator/runner.py`
 **Tasks:**
-1. Read `new_note` from `result` near `runner.py:2982`.
-2. Append `{bead_id, note}` to `all_design_notes` in `_context` in the accumulation block at `runner.py:3007-3013`. No new save call — the existing `save_context` at `:3026-3027` persists it.
+1. Read `new_note` from `result` **unconditionally** alongside `files_changed`/`tests_added` at `runner.py:3003-3004` — outside the `if impl_trigger in ("initial", "next_bead")` guard.
+2. For `initial`/`next_bead` triggers: append `{bead_id, note}` to `all_design_notes` in `_context` in the bead-close block at `runner.py:3028`.
+3. For retry triggers (`test_failure`/`review_changes`): if `new_note` is non-empty, replace the existing entry for this `bead_id` in `all_design_notes` (or append if none exists). If `new_note` is empty, leave the existing entry unchanged.
+4. No new save call — the existing `save_context` at `:3048` persists it.
 
 ### Phase 3: Rendering
 **Files:** `src/worca/orchestrator/prompt_builder.py`, `src/worca/agents/core/implement.block.md`
 **Tasks:**
-1. In `build_context()` (alongside `:167-169`) compute `accumulated_design_notes` (attributed bullet list, self-exclusion of `assigned_bead_id`, drop-oldest block cap) and `has_design_notes`. Add a small `_render_notes` helper.
-2. In `implement.block.md`, add the `{{#if has_design_notes}} ## Accumulated design notes (advisory) … {{/if}}` block below `{{work_request}}` in **both** the `is_retry` and first-run branches.
+1. Add constant `_DESIGN_NOTES_CAP = 2000` at module level in `prompt_builder.py`.
+2. In `build_context()` (alongside `:167-169`) compute `accumulated_design_notes` (attributed bullet list, self-exclusion of `assigned_bead_id`, drop-oldest to fit within `_DESIGN_NOTES_CAP`) and `has_design_notes`. Add a small `_render_notes(notes, cap=_DESIGN_NOTES_CAP)` helper.
+3. In `implement.block.md`, add the `{{#if has_design_notes}} ## Accumulated design notes (advisory) … {{/if}}` block below `{{work_request}}` in **both** the `is_retry` and first-run branches.
 
 ### Phase 4: Implementer prompt
 **Files:** `src/worca/agents/core/implementer.md`
@@ -178,6 +204,7 @@ Within one pipeline, beads are sequential (`runner.py:2266`), so bead *N* determ
 
 - **Advisory ≠ enforced.** A non-binding note relies on the model voluntarily aligning; convergence is probabilistic, not guaranteed. Accepted: the cheaper, no-arbiter design is worth more than enforced consistency, and the cost of a note being ignored is "no worse than today."
 - **The implementer is poorly positioned to judge cross-bead relevance** (it sees only its own bead). Mitigated, not solved, by the "plan didn't specify" criterion + the 400-char cap + a small per-run volume. A note that strays into restating what the code does is redundant with reading the code/graph and should be discouraged in the prompt.
+- **Retry semantics.** When the implementer re-runs due to `test_failure` or `review_changes`, a new note **replaces** the original for that bead (at most one entry per `bead_id`). If the retry emits no note, the original stands. This is correct because a retry may revise the design decision (e.g., switching error-handling strategy after a test failure), and subsequent beads should see the final decision, not the stale original.
 - **Ordering.** A note is only visible to beads that start after the authoring bead closes. Sequential execution makes this deterministic; parallel execution (W-002/W-030) breaks it and is out of scope.
 - **Governance:** no new governed surface. The implementer does **not** write a file — it returns a structured field; the runner does the accumulation. So there is no `pre_tool_use` hook carve-out to add, and no file-write race.
 - **Breaking changes:** none. `design_notes` is optional and additive; existing implementer outputs validate unchanged; absent the field, no block renders.
@@ -192,9 +219,12 @@ Within one pipeline, beads are sequential (`runner.py:2266`), so bead *N* determ
 | Python | `test_implement_schema_rejects_overlong_design_notes` | `maxLength` 400 enforced |
 | Python | `test_runner_accumulates_design_notes` | `result["design_notes"]` appends `{bead_id, note}` to `all_design_notes` |
 | Python | `test_runner_skips_empty_design_notes` | Empty/absent note adds nothing |
+| Python | `test_runner_retry_replaces_design_note` | `test_failure`/`review_changes` trigger with new note replaces the existing entry for that bead |
+| Python | `test_runner_retry_empty_note_preserves_original` | Retry with empty/absent note leaves the original entry unchanged |
+| Python | `test_runner_retry_appends_if_no_prior_note` | Retry that emits a note for a bead with no existing entry appends it |
 | Python | `test_build_context_renders_accumulated_notes` | `has_design_notes` true, bullet list present |
 | Python | `test_build_context_excludes_current_bead` | A bead does not see its own note |
-| Python | `test_render_notes_drop_oldest_cap` | Block-level cap drops oldest, keeps most recent |
+| Python | `test_render_notes_drop_oldest_cap` | Block-level cap (2000 chars) drops oldest entries, keeps most recent |
 | Python | `test_implement_block_no_notes_no_section` | `has_design_notes` false → no `## Accumulated design notes` heading |
 
 ### Integration / E2E Tests

--- a/src/worca/agents/core/implement.block.md
+++ b/src/worca/agents/core/implement.block.md
@@ -43,6 +43,15 @@ description, and surface it rather than silently resolving it.
 {{/if}}
 {{work_request}}
 
+{{#if has_design_notes}}
+## Accumulated design notes (advisory)
+
+Sibling beads recorded these design decisions during this run. They are
+advisory — lowest authority after guide, plan, graph, and description.
+
+{{accumulated_design_notes}}
+
+{{/if}}
 {{#if has_graphify}}
 _A code knowledge graph is preloaded for this repo — explore it on demand with `graphify query "<question>"` (see the Knowledge graph section of your role)._
 
@@ -74,6 +83,15 @@ description, and surface it rather than silently resolving it.
 {{/if}}
 {{work_request}}
 
+{{#if has_design_notes}}
+## Accumulated design notes (advisory)
+
+Sibling beads recorded these design decisions during this run. They are
+advisory — lowest authority after guide, plan, graph, and description.
+
+{{accumulated_design_notes}}
+
+{{/if}}
 {{#if has_graphify}}
 _A code knowledge graph is preloaded for this repo — explore it on demand with `graphify query "<question>"` (see the Knowledge graph section of your role)._
 

--- a/src/worca/agents/core/implementer.md
+++ b/src/worca/agents/core/implementer.md
@@ -47,6 +47,10 @@ When your prompt says "Fix All Issues" or "Fix Test Failures" or "Fix Review Iss
 Produce a structured result following the `implement.json` schema.
 In fix mode, set `bead_id` to `"fix"` (sentinel value).
 
+Set `design_notes` when you made a design decision the plan did not specify — naming convention, error strategy, where shared state lives, etc. Keep it to 2–3 sentences (max 400 chars). Omit the field when the plan already covered everything.
+
+Your task prompt may include an **Accumulated design notes (advisory)** block containing decisions recorded by earlier sibling beads in this run. Use them as a consistency nudge — prefer aligning with sibling choices unless the plan or guide says otherwise. Authority order: guide > plan > graph > description > accumulated design notes.
+
 > When reading `status.json`, `stages` is keyed by stage name (`preflight`, `plan`, …, `pr`, `learn`), never by agent name. The `pr` stage is run by the `guardian` agent — `guardian` will never appear as a stage key. Writing `stages.guardian` will silently no-op in production while passing tests.
 
 ## Rules

--- a/src/worca/orchestrator/prompt_builder.py
+++ b/src/worca/orchestrator/prompt_builder.py
@@ -9,6 +9,19 @@ import tempfile
 from pathlib import Path
 
 _MAX_CONTEXT_BYTES = 100_000  # 100KB cap for prompt_context.json
+_DESIGN_NOTES_CAP = 2000
+
+
+def _render_notes(notes: list[dict], cap: int) -> str:
+    """Render design notes as an attributed bullet list, drop-oldest to fit cap."""
+    if not notes or cap <= 0:
+        return ""
+    lines = [f"- [{n['bead_id']}] {n['note']}" for n in notes]
+    result = "\n".join(lines)
+    while len(result) > cap and lines:
+        lines.pop(0)
+        result = "\n".join(lines)
+    return result
 
 
 class PromptBuilder:
@@ -167,6 +180,14 @@ class PromptBuilder:
         ctx["guide_content"] = self._guide_content
         ctx["has_guide"] = bool(self._guide_content)
         ctx["has_graphify"] = self._graphify_available
+
+        all_notes = ctx.get("all_design_notes") or []
+        assigned = ctx.get("assigned_bead_id") or ""
+        sibling_notes = [n for n in all_notes if n.get("bead_id") != assigned]
+        rendered = _render_notes(sibling_notes, _DESIGN_NOTES_CAP)
+        ctx["accumulated_design_notes"] = rendered
+        ctx["has_design_notes"] = bool(rendered)
+
         self._apply_stage_context(stage, iteration, ctx)
         return ctx
 

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -1576,6 +1576,30 @@ def handle_pr_review(outcome: str, status: dict) -> tuple:
         return (None, status)
 
 
+def _accumulate_design_note(prompt_builder, result: dict, trigger: str) -> None:
+    """Accumulate design_notes from an implement result into prompt context."""
+    new_note = result.get("design_notes", "")
+    all_notes = prompt_builder.get_context("all_design_notes") or []
+
+    if trigger in ("initial", "next_bead"):
+        if new_note:
+            bead_id = result.get("bead_id", "")
+            all_notes.append({"bead_id": bead_id, "note": new_note})
+        prompt_builder.update_context("all_design_notes", all_notes)
+    elif trigger in ("test_failure", "review_changes"):
+        if new_note:
+            bead_id = prompt_builder.get_context("assigned_bead_id") or result.get("bead_id", "")
+            replaced = False
+            for i, entry in enumerate(all_notes):
+                if entry["bead_id"] == bead_id:
+                    all_notes[i] = {"bead_id": bead_id, "note": new_note}
+                    replaced = True
+                    break
+            if not replaced:
+                all_notes.append({"bead_id": bead_id, "note": new_note})
+            prompt_builder.update_context("all_design_notes", all_notes)
+
+
 def _query_ready_bead(allowed_ids: list[str] | None = None, run_id: str | None = None) -> dict | None:
     """Query bd ready and return the first available bead, or None.
 
@@ -3006,6 +3030,7 @@ def run_pipeline(
                 prompt_builder.update_context("tests_added", new_tests)
 
                 impl_trigger = trigger  # trigger was popped earlier in the loop
+                _accumulate_design_note(prompt_builder, result, impl_trigger)
                 if impl_trigger in ("initial", "next_bead"):
                     # Phase 1: close the bead we just implemented
                     claimed_bead = prompt_builder.get_context("assigned_bead_id")

--- a/src/worca/schemas/implement.json
+++ b/src/worca/schemas/implement.json
@@ -12,6 +12,10 @@
     "tests_added": {
       "type": "array",
       "items": { "type": "string" }
+    },
+    "design_notes": {
+      "type": "string",
+      "maxLength": 400
     }
   }
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -70,10 +70,13 @@ def pipeline_env(tmp_path):
     subprocess.run(["git", "commit", "-m", "init"], cwd=str(project),
                    check=True, capture_output=True)
 
-    # 2. Run worca init to copy full runtime (agents, schemas, hooks, scripts)
+    # 2. Run worca init to copy full runtime (agents, schemas, hooks, scripts).
+    #    PYTHONPATH ensures init copies from the worktree source tree (not a
+    #    stale site-packages install) — mirrors pyproject.toml pythonpath=["src"].
+    _init_env = {**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")}
     subprocess.run(
         [sys.executable, "-m", "worca.cli.main", "init"],
-        cwd=str(project), check=True, capture_output=True,
+        cwd=str(project), check=True, capture_output=True, env=_init_env,
     )
 
 
@@ -123,6 +126,7 @@ def pipeline_env(tmp_path):
             "WORCA_CLAUDE_BIN": f"{sys.executable} {MOCK_CLAUDE_BIN}",
             "WORCA_AGENT": "",  # not in agent mode — hooks should not enforce agent guards
             "WORCA_SKIP_BEADS": "1",  # bd binary may not work in CI
+            "PYTHONPATH": str(REPO_ROOT / "src"),
         }
         # Strip pipeline-specific WORCA_* vars that leak from the parent shell.
         # WORCA_PLAN_FILE and WORCA_PROJECT_ROOT in particular cause plan_check

--- a/tests/integration/test_design_notes_integration.py
+++ b/tests/integration/test_design_notes_integration.py
@@ -17,16 +17,16 @@ import time
 
 import pytest
 
-# Integration tests run the full pipeline as a subprocess; a background
-# worca-ui server writing to ~/.worca/worca-ui-global.log during that
-# window is falsely attributed to the test by the leak detector.
-pytestmark = pytest.mark.allow_worca_writes
-
 from tests.integration.helpers import (
     _find_latest_run_id,
     run_and_act,
     send_sigkill,
 )
+
+# Integration tests run the full pipeline as a subprocess; a background
+# worca-ui server writing to ~/.worca/worca-ui-global.log during that
+# window is falsely attributed to the test by the leak detector.
+pytestmark = pytest.mark.allow_worca_writes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_design_notes_integration.py
+++ b/tests/integration/test_design_notes_integration.py
@@ -1,0 +1,329 @@
+"""Integration tests for cross-bead design notes (W-005).
+
+Two scenarios:
+
+  1. Multi-bead run (3 beads): bead 1 emits design_notes; assert bead 2's
+     resolved implement prompt contains '## Accumulated design notes (advisory)'
+     with bead 1's note and NOT bead 2's own note.
+
+  2. Resume survival: kill after bead 1, resume; assert all_design_notes
+     survives via prompt_context.json and is injected into the next bead's prompt.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+import pytest
+
+# Integration tests run the full pipeline as a subprocess; a background
+# worca-ui server writing to ~/.worca/worca-ui-global.log during that
+# window is falsely attributed to the test by the leak detector.
+pytestmark = pytest.mark.allow_worca_writes
+
+from tests.integration.helpers import (
+    _find_latest_run_id,
+    run_and_act,
+    send_sigkill,
+)
+
+
+# ---------------------------------------------------------------------------
+# Local helpers
+# ---------------------------------------------------------------------------
+
+def _beads_file(tmp_path, beads):
+    """Write a stateful bead pool file and return the path."""
+    path = tmp_path / "beads_pool.json"
+    path.write_text(json.dumps({"beads": beads}))
+    return path
+
+
+def _read_implement_prompts(worca_dir):
+    """Return a dict of {iter_N: prompt_text} from status.json iteration records.
+
+    The design notes section lives in the implement.block.md which is resolved
+    into the -p prompt (stored in status iterations), not the agent .md file.
+    """
+    run_id = _find_latest_run_id(worca_dir)
+    status_path = worca_dir / "runs" / run_id / "status.json"
+    if not status_path.exists():
+        return {}
+    status = json.loads(status_path.read_text())
+    implement = status.get("stages", {}).get("implement", {})
+    prompts = {}
+    for it in implement.get("iterations", []):
+        num = it.get("number")
+        prompt = it.get("prompt", "")
+        if num is not None and prompt:
+            prompts[f"iter_{num}"] = prompt
+    return prompts
+
+
+def _read_prompt_context(worca_dir) -> dict:
+    run_id = _find_latest_run_id(worca_dir)
+    ctx_path = worca_dir / "runs" / run_id / "prompt_context.json"
+    if not ctx_path.exists():
+        return {}
+    return json.loads(ctx_path.read_text())
+
+
+def _wait_for_context_key(worca_dir, key, timeout=30.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            ctx = _read_prompt_context(worca_dir)
+            if ctx.get(key):
+                return
+        except Exception:
+            pass
+        time.sleep(0.1)
+    raise TimeoutError(
+        f"prompt_context.json did not contain non-empty {key!r} within {timeout}s"
+    )
+
+
+THREE_BEADS = [
+    {"id": "beads-aaa", "title": "Bead A", "priority": "P2", "type": "task"},
+    {"id": "beads-bbb", "title": "Bead B", "priority": "P2", "type": "task"},
+    {"id": "beads-ccc", "title": "Bead C", "priority": "P2", "type": "task"},
+]
+
+_ALL_SUCCEED = {"default": {"action": "succeed", "delay_s": 0.05}}
+
+
+# ---------------------------------------------------------------------------
+# Test 1: multi-bead design notes injection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.timeout(180)
+def test_multi_bead_design_notes_injected_into_subsequent_beads(
+    pipeline_env, tmp_path
+):
+    """Bead 1 emits design_notes; bead 2 and 3's resolved prompts must contain
+    the '## Accumulated design notes (advisory)' section with bead 1's note.
+    Bead 2's own note must NOT appear in bead 2's prompt (only siblings)."""
+    bf = _beads_file(tmp_path, THREE_BEADS)
+    pipeline_env.enable_beads(beads_file=bf)
+
+    scenario = {
+        "agents": {
+            "coordinator": {
+                "action": "succeed",
+                "delay_s": 0.05,
+                "structured_output": {
+                    "beads_ids": ["beads-aaa", "beads-bbb", "beads-ccc"],
+                    "dependency_graph": {},
+                },
+            },
+            "tester": {
+                "action": "succeed",
+                "delay_s": 0.05,
+                "structured_output": {"passed": True},
+            },
+            "implementer": {
+                "iter_1": {
+                    "action": "succeed",
+                    "delay_s": 0.05,
+                    "structured_output": {
+                        "files_changed": ["a.py"],
+                        "tests_added": [],
+                        "bead_id": "beads-aaa",
+                        "design_notes": "Use dataclass for Config, not dict.",
+                    },
+                },
+                "iter_2": {
+                    "action": "succeed",
+                    "delay_s": 0.05,
+                    "structured_output": {
+                        "files_changed": ["b.py"],
+                        "tests_added": [],
+                        "bead_id": "beads-bbb",
+                        "design_notes": "Validate inputs at the boundary.",
+                    },
+                },
+                "iter_3": {
+                    "action": "succeed",
+                    "delay_s": 0.05,
+                    "structured_output": {
+                        "files_changed": ["c.py"],
+                        "tests_added": [],
+                        "bead_id": "beads-ccc",
+                    },
+                },
+                "default": {"action": "succeed", "delay_s": 0.05},
+            },
+        },
+        "default": {"action": "succeed", "delay_s": 0.05},
+    }
+
+    result = pipeline_env.run(scenario, timeout=90)
+
+    assert result.returncode == 0, (
+        f"pipeline should complete; rc={result.returncode}\n"
+        f"stderr: {result.stderr[:500]}"
+    )
+
+    prompts = _read_implement_prompts(pipeline_env.worca_dir)
+    assert "iter_1" in prompts, f"resolved prompt iter_1 not found; got: {sorted(prompts)}"
+    assert "iter_2" in prompts, f"resolved prompt iter_2 not found; got: {sorted(prompts)}"
+    assert "iter_3" in prompts, f"resolved prompt iter_3 not found; got: {sorted(prompts)}"
+
+    # iter_1 (bead A): no prior notes → section should NOT appear
+    assert "## Accumulated design notes (advisory)" not in prompts["iter_1"], (
+        "bead 1 should NOT have design notes section (no prior beads)"
+    )
+
+    # iter_2 (bead B): should see bead A's note
+    assert "## Accumulated design notes (advisory)" in prompts["iter_2"], (
+        "bead 2 must have the design notes section with bead 1's note"
+    )
+    assert "Use dataclass for Config, not dict." in prompts["iter_2"], (
+        "bead 2's prompt must contain bead A's design note"
+    )
+    # bead B's own note must NOT be in its own prompt (only siblings)
+    assert "Validate inputs at the boundary." not in prompts["iter_2"], (
+        "bead 2's OWN design note must not appear in its own prompt"
+    )
+
+    # iter_3 (bead C): should see both bead A and bead B notes
+    assert "## Accumulated design notes (advisory)" in prompts["iter_3"], (
+        "bead 3 must have the design notes section"
+    )
+    assert "Use dataclass for Config, not dict." in prompts["iter_3"], (
+        "bead 3's prompt must contain bead A's design note"
+    )
+    assert "Validate inputs at the boundary." in prompts["iter_3"], (
+        "bead 3's prompt must contain bead B's design note"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: design notes survive resume via prompt_context.json
+# ---------------------------------------------------------------------------
+
+@pytest.mark.timeout(180)
+@pytest.mark.skipif(sys.platform == "win32", reason="signal-based tests require Unix")
+def test_design_notes_survive_resume(pipeline_env, tmp_path):
+    """Kill after bead 1 completes; resume and verify all_design_notes
+    persisted in prompt_context.json is injected into bead 2's prompt."""
+    bf = _beads_file(tmp_path, THREE_BEADS)
+    pipeline_env.enable_beads(beads_file=bf)
+
+    scenario = {
+        "agents": {
+            "coordinator": {
+                "action": "succeed",
+                "delay_s": 0.05,
+                "structured_output": {
+                    "beads_ids": ["beads-aaa", "beads-bbb", "beads-ccc"],
+                    "dependency_graph": {},
+                },
+            },
+            "tester": {
+                "action": "succeed",
+                "delay_s": 0.05,
+                "structured_output": {"passed": True},
+            },
+            "implementer": {
+                "iter_1": {
+                    "action": "succeed",
+                    "delay_s": 0.05,
+                    "structured_output": {
+                        "files_changed": ["a.py"],
+                        "tests_added": [],
+                        "bead_id": "beads-aaa",
+                        "design_notes": "Error codes use IntEnum, not plain ints.",
+                    },
+                },
+                "iter_2": {"action": "hang"},
+                "default": {"action": "succeed", "delay_s": 0.05},
+            },
+        },
+        "default": {"action": "succeed", "delay_s": 0.05},
+    }
+
+    def _act(proc, env):
+        _wait_for_context_key(env.worca_dir, "all_design_notes")
+        send_sigkill(proc, env)
+
+    first = run_and_act(pipeline_env, scenario, _act, timeout=40)
+
+    assert first.status.get("pipeline_status") not in (
+        "completed", "failed", "interrupted"
+    ), (
+        f"run must be non-terminal after SIGKILL; "
+        f"got {first.status.get('pipeline_status')!r}"
+    )
+
+    # Verify all_design_notes persisted in prompt_context.json
+    ctx = _read_prompt_context(pipeline_env.worca_dir)
+    assert "all_design_notes" in ctx, (
+        f"prompt_context.json must contain all_design_notes; "
+        f"keys: {sorted(ctx.keys())}"
+    )
+    notes = ctx["all_design_notes"]
+    assert len(notes) >= 1, f"expected at least one design note; got {notes}"
+    assert notes[0]["bead_id"] == "beads-aaa"
+    assert "IntEnum" in notes[0]["note"]
+
+    # Resume — bead 2 should get the design notes from bead 1
+    resume_scenario = {
+        "agents": {
+            "tester": {
+                "action": "succeed",
+                "delay_s": 0.05,
+                "structured_output": {"passed": True},
+            },
+            "implementer": {
+                "iter_2": {
+                    "action": "succeed",
+                    "delay_s": 0.05,
+                    "structured_output": {
+                        "files_changed": ["b.py"],
+                        "tests_added": [],
+                        "bead_id": "beads-bbb",
+                    },
+                },
+                "default": {"action": "succeed", "delay_s": 0.05},
+            },
+        },
+        "default": {"action": "succeed", "delay_s": 0.05},
+    }
+    resumed = pipeline_env.run(
+        resume_scenario, extra_args=["--resume"], timeout=60
+    )
+    assert resumed.returncode == 0, (
+        f"resume must complete; rc={resumed.returncode}\n"
+        f"stderr: {resumed.stderr[:500]}"
+    )
+    assert resumed.status.get("pipeline_status") == "completed"
+
+    # After resume, check that bead 2's resolved prompt had the design notes
+    prompts = _read_implement_prompts(pipeline_env.worca_dir)
+    # iter_2 is the first implement call in the resumed run
+    bead2_prompt = None
+    for key in sorted(prompts):
+        content = prompts[key]
+        if "beads-bbb" in content or "Bead B" in content:
+            bead2_prompt = content
+            break
+
+    if bead2_prompt is None:
+        # Fall back: any implement prompt after resume should have the notes
+        for key in sorted(prompts):
+            if "## Accumulated design notes (advisory)" in prompts[key]:
+                bead2_prompt = prompts[key]
+                break
+
+    assert bead2_prompt is not None, (
+        f"could not find bead 2's resolved prompt after resume; "
+        f"available: {sorted(prompts.keys())}"
+    )
+    assert "## Accumulated design notes (advisory)" in bead2_prompt, (
+        "bead 2's prompt after resume must contain design notes section"
+    )
+    assert "IntEnum" in bead2_prompt, (
+        "bead 2's prompt after resume must contain bead A's design note"
+    )

--- a/tests/test_agent_md_refs.py
+++ b/tests/test_agent_md_refs.py
@@ -196,6 +196,26 @@ def test_implementer_has_stage_key_nudge():
     )
 
 
+def test_implementer_has_design_notes_write_guidance():
+    content = _read("implementer.md")
+    assert "design_notes" in content, (
+        "implementer.md must instruct the implementer to populate design_notes"
+    )
+    assert "plan didn" in content.lower() or "plan did not" in content.lower(), (
+        "write guidance must scope design_notes to decisions the plan didn't specify"
+    )
+
+
+def test_implementer_has_design_notes_read_guidance():
+    content = _read("implementer.md")
+    assert "Accumulated design notes" in content, (
+        "implementer.md must explain the accumulated design notes block"
+    )
+    assert "advisory" in content.lower(), (
+        "read guidance must state that accumulated design notes are advisory"
+    )
+
+
 # ---------------------------------------------------------------------------
 # tester.md
 # ---------------------------------------------------------------------------

--- a/tests/test_implement_schema.py
+++ b/tests/test_implement_schema.py
@@ -1,0 +1,44 @@
+"""Tests for the implement JSON schema (src/worca/schemas/implement.json)."""
+import json
+import os
+
+import jsonschema
+import pytest
+
+import worca
+
+SCHEMA_PATH = os.path.join(
+    os.path.dirname(worca.__file__), "schemas", "implement.json",
+)
+
+
+@pytest.fixture
+def schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def _minimal_doc():
+    return {
+        "bead_id": "beads-abc",
+        "files_changed": ["src/foo.py"],
+    }
+
+
+def test_implement_schema_allows_missing_design_notes(schema):
+    doc = _minimal_doc()
+    assert "design_notes" not in doc
+    jsonschema.validate(doc, schema)
+
+
+def test_implement_schema_rejects_overlong_design_notes(schema):
+    doc = _minimal_doc()
+    doc["design_notes"] = "x" * 401
+    with pytest.raises(jsonschema.ValidationError, match="maxLength"):
+        jsonschema.validate(doc, schema)
+
+
+def test_implement_schema_accepts_valid_design_notes(schema):
+    doc = _minimal_doc()
+    doc["design_notes"] = "Use snake_case for all helper functions in this module."
+    jsonschema.validate(doc, schema)

--- a/tests/test_prompt_builder_design_notes.py
+++ b/tests/test_prompt_builder_design_notes.py
@@ -1,0 +1,115 @@
+"""Tests for design notes rendering in PromptBuilder."""
+
+from worca.orchestrator.prompt_builder import PromptBuilder, _render_notes, _DESIGN_NOTES_CAP
+
+
+def test_render_notes_empty_list():
+    assert _render_notes([], 2000) == ""
+
+
+def test_render_notes_single_note():
+    notes = [{"bead_id": "bead-1", "note": "Use snake_case for helpers"}]
+    result = _render_notes(notes, 2000)
+    assert result == "- [bead-1] Use snake_case for helpers"
+
+
+def test_render_notes_multiple_notes():
+    notes = [
+        {"bead_id": "bead-1", "note": "Use snake_case"},
+        {"bead_id": "bead-2", "note": "Error codes are ints"},
+    ]
+    result = _render_notes(notes, 2000)
+    assert "- [bead-1] Use snake_case" in result
+    assert "- [bead-2] Error codes are ints" in result
+    lines = result.strip().split("\n")
+    assert len(lines) == 2
+
+
+def test_render_notes_drop_oldest_cap():
+    notes = [
+        {"bead_id": "bead-old", "note": "A" * 100},
+        {"bead_id": "bead-new", "note": "B" * 50},
+    ]
+    cap = len("- [bead-new] " + "B" * 50) + 10
+    result = _render_notes(notes, cap)
+    assert "bead-new" in result
+    assert "bead-old" not in result
+
+
+def test_render_notes_cap_zero_returns_empty():
+    notes = [{"bead_id": "x", "note": "hello"}]
+    assert _render_notes(notes, 0) == ""
+
+
+def test_design_notes_cap_constant():
+    assert _DESIGN_NOTES_CAP == 2000
+
+
+def test_build_context_renders_accumulated_notes():
+    pb = PromptBuilder("Title", "Desc")
+    pb.update_context("all_design_notes", [
+        {"bead_id": "bead-1", "note": "Use snake_case"},
+        {"bead_id": "bead-2", "note": "Error codes are ints"},
+    ])
+    pb.update_context("assigned_bead_id", "bead-3")
+    ctx = pb.build_context("implement", iteration=0)
+    assert ctx["has_design_notes"] is True
+    assert "bead-1" in ctx["accumulated_design_notes"]
+    assert "bead-2" in ctx["accumulated_design_notes"]
+
+
+def test_build_context_excludes_current_bead():
+    pb = PromptBuilder("Title", "Desc")
+    pb.update_context("all_design_notes", [
+        {"bead_id": "bead-1", "note": "Keep this"},
+        {"bead_id": "bead-2", "note": "Exclude this"},
+    ])
+    pb.update_context("assigned_bead_id", "bead-2")
+    ctx = pb.build_context("implement", iteration=0)
+    assert "bead-1" in ctx["accumulated_design_notes"]
+    assert "bead-2" not in ctx["accumulated_design_notes"]
+
+
+def test_build_context_no_notes():
+    pb = PromptBuilder("Title", "Desc")
+    pb.update_context("assigned_bead_id", "bead-1")
+    ctx = pb.build_context("implement", iteration=0)
+    assert ctx["has_design_notes"] is False
+    assert ctx["accumulated_design_notes"] == ""
+
+
+def test_build_context_all_notes_from_current_bead():
+    pb = PromptBuilder("Title", "Desc")
+    pb.update_context("all_design_notes", [
+        {"bead_id": "bead-1", "note": "My own note"},
+    ])
+    pb.update_context("assigned_bead_id", "bead-1")
+    ctx = pb.build_context("implement", iteration=0)
+    assert ctx["has_design_notes"] is False
+    assert ctx["accumulated_design_notes"] == ""
+
+
+def test_build_context_design_notes_on_retry():
+    pb = PromptBuilder("Title", "Desc")
+    pb.update_context("all_design_notes", [
+        {"bead_id": "bead-1", "note": "Use snake_case"},
+    ])
+    pb.update_context("assigned_bead_id", "bead-2")
+    ctx = pb.build_context("implement", iteration=1)
+    assert ctx["has_design_notes"] is True
+    assert "bead-1" in ctx["accumulated_design_notes"]
+
+
+def test_implement_block_no_notes_no_section():
+    """When has_design_notes is False, the block template should not contain
+    the design notes section. We verify by checking the template source."""
+    import os
+    block_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "src", "worca", "agents", "core", "implement.block.md",
+    )
+    with open(block_path) as f:
+        content = f.read()
+    assert "{{#if has_design_notes}}" in content
+    assert "{{accumulated_design_notes}}" in content
+    assert "{{/if}}" in content

--- a/tests/test_runner_design_notes.py
+++ b/tests/test_runner_design_notes.py
@@ -1,0 +1,114 @@
+"""Tests for design_notes accumulation in the IMPLEMENT stage of runner.py."""
+
+from worca.orchestrator.prompt_builder import PromptBuilder
+
+
+def _make_prompt_builder():
+    return PromptBuilder(work_request_title="test")
+
+
+def test_runner_accumulates_design_notes():
+    """Initial/next_bead trigger: non-empty design_notes appended to all_design_notes."""
+    pb = _make_prompt_builder()
+    result = {
+        "bead_id": "beads-aaa",
+        "files_changed": ["src/a.py"],
+        "tests_added": [],
+        "design_notes": "Use snake_case for helpers.",
+    }
+    _simulate_bead_close(pb, result, trigger="initial")
+
+    notes = pb.get_context("all_design_notes")
+    assert notes == [{"bead_id": "beads-aaa", "note": "Use snake_case for helpers."}]
+
+
+def test_runner_skips_empty_design_notes():
+    """Initial/next_bead trigger: empty or missing design_notes not appended."""
+    pb = _make_prompt_builder()
+
+    # Missing design_notes
+    result1 = {"bead_id": "beads-bbb", "files_changed": ["src/b.py"], "tests_added": []}
+    _simulate_bead_close(pb, result1, trigger="initial")
+    assert pb.get_context("all_design_notes") == []
+
+    # Empty string
+    result2 = {"bead_id": "beads-ccc", "files_changed": ["src/c.py"], "tests_added": [], "design_notes": ""}
+    _simulate_bead_close(pb, result2, trigger="next_bead")
+    assert pb.get_context("all_design_notes") == []
+
+
+def test_runner_retry_replaces_design_note():
+    """Retry trigger: fix-mode emits bead_id='fix'; runner uses assigned_bead_id to replace."""
+    pb = _make_prompt_builder()
+    pb.update_context("assigned_bead_id", "beads-aaa")
+    pb.update_context("all_design_notes", [{"bead_id": "beads-aaa", "note": "Old note."}])
+
+    result = {
+        "bead_id": "fix",
+        "files_changed": ["src/a.py"],
+        "tests_added": [],
+        "design_notes": "Updated note.",
+    }
+    _simulate_retry(pb, result, trigger="test_failure")
+
+    notes = pb.get_context("all_design_notes")
+    assert notes == [{"bead_id": "beads-aaa", "note": "Updated note."}]
+
+
+def test_runner_retry_empty_note_preserves_original():
+    """Retry trigger: empty design_notes leaves existing entry unchanged."""
+    pb = _make_prompt_builder()
+    pb.update_context("all_design_notes", [{"bead_id": "beads-aaa", "note": "Original."}])
+
+    result = {
+        "bead_id": "beads-aaa",
+        "files_changed": ["src/a.py"],
+        "tests_added": [],
+        "design_notes": "",
+    }
+    _simulate_retry(pb, result, trigger="test_failure")
+
+    notes = pb.get_context("all_design_notes")
+    assert notes == [{"bead_id": "beads-aaa", "note": "Original."}]
+
+
+def test_runner_retry_appends_if_no_prior_note():
+    """Retry trigger: non-empty note appends when no prior entry for this bead."""
+    pb = _make_prompt_builder()
+    pb.update_context("all_design_notes", [{"bead_id": "beads-other", "note": "Other note."}])
+
+    result = {
+        "bead_id": "beads-new",
+        "files_changed": ["src/new.py"],
+        "tests_added": [],
+        "design_notes": "Brand new note.",
+    }
+    _simulate_retry(pb, result, trigger="review_changes")
+
+    notes = pb.get_context("all_design_notes")
+    assert len(notes) == 2
+    assert notes[0] == {"bead_id": "beads-other", "note": "Other note."}
+    assert notes[1] == {"bead_id": "beads-new", "note": "Brand new note."}
+
+
+# ---------------------------------------------------------------------------
+# Helpers that replicate the runner logic we're testing (extracted to keep
+# tests independent of the full pipeline loop).  These will initially fail
+# because the runner doesn't have the logic yet — the implementation will
+# make them pass by adding equivalent code to runner.py.
+# ---------------------------------------------------------------------------
+
+def _accumulate_design_note(pb, result, trigger):
+    """Replicate the design_notes accumulation logic from runner.py."""
+    from worca.orchestrator.runner import _accumulate_design_note as impl
+    impl(pb, result, trigger)
+
+
+def _simulate_bead_close(pb, result, *, trigger):
+    """Simulate an initial/next_bead trigger's design_notes handling."""
+    _accumulate_design_note(pb, result, trigger)
+
+
+def _simulate_retry(pb, result, *, trigger):
+    """Simulate a retry trigger's design_notes handling."""
+    _accumulate_design_note(pb, result, trigger)


### PR DESCRIPTION
## Summary

- Add optional `design_notes` (max 400 chars) to `implement.json` schema so each bead can record micro-decisions the plan didn't specify (naming, error strategy, shared state location)
- Runner accumulates notes into `_context` via `prompt_context.json` (surviving pause/resume) with replace-on-retry semantics (at most one entry per `bead_id`)
- Prompt builder renders `## Accumulated design notes (advisory)` block with self-exclusion and 2000-char drop-oldest cap
- Implementer prompt updated with write/read guidance; authority order: guide > plan > graph > description > accumulated design notes

## Test plan

- [x] Schema validation: accepts valid notes, rejects >400 chars, optional field
- [x] Runner accumulation: initial append, empty skip, retry replace, retry empty preserves, retry append-if-no-prior
- [x] Prompt builder: rendering, self-exclusion, drop-oldest cap, no-notes-no-section
- [x] Agent MD refs: write guidance and read guidance present in implementer.md
- [x] Integration: multi-bead injection (3 beads, notes flow correctly), resume survival via prompt_context.json
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)