### PR TITLE
test(ui): stabilize CI — fix WebSocket hello race (#257)

### DIFF
--- a/tests/integration/test_fleet_lifecycle_e2e.py
+++ b/tests/integration/test_fleet_lifecycle_e2e.py
@@ -625,6 +625,19 @@ def test_fleet_stop_then_resume(tmp_path):
         for child, (_, wt) in zip(children, cleanup_pairs):
             _wait_for_pipeline_terminal(wt, child["run_id"], timeout=120)
 
+        # status.json -> registry mirror lags by tens to hundreds of ms,
+        # and poll_and_update_fleet_manifest reads the registry. Wait for
+        # the mirror so the final derivation isn't racing the atexit write
+        # (the macOS flake — children terminal in status.json, registry
+        # still "resuming"/"running" -> fleet derives RUNNING).
+        for child, (repo_path, _) in zip(children, cleanup_pairs):
+            _wait_for_registry_status(
+                repo_path,
+                child["run_id"],
+                {"completed", "failed", "interrupted"},
+                timeout=30,
+            )
+
         final = poll_and_update_fleet_manifest(fleet_id)
         # Resume may produce "completed" (all resumed and finished) or
         # "failed" (some resumes didn't replay cleanly). The contract under

--- a/worca-ui/test/server-e2e.test.js
+++ b/worca-ui/test/server-e2e.test.js
@@ -26,6 +26,35 @@ function waitForOpen(ws) {
   });
 }
 
+// Open a WebSocket and drain the server's protocol-2 `hello` message before
+// returning. The message listener is attached **before** awaiting `'open'`
+// because on some platforms (notably macOS) the `hello` is emitted in the
+// same tick as `'open'` — if we attach later, we miss it and hang. Without
+// this drain, a `sendAndReceive` issued right after open can also race the
+// handshake and consume `hello` as its reply (issue #257).
+async function openAndHandshake(url) {
+  const ws = new WebSocket(url);
+  const helloReceived = new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('no hello message in 2s')),
+      2000,
+    );
+    ws.once('message', (data) => {
+      clearTimeout(timer);
+      const msg = JSON.parse(data.toString());
+      if (msg.type === 'hello') resolve();
+      else reject(new Error(`expected hello, got ${msg.type}`));
+    });
+    ws.once('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+  await waitForOpen(ws);
+  await helloReceived;
+  return ws;
+}
+
 function sendAndReceive(ws, msg) {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error('timeout')), 5000);
@@ -89,8 +118,7 @@ describe('server e2e', () => {
   });
 
   it('WebSocket connects through full server stack', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
-    await waitForOpen(ws);
+    const ws = await openAndHandshake(`ws://127.0.0.1:${port}/ws`);
     const reply = await sendAndReceive(ws, { id: '1', type: 'list-runs' });
     expect(reply.ok).toBe(true);
     ws.close();
@@ -109,8 +137,7 @@ describe('server e2e', () => {
     const res = await fetch(`http://127.0.0.1:${port}/`);
     expect(res.status).toBe(200);
 
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
-    await waitForOpen(ws);
+    const ws = await openAndHandshake(`ws://127.0.0.1:${port}/ws`);
     const reply = await sendAndReceive(ws, { id: '2', type: 'list-runs' });
     expect(reply.payload.runs.length).toBe(1);
     expect(reply.payload.runs[0].active).toBe(true);
@@ -118,8 +145,7 @@ describe('server e2e', () => {
   });
 
   it('preferences round-trip through full stack', async () => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
-    await waitForOpen(ws);
+    const ws = await openAndHandshake(`ws://127.0.0.1:${port}/ws`);
 
     const getReply = await sendAndReceive(ws, { id: '3', type: 'get-preferences' });
     expect(getReply.payload.theme).toBe('light');


### PR DESCRIPTION
## Summary

Branch for ongoing test-suite stability work — first commit fixes the macOS `server-e2e.test.js` flake from #257.

The server-e2e tests opened a WebSocket, awaited `'open'`, then attached a `ws.once('message')` for their reply. On macOS the protocol-2 `hello` handshake sometimes arrived *after* the test's `sendAndReceive` listener was attached, so the test consumed `hello` instead of the actual reply — `reply.payload.runs` was `undefined`, `.length` threw, and the dangling WebSocket then prevented `server.close()` from resolving, cascading into a 10s `afterEach` hook timeout.

Adds `openAndHandshake(url)` which:
- Attaches the message listener **before** `await waitForOpen` (so a hello emitted in the same tick as `'open'` is never missed — the failure mode that Option A in the issue didn't account for).
- Validates the first message is `{type: 'hello'}` and rejects with the unexpected type otherwise — failing closed beats hanging.
- 2s timeout with a clear error rather than letting the bug cascade into the afterEach hook.

Replaces all three `new WebSocket + waitForOpen` sites in `worca-ui/test/server-e2e.test.js`.

## Test plan

- [x] 20× local stress run on macOS: 20/20 pass (was previously flaky enough to surface on CI)
- [ ] 3 consecutive green CI runs across Linux / macOS / Windows
- [x] biome lint clean

Closes #257