### PR TITLE
fix: stop leaked beads daemons in integration test harness

### DIFF
--- a/src/worca/cli/init.py
+++ b/src/worca/cli/init.py
@@ -684,6 +684,8 @@ def _ensure_gitignore(git_root: Path) -> list[str]:
 
 def _init_beads(git_root: Path) -> bool:
     """Run bd init if .beads/ doesn't exist. Returns True if initialized."""
+    if os.environ.get("WORCA_SKIP_BEADS"):
+        return False
     if (git_root / ".beads").is_dir():
         return False
     try:
@@ -700,6 +702,8 @@ def _init_beads(git_root: Path) -> bool:
 
 def _upgrade_beads(git_root: Path) -> bool:
     """Update beads repo fingerprint if .beads/ exists. Idempotent."""
+    if os.environ.get("WORCA_SKIP_BEADS"):
+        return False
     if not (git_root / ".beads").is_dir():
         return False
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,9 @@ entries that would then show up in the global worca-ui.
 """
 import atexit
 import os
+import signal
 import shutil
+import subprocess
 import tempfile
 
 import pytest
@@ -171,3 +173,75 @@ def _isolate_project_registry(monkeypatch, tmp_path):
         return _original(project_root, prefs_dir=prefs_dir)
 
     monkeypatch.setattr(reg, "auto_register_project", _isolated)
+
+
+# ---------------------------------------------------------------------------
+# Session-end orphan bd-daemon sweep
+# ---------------------------------------------------------------------------
+
+def _find_bd_daemon_pids() -> list[int]:
+    """Return PIDs of all `bd daemon start` processes via pgrep."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "bd daemon start"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            return []
+        return [int(p) for p in result.stdout.strip().splitlines() if p.strip()]
+    except Exception:
+        return []
+
+
+def _get_pid_cwd(pid: int) -> str | None:
+    """Return the cwd of a process via lsof (macOS) or /proc (Linux)."""
+    proc_cwd = f"/proc/{pid}/cwd"
+    if os.path.islink(proc_cwd):
+        try:
+            return os.readlink(proc_cwd)
+        except OSError:
+            return None
+    try:
+        result = subprocess.run(
+            ["lsof", "-a", "-d", "cwd", "-p", str(pid), "-Fpn"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            return None
+        for line in result.stdout.splitlines():
+            if line.startswith("n") and line != "n":
+                return line[1:]
+        return None
+    except Exception:
+        return None
+
+
+def _sweep_orphan_bd_daemons(pytest_tmp_root: str) -> None:
+    """SIGTERM any `bd daemon start` process whose cwd is under the pytest
+    tmp root or no longer exists on disk. Best-effort, all failures swallowed."""
+    try:
+        pids = _find_bd_daemon_pids()
+        for pid in pids:
+            try:
+                cwd = _get_pid_cwd(pid)
+                if cwd is None:
+                    continue
+                should_kill = (
+                    not os.path.isdir(cwd)
+                    or os.path.commonpath([cwd, pytest_tmp_root]) == pytest_tmp_root
+                )
+                if should_kill:
+                    os.kill(pid, signal.SIGTERM)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Sweep orphan bd daemon processes after the entire test session."""
+    try:
+        tmp_root = str(session.config._tmp_path_factory.getbasetemp())
+    except Exception:
+        tmp_root = tempfile.gettempdir()
+    _sweep_orphan_bd_daemons(tmp_root)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,6 +49,25 @@ def _wrap_with_coverage(cmd: list) -> list:
     ] + cmd[1:]
 
 
+def _stop_beads_daemons(project: Path, worktree_paths: list[str]) -> None:
+    """Best-effort stop of beads daemons for the main project and worktrees."""
+    from worca.utils.beads import bd_daemon_stop
+
+    targets = []
+    main_beads = project / ".beads"
+    if main_beads.is_dir():
+        targets.append(str(main_beads))
+    for wt in worktree_paths:
+        wt_beads = Path(wt) / ".beads"
+        if wt_beads.is_dir():
+            targets.append(str(wt_beads))
+    for beads_dir in targets:
+        try:
+            bd_daemon_stop(beads_dir)
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # pipeline_env fixture
 # ---------------------------------------------------------------------------
@@ -480,6 +499,8 @@ def pipeline_env(tmp_path):
         stub_log_path=_stub_log_path,
         stub_response_files=_stub_response_files,
     )
+
+    _stop_beads_daemons(project, _created_worktrees)
 
     # W-050 Phase 3 — fixture finalizer (plan rule #15): always remove
     # worktrees we created, even on test failure, so the parent repo isn't

--- a/tests/integration/test_fleet_e2e.py
+++ b/tests/integration/test_fleet_e2e.py
@@ -71,6 +71,7 @@ def _setup_repo(path: Path) -> None:
         cwd=str(path),
         check=True,
         capture_output=True,
+        env={**os.environ, "WORCA_SKIP_BEADS": "1"},
     )
     # Speed up: disable slow stages and cap max_turns
     settings_path = path / ".claude" / "settings.json"

--- a/tests/integration/test_fleet_lifecycle_e2e.py
+++ b/tests/integration/test_fleet_lifecycle_e2e.py
@@ -54,6 +54,7 @@ def _setup_repo(path: Path) -> None:
         cwd=str(path),
         check=True,
         capture_output=True,
+        env={**os.environ, "WORCA_SKIP_BEADS": "1"},
     )
     settings_path = path / ".claude" / "settings.json"
     settings = json.loads(settings_path.read_text())

--- a/tests/integration/test_workspace_e2e.py
+++ b/tests/integration/test_workspace_e2e.py
@@ -87,6 +87,7 @@ def _setup_workspace_repo(path: Path) -> None:
         cwd=str(path),
         check=True,
         capture_output=True,
+        env={**os.environ, "WORCA_SKIP_BEADS": "1"},
     )
     settings_path = path / ".claude" / "settings.json"
     settings = json.loads(settings_path.read_text())

--- a/tests/integration/test_workspace_fullstack.py
+++ b/tests/integration/test_workspace_fullstack.py
@@ -74,6 +74,7 @@ def _setup_workspace_repo(path: Path) -> None:
     subprocess.run(
         [sys.executable, "-m", "worca.cli.main", "init"],
         cwd=str(path), check=True, capture_output=True,
+        env={**os.environ, "WORCA_SKIP_BEADS": "1"},
     )
     settings_path = path / ".claude" / "settings.json"
     settings = json.loads(settings_path.read_text())

--- a/tests/test_daemon_stop_in_finalizer.py
+++ b/tests/test_daemon_stop_in_finalizer.py
@@ -1,0 +1,116 @@
+"""Verify pipeline_env finalizer stops beads daemons for worktrees and main project."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFTEST = REPO_ROOT / "tests" / "integration" / "conftest.py"
+
+
+@pytest.fixture
+def fake_project(tmp_path):
+    """Create a minimal git repo with .beads/ dir to simulate a test project."""
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init"], cwd=str(project), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"],
+        cwd=str(project), check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "T"],
+        cwd=str(project), check=True, capture_output=True,
+    )
+    (project / ".beads").mkdir()
+    return project
+
+
+class TestFinalizerStopsDaemons:
+    def test_stops_daemon_for_main_project(self, fake_project):
+        """Finalizer calls bd_daemon_stop for the main project's .beads/ dir."""
+
+        stopped = []
+
+        def track_stop(beads_dir, **kwargs):
+            stopped.append(str(beads_dir))
+            return True
+
+        with patch("worca.utils.beads.bd_daemon_stop", side_effect=track_stop):
+            from tests.integration.conftest import _stop_beads_daemons
+            _stop_beads_daemons(fake_project, [])
+
+        main_beads = str(fake_project / ".beads")
+        assert main_beads in stopped, (
+            f"Expected daemon stop for main project .beads at {main_beads}"
+        )
+
+    def test_stops_daemon_for_worktrees(self, fake_project, tmp_path):
+        """Finalizer calls bd_daemon_stop for each worktree with a .beads/ dir."""
+        wt1 = tmp_path / "wt1"
+        wt1.mkdir()
+        (wt1 / ".beads").mkdir()
+
+        wt2 = tmp_path / "wt2"
+        wt2.mkdir()
+        (wt2 / ".beads").mkdir()
+
+        stopped = []
+
+        def track_stop(beads_dir, **kwargs):
+            stopped.append(str(beads_dir))
+            return True
+
+        with patch("worca.utils.beads.bd_daemon_stop", side_effect=track_stop):
+            from tests.integration.conftest import _stop_beads_daemons
+            _stop_beads_daemons(fake_project, [str(wt1), str(wt2)])
+
+        assert str(wt1 / ".beads") in stopped
+        assert str(wt2 / ".beads") in stopped
+
+    def test_skips_worktree_without_beads_dir(self, fake_project, tmp_path):
+        """Finalizer skips worktrees that don't have a .beads/ dir."""
+        wt_no_beads = tmp_path / "wt_no_beads"
+        wt_no_beads.mkdir()
+
+        stopped = []
+
+        def track_stop(beads_dir, **kwargs):
+            stopped.append(str(beads_dir))
+            return True
+
+        with patch("worca.utils.beads.bd_daemon_stop", side_effect=track_stop):
+            from tests.integration.conftest import _stop_beads_daemons
+            _stop_beads_daemons(fake_project, [str(wt_no_beads)])
+
+        wt_beads = str(wt_no_beads / ".beads")
+        assert wt_beads not in stopped
+
+    def test_exception_in_stop_does_not_propagate(self, fake_project):
+        """Daemon stop errors are swallowed (best-effort)."""
+        def exploding_stop(beads_dir, **kwargs):
+            raise RuntimeError("daemon stop failed")
+
+        with patch("worca.utils.beads.bd_daemon_stop", side_effect=exploding_stop):
+            from tests.integration.conftest import _stop_beads_daemons
+            _stop_beads_daemons(fake_project, [])
+
+    def test_skips_main_project_without_beads_dir(self, tmp_path):
+        """No error when main project has no .beads/ dir."""
+        project = tmp_path / "project_no_beads"
+        project.mkdir()
+
+        stopped = []
+
+        def track_stop(beads_dir, **kwargs):
+            stopped.append(str(beads_dir))
+            return True
+
+        with patch("worca.utils.beads.bd_daemon_stop", side_effect=track_stop):
+            from tests.integration.conftest import _stop_beads_daemons
+            _stop_beads_daemons(project, [])
+
+        assert len(stopped) == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,43 @@
+"""Tests for WORCA_SKIP_BEADS gate in _init_beads / _upgrade_beads."""
+
+from unittest.mock import patch
+
+from worca.cli.init import _init_beads, _upgrade_beads
+
+
+def test_init_beads_skipped_when_env_set(monkeypatch, tmp_path):
+    """_init_beads returns False without invoking bd when WORCA_SKIP_BEADS=1."""
+    monkeypatch.setenv("WORCA_SKIP_BEADS", "1")
+    with patch("worca.cli.init.subprocess.run") as mock_run:
+        result = _init_beads(tmp_path)
+    assert result is False
+    mock_run.assert_not_called()
+
+
+def test_upgrade_beads_skipped_when_env_set(monkeypatch, tmp_path):
+    """_upgrade_beads returns False without invoking bd when WORCA_SKIP_BEADS=1."""
+    monkeypatch.setenv("WORCA_SKIP_BEADS", "1")
+    (tmp_path / ".beads").mkdir()
+    with patch("worca.cli.init.subprocess.run") as mock_run:
+        result = _upgrade_beads(tmp_path)
+    assert result is False
+    mock_run.assert_not_called()
+
+
+def test_init_beads_runs_when_env_not_set(monkeypatch, tmp_path):
+    """_init_beads still calls bd when WORCA_SKIP_BEADS is not set."""
+    monkeypatch.delenv("WORCA_SKIP_BEADS", raising=False)
+    with patch("worca.cli.init.subprocess.run") as mock_run:
+        result = _init_beads(tmp_path)
+    assert result is True
+    mock_run.assert_called_once()
+
+
+def test_upgrade_beads_runs_when_env_not_set(monkeypatch, tmp_path):
+    """_upgrade_beads still calls bd when WORCA_SKIP_BEADS is not set."""
+    monkeypatch.delenv("WORCA_SKIP_BEADS", raising=False)
+    (tmp_path / ".beads").mkdir()
+    with patch("worca.cli.init.subprocess.run") as mock_run:
+        result = _upgrade_beads(tmp_path)
+    assert result is True
+    mock_run.assert_called_once()

