### PR TITLE
Ship feature-minor as a built-in pipeline template

### DIFF
--- a/docs-site/src/content/docs/concepts/pipeline-templates.md
+++ b/docs-site/src/content/docs/concepts/pipeline-templates.md
@@ -12,6 +12,7 @@ worca ships with these built-in templates:
 | Template | What it's for |
 |---|---|
 | **`feature`** | Substantial new work. Full pipeline with Plan Review and Learn enabled, higher retry limits, and all approval gates active. |
+| **`feature-minor`** | A well-scoped feature a planner can handle confidently. Full implement/test/review/PR, but **no Plan Review, no Learn, and no approval gates** — runs autonomously. Lower retry limits and effort capped at `high`. |
 | **`bugfix`** | A focused fix. The planner investigates the root cause, the coordinator creates tight tasks, the implementer fixes it. |
 | **`quick-fix`** | Trivial changes. Plan and implement only — no test, review, or PR; the change is left on the branch for you to commit. |
 | **`refactor`** | Behavior-preserving change. The reviewer enforces that behavior doesn't change, a PR is opened for human review, and Learn captures invariants surfaced along the way. |
@@ -22,18 +23,18 @@ worca ships with these built-in templates:
 
 A template's main effect is the set of stages it enables. This matrix shows what runs where (Preflight always runs and is omitted):
 
-| Stage | `feature` | `bugfix` | `quick-fix` | `refactor` | `investigate` | `test-only` |
-|---|:--:|:--:|:--:|:--:|:--:|:--:|
-| Plan | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Plan Review | ✓ | — | — | ✓ | ✓ | ✓ |
-| Coordinate | ✓ | ✓ | ✓ | ✓ | — | ✓ |
-| Implement | ✓ | ✓ | ✓ | ✓ | — | ✓ |
-| Test | ✓ | ✓ | — | ✓ | — | ✓ |
-| Review | ✓ | ✓ | — | ✓ | — | ✓ |
-| PR | ✓ | ✓ | — | ✓ | ✓ | ✓ |
-| Learn | ✓ | — | — | ✓ | — | — |
+| Stage | `feature` | `feature-minor` | `bugfix` | `quick-fix` | `refactor` | `investigate` | `test-only` |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| Plan | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Plan Review | ✓ | — | — | — | ✓ | ✓ | ✓ |
+| Coordinate | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ |
+| Implement | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ |
+| Test | ✓ | ✓ | ✓ | — | ✓ | — | ✓ |
+| Review | ✓ | ✓ | ✓ | — | ✓ | — | ✓ |
+| PR | ✓ | ✓ | ✓ | — | ✓ | ✓ | ✓ |
+| Learn | ✓ | — | — | — | ✓ | — | — |
 
-`feature` and `refactor` run the same stages — they differ in *tuning*, not stage set: `refactor` puts every agent on Opus and has the Reviewer enforce behavior preservation. `quick-fix` stops after Implement, leaving the change on the branch for you to commit. `investigate` skips coding entirely and uses the PR stage to publish its report.
+`feature` and `refactor` run the same stages — they differ in *tuning*, not stage set: `refactor` puts every agent on Opus and has the Reviewer enforce behavior preservation. `feature-minor` runs the same stages as `bugfix` (full implement→test→review→PR, no Plan Review or Learn) but is framed for well-scoped *features* rather than fixes, caps effort at `high`, uses lower retry limits, and disables the plan-approval gate so it runs unattended. `quick-fix` stops after Implement, leaving the change on the branch for you to commit. `investigate` skips coding entirely and uses the PR stage to publish its report.
 
 ## Authoring your own
 

--- a/docs-site/src/content/docs/getting-started/your-first-run.md
+++ b/docs-site/src/content/docs/getting-started/your-first-run.md
@@ -12,7 +12,7 @@ With your project added, you're ready to run the pipeline — all from the dashb
 1. Select your project in the sidebar.
 2. Click **Run Pipeline**.
 3. Describe the work: type a **prompt**, or point at a **GitHub issue** or a **spec file**.
-4. *(Optional)* Pick a **template** — `feature`, `bugfix`, `quick-fix`, `refactor`, `investigate`, or `test-only` — to tailor the stages and rules to the kind of work.
+4. *(Optional)* Pick a **template** — `feature`, `feature-minor`, `bugfix`, `quick-fix`, `refactor`, `investigate`, or `test-only` — to tailor the stages and rules to the kind of work.
 5. Click **Launch**.
 
 :::note[Screenshot — coming soon]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,7 +19,7 @@ worca run --worktree --source gh:issue:42 --template feature
 | `--spec FILE` | Path to spec/requirements file |
 | `--source TEXT` | Source reference (`gh:issue:42`, `bd:bd-abc`, or issue URL) |
 | `--plan FILE` | Pre-made plan file (skips Plan stage) |
-| `--template ID` | Pipeline template to apply (`feature`, `bugfix`, `quick-fix`, `refactor`, `investigate`, `test-only`, or any project/user template — see `worca templates list`) |
+| `--template ID` | Pipeline template to apply (`feature`, `feature-minor`, `bugfix`, `quick-fix`, `refactor`, `investigate`, `test-only`, or any project/user template — see `worca templates list`) |
 | `--param KEY=VALUE` | Override a template parameter (repeatable) |
 | `--resume` | Resume a previous run from status.json |
 | `--worktree` | Launch in an isolated git worktree (parallel-safe). Falls back to in-place if `run_worktree.py` is missing in the project runtime |

