### PR TITLE
perf(ui): fast run-detail Beads panel — O(1) findRun + cached discoverRuns + gated spinner

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -147,7 +147,12 @@ def test_shell_hook_receives_event_json_on_stdin(tmp_path, hooked_ctx):
     emit_event(ctx, "pipeline.run.started", {"resume": False, "started_at": "2026-03-20T00:00:00Z"})
 
     deadline = time.time() + 3.0
-    while not out_file.exists() and time.time() < deadline:
+    while time.time() < deadline:
+        # Wait for content, not just existence: `cat > file` creates the file
+        # before writing, so reading on existence alone races to an empty file
+        # (flaky JSONDecodeError, esp. on slower Windows IO).
+        if out_file.exists() and out_file.stat().st_size > 0:
+            break
         time.sleep(0.05)
 
     assert out_file.exists(), "Shell hook was not invoked"
@@ -241,7 +246,10 @@ def test_wildcard_handler_fires_for_any_event_type(tmp_path, hooked_ctx):
     })
 
     deadline = time.time() + 3.0
-    while not out_file.exists() and time.time() < deadline:
+    while time.time() < deadline:
+        # Wait for content, not just existence (avoids the empty-file read race).
+        if out_file.exists() and out_file.stat().st_size > 0:
+            break
         time.sleep(0.05)
 
     assert out_file.exists(), "Wildcard handler was not invoked"

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -517,7 +517,9 @@ let beadsStatusFilter = 'all';
 let beadsPriorityFilter = 'all';
 let beadsStarting = null; // null | issueId
 let beadsStartError = null; // null | string
-const runBeads = new Map(); // runId → issues[]
+const runBeads = new Map(); // runId → issues[] | null (null = load failed)
+const beadsSpinner = new Set(); // runId → show the 150ms-gated loading spinner
+const beadsSpinnerTimers = new Map(); // runId → setTimeout handle
 let beadsCounts = {}; // { runId: count }
 let lastBeadsPayload = null;
 let beadsRunIssues = []; // issues for the currently viewed run
