### PR TITLE
fix: carry unresolved plan-review issues into COORDINATE, scope revision rounds for convergence

### DIFF
--- a/src/worca/agents/core/coordinate.block.md
+++ b/src/worca/agents/core/coordinate.block.md
@@ -36,3 +36,16 @@ _A code knowledge graph is preloaded for this repo — explore it on demand with
 {{plan_summary}}
 </approved_plan>
 {{/if}}
+
+{{#if unresolved_plan_issues_formatted}}
+## Unresolved plan concerns (from Plan Reviewer)
+
+The Plan Reviewer flagged these blocking issues, and the plan-review loop was
+exhausted before they were resolved. They are NOT addressed in the plan above.
+
+When decomposing, account for each one — either create an explicit bead to
+resolve it, or record it in the description of the bead it affects so the
+implementer is aware. Do not silently ignore them.
+
+{{unresolved_plan_issues_formatted}}
+{{/if}}

--- a/src/worca/agents/core/plan-review.block.md
+++ b/src/worca/agents/core/plan-review.block.md
@@ -38,6 +38,15 @@ _A code knowledge graph is preloaded for this repo — explore it on demand with
 
 {{plan_review_history_formatted}}
 
-Check whether the issues from previous review attempts have been addressed
-in the revised plan above.
+**This is a revision round — your primary task is to verify convergence, not to
+re-review the whole plan from scratch.**
+
+- Confirm each prior critical/major issue is resolved. If one is still
+  unresolved, re-raise it at its original severity.
+- A plan grows as it fixes issues; added detail exposes new surface. Raise a
+  *newly observed* problem as `critical` or `major` ONLY if it would genuinely
+  block implementation. Otherwise record it as `minor`/`suggestion` so the
+  plan can converge — an implementer can handle reasonable refinements.
+- Return `outcome: "approve"` once no blocking (critical/major) issues remain,
+  even if further polish is possible.
 {{/if}}

--- a/src/worca/agents/core/plan_reviewer.md
+++ b/src/worca/agents/core/plan_reviewer.md
@@ -58,6 +58,8 @@ Produce a structured result following the `plan_review.json` schema:
 
 Only `critical` and `major` issues trigger a `"revise"` outcome. `minor` and `suggestion` issues are logged but the outcome is `"approve"`.
 
+Severity reflects **implementation-blocking impact**, not plan polish. Reserve `critical`/`major` for issues that would actually derail implementation; an issue an implementer can resolve in stride is `minor` or `suggestion`. This matters most on revision rounds, where over-escalating newly-exposed detail prevents the plan from ever converging.
+
 ## Rules
 
 <!-- governance -->

--- a/src/worca/orchestrator/prompt_builder.py
+++ b/src/worca/orchestrator/prompt_builder.py
@@ -242,6 +242,12 @@ class PromptBuilder:
             else:
                 ctx["plan_summary"] = ""
 
+            unresolved = ctx.get("unresolved_plan_issues")
+            if unresolved:
+                ctx["unresolved_plan_issues_formatted"] = self._format_plan_review_issues(unresolved)
+            else:
+                ctx["unresolved_plan_issues_formatted"] = ""
+
         elif stage == "implement":
             ctx["is_retry"] = iteration > 0
             if iteration > 0:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -2973,8 +2973,8 @@ def run_pipeline(
                         stage_idx = stage_order.index(Stage.PLAN)
                         continue  # Loop back to PLAN
                     else:
-                        # Loop exhausted — clean up revision context keys so they
-                        # don't leak into COORDINATE or later PLAN re-runs.
+                        if critical_issues:
+                            prompt_builder.update_context("unresolved_plan_issues", list(critical_issues))
                         prompt_builder.pop_context("plan_review_issues")
                         prompt_builder.pop_context("plan_revision_mode")
                         prompt_builder.pop_context("plan_review_history")
@@ -2987,7 +2987,8 @@ def run_pipeline(
                                 iteration=loop_counters["plan_review"],
                                 limit=_get_loop_limit("plan_review", settings_path, mloops),
                             ))
-                        _log("Plan review loop exhausted -- proceeding to COORDINATE", "warn")
+                        n_carried = len(critical_issues) if critical_issues else 0
+                        _log(f"Plan review loop exhausted — {n_carried} unresolved issues carried to COORDINATE", "warn")
                 else:
                     # Approve path — pop cross-context keys to prevent leaking
                     prompt_builder.pop_context("plan_review_issues")
@@ -3029,6 +3030,7 @@ def run_pipeline(
                 max_beads = len(beads_ids)
                 prompt_builder.update_context("beads_ids", beads_ids)
                 prompt_builder.update_context("dependency_graph", result.get("dependency_graph", {}))
+                prompt_builder.pop_context("unresolved_plan_issues")
                 # Link beads to this run via label
                 if beads_ids:
                     run_label = f"run:{status['run_id']}"

--- a/tests/test_block_files.py
+++ b/tests/test_block_files.py
@@ -86,6 +86,21 @@ def test_plan_review_block_has_history_conditional():
     assert "{{#if plan_review_history_formatted}}" in content
 
 
+def test_plan_review_block_has_convergence_directive():
+    content = _read("plan-review.block.md")
+    assert "verify convergence" in content
+
+
+def test_plan_review_block_convergence_inside_history_conditional():
+    content = _read("plan-review.block.md")
+    if_tag = "{{#if plan_review_history_formatted}}"
+    endif_tag = "{{/if}}"
+    start = content.index(if_tag)
+    end = content.index(endif_tag, start)
+    history_block = content[start:end]
+    assert "verify convergence" in history_block
+
+
 # ---------------------------------------------------------------------------
 # coordinate.block.md
 # ---------------------------------------------------------------------------
@@ -99,6 +114,11 @@ def test_coordinate_block_has_work_request():
 def test_coordinate_block_has_plan_summary_conditional():
     content = _read("coordinate.block.md")
     assert "{{#if plan_summary}}" in content
+
+
+def test_coordinate_block_has_unresolved_plan_issues_conditional():
+    content = _read("coordinate.block.md")
+    assert "{{#if unresolved_plan_issues_formatted}}" in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -365,6 +365,24 @@ def test_build_context_coordinate_no_plan_summary_without_approach():
     assert not ctx.get("plan_summary")
 
 
+def test_build_context_coordinate_formats_unresolved_plan_issues():
+    pb = PromptBuilder("Add auth", "Desc")
+    pb.update_context("unresolved_plan_issues", [
+        {"category": "completeness", "severity": "critical", "description": "Missing error handling"},
+        {"category": "risk", "severity": "major", "description": "No rollback strategy"},
+    ])
+    ctx = pb.build_context("coordinate")
+    formatted = ctx.get("unresolved_plan_issues_formatted", "")
+    assert "[critical] (completeness) Missing error handling" in formatted
+    assert "[major] (risk) No rollback strategy" in formatted
+
+
+def test_build_context_coordinate_empty_string_when_unresolved_plan_issues_absent():
+    pb = PromptBuilder("Add auth", "Desc")
+    ctx = pb.build_context("coordinate")
+    assert ctx.get("unresolved_plan_issues_formatted") == ""
+
+
 def test_build_context_implement_initial_is_retry_false():
     pb = PromptBuilder("Add auth", "Desc")
     ctx = pb.build_context("implement", iteration=0)

--- a/tests/test_runner_plan_review.py
+++ b/tests/test_runner_plan_review.py
@@ -721,6 +721,124 @@ class TestPlanReviewLoopExhaustion:
         # Counter should be 1 (one revise iteration)
         assert final_status["loop_counters"].get("plan_review", 0) == 1
 
+    def test_loop_exhaustion_carries_unresolved_issues(self, tmp_path):
+        """On exhaustion, unresolved_plan_issues is set in prompt context before COORDINATE."""
+        settings_path, status_path, wr = _make_runner(tmp_path, plan_review_loops=1)
+        critical_issue = {"category": "risk", "severity": "critical",
+                          "description": "No rollback strategy"}
+        major_issue = {"category": "feasibility", "severity": "major",
+                       "description": "Infeasible timeline"}
+
+        from worca.orchestrator.prompt_builder import PromptBuilder
+        updated_keys = {}
+        original_update = PromptBuilder.update_context
+
+        def tracking_update(self, key, value):
+            import copy
+            updated_keys[key] = copy.deepcopy(value)
+            return original_update(self, key, value)
+
+        def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                           prompt_override=None, **kwargs):
+            if stage == Stage.PLAN:
+                return _mock_stage(stage, {"approved": True, "approach": "x", "tasks_outline": []})
+            if stage == Stage.PLAN_REVIEW:
+                return _mock_stage(stage, {
+                    "outcome": "revise",
+                    "issues": [critical_issue, major_issue],
+                    "summary": "Blocking issues",
+                })
+            if stage == Stage.COORDINATE:
+                return _mock_stage(stage, {"beads_ids": [], "dependency_graph": {}})
+            return _mock_stage(stage, {})
+
+        with patch.object(PromptBuilder, "update_context", tracking_update):
+            with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage):
+                with patch("worca.orchestrator.runner.create_branch"):
+                    with patch("worca.orchestrator.runner._write_pid"):
+                        with patch("worca.orchestrator.runner._remove_pid"):
+                            run_pipeline(wr, settings_path=settings_path, status_path=status_path)
+
+        assert "unresolved_plan_issues" in updated_keys, (
+            "unresolved_plan_issues must be set in prompt context before COORDINATE"
+        )
+        carried = updated_keys["unresolved_plan_issues"]
+        assert len(carried) == 2
+        severities = {i["severity"] for i in carried}
+        assert severities == {"critical", "major"}
+
+    def test_loop_exhaustion_pops_unresolved_after_coordinate(self, tmp_path):
+        """unresolved_plan_issues is popped after COORDINATE (not in final context)."""
+        settings_path, status_path, wr = _make_runner(tmp_path, plan_review_loops=1)
+        critical_issue = {"category": "risk", "severity": "critical",
+                          "description": "Critical gap"}
+
+        from worca.orchestrator.prompt_builder import PromptBuilder
+        popped_keys = []
+        original_pop = PromptBuilder.pop_context
+
+        def tracking_pop(self, key):
+            popped_keys.append(key)
+            return original_pop(self, key)
+
+        def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                           prompt_override=None, **kwargs):
+            if stage == Stage.PLAN:
+                return _mock_stage(stage, {"approved": True, "approach": "x", "tasks_outline": []})
+            if stage == Stage.PLAN_REVIEW:
+                return _mock_stage(stage, {
+                    "outcome": "revise",
+                    "issues": [critical_issue],
+                    "summary": "Issues",
+                })
+            if stage == Stage.COORDINATE:
+                return _mock_stage(stage, {"beads_ids": [], "dependency_graph": {}})
+            return _mock_stage(stage, {})
+
+        with patch.object(PromptBuilder, "pop_context", tracking_pop):
+            with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage):
+                with patch("worca.orchestrator.runner.create_branch"):
+                    with patch("worca.orchestrator.runner._write_pid"):
+                        with patch("worca.orchestrator.runner._remove_pid"):
+                            run_pipeline(wr, settings_path=settings_path, status_path=status_path)
+
+        assert "unresolved_plan_issues" in popped_keys, (
+            "unresolved_plan_issues must be popped after COORDINATE to prevent leaking"
+        )
+
+    def test_approve_path_does_not_set_unresolved_issues(self, tmp_path):
+        """The approve path never sets unresolved_plan_issues."""
+        settings_path, status_path, wr = _make_runner(tmp_path)
+
+        from worca.orchestrator.prompt_builder import PromptBuilder
+        updated_keys = set()
+        original_update = PromptBuilder.update_context
+
+        def tracking_update(self, key, value):
+            updated_keys.add(key)
+            return original_update(self, key, value)
+
+        def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                           prompt_override=None, **kwargs):
+            if stage == Stage.PLAN:
+                return _mock_stage(stage, {"approved": True, "approach": "x", "tasks_outline": []})
+            if stage == Stage.PLAN_REVIEW:
+                return _mock_stage(stage, {"outcome": "approve", "issues": [], "summary": "Good"})
+            if stage == Stage.COORDINATE:
+                return _mock_stage(stage, {"beads_ids": [], "dependency_graph": {}})
+            return _mock_stage(stage, {})
+
+        with patch.object(PromptBuilder, "update_context", tracking_update):
+            with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage):
+                with patch("worca.orchestrator.runner.create_branch"):
+                    with patch("worca.orchestrator.runner._write_pid"):
+                        with patch("worca.orchestrator.runner._remove_pid"):
+                            run_pipeline(wr, settings_path=settings_path, status_path=status_path)
+
+        assert "unresolved_plan_issues" not in updated_keys, (
+            "unresolved_plan_issues must never be set on the approve path"
+        )
+
     def test_persist_calls_happen_before_plan_reruns(self, tmp_path):
         """save_status and save_context are called before PLAN re-runs on loop-back."""
         settings_path, status_path, wr = _make_runner(tmp_path, plan_review_loops=2)


