### PR TITLE
feat(ui): add run-level Source metadata to learnings copy prompts

### DIFF
--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -43,7 +43,7 @@ import {
   resetLauncherState,
   submitFleetLauncher,
 } from './views/fleet-launcher.js';
-import { learningsSectionView } from './views/learnings-panel.js';
+import { buildRunMeta, learningsSectionView } from './views/learnings-panel.js';
 import {
   clearLiveTerminal,
   disposeLiveTerminal,
@@ -3239,6 +3239,7 @@ function mainContentView() {
             onRunLearn: actionAllowed('learn', run?.pipeline_status)
               ? handleRunLearn
               : null,
+            runMeta: buildRunMeta(run, route.runId),
           })}
         </div>
       </div>

--- a/worca-ui/app/views/learnings-panel.js
+++ b/worca-ui/app/views/learnings-panel.js
@@ -44,7 +44,39 @@ function timingStripView(startedAt, completedAt) {
   `;
 }
 
-export function observationPrompt(obs) {
+export function buildRunMeta(run, routeRunId) {
+  if (!run) return null;
+  return {
+    project: run.project || run._project,
+    runId: run.id || routeRunId,
+    workRequest: run.work_request?.title,
+    branch: run.head_branch || run.branch || run.work_request?.branch,
+    startedAt: run.started_at,
+    fleetId: run.fleet_id,
+    workspaceId: run.workspace_id,
+  };
+}
+
+export function sourceBlock(meta) {
+  if (!meta) return '';
+  const lines = [];
+  if (meta.project) lines.push(`- **Project**: ${meta.project}`);
+  if (meta.runId) {
+    lines.push(`- **Pipeline run**: ${meta.runId}`);
+    lines.push(
+      `- **Run artifacts**: .worca/runs/${meta.runId}/ (status.json, plan-NNN.md, agent logs)`,
+    );
+  }
+  if (meta.workRequest) lines.push(`- **Work request**: "${meta.workRequest}"`);
+  if (meta.branch) lines.push(`- **Branch**: ${meta.branch}`);
+  if (meta.startedAt) lines.push(`- **Started**: ${meta.startedAt}`);
+  if (meta.fleetId) lines.push(`- **Fleet**: ${meta.fleetId}`);
+  if (meta.workspaceId) lines.push(`- **Workspace**: ${meta.workspaceId}`);
+  if (lines.length === 0) return '';
+  return `\n## Source\n${lines.join('\n')}\n`;
+}
+
+export function observationPrompt(obs, meta) {
   return `Investigate the following observation from a pipeline learning analysis and suggest concrete fixes.
 
 ## Observation
@@ -59,10 +91,10 @@ export function observationPrompt(obs) {
 2. Find the specific files and code sections involved.
 3. Propose concrete changes to prevent this from recurring.
 4. If this relates to test failures or loops, identify what test coverage or prompt changes would help.
-`;
+${sourceBlock(meta)}`;
 }
 
-export function suggestionPrompt(s) {
+export function suggestionPrompt(s, meta) {
   return `Implement the following suggestion from a pipeline learning analysis.
 
 ## Suggestion
@@ -75,7 +107,7 @@ export function suggestionPrompt(s) {
 2. Understand the current behavior and why the suggestion was made.
 3. Implement the suggested change with minimal disruption.
 4. Verify the change doesn't break existing functionality.
-`;
+${sourceBlock(meta)}`;
 }
 
 function copyToClipboard(text, btn) {
@@ -110,7 +142,7 @@ function sortByImportance(observations) {
   );
 }
 
-function observationsTableView(observations) {
+function observationsTableView(observations, meta) {
   const sorted = sortByImportance(observations);
   return html`
     <h4 class="learnings-table-title">Observations</h4>
@@ -136,7 +168,7 @@ function observationsTableView(observations) {
           <span class="learnings-evidence">${obs.evidence}</span>
           <span class="col-center">${obs.occurrences || 1}</span>
           <sl-tooltip content="Copy investigation prompt">
-            <button class="learnings-copy-btn" @click=${(e) => copyToClipboard(observationPrompt(obs), e.currentTarget)}>
+            <button class="learnings-copy-btn" @click=${(e) => copyToClipboard(observationPrompt(obs, meta), e.currentTarget)}>
               <span class="copy-icon">${unsafeHTML(iconSvg(ClipboardCopy, 14))}</span>
             </button>
           </sl-tooltip>
@@ -147,7 +179,7 @@ function observationsTableView(observations) {
   `;
 }
 
-function suggestionsTableView(suggestions) {
+function suggestionsTableView(suggestions, meta) {
   return html`
     <h4 class="learnings-table-title">Suggestions</h4>
     <div class="learnings-table">
@@ -164,7 +196,7 @@ function suggestionsTableView(suggestions) {
           <span class="markdown-body markdown-inline">${unsafeHTML(renderMarkdown(s.description))}</span>
           <span class="learnings-rationale">${s.rationale}</span>
           <sl-tooltip content="Copy implementation prompt">
-            <button class="learnings-copy-btn" @click=${(e) => copyToClipboard(suggestionPrompt(s), e.currentTarget)}>
+            <button class="learnings-copy-btn" @click=${(e) => copyToClipboard(suggestionPrompt(s, meta), e.currentTarget)}>
               <span class="copy-icon">${unsafeHTML(iconSvg(ClipboardCopy, 14))}</span>
             </button>
           </sl-tooltip>
@@ -353,8 +385,8 @@ export function learningsSectionView(learnStage, options = {}) {
         ${costUsd != null ? html`<span class="stage-info-item"><span class="meta-label">Cost:</span> <span class="meta-value">$${Number(costUsd).toFixed(2)}</span></span>` : nothing}
       </div>
       ${summaryStripView(output.run_summary)}
-      ${observationsTableView(output.observations)}
-      ${suggestionsTableView(output.suggestions || [])}
+      ${observationsTableView(output.observations, options.runMeta)}
+      ${suggestionsTableView(output.suggestions || [], options.runMeta)}
       ${recurringPatternsView(output.recurring_patterns)}
       ${
         options.onRunLearn

--- a/worca-ui/app/views/learnings-panel.test.js
+++ b/worca-ui/app/views/learnings-panel.test.js
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import {
+  buildRunMeta,
   importanceBadge,
   learningsSectionView,
   observationPrompt,
+  sourceBlock,
   suggestionPrompt,
 } from './learnings-panel.js';
 
@@ -437,6 +439,167 @@ describe('suggestionPrompt', () => {
   });
 });
 
+const FULL_META = {
+  project: 'worca-cc',
+  runId: '20260526-152024-226-ecd5e5a9',
+  workRequest: 'Add user authentication',
+  branch: 'feature/user-auth',
+  startedAt: '2026-05-26T15:20:24.000Z',
+  fleetId: 'fleet-abc-123',
+  workspaceId: 'ws-xyz-789',
+};
+
+describe('sourceBlock', () => {
+  it('returns empty string when meta is null', () => {
+    expect(sourceBlock(null)).toBe('');
+  });
+
+  it('returns empty string when meta is undefined', () => {
+    expect(sourceBlock(undefined)).toBe('');
+  });
+
+  it('returns empty string when meta is empty object', () => {
+    expect(sourceBlock({})).toBe('');
+  });
+
+  it('includes ## Source header with all fields when fully populated', () => {
+    const block = sourceBlock(FULL_META);
+    expect(block).toContain('## Source');
+    expect(block).toContain('**Project**: worca-cc');
+    expect(block).toContain('**Pipeline run**: 20260526-152024-226-ecd5e5a9');
+    expect(block).toContain('.worca/runs/20260526-152024-226-ecd5e5a9/');
+    expect(block).toContain('**Work request**: "Add user authentication"');
+    expect(block).toContain('**Branch**: feature/user-auth');
+    expect(block).toContain('**Started**: 2026-05-26T15:20:24.000Z');
+    expect(block).toContain('**Fleet**: fleet-abc-123');
+    expect(block).toContain('**Workspace**: ws-xyz-789');
+  });
+
+  it('omits fleet line when fleetId is absent', () => {
+    const meta = { ...FULL_META, fleetId: undefined };
+    const block = sourceBlock(meta);
+    expect(block).toContain('## Source');
+    expect(block).not.toContain('**Fleet**');
+  });
+
+  it('omits workspace line when workspaceId is absent', () => {
+    const meta = { ...FULL_META, workspaceId: undefined };
+    const block = sourceBlock(meta);
+    expect(block).toContain('## Source');
+    expect(block).not.toContain('**Workspace**');
+  });
+
+  it('omits both fleet and workspace when neither present', () => {
+    const meta = { ...FULL_META, fleetId: undefined, workspaceId: undefined };
+    const block = sourceBlock(meta);
+    expect(block).toContain('## Source');
+    expect(block).not.toContain('**Fleet**');
+    expect(block).not.toContain('**Workspace**');
+  });
+
+  it('omits branch line when branch is absent', () => {
+    const meta = { ...FULL_META, branch: undefined };
+    const block = sourceBlock(meta);
+    expect(block).toContain('## Source');
+    expect(block).not.toContain('**Branch**');
+  });
+
+  it('gracefully handles partial meta with only project and runId', () => {
+    const meta = { project: 'my-app', runId: 'run-001' };
+    const block = sourceBlock(meta);
+    expect(block).toContain('## Source');
+    expect(block).toContain('**Project**: my-app');
+    expect(block).toContain('**Pipeline run**: run-001');
+    expect(block).not.toContain('**Branch**');
+    expect(block).not.toContain('**Fleet**');
+    expect(block).not.toContain('**Workspace**');
+    expect(block).not.toContain('**Work request**');
+    expect(block).not.toContain('**Started**');
+  });
+});
+
+describe('observationPrompt with meta', () => {
+  const obs = {
+    category: 'test_loop',
+    importance: 'high',
+    description: 'Repeated failures',
+    evidence: 'Failed 3 times',
+    occurrences: 3,
+  };
+
+  it('includes ## Source block when meta is provided', () => {
+    const prompt = observationPrompt(obs, FULL_META);
+    expect(prompt).toContain('## Source');
+    expect(prompt).toContain('**Project**: worca-cc');
+    expect(prompt).toContain('**Pipeline run**: 20260526-152024-226-ecd5e5a9');
+  });
+
+  it('is byte-identical to no-meta output when meta is undefined', () => {
+    const withMeta = observationPrompt(obs, undefined);
+    const without = observationPrompt(obs);
+    expect(withMeta).toBe(without);
+  });
+
+  it('is byte-identical to no-meta output when meta is null', () => {
+    const withMeta = observationPrompt(obs, null);
+    const without = observationPrompt(obs);
+    expect(withMeta).toBe(without);
+  });
+
+  it('is byte-identical to no-meta output when meta is empty object', () => {
+    const withMeta = observationPrompt(obs, {});
+    const without = observationPrompt(obs);
+    expect(withMeta).toBe(without);
+  });
+
+  it('still contains observation fields when meta is present', () => {
+    const prompt = observationPrompt(obs, FULL_META);
+    expect(prompt).toContain('test_loop');
+    expect(prompt).toContain('Repeated failures');
+    expect(prompt).toContain('root cause');
+  });
+});
+
+describe('suggestionPrompt with meta', () => {
+  const s = {
+    target: 'prompt:tester',
+    description: 'Add edge case guidance',
+    rationale: 'Prevents loops',
+  };
+
+  it('includes ## Source block when meta is provided', () => {
+    const prompt = suggestionPrompt(s, FULL_META);
+    expect(prompt).toContain('## Source');
+    expect(prompt).toContain('**Project**: worca-cc');
+    expect(prompt).toContain('**Pipeline run**: 20260526-152024-226-ecd5e5a9');
+  });
+
+  it('is byte-identical to no-meta output when meta is undefined', () => {
+    const withMeta = suggestionPrompt(s, undefined);
+    const without = suggestionPrompt(s);
+    expect(withMeta).toBe(without);
+  });
+
+  it('is byte-identical to no-meta output when meta is null', () => {
+    const withMeta = suggestionPrompt(s, null);
+    const without = suggestionPrompt(s);
+    expect(withMeta).toBe(without);
+  });
+
+  it('is byte-identical to no-meta output when meta is empty object', () => {
+    const withMeta = suggestionPrompt(s, {});
+    const without = suggestionPrompt(s);
+    expect(withMeta).toBe(without);
+  });
+
+  it('still contains suggestion fields when meta is present', () => {
+    const prompt = suggestionPrompt(s, FULL_META);
+    expect(prompt).toContain('prompt:tester');
+    expect(prompt).toContain('Add edge case guidance');
+    expect(prompt).toContain('Locate the target');
+  });
+});
+
 describe('markdown rendering in learnings', () => {
   it('renders observation descriptions as markdown HTML', () => {
     const data = {
@@ -494,5 +657,95 @@ describe('copy buttons in rendered output', () => {
       }),
     );
     expect(html).toContain('Copy implementation prompt');
+  });
+});
+
+describe('learningsSectionView threads runMeta to prompt builders', () => {
+  it('observation copy handler calls observationPrompt with meta', () => {
+    const meta = { project: 'test-proj', runId: 'run-42' };
+    const obs = SAMPLE_OUTPUT.observations[0];
+    const promptWithMeta = observationPrompt(obs, meta);
+    expect(promptWithMeta).toContain('## Source');
+    expect(promptWithMeta).toContain('**Project**: test-proj');
+  });
+
+  it('suggestion copy handler calls suggestionPrompt with meta', () => {
+    const meta = { project: 'test-proj', runId: 'run-42' };
+    const s = SAMPLE_OUTPUT.suggestions[0];
+    const promptWithMeta = suggestionPrompt(s, meta);
+    expect(promptWithMeta).toContain('## Source');
+    expect(promptWithMeta).toContain('**Project**: test-proj');
+  });
+
+  it('omits source block when runMeta is not provided', () => {
+    const obs = SAMPLE_OUTPUT.observations[0];
+    const prompt = observationPrompt(obs);
+    expect(prompt).not.toContain('## Source');
+  });
+
+  it('renders without error when runMeta is passed to learningsSectionView', () => {
+    const meta = { project: 'test-proj', runId: 'run-42' };
+    const html = renderToString(
+      learningsSectionView(completedStage(SAMPLE_OUTPUT), {
+        onRunLearn: () => {},
+        runMeta: meta,
+      }),
+    );
+    expect(html).toContain('learnings-copy-btn');
+    expect(html).toContain('Copy investigation prompt');
+    expect(html).toContain('Copy implementation prompt');
+  });
+});
+
+describe('buildRunMeta constructs the correct shape from a run object', () => {
+  it('extracts all fields from a full run object', () => {
+    const run = {
+      id: 'run-123',
+      project: 'my-project',
+      work_request: { title: 'Add auth', branch: 'feat/auth' },
+      head_branch: 'feat/auth-v2',
+      branch: 'feat/auth-old',
+      started_at: '2026-05-26T10:00:00Z',
+      fleet_id: 'fleet-1',
+      workspace_id: 'ws-1',
+    };
+    const meta = buildRunMeta(run, 'fallback-id');
+    expect(meta).toEqual({
+      project: 'my-project',
+      runId: 'run-123',
+      workRequest: 'Add auth',
+      branch: 'feat/auth-v2',
+      startedAt: '2026-05-26T10:00:00Z',
+      fleetId: 'fleet-1',
+      workspaceId: 'ws-1',
+    });
+  });
+
+  it('falls back to _project when project is absent', () => {
+    const run = { _project: 'fallback-proj', id: 'r1' };
+    const meta = buildRunMeta(run, 'r1');
+    expect(meta.project).toBe('fallback-proj');
+  });
+
+  it('falls back to routeRunId when run.id is absent', () => {
+    const run = { project: 'p' };
+    const meta = buildRunMeta(run, 'route-id');
+    expect(meta.runId).toBe('route-id');
+  });
+
+  it('falls back through branch precedence chain', () => {
+    const runWithBranch = { id: 'r', branch: 'b1' };
+    expect(buildRunMeta(runWithBranch).branch).toBe('b1');
+
+    const runWithWrBranch = {
+      id: 'r',
+      work_request: { branch: 'wr-branch' },
+    };
+    expect(buildRunMeta(runWithWrBranch).branch).toBe('wr-branch');
+  });
+
+  it('returns null for null/undefined run', () => {
+    expect(buildRunMeta(null)).toBeNull();
+    expect(buildRunMeta(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a conditional `## Source` markdown block to investigation and implementation prompts copied from the Learnings panel, including project, run id, artifacts path, work request, branch, start time, and fleet/workspace ids
- Threads `runMeta` from the `run` object (already in scope at the call site in `main.js`) through `learningsSectionView` → table views → prompt builders via `options.runMeta`
- When no metadata is available (or all fields empty), the prompt is byte-identical to today — full backward compatibility

## Test plan

- [x] `sourceBlock` unit tests: null/undefined/empty meta returns `""`, full meta renders all fields, partial meta omits absent lines
- [x] `observationPrompt`/`suggestionPrompt` with meta: includes `## Source` block; byte-identical to no-meta when meta is null/undefined/empty
- [x] `buildRunMeta` tests: field extraction, fallback chain (`_project`, `routeRunId`, branch precedence), null run returns null
- [x] `learningsSectionView` integration: renders without error when `runMeta` is passed
- [x] Biome lint passes
- [x] All 64 vitest tests pass
- [x] Pre-commit hooks (ruff + biome + build) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)