### PR TITLE
fix: accumulate stage metrics across auto-resume result events

### DIFF
--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -308,6 +308,38 @@ def _format_log_line(event: dict) -> Optional[str]:
     return None
 
 
+_USAGE_NUMERIC_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
+
+_USAGE_SUB_DICTS = ("server_tool_use", "cache_creation")
+
+
+def _accumulate_usage(acc: dict, usage: dict) -> None:
+    """Sum numeric token fields from *usage* into *acc* in place.
+
+    Top-level numeric fields (input_tokens, output_tokens, etc.) are summed
+    directly.  Nested sub-dicts (server_tool_use, cache_creation) are merged
+    key-by-key, summing every numeric value found.
+    """
+    for key in _USAGE_NUMERIC_KEYS:
+        val = usage.get(key)
+        if isinstance(val, (int, float)):
+            acc[key] = acc.get(key, 0) + val
+
+    for sub_key in _USAGE_SUB_DICTS:
+        sub = usage.get(sub_key)
+        if not isinstance(sub, dict):
+            continue
+        acc_sub = acc.setdefault(sub_key, {})
+        for k, v in sub.items():
+            if isinstance(v, (int, float)):
+                acc_sub[k] = acc_sub.get(k, 0) + v
+
+
 def process_stream(
     stdout,
     log_file=None,
@@ -327,6 +359,11 @@ def process_stream(
     result_event = None
     resolved_model = None
     sticky_structured_output = None
+    _accum_duration_ms = 0
+    _accum_duration_api_ms = 0
+    _accum_num_turns = 0
+    _accum_usage: dict = {}
+    _result_count = 0
 
     for raw_line in stdout:
         line = raw_line.strip()
@@ -363,10 +400,24 @@ def process_stream(
             so = event.get("structured_output")
             if so:
                 sticky_structured_output = so
+            _result_count += 1
+            _accum_duration_ms += event.get("duration_ms", 0)
+            _accum_duration_api_ms += event.get("duration_api_ms", 0)
+            _accum_num_turns += event.get("num_turns", 0)
+            usage = event.get("usage")
+            if isinstance(usage, dict):
+                _accumulate_usage(_accum_usage, usage)
             result_event = event
 
     if result_event is None:
         raise RuntimeError("No result event found in stream-json output")
+
+    if _result_count > 1:
+        result_event["duration_ms"] = _accum_duration_ms
+        result_event["duration_api_ms"] = _accum_duration_api_ms
+        result_event["num_turns"] = _accum_num_turns
+        if _accum_usage:
+            result_event["usage"] = _accum_usage
 
     if sticky_structured_output and not result_event.get("structured_output"):
         result_event["structured_output"] = sticky_structured_output

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -417,7 +417,19 @@ def process_stream(
         result_event["duration_api_ms"] = _accum_duration_api_ms
         result_event["num_turns"] = _accum_num_turns
         if _accum_usage:
-            result_event["usage"] = _accum_usage
+            # Merge summed totals over the last event's full usage block so
+            # non-numeric / unrecognized keys (e.g. service_tier) survive
+            # instead of being dropped when accumulation rebuilds usage. Nested
+            # sub-dicts are likewise overlaid, preserving any non-numeric keys.
+            merged = dict(result_event.get("usage") or {})
+            for key, val in _accum_usage.items():
+                if isinstance(val, dict):
+                    sub = dict(merged.get(key) or {})
+                    sub.update(val)
+                    merged[key] = sub
+                else:
+                    merged[key] = val
+            result_event["usage"] = merged
 
     if sticky_structured_output and not result_event.get("structured_output"):
         result_event["structured_output"] = sticky_structured_output

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock
 
 from worca.utils.claude_cli import (
     AgentSubprocessError,
+    _accumulate_usage,
     _resolve_tool_args,
     _resolve_tool_disallows,
     build_command,
@@ -437,9 +438,10 @@ def test_process_stream_preserves_structured_output_across_task_notification_res
 
     # structured_output must stick from the first result event
     assert result["structured_output"] == {"passed": True, "failures": []}
-    # but cost / turns continue updating from the latest event
+    # cost is cumulative from the CLI — take the last event's value
     assert result["total_cost_usd"] == 0.13
-    assert result["num_turns"] == 9
+    # num_turns is now accumulated across result events
+    assert result["num_turns"] == 17
 
 
 def test_process_stream_single_result_with_structured_output_passthrough():
@@ -813,3 +815,320 @@ def test_build_command_per_agent_tools_apply_on_resolved_path():
     assert "Bash" in tools
     assert "Skill" in tools  # auto-included so hook fires
     assert "Agent" in tools
+
+
+# --- _accumulate_usage ---
+
+
+def test_accumulate_usage_sums_top_level_fields():
+    acc = {}
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_creation_input_tokens": 10,
+        "cache_read_input_tokens": 20,
+    }
+    _accumulate_usage(acc, usage)
+    assert acc["input_tokens"] == 100
+    assert acc["output_tokens"] == 50
+    assert acc["cache_creation_input_tokens"] == 10
+    assert acc["cache_read_input_tokens"] == 20
+
+
+def test_accumulate_usage_sums_across_calls():
+    acc = {}
+    _accumulate_usage(acc, {"input_tokens": 100, "output_tokens": 50})
+    _accumulate_usage(acc, {"input_tokens": 200, "output_tokens": 30})
+    assert acc["input_tokens"] == 300
+    assert acc["output_tokens"] == 80
+
+
+def test_accumulate_usage_handles_server_tool_use():
+    acc = {}
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "server_tool_use": {
+            "web_search_requests": 3,
+            "web_fetch_requests": 1,
+        },
+    }
+    _accumulate_usage(acc, usage)
+    assert acc["server_tool_use"]["web_search_requests"] == 3
+    assert acc["server_tool_use"]["web_fetch_requests"] == 1
+
+
+def test_accumulate_usage_handles_cache_creation_sub_dict():
+    acc = {}
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_creation": {
+            "ephemeral_1h_input_tokens": 100,
+            "ephemeral_5m_input_tokens": 200,
+        },
+    }
+    _accumulate_usage(acc, usage)
+    assert acc["cache_creation"]["ephemeral_1h_input_tokens"] == 100
+    assert acc["cache_creation"]["ephemeral_5m_input_tokens"] == 200
+
+
+def test_accumulate_usage_sums_nested_dicts_across_calls():
+    acc = {}
+    _accumulate_usage(acc, {
+        "input_tokens": 10,
+        "server_tool_use": {"web_search_requests": 2},
+        "cache_creation": {"ephemeral_5m_input_tokens": 50},
+    })
+    _accumulate_usage(acc, {
+        "input_tokens": 20,
+        "server_tool_use": {"web_search_requests": 1, "web_fetch_requests": 3},
+        "cache_creation": {"ephemeral_5m_input_tokens": 30, "ephemeral_1h_input_tokens": 10},
+    })
+    assert acc["input_tokens"] == 30
+    assert acc["server_tool_use"]["web_search_requests"] == 3
+    assert acc["server_tool_use"]["web_fetch_requests"] == 3
+    assert acc["cache_creation"]["ephemeral_5m_input_tokens"] == 80
+    assert acc["cache_creation"]["ephemeral_1h_input_tokens"] == 10
+
+
+def test_accumulate_usage_missing_fields_default_zero():
+    acc = {}
+    _accumulate_usage(acc, {"input_tokens": 5})
+    assert acc.get("output_tokens", 0) == 0
+    assert acc["input_tokens"] == 5
+
+
+def test_accumulate_usage_empty_usage():
+    acc = {"input_tokens": 10}
+    _accumulate_usage(acc, {})
+    assert acc["input_tokens"] == 10
+
+
+def test_accumulate_usage_preserves_non_numeric_fields():
+    acc = {}
+    _accumulate_usage(acc, {"input_tokens": 5, "speed": "fast"})
+    assert acc["input_tokens"] == 5
+    assert "speed" not in acc
+
+
+# --- process_stream: multi-result metric accumulation ---
+
+
+def test_process_stream_accumulates_duration_across_results():
+    r1 = {"type": "result", "duration_ms": 5000, "duration_api_ms": 3000,
+           "num_turns": 10, "total_cost_usd": 0.50,
+           "usage": {"input_tokens": 100, "output_tokens": 50}}
+    r2 = {"type": "result", "duration_ms": 2000, "duration_api_ms": 1000,
+           "num_turns": 3, "total_cost_usd": 0.80,
+           "usage": {"input_tokens": 200, "output_tokens": 30}}
+    result = process_stream(_stream(r1, r2))
+    assert result["duration_ms"] == 7000
+    assert result["duration_api_ms"] == 4000
+    assert result["num_turns"] == 13
+    assert result["total_cost_usd"] == 0.80  # cumulative, not summed
+    assert result["usage"]["input_tokens"] == 300
+    assert result["usage"]["output_tokens"] == 80
+
+
+def test_process_stream_single_result_no_accumulation():
+    usage = {"input_tokens": 100, "output_tokens": 50,
+             "cache_read_input_tokens": 2000,
+             "server_tool_use": {"input_tokens": 10}}
+    r1 = {"type": "result", "duration_ms": 5000, "duration_api_ms": 4500,
+           "num_turns": 10, "total_cost_usd": 0.50, "usage": usage}
+    result = process_stream(_stream(r1))
+    assert result["duration_ms"] == 5000
+    assert result["duration_api_ms"] == 4500
+    assert result["num_turns"] == 10
+    assert result["total_cost_usd"] == 0.50
+    assert result["usage"] == usage
+    assert result["usage"]["input_tokens"] == 100
+    assert result["usage"]["output_tokens"] == 50
+    assert result["usage"]["cache_read_input_tokens"] == 2000
+    assert result["usage"]["server_tool_use"]["input_tokens"] == 10
+
+
+def test_process_stream_accumulates_three_results():
+    events = [
+        {"type": "result", "duration_ms": 1000, "num_turns": 5,
+         "total_cost_usd": 0.10,
+         "usage": {"input_tokens": 50, "output_tokens": 20}},
+        {"type": "result", "duration_ms": 2000, "num_turns": 3,
+         "total_cost_usd": 0.25,
+         "usage": {"input_tokens": 100, "output_tokens": 40}},
+        {"type": "result", "duration_ms": 500, "num_turns": 1,
+         "total_cost_usd": 0.30,
+         "usage": {"input_tokens": 10, "output_tokens": 5}},
+    ]
+    result = process_stream(_stream(*events))
+    assert result["duration_ms"] == 3500
+    assert result["num_turns"] == 9
+    assert result["usage"]["input_tokens"] == 160
+    assert result["usage"]["output_tokens"] == 65
+    assert result["total_cost_usd"] == 0.30
+
+
+def test_process_stream_accumulates_nested_usage_sub_dicts():
+    r1 = {"type": "result", "duration_ms": 1000, "num_turns": 1,
+           "total_cost_usd": 0.10,
+           "usage": {"input_tokens": 50, "cache_read_input_tokens": 1000,
+                     "server_tool_use": {"input_tokens": 10}}}
+    r2 = {"type": "result", "duration_ms": 2000, "num_turns": 2,
+           "total_cost_usd": 0.20,
+           "usage": {"input_tokens": 30, "cache_read_input_tokens": 500,
+                     "server_tool_use": {"input_tokens": 20}}}
+    result = process_stream(_stream(r1, r2))
+    assert result["usage"]["input_tokens"] == 80
+    assert result["usage"]["cache_read_input_tokens"] == 1500
+    assert result["usage"]["server_tool_use"]["input_tokens"] == 30
+
+
+def test_process_stream_accumulation_preserves_structured_output():
+    r1 = {"type": "result", "duration_ms": 5000, "num_turns": 10,
+           "total_cost_usd": 0.50,
+           "usage": {"output_tokens": 50},
+           "structured_output": {"passed": True, "failures": []}}
+    r2 = {"type": "result", "duration_ms": 2000, "num_turns": 2,
+           "total_cost_usd": 0.80,
+           "usage": {"output_tokens": 30}}
+    result = process_stream(_stream(r1, r2))
+    assert result["duration_ms"] == 7000
+    assert result["structured_output"] == {"passed": True, "failures": []}
+
+
+def test_process_stream_multi_resume_metrics_accumulation():
+    """Regression test: 3 result events (2 auto-resumes) must sum duration_ms,
+    duration_api_ms, num_turns, and all usage token fields, while
+    total_cost_usd takes the last event's cumulative value."""
+    r1 = {"type": "result", "duration_ms": 120000, "duration_api_ms": 80000,
+           "num_turns": 45, "total_cost_usd": 1.20,
+           "usage": {"input_tokens": 50000, "output_tokens": 8000,
+                     "cache_read_input_tokens": 200000,
+                     "cache_creation_input_tokens": 5000}}
+    r2 = {"type": "result", "duration_ms": 90000, "duration_api_ms": 60000,
+           "num_turns": 30, "total_cost_usd": 2.50,
+           "usage": {"input_tokens": 40000, "output_tokens": 6000,
+                     "cache_read_input_tokens": 180000,
+                     "cache_creation_input_tokens": 3000}}
+    r3 = {"type": "result", "duration_ms": 19000, "duration_api_ms": 12000,
+           "num_turns": 2, "total_cost_usd": 3.45,
+           "usage": {"input_tokens": 5000, "output_tokens": 466,
+                     "cache_read_input_tokens": 258000,
+                     "cache_creation_input_tokens": 0}}
+    result = process_stream(_stream(r1, r2, r3))
+
+    assert result["duration_ms"] == 229000
+    assert result["duration_api_ms"] == 152000
+    assert result["num_turns"] == 77
+
+    assert result["total_cost_usd"] == 3.45
+
+    u = result["usage"]
+    assert u["input_tokens"] == 95000
+    assert u["output_tokens"] == 14466
+    assert u["cache_read_input_tokens"] == 638000
+    assert u["cache_creation_input_tokens"] == 8000
+
+
+def test_process_stream_cost_not_summed_across_resumes():
+    """total_cost_usd must NOT be accumulated across resumes — it stays at the
+    last event's value.  The CLI already reports cumulative session cost in each
+    result event, so summing would double-count.  This is intentionally
+    asymmetric with duration_ms/num_turns/usage which ARE per-segment and must
+    be summed."""
+    r1 = {"type": "result", "duration_ms": 60000, "num_turns": 20,
+           "total_cost_usd": 0.50,
+           "usage": {"input_tokens": 10000, "output_tokens": 2000}}
+    r2 = {"type": "result", "duration_ms": 30000, "num_turns": 10,
+           "total_cost_usd": 0.85,
+           "usage": {"input_tokens": 8000, "output_tokens": 1500}}
+
+    result = process_stream(_stream(r1, r2))
+
+    # Cost: last event's cumulative value, NOT 0.50 + 0.85
+    assert result["total_cost_usd"] == 0.85
+
+    # Contrast: these ARE summed across segments
+    assert result["duration_ms"] == 90000
+    assert result["num_turns"] == 30
+    assert result["usage"]["input_tokens"] == 18000
+    assert result["usage"]["output_tokens"] == 3500
+
+
+def test_process_stream_no_duration_fields_still_works():
+    r1 = {"type": "result", "total_cost_usd": 0.10,
+           "usage": {"input_tokens": 50}}
+    r2 = {"type": "result", "total_cost_usd": 0.20,
+           "usage": {"input_tokens": 30}}
+    result = process_stream(_stream(r1, r2))
+    assert result["usage"]["input_tokens"] == 80
+    assert result["total_cost_usd"] == 0.20
+
+
+def test_process_stream_accumulates_nested_server_tool_use_and_cache_creation():
+    r1 = {"type": "result", "duration_ms": 3000, "num_turns": 5,
+           "total_cost_usd": 0.30,
+           "usage": {"input_tokens": 100, "output_tokens": 20,
+                     "server_tool_use": {
+                         "web_search_requests": 2,
+                         "web_fetch_requests": 1,
+                     },
+                     "cache_creation": {
+                         "ephemeral_1h_input_tokens": 500,
+                         "ephemeral_5m_input_tokens": 200,
+                     }}}
+    r2 = {"type": "result", "duration_ms": 2000, "num_turns": 3,
+           "total_cost_usd": 0.50,
+           "usage": {"input_tokens": 80, "output_tokens": 15,
+                     "server_tool_use": {
+                         "web_search_requests": 1,
+                         "web_fetch_requests": 3,
+                     },
+                     "cache_creation": {
+                         "ephemeral_1h_input_tokens": 300,
+                     }}}
+    r3 = {"type": "result", "duration_ms": 1000, "num_turns": 1,
+           "total_cost_usd": 0.70,
+           "usage": {"input_tokens": 40, "output_tokens": 10,
+                     "server_tool_use": {
+                         "web_search_requests": 4,
+                     },
+                     "cache_creation": {
+                         "ephemeral_5m_input_tokens": 100,
+                     }}}
+    result = process_stream(_stream(r1, r2, r3))
+
+    assert result["duration_ms"] == 6000
+    assert result["num_turns"] == 9
+    assert result["total_cost_usd"] == 0.70
+
+    u = result["usage"]
+    assert u["input_tokens"] == 220
+    assert u["output_tokens"] == 45
+    assert u["server_tool_use"]["web_search_requests"] == 7
+    assert u["server_tool_use"]["web_fetch_requests"] == 4
+    assert u["cache_creation"]["ephemeral_1h_input_tokens"] == 800
+    assert u["cache_creation"]["ephemeral_5m_input_tokens"] == 300
+
+
+def test_process_stream_missing_usage_fields_handled_gracefully():
+    """Result events with missing usage or partial sub-fields must not raise
+    KeyError, and partial fields still accumulate correctly."""
+    r1 = {"type": "result", "duration_ms": 1000, "num_turns": 3,
+           "total_cost_usd": 0.10,
+           "usage": {"input_tokens": 100, "output_tokens": 20}}
+    r2 = {"type": "result", "duration_ms": 2000, "num_turns": 2,
+           "total_cost_usd": 0.25}
+    r3 = {"type": "result", "duration_ms": 500, "num_turns": 1,
+           "total_cost_usd": 0.40,
+           "usage": {"output_tokens": 15}}
+    result = process_stream(_stream(r1, r2, r3))
+
+    assert result["duration_ms"] == 3500
+    assert result["num_turns"] == 6
+    assert result["total_cost_usd"] == 0.40
+
+    u = result["usage"]
+    assert u["input_tokens"] == 100
+    assert u["output_tokens"] == 35

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -1132,3 +1132,27 @@ def test_process_stream_missing_usage_fields_handled_gracefully():
     u = result["usage"]
     assert u["input_tokens"] == 100
     assert u["output_tokens"] == 35
+
+
+def test_process_stream_preserves_non_numeric_usage_keys_across_resumes():
+    """Multi-resume accumulation must not drop non-numeric or unrecognized
+    usage keys (e.g. service_tier).  The summed envelope merges numeric totals
+    over the last event's full usage block rather than rebuilding it from
+    scratch, so unknown keys survive — taking the last event's value, just like
+    total_cost_usd."""
+    r1 = {"type": "result", "duration_ms": 1000, "num_turns": 2,
+           "total_cost_usd": 0.10,
+           "usage": {"input_tokens": 100, "output_tokens": 20,
+                     "service_tier": "standard"}}
+    r2 = {"type": "result", "duration_ms": 2000, "num_turns": 3,
+           "total_cost_usd": 0.20,
+           "usage": {"input_tokens": 50, "output_tokens": 10,
+                     "service_tier": "priority"}}
+    result = process_stream(_stream(r1, r2))
+
+    u = result["usage"]
+    # numeric fields are summed across segments
+    assert u["input_tokens"] == 150
+    assert u["output_tokens"] == 30
+    # non-numeric / unrecognized keys survive, taking the last event's value
+    assert u["service_tier"] == "priority"


### PR DESCRIPTION
## Summary

- When the claude CLI auto-resumes mid-stage (e.g. after a `run_in_background` pytest), it emits multiple `result` events. `process_stream()` was overwriting the result envelope with each event, so `duration_ms`, `num_turns`, and usage tokens reflected only the final (often trivial) segment — a 38-min test stage reported `time=19s | turns=2`.
- Now accumulates `duration_ms`, `duration_api_ms`, `num_turns`, and all `usage` token fields (including nested `server_tool_use` and `cache_creation` sub-dicts) across result events. `total_cost_usd` intentionally takes the last event's cumulative value. Single-result streams are unchanged.
- Added `_accumulate_usage()` helper and 18 new tests covering multi-resume accumulation, cost asymmetry, nested sub-dicts, partial fields, single-result no-op, and non-numeric usage-key preservation.
- **Follow-up fix:** the multi-resume path rebuilt `usage` from summed numeric keys only, silently dropping non-numeric / unrecognized keys (e.g. `service_tier`) — and only when `_result_count > 1`. Now the summed totals are merged over a copy of the last event's full `usage` block (nested sub-dicts overlaid too), so unknown keys survive and take the last event's value, consistent with `total_cost_usd`.

## Test plan

- [x] All 74 `test_claude_cli.py` tests pass (including 18 new tests)
- [x] Existing `test_process_stream_preserves_structured_output_across_task_notification_resume` updated to match new accumulation semantics (`num_turns` 9 → 17)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