### PR DESCRIPTION
## Summary

- **Fix C**: On plan-review loop exhaustion, thread the final round's critical/major issues into the COORDINATE prompt via `unresolved_plan_issues` context key — mirrors the existing code-review → implement precedent. The coordinator gets a new "Unresolved plan concerns" section so decomposition accounts for known gaps instead of proceeding blind. Context is popped after COORDINATE (single-use, resume-safe).
- **Fix D**: On revision rounds (2+), replace the thin "check whether issues were addressed" instruction with a convergence directive: verify prior fixes, only escalate genuinely implementation-blocking new issues to critical/major, approve once no blockers remain. Round 1 stays a full strict review. Reinforcing note in `plan_reviewer.md` anchors severity to implementation-blocking impact.

Closes #218

## Test plan

- [x] `test_loop_exhaustion_carries_unresolved_issues` — exhaustion populates `unresolved_plan_issues` with critical/major issues
- [x] `test_loop_exhaustion_pops_unresolved_after_coordinate` — key is popped after COORDINATE, no leak
- [x] `test_approve_path_does_not_set_unresolved_issues` — approve path never sets the key
- [x] `test_build_context_coordinate_formats_unresolved_plan_issues` — prompt builder formats issues via `_format_plan_review_issues`
- [x] `test_build_context_coordinate_empty_string_when_unresolved_plan_issues_absent` — empty string when no issues
- [x] `test_plan_review_block_has_convergence_directive` — revision-round directive present in block
- [x] `test_plan_review_block_convergence_inside_history_conditional` — directive is inside `{{#if plan_review_history_formatted}}` (only on revision rounds)
- [x] `test_coordinate_block_has_unresolved_plan_issues_conditional` — coordinate block has the `{{#if unresolved_plan_issues_formatted}}` section
- [x] All 144 tests pass (`test_runner_plan_review.py` + `test_prompt_builder.py` + `test_block_files.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)