--- a/docs/effort.md
+++ b/docs/effort.md
@@ -260,6 +260,7 @@ Templates override the project defaults via deep-merge (see [Precedence](#preced
 |---|---|---|
 | `quick-fix` | `effort.auto_mode: disabled`; planner `medium`, coordinator `low`, implementer `low` | Trivial work — deterministic and cheap; intentional disable prevents wasted escalation |
 | `bugfix` | `effort.auto_cap: high` | Clamp escalation cost on focused fixes; prevents auto-escalation to `max` |
+| `feature-minor` | `effort.auto_cap: high` | Well-scoped features — keep adaptive labels but bound cost like `bugfix` |
 | `feature` | none (baseline + adaptive) | Complex beads get `high`/`xhigh` naturally via the coordinator's classification |
 | `investigate` | none (baseline + adaptive) | Same as feature |
 | `refactor` | none (baseline + adaptive) | Same as feature |

--- a/src/worca/templates/feature-minor/template.json
+++ b/src/worca/templates/feature-minor/template.json
@@ -1,0 +1,13 @@
+{
+  "id": "feature-minor",
+  "name": "Minor Feature",
+  "description": "Lean feature pipeline for well-scoped work a planner can handle confidently. Full implement/test/review/PR; no plan-review stage, no learn stage, no plan-approval gate — runs autonomously. Supplying a plan skips the PLAN stage.",
+  "builtin": true,
+  "created_at": "2026-05-27T00:00:00Z",
+  "tags": ["feature", "minor", "no-gate"],
+  "config": {
+    "effort": { "auto_cap": "high" },
+    "loops": { "implement_test": 8, "pr_changes": 4 },
+    "milestones": { "plan_approval": false, "deploy_approval": false }
+  }
+}

--- a/tests/test_preset_templates.py
+++ b/tests/test_preset_templates.py
@@ -1,4 +1,4 @@
-"""Tests for the 6 built-in preset template directories."""
+"""Tests for the 7 built-in preset template directories."""
 
 import json
 from pathlib import Path
@@ -7,16 +7,25 @@ import pytest
 
 TEMPLATES_DIR = Path(__file__).parent.parent / "src" / "worca" / "templates"
 
-PRESETS = ["bugfix", "feature", "refactor", "quick-fix", "investigate", "test-only"]
+PRESETS = [
+    "bugfix",
+    "feature",
+    "feature-minor",
+    "refactor",
+    "quick-fix",
+    "investigate",
+    "test-only",
+]
 
 # Agent overlay files expected per preset
 EXPECTED_OVERLAYS = {
-    "bugfix":      {"planner.md", "coordinator.md"},
-    "feature":     set(),
-    "refactor":    {"planner.md", "reviewer.md"},
-    "quick-fix":   {"planner.md", "coordinator.md"},
-    "investigate": {"planner.md", "guardian.md", "pr.block.md"},
-    "test-only":   {"planner.md", "coordinator.md", "implementer.md"},
+    "bugfix":        {"planner.md", "coordinator.md"},
+    "feature":       set(),
+    "feature-minor": set(),
+    "refactor":      {"planner.md", "reviewer.md"},
+    "quick-fix":     {"planner.md", "coordinator.md"},
+    "investigate":   {"planner.md", "guardian.md", "pr.block.md"},
+    "test-only":     {"planner.md", "coordinator.md", "implementer.md"},
 }
 
 


### PR DESCRIPTION
## Problem

`feature-minor` ("Minor Feature") existed only as a user-level template (`~/.worca/templates/`), so it wasn't available to other worca-cc users or consumer projects.

## Proposal

Promote it to a shipped built-in under `src/worca/templates/feature-minor/`. It's a lean feature pipeline for well-scoped work a planner can handle confidently:

- Full **implement → test → review → PR**
- **No** Plan Review, **no** Learn stage, **no** plan-approval gate → runs autonomously
- `effort.auto_cap: high`, lower retry limits (`implement_test: 8`, `pr_changes: 4`)

Same stage set as `bugfix`, but framed for features and tuned for unattended runs.

## What changed

- **New:** `src/worca/templates/feature-minor/template.json` (`builtin: true`). Ships via the existing `templates/*/template.json` package glob — no packaging change.
- **Test:** `tests/test_preset_templates.py` updated to the 7-preset set (`feature-minor` has no agent overlays, like `feature`).
- **Docs:** `concepts/pipeline-templates.md` (table row + stage-matrix column + tuning note), `getting-started/your-first-run.md`, `docs/cli-reference.md`, `docs/effort.md` (per-template effort table).

The user-level copy is being removed separately so the built-in becomes the active tier (it previously shadowed it under user > builtin resolution).

## Verification

- `pytest tests/test_preset_templates.py tests/test_templates.py tests/test_cli_templates.py tests/test_cli_init.py tests/test_builtin_templates.py` — green
- docs-site build — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)