### PR TITLE
feat(templates): guided template authoring skill + create CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ worca-cc is a multi-agent pipeline that plans, coordinates, implements, tests, r
 - **Multiple input modes** — prompt, spec file, GitHub issue (`gh:issue:42`), beads task (`bd:bd-abc`), or issue URL
 - **GitHub issue lifecycle** — start from issues with `--source gh:issue:N`, auto-post progress comments, link PRs, close issues on completion
 - **Guided issue triage** (`/worca-analyze`) — Claude Code skill that analyzes a GitHub issue, surfaces open design decisions with recommended options, optionally writes a `## Decisions` section back to the issue body, recommends the right pipeline template, and offers to launch a worktree-based pipeline — all in one pass
+- **Guided template authoring** (`/worca-template`) — Claude Code skill that interviews you about your pipeline needs, proposes reusing or extending an existing template, asks for project-vs-user scope, and writes a minimal-delta `template.json` via the CLI — no hand-editing required
 - **Multi-host PR metadata** (W-051) — provider detection across GitHub, GitLab, Bitbucket, Azure DevOps, and Gitea; PR stage records commit SHA, source/target branch flow, and draft/review status; UI surfaces a collapsible "PR details" panel on the PR stage card
 - **Smart title generation** — `--prompt` is optional; when omitted, the title is generated from the spec or plan file and sanitized for branch names
 - **Pipeline events & webhooks** — 52 structured event types emitted as a real-time JSONL stream; subscribe via configurable webhooks with HMAC-SHA256 signing, retry logic, and secret management; control webhooks can pause or abort the pipeline
@@ -38,6 +39,7 @@ worca-cc is a multi-agent pipeline that plans, coordinates, implements, tests, r
 - **Built-in templates** — `feature`, `bugfix`, `quick-fix`, `refactor`, `investigate`, `test-only` — each with tailored stage flows, agent selection, and governance rules for different work types. `investigate` publishes its plan as a PR (W-046); `test-only` runs tests and coverage analysis without code changes
 - **Template selection UI** — styled dropdown on the new-run page with group headers, descriptions, and indentation; also selectable via CLI
 - **Agent prompt overrides** — templates wire their own agent prompt overrides through the overlay resolver, so each work type gets purpose-built instructions
+- **Guided authoring** — `/worca-template` walks you through creating a new template with a reuse-first interview, minimal config delta, and explicit scope selection; backed by `worca templates create --from-file` for validated writes
 
 ### Customization
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -39,10 +39,13 @@ worca templates list                    # tabular output
 worca templates list --json             # machine-readable JSON (id, name, description, tier, tags, builtin, created_at)
 worca templates show <id>               # pretty-print template.json (resolved tier marked)
 worca templates save <id> [--global]    # snapshot current settings as a project (default) or user template
