### PR TITLE
fix(tests): filter ephemeral files from ~/.worca leak detector

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,18 +33,29 @@ if "WORCA_HOME" not in os.environ:
 _leak_baseline: dict | None = None
 
 
+_IGNORED_SUFFIXES = {".log", ".pid"}
+_IGNORED_NAMES = {".DS_Store"}
+_IGNORED_DIRS = {"cache"}
+
+
 def _snapshot_worca_home() -> dict:
     """Return {relative_path: (size, mtime_ns)} for every file under the
     real ~/.worca/.
 
     Cheap stat-only scan — does not read file contents. Returns {} when the
-    directory does not exist.
+    directory does not exist. Filters out process-owned ephemera (logs, pid
+    files, shared cache) that external processes may write concurrently.
     """
     if not os.path.isdir(_REAL_WORCA_HOME):
         return {}
     snap: dict = {}
-    for dirpath, _, filenames in os.walk(_REAL_WORCA_HOME):
+    for dirpath, dirnames, filenames in os.walk(_REAL_WORCA_HOME):
+        dirnames[:] = [d for d in dirnames if d not in _IGNORED_DIRS]
         for name in filenames:
+            if name in _IGNORED_NAMES:
+                continue
+            if any(name.endswith(s) for s in _IGNORED_SUFFIXES):
+                continue
             full = os.path.join(dirpath, name)
             try:
                 st = os.stat(full)

--- a/tests/integration/test_effort_integration.py
+++ b/tests/integration/test_effort_integration.py
@@ -8,8 +8,6 @@ import json
 
 import pytest
 
-pytestmark = pytest.mark.allow_worca_writes
-
 from tests.integration.helpers import make_iteration_scenario  # noqa: E402
 
 

--- a/tests/test_runner_effort.py
+++ b/tests/test_runner_effort.py
@@ -11,11 +11,6 @@ from worca.orchestrator.runner import run_stage, run_pipeline
 from worca.orchestrator.stages import Stage
 from worca.orchestrator.work_request import WorkRequest
 
-# Pipeline tests trigger run_pipeline which takes non-trivial wall time;
-# a background worca-ui server writing to ~/.worca/worca-ui-global.log
-# during that window is falsely attributed to the test by the leak detector.
-pytestmark = pytest.mark.allow_worca_writes
-
 
 @pytest.fixture(autouse=True)
 def _mock_beads_init():

--- a/tests/test_runner_effort_backfill.py
+++ b/tests/test_runner_effort_backfill.py
@@ -9,8 +9,6 @@ import pytest
 from worca.orchestrator.runner import run_pipeline
 from worca.orchestrator.work_request import WorkRequest
 
-pytestmark = pytest.mark.allow_worca_writes
-
 
 @pytest.fixture(autouse=True)
 def _mock_beads_init():

--- a/tests/test_worca_home_snapshot_filter.py
+++ b/tests/test_worca_home_snapshot_filter.py
@@ -9,7 +9,7 @@ def test_snapshot_worca_home_ignores_ephemeral_files(monkeypatch):
     """_snapshot_worca_home should exclude *.log, *.pid, .DS_Store, and cache/**
     while including durable state files (projects.d/, fleet-runs/, settings.json).
     """
-    from tests.conftest import _snapshot_worca_home, _REAL_WORCA_HOME
+    from tests.conftest import _snapshot_worca_home
 
     with tempfile.TemporaryDirectory(prefix="worca-home-test-") as tmp:
         monkeypatch.setattr("tests.conftest._REAL_WORCA_HOME", tmp)

--- a/tests/test_worca_home_snapshot_filter.py
+++ b/tests/test_worca_home_snapshot_filter.py
@@ -1,0 +1,69 @@
+"""Tests for _snapshot_worca_home ignore filter."""
+import os
+import tempfile
+
+import pytest
+
+
+def test_snapshot_worca_home_ignores_ephemeral_files(monkeypatch):
+    """_snapshot_worca_home should exclude *.log, *.pid, .DS_Store, and cache/**
+    while including durable state files (projects.d/, fleet-runs/, settings.json).
+    """
+    from tests.conftest import _snapshot_worca_home, _REAL_WORCA_HOME
+
+    with tempfile.TemporaryDirectory(prefix="worca-home-test-") as tmp:
+        monkeypatch.setattr("tests.conftest._REAL_WORCA_HOME", tmp)
+
+        # --- Ignored files (should NOT appear in snapshot) ---
+        # *.log
+        _touch(tmp, "worca-ui-global.log")
+        # *.pid
+        _touch(tmp, "worca-ui-global.pid")
+        # .DS_Store
+        _touch(tmp, ".DS_Store")
+        # cache/** (graphify AST cache)
+        _touch(tmp, "cache/ast/foo/graph.json")
+        _touch(tmp, "cache/ast/bar/baz/data.json")
+
+        # --- Watched files (SHOULD appear in snapshot) ---
+        _touch(tmp, "projects.d/myproject.json")
+        _touch(tmp, "fleet-runs/abc/status.json")
+        _touch(tmp, "settings.json")
+
+        snap = _snapshot_worca_home()
+
+    keys = set(snap.keys())
+
+    # Watched files must be present
+    assert "projects.d/myproject.json" in keys
+    assert "fleet-runs/abc/status.json" in keys
+    assert "settings.json" in keys
+
+    # Ignored files must be absent
+    assert "worca-ui-global.log" not in keys
+    assert "worca-ui-global.pid" not in keys
+    assert ".DS_Store" not in keys
+    assert "cache/ast/foo/graph.json" not in keys
+    assert "cache/ast/bar/baz/data.json" not in keys
+
+
+@pytest.mark.parametrize("test_file", [
+    "tests/test_runner_effort.py",
+    "tests/test_runner_effort_backfill.py",
+    "tests/integration/test_effort_integration.py",
+])
+def test_effort_files_have_no_allow_worca_writes_marker(test_file):
+    """The allow_worca_writes workaround is no longer needed now that
+    _snapshot_worca_home filters ephemeral files."""
+    import pathlib
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    content = (repo_root / test_file).read_text()
+    assert "allow_worca_writes" not in content
+
+
+def _touch(base: str, relpath: str) -> None:
+    """Create an empty file at base/relpath, making parent dirs as needed."""
+    full = os.path.join(base, relpath)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w") as f:
+        f.write("x")


### PR DESCRIPTION
## Summary

- Scopes `_snapshot_worca_home()` in `tests/conftest.py` to ignore `*.log`, `*.pid`, `.DS_Store`, and the entire `cache/` subtree — files written by concurrent external processes (worca-ui server, parallel pipelines, macOS Finder) that the leak detector was falsely attributing to the test under inspection.
- Removes the `@pytest.mark.allow_worca_writes` workaround from 3 effort test files that were only using it to dodge this false-positive class.
- Adds `tests/test_worca_home_snapshot_filter.py` with 4 tests: one verifying the filter behavior against a synthetic `~/.worca/` tree, and three parametrized tests asserting the workaround markers are gone.

Durable state paths (`fleet-runs/`, `projects.d/`, `settings.json`, etc.) remain watched — the issue #162 guarantee is preserved.

## Test plan

- [x] `pytest tests/test_worca_home_snapshot_filter.py` — 4/4 pass
- [ ] CI green on full `pytest tests/` suite
- [ ] Verify no false-positive teardown failures when worca-ui server is running concurrently

🤖 Generated with [Claude Code](https://claude.com/claude-code)