### PR TITLE
fix(templates): stage settings.json next to target for cross-device safety

### DIFF
--- a/src/worca/cli/templates.py
+++ b/src/worca/cli/templates.py
@@ -341,6 +341,18 @@ def _atomic_import(templates, settings_patch, target_dir, settings_path):
     The backup-aside step uses `shutil.move` (rename within the same parent
     directory — single FS, atomic on POSIX) before any destructive mutation,
     so a write failure in step 3 always has something to roll back to.
+
+    Cross-filesystem safety: `os.replace` requires source and destination on
+    the same filesystem (EXDEV on POSIX, ERROR_NOT_SAME_DEVICE on Windows
+    cross-drive). The system tempdir is on a different volume from the repo
+    in common setups — macOS (`/private/var/folders/...` vs `/Volumes/X`),
+    Linux (`/tmp` tmpfs vs ext4 on `/home`), Windows (`C:\\Users\\…\\Temp`
+    vs `D:\\repo`). To guarantee single-FS for the atomic replace, we stage
+    `settings.json` in the SAME parent directory as the target, not in the
+    system tempdir. Template directories can keep staging in the system
+    tempdir because `shutil.copytree` is a file-by-file copy (no rename),
+    which handles cross-device natively. Same pattern as `state/status.py`
+    and `cli/init.py`.
     """
     target_real = target_dir.resolve()
     for tmpl_id in templates:
@@ -354,6 +366,10 @@ def _atomic_import(templates, settings_patch, target_dir, settings_path):
     # (original_path, backup_path, kind) — kind is "dir" or "file"
     backups: list[tuple[Path, Path, str]] = []
     committed_templates: list[Path] = []
+    # Settings staging file lives next to the target (see docstring). Tracked
+    # separately so the finally block can sweep it on rollback / mid-commit
+    # failure without relying on the system-tempdir cleanup.
+    staged_settings_local: Path | None = None
 
     def _bak_name(p: Path) -> Path:
         return p.with_name(p.name + f".bak-{uuid.uuid4().hex[:8]}")
@@ -367,7 +383,10 @@ def _atomic_import(templates, settings_patch, target_dir, settings_path):
                 json.dumps(tmpl_data, indent=2), encoding="utf-8"
             )
 
-        staged_settings = None
+        # Serialize the patched settings now (early failure on JSON errors)
+        # but defer the file write to the commit phase so it lands in the
+        # target's directory — required for same-FS os.replace below.
+        new_settings_text: str | None = None
         if settings_patch and settings_path:
             sp = Path(settings_path)
             if sp.exists():
@@ -375,10 +394,7 @@ def _atomic_import(templates, settings_patch, target_dir, settings_path):
             else:
                 current = {}
             patched = deep_merge(current, {"worca": settings_patch})
-            staged_settings = staging / "settings.json"
-            staged_settings.write_text(
-                json.dumps(patched, indent=2), encoding="utf-8"
-            )
+            new_settings_text = json.dumps(patched, indent=2)
 
         # ---- Commit with backup-first ----
         try:
@@ -392,13 +408,31 @@ def _atomic_import(templates, settings_patch, target_dir, settings_path):
                 shutil.copytree(str(src), str(dst))
                 committed_templates.append(dst)
 
-            if staged_settings is not None and settings_path:
+            if new_settings_text is not None and settings_path:
                 sp = Path(settings_path)
+                # Ensure the target's parent exists before staging next to it.
+                # In normal usage this is always `.claude/`, which the caller
+                # guarantees exists, but be defensive.
+                sp.parent.mkdir(parents=True, exist_ok=True)
                 if sp.exists():
                     bak = _bak_name(sp)
                     shutil.copy2(str(sp), str(bak))
                     backups.append((sp, bak, "file"))
-                os.replace(str(staged_settings), settings_path)
+                # Stage in target's directory so os.replace is single-FS on
+                # POSIX (no EXDEV) and Windows (no ERROR_NOT_SAME_DEVICE).
+                # The hidden prefix keeps the staging file out of casual
+                # `ls` and prevents tools watching the directory from
+                # confusing it with a real settings.json.
+                fd, tmp_name = tempfile.mkstemp(
+                    prefix=".settings.json.import-",
+                    suffix=".tmp",
+                    dir=str(sp.parent),
+                )
+                staged_settings_local = Path(tmp_name)
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(new_settings_text)
+                os.replace(str(staged_settings_local), str(sp))
+                staged_settings_local = None  # consumed by os.replace
         except Exception:
             # Rollback: tear down what we committed, then restore backups.
             for d in committed_templates:
@@ -425,6 +459,15 @@ def _atomic_import(templates, settings_patch, target_dir, settings_path):
                     except OSError:
                         pass
     finally:
+        # Sweep any staged-next-to-target settings file that wasn't consumed
+        # (write failure, os.replace failure, or pre-replace exception).
+        # Required so the rollback-leftover assertion `no .bak-* siblings`
+        # also holds for our import-staging file.
+        if staged_settings_local is not None:
+            try:
+                staged_settings_local.unlink()
+            except OSError:
+                pass
         shutil.rmtree(staging, ignore_errors=True)
 
 

--- a/tests/test_cli_templates.py
+++ b/tests/test_cli_templates.py
@@ -1,6 +1,7 @@
 """Tests for worca templates CLI subcommands (list, show, create)."""
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1500,6 +1501,128 @@ class TestImportRollbackOnSettingsFailure:
             p for p in settings_dir.iterdir() if ".bak-" in p.name
         ]
         assert leftovers == [], f"leftover backups after rollback: {leftovers}"
+
+
+class TestImportCrossDeviceSafety:
+    """Regression: settings.json staging file must live in the SAME parent
+    directory as the target so the final `os.replace` is single-filesystem.
+
+    Background: `tempfile.mkdtemp()` returns a path under `tempfile.gettempdir()`
+    (`/private/var/folders/...` on macOS, `/tmp` on Linux, `C:\\…\\Temp` on
+    Windows) which is frequently on a different filesystem from the project
+    repo (`/Volumes/X`, ext4 on `/home`, a `D:\\` drive). Staging settings.json
+    in the system tempdir and then calling `os.replace(staged, target)` raises
+    `OSError: [Errno 18] Cross-device link` on POSIX and
+    `ERROR_NOT_SAME_DEVICE` on Windows — wiping the import via the rollback
+    path even though nothing is actually wrong with the bundle.
+    """
+
+    def test_settings_staged_in_target_dir(self, tmp_path):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.json"
+        settings_path.write_text(json.dumps({"worca": {}}))
+
+        # Bundle must include a model the imported template references, so
+        # the settings.json patch is non-empty and os.replace is reached.
+        bundle = _make_bundle(models={"opus": "claude-opus-4-6"})
+        bundle["templates"][0]["config"] = {"agents": {"planner": {"model": "opus"}}}
+        bundle_file = tmp_path / "bundle.json"
+        bundle_file.write_text(json.dumps(bundle))
+
+        captured: list[tuple[str, str]] = []
+        original_replace = os.replace
+
+        def capturing_replace(src, dst, *args, **kwargs):
+            captured.append((str(src), str(dst)))
+            return original_replace(src, dst, *args, **kwargs)
+
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ), patch(
+            "worca.cli.templates._find_settings_path",
+            return_value=str(settings_path),
+        ), patch("worca.cli.templates.os.replace", side_effect=capturing_replace):
+            main(["templates", "import", "--from", str(bundle_file)])
+
+        settings_calls = [c for c in captured if c[1] == str(settings_path)]
+        assert len(settings_calls) == 1, (
+            f"expected exactly one os.replace targeting settings.json, "
+            f"got {settings_calls}"
+        )
+        src, dst = settings_calls[0]
+        assert Path(src).parent == Path(dst).parent, (
+            f"settings.json staging must be in the same directory as the target "
+            f"so os.replace stays single-filesystem. "
+            f"src parent: {Path(src).parent}, dst parent: {Path(dst).parent}. "
+            f"Cross-device staging triggers EXDEV on POSIX / ERROR_NOT_SAME_DEVICE "
+            f"on Windows and silently routes the import through the rollback path."
+        )
+
+    def test_import_succeeds_under_simulated_cross_device_rename(self, tmp_path):
+        """Simulate a real cross-device rename by raising EXDEV from os.replace
+        whenever src and dst are in different parent directories — that's the
+        kernel's actual EXDEV trigger condition. Before the fix, the settings
+        staging file lived under the system tempdir while the target lived in
+        the project's `.claude/`, so this check would fire and the import would
+        bail. After the fix, every `os.replace` in the import path has src and
+        dst as siblings, so the simulated EXDEV never fires."""
+        import errno
+
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.json"
+        settings_path.write_text(json.dumps({"worca": {}}))
+
+        bundle = _make_bundle(models={"opus": "claude-opus-4-6"})
+        bundle["templates"][0]["config"] = {"agents": {"planner": {"model": "opus"}}}
+        bundle_file = tmp_path / "bundle.json"
+        bundle_file.write_text(json.dumps(bundle))
+
+        original_replace = os.replace
+
+        def exdev_on_different_parents(src, dst, *args, **kwargs):
+            if Path(src).parent.resolve() != Path(dst).parent.resolve():
+                raise OSError(errno.EXDEV, "simulated cross-device link")
+            return original_replace(src, dst, *args, **kwargs)
+
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ), patch(
+            "worca.cli.templates._find_settings_path",
+            return_value=str(settings_path),
+        ), patch(
+            "worca.cli.templates.os.replace",
+            side_effect=exdev_on_different_parents,
+        ):
+            main(["templates", "import", "--from", str(bundle_file)])
+
+        # Template landed
+        landed = json.loads(
+            (project_dir / "imported-tmpl" / "template.json").read_text()
+        )
+        assert landed["config"]["agents"]["planner"]["model"] == "opus"
+        # Settings.json picked up the new model alias
+        post = json.loads(settings_path.read_text())
+        assert post["worca"]["models"]["opus"] == "claude-opus-4-6"
+        # And no staged-import or .bak-* leftovers next to settings.json
+        leftovers = [
+            p for p in settings_dir.iterdir()
+            if p.name != "settings.json" and (
+                ".bak-" in p.name or p.name.startswith(".settings.json.import-")
+            )
+        ]
+        assert leftovers == [], f"leftover staging/backup files: {leftovers}"
 
 
 class TestImportMixedCollision:


### PR DESCRIPTION
## Problem

`worca templates import` failed with `OSError: [Errno 18] Cross-device link` whenever the system tempdir was on a different filesystem from the repo. Concrete repros:

- **macOS**: system tempdir is `/private/var/folders/...`, repos on external volumes live under `/Volumes/X` → cross-device.
- **Linux**: `/tmp` is frequently a `tmpfs` mount while `/home` is ext4/btrfs → cross-device.
- **Windows**: `%LOCALAPPDATA%\Temp` is on `C:`, repos on a secondary `D:` drive → `ERROR_NOT_SAME_DEVICE`.

Symptom (real run from this machine):

```
$ worca templates import --from https://gist.github.com/.../bundle.json
error: import failed: [Errno 18] Cross-device link:
  '/tmp/worca-import-nxel3xa_/settings.json'
  -> '/Volumes/Apps/dev/ccexperiments/worca-cc/.claude/settings.json'
```

The bug is in `_atomic_import` in `src/worca/cli/templates.py`: it staged `settings.json` inside `tempfile.mkdtemp()` (system tempdir) and then called `os.replace(staged, target)`. `os.replace` is documented to fail with EXDEV on POSIX and `ERROR_NOT_SAME_DEVICE` on Windows when source and destination are on different filesystems — atomicity is only guaranteed within a single FS.

## Fix

Stage `settings.json` in the **same parent directory** as the target so the final `os.replace` is single-filesystem on all three platforms. Template directories continue to stage in the system tempdir — they're committed via `shutil.copytree`, which is a file-by-file copy and handles cross-device natively.

This matches the pattern already used by every other atomic-write site in the codebase (`state/status.py`, `cli/init.py`, `state/iteration.py`, etc.) — they all `tempfile.mkstemp(dir=p.parent, ...)` then `os.replace`. `_atomic_import` was the outlier.

## What's preserved

- **Rollback semantics**: the existing `test_rollback_restores_settings_and_templates` (which simulates `os.replace` failure on `settings.json`) still passes — restoring the original settings, restoring the original template content, and leaving no `.bak-*` leftovers.
- **Atomicity**: still a single `os.replace` for `settings.json`.
- **Public API**: no behavior change for the success path; no config schema change.
- **No MIGRATION.md entry**: pure bugfix.

## Tests

Two new regression tests under `TestImportCrossDeviceSafety`:

1. **`test_settings_staged_in_target_dir`** — captures every `os.replace` call during a real import and asserts the `settings.json` call has `src.parent == dst.parent`. Direct assertion that we never re-introduce cross-FS staging.
2. **`test_import_succeeds_under_simulated_cross_device_rename`** — patches `os.replace` to raise `OSError(errno.EXDEV)` whenever src and dst are in different parent directories (the kernel's actual EXDEV trigger condition) and verifies the import still lands the template + model with no leftover staging or `.bak-*` files.

All 195 template-related tests pass locally (`pytest tests/test_cli_templates.py tests/test_templates.py tests/test_templates_utils.py`).

## End-to-end verification

The same gist import that originally failed now succeeds against the system `/tmp` without the `TMPDIR=<inside-repo>` workaround:

```
$ unset TMPDIR
$ PYTHONPATH=src python3 -m worca.cli.main templates import \
    --from https://gist.github.com/SinishaDjukic/8fcaabc485b864a284d29716f732b315 \
    --scope project --non-interactive
info: 1 secret placeholder(s) landed — replace '<YOUR-SECRET-HERE>' before running the pipeline:
  - settings.worca.models.glm-ds.env.ANTHROPIC_AUTH_TOKEN
imported 1 template(s), 1 model(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
