### PR TITLE
perf(ui): coalesce re-renders so opening a run no longer freezes the page

### DIFF
--- a/worca-ui/app/main-beads-update-dedup.test.js
+++ b/worca-ui/app/main-beads-update-dedup.test.js
@@ -71,8 +71,10 @@ describe('beads-update handler: client-side dedup', () => {
     // The handler must store the new serialized payload for the next comparison
     expect(handler).toMatch(/lastBeadsPayload\s*=/);
 
-    // rerender() must still be called (it was there before dedup was added)
-    expect(handler).toContain('rerender()');
+    // A render must still be triggered after a changed payload. The handler
+    // routes through scheduleRerender() so a burst of beads WAL ticks coalesces
+    // into one render instead of one synchronous full render per tick.
+    expect(handler).toMatch(/scheduleRerender\(\)|[^e]rerender\(\)/);
   });
 
   it('resets dedup state on project switch', () => {

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -977,11 +977,15 @@ ws.on('log-line', (payload) => {
       writeLiveIterationSeparator(payload.iteration);
     }
     writeLiveLogLine(payload);
+    // appendLog no longer emits; coalesced rerender keeps the Log History
+    // stage-dropdown fallback current as new stages produce output.
+    scheduleRerender();
   }
 });
 
 ws.on('log-bulk', (payload) => {
   if (payload && Array.isArray(payload.lines)) {
+    const entries = [];
     for (const line of payload.lines) {
       // NB: timestamp is receive-time, not original write-time (log files lack per-line timestamps)
       const entry = {
@@ -990,11 +994,15 @@ ws.on('log-bulk', (payload) => {
         line,
         timestamp: new Date().toISOString(),
       };
-      store.appendLog(entry);
+      entries.push(entry);
       // Log History: only write to the history terminal when a specific stage is selected
       if (logFilter !== '*') writeLogLine(entry);
       writeLiveLogLine(entry);
     }
+    // Single buffered append + one coalesced rerender for the whole backfill,
+    // instead of one full app render per line.
+    store.appendLogs(entries);
+    scheduleRerender();
   }
 });
 
@@ -1047,7 +1055,7 @@ ws.on('beads-update', (payload, msg) => {
     if (route.runId && route.section !== 'beads') fetchRunBeads(route.runId);
     if (route.runId && route.section === 'beads')
       fetchBeadsRunIssues(route.runId);
-    rerender();
+    scheduleRerender();
   }
 });
 
@@ -3704,6 +3712,26 @@ function rerender() {
   }
 }
 
+// Coalesce re-renders: a burst of state changes (the log-bulk backfill on
+// opening a run, beads-update WAL ticks, rapid status events) collapses into a
+// single synchronous render on the next animation frame instead of one full
+// app render per change. Direct rerender() calls from user actions stay
+// synchronous for immediate feedback.
+let _rerenderScheduled = false;
+function scheduleRerender() {
+  if (_rerenderScheduled) return;
+  _rerenderScheduled = true;
+  const flush = () => {
+    _rerenderScheduled = false;
+    rerender();
+  };
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(flush);
+  } else {
+    setTimeout(flush, 0);
+  }
+}
+
 // --- Sticky header scroll shadow ---
 let scrollListenerAttached = false;
 
@@ -3730,7 +3758,7 @@ function attachStickyHeaderListener() {
 // --- Bootstrap ---
 
 notificationManager.setRerender(rerender);
-store.subscribe(() => rerender());
+store.subscribe(() => scheduleRerender());
 applyTheme(store.getState().preferences.theme);
 if (route.projectId) {
   store.setState({ currentProjectId: route.projectId });

--- a/worca-ui/app/state.js
+++ b/worca-ui/app/state.js
@@ -178,12 +178,28 @@ export function createStore(initial = {}) {
     getRunById(id) {
       return state.runs[id] ?? state.archivedRuns[id];
     },
+    // Log lines feed the xterm terminals directly (writeLogLine /
+    // writeLiveLogLine in the WS handlers), not the lit-html tree — the only
+    // lit-html consumer is the Log History stage-dropdown fallback. So append
+    // is a pure buffer mutation and deliberately does NOT emit(): the WS
+    // handlers schedule a single coalesced rerender after a batch. Emitting per
+    // line turned a backfill of N lines into N full synchronous app re-renders.
     appendLog(entry) {
       const logLines = [...state.logLines, entry];
       if (logLines.length > LOG_CAP)
         logLines.splice(0, logLines.length - LOG_CAP);
       state = { ...state, logLines };
-      emit();
+    },
+
+    // Batch variant for the log-bulk backfill: append all entries with a single
+    // array build (avoids the O(n^2) per-line spread) and, like appendLog, does
+    // not emit — the handler triggers one coalesced rerender afterwards.
+    appendLogs(entries) {
+      if (!entries || entries.length === 0) return;
+      const logLines = state.logLines.concat(entries);
+      if (logLines.length > LOG_CAP)
+        logLines.splice(0, logLines.length - LOG_CAP);
+      state = { ...state, logLines };
     },
 
     clearLog() {


### PR DESCRIPTION
## Summary

Opening a run with a large log backlog froze the page for ~10s (Chrome's "Page Unresponsive" dialog). Root cause was a client-side render storm, not the server-side `bd` work fixed in 0.32.0:

- The Log-History backfill (`log-bulk`) replays **every** stage/iteration's log lines on subscribe.
- `store.appendLog` `emit()`'d on **every** line, and the store subscription was wired straight to a **full synchronous app re-render**.
- So N backfilled lines = N full re-renders — each now also re-parsing every agent-prompt block's markdown (`marked` + `DOMPurify`, added in 0.32.0), which pushed it over into a visible freeze.

## Changes (all client-side, no server changes)

1. **`appendLog` no longer `emit()`s** — log lines feed the xterm terminals directly; the only lit-html consumer is the Log-History stage-dropdown *fallback*, so per-line appends don't need to drive the tree.
2. **Batched `appendLogs(entries)`** — one array build (fixes the O(n²) per-line spread) for the whole `log-bulk` backfill, then a single render.
3. **`scheduleRerender()`** — coalesces renders onto `requestAnimationFrame`. The store subscription, both log handlers, and the `beads-update` broadcast route through it; direct user-action `rerender()` stays synchronous for immediate feedback.

Updated the `beads-update` dedup contract test to accept the coalesced `scheduleRerender()` — its stated intent ("a render must still be triggered after a changed payload") is preserved.

## Test plan

- [x] biome clean
- [x] `state.test.js`, `main-log-line-handler.test.js`, `main-beads-update-dedup.test.js` pass
- [x] Full vitest green except a pre-existing flaky `server/ws-pipeline-lifecycle.test.js` hook timeout (verified failing identically on clean master with these changes stashed; imports none of the touched files)
- [x] Manually verified in a live global UI on a large run — page stays interactive immediately, no freeze
- [ ] CI green (Playwright e2e — diff touches `worca-ui/app/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)