--- a/tests/test_session_orphan_sweep.py
+++ b/tests/test_session_orphan_sweep.py
@@ -1,0 +1,172 @@
+"""Tests for the pytest_sessionfinish orphan bd-daemon sweep in conftest.py."""
+
+import os
+import signal
+from unittest.mock import MagicMock, patch
+
+
+
+class TestSweepOrphanBdDaemons:
+    """Unit tests for _sweep_orphan_bd_daemons."""
+
+    def test_kills_daemon_with_deleted_cwd(self, tmp_path):
+        """A bd daemon whose cwd no longer exists gets SIGTERM'd."""
+        from tests.conftest import _sweep_orphan_bd_daemons
+
+        deleted_dir = str(tmp_path / "gone")
+
+        with patch("tests.conftest._find_bd_daemon_pids", return_value=[99999]), \
+             patch("tests.conftest._get_pid_cwd", return_value=deleted_dir), \
+             patch("os.kill") as mock_kill:
+            _sweep_orphan_bd_daemons(str(tmp_path))
+
+        mock_kill.assert_called_once_with(99999, signal.SIGTERM)
+
+    def test_kills_daemon_under_pytest_tmp_root(self, tmp_path):
+        """A bd daemon whose cwd is under the pytest tmp root gets SIGTERM'd."""
+        from tests.conftest import _sweep_orphan_bd_daemons
+
+        cwd_under_tmp = str(tmp_path / "pytest-of-user" / "test_foo" / ".beads")
+        os.makedirs(cwd_under_tmp, exist_ok=True)
+
+        with patch("tests.conftest._find_bd_daemon_pids", return_value=[88888]), \
+             patch("tests.conftest._get_pid_cwd", return_value=cwd_under_tmp), \
+             patch("os.kill") as mock_kill:
+            _sweep_orphan_bd_daemons(str(tmp_path))
+
+        mock_kill.assert_called_once_with(88888, signal.SIGTERM)
+
+    def test_spares_daemon_outside_tmp_root(self, tmp_path):
+        """A bd daemon with a live cwd outside the tmp root is NOT killed."""
+        from tests.conftest import _sweep_orphan_bd_daemons
+
+        live_dir = "/Users/dev/real-project/.beads"
+
+        with patch("tests.conftest._find_bd_daemon_pids", return_value=[77777]), \
+             patch("tests.conftest._get_pid_cwd", return_value=live_dir), \
+             patch("os.path.isdir", return_value=True), \
+             patch("os.kill") as mock_kill:
+            _sweep_orphan_bd_daemons(str(tmp_path))
+
+        mock_kill.assert_not_called()
+
+    def test_swallows_all_exceptions(self, tmp_path):
+        """Errors during sweep are silently swallowed."""
+        from tests.conftest import _sweep_orphan_bd_daemons
+
+        with patch("tests.conftest._find_bd_daemon_pids", side_effect=RuntimeError("boom")):
+            _sweep_orphan_bd_daemons(str(tmp_path))
+
+    def test_handles_no_daemons(self, tmp_path):
+        """No-op when no bd daemon processes exist."""
+        from tests.conftest import _sweep_orphan_bd_daemons
+
+        with patch("tests.conftest._find_bd_daemon_pids", return_value=[]), \
+             patch("os.kill") as mock_kill:
+            _sweep_orphan_bd_daemons(str(tmp_path))
+
+        mock_kill.assert_not_called()
+
+    def test_handles_kill_permission_error(self, tmp_path):
+        """PermissionError from os.kill is swallowed."""
+        from tests.conftest import _sweep_orphan_bd_daemons
+
+        with patch("tests.conftest._find_bd_daemon_pids", return_value=[66666]), \
+             patch("tests.conftest._get_pid_cwd", return_value=str(tmp_path / "gone")), \
+             patch("os.kill", side_effect=PermissionError("not allowed")):
+            _sweep_orphan_bd_daemons(str(tmp_path))
+
+    def test_handles_cwd_lookup_failure(self, tmp_path):
+        """If cwd lookup fails for a PID, that PID is skipped."""
+        from tests.conftest import _sweep_orphan_bd_daemons
+
+        with patch("tests.conftest._find_bd_daemon_pids", return_value=[55555]), \
+             patch("tests.conftest._get_pid_cwd", return_value=None), \
+             patch("os.kill") as mock_kill:
+            _sweep_orphan_bd_daemons(str(tmp_path))
+
+        mock_kill.assert_not_called()
+
+    def test_multiple_daemons_mixed(self, tmp_path):
+        """Multiple daemons: only orphans get killed."""
+        from tests.conftest import _sweep_orphan_bd_daemons
+
+        gone_dir = str(tmp_path / "gone")
+        live_dir = "/Users/dev/real-project"
+
+        def fake_cwd(pid):
+            return gone_dir if pid == 111 else live_dir
+
+        with patch("tests.conftest._find_bd_daemon_pids", return_value=[111, 222]), \
+             patch("tests.conftest._get_pid_cwd", side_effect=fake_cwd), \
+             patch("os.path.isdir", side_effect=lambda p: p == live_dir), \
+             patch("os.kill") as mock_kill:
+            _sweep_orphan_bd_daemons(str(tmp_path))
+
+        mock_kill.assert_called_once_with(111, signal.SIGTERM)
+
+
+class TestFindBdDaemonPids:
+    """Tests for _find_bd_daemon_pids helper."""
+
+    def test_parses_pgrep_output(self):
+        from tests.conftest import _find_bd_daemon_pids
+
+        fake_output = "12345\n67890\n"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=fake_output,
+            )
+            pids = _find_bd_daemon_pids()
+
+        assert pids == [12345, 67890]
+
+    def test_returns_empty_on_no_match(self):
+        from tests.conftest import _find_bd_daemon_pids
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            pids = _find_bd_daemon_pids()
+
+        assert pids == []
+
+    def test_returns_empty_on_exception(self):
+        from tests.conftest import _find_bd_daemon_pids
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("no pgrep")):
+            pids = _find_bd_daemon_pids()
+
+        assert pids == []
+
+
+class TestGetPidCwd:
+    """Tests for _get_pid_cwd helper."""
+
+    def test_parses_lsof_output(self):
+        from tests.conftest import _get_pid_cwd
+
+        lsof_output = "p12345\ncwd\nn/some/path\n"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=lsof_output,
+            )
+            cwd = _get_pid_cwd(12345)
+
+        assert cwd == "/some/path"
+
+    def test_returns_none_on_failure(self):
+        from tests.conftest import _get_pid_cwd
+
+        with patch("subprocess.run", side_effect=OSError("fail")):
+            cwd = _get_pid_cwd(12345)
+
+        assert cwd is None
+
+    def test_returns_none_on_no_cwd_line(self):
+        from tests.conftest import _get_pid_cwd
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="p12345\n")
+            cwd = _get_pid_cwd(12345)
+
+        assert cwd is None

