### PR TITLE
fix: use alias pricing for alt-endpoint models; preserve literal case in UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Key gotchas:
 - **Reserved keys** matching `WORCA_*`, `PATH`, or `CLAUDECODE` are silently stripped with a stderr warning. Denylist shared between Python (`src/worca/utils/env.py`) and JS (`worca-ui/server/reserved-env-keys.json`).
 - **Worktree materialization:** parent's `settings.local.json` secrets are materialized into the worktree's `settings.json` (gitignored). Same on-disk plaintext exposure model as `~/.aws/credentials`.
 - **`work_request.py` haiku coupling:** `extract_work_request` resolves its hardcoded `--model haiku` through `resolve_model()`, so customizing the `haiku` entry also retargets work-request title generation. Intentional.
+- **Cost source per alias:** if an alias's `env` block sets `ANTHROPIC_BASE_URL` (alt-endpoint routing), worca overrides Claude CLI's `total_cost_usd` using `worca.pricing.models.<alias>`. Otherwise Claude CLI's number is authoritative and the Pricing tab is informational/fallback. The trigger set lives in `_ALT_ENDPOINT_ENV_KEYS` in `src/worca/orchestrator/stages.py`.
 
 ### Effort Levels (`worca.effort`)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -797,7 +797,9 @@ W-059: Plan review `review_and_edit` mode — optional in-place plan editing by 
 
 ### 0.44.x → 0.45.0
 
