### PR TITLE
feat(cli): allow --guide on in-place worca run

### DIFF
--- a/src/worca/cli/main.py
+++ b/src/worca/cli/main.py
@@ -207,7 +207,7 @@ def create_parser() -> argparse.ArgumentParser:
         action="append",
         metavar="PATH",
         default=None,
-        help="Path to a reference guide injected into the plan prompt (--worktree only, repeatable)",
+        help="Path to a reference guide injected into the plan prompt (repeatable)",
     )
 
     # lifecycle commands: pause, stop, resume, status

--- a/src/worca/cli/run_pipeline.py
+++ b/src/worca/cli/run_pipeline.py
@@ -24,10 +24,11 @@ from worca.cli.main import (
 def _validate_worktree_args(args: Namespace) -> None:
     """Reject mutually-exclusive flag combinations before spawning anything.
 
-    `--branch` / `--guide` are forwarded to run_worktree.py only and silently
-    no-op against run_pipeline.py — surface the misuse as a clear error rather
-    than letting the in-place runner ignore them. `--resume` must run inside
-    the original tree, so combining it with `--worktree` is also nonsensical.
+    `--branch` is forwarded to run_worktree.py only and silently no-ops
+    against run_pipeline.py — surface the misuse as a clear error rather than
+    letting the in-place runner ignore it. `--guide` is supported on both
+    paths, so it is not gated here. `--resume` must run inside the original
+    tree, so combining it with `--worktree` is also nonsensical.
     """
     if args.worktree and args.resume:
         print("error: --worktree cannot be combined with --resume "

--- a/src/worca/cli/run_pipeline.py
+++ b/src/worca/cli/run_pipeline.py
@@ -37,9 +37,6 @@ def _validate_worktree_args(args: Namespace) -> None:
         if args.branch:
             print("error: --branch requires --worktree", file=sys.stderr)
             raise SystemExit(2)
-        if args.guide:
-            print("error: --guide requires --worktree", file=sys.stderr)
-            raise SystemExit(2)
 
 
 def cmd_run(args: Namespace) -> None:
@@ -85,11 +82,11 @@ def cmd_run(args: Namespace) -> None:
     for p in args.param or []:
         cmd.extend(["--param", p])
 
+    for g in args.guide or []:
+        cmd.extend(["--guide", g])
     if use_worktree:
         if args.branch:
             cmd.extend(["--branch", args.branch])
-        for g in args.guide or []:
-            cmd.extend(["--guide", g])
 
     result = subprocess.run(cmd, cwd=str(git_root))
     raise SystemExit(result.returncode)

--- a/tests/test_cli_run_pipeline.py
+++ b/tests/test_cli_run_pipeline.py
@@ -129,14 +129,26 @@ class TestCmdRunWorktree:
         assert exc_info.value.code == 2
         assert "--branch requires --worktree" in capsys.readouterr().err
 
-    def test_guide_without_worktree_rejected(self, tmp_path, monkeypatch, capsys):
-        """--guide without --worktree exits 2 with a clear error."""
+    def test_guide_without_worktree_forwarded(self, tmp_path, monkeypatch):
+        """--guide without --worktree is forwarded to the in-place script."""
         self._scaffold(tmp_path, monkeypatch)
-        from worca.cli.main import main
-        with pytest.raises(SystemExit) as exc_info:
-            main(["run", "--prompt", "x", "--guide", "spec.md"])
-        assert exc_info.value.code == 2
-        assert "--guide requires --worktree" in capsys.readouterr().err
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            from worca.cli.main import main
+            with pytest.raises(SystemExit):
+                main(["run", "--prompt", "x", "--guide", "spec.md", "--guide", "notes.md"])
+        argv = mock_run.call_args[0][0]
+        assert "run_pipeline.py" in argv[1]
+        guides = [argv[i + 1] for i, a in enumerate(argv) if a == "--guide"]
+        assert guides == ["spec.md", "notes.md"]
+
+    def test_guide_help_text_no_worktree_only(self):
+        """--guide help string should not say '--worktree only'."""
+        from worca.cli.main import create_parser
+        parser = create_parser()
+        run_parser = parser._subparsers._group_actions[0].choices["run"]
+        guide_action = [a for a in run_parser._actions if "--guide" in a.option_strings][0]
+        assert "--worktree only" not in guide_action.help
 
     def test_worktree_with_resume_rejected(self, tmp_path, monkeypatch, capsys):
         """--worktree + --resume is nonsensical (resume must use original tree)."""


### PR DESCRIPTION
## Summary
- Remove the `--guide requires --worktree` guard in the `worca run` wrapper — the in-place backend (`run_pipeline.py`) already handles `--guide` end-to-end via `attach_guide()`.
- Forward `--guide` on both the in-place and worktree code paths, enabling guided continuations on an existing branch without bypassing the wrapper.
- Update help text to drop the "(--worktree only)" qualifier.

## Test plan
- [x] Existing `test_guide_without_worktree_forwarded` verifies `--guide` args are forwarded to the in-place script
- [x] New `test_guide_help_text_no_worktree_only` asserts help text no longer says "--worktree only"
- [x] `pytest tests/test_cli_run_pipeline.py` — all 15 tests pass
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)