--- a/tests/test_skip_beads_in_setup_helpers.py
+++ b/tests/test_skip_beads_in_setup_helpers.py
@@ -1,0 +1,80 @@
+"""Verify _setup_repo helpers pass WORCA_SKIP_BEADS=1 to worca init subprocess."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _fake_worca_init(path):
+    """Create the .claude/settings.json that worca init would produce."""
+    settings_dir = Path(path) / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "settings.json").write_text(json.dumps({"worca": {}}))
+
+
+def _make_tracking_run(calls, repo_path):
+    original_run = subprocess.run
+
+    def tracking_run(cmd, **kwargs):
+        if isinstance(cmd, list) and "worca.cli.main" in cmd:
+            calls.append(kwargs)
+            _fake_worca_init(kwargs.get("cwd", repo_path))
+            return subprocess.CompletedProcess(cmd, 0)
+        return original_run(cmd, **kwargs)
+
+    return tracking_run
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.com"],
+        cwd=str(tmp_path), check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "T"],
+        cwd=str(tmp_path), check=True, capture_output=True,
+    )
+    return tmp_path
+
+
+def _assert_skip_beads_in_env(calls):
+    assert len(calls) == 1, "Expected exactly one worca init call"
+    env = calls[0].get("env", {})
+    assert env.get("WORCA_SKIP_BEADS") == "1", (
+        "worca init subprocess must pass WORCA_SKIP_BEADS=1 in env"
+    )
+
+
+class TestFleetLifecycleSetupRepo:
+    def test_worca_init_passes_skip_beads(self, git_repo):
+        from tests.integration.test_fleet_lifecycle_e2e import _setup_repo
+
+        calls = []
+        with patch("subprocess.run", side_effect=_make_tracking_run(calls, git_repo)):
+            _setup_repo(git_repo)
+        _assert_skip_beads_in_env(calls)
+
+
+class TestFleetE2eSetupRepo:
+    def test_worca_init_passes_skip_beads(self, git_repo):
+        from tests.integration.test_fleet_e2e import _setup_repo
+
+        calls = []
+        with patch("subprocess.run", side_effect=_make_tracking_run(calls, git_repo)):
+            _setup_repo(git_repo)
+        _assert_skip_beads_in_env(calls)
+
+
+class TestWorkspaceE2eSetupRepo:
+    def test_worca_init_passes_skip_beads(self, git_repo):
+        from tests.integration.test_workspace_e2e import _setup_workspace_repo
+
+        calls = []
+        with patch("subprocess.run", side_effect=_make_tracking_run(calls, git_repo)):
+            _setup_workspace_repo(git_repo)
+        _assert_skip_beads_in_env(calls)

--- a/tests/test_skip_beads_in_setup_helpers.py
+++ b/tests/test_skip_beads_in_setup_helpers.py
@@ -78,3 +78,13 @@ class TestWorkspaceE2eSetupRepo:
         with patch("subprocess.run", side_effect=_make_tracking_run(calls, git_repo)):
             _setup_workspace_repo(git_repo)
         _assert_skip_beads_in_env(calls)
+
+
+class TestWorkspaceFullstackSetupRepo:
+    def test_worca_init_passes_skip_beads(self, git_repo):
+        from tests.integration.test_workspace_fullstack import _setup_workspace_repo
+
+        calls = []
+        with patch("subprocess.run", side_effect=_make_tracking_run(calls, git_repo)):
+            _setup_workspace_repo(git_repo)
+        _assert_skip_beads_in_env(calls)


### PR DESCRIPTION
## Summary

- Gate `_init_beads()` / `_upgrade_beads()` on `WORCA_SKIP_BEADS` so `worca init` never spawns a `bd daemon` in test contexts
- Pass `WORCA_SKIP_BEADS=1` into the `worca init` subprocess env in all fleet/workspace `_setup_repo()` helpers (`test_fleet_e2e.py`, `test_fleet_lifecycle_e2e.py`, `test_workspace_e2e.py`)
- Add `_stop_beads_daemons()` in the `pipeline_env` fixture finalizer (before worktree removal) to stop daemons for the main project and any tracked worktrees
- Add `pytest_sessionfinish` orphan sweep in `tests/conftest.py` that SIGTERMs any `bd daemon start` process whose cwd is deleted or under the pytest tmp root

## Test plan

- [x] 4 unit tests for `_init_beads`/`_upgrade_beads` env-var gate (`tests/test_init.py`)
- [x] 5 unit tests for `_stop_beads_daemons` finalizer behavior (`tests/test_daemon_stop_in_finalizer.py`)
- [x] 14 unit tests for the orphan sweep helpers (`tests/test_session_orphan_sweep.py`)
- [x] 4 unit tests verifying `_setup_repo` helpers pass `WORCA_SKIP_BEADS=1` (`tests/test_skip_beads_in_setup_helpers.py`) — now covers `test_workspace_fullstack.py` too
- [x] Empirically verified no orphan `bd daemon` processes accumulate (A/B below)


## Empirical verification

Reproduced the leak and confirmed the fix with a controlled A/B on the literal
reported leaker, counting `bd daemon start` processes by cwd (under-test-root /
deleted / valid-untouched):

| Run | `test_fleet_plan_propagates_to_children` | daemons under its temp root |
|---|---|---|
| **master (pre-fix)** | same test | **2 leaked** — `repo_0/.beads`, `repo_1/.beads` (matches the issue's reported path exactly) |
| **this branch** | same test | **0** — the `WORCA_SKIP_BEADS` gate prevents `bd init` from spawning |

- **Sweep backstop** independently verified: invoking `_sweep_orphan_bd_daemons`
  against the master run's basetemp reaped both orphans while leaving all 13
  unrelated live daemons untouched (global count returned to its 13-daemon baseline).
- Both mechanisms confirmed end-to-end: **prevention** (gate → 0 spawned on gated
  paths) and **cleanup** (finalizer + session sweep → reaps orphans, spares live daemons).

> Note: on macOS the session sweep matches cwd via `lsof` realpaths
> (`/private/var/...`). With the default pytest basetemp (already canonical) this
> is fine; a `--basetemp=/tmp/...` symlinked root could make the "under root"
> branch miss (fails toward leaving a leak, never toward killing a live daemon).
> Optional hardening: `os.path.realpath` both sides before `commonpath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
