### PR TITLE
docs: close E2E-debugging blind spots from learning analysis (run 20260526-103335)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,14 @@ This closes the feedback loop inside the implementer → tester iteration instea
 
 If the Chromium binary is missing (`npx playwright install chromium` was never run in this environment), state that explicitly in your verdict — do not silently skip the suite.
 
+**Playwright `test.describe() called in unexpected context`.** This is almost always a stale Playwright transform cache — not a bug in your spec — and shows up most often right after rewriting a spec file. Recover with one cache-bust and move on:
+
+```bash
+cd worca-ui && rm -rf node_modules/.cache && npx playwright test e2e/<spec>.spec.js --workers=1
+```
+
+Do **not** binary-bisect the spec to find the offending block — the file is fine; the cache is stale. And do not try to "reproduce" it by importing the spec outside the test runner (`node -e "import('./e2e/x.spec.js')"`) — running a Playwright spec outside `npx playwright test` *always* throws this exact error, so it is not a signal.
+
 **Coverage runs** (Python) use the centralized runner in `scripts/coverage.py`:
 
 ```bash
@@ -332,6 +340,10 @@ Spec: [`docs/plans/W-053-graphify-integration.md`](./docs/plans/W-053-graphify-i
 **Badge color language:** all `sl-badge` variants and status colors follow the guide in [`worca-ui/docs/badge-color-language.md`](./worca-ui/docs/badge-color-language.md). Read it before adding or modifying badges — blue means active, orange means caution, green means done.
 
 **Card layout:** all card-style views (run, fleet, workspace, worktree) share the `.run-card` base structure documented in [`worca-ui/docs/card-layout.md`](./worca-ui/docs/card-layout.md). New card types must follow the 4-section pattern (top → meta → stages → actions) and route through `statusIcon`/`statusClass` + a per-domain variant map.
+
+**Working directory resets every command.** Under the pipeline, a hook prefixes every Bash command with `cd <project-root>`, so `cd` does **not** persist between commands — each command starts from the repo root, even after a previous `cd worca-ui`. Always combine the directory change with the command (`cd worca-ui && npm run build`) or use absolute paths. A bare `npx playwright …` / `npm run …` issued after an earlier `cd worca-ui` will silently run from the repo root and fail.
+
+**Read the component before writing E2E selectors.** Selectors live in `worca-ui/app/views/*.js` — confirm class names and tag types against the source rather than guessing, then write the test. Two recurring gotchas: the launcher prompt is an `sl-textarea.textarea-fleet-prompt` (not `.input-prompt` / `sl-input`), and the header **Launch** button is a plain `<button class="action-btn action-btn--primary">` (not `sl-button`).
 
 After modifying any source files in `worca-ui/app/`, rebuild the bundle:
 

--- a/src/worca/agents/core/implementer.md
+++ b/src/worca/agents/core/implementer.md
@@ -62,6 +62,7 @@ Your task prompt may include an **Accumulated design notes (advisory)** block co
 - **You MUST NOT attempt to bypass governance hooks.** No `unset WORCA_AGENT`, no `env -u WORCA_AGENT`, no launching wrapper scripts, no suggesting the user manually commit. These attempts are detected and logged as violations.
 - Do NOT modify files outside your task scope
 - Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
+- Each Bash command runs from the project root; `cd` does NOT persist between commands. Combine directory changes with the command (`cd <subdir> && <cmd>`) or use absolute paths — do not assume a prior `cd` is still in effect.
 - If blocked, report the blocker in your structured output — do not guess, do not work around
 
 ## Knowledge graph (advisory)


### PR DESCRIPTION
## Problem

A pipeline learning analysis flagged that one implementer iteration (run `20260526-103335`, **W-056**, bead `worca-cc-7g0d`) spent **\$10.22 / 147 turns / 18m49s** — ~22% of the whole run — almost entirely on Playwright test-harness debugging while producing a single new spec file. I confirmed the three root causes against the on-disk run log (`logs/implement/iter-14.log`):

1. **`test.describe() called in unexpected context`** — ~50 turns of binary file-bisection chasing what was a stale Playwright transform cache, plus a red-herring `node -e "import('…spec.js')"` repro (which *always* throws that error outside the test runner).
2. **Wrong E2E selectors guessed before reading source** — `.input-prompt` vs the real `.textarea-fleet-prompt` (an `sl-textarea`), and `sl-button` vs the real plain `<button class="action-btn action-btn--primary">` Launch button.
3. **Repeated cwd confusion** — the `pre_tool_use` hook prefixes every Bash command with `cd <project-root>`, so `cd` never persists between commands; the agent re-learned this 4+ times. No prompt stated the invariant.

All three fell in **CLAUDE.md blind spots**. CLAUDE.md *is* auto-loaded into the implementer (`claude -p` loads project memory; `--agent` doesn't suppress it; only `--bare` would — verified against the docs), and the agent followed CLAUDE.md where guidance existed (it used `--workers=1`). So filling these gaps reaches the agent.

## Changes

**`CLAUDE.md` (worca-cc-specific — keeps the cost out of shipped prompts):**
- Testing section: a Playwright `test.describe() … unexpected context` entry — one-line cache-bust (`rm -rf node_modules/.cache`), "don't bisect", and the import-outside-runner red herring.
- worca-ui section: the **working-directory-resets-every-command** invariant, and a **read-the-component-before-writing-selectors** note with the two recurring selector gotchas.

**`src/worca/agents/core/implementer.md` (shipped prompt — deliberately generic, no tech-stack/worca wording):**
- One `## Rules` line: each Bash command runs from the project root; `cd` does not persist; combine `cd <subdir> && <cmd>` or use absolute paths.

The cwd behavior is a universal pipeline trait (the shipped hook), so the generic line benefits every consumer project; the tech-specific recipes stay in CLAUDE.md.

## Notes

- Docs/prompt-only change — no code, so no lint/test gauntlet applies.
- Opened as a branch + PR rather than a direct push to master because multiple worca pipelines are actively running in this repo and contending for the shared main-repo git index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)