@@ -765,6 +767,9 @@ function resetProjectState() {
   beadsStarting = null;
   beadsStartError = null;
   runBeads.clear();
+  beadsSpinner.clear();
+  for (const t of beadsSpinnerTimers.values()) clearTimeout(t);
+  beadsSpinnerTimers.clear();
   beadsCounts = {};
   lastBeadsPayload = null;
   beadsRunIssues = [];
@@ -791,12 +796,41 @@ function handleStageTabChange(stageKey, iterationNumber) {
 
 function fetchRunBeads(runId) {
   if (!runId) return;
+  // 150ms-gated spinner: only surface a spinner if the fetch is still pending
+  // after 150ms, so a fast load (warm path) never flashes one. Arm the timer
+  // only when there's no loaded value yet (a refetch over existing data keeps
+  // showing that data, not a spinner).
+  if (!runBeads.has(runId) && !beadsSpinnerTimers.has(runId)) {
+    const timer = setTimeout(() => {
+      beadsSpinnerTimers.delete(runId);
+      if (!runBeads.has(runId)) {
+        beadsSpinner.add(runId);
+        rerender();
+      }
+    }, 150);
+    beadsSpinnerTimers.set(runId, timer);
+  }
+  const settle = () => {
+    const t = beadsSpinnerTimers.get(runId);
+    if (t) {
+      clearTimeout(t);
+      beadsSpinnerTimers.delete(runId);
+    }
+    beadsSpinner.delete(runId);
+  };
   ws.send('list-beads-by-run', { runId, projectId: _runProjectId(runId) })
     .then((payload) => {
+      settle();
       runBeads.set(runId, payload.issues || []);
       rerender();
     })
-    .catch(() => {});
+    .catch(() => {
+      settle();
+      // null = load failed — distinct from [] ("no linked beads") so the panel
+      // doesn't falsely claim the run has no beads when the query errored.
+      runBeads.set(runId, null);
+      rerender();
+    });
 }
 
 function fetchAgentPrompts(runId, stages) {
@@ -3242,7 +3276,10 @@ function mainContentView() {
             stageIterations,
             runStages: run?.stages,
           })}
-          ${runBeadsSectionView(runBeads.get(route.runId))}
+          ${runBeadsSectionView(runBeads.get(route.runId), {
+            loaded: runBeads.has(route.runId),
+            showSpinner: beadsSpinner.has(route.runId),
+          })}
           ${learningsSectionView(run?.stages?.learn, {
             onRunLearn: actionAllowed('learn', run?.pipeline_status)
               ? handleRunLearn

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -1025,51 +1025,74 @@ export function prApprovalPanelView(run, options = {}) {
   `;
 }
 
-export function runBeadsSectionView(beads) {
-  if (!beads) return nothing;
-  const isEmpty = beads.length === 0;
-  const closed = beads.filter((b) => b.status === 'closed').length;
-  const total = beads.length;
-  const variant =
-    total === 0 ? 'neutral' : closed === total ? 'success' : 'primary';
+export function runBeadsSectionView(beads, options = {}) {
+  // `loaded` defaults to "a value was passed" so existing callers that pass just
+  // the issues array keep rendering data; main.js passes it explicitly to drive
+  // the not-loaded (spinner) state.
+  const { loaded = beads !== undefined, showSpinner = false } = options;
+
+  // Summary-right (badge / spinner / nothing) and body, resolved per state:
+  //   not loaded            → panel appears immediately; spinner only after the
+  //                           150ms gate (showSpinner), else an empty summary.
+  //   loaded, beads === null → load failed (don't claim "no beads").
+  //   loaded, []            → no linked beads.
+  //   loaded, [...]         → count badge + list (+ graph).
+  let summaryRight = nothing;
+  let body = nothing;
+
+  if (!loaded) {
+    summaryRight = showSpinner
+      ? html`<sl-spinner
+          class="run-beads-loading"
+          data-testid="run-beads-loading"
+        ></sl-spinner>`
+      : nothing;
+    body = showSpinner
+      ? html`<div class="run-beads-empty">Loading Beads…</div>`
+      : nothing;
+  } else if (beads === null) {
+    summaryRight = html`<sl-badge variant="warning" pill>—</sl-badge>`;
+    body = html`<div class="run-beads-empty">Couldn't load Beads issues</div>`;
+  } else if (beads.length === 0) {
+    body = html`<div class="run-beads-empty">No linked Beads issues</div>`;
+  } else {
+    const closed = beads.filter((b) => b.status === 'closed').length;
+    const total = beads.length;
+    const variant = closed === total ? 'success' : 'primary';
+    summaryRight = html`<sl-badge variant="${variant}" pill>${closed}/${total}</sl-badge>`;
+    body = html`
+      <div class="run-beads-list">
+        ${beads.map(
+          (issue) => html`
+          <sl-tooltip class="bead-tooltip" hoist placement="bottom" distance="4">
+            <div slot="content">${beadTooltipContent(issue)}</div>
+            <div class="run-bead-row">
+              <sl-badge variant="${priorityVariant(issue.priority)}" pill>P${issue.priority}</sl-badge>
+              ${
+                issue.blocked_by?.length
+                  ? html`<sl-badge variant="warning" pill>blocked</sl-badge>`
+                  : html`<sl-badge variant="${statusVariant(issue.status, issue)}" pill>${issue.status}</sl-badge>`
+              }
+              <span class="run-bead-id">#${issue.id}</span>
+              <span class="run-bead-title">${issue.title}</span>
+            </div>
+          </sl-tooltip>
+        `,
+        )}
+      </div>
+      ${beads.length > 1 ? _graphWithTooltips(beads) : nothing}
+    `;
+  }
+
   return html`
     <div class="run-beads-section">
       <sl-details class="run-beads-panel" @sl-after-show=${scrollOnExpand}>
         <div slot="summary" class="run-beads-header">
           <span class="run-beads-icon">${unsafeHTML(iconSvg(List, 16))}</span>
           <span class="run-beads-title">Beads</span>
-          ${
-            isEmpty
-              ? nothing
-              : html`<sl-badge variant="${variant}" pill>${closed}/${total}</sl-badge>`
-          }
+          ${summaryRight}
         </div>
-        ${
-          isEmpty
-            ? html`<div class="run-beads-empty">No linked Beads issues</div>`
-            : html`
-              <div class="run-beads-list">
-                ${beads.map(
-                  (issue) => html`
-                  <sl-tooltip class="bead-tooltip" hoist placement="bottom" distance="4">
-                    <div slot="content">${beadTooltipContent(issue)}</div>
-                    <div class="run-bead-row">
-                      <sl-badge variant="${priorityVariant(issue.priority)}" pill>P${issue.priority}</sl-badge>
-                      ${
-                        issue.blocked_by?.length
-                          ? html`<sl-badge variant="warning" pill>blocked</sl-badge>`
-                          : html`<sl-badge variant="${statusVariant(issue.status, issue)}" pill>${issue.status}</sl-badge>`
-                      }
-                      <span class="run-bead-id">#${issue.id}</span>
-                      <span class="run-bead-title">${issue.title}</span>
-                    </div>
-                  </sl-tooltip>
-                `,
-                )}
-              </div>
-              ${beads.length > 1 ? _graphWithTooltips(beads) : nothing}
-            `
-        }
+        ${body}
       </sl-details>
     </div>
   `;

--- a/worca-ui/app/views/run-detail.test.js
+++ b/worca-ui/app/views/run-detail.test.js
@@ -91,6 +91,35 @@ describe('runBeadsSectionView - blocked state', () => {
   });
 });
 
+describe('runBeadsSectionView - loading and error states', () => {
+  it('renders the panel with no spinner before the 150ms gate', () => {
+    const out = renderToString(
+      runBeadsSectionView(undefined, { loaded: false, showSpinner: false }),
+    );
+    expect(out).toContain('run-beads-panel');
+    expect(out).toContain('Beads');
+    expect(out).not.toContain('run-beads-loading');
+  });
+
+  it('shows the loading spinner once the 150ms gate fires', () => {
+    const out = renderToString(
+      runBeadsSectionView(undefined, { loaded: false, showSpinner: true }),
+    );
+    expect(out).toContain('run-beads-loading');
+  });
+
+  it('shows an error state (not "no beads") when the query failed', () => {
+    const out = renderToString(runBeadsSectionView(null, { loaded: true }));
+    expect(out).toContain("Couldn't load Beads issues");
+    expect(out).not.toContain('No linked Beads issues');
+  });
+
+  it('shows "No linked Beads issues" when loaded with an empty array', () => {
+    const out = renderToString(runBeadsSectionView([], { loaded: true }));
+    expect(out).toContain('No linked Beads issues');
+  });
+});
+
 describe('runDetailView - endTime for active runs', () => {
   const startedAt = '2026-04-10T10:00:00Z';
   const stageEnd = '2026-04-10T10:05:43Z';

--- a/worca-ui/e2e/markdown-rendering.spec.js
+++ b/worca-ui/e2e/markdown-rendering.spec.js
@@ -203,11 +203,14 @@ test.describe('markdown rendering — bead tooltip', () => {
       await openRunDetail(page, ctx.url, runId);
 
       const beadsPanel = page.locator('.run-beads-panel');
+      // The panel now renders immediately in a loading state; wait for the bead
+      // rows to load into the DOM (the bd query can be slow on a cold daemon)
+      // before expanding, so we don't race the loading→loaded re-render.
+      const beadRow = page.locator('.run-bead-row').first();
+      await expect(beadRow).toBeAttached({ timeout: 20000 });
       await beadsPanel.scrollIntoViewIfNeeded();
       await beadsPanel.locator('[slot="summary"]').click();
       await expect(beadsPanel).toHaveAttribute('open', '', { timeout: 5000 });
-
-      const beadRow = page.locator('.run-bead-row').first();
       await expect(beadRow).toBeVisible({ timeout: 8000 });
 
       await beadRow.hover();
@@ -245,6 +248,11 @@ test.describe('markdown rendering — bead row', () => {
       await openRunDetail(page, ctx.url, runId);
 
       const beadsPanel = page.locator('.run-beads-panel');
+      // Panel renders immediately (loading); wait for bead data in the DOM
+      // before expanding (cold-daemon bd query can be slow).
+      await expect(page.locator('.run-bead-row').first()).toBeAttached({
+        timeout: 20000,
+      });
       await beadsPanel.scrollIntoViewIfNeeded();
       await beadsPanel.locator('[slot="summary"]').click();
       await expect(beadsPanel).toHaveAttribute('open', '', { timeout: 5000 });

--- a/worca-ui/e2e/run-detail-beads-panel.spec.js
+++ b/worca-ui/e2e/run-detail-beads-panel.spec.js
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+/**
+ * Guards the run-detail beads-panel wiring (main.js call site passing
+ * { loaded, showSpinner } from runBeads/beadsSpinner into runBeadsSectionView).
+ *
+ * The panel now renders as part of run-detail immediately — previously it was
+ * absent until the list-beads-by-run response arrived. With no .beads/ db the
+ * WS resolves to an empty list, so the panel settles on its empty state; the
+ * point of this test is that the panel renders (and doesn't throw) on open.
+ */
+test.describe('run-detail beads panel', () => {
+  test('renders on run open and does not stay absent', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-beads-panel-wiring';
+      seedRun(ctx.worcaDir, runId, {
+        pipeline_status: 'completed',
+        stage: 'implement',
+        stages: {
+          plan: { status: 'completed' },
+          implement: { status: 'completed' },
+        },
+      });
+
+      await page.goto(`${ctx.url}/#/history?run=${runId}`, GOTO_OPTS);
+      await expect(page.locator('.run-detail .stage-panels')).toBeVisible({
+        timeout: 8000,
+      });
+
+      const panel = page.locator('.run-beads-panel');
+      await expect(panel).toBeVisible({ timeout: 8000 });
+      // The summary title is always rendered (collapsed sl-details).
+      await expect(panel.locator('.run-beads-title')).toHaveText('Beads');
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/server/watcher.js
+++ b/worca-ui/server/watcher.js
@@ -6,6 +6,7 @@ import {
   assignEventsToIterations,
   readDispatchEventsFromJsonl,
 } from './dispatch-events-aggregator.js';
+import { readPipelineOverlay } from './run-dir-resolver.js';
 import { safeWatch } from './safe-watch.js';
 
 /**
@@ -46,7 +47,137 @@ function isTerminal(status) {
   );
 }
 
+const _discoverRunsCache = new Map(); // worcaDir → { ts, runs }
+// TTL defaults to 0 under vitest (NODE_ENV=test) so the cache is a no-op in
+// tests — they build fixture dirs from Date.now() and a shared path could
+// otherwise serve a stale cached scan across tests. Production uses 1500ms;
+// _setDiscoverRunsTtlForTest lets the dedicated cache test exercise real TTL.
+let _discoverRunsTtlMs = process.env.NODE_ENV === 'test' ? 0 : 1500;
+
+/** Test hook: override the discoverRuns cache TTL in ms. */
+export function _setDiscoverRunsTtlForTest(ms) {
+  _discoverRunsTtlMs = ms;
+}
+
+/**
+ * Cached wrapper around the run-discovery scan. The scan reads + JSON-parses
+ * every run's status.json across runs/, results/, and pipelines.d/ worktree
+ * overlays — hundreds of ms on a large project. Whole-list callers (list-runs,
+ * REST /runs) hit this; a short TTL collapses repeated calls in a burst into a
+ * single scan. Per-run handlers use findRun() instead. Live status changes
+ * still reach clients via the statusWatcher broadcast, so TTL-window staleness
+ * here is invisible in the UI.
+ */
 export function discoverRuns(worcaDir) {
+  const cached = _discoverRunsCache.get(worcaDir);
+  if (cached && Date.now() - cached.ts < _discoverRunsTtlMs) {
+    return cached.runs;
+  }
+  const runs = _discoverRunsUncached(worcaDir);
+  _discoverRunsCache.set(worcaDir, { ts: Date.now(), runs });
+  return runs;
+}
+
+/** Clear the discoverRuns TTL cache (tests, or explicit invalidation). */
+export function clearDiscoverRunsCache() {
+  _discoverRunsCache.clear();
+}
+
+/**
+ * Resolve a SINGLE run by id without scanning every run on disk — the O(1)
+ * counterpart to discoverRuns().find(r => r.id === runId), for hot WS handlers
+ * (subscribe-run, get-agent-prompt) that need exactly one run. Mirrors
+ * discoverRuns' per-source shaping: dispatch-event enrichment for runs/ and
+ * worktree sources (not results/), plus the worktree registry fields. The
+ * findRun-vs-discoverRuns parity test keeps the two aligned.
+ *
+ * Falls back to a (TTL-cached) discoverRuns scan for legacy layouts where the
+ * on-disk name doesn't equal the computed id (flat `.worca/status.json`, hashed
+ * legacy ids), so it never resolves fewer runs than discoverRuns().find().
+ *
+ * @returns {object|null} a run record shaped like a discoverRuns entry, or null
+ */
+export function findRun(worcaDir, runId) {
+  if (!worcaDir || !runId) return null;
+
+  // 1. Local active: runs/<id>/status.json (enriched)
+  const localRunDir = join(worcaDir, 'runs', runId);
+  if (existsSync(join(localRunDir, 'status.json'))) {
+    return _shapeRunFromFile(join(localRunDir, 'status.json'), {
+      enrich: true,
+      runDir: localRunDir,
+    });
+  }
+
+  // 2. Local archived dir: results/<id>/status.json (not enriched)
+  const resultsDirStatus = join(worcaDir, 'results', runId, 'status.json');
+  if (existsSync(resultsDirStatus)) {
+    return _shapeRunFromFile(resultsDirStatus, { enrich: false });
+  }
+
+  // 2b. Legacy archived file: results/<id>.json (not enriched)
+  const legacyFile = join(worcaDir, 'results', `${runId}.json`);
+  if (existsSync(legacyFile)) {
+    return _shapeRunFromFile(legacyFile, {
+      enrich: false,
+      requireStartedAt: true,
+    });
+  }
+
+  // 3. Worktree overlay: pipelines.d/<id>.json → <worktree>/.worca/runs/<id>
+  const reg = readPipelineOverlay(worcaDir, runId);
+  if (reg?.worktree_path) {
+    const wtRunDir = join(reg.worktree_path, '.worca', 'runs', runId);
+    if (existsSync(join(wtRunDir, 'status.json'))) {
+      return _shapeRunFromFile(join(wtRunDir, 'status.json'), {
+        enrich: true,
+        runDir: wtRunDir,
+        worktreeReg: reg,
+      });
+    }
+  }
+
+  // Fallback for legacy layouts where the on-disk name != the computed id
+  // (flat .worca/status.json, hashed legacy ids). Rare — pay one (TTL-cached)
+  // full scan rather than regress correctness vs discoverRuns().find().
+  return discoverRuns(worcaDir).find((r) => r.id === runId) || null;
+}
+
+function _shapeRunFromFile(
+  statusPath,
+  {
+    enrich = false,
+    runDir = null,
+    worktreeReg = null,
+    requireStartedAt = false,
+  } = {},
+) {
+  try {
+    let status = JSON.parse(readFileSync(statusPath, 'utf8'));
+    if (requireStartedAt && !status.started_at) return null;
+    if (enrich && runDir) status = enrichWithDispatchEvents(status, runDir);
+    const id = createRunId(status);
+    const active = !isTerminal(status) && status.pipeline_status === 'running';
+    const base = { id, active, ...status };
+    if (worktreeReg) {
+      return {
+        ...base,
+        worktree_worca_dir: join(worktreeReg.worktree_path, '.worca'),
+        is_worktree_run: true,
+        head_branch: worktreeReg.branch || null,
+        fleet_id: worktreeReg.fleet_id || null,
+        workspace_id: worktreeReg.workspace_id || null,
+        group_type: worktreeReg.group_type || null,
+        target_branch: worktreeReg.target_branch || null,
+      };
+    }
+    return base;
+  } catch {
+    return null;
+  }
+}
+
+function _discoverRunsUncached(worcaDir) {
   const runs = [];
   const seenIds = new Set();
 

--- a/worca-ui/server/watcher.test.js
+++ b/worca-ui/server/watcher.test.js
@@ -2,7 +2,14 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createRunId, discoverRuns, discoverRunsAsync } from './watcher.js';
+import {
+  _setDiscoverRunsTtlForTest,
+  clearDiscoverRunsCache,
+  createRunId,
+  discoverRuns,
+  discoverRunsAsync,
+  findRun,
+} from './watcher.js';
 
 describe('watcher', () => {
   let dir;
@@ -10,7 +17,160 @@ describe('watcher', () => {
     dir = join(tmpdir(), `worca-watch-${Date.now()}`);
     mkdirSync(join(dir, 'results'), { recursive: true });
   });
-  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    // Reset discoverRuns cache state so the cache test's TTL override can't
+    // leak into other tests.
+    clearDiscoverRunsCache();
+    _setDiscoverRunsTtlForTest(0);
+  });
+
+  // ---- findRun: O(1) single-run lookup, parity with discoverRuns ----
+  it('findRun returns null when the run does not exist', () => {
+    expect(findRun(dir, 'does-not-exist')).toBeNull();
+    expect(findRun(dir, '')).toBeNull();
+    expect(findRun('', 'x')).toBeNull();
+  });
+
+  it('findRun matches discoverRuns for a runs/ (active) run', () => {
+    const runId = 'run-active-1';
+    const runDir = join(dir, 'runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-05-01T10:00:00Z',
+        pipeline_status: 'running',
+        work_request: { title: 'active' },
+        stages: { plan: { status: 'in_progress' } },
+      }),
+    );
+    const viaFind = findRun(dir, runId);
+    const viaScan = discoverRuns(dir).find((r) => r.id === runId);
+    expect(viaFind).toEqual(viaScan);
+    expect(viaFind.active).toBe(true);
+  });
+
+  it('findRun matches discoverRuns for a results/<id>/ (archived) run', () => {
+    const runId = 'run-archived-1';
+    const runDir = join(dir, 'results', runId);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-05-01T11:00:00Z',
+        completed_at: '2026-05-01T11:30:00Z',
+        pipeline_status: 'completed',
+        work_request: { title: 'done' },
+        stages: { plan: { status: 'completed' } },
+      }),
+    );
+    const viaFind = findRun(dir, runId);
+    const viaScan = discoverRuns(dir).find((r) => r.id === runId);
+    expect(viaFind).toEqual(viaScan);
+    expect(viaFind.active).toBe(false);
+  });
+
+  it('findRun matches discoverRuns for a legacy results/<id>.json file', () => {
+    const runId = 'run-legacy-1';
+    writeFileSync(
+      join(dir, 'results', `${runId}.json`),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-05-01T12:00:00Z',
+        completed_at: '2026-05-01T12:30:00Z',
+        pipeline_status: 'completed',
+        work_request: { title: 'legacy' },
+        stages: { plan: { status: 'completed' } },
+      }),
+    );
+    const viaFind = findRun(dir, runId);
+    const viaScan = discoverRuns(dir).find((r) => r.id === runId);
+    expect(viaFind).toEqual(viaScan);
+  });
+
+  it('findRun matches discoverRuns for a worktree (pipelines.d) run incl. worktree fields', () => {
+    const runId = 'run-wt-1';
+    const wtDir = join(dir, 'worktrees', 'wt-1');
+    const wtRunDir = join(wtDir, '.worca', 'runs', runId);
+    mkdirSync(wtRunDir, { recursive: true });
+    writeFileSync(
+      join(wtRunDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-05-01T13:00:00Z',
+        pipeline_status: 'running',
+        work_request: { title: 'wt task' },
+        stages: { plan: { status: 'in_progress' } },
+      }),
+    );
+    const pipelinesDir = join(dir, 'multi', 'pipelines.d');
+    mkdirSync(pipelinesDir, { recursive: true });
+    writeFileSync(
+      join(pipelinesDir, `${runId}.json`),
+      JSON.stringify({
+        run_id: runId,
+        worktree_path: wtDir,
+        branch: 'feat/x',
+        target_branch: 'main',
+        fleet_id: 'fleet-9',
+        status: 'running',
+      }),
+    );
+    const viaFind = findRun(dir, runId);
+    const viaScan = discoverRuns(dir).find((r) => r.id === runId);
+    expect(viaFind).toEqual(viaScan);
+    expect(viaFind.is_worktree_run).toBe(true);
+    expect(viaFind.worktree_worca_dir).toBe(join(wtDir, '.worca'));
+    expect(viaFind.head_branch).toBe('feat/x');
+    expect(viaFind.target_branch).toBe('main');
+    expect(viaFind.fleet_id).toBe('fleet-9');
+  });
+
+  it('findRun falls back to a scan for the legacy flat status.json (name != id)', () => {
+    const status = {
+      started_at: '2026-05-01T14:00:00Z',
+      pipeline_status: 'running',
+      work_request: { title: 'flat legacy' },
+      stages: { plan: { status: 'in_progress' } },
+    };
+    writeFileSync(join(dir, 'status.json'), JSON.stringify(status));
+    const id = createRunId(status); // hashed id (no run_id) → no matching dir
+    const viaFind = findRun(dir, id);
+    const viaScan = discoverRuns(dir).find((r) => r.id === id);
+    expect(viaFind).not.toBeNull();
+    expect(viaFind).toEqual(viaScan);
+  });
+
+  // ---- discoverRuns TTL cache (#2) ----
+  it('discoverRuns caches within the TTL and refreshes after clear', () => {
+    _setDiscoverRunsTtlForTest(5000);
+    clearDiscoverRunsCache();
+    const mk = (id) => {
+      const rd = join(dir, 'runs', id);
+      mkdirSync(rd, { recursive: true });
+      writeFileSync(
+        join(rd, 'status.json'),
+        JSON.stringify({
+          run_id: id,
+          started_at: '2026-05-01T10:00:00Z',
+          pipeline_status: 'running',
+          work_request: { title: id },
+          stages: { plan: { status: 'in_progress' } },
+        }),
+      );
+    };
+    mk('cache-r1');
+    expect(discoverRuns(dir).length).toBe(1);
+    mk('cache-r2');
+    // Within the TTL window the cached scan is reused — the new run isn't seen.
+    expect(discoverRuns(dir).length).toBe(1);
+    clearDiscoverRunsCache();
+    // After invalidation the fresh scan picks up both runs.
+    expect(discoverRuns(dir).length).toBe(2);
+  });
 
   it('createRunId generates deterministic ID from status', () => {
     const status = {

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -33,7 +33,7 @@ import {
 } from './process-manager.js';
 import { resolveRunDir } from './run-dir-resolver.js';
 import { readSettings } from './settings-reader.js';
-import { discoverRuns } from './watcher.js';
+import { discoverRuns, findRun } from './watcher.js';
 import { resolveBeadsCounts } from './ws-beads-watcher.js';
 
 /**
@@ -165,8 +165,7 @@ export function createMessageRouter({
       }
       _adoptProjectFromPayload(ws, req.payload);
       const proj = resolveProject(ws, req.payload);
-      const runs = discoverRuns(proj.worcaDir);
-      const run = runs.find((r) => r.id === runId);
+      const run = findRun(proj.worcaDir, runId);
       if (!run) {
         ws.send(
           JSON.stringify(makeError(req, 'NOT_FOUND', `Run ${runId} not found`)),
@@ -321,8 +320,7 @@ export function createMessageRouter({
       }
       const s = clientManager.ensureSubs(ws);
       s.runId = runId;
-      const runs = discoverRuns(proj.worcaDir);
-      const run = runs.find((r) => r.id === runId);
+      const run = findRun(proj.worcaDir, runId);
       if (run) {
         if (
           run.pipeline_status !== undefined &&


### PR DESCRIPTION
## Problem

Opening a historic run in worca-ui, the **Beads panel** took 6–14s to appear on a large project (worca-cc: 86 runs, 797 beads) while showing instantly on a small one (test-multi-01: ~6 runs). The rest of run-detail rendered immediately.

## Root cause

Measured with Playwright + an instrumented `runBd` + a `bd` PATH shim + an event-loop-lag monitor: the per-run beads query is fast (`bd list --label-any` = **84ms**; the daemon serves everything <0.2s). The delay is the worca-ui **single event loop being blocked**, so Node delivers the already-finished result seconds late.

The blocker is **`get-agent-prompt`**: each call ran `discoverRuns()` — a synchronous `readFileSync`+`JSON.parse` of **every** run's `status.json` across `runs/`, `results/`, and `pipelines.d/` (~725ms at 86 runs) — and the client fires it **once per stage (~9×)** per open. ~6.5s of back-to-back synchronous blocking; the beads query just waited behind it. `subscribe-run` did the same scan. Cost scales with **run count**, not beads count — which is why small projects felt instant.

Ruled out (all measured): the beads query, the bd daemon, daemon git-sync, the all-projects subscribe herd, a second connected browser, and `readLastLines` log backfill.

## Changes

1. **`findRun()`** — O(1) single-run resolver used by `subscribe-run` and `get-agent-prompt` instead of `discoverRuns().find()`. Mirrors `discoverRuns`' per-source shaping (incl. worktree-overlay registry fields) and **falls back to a (TTL-cached) `discoverRuns` scan** for legacy layouts where the on-disk name ≠ the computed id, so it never resolves fewer runs than before.
2. **`discoverRuns()` TTL cache** (1.5s; no-op under vitest) — collapses the remaining whole-list callers' bursts into a single scan.
3. **Beads panel UX** — renders immediately as part of run-detail with a **150ms-gated spinner** in the count-badge slot, then swaps in data. A `null` error sentinel shows a distinct "couldn't load" state instead of falsely claiming "no linked beads".

## Result

Warm run-opens: **6–8s → ~100–350ms** (Playwright-measured). The gated spinner suppresses any flash on fast loads.

## Tests

- `findRun`-vs-`discoverRuns` parity across runs/ (active), results/ dir, legacy results file, worktree overlay, plus the legacy-flat fallback.
- `discoverRuns` TTL cache (caches within TTL, refreshes on clear).
- Beads-panel loading / spinner / error / empty / data states.
- New beads-panel wiring e2e; existing `run-detail-agent-prompt` + `run-lifecycle` e2e (which exercise `findRun`) pass.
- Full vitest **4007 pass**, biome lint clean.

## Follow-up (separate PR)

The **first** open right after a cold history-page load can still stall on the *all-projects bead-count herd* (11 projects warming counts simultaneously on the event loop via `peekBeadsCounts` fan-out). Distinct code path — warrants its own change (concurrency-cap the warm queue + prioritize the viewed project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
