### PR TITLE
Allow general-purpose subagent via default_denied (allowable per-agent)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -690,6 +690,38 @@ W-053: Optional Graphify knowledge-graph integration (query-based agent consumpt
 
 **Full reference:** [`docs/plans/W-053-graphify-integration.md`](./docs/plans/W-053-graphify-integration.md).
 
+### 0.40.x → 0.41.0
+
+`general-purpose` subagent moves from `always_disallowed` to `default_denied` — still off by default, but now allowable per-agent.
+
+**Why:** the `general-purpose` subagent (which spawns an unconstrained, full-tool Claude session) was on `subagents.always_disallowed`. The resolver checks `always_disallowed` *before* `per_agent_allow`, so there was **no way to opt an agent in** — even naming `general-purpose` explicitly in a per-agent allow list (or the UI editor) was silently overruled. Moving it to `default_denied` keeps it blocked under the `"*"` wildcard (default behavior is unchanged — it stays denied) while making the per-agent opt-in path actually work.
+
+**Behavior change (no config edits required):** on upgrade, a config whose `governance.dispatch.subagents.always_disallowed` is *exactly* `["general-purpose"]` (the untouched default) is rewritten to `always_disallowed: []` + `default_denied: ["general-purpose"]` (any pre-existing `default_denied` entries are preserved). A **customized denylist** (extra entries) is left untouched. The UI Governance editor no longer hard-blocks typing `general-purpose` into an allow list.
+
+**One-time and version-stamped.** This is the **v2** dispatch normalization, gated by `governance.dispatch_migration_version` (bumped `1 → 2`). It runs exactly once per config — on `worca init --upgrade` (Python) or the next Governance-panel save (UI) — then the stamp prevents re-runs.
+
+**To re-allow `general-purpose` for an agent** after upgrading, name it in `per_agent_allow` (the mixed form keeps the wildcard for everything else):
+
+```jsonc
+"subagents": {
+  "default_denied": ["general-purpose"],
+  "per_agent_allow": {
+    "_defaults": ["*"],
+    "implementer": ["*", "general-purpose"]
+  }
+}
+```
+
+**To forbid it everywhere** (no per-agent opt-in possible), add it back to `always_disallowed`.
+
+**Automatic migration message via `worca init --upgrade`:**
+
+```
+governance.dispatch.subagents: moved general-purpose from always_disallowed to default_denied (now allowable per-agent)
+```
+
+**Full reference:** [`docs/governance.md`](./docs/governance.md) § Subagents.
+
 ## Getting help
 
 - Issues: https://github.com/SinishaDjukic/worca-cc/issues

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ worca-cc is a multi-agent pipeline that plans, coordinates, implements, tests, r
 ### Governance & Safety
 
 - **Governance hooks** — block dangerous operations (rm -rf, force push, env writes), enforce test gates, validate plans (each guard can be toggled independently)
-- **Configurable subagent dispatch** — per-agent allowlists control which Claude Code subagents each pipeline agent can spawn; `general-purpose` is on an unbypassable denylist; dispatch events render as green/red badges per iteration in the UI
+- **Configurable subagent dispatch** — per-agent allowlists control which Claude Code subagents each pipeline agent can spawn; `general-purpose` is denied by default (opt an agent in explicitly when needed); dispatch events render as green/red badges per iteration in the UI
 - **Human approval gates** — optional checkpoints after planning, before merge, and before deploy (configurable per gate)
 - **Token and cost tracking** — per-agent usage with model-specific pricing, web search/fetch cost tracking, cache tier breakdown, budget warnings at configurable thresholds
 
@@ -228,7 +228,7 @@ All configuration lives in `.claude/settings.json` under the `worca` key:
 - **`worca.effort`** — adaptive reasoning-effort control: `auto_mode` (`adaptive` default / `reactive` / `disabled`), an `auto_cap` ceiling, and per-agent `effort` levels (`low | medium | high | xhigh | max`). See [docs/effort.md](docs/effort.md)
 - **`worca.stages`** — enable/disable pipeline stages (preflight, plan, coordinate, implement, test, review, pr, learn), assign agents
 - **`worca.loops`** — iteration limits (implement/test: 5, code review: 5, PR changes: 5, restart planning: 2)
-- **`worca.governance`** — guards (block rm -rf, force push, env writes), test gate strike limit, `subagent_dispatch` per-agent allowlists (user config replaces defaults per agent; `general-purpose` denylist enforced)
+- **`worca.governance`** — guards (block rm -rf, force push, env writes), test gate strike limit, `subagent_dispatch` per-agent allowlists (user config replaces defaults per agent; `general-purpose` denied by default, allowable per-agent)
 - **`worca.milestones`** — human approval gates (plan, PR, deploy)
 - **`worca.pricing`** — per-model token pricing for cost tracking
 - **`worca.circuit_breaker`** — max failures before halting, transient error retry logic

--- a/docs-site/src/content/docs/concepts/governance.md
+++ b/docs-site/src/content/docs/concepts/governance.md
@@ -13,7 +13,7 @@ worca is built on the idea that an autonomous pipeline needs guardrails. Governa
 - **Dangerous operations are blocked.** Recursive force-deletes (`rm -rf`), force-pushes, and writes to environment files are denied outright.
 - **A plan must exist first.** Source-file writes are blocked until the plan (`MASTER_PLAN.md`) is in place, so implementation can't start before there's a plan to follow.
 - **A test gate halts runaway failures.** After repeated consecutive test-run failures, the pipeline stops rather than burning tokens on a broken approach.
-- **Dispatch is scoped per agent.** Each agent can only invoke the tools, skills, and subagents on its allow-list; broad escape hatches like the `general-purpose` subagent are denied to everyone.
+- **Dispatch is scoped per agent.** Each agent can only invoke the tools, skills, and subagents on its allow-list; broad escape hatches like the `general-purpose` subagent are denied by default (a project can opt a specific agent in by naming it explicitly in its allow-list).
 
 ## Why hooks, not prompts
 

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -38,7 +38,7 @@ See [`docs/state-action-matrix.md`](./state-action-matrix.md) for the full state
 - **Source writes blocked until the plan file exists** — plan-first is enforced, not suggested.
 - **Consecutive test failures halt the pipeline** — circuit breaker against runaway broken loops.
 - **All governance lives in Python hooks** — enforcement at every tool call, not in agent prompts.
-- **`general-purpose` subagent is on an unbypassable denylist** — hard safety guardrail.
+- **`general-purpose` subagent is denied by default** — it spawns an unconstrained full-tool session, so it sits in `default_denied` (off under the wildcard); a project opts an agent in explicitly. Hard safety guardrail without a dead-end.
 - **Subagent dispatch uses per-agent allowlists** — least-privilege per role over global controls.
 
 ## Modularity & Configuration

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -118,15 +118,17 @@ When `WORCA_AGENT` is empty (interactive mode), all dispatches are allowed — h
 
 ```jsonc
 {
-  "always_disallowed": ["general-purpose"],
-  "default_denied": [],
+  "always_disallowed": [],
+  "default_denied": ["general-purpose"],
   "per_agent_allow": { "_defaults": ["*"] }
 }
 ```
 
-**Default: wide open (`["*"]`).** All built-in subagents (`Explore`, `Plan`, `claude-code-guide`, `statusline-setup`) plus user/plugin subagents resolve via wildcard. The `general-purpose` subagent is in `always_disallowed` because it spawns an unconstrained Claude session with full tool access — the one footgun.
+**Default: wide open (`["*"]`).** All built-in subagents (`Explore`, `Plan`, `claude-code-guide`, `statusline-setup`) plus user/plugin subagents resolve via wildcard. The `general-purpose` subagent is in `default_denied` because it spawns an unconstrained Claude session with full tool access — so it stays **off by default** (the `"*"` wildcard excludes `default_denied`), but a project can re-allow it for a specific agent by naming it in `per_agent_allow` (e.g. `"implementer": ["*", "general-purpose"]`).
 
-Projects that need tighter control add specific subagents to `default_denied` and opt in per agent. The plain wildcard default reflects an operational reality: hand-curating allowlists for an evolving set of project/plugin subagents creates more drift than safety.
+> **Why `default_denied`, not `always_disallowed`?** It used to be on `always_disallowed`, which the resolver checks *before* `per_agent_allow` — so there was no way to opt in even by naming it explicitly. Moving it to `default_denied` keeps the footgun guarded by default while making the opt-in path actually work. Upgrading projects self-heal via the v2 dispatch normalization (stamped on `governance.dispatch_migration_version`); the UI editor no longer hard-blocks typing `general-purpose` into an allow list.
+
+Projects that need tighter control add specific subagents to `default_denied` and opt in per agent. The plain wildcard default reflects an operational reality: hand-curating allowlists for an evolving set of project/plugin subagents creates more drift than safety. To genuinely forbid a subagent everywhere (no per-agent opt-in possible), add it to `always_disallowed`.
 
 ## Asymmetric defaults
 
@@ -134,11 +136,11 @@ All three sections now default to `["*"]` (PR B for subagents). The deny tiers c
 
 | Section | `_defaults` | Tier-1 denials |
 |---------|-------------|----------------|
-| tools | `["*"]` | `EnterPlanMode`, `EnterWorktree`, `TodoWrite` |
-| skills | `["*"]` | `batch`, `fewer-permission-prompts`, `loop`, `schedule`, `worca-*`, `update-config`, `hookify:*`, `init` |
-| subagents | `["*"]` | `general-purpose` |
+| tools | `["*"]` | `EnterPlanMode`, `EnterWorktree`, `TodoWrite` (always_disallowed) |
+| skills | `["*"]` | `batch`, `fewer-permission-prompts`, `loop`, `schedule`, `worca-*`, `update-config`, `hookify:*`, `init` (always_disallowed) |
+| subagents | `["*"]` | `general-purpose` (default_denied — off by default, allowable per-agent) |
 
-The skills section additionally uses `default_denied` to gate per-agent opt-ins (`simplify`, `debug`, `claude-api`, `review`, etc.). Subagents and tools use `default_denied` rarely — projects can add entries to express "this is normally off; reviewer can opt in" without flipping per-agent allowlists.
+The skills section additionally uses `default_denied` to gate per-agent opt-ins (`simplify`, `debug`, `claude-api`, `review`, etc.). The subagents section uses `default_denied` for `general-purpose` (same pattern: normally off; an agent can opt in). `always_disallowed` is empty by default for subagents — projects add to it only to forbid a subagent with no opt-in path.
 
 ## Wildcard semantics
 
@@ -251,6 +253,20 @@ Add it to `default_denied`. The wildcard does not include `default_denied` entri
   "default_denied": ["claude-code-guide"],
   "per_agent_allow": {
     "_defaults": ["*"]
+  }
+}
+```
+
+### Re-allow `general-purpose` for one agent
+
+`general-purpose` ships in `default_denied`, so it is blocked under the wildcard. Name it explicitly in a per-agent entry to opt that agent in (the mixed form `["*", …]` keeps the wildcard for everything else):
+
+```jsonc
+"subagents": {
+  "default_denied": ["general-purpose"],
+  "per_agent_allow": {
+    "_defaults": ["*"],
+    "implementer": ["*", "general-purpose"]
   }
 }
 ```

--- a/docs/plans/W-054-configurable-dispatch-governance.md
+++ b/docs/plans/W-054-configurable-dispatch-governance.md
@@ -6,6 +6,8 @@
 **Date:** 2026-05-17
 **Depends on:** W-038 (configurable subagent dispatch — establishes today's settings-driven dispatch shape)
 
+> **Partially superseded (v2 dispatch normalization).** This plan places `general-purpose` on the subagents `always_disallowed` tier. That was later moved to `default_denied` (still off by default, but allowable per-agent) because `always_disallowed` is checked before `per_agent_allow`, leaving no opt-in path. The canonical reference is [`docs/governance.md`](../governance.md) § Subagents; the upgrade behavior is the v2 normalization in [`MIGRATION.md`](../../MIGRATION.md) (`0.40.x → 0.41.0`).
+
 ## Problem
 
 Worca's dispatch governance is split across two enforcement layers that are wired up

--- a/src/worca/hooks/tracking.py
+++ b/src/worca/hooks/tracking.py
@@ -73,8 +73,13 @@ _DISPATCH_DEFAULTS = {
         },
     },
     "subagents": {
-        "always_disallowed": ["general-purpose"],
-        "default_denied": [],
+        "always_disallowed": [],
+        # general-purpose spawns an unconstrained full-tool Claude session, so
+        # it stays denied under the "*" wildcard — but as default_denied (not
+        # always_disallowed) a project can re-allow it per agent by naming it
+        # in per_agent_allow. The old always_disallowed placement made that
+        # impossible: the denylist short-circuits before per_agent_allow.
+        "default_denied": ["general-purpose"],
         "per_agent_allow": {"_defaults": ["*"]},
     },
 }
@@ -85,7 +90,10 @@ _DISPATCH_DEFAULTS = {
 # governance.dispatch_migration_version so the normalization runs exactly once
 # per config; re-runs (and fresh installs already at this version) are no-ops.
 # Bump when adding a new one-time normalization below.
-DISPATCH_MIGRATION_VERSION = 1
+#   v1: collapse stale Explore-only subagent default; narrow worca-* skills glob.
+#   v2: move general-purpose from subagents.always_disallowed to default_denied
+#       (still denied by default, but allowable per-agent).
+DISPATCH_MIGRATION_VERSION = 2
 
 # The pre-W-054 (W-038-era) shipped subagent dispatch default: every pipeline
 # agent capped to Explore-only. W-054 changed the default to `_defaults: ["*"]`,
@@ -174,15 +182,45 @@ def adopt_narrowed_skills_denylist(skills_cfg: dict) -> bool:
     return True
 
 
+def adopt_general_purpose_allowable(subagents_cfg: dict) -> bool:
+    """Move general-purpose from always_disallowed to default_denied.
+
+    W-054 hard-denied general-purpose via always_disallowed, which meant a
+    project could not re-allow it even by naming it explicitly in
+    per_agent_allow (the denylist short-circuits first). The current default
+    lists it in default_denied instead: still blocked under the "*" wildcard,
+    but allowable per-agent. We migrate an *untouched* denylist (exactly
+    ``["general-purpose"]``) to the new shape; a customized denylist (extra
+    entries) is a deliberate operator choice and is left alone.
+
+    Returns True if migrated, else False. Preserves any existing default_denied
+    entries (general-purpose is appended, de-duplicated).
+    """
+    if not isinstance(subagents_cfg, dict):
+        return False
+    if subagents_cfg.get("always_disallowed") != ["general-purpose"]:
+        return False
+    denied = subagents_cfg.get("default_denied")
+    if not isinstance(denied, list):
+        denied = []
+    subagents_cfg["always_disallowed"] = []
+    if "general-purpose" not in denied:
+        denied = [*denied, "general-purpose"]
+    subagents_cfg["default_denied"] = denied
+    return True
+
+
 def normalize_dispatch_defaults(governance_cfg: dict) -> list[str]:
     """Apply one-time dispatch-default normalizations, gated by a version stamp.
 
-    Brings an *untouched* config up to the current shipped defaults for the two
+    Brings an *untouched* config up to the current shipped defaults for the
     things that changed after W-054:
-      1. subagents.per_agent_allow pinned to the legacy Explore-only set, and
-      2. skills.always_disallowed carrying the broad ``worca-*`` glob.
+      1. subagents.per_agent_allow pinned to the legacy Explore-only set,
+      2. skills.always_disallowed carrying the broad ``worca-*`` glob, and
+      3. subagents.always_disallowed hard-denying general-purpose (moved to
+         default_denied so it is allowable per-agent).
 
-    Both are exact-match guarded so a customized config is never silently
+    Each is exact-match guarded so a customized config is never silently
     widened. Stamps ``dispatch_migration_version`` so it runs once. Mutates
     ``governance_cfg`` in place; returns a list of change descriptions.
     """
@@ -206,6 +244,11 @@ def normalize_dispatch_defaults(governance_cfg: dict) -> list[str]:
         changes.append(
             "  governance.dispatch.skills.always_disallowed: narrowed legacy "
             '"worca-*" glob to the current must-disallow set'
+        )
+    if adopt_general_purpose_allowable(dispatch.get("subagents")):
+        changes.append(
+            "  governance.dispatch.subagents: moved general-purpose from "
+            "always_disallowed to default_denied (now allowable per-agent)"
         )
     governance_cfg["dispatch_migration_version"] = DISPATCH_MIGRATION_VERSION
     return changes

--- a/src/worca/settings.json
+++ b/src/worca/settings.json
@@ -283,7 +283,7 @@
         "block_graphify_mutation": true
       },
       "test_gate_strikes": 2,
-      "dispatch_migration_version": 1,
+      "dispatch_migration_version": 2,
       "dispatch": {
         "tools": {
           "always_disallowed": ["EnterPlanMode", "EnterWorktree", "TodoWrite"],
@@ -320,8 +320,8 @@
           }
         },
         "subagents": {
-          "always_disallowed": ["general-purpose"],
-          "default_denied": [],
+          "always_disallowed": [],
+          "default_denied": ["general-purpose"],
           "per_agent_allow": {
             "_defaults": ["*"]
           }

--- a/tests/integration/test_governance_hooks_live.py
+++ b/tests/integration/test_governance_hooks_live.py
@@ -212,8 +212,9 @@ def test_force_push_blocked(pipeline_env):
 
 
 def test_dispatch_blocks_denylisted_subagent(pipeline_env):
-    """`general-purpose` is unconditionally denylisted, even when settings
-    would allow it. The denylist is enforced before the per-agent allow-list."""
+    """`general-purpose` is denied by default: it sits in default_denied, so the
+    `*` wildcard excludes it and an agent without an explicit allow entry is
+    blocked. (It is allowable per-agent by naming it in per_agent_allow.)"""
     pipeline_env.set_governance_agent("implementer")
     proc = pipeline_env.run_hook(
         "subagent_start",

--- a/tests/test_denylist_sync.py
+++ b/tests/test_denylist_sync.py
@@ -153,7 +153,10 @@ _MIGRATION_FIXTURES = {
             },
         }
     },
-    # 3) Already-migrated input — must be a no-op for both implementations.
+    # 3) Nested-shape input with no version stamp: both implementations stamp
+    #    the current version and move general-purpose from always_disallowed to
+    #    default_denied (v2 normalization). The assertion is parity — Python and
+    #    JS must produce byte-identical governance output.
     "already_migrated": {
         "worca": {
             "governance": {

--- a/tests/test_dispatch_default_normalization.py
+++ b/tests/test_dispatch_default_normalization.py
@@ -13,6 +13,7 @@ from worca.cli.init import _migrate_dispatch_governance
 from worca.hooks.tracking import (
     DISPATCH_MIGRATION_VERSION,
     _DISPATCH_DEFAULTS,
+    adopt_general_purpose_allowable,
     adopt_narrowed_skills_denylist,
     adopt_stale_subagent_default,
     normalize_dispatch_defaults,
@@ -141,14 +142,47 @@ def test_adopt_preserves_customized_skills_denylist():
     assert "worca-*" in cfg["always_disallowed"]
 
 
+# --- adopt_general_purpose_allowable -----------------------------------------
+
+
+def test_adopt_moves_general_purpose_to_default_denied():
+    cfg = {"always_disallowed": ["general-purpose"], "default_denied": []}
+    assert adopt_general_purpose_allowable(cfg) is True
+    assert cfg["always_disallowed"] == []
+    assert cfg["default_denied"] == ["general-purpose"]
+
+
+def test_adopt_general_purpose_preserves_existing_default_denied():
+    cfg = {"always_disallowed": ["general-purpose"], "default_denied": ["foo"]}
+    assert adopt_general_purpose_allowable(cfg) is True
+    assert cfg["always_disallowed"] == []
+    assert cfg["default_denied"] == ["foo", "general-purpose"]
+
+
+def test_adopt_general_purpose_preserves_customized_denylist():
+    """A denylist with extra entries is a deliberate operator choice — leave it."""
+    cfg = {"always_disallowed": ["general-purpose", "custom-deny"], "default_denied": []}
+    assert adopt_general_purpose_allowable(cfg) is False
+    assert cfg["always_disallowed"] == ["general-purpose", "custom-deny"]
+
+
+def test_adopt_general_purpose_noop_when_already_migrated():
+    cfg = {"always_disallowed": [], "default_denied": ["general-purpose"]}
+    assert adopt_general_purpose_allowable(cfg) is False
+
+
 # --- normalize_dispatch_defaults (Pop 1) -------------------------------------
 
 
 def test_normalize_pop1_collapses_and_narrows_and_stamps():
     gov = _pop1_config()
     changes = normalize_dispatch_defaults(gov)
-    assert len(changes) == 2
+    # Three normalizations fire: subagent default collapse, skills-glob narrow,
+    # and general-purpose moved to default_denied.
+    assert len(changes) == 3
     assert gov["dispatch"]["subagents"]["per_agent_allow"] == {"_defaults": ["*"]}
+    assert gov["dispatch"]["subagents"]["always_disallowed"] == []
+    assert gov["dispatch"]["subagents"]["default_denied"] == ["general-purpose"]
     assert "worca-*" not in gov["dispatch"]["skills"]["always_disallowed"]
     assert "worca-release" in gov["dispatch"]["skills"]["always_disallowed"]
     assert gov["dispatch_migration_version"] == DISPATCH_MIGRATION_VERSION

--- a/tests/test_hook_governance_events.py
+++ b/tests/test_hook_governance_events.py
@@ -356,8 +356,10 @@ class TestSubagentStartDispatchBlockedEvent:
         events = [json.loads(line) for line in open(events_file).readlines() if line.strip()]
         e = events[0]
         # `candidate` carries the child name; `reason` is the rule path.
+        # general-purpose is denied by default via default_denied (it is
+        # excluded from the '*' wildcard), not the always_disallowed tier.
         assert e["payload"]["candidate"] == "general-purpose"
-        assert e["payload"]["reason"] == "always_disallowed"
+        assert e["payload"]["reason"] == "default_denied"
 
     def test_emit_noop_when_events_path_missing(self):
         """No crash when WORCA_EVENTS_PATH is not set — dispatch still blocked."""

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -141,11 +141,15 @@ def test_allows_learner_dispatching_explore():
     assert code == 0
 
 
-def test_denylist_blocks_general_purpose():
-    """general-purpose is blocked by denylist even when parent has no dispatch rules."""
+def test_check_dispatch_blocks_general_purpose_by_default():
+    """check_dispatch denies general-purpose for an agent with no explicit allow
+    entry: it resolves via the `*` wildcard, which excludes default_denied. The
+    returned message is the default_denied ("cannot dispatch") path, not the
+    always_disallowed ("denylist") one."""
     code, reason = check_dispatch("coordinator", "general-purpose")
     assert code == 2
-    assert "denylist" in reason.lower() or "Blocked" in reason
+    assert "cannot dispatch" in reason
+    assert "denylist" not in reason.lower()
 
 
 def test_always_disallowed_wins_over_per_agent_allow():
@@ -618,13 +622,33 @@ def test_subagents_wildcard_default_allows_any_non_denied(agent):
     assert via == "wildcard"
 
 
-def test_subagents_general_purpose_still_denied_under_wildcard():
-    """PR B: general-purpose stays in always_disallowed even with wildcard."""
+def test_subagents_general_purpose_denied_by_default_via_default_denied():
+    """general-purpose is denied by default — but via default_denied (not
+    always_disallowed), so the '*' wildcard excludes it while leaving it
+    allowable per-agent."""
     allowed, reason, _ = check_allowed(
         "subagents", "implementer", "general-purpose", settings_override={},
     )
     assert allowed is False
-    assert reason == "always_disallowed"
+    assert reason == "default_denied"
+
+
+def test_subagents_general_purpose_allowable_when_named_explicitly():
+    """Because general-purpose is default_denied (not always_disallowed), a
+    project can re-allow it for an agent by naming it in per_agent_allow."""
+    cfg = _settings_with_dispatch("subagents", {
+        "always_disallowed": [],
+        "default_denied": ["general-purpose"],
+        "per_agent_allow": {
+            "_defaults": ["*"],
+            "implementer": ["*", "general-purpose"],
+        },
+    })
+    allowed, reason, via = check_allowed(
+        "subagents", "implementer", "general-purpose", settings_override=cfg,
+    )
+    assert allowed is True
+    assert via == "explicit"
 
 
 def test_subagents_explore_now_via_wildcard():

--- a/worca-ui/app/views/dispatch-tag-state.js
+++ b/worca-ui/app/views/dispatch-tag-state.js
@@ -3,10 +3,13 @@
  * These are extracted for testability and reuse in settings.js.
  */
 
-// Keep in sync with _SUBAGENT_DENYLIST in src/worca/hooks/tracking.py —
-// the backend is the authoritative enforcer; this set mirrors it so the
-// UI can show the same types as blocked.
-export const SUBAGENT_DENYLIST = new Set(['general-purpose']);
+// Mirrors the subagents `always_disallowed` default in
+// _DISPATCH_DEFAULTS (src/worca/hooks/tracking.py) — the hard-deny tier whose
+// items cannot be added to any per_agent_allow list. The backend is the
+// authoritative enforcer; this set lets the editor show the same types as
+// blocked. Empty by default: general-purpose now lives in default_denied
+// (allowable per-agent), not always_disallowed, so nothing is hard-denied.
+export const SUBAGENT_DENYLIST = new Set([]);
 
 // Fallback used when `GET /api/subagents` is unavailable or hasn't returned
 // yet. The server endpoint does the real directory walk (builtins + user +

--- a/worca-ui/app/views/dispatch-tag-state.test.js
+++ b/worca-ui/app/views/dispatch-tag-state.test.js
@@ -24,11 +24,22 @@ describe('dispatch-tag-state', () => {
       expect(result.rejected).toBe(false);
     });
 
-    it('rejects denied type', () => {
-      const result = addTag([], 'general-purpose', SUBAGENT_DENYLIST);
+    it('rejects a type on the supplied denylist', () => {
+      // The denylist mechanism still works; pass an explicit set since the
+      // default SUBAGENT_DENYLIST is now empty (nothing is hard-denied).
+      const result = addTag([], 'locked-agent', new Set(['locked-agent']));
       expect(result.tags).toEqual([]);
       expect(result.rejected).toBe(true);
       expect(result.reason).toBeTruthy();
+    });
+
+    it('allows general-purpose under the default denylist (now default_denied)', () => {
+      // general-purpose moved from always_disallowed to default_denied, so it
+      // is no longer on the UI hard-deny set and can be added per-agent.
+      expect(SUBAGENT_DENYLIST.has('general-purpose')).toBe(false);
+      const result = addTag([], 'general-purpose', SUBAGENT_DENYLIST);
+      expect(result.tags).toEqual(['general-purpose']);
+      expect(result.rejected).toBe(false);
     });
   });
 
@@ -76,16 +87,24 @@ describe('dispatch-tag-state', () => {
       expect(result.every((r) => r.name.startsWith('feature-dev:'))).toBe(true);
     });
 
-    it('marks denied types', () => {
+    it('marks types on the supplied denylist', () => {
+      const denylist = new Set(['general-purpose']);
+      const result = filterSuggestions('general', KNOWN_TYPES, [], denylist);
+      const denied = result.find((r) => r.name === 'general-purpose');
+      expect(denied).toBeDefined();
+      expect(denied.denied).toBe(true);
+    });
+
+    it('does not mark general-purpose denied under the default denylist', () => {
       const result = filterSuggestions(
         'general',
         KNOWN_TYPES,
         [],
         SUBAGENT_DENYLIST,
       );
-      const denied = result.find((r) => r.name === 'general-purpose');
-      expect(denied).toBeDefined();
-      expect(denied.denied).toBe(true);
+      const gp = result.find((r) => r.name === 'general-purpose');
+      expect(gp).toBeDefined();
+      expect(gp.denied).toBe(false);
     });
   });
 

--- a/worca-ui/e2e/settings-dispatch.spec.js
+++ b/worca-ui/e2e/settings-dispatch.spec.js
@@ -205,9 +205,11 @@ test('remove a tag chip', async ({ page }) => {
   }
 });
 
-// ─── Test 5: denied type greyed out in suggestions ───────────────────────────
+// ─── Test 5: general-purpose is addable (default_denied, not always_disallowed) ─
 
-test('denied type shown greyed out and cannot be added', async ({ page }) => {
+test('general-purpose is suggested without denied styling and can be added', async ({
+  page,
+}) => {
   const ctx = await startServer();
   try {
     // Default settings: coordinator starts with []
@@ -217,21 +219,20 @@ test('denied type shown greyed out and cannot be added', async ({ page }) => {
     await input.click();
     await input.fill('general');
 
-    // Suggestions popup should show "general-purpose" with denied styling
+    // Suggestions popup shows "general-purpose" as a normal (non-denied) item.
     const suggestions = page.locator(
       '.settings-dispatch-row:has(#dispatch-subagents-coordinator) .dispatch-suggestions',
     );
     await expect(suggestions).toBeVisible();
-    const deniedItem = suggestions
-      .locator('.item.denied')
-      .filter({ hasText: 'general-purpose' });
-    await expect(deniedItem).toBeVisible();
+    const item = suggestions.locator('.item').filter({ hasText: 'general-purpose' });
+    await expect(item).toBeVisible();
+    await expect(item).not.toHaveClass(/denied/);
 
-    // Click the denied item — it should NOT be added
-    await deniedItem.click();
+    // Clicking it adds it to coordinator's allow list.
+    await item.click();
     await expect(
       page.locator('#dispatch-subagents-coordinator sl-tag[data-value="general-purpose"]'),
-    ).not.toBeAttached();
+    ).toBeAttached();
   } finally {
     await ctx.close();
   }

--- a/worca-ui/server/dispatch-defaults.js
+++ b/worca-ui/server/dispatch-defaults.js
@@ -64,8 +64,12 @@ export const DISPATCH_DEFAULTS = {
     },
   },
   subagents: {
-    always_disallowed: ['general-purpose'],
-    default_denied: [],
+    always_disallowed: [],
+    // general-purpose spawns an unconstrained full-tool Claude session, so it
+    // stays denied under the '*' wildcard — but as default_denied (not
+    // always_disallowed) a project can re-allow it per agent by naming it in
+    // per_agent_allow.
+    default_denied: ['general-purpose'],
     per_agent_allow: { _defaults: ['*'] },
   },
 };

--- a/worca-ui/server/dispatch-defaults.test.js
+++ b/worca-ui/server/dispatch-defaults.test.js
@@ -108,14 +108,14 @@ describe('DISPATCH_DEFAULTS', () => {
     );
   });
 
-  it('subagents always_disallowed is general-purpose', () => {
-    expect(DISPATCH_DEFAULTS.subagents.always_disallowed).toEqual([
-      'general-purpose',
-    ]);
+  it('subagents always_disallowed is empty (nothing hard-denied)', () => {
+    expect(DISPATCH_DEFAULTS.subagents.always_disallowed).toEqual([]);
   });
 
-  it('subagents default_denied is empty', () => {
-    expect(DISPATCH_DEFAULTS.subagents.default_denied).toEqual([]);
+  it('subagents default_denied is general-purpose (allowable per-agent)', () => {
+    expect(DISPATCH_DEFAULTS.subagents.default_denied).toEqual([
+      'general-purpose',
+    ]);
   });
 
   it('subagents _defaults is wildcard (PR B)', () => {

--- a/worca-ui/server/dispatch-migration.js
+++ b/worca-ui/server/dispatch-migration.js
@@ -60,7 +60,10 @@ function _absorbFlatDispatchKeys(dispatch) {
 // Mirror of normalize_dispatch_defaults() in src/worca/hooks/tracking.py.
 // Bumped when a new one-time normalization is added; stamped onto
 // governance.dispatch_migration_version so it runs exactly once per config.
-export const DISPATCH_MIGRATION_VERSION = 1;
+//   v1: collapse stale Explore-only subagent default; narrow worca-* skills glob.
+//   v2: move general-purpose from subagents.always_disallowed to default_denied
+//       (still denied by default, but allowable per-agent).
+export const DISPATCH_MIGRATION_VERSION = 2;
 
 // Pre-W-054 (W-038-era) shipped subagent default: every pipeline agent capped
 // to Explore-only. coordinator:[] / empty lists fall through to _defaults and
@@ -152,6 +155,36 @@ export function adoptNarrowedSkillsDenylist(skillsCfg) {
 }
 
 /**
+ * Move general-purpose from subagents.always_disallowed to default_denied so
+ * it is allowable per-agent (still denied under the '*' wildcard). Only fires
+ * on an untouched denylist (exactly `['general-purpose']`); a customized list
+ * is left alone. Preserves existing default_denied entries. Returns true if
+ * changed. Mirror of adopt_general_purpose_allowable() in tracking.py.
+ *
+ * @param {object} subagentsCfg
+ * @returns {boolean}
+ */
+export function adoptGeneralPurposeAllowable(subagentsCfg) {
+  if (!subagentsCfg || typeof subagentsCfg !== 'object') return false;
+  const current = subagentsCfg.always_disallowed;
+  if (
+    !Array.isArray(current) ||
+    current.length !== 1 ||
+    current[0] !== 'general-purpose'
+  ) {
+    return false;
+  }
+  const denied = Array.isArray(subagentsCfg.default_denied)
+    ? subagentsCfg.default_denied
+    : [];
+  subagentsCfg.always_disallowed = [];
+  subagentsCfg.default_denied = denied.includes('general-purpose')
+    ? denied
+    : [...denied, 'general-purpose'];
+  return true;
+}
+
+/**
  * Apply one-time dispatch-default normalizations, gated by a version stamp.
  * Brings an *untouched* config up to current shipped defaults for the two
  * things that changed after W-054 (subagent per_agent_allow, skills denylist).
@@ -175,6 +208,11 @@ export function normalizeDispatchDefaults(governanceCfg) {
   if (adoptNarrowedSkillsDenylist(dispatch.skills)) {
     changes.push(
       'governance.dispatch.skills.always_disallowed: narrowed legacy "worca-*" glob to the current must-disallow set',
+    );
+  }
+  if (adoptGeneralPurposeAllowable(dispatch.subagents)) {
+    changes.push(
+      'governance.dispatch.subagents: moved general-purpose from always_disallowed to default_denied (now allowable per-agent)',
     );
   }
   governanceCfg.dispatch_migration_version = DISPATCH_MIGRATION_VERSION;

--- a/worca-ui/server/dispatch-migration.test.js
+++ b/worca-ui/server/dispatch-migration.test.js
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { DISPATCH_DEFAULTS } from './dispatch-defaults.js';
-import { migrateDispatchGovernance } from './dispatch-migration.js';
+import {
+  adoptGeneralPurposeAllowable,
+  DISPATCH_MIGRATION_VERSION,
+  migrateDispatchGovernance,
+} from './dispatch-migration.js';
 
 describe('migrateDispatchGovernance', () => {
   it('migrates subagent_dispatch to dispatch.subagents.per_agent_allow', () => {
@@ -186,7 +190,7 @@ describe('migrateDispatchGovernance', () => {
     migrateDispatchGovernance(worca);
     const pa = worca.governance.dispatch.subagents.per_agent_allow;
     expect(pa).toEqual({ _defaults: ['*'] });
-    expect(worca.governance.dispatch_migration_version).toBe(1);
+    expect(worca.governance.dispatch_migration_version).toBe(2);
   });
 
   it('preserves a genuinely customized subagent shape', () => {
@@ -267,9 +271,11 @@ describe('normalizeDispatchDefaults (W-054 follow-up)', () => {
     const changes = migrateDispatchGovernance(worca);
     const d = worca.governance.dispatch;
     expect(d.subagents.per_agent_allow).toEqual({ _defaults: ['*'] });
+    expect(d.subagents.always_disallowed).toEqual([]);
+    expect(d.subagents.default_denied).toEqual(['general-purpose']);
     expect(d.skills.always_disallowed).not.toContain('worca-*');
     expect(d.skills.always_disallowed).toContain('worca-release');
-    expect(worca.governance.dispatch_migration_version).toBe(1);
+    expect(worca.governance.dispatch_migration_version).toBe(2);
     expect(changes.length).toBeGreaterThan(0);
   });
 
@@ -284,7 +290,7 @@ describe('normalizeDispatchDefaults (W-054 follow-up)', () => {
 
   it('does not touch a config already stamped at the current version', () => {
     const worca = pop1Config();
-    worca.governance.dispatch_migration_version = 1;
+    worca.governance.dispatch_migration_version = DISPATCH_MIGRATION_VERSION;
     const changes = migrateDispatchGovernance(worca);
     // Stamp present → stale shapes are left exactly as the operator left them.
     expect(changes).toEqual([]);
@@ -304,5 +310,41 @@ describe('normalizeDispatchDefaults (W-054 follow-up)', () => {
     expect(worca.governance.dispatch.subagents.per_agent_allow.planner).toEqual(
       ['Explore'],
     );
+  });
+});
+
+describe('adoptGeneralPurposeAllowable', () => {
+  it('moves general-purpose from always_disallowed to default_denied', () => {
+    const cfg = { always_disallowed: ['general-purpose'], default_denied: [] };
+    expect(adoptGeneralPurposeAllowable(cfg)).toBe(true);
+    expect(cfg.always_disallowed).toEqual([]);
+    expect(cfg.default_denied).toEqual(['general-purpose']);
+  });
+
+  it('preserves existing default_denied entries', () => {
+    const cfg = {
+      always_disallowed: ['general-purpose'],
+      default_denied: ['foo'],
+    };
+    expect(adoptGeneralPurposeAllowable(cfg)).toBe(true);
+    expect(cfg.default_denied).toEqual(['foo', 'general-purpose']);
+  });
+
+  it('leaves a customized denylist (extra entries) alone', () => {
+    const cfg = {
+      always_disallowed: ['general-purpose', 'custom-deny'],
+      default_denied: [],
+    };
+    expect(adoptGeneralPurposeAllowable(cfg)).toBe(false);
+    expect(cfg.always_disallowed).toEqual(['general-purpose', 'custom-deny']);
+  });
+
+  it('is a no-op when already migrated', () => {
+    const cfg = { always_disallowed: [], default_denied: ['general-purpose'] };
+    expect(adoptGeneralPurposeAllowable(cfg)).toBe(false);
+  });
+
+  it('current migration version is 2', () => {
+    expect(DISPATCH_MIGRATION_VERSION).toBe(2);
   });
 });


### PR DESCRIPTION
## Problem

The `general-purpose` subagent was hard-denied via `subagents.always_disallowed`. Because the dispatch resolver checks `always_disallowed` **before** `per_agent_allow`, there was **no way to opt an agent in** — naming it explicitly in a per-agent allow list (or trying to add it in the UI editor) was silently overruled. The only escape was hand-editing `always_disallowed` itself.

## Proposal

Move `general-purpose` from `always_disallowed` to `default_denied`:

- **Default behavior unchanged** — it stays denied under the `"*"` wildcard (the wildcard excludes `default_denied`), so existing pipelines see no difference.
- **Opt-in now works** — a project can re-allow it for a specific agent: `"implementer": ["*", "general-purpose"]`.
- The footgun (an unconstrained full-tool session) stays guarded by default, but without the dead-end.

## What changed

| Surface | Change |
|---|---|
| `src/worca/hooks/tracking.py` | `_DISPATCH_DEFAULTS["subagents"]`: `always_disallowed: []`, `default_denied: ["general-purpose"]`; new `adopt_general_purpose_allowable()`; `DISPATCH_MIGRATION_VERSION` 1→2 |
| `worca-ui/server/dispatch-defaults.js` / `dispatch-migration.js` | JS mirror of the default + the v2 normalization (`adoptGeneralPurposeAllowable`) |
| `worca-ui/app/views/dispatch-tag-state.js` | `SUBAGENT_DENYLIST` emptied so the editor no longer hard-blocks typing `general-purpose` |
| `src/worca/settings.json` | template default + `dispatch_migration_version: 2` |
| docs | `governance.md`, `MIGRATION.md` (`0.40.x → 0.41.0`), `design-principles.md`, docs-site, `README.md` |

**Fresh installs** get the new default. **Upgrades** self-heal via the v2 dispatch normalization — exact-match guarded (only an untouched `["general-purpose"]` denylist migrates; customized lists are preserved), version-stamped so it runs once. Dogfooded: `worca init --upgrade` migrated this repo's own settings.

## Considerations

- Strict broadening of the per-agent opt-in path; no agent loses access.
- To forbid a subagent everywhere with no opt-in path, projects add it back to `always_disallowed`.

## Verification

- Python: full unit suite + governance integration test
- JS: full vitest (3993) + biome; E2E `settings-dispatch` (8) + `settings-dispatch-sections` (20)
- docs-site build, ruff
- `worca-dispatch-governance-reviewer` → **approve** (no critical/major; both minor findings fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)