-- Cost tracking now uses the model alias (from `worca.models`) as the pricing lookup key, so custom endpoint models match their configured pricing entry without needing a separate override. If no pricing entry matches the alias, cost is reported as $0 with a one-time stderr warning.
+- **Cost override for alt-endpoint aliases.** Model aliases that route Claude CLI through a non-Anthropic endpoint (i.e., the alias's `env` block in `worca.models` sets `ANTHROPIC_BASE_URL`) now have their run cost computed from your `worca.pricing.models.<alias>` entry instead of from Claude CLI's built-in Anthropic pricing — Claude CLI's number is wrong against a non-Anthropic endpoint. If no matching pricing entry exists, cost is recorded as $0 with a one-time stderr warning prompting you to add one.
+- **Vanilla installs are unchanged.** The built-in `opus` / `sonnet` / `haiku` shorthands (and any user rename that doesn't set `ANTHROPIC_BASE_URL`) continue to use Claude CLI's authoritative `total_cost_usd`. The Pricing tab numbers for these rows remain a fallback for interrupted runs and a reference for forecasting — they do not override live cost.
+- **`status.json` schema (additive).** Runs that use an alt-endpoint alias now carry `token_usage.model_alias` and `token_usage.cost_source: "alias"`. Absence of these fields means Claude CLI was authoritative — backward-compatible with existing consumers.
 
 ## Getting help
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -795,6 +795,10 @@ W-059: Plan review `review_and_edit` mode — optional in-place plan editing by 
 
 **No automatic migration required.** All changes are additive. Run `worca init --upgrade` once to pull the new defaults into your project's `settings.json`.
 
+### 0.44.x → 0.45.0
+
+- Cost tracking now uses the model alias (from `worca.models`) as the pricing lookup key, so custom endpoint models match their configured pricing entry without needing a separate override. If no pricing entry matches the alias, cost is reported as $0 with a one-time stderr warning.
+
 ## Getting help
 
 - Issues: https://github.com/SinishaDjukic/worca-cc/issues

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -836,8 +836,21 @@ def format_effort_log_line(
     return " ".join(parts)
 
 
-def _log_stage_metrics(stage_label: str, result: dict, raw_envelope: dict) -> None:
-    """Log detailed metrics from a completed stage."""
+def _log_stage_metrics(
+    stage_label: str,
+    result: dict,
+    raw_envelope: dict,
+    *,
+    cost_override: Optional[float] = None,
+) -> None:
+    """Log detailed metrics from a completed stage.
+
+    When `cost_override` is provided, it is used as the cost figure instead of
+    raw_envelope["total_cost_usd"]. The caller passes the override-aware value
+    from `extract_token_usage(..., settings_path=...)` so the human-readable
+    spawn-log line agrees with the persisted status.json record for
+    alt-endpoint aliases (where Claude CLI's raw cost is not authoritative).
+    """
     parts = []
 
     # Duration from envelope (more accurate than wall clock for agent time)
@@ -850,8 +863,9 @@ def _log_stage_metrics(stage_label: str, result: dict, raw_envelope: dict) -> No
     if turns:
         parts.append(f"turns={turns}")
 
-    # Cost
-    cost = raw_envelope.get("total_cost_usd")
+    # Cost — prefer the override-aware value from extract_token_usage when
+    # supplied, fall back to the raw envelope number otherwise.
+    cost = cost_override if cost_override is not None else raw_envelope.get("total_cost_usd")
     if cost:
         parts.append(f"cost=${cost:.2f}")
 
@@ -2936,15 +2950,24 @@ def run_pipeline(
             elapsed = time.time() - t0
             _log(f"{stage_label}{iter_label} completed ({_format_duration(elapsed)})", "ok")
 
+            # Extract token usage from the raw envelope first so the metrics
+            # log line below uses the same override-aware cost as the values
+            # persisted into status.json (otherwise an alt-endpoint alias
+            # silently shows Claude CLI's raw Anthropic-priced number in the
+            # spawn log while the run record carries the overridden $0/local).
+            usage = extract_token_usage(raw_envelope, settings_path=settings_path) if isinstance(raw_envelope, dict) else {}
+
             # Log detailed metrics
             if isinstance(raw_envelope, dict):
-                _log_stage_metrics(stage_label, result, raw_envelope)
+                _log_stage_metrics(
+                    stage_label,
+                    result,
+                    raw_envelope,
+                    cost_override=usage.get("total_cost_usd"),
+                )
 
             # Save full envelope for resume/debugging (per-iteration)
             _save_stage_output(current_stage, raw_envelope, logs_dir, iteration=iter_num)
-
-            # Extract token usage from the raw envelope
-            usage = extract_token_usage(raw_envelope, settings_path=settings_path) if isinstance(raw_envelope, dict) else {}
 
             # Emit cost events after token extraction
             if ctx and isinstance(raw_envelope, dict):

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -1001,6 +1001,7 @@ def _run_learn_stage(status, prompt_builder, settings_path, run_dir,
             "duration_ms": duration_ms,
             "output": result,
         }
+        usage = extract_token_usage(raw, settings_path=settings_path) if isinstance(raw, dict) else {}
         if isinstance(raw, dict):
             if raw.get("duration_api_ms"):
                 iter_extras["duration_api_ms"] = raw["duration_api_ms"]
@@ -1008,9 +1009,9 @@ def _run_learn_stage(status, prompt_builder, settings_path, run_dir,
                 iter_extras["duration_session_ms"] = raw["duration_ms"]
             if raw.get("num_turns"):
                 iter_extras["turns"] = raw["num_turns"]
-            if raw.get("total_cost_usd"):
-                iter_extras["cost_usd"] = raw["total_cost_usd"]
-        usage = extract_token_usage(raw) if isinstance(raw, dict) else {}
+            _learn_cost = usage.get("total_cost_usd", raw.get("total_cost_usd"))
+            if _learn_cost:
+                iter_extras["cost_usd"] = _learn_cost
         if usage:
             iter_extras["token_usage"] = usage
 
@@ -1334,6 +1335,7 @@ def run_stage(
         output_format="stream-json",
         json_schema=_schema_path(config["schema"]),
         model=config.get("model"),
+        model_alias=config.get("model_alias"),
         model_env=merged_env,
         log_path=log_path,
         on_event=on_event,
@@ -2942,11 +2944,11 @@ def run_pipeline(
             _save_stage_output(current_stage, raw_envelope, logs_dir, iteration=iter_num)
 
             # Extract token usage from the raw envelope
-            usage = extract_token_usage(raw_envelope) if isinstance(raw_envelope, dict) else {}
+            usage = extract_token_usage(raw_envelope, settings_path=settings_path) if isinstance(raw_envelope, dict) else {}
 
             # Emit cost events after token extraction
             if ctx and isinstance(raw_envelope, dict):
-                _stage_cost = raw_envelope.get("total_cost_usd") or 0.0
+                _stage_cost = usage.get("total_cost_usd", raw_envelope.get("total_cost_usd") or 0.0)
                 _stage_input = usage.get("input_tokens", 0)
                 _stage_output = usage.get("output_tokens", 0)
                 if _stage_cost or _stage_input or _stage_output:
@@ -3012,8 +3014,9 @@ def run_pipeline(
                     iter_extras["duration_session_ms"] = raw_envelope["duration_ms"]
                 if raw_envelope.get("num_turns"):
                     iter_extras["turns"] = raw_envelope["num_turns"]
-                if raw_envelope.get("total_cost_usd"):
-                    iter_extras["cost_usd"] = raw_envelope["total_cost_usd"]
+                _iter_cost = usage.get("total_cost_usd", raw_envelope.get("total_cost_usd"))
+                if _iter_cost:
+                    iter_extras["cost_usd"] = _iter_cost
                 if current_stage != Stage.PREFLIGHT:
                     iter_extras["graphify_invocations"] = raw_envelope.get(
                         "graphify_invocations", 0
@@ -3035,8 +3038,9 @@ def run_pipeline(
             if isinstance(raw_envelope, dict):
                 if raw_envelope.get("num_turns"):
                     stage_extras["turns"] = raw_envelope["num_turns"]
-                if raw_envelope.get("total_cost_usd"):
-                    stage_extras["cost_usd"] = raw_envelope["total_cost_usd"]
+                _stg_cost = usage.get("total_cost_usd", raw_envelope.get("total_cost_usd"))
+                if _stg_cost:
+                    stage_extras["cost_usd"] = _stg_cost
 
             # Compute stage-level token aggregate across all iterations
             all_iter_usages = []

--- a/src/worca/orchestrator/stages.py
+++ b/src/worca/orchestrator/stages.py
@@ -81,6 +81,13 @@ STAGE_ORDER = [Stage.PREFLIGHT, Stage.PLAN, Stage.PLAN_REVIEW, Stage.COORDINATE,
 # Stages that default to disabled when not configured in settings.json
 _STAGES_DEFAULT_DISABLED = {Stage.PLAN_REVIEW, Stage.LEARN}
 
+# Env-var names that, when set on a model alias's `env` block in worca.models,
+# reroute Claude CLI to a non-Anthropic endpoint. Their presence is the signal
+# that Claude CLI's total_cost_usd was computed against the wrong pricing table
+# and worca should override it from worca.pricing.models.<alias>. Conservative
+# and explicit by design — new entries are added deliberately, never inferred.
+_ALT_ENDPOINT_ENV_KEYS = frozenset({"ANTHROPIC_BASE_URL"})
+
 
 def _read_settings(settings_path: str) -> dict:
     """Read and parse settings, with .local.json merge support."""
@@ -118,11 +125,16 @@ def get_stage_config(stage: Stage, settings_path: str = ".claude/settings.json")
     model_map = worca.get("models", {})
     raw_model = agent_config.get("model", "sonnet")
     model_id, model_env = _resolve_model(raw_model, model_map)
-    # model_alias preserves what the user typed (e.g. "glm-ds"), so the UI can
-    # show "Model: glm-ds  ID: opus" — the alias is otherwise lost at this seam
-    # because the runner only persists the resolved id downstream. None means
-    # "no distinct alias" (the user's configured value is already a model id).
-    model_alias = raw_model if raw_model != model_id else None
+    # model_alias is set only when this alias rewires Claude CLI to a non-
+    # Anthropic endpoint (via ANTHROPIC_BASE_URL in the alias's env block).
+    # That's the one case where Claude CLI's total_cost_usd is computed against
+    # the wrong pricing table and worca needs to override it from
+    # worca.pricing.models.<alias>. For every other alias (built-in shorthands
+    # like "opus"/"sonnet"/"haiku", or user renames that don't reroute the
+    # API), Claude CLI's cost number remains authoritative and model_alias
+    # stays None — no override path is taken downstream.
+    _reroutes_api = bool(_ALT_ENDPOINT_ENV_KEYS & set(model_env or {}))
+    model_alias = raw_model if _reroutes_api else None
     return {
         "agent": agent_name,
         "model": model_id,

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -496,6 +496,7 @@ def run_agent(
     on_event: Optional[Callable[[dict], None]] = None,
     settings: Optional[dict] = None,
     graphify_out: Optional[str] = None,
+    model_alias: Optional[str] = None,
     mcp_config: Optional[str] = None,
     run_dir: Optional[str] = None,
     stage: Optional[str] = None,
@@ -659,5 +660,8 @@ def run_agent(
             + (f": {error_msg[:500]}" if error_msg else ""),
             returncode=proc.returncode,
         )
+
+    if model_alias and result_event:
+        result_event["_model_alias"] = model_alias
 
     return result_event

--- a/src/worca/utils/token_usage.py
+++ b/src/worca/utils/token_usage.py
@@ -4,12 +4,18 @@ Provides functions to extract token usage from Claude CLI result events,
 aggregate usage across iterations/stages, and estimate costs from pricing tables.
 """
 
+import sys
 from typing import Optional
 
 from worca.utils.settings import load_settings
 
+_warned_aliases: set[str] = set()
 
-def extract_token_usage(raw_envelope: dict) -> dict:
+
+def extract_token_usage(
+    raw_envelope: dict,
+    settings_path: Optional[str] = None,
+) -> dict:
     """Extract a normalized token_usage dict from a Claude CLI result event.
 
     Pulls token fields from raw_envelope["usage"] and top-level fields
@@ -17,6 +23,7 @@ def extract_token_usage(raw_envelope: dict) -> dict:
 
     Args:
         raw_envelope: The full result event dict from Claude CLI.
+        settings_path: Optional path to settings.json for alias pricing lookup.
 
     Returns:
         A dict with normalized token usage fields. Missing fields default to 0.
@@ -28,7 +35,7 @@ def extract_token_usage(raw_envelope: dict) -> dict:
     server_tool_use = usage.get("server_tool_use") or {}
     cache_creation = usage.get("cache_creation") or {}
 
-    return {
+    result = {
         "input_tokens": usage.get("input_tokens", 0) or 0,
         "output_tokens": usage.get("output_tokens", 0) or 0,
         "cache_creation_input_tokens": usage.get("cache_creation_input_tokens", 0) or 0,
@@ -44,6 +51,33 @@ def extract_token_usage(raw_envelope: dict) -> dict:
         "cache_ephemeral_5m_tokens": cache_creation.get("ephemeral_5m_input_tokens", 0) or 0,
         "speed": usage.get("speed", "") or "",
     }
+
+    model_alias = raw_envelope.get("_model_alias")
+    if model_alias:
+        result["model_alias"] = model_alias
+        if settings_path:
+            pricing_table = load_pricing(settings_path)
+            pricing_entry = pricing_table.get(model_alias)
+            if pricing_entry is not None:
+                settings = load_settings(settings_path)
+                server_tools_pricing = (
+                    settings.get("worca", {}).get("pricing", {}).get("server_tools")
+                )
+                result["total_cost_usd"] = estimate_cost(
+                    result, pricing_entry, server_tools_pricing
+                )
+            else:
+                result["total_cost_usd"] = 0
+                if model_alias not in _warned_aliases:
+                    _warned_aliases.add(model_alias)
+                    print(
+                        f"worca: no pricing entry for alias '{model_alias}' — cost recorded as $0. "
+                        f"Add worca.pricing.models.{model_alias} to settings.json.",
+                        file=sys.stderr,
+                    )
+            result["cost_source"] = "alias"
+
+    return result
 
 
 def _empty_token_usage() -> dict:
@@ -118,7 +152,7 @@ def aggregate_by_model(usages: list[dict]) -> dict:
     by_model: dict[str, dict] = {}
 
     for usage in usages:
-        model = usage.get("model", "") or "unknown"
+        model = usage.get("model_alias") or usage.get("model", "") or "unknown"
         if model not in by_model:
             by_model[model] = {
                 "input_tokens": 0,

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -1380,6 +1380,27 @@ def test_run_agent_no_mcp_config_omits_flags():
 
 
 # ---------------------------------------------------------------------------
+# model_alias stamping
+# ---------------------------------------------------------------------------
+
+
+def test_run_agent_stamps_model_alias_on_result():
+    result_event = {"result": "ok"}
+    mock_proc = _make_mock_popen(result_event)
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent("prompt", agent="planner", model_alias="glm-ds", settings={})
+    assert result["_model_alias"] == "glm-ds"
+
+
+def test_run_agent_omits_model_alias_when_none():
+    result_event = {"result": "ok"}
+    mock_proc = _make_mock_popen(result_event)
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent("prompt", agent="planner", settings={})
+    assert "_model_alias" not in result
+
+
+# ---------------------------------------------------------------------------
 # terminate_current: migrated from src/worca/utils/test_claude_cli.py
 # ---------------------------------------------------------------------------
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4566,3 +4566,64 @@ class TestExtractTokenUsageSettingsPath:
             assert call_kwargs[1].get("settings_path") == str(settings) or \
                 (len(call_kwargs[0]) > 1 and call_kwargs[0][1] == str(settings)), \
                 f"extract_token_usage not called with settings_path, got: {call_kwargs}"
+
+
+class TestLogStageMetricsCostOverride:
+    """_log_stage_metrics prefers the override-aware cost over the raw envelope.
+
+    Regression test for the spawn-log vs status.json cost-mismatch wart in
+    PR #255 — confirmed on a real GLM-DS run: 16 iterations each logging
+    Claude CLI's raw Anthropic-priced number (~$42 cumulative) while
+    status.json correctly carried the overridden $0 from the alt-endpoint
+    pricing path. With the override plumbed through, both surfaces agree.
+    """
+
+    def test_log_stage_metrics_uses_cost_override_when_provided(self, capsys):
+        from worca.orchestrator.runner import _log_stage_metrics
+
+        raw_envelope = {
+            "total_cost_usd": 4.09,  # Claude CLI's raw number (alt-endpoint)
+            "num_turns": 30,
+            "duration_ms": 156_000,
+            "usage": {"output_tokens": 6841},
+        }
+        _log_stage_metrics("PLAN", {}, raw_envelope, cost_override=0)
+
+        out = capsys.readouterr().err
+        # The override (0) suppresses the cost line entirely — matching the
+        # `if cost:` guard. The raw $4.09 must NOT appear in the log.
+        assert "$4.09" not in out, f"raw envelope cost leaked into log: {out}"
+
+    def test_log_stage_metrics_falls_back_to_raw_when_no_override(self, capsys):
+        from worca.orchestrator.runner import _log_stage_metrics
+
+        raw_envelope = {
+            "total_cost_usd": 4.09,
+            "num_turns": 30,
+            "duration_ms": 156_000,
+            "usage": {"output_tokens": 6841},
+        }
+        _log_stage_metrics("PLAN", {}, raw_envelope)
+
+        out = capsys.readouterr().err
+        # No override → preserve the historical behavior of printing the
+        # envelope's number, so vanilla Anthropic-endpoint runs are unchanged.
+        assert "cost=$4.09" in out, f"raw envelope cost missing from log: {out}"
+
+    def test_log_stage_metrics_uses_nonzero_override(self, capsys):
+        """When the alias has a configured pricing entry, the override is a
+        positive number computed locally — that's what should land in the
+        log, not the (different) Claude CLI figure."""
+        from worca.orchestrator.runner import _log_stage_metrics
+
+        raw_envelope = {
+            "total_cost_usd": 4.09,
+            "num_turns": 30,
+            "duration_ms": 156_000,
+            "usage": {"output_tokens": 6841},
+        }
+        _log_stage_metrics("PLAN", {}, raw_envelope, cost_override=2.50)
+
+        out = capsys.readouterr().err
+        assert "cost=$2.50" in out, f"override cost not in log: {out}"
+        assert "$4.09" not in out, f"raw envelope cost leaked into log: {out}"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4524,3 +4524,45 @@ def test_wr_dict_includes_plan_path(tmp_path, monkeypatch):
         )
 
     assert result["work_request"]["plan_path"] == plan_path
+
+
+class TestExtractTokenUsageSettingsPath:
+    """extract_token_usage receives settings_path from the runner."""
+
+    def test_learn_stage_passes_settings_path(self, tmp_path):
+        """_run_learn_stage passes settings_path to extract_token_usage."""
+        from worca.orchestrator.runner import _run_learn_stage
+
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text(json.dumps({"worca": {"stages": {"learn": {"enabled": True}}}}))
+
+        raw_envelope = {"model": "claude-sonnet-4-6", "input_tokens": 100, "output_tokens": 50}
+
+        with patch("worca.orchestrator.runner.is_learn_enabled", return_value=True), \
+             patch("worca.orchestrator.runner.run_stage", return_value=("learned", raw_envelope)), \
+             patch("worca.orchestrator.runner.extract_token_usage") as mock_extract, \
+             patch("worca.orchestrator.runner.complete_iteration"), \
+             patch("worca.orchestrator.runner.update_cumulative_stats"), \
+             patch("worca.orchestrator.runner.emit_event"), \
+             patch("worca.orchestrator.runner.save_status"):
+            mock_extract.return_value = {"model": "claude-sonnet-4-6", "input_tokens": 100, "output_tokens": 50}
+            status = MagicMock()
+            status.get.return_value = {}
+
+            _run_learn_stage(
+                status=status,
+                prompt_builder=MagicMock(),
+                settings_path=str(settings),
+                run_dir=str(tmp_path),
+                termination_type="completed",
+                termination_reason="done",
+                msize="100k",
+                logs_dir=str(tmp_path),
+            )
+
+            mock_extract.assert_called_once()
+            call_kwargs = mock_extract.call_args
+            assert call_kwargs[1].get("settings_path") == str(settings) or \
+                (len(call_kwargs[0]) > 1 and call_kwargs[0][1] == str(settings)), \
+                f"extract_token_usage not called with settings_path, got: {call_kwargs}"

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -702,9 +702,10 @@ class TestStageConfigModelEnv:
         config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
         assert config["model"] == "full-id"
 
-    def test_stage_config_records_model_alias_when_distinct_from_id(self, tmp_path):
-        """The user-typed alias survives next to the resolved id, so the UI can
-        render ``Model: glm-ds  ID: opus`` without re-resolving."""
+    def test_stage_config_records_model_alias_for_alt_endpoint(self, tmp_path):
+        """Aliases that rewire Claude CLI via ANTHROPIC_BASE_URL get a
+        model_alias so the cost-override path fires — that's the one case
+        Claude CLI's total_cost_usd is computed against the wrong table."""
         settings = {
             "worca": {
                 "models": {
@@ -719,9 +720,10 @@ class TestStageConfigModelEnv:
         assert config["model"] == "opus"
         assert config["model_alias"] == "glm-ds"
 
-    def test_stage_config_model_alias_is_none_when_alias_equals_id(self, tmp_path):
-        """Plain-model configs (no alias->id mapping) record model_alias=None so
-        the UI falls back to the single 'Model:' line — backward-compatible."""
+    def test_stage_config_model_alias_none_for_shorthand_without_env(self, tmp_path):
+        """Built-in-style shorthand (``"opus"`` → ``"claude-opus-4-6"``) without
+        an env block must NOT set model_alias — otherwise vanilla installs
+        silently switch from Claude CLI's cost to the local pricing table."""
         settings = {
             "worca": {
                 "models": {"opus": "claude-opus-4-6"},
@@ -731,14 +733,44 @@ class TestStageConfigModelEnv:
         settings_file = tmp_path / "settings.json"
         settings_file.write_text(json.dumps(settings))
         config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
-        # The user typed "opus", resolve_model returns "claude-opus-4-6",
-        # so they differ — alias preserved.
         assert config["model"] == "claude-opus-4-6"
-        assert config["model_alias"] == "opus"
+        assert config["model_alias"] is None
+
+    def test_stage_config_model_alias_none_for_rename_without_endpoint_env(self, tmp_path):
+        """A user rename that ships env vars unrelated to API routing (e.g. a
+        ``CLAUDE_CODE_MAX_OUTPUT_TOKENS`` tuning knob) stays on Claude CLI's
+        cost — the override is opt-in via ANTHROPIC_BASE_URL, nothing else."""
+        settings = {
+            "worca": {
+                "models": {
+                    "tuned-opus": {
+                        "id": "claude-opus-4-6",
+                        "env": {"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "8000"}
+                    }
+                },
+                "agents": {"planner": {"model": "tuned-opus"}}
+            }
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+        config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
+        assert config["model"] == "claude-opus-4-6"
+        assert config["model_alias"] is None
+
+    def test_stage_config_model_alias_none_on_vanilla_install(self, tmp_path):
+        """No ``worca.models`` at all, agent uses the default ``"sonnet"`` →
+        alias must be None so Claude CLI's authoritative cost is preserved.
+        This is the regression-prevention test for the broad-trigger bug."""
+        settings = {"worca": {"agents": {"planner": {"model": "sonnet"}}}}
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+        config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
+        assert config["model"] == "claude-sonnet-4-6"
+        assert config["model_alias"] is None
 
     def test_stage_config_model_alias_is_none_for_passthrough_id(self, tmp_path):
-        """When the user types an id with no model-map entry (passthrough), the
-        alias equals the id, so model_alias stays None — no UI churn."""
+        """When the user types an id with no model-map entry (passthrough), no
+        env is attached either — model_alias stays None."""
         settings = {
             "worca": {
                 "agents": {"planner": {"model": "claude-opus-4-6"}}

--- a/tests/unit/test_token_usage.py
+++ b/tests/unit/test_token_usage.py
@@ -342,3 +342,173 @@ def test_get_model_pricing_empty():
     assert get_model_pricing("", {}) is None
     assert get_model_pricing("model", {}) is None
     assert get_model_pricing("", {"opus": {}}) is None
+
+
+# --- extract_token_usage: model_alias & cost override ---
+
+def test_extract_records_model_alias_from_envelope():
+    raw = {
+        "type": "result",
+        "_model_alias": "glm-ds",
+        "_resolved_model": "claude-sonnet-4-20250514",
+        "total_cost_usd": 0.42,
+        "usage": {"input_tokens": 1000, "output_tokens": 200},
+    }
+    result = extract_token_usage(raw)
+    assert result["model_alias"] == "glm-ds"
+
+
+def test_extract_overrides_cost_from_alias_pricing(tmp_path):
+    settings = {
+        "worca": {
+            "pricing": {
+                "models": {
+                    "glm-ds": {
+                        "input_per_mtok": 2.0,
+                        "output_per_mtok": 10.0,
+                        "cache_write_per_mtok": 0,
+                        "cache_read_per_mtok": 0,
+                    }
+                },
+                "server_tools": {
+                    "web_search_per_request": 0.01,
+                },
+            }
+        }
+    }
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(settings))
+
+    raw = {
+        "type": "result",
+        "_model_alias": "glm-ds",
+        "_resolved_model": "claude-sonnet-4-20250514",
+        "total_cost_usd": 99.99,
+        "usage": {"input_tokens": 1_000_000, "output_tokens": 100_000},
+    }
+    result = extract_token_usage(raw, settings_path=str(path))
+    # 1M * 2/1M + 100K * 10/1M = 2.0 + 1.0 = 3.0
+    assert abs(result["total_cost_usd"] - 3.0) < 0.001
+    assert result["cost_source"] == "alias"
+
+
+def test_extract_alias_no_pricing_entry_cost_is_zero(tmp_path, capsys):
+    settings = {"worca": {"pricing": {"models": {}}}}
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(settings))
+
+    raw = {
+        "type": "result",
+        "_model_alias": "unknown-alias",
+        "_resolved_model": "claude-sonnet-4-20250514",
+        "total_cost_usd": 5.0,
+        "usage": {"input_tokens": 1000, "output_tokens": 200},
+    }
+    # Reset the warning set so this test gets a fresh warning
+    from worca.utils.token_usage import _warned_aliases
+    _warned_aliases.discard("unknown-alias")
+
+    result = extract_token_usage(raw, settings_path=str(path))
+    assert result["total_cost_usd"] == 0
+    assert result["cost_source"] == "alias"
+
+    captured = capsys.readouterr()
+    assert "unknown-alias" in captured.err
+
+
+def test_extract_alias_all_zero_pricing_cost_is_zero(tmp_path, capsys):
+    settings = {
+        "worca": {
+            "pricing": {
+                "models": {
+                    "zero-model": {
+                        "input_per_mtok": 0,
+                        "output_per_mtok": 0,
+                        "cache_write_per_mtok": 0,
+                        "cache_read_per_mtok": 0,
+                    }
+                }
+            }
+        }
+    }
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(settings))
+
+    raw = {
+        "type": "result",
+        "_model_alias": "zero-model",
+        "_resolved_model": "claude-sonnet-4-20250514",
+        "total_cost_usd": 5.0,
+        "usage": {"input_tokens": 1000, "output_tokens": 200},
+    }
+    result = extract_token_usage(raw, settings_path=str(path))
+    assert result["total_cost_usd"] == 0
+    assert result["cost_source"] == "alias"
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_extract_no_alias_cost_unchanged():
+    raw = {
+        "type": "result",
+        "_resolved_model": "claude-sonnet-4-20250514",
+        "total_cost_usd": 0.42,
+        "usage": {"input_tokens": 1000, "output_tokens": 200},
+    }
+    result = extract_token_usage(raw)
+    assert result["total_cost_usd"] == 0.42
+    assert "cost_source" not in result
+    assert "model_alias" not in result
+
+
+def test_extract_alias_warning_emitted_once(tmp_path, capsys):
+    settings = {"worca": {"pricing": {"models": {}}}}
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(settings))
+
+    from worca.utils.token_usage import _warned_aliases
+    _warned_aliases.discard("warn-once-alias")
+
+    raw = {
+        "type": "result",
+        "_model_alias": "warn-once-alias",
+        "total_cost_usd": 1.0,
+        "usage": {"input_tokens": 100},
+    }
+
+    extract_token_usage(raw, settings_path=str(path))
+    first = capsys.readouterr()
+    assert "warn-once-alias" in first.err
+
+    extract_token_usage(raw, settings_path=str(path))
+    second = capsys.readouterr()
+    assert "warn-once-alias" not in second.err
+
+
+# --- aggregate_by_model: prefers model_alias ---
+
+def test_aggregate_by_model_prefers_alias():
+    usages = [
+        {
+            "model": "claude-sonnet-4-20250514",
+            "model_alias": "glm-ds",
+            "input_tokens": 1000,
+            "output_tokens": 200,
+            "total_cost_usd": 0.10,
+            "num_turns": 3,
+        },
+        {
+            "model": "claude-sonnet-4-20250514",
+            "input_tokens": 500,
+            "output_tokens": 100,
+            "total_cost_usd": 0.05,
+            "num_turns": 2,
+        },
+    ]
+    result = aggregate_by_model(usages)
+    assert "glm-ds" in result
+    assert "claude-sonnet-4-20250514" in result
+    assert result["glm-ds"]["input_tokens"] == 1000
+    assert result["glm-ds"]["invocations"] == 1
+    assert result["claude-sonnet-4-20250514"]["input_tokens"] == 500

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -2225,6 +2225,28 @@ sl-input.pricing-input::part(input) {
   margin-bottom: 8px;
 }
 
+/* Inline explainer that distinguishes alt-endpoint overrides from default
+   Anthropic runs (where Claude CLI's total_cost_usd remains authoritative). */
+.pricing-source-note {
+  display: block;
+  margin: 12px 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.pricing-source-note strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.pricing-source-note code {
+  font-family: var(--sl-font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.92em;
+  padding: 1px 4px;
+  background: var(--sl-color-neutral-100, rgba(127, 127, 127, 0.12));
+  border-radius: 3px;
+}
+
 /* Settings toast overlay */
 .settings-toast {
   position: fixed;

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -2202,7 +2202,6 @@ sl-details.dispatch-section-details::part(content) {
 
 .pricing-model-name {
   font-weight: 500;
-  text-transform: uppercase;
 }
 
 .pricing-table sl-input {
@@ -5306,6 +5305,10 @@ sl-tooltip.bead-tooltip::part(body) {
   display: flex;
   flex-direction: column;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.model-card .settings-card-title {
+  text-transform: none;
 }
 
 .model-card.is-dirty {

--- a/worca-ui/app/views/settings-pricing-css.test.js
+++ b/worca-ui/app/views/settings-pricing-css.test.js
@@ -28,9 +28,15 @@ describe('Pricing table CSS', () => {
     expect(css).toMatch(/\.pricing-table\s+th\s*\{[^}]*letter-spacing/);
   });
 
-  it('has .pricing-model-name with uppercase (matches column header style)', () => {
-    expect(css).toMatch(
+  it('has .pricing-model-name without text-transform uppercase', () => {
+    expect(css).not.toMatch(
       /\.pricing-model-name\s*\{[^}]*text-transform:\s*uppercase/,
+    );
+  });
+
+  it('has .model-card .settings-card-title with text-transform none', () => {
+    expect(css).toMatch(
+      /\.model-card\s+\.settings-card-title\s*\{[^}]*text-transform:\s*none/,
     );
   });
 

--- a/worca-ui/app/views/settings-pricing.test.js
+++ b/worca-ui/app/views/settings-pricing.test.js
@@ -27,3 +27,19 @@ describe('Pricing Editor constants and readPricingFromDom', () => {
     expect(typeof readPricingFromDom).toBe('function');
   });
 });
+
+describe('Pricing source-of-truth explainer', () => {
+  it('settings.js source contains the alt-endpoint explainer note', async () => {
+    // The note is inside the internal pricingTab() template literal — not
+    // exported — so we grep the source rather than try to render the tab.
+    // This guards against the explainer being silently removed when the
+    // pricing tab is restructured (e.g. moved into a sub-tab).
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const here = path.dirname(new URL(import.meta.url).pathname);
+    const src = fs.readFileSync(path.join(here, 'settings.js'), 'utf8');
+    expect(src).toMatch(/pricing-source-note/);
+    expect(src).toMatch(/ANTHROPIC_BASE_URL/);
+    expect(src).toMatch(/non-Anthropic endpoint/);
+  });
+});

--- a/worca-ui/app/views/settings.js
+++ b/worca-ui/app/views/settings.js
@@ -2805,6 +2805,17 @@ function pricingTab(worca, rerender) {
         </table>
       </div>
 
+      <sl-alert variant="neutral" open class="pricing-source-note">
+        <strong>When are these rates applied?</strong>
+        Only for model aliases whose <code>env</code> block in
+        <code>worca.models</code> sets <code>ANTHROPIC_BASE_URL</code>
+        (i.e. routes Claude CLI to a non-Anthropic endpoint). For runs against
+        the default Anthropic endpoint — including the built-in
+        <code>opus</code>, <code>sonnet</code>, and <code>haiku</code>
+        shorthands — Claude CLI's own cost is the source of truth; the rates
+        above are kept as a fallback for runs that end without a reported cost.
+      </sl-alert>
+
       <div class="pricing-info">
         <span class="settings-muted">Currency: ${pricing.currency || 'USD'}</span>
         <span class="settings-muted">Last updated: ${pricing.last_updated || 'N/A'}</span>


### PR DESCRIPTION
## Summary

- **Pricing fix:** Run cost for alt-endpoint model aliases (e.g. `glm-ds` routed via `ANTHROPIC_BASE_URL`) was computed from Claude CLI's internal pricing table instead of the user-configured `worca.pricing.models` entry. Plumb `model_alias` through `run_agent` → `_model_alias` → `extract_token_usage`, then override `total_cost_usd` using the alias's pricing entry. Missing entry → `$0` with a one-shot stderr warning.
- **CSS fix:** `text-transform: uppercase` on Models tab card headers and Pricing tab model/server-tool columns hid alias case, making typos invisible. Scoped `.model-card .settings-card-title { text-transform: none }` and dropped `text-transform` from `.pricing-model-name`.
- Adds `model_alias` and `cost_source` fields to `token_usage` in `status.json` (additive, backward-compatible).
- `aggregate_by_model` now groups by `model_alias` when present.
- MIGRATION.md entry for the alias-as-pricing-key contract.

## Test plan

- [ ] `pytest tests/unit/test_token_usage.py` — 7 new tests covering alias cost override, zero pricing, missing entry warning (one-shot), backward compat (no alias)
- [ ] `pytest tests/test_claude_cli.py -k model_alias` — 2 tests for `_model_alias` stamping on result event
- [ ] `pytest tests/test_runner.py -k settings_path` — learn-stage passes `settings_path` to `extract_token_usage`
- [ ] `cd worca-ui && npx vitest run app/views/settings-pricing-css.test.js` — CSS assertions flipped for literal-case rendering
- [ ] Manual: configure a `glm-ds` alias with custom pricing, run a pipeline, verify `status.json` cost matches the configured rates (not CLI rates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)