+worca templates create --from-file <path> [--global]  # create a template from a JSON file (project default, --global for user)
 worca templates delete <id> [--global]  # remove a project or user template (built-ins are protected)
 ```
 
-`worca templates list --json` is the canonical enumeration used by the `/worca-analyze` skill and any external tooling.
+`--from-file -` reads the JSON payload from stdin.
+
+`worca templates list --json` is the canonical enumeration used by the `/worca-analyze` and `/worca-template` skills and any external tooling.
 
 ## `worca cleanup`
 

--- a/src/worca/cli/templates.py
+++ b/src/worca/cli/templates.py
@@ -5,6 +5,7 @@ Subcommands:
   worca templates list --json       — machine-readable JSON for tooling
   worca templates show <id>         — pretty-print template.json for a given ID
   worca templates save <id>         — snapshot current settings as template
+  worca templates create --from-file <path>  — create template from JSON file
   worca templates delete <id>       — remove a project or user template
 """
 
@@ -135,6 +136,24 @@ def register_subcommand(sub):
         help="Save to user-global scope (~/.worca/templates/)",
     )
 
+    # create
+    create_parser = templates_sub.add_parser(
+        "create", help="Create a template from a JSON file"
+    )
+    create_parser.add_argument(
+        "--from-file",
+        dest="from_file",
+        required=True,
+        help="Path to JSON file with template data (use '-' for stdin)",
+    )
+    create_parser.add_argument(
+        "--global",
+        dest="global_",
+        action="store_true",
+        default=False,
+        help="Save to user-global scope (~/.worca/templates/)",
+    )
+
     # delete
     delete_parser = templates_sub.add_parser("delete", help="Delete a project or user template")
     delete_parser.add_argument("template_id", help="Template ID to delete")
@@ -193,6 +212,39 @@ def cmd_templates_save(args):
     print(f"saved template '{template.id}' to {tier_label}")
 
 
+def cmd_templates_create(args):
+    """worca templates create --from-file <path> — create a template from JSON."""
+    from worca.orchestrator.templates import TemplateError
+
+    from_file = args.from_file
+    try:
+        if from_file == "-":
+            raw = sys.stdin.read()
+        else:
+            raw = Path(from_file).read_text()
+        template_data = json.loads(raw)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"error: failed to read template JSON: {e}", file=sys.stderr)
+        raise SystemExit(1)
+
+    resolver = _make_resolver()
+    scope = "user" if args.global_ else "project"
+
+    try:
+        template = resolver.save(template_data, scope=scope)
+    except TemplateError as e:
+        if e.code == "validation_error" and e.details:
+            print("error: template validation failed:", file=sys.stderr)
+            for detail in e.details:
+                print(f"  - {detail['field']}: {detail['message']}", file=sys.stderr)
+        else:
+            print(f"error: {e}", file=sys.stderr)
+        raise SystemExit(1)
+
+    tier_label = "user (~/.worca/templates/)" if scope == "user" else "project (.claude/templates/)"
+    print(f"created template '{template.id}' in {tier_label}")
+
+
 def cmd_templates_delete(args):
     """worca templates delete <id> — remove a project or user template."""
     resolver = _make_resolver()
@@ -213,7 +265,7 @@ def cmd_templates_delete(args):
 def cmd_templates(args):
     """Dispatch worca templates subcommand."""
     if not args.templates_command:
-        print("error: specify a templates subcommand: list, show, save, delete", file=sys.stderr)
+        print("error: specify a templates subcommand: list, show, save, create, delete", file=sys.stderr)
         raise SystemExit(1)
     if args.templates_command == "list":
         cmd_templates_list(args)
@@ -221,6 +273,8 @@ def cmd_templates(args):
         cmd_templates_show(args)
     elif args.templates_command == "save":
         cmd_templates_save(args)
+    elif args.templates_command == "create":
+        cmd_templates_create(args)
     elif args.templates_command == "delete":
         cmd_templates_delete(args)
     else:

--- a/src/worca/skills/worca-template/SKILL.md
+++ b/src/worca/skills/worca-template/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: worca-template
+description: Guided pipeline-template authoring — interviews the user for intent, proposes reusing or extending existing templates, composes a minimal config delta, and writes it via CLI. Triggers on "new template", "create pipeline template", "create template", "customize my pipeline", "worca-template".
+---
+
+# Worca Template
+
+Guided creation of pipeline templates. Interviews the user, proposes reusing or extending existing templates before building from scratch, composes a *minimal config delta* (not a settings snapshot), and writes it via the CLI with full validation.
+
+**Usage:**
+- `/worca-template` — start the guided interview
+- "create a new template" / "new pipeline template" / "customize my pipeline" — natural phrases
+
+## Procedure
+
+### Phase 0: Enumerate existing templates
+
+Run the CLI to discover all templates across all three tiers (built-in, project, user):
+
+```bash
+worca templates list --json
+```
+
+This returns a JSON array with `{id, name, description, tier, tags, builtin, created_at}` per entry. The resolver enforces user > project > built-in priority on ID collision — the JSON reflects what will actually be applied at runtime.
+
+For each template, also read its `config` to understand what it overrides. Use `worca templates show <id>` for each, or read the `template.json` files directly:
+- Built-in: `.claude/worca/templates/*/template.json`
+- Project: `.claude/templates/*/template.json`
+- User: `~/.worca/templates/*/template.json`
+
+Summarize the available templates to the user in one compact table: ID, tier, and a one-line diff summary (e.g. "disables test+review+PR, sonnet implementer" for `quick-fix`).
+
+### Phase 1: Intent interview
+
+Use **batched `AskUserQuestion`** — present all questions in a single message so the user answers them at once, not iteratively.
+
+Ask these questions (adapt phrasing to what you already know from the conversation):
+
+1. **Purpose / use-case** — "What kind of work is this template for?" Options: feature development, bug fixing, refactoring, investigation/analysis, test coverage, quick one-off fix, other.
+
+2. **Rigor vs speed** — "How thorough should the pipeline be?" Options:
+   - Full rigor (plan review + learn + all approval gates)
+   - Balanced (standard stages, no extra gates)
+   - Fast (skip optional stages, minimal loops)
+   - Minimal (bare minimum — plan + implement only)
+
+3. **Stages to toggle** — "Which optional stages should be ON?" (multi-select). Options:
+   - Plan review (`stages.plan_review.enabled`)
+   - Test (`stages.test.enabled`)
+   - Code review (`stages.review.enabled`)
+   - PR creation (`stages.pr.enabled`)
+   - Learn (`stages.learn.enabled`)
+
+   Pre-select based on the rigor answer. Let the user override.
+
+4. **Model tier** — "Which model tier for key agents?" Options:
+   - All Opus (thorough, slower)
+   - Opus planning + Sonnet implementation (balanced — the default)
+   - All Sonnet (fastest, lower quality on complex tasks)
+   - Custom (will ask per-agent in a follow-up)
+
+If the user selected "Custom" for model tier, ask a follow-up with per-agent model selection for planner, coordinator, implementer, tester, and reviewer.
+
+### Phase 2: Reuse-first proposal
+
+Compare the user's stated needs against every existing template's `config`. For each existing template, compute how many config keys would need to change to match the user's intent.
+
+Recommend one of three paths:
+
+1. **Use an existing template as-is** — if one matches exactly. Name it and explain why it fits. Done (skip to Phase 6 — no template to create).
+
+2. **Extend a close match** — if an existing template covers most needs with ≤3 key differences. Clone its `config` as the starting delta, list what changes. Name the differentiator explicitly, e.g. "this is `feature` minus `plan_review`, with `implementer` on `sonnet`".
+
+3. **Build fresh** — if no existing template is close (>3 key differences from all candidates). Start from an empty config delta.
+
+If two templates fit comparably, present both with their config deltas side by side and let the user pick the base.
+
+Always explain the recommendation before proceeding. If the user disagrees, follow their lead.
+
+### Phase 3: Scope (mandatory — never infer or default silently)
+
+You **MUST** explicitly ask the user where to save the template. Do not infer scope from context, skip this step, or default silently.
+
+Use `AskUserQuestion`:
+
+**"Where should this template be saved?"**
+
+| Option | Location | Visibility | Notes |
+|--------|----------|------------|-------|
+| **Project** (default) | `.claude/templates/` | Git-shared, team-wide | Checked into the repo; all team members get it |
+| **User** | `~/.worca/templates/` | Personal, cross-project | Only on your machine; works across all your projects |
+
+Explain: user-scope templates override project-scope templates on ID collision (user > project > built-in). Built-in IDs cannot be reused — the resolver rejects them.
+
+The answer maps to the CLI flag: user scope → `--global`, project scope → default (no flag).
+
+### Phase 4: Compose minimal config delta
+
+Build a `template.json` payload with only the keys that differ from the project default settings. This is the core value — a minimal delta, not a full settings snapshot.
+
+Required fields:
+- `id` — lowercase alphanumeric + hyphens, 1-64 chars (regex: `^[a-z0-9-]{1,64}$`)
+- `name` — human-readable, ≤80 chars
+- `description` — one sentence explaining the template's purpose and key differentiators
+- `tags` — ≤5 tags, each `^[a-z0-9-]{1,20}$`
+- `config` — the minimal delta dict (only keys that differ from defaults)
+
+Optional:
+- `params` — `{key: {description, default}}` for any `{{placeholder}}` values used in the config
+
+Propose the `id` and `name` to the user and let them adjust. The `id` must not collide with a built-in template.
+
+Show the user the composed JSON before writing. Highlight what each config key does.
+
+### Phase 5: Validate and write via CLI
+
+Write the composed JSON to a temporary file, then create the template using the CLI:
+
+```bash
+# Project scope (default):
+worca templates create --from-file /tmp/template-<id>.json
+
+# User scope:
+worca templates create --from-file /tmp/template-<id>.json --global
+```
+
+The CLI routes through `TemplateResolver.save()`, which validates all fields (`id` regex, `name` length, tag count/format, `config` is a dict) and rejects built-in ID collisions. If validation fails, it prints structured per-field error details — relay them to the user and offer to fix.
+
+After successful creation, confirm with:
+
+```bash
+worca templates show <id>
+```
+
+### Phase 6: Offer dry-run and next steps
+
+After the template is created (or if an existing template was selected in Phase 2), offer:
+
+1. **Dry-run test** — "Want to test it? Run: `worca run --template <id> --dry-run`"
+2. **Launch a pipeline** — "Ready to use it? `worca run --worktree --template <id> --source gh:issue:N`"
+3. **UI launcher** — "Or select it from the template dropdown in the worca-ui launcher"
+
+## Out of Scope (v1)
+
+These are explicitly deferred to follow-up work:
+
+- **Agent-prompt overrides** — `agents/<agent>.md` / `.block.md` overlays exist in the template system (`src/worca/orchestrator/overlay.py`) but authoring them via this skill is deferred.
+- **UI-based template creation** — the UI stays list/select only.
+- **Editing or cloning existing templates** — this skill creates new templates only. Use `worca templates delete` + re-create to replace.
+- **Approval gate configuration** — `milestones.plan_approval`, `pr_approval`, `deploy_approval` are configurable in the config delta but not surfaced as a separate interview question in v1. Users who need them can specify via the "other" path or edit the composed JSON.
+- **Loop limit tuning** — `loops.implement_test`, `loops.pr_changes`, etc. are settable in the config delta but not individually interviewed. The rigor level sets sensible defaults.
+
+## Failure Modes
+
+- **`worca` CLI not installed** — if `worca templates list --json` fails, fall back to reading `template.json` files directly from the three tier directories. If none exist, proceed with an empty baseline and note that only built-in templates will be available after `worca init`.
+- **`worca templates create` fails validation** — relay the structured error details to the user. Offer to fix the offending fields and retry.
+- **Built-in ID collision** — the CLI rejects it. Suggest an alternative ID (e.g. `my-bugfix` instead of `bugfix`).

--- a/tests/test_cli_templates.py
+++ b/tests/test_cli_templates.py
@@ -1,4 +1,4 @@
-"""Tests for worca templates CLI subcommands (list, show)."""
+"""Tests for worca templates CLI subcommands (list, show, create)."""
 
 import json
 from pathlib import Path
@@ -503,3 +503,316 @@ class TestResolveDirs:
         monkeypatch.chdir(tmp_path)
         _, project_dir, _ = _resolve_dirs()
         assert project_dir is None
+
+
+# ---------------------------------------------------------------------------
+# worca templates create --from-file
+# ---------------------------------------------------------------------------
+
+
+class TestTemplatesCreate:
+    def _run_create(self, args, capsys, builtin_dir=None, project_dir=None, user_dir=None):
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ):
+            main(["templates", "create"] + args)
+        return capsys.readouterr()
+
+    def _valid_payload(self, **overrides):
+        data = {
+            "id": "my-pipeline",
+            "name": "My Pipeline",
+            "description": "A custom pipeline",
+            "tags": ["fast"],
+            "config": {"stages": {"test": {"enabled": False}}},
+        }
+        data.update(overrides)
+        return data
+
+    # --- parser ---
+
+    def test_create_subcommand_parsed(self):
+        parser = create_parser()
+        args = parser.parse_args(["templates", "create", "--from-file", "payload.json"])
+        assert args.command == "templates"
+        assert args.templates_command == "create"
+        assert args.from_file == "payload.json"
+
+    def test_create_global_flag_defaults_false(self):
+        parser = create_parser()
+        args = parser.parse_args(["templates", "create", "--from-file", "payload.json"])
+        assert args.global_ is False
+
+    def test_create_global_flag_set(self):
+        parser = create_parser()
+        args = parser.parse_args(["templates", "create", "--from-file", "payload.json", "--global"])
+        assert args.global_ is True
+
+    def test_create_from_file_is_required(self):
+        parser = create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["templates", "create"])
+
+    # --- happy path: project scope ---
+
+    def test_create_writes_project_template(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(self._valid_payload()))
+        self._run_create(
+            ["--from-file", str(payload_file)],
+            capsys, builtin_dir, project_dir, user_dir,
+        )
+        assert (project_dir / "my-pipeline" / "template.json").exists()
+
+    def test_create_roundtrips_via_resolver_get(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(self._valid_payload()))
+        self._run_create(
+            ["--from-file", str(payload_file)],
+            capsys, builtin_dir, project_dir, user_dir,
+        )
+        from worca.orchestrator.templates import TemplateResolver
+        resolver = TemplateResolver(builtin_dir, project_dir, user_dir)
+        tmpl = resolver.get("my-pipeline")
+        assert tmpl is not None
+        assert tmpl.name == "My Pipeline"
+        assert tmpl.config == {"stages": {"test": {"enabled": False}}}
+
+    def test_create_prints_success_message(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(self._valid_payload()))
+        out = self._run_create(
+            ["--from-file", str(payload_file)],
+            capsys, builtin_dir, project_dir, user_dir,
+        )
+        assert "my-pipeline" in out.out
+
+    # --- happy path: user scope ---
+
+    def test_create_global_writes_user_template(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(self._valid_payload()))
+        self._run_create(
+            ["--from-file", str(payload_file), "--global"],
+            capsys, builtin_dir, project_dir, user_dir,
+        )
+        assert (user_dir / "my-pipeline" / "template.json").exists()
+        assert not (project_dir / "my-pipeline").exists()
+
+    # --- validation errors ---
+
+    def test_create_rejects_invalid_id(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(self._valid_payload(id="INVALID ID!")))
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_create(
+                ["--from-file", str(payload_file)],
+                capsys, builtin_dir, project_dir, tmp_path / "user",
+            )
+        assert exc_info.value.code != 0
+        err = capsys.readouterr().err
+        assert "validation_error" in err or "id" in err.lower()
+
+    def test_create_rejects_too_many_tags(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(
+            self._valid_payload(tags=["a", "b", "c", "d", "e", "f"])
+        ))
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_create(
+                ["--from-file", str(payload_file)],
+                capsys, builtin_dir, project_dir, tmp_path / "user",
+            )
+        assert exc_info.value.code != 0
+
+    def test_create_rejects_bad_tag_chars(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(
+            self._valid_payload(tags=["BAD TAG!"])
+        ))
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_create(
+                ["--from-file", str(payload_file)],
+                capsys, builtin_dir, project_dir, tmp_path / "user",
+            )
+        assert exc_info.value.code != 0
+
+    def test_create_rejects_nondict_config(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(
+            self._valid_payload(config="not-a-dict")
+        ))
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_create(
+                ["--from-file", str(payload_file)],
+                capsys, builtin_dir, project_dir, tmp_path / "user",
+            )
+        assert exc_info.value.code != 0
+
+    def test_create_validation_error_prints_details(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(
+            self._valid_payload(id="INVALID!", config="bad")
+        ))
+        with pytest.raises(SystemExit):
+            self._run_create(
+                ["--from-file", str(payload_file)],
+                capsys, builtin_dir, project_dir, tmp_path / "user",
+            )
+        err = capsys.readouterr().err
+        assert "id" in err.lower()
+        assert "config" in err.lower()
+
+    # --- builtin conflict ---
+
+    def test_create_rejects_builtin_id(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        _write_template(builtin_dir / "bugfix", _minimal("bugfix"))
+        project_dir = tmp_path / "project"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(
+            self._valid_payload(id="bugfix", name="Bugfix Override")
+        ))
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_create(
+                ["--from-file", str(payload_file)],
+                capsys, builtin_dir, project_dir, tmp_path / "user",
+            )
+        assert exc_info.value.code != 0
+        err = capsys.readouterr().err
+        assert "bugfix" in err or "built-in" in err.lower()
+
+    # --- stdin support ---
+
+    def test_create_from_stdin(self, capsys, tmp_path, monkeypatch):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        payload_json = json.dumps(self._valid_payload())
+        import io
+        monkeypatch.setattr("sys.stdin", io.StringIO(payload_json))
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ):
+            main(["templates", "create", "--from-file", "-"])
+        assert (project_dir / "my-pipeline" / "template.json").exists()
+
+    # --- round-trip via list --json ---
+
+    def test_create_roundtrips_via_list_json(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text(json.dumps(self._valid_payload()))
+        self._run_create(
+            ["--from-file", str(payload_file)],
+            capsys, builtin_dir, project_dir, user_dir,
+        )
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ):
+            main(["templates", "list", "--json"])
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        by_id = {e["id"]: e for e in payload}
+        assert "my-pipeline" in by_id
+        assert by_id["my-pipeline"]["name"] == "My Pipeline"
+        assert by_id["my-pipeline"]["tier"] == "project"
+        assert by_id["my-pipeline"]["tags"] == ["fast"]
+
+    # --- invalid JSON ---
+
+    def test_create_invalid_json_exits_nonzero(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        payload_file = tmp_path / "payload.json"
+        payload_file.write_text("not valid json {{{")
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_create(
+                ["--from-file", str(payload_file)],
+                capsys, builtin_dir, project_dir, tmp_path / "user",
+            )
+        assert exc_info.value.code != 0
+
+    def test_create_file_not_found_exits_nonzero(self, capsys, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_create(
+                ["--from-file", str(tmp_path / "no-such-file.json")],
+                capsys, builtin_dir, project_dir, tmp_path / "user",
+            )
+        assert exc_info.value.code != 0
+        err = capsys.readouterr().err
+        assert "error" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Skill-shipping regression: worca-template installs via _install_skills
+# ---------------------------------------------------------------------------
+
+
+class TestWorcaTemplateSkillShipping:
+    def test_install_skills_copies_worca_template(self, tmp_path):
+        """_install_skills must install worca-template/SKILL.md into .claude/skills/."""
+        from worca.cli.init import _install_skills
+
+        source = Path(__file__).resolve().parent.parent / "src" / "worca"
+        git_root = tmp_path / "project"
+        git_root.mkdir()
+        changes = _install_skills(source, git_root)
+        installed = git_root / ".claude" / "skills" / "worca-template" / "SKILL.md"
+        assert installed.exists(), "worca-template/SKILL.md was not installed"
+        assert any("worca-template" in c for c in changes)
+
+    def test_installed_skill_has_valid_frontmatter(self, tmp_path):
+        """Installed SKILL.md must have name: worca-template in its frontmatter."""
+        from worca.cli.init import _install_skills
+
+        source = Path(__file__).resolve().parent.parent / "src" / "worca"
+        git_root = tmp_path / "project"
+        git_root.mkdir()
+        _install_skills(source, git_root)
+        installed = git_root / ".claude" / "skills" / "worca-template" / "SKILL.md"
+        content = installed.read_text()
+        assert content.startswith("---")
+        assert "name: worca-template" in content


### PR DESCRIPTION
## Summary

- Add **`/worca-template`** shippable skill — a phased interview that enumerates existing templates, asks for intent/rigor/stages/models, proposes reusing or extending a close match (reuse-first), explicitly prompts for project-vs-user scope, composes a minimal config delta, and writes it via the new CLI command with full validation.
- Add **`worca templates create --from-file <path> [--global]`** CLI command — reads a JSON payload and routes through the existing `TemplateResolver.save()` for validation (id regex, tag limits, config type, builtin-id collision). Supports `--from-file -` for stdin.
- Update `docs/cli-reference.md` and `README.md` to document both pieces.
- Verified the skill ships in the wheel via the existing `skills/*/SKILL.md` glob.

## Test plan

- [x] 63 tests pass in `tests/test_cli_templates.py` (17 new for `create` + 2 skill-shipping regression tests)
- [x] `python -m build --wheel && unzip -l dist/*.whl | grep worca-template` confirms the skill ships
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
