### PR TITLE
fix(ui): correct misleading plan + model state during PLAN-stage transitions

### DIFF
--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -1349,7 +1349,7 @@ def run_stage(
         output_format="stream-json",
         json_schema=_schema_path(config["schema"]),
         model=config.get("model"),
-        model_alias=config.get("model_alias"),
+        model_alias=config.get("cost_alias"),
         model_env=merged_env,
         log_path=log_path,
         on_event=on_event,

--- a/src/worca/orchestrator/stages.py
+++ b/src/worca/orchestrator/stages.py
@@ -119,26 +119,20 @@ def get_stage_config(stage: Stage, settings_path: str = ".claude/settings.json")
     agent_name = stage_entry.get("agent") or STAGE_AGENT_MAP.get(stage)
 
     if agent_name is None:
-        return {"agent": None, "model": None, "model_env": {}, "max_turns": None, "effort": None, "schema": None}
+        return {"agent": None, "model": None, "model_env": {}, "max_turns": None, "effort": None, "schema": None, "cost_alias": None}
 
     agent_config = worca.get("agents", {}).get(agent_name, {})
     model_map = worca.get("models", {})
     raw_model = agent_config.get("model", "sonnet")
     model_id, model_env = _resolve_model(raw_model, model_map)
-    # model_alias is set only when this alias rewires Claude CLI to a non-
-    # Anthropic endpoint (via ANTHROPIC_BASE_URL in the alias's env block).
-    # That's the one case where Claude CLI's total_cost_usd is computed against
-    # the wrong pricing table and worca needs to override it from
-    # worca.pricing.models.<alias>. For every other alias (built-in shorthands
-    # like "opus"/"sonnet"/"haiku", or user renames that don't reroute the
-    # API), Claude CLI's cost number remains authoritative and model_alias
-    # stays None — no override path is taken downstream.
+    model_alias = raw_model if raw_model != model_id else None
     _reroutes_api = bool(_ALT_ENDPOINT_ENV_KEYS & set(model_env or {}))
-    model_alias = raw_model if _reroutes_api else None
+    cost_alias = raw_model if _reroutes_api else None
     return {
         "agent": agent_name,
         "model": model_id,
         "model_alias": model_alias,
+        "cost_alias": cost_alias,
         "model_env": model_env,
         "max_turns": agent_config.get("max_turns", 30),
         "effort": agent_config.get("effort"),

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -719,11 +719,12 @@ class TestStageConfigModelEnv:
         config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
         assert config["model"] == "opus"
         assert config["model_alias"] == "glm-ds"
+        assert config["cost_alias"] == "glm-ds"
 
-    def test_stage_config_model_alias_none_for_shorthand_without_env(self, tmp_path):
-        """Built-in-style shorthand (``"opus"`` → ``"claude-opus-4-6"``) without
-        an env block must NOT set model_alias — otherwise vanilla installs
-        silently switch from Claude CLI's cost to the local pricing table."""
+    def test_stage_config_model_alias_set_for_shorthand_without_env(self, tmp_path):
+        """Built-in-style shorthand (``"opus"`` → ``"claude-opus-4-6"``) records
+        model_alias for UI display, but cost_alias stays None because no
+        alt-endpoint env key is present."""
         settings = {
             "worca": {
                 "models": {"opus": "claude-opus-4-6"},
@@ -734,12 +735,13 @@ class TestStageConfigModelEnv:
         settings_file.write_text(json.dumps(settings))
         config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
         assert config["model"] == "claude-opus-4-6"
-        assert config["model_alias"] is None
+        assert config["model_alias"] == "opus"
+        assert config["cost_alias"] is None
 
-    def test_stage_config_model_alias_none_for_rename_without_endpoint_env(self, tmp_path):
-        """A user rename that ships env vars unrelated to API routing (e.g. a
-        ``CLAUDE_CODE_MAX_OUTPUT_TOKENS`` tuning knob) stays on Claude CLI's
-        cost — the override is opt-in via ANTHROPIC_BASE_URL, nothing else."""
+    def test_stage_config_model_alias_set_for_rename_without_endpoint_env(self, tmp_path):
+        """A user rename (``"tuned-opus"`` → ``"claude-opus-4-6"``) records
+        model_alias for UI display, but cost_alias stays None because the env
+        block has no alt-endpoint key."""
         settings = {
             "worca": {
                 "models": {
@@ -755,18 +757,20 @@ class TestStageConfigModelEnv:
         settings_file.write_text(json.dumps(settings))
         config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
         assert config["model"] == "claude-opus-4-6"
-        assert config["model_alias"] is None
+        assert config["model_alias"] == "tuned-opus"
+        assert config["cost_alias"] is None
 
-    def test_stage_config_model_alias_none_on_vanilla_install(self, tmp_path):
+    def test_stage_config_cost_alias_none_on_vanilla_install(self, tmp_path):
         """No ``worca.models`` at all, agent uses the default ``"sonnet"`` →
-        alias must be None so Claude CLI's authoritative cost is preserved.
-        This is the regression-prevention test for the broad-trigger bug."""
+        model_alias is ``"sonnet"`` for UI display, cost_alias is None so
+        Claude CLI's authoritative cost is preserved."""
         settings = {"worca": {"agents": {"planner": {"model": "sonnet"}}}}
         settings_file = tmp_path / "settings.json"
         settings_file.write_text(json.dumps(settings))
         config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
         assert config["model"] == "claude-sonnet-4-6"
-        assert config["model_alias"] is None
+        assert config["model_alias"] == "sonnet"
+        assert config["cost_alias"] is None
 
     def test_stage_config_model_alias_is_none_for_passthrough_id(self, tmp_path):
         """When the user types an id with no model-map entry (passthrough), no
@@ -781,6 +785,7 @@ class TestStageConfigModelEnv:
         config = get_stage_config(Stage.PLAN, settings_path=str(settings_file))
         assert config["model"] == "claude-opus-4-6"
         assert config["model_alias"] is None
+        assert config["cost_alias"] is None
 
 
 class TestResolvePlanReviewMode:

--- a/worca-ui/app/views/run-detail-dispatch.test.js
+++ b/worca-ui/app/views/run-detail-dispatch.test.js
@@ -102,7 +102,7 @@ describe('iteration tags layout', () => {
     const html = renderToString(runDetailView(run));
     expect(html).toContain('Agent:');
     expect(html).toContain('implementer');
-    expect(html).toContain('Model:');
+    expect(html).toContain('Model ID:');
     expect(html).toContain('claude-sonnet-4-6');
     // Old parenthesized format should not appear
     expect(html).not.toContain('(claude-sonnet-4-6)');

--- a/worca-ui/app/views/run-detail-model-alias.test.js
+++ b/worca-ui/app/views/run-detail-model-alias.test.js
@@ -47,58 +47,64 @@ function makeRun({
   return { stages: { plan: stage } };
 }
 
-describe('stage-level Model / ID rendering', () => {
-  it('renders a single "Model:" label when no alias is recorded (backward-compatible)', () => {
+describe('stage-level Model Alias / Model ID rendering', () => {
+  it('renders a single "Model ID:" label when no alias is recorded (backward-compatible)', () => {
     const html = renderToString(runDetailView(makeRun({ stageModel: 'opus' })));
-    // Single Model: label, the resolved id appears next to it, no ID: label
-    // is added — old runs and plain-model configs are untouched.
-    const modelCount = (
-      html.match(/<span class="meta-label">Model:<\/span>/g) || []
+    const modelIdCount = (
+      html.match(/<span class="meta-label">Model ID:<\/span>/g) || []
     ).length;
-    const idCount = (html.match(/<span class="meta-label">ID:<\/span>/g) || [])
-      .length;
-    expect(modelCount).toBe(1);
-    expect(idCount).toBe(0);
+    const aliasCount = (
+      html.match(/<span class="meta-label">Model Alias:<\/span>/g) || []
+    ).length;
+    expect(modelIdCount).toBe(1);
+    expect(aliasCount).toBe(0);
     expect(html).toContain('>opus<');
   });
 
-  it('renders Model: <alias> + ID: <id> when alias differs from the resolved id', () => {
+  it('renders Model Alias: <alias> + Model ID: <id> when alias differs from the resolved id', () => {
     const html = renderToString(
       runDetailView(makeRun({ stageModel: 'opus', stageModelAlias: 'glm-ds' })),
     );
-    expect(html).toContain('<span class="meta-label">Model:</span>');
-    expect(html).toContain('<span class="meta-label">ID:</span>');
+    expect(html).toContain('<span class="meta-label">Model Alias:</span>');
+    expect(html).toContain('<span class="meta-label">Model ID:</span>');
     expect(html).toContain('>glm-ds<');
     expect(html).toContain('>opus<');
-    // The alias is what's surfaced as the primary value, not the resolved id.
     const aliasIdx = html.indexOf('>glm-ds<');
     const idIdx = html.indexOf('>opus<');
     expect(aliasIdx).toBeLessThan(idIdx);
   });
 
-  it('collapses to a single label when alias equals the resolved id (no churn)', () => {
-    // Defensive: even if the runner ever writes model_alias == model, the UI
-    // should NOT produce a redundant "Model: opus  ID: opus" pair.
+  it('renders Model Alias: + Model ID: for built-in shorthand aliases', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({ stageModel: 'claude-opus-4-6', stageModelAlias: 'opus' }),
+      ),
+    );
+    expect(html).toContain('<span class="meta-label">Model Alias:</span>');
+    expect(html).toContain('<span class="meta-label">Model ID:</span>');
+    expect(html).toContain('>opus<');
+    expect(html).toContain('>claude-opus-4-6<');
+  });
+
+  it('collapses to a single "Model ID:" label when alias equals the resolved id', () => {
     const html = renderToString(
       runDetailView(makeRun({ stageModel: 'opus', stageModelAlias: 'opus' })),
     );
-    const idCount = (html.match(/<span class="meta-label">ID:<\/span>/g) || [])
-      .length;
-    expect(idCount).toBe(0);
+    const aliasCount = (
+      html.match(/<span class="meta-label">Model Alias:<\/span>/g) || []
+    ).length;
+    expect(aliasCount).toBe(0);
+    expect(html).toContain('<span class="meta-label">Model ID:</span>');
   });
 
-  it('does not render any Model row when no model is recorded', () => {
+  it('does not render any model row when no model is recorded', () => {
     const html = renderToString(runDetailView(makeRun({})));
-    expect(html).not.toContain('<span class="meta-label">Model:</span>');
-    expect(html).not.toContain('<span class="meta-label">ID:</span>');
+    expect(html).not.toContain('<span class="meta-label">Model ID:</span>');
+    expect(html).not.toContain('<span class="meta-label">Model Alias:</span>');
   });
 });
 
-describe('iteration-level Model / ID rendering (multi-iteration tab panel)', () => {
-  // The single-iteration path delegates to stageModel + stage.model_alias
-  // (covered above). Multi-iteration runs render per-iteration model info
-  // from iter.model + iter.model_alias — confirm the same alias/id semantics
-  // apply on that path.
+describe('iteration-level Model Alias / Model ID rendering (multi-iteration tab panel)', () => {
   function makeMultiIterRun(iters) {
     return {
       stages: {
@@ -107,7 +113,7 @@ describe('iteration-level Model / ID rendering (multi-iteration tab panel)', () 
     };
   }
 
-  it('renders Model: <alias> + ID: <id> on a per-iteration row when alias is set', () => {
+  it('renders Model Alias: <alias> + Model ID: <id> on a per-iteration row when alias is set', () => {
     const html = renderToString(
       runDetailView(
         makeMultiIterRun([
@@ -121,13 +127,12 @@ describe('iteration-level Model / ID rendering (multi-iteration tab panel)', () 
         ]),
       ),
     );
-    expect(html).toContain('<span class="meta-label">ID:</span>');
+    expect(html).toContain('<span class="meta-label">Model ID:</span>');
     expect(html).toContain('>glm-ds<');
-    // The second iter has no alias — only a single Model row for it.
-    // Count is at least 2 Model rows total (one per iter).
-    const modelCount = (
-      html.match(/<span class="meta-label">Model:<\/span>/g) || []
+    expect(html).toContain('<span class="meta-label">Model Alias:</span>');
+    const modelIdCount = (
+      html.match(/<span class="meta-label">Model ID:<\/span>/g) || []
     ).length;
-    expect(modelCount).toBeGreaterThanOrEqual(2);
+    expect(modelIdCount).toBeGreaterThanOrEqual(2);
   });
 });

--- a/worca-ui/app/views/run-detail-plan-button-gating.test.js
+++ b/worca-ui/app/views/run-detail-plan-button-gating.test.js
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _ensureRunPlanFetched,
+  _runPlanTextNotFound,
+  runDetailView,
+} from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (template._$litDirective$ && template.values)
+    return template.values[0] || '';
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+      else if (v?._$litDirective$ && v?.values) result += v.values[0] || '';
+    }
+  });
+  return result;
+}
+
+function flush() {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+// ---------------------------------------------------------------------------
+// _planIterationButton completion guard
+// ---------------------------------------------------------------------------
+describe('plan iteration button gating', () => {
+  it('does NOT render View plan button when plan iteration is in_progress', () => {
+    const run = {
+      id: 'run-gate-1',
+      worktree_path: '/tmp/wt',
+      stages: {
+        plan: {
+          status: 'in_progress',
+          iterations: [{ number: 1, status: 'in_progress' }],
+        },
+      },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).not.toContain('btn-view-run-plan');
+    expect(out).not.toContain('View plan');
+  });
+
+  it('renders View plan button when plan iteration is completed', () => {
+    const run = {
+      id: 'run-gate-2',
+      worktree_path: '/tmp/wt',
+      stages: {
+        plan: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed' }],
+        },
+      },
+    };
+    const out = renderToString(runDetailView(run));
+    expect(out).toContain('btn-view-run-plan');
+    expect(out).toContain('View plan · plan-001.md');
+  });
+
+  it('does NOT render View plan button when plan_review iteration is in_progress', () => {
+    const run = {
+      id: 'run-gate-3',
+      worktree_path: '/tmp/wt',
+      stages: {
+        plan: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed' }],
+        },
+        plan_review: {
+          status: 'in_progress',
+          iterations: [{ number: 1, status: 'in_progress' }],
+        },
+      },
+    };
+    const out = renderToString(runDetailView(run));
+    // plan stage button should be present (completed)
+    expect(out).toContain('View plan · plan-001.md');
+    // plan_review button should NOT be present (in_progress)
+    const buttons = out.match(/btn-view-plan-iter/g) || [];
+    // Only 1 button (from plan stage), not 2
+    expect(buttons.length).toBe(1);
+  });
+
+  it('plan_review with approve_with_edits shows revision N+1', () => {
+    const run = {
+      id: 'run-gate-4',
+      worktree_path: '/tmp/wt',
+      stages: {
+        plan: {
+          status: 'completed',
+          iterations: [{ number: 1, status: 'completed' }],
+        },
+        plan_review: {
+          status: 'completed',
+          iterations: [
+            {
+              number: 1,
+              status: 'completed',
+              outcome: 'approve_with_edits',
+            },
+          ],
+        },
+      },
+    };
+    const out = renderToString(runDetailView(run));
+    // plan_review iter 1 with approve_with_edits → rev 2 → plan-002.md
+    expect(out).toContain('View plan · plan-002.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dialog empty states (in_progress vs terminal)
+// ---------------------------------------------------------------------------
+describe('plan dialog empty states', () => {
+  let nextRunId = 0;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete globalThis.fetch;
+  });
+
+  it("shows 'Planner is still writing' when plan stage is in_progress and plan not found", async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    });
+    const runId = `run-dialog-${++nextRunId}`;
+    const run = {
+      id: runId,
+      project: 'proj',
+      worktree_path: '/tmp/wt',
+      stages: { plan: { status: 'in_progress' } },
+    };
+    const rerender = vi.fn();
+
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+
+    expect(_runPlanTextNotFound.has(`${runId}#latest`)).toBe(true);
+  });
+
+  it('marks key as not-found on 404, clears on subsequent success', async () => {
+    const runId = `run-dialog-${++nextRunId}`;
+    const run = {
+      id: runId,
+      project: 'proj',
+      worktree_path: '/tmp/wt',
+      stages: { plan: { status: 'in_progress' } },
+    };
+    const rerender = vi.fn();
+
+    // 404 first
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(''),
+    });
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(_runPlanTextNotFound.has(`${runId}#latest`)).toBe(true);
+
+    // Success after
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('# Plan'),
+    });
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(_runPlanTextNotFound.has(`${runId}#latest`)).toBe(false);
+  });
+});

--- a/worca-ui/app/views/run-detail-plan-cache.test.js
+++ b/worca-ui/app/views/run-detail-plan-cache.test.js
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _ensurePlanItersFetched,
+  _ensureRunPlanFetched,
+} from './run-detail.js';
+
+let nextId = 0;
+function makeRun() {
+  return {
+    id: `plan-cache-${++nextId}`,
+    project: 'proj',
+    worktree_path: '/tmp/wt',
+    stages: { plan: { status: 'completed' } },
+  };
+}
+
+function flush() {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete globalThis.fetch;
+});
+
+// ---------------------------------------------------------------------------
+// _ensureRunPlanFetched (plan text)
+// ---------------------------------------------------------------------------
+describe('plan text cache (_ensureRunPlanFetched)', () => {
+  it('does not cache on 404 — re-fetches on next call', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(''),
+    });
+    const run = makeRun();
+    const rerender = vi.fn();
+
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(rerender).toHaveBeenCalled();
+
+    globalThis.fetch.mockClear();
+    rerender.mockClear();
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(''),
+    });
+
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches successfully after a prior 404', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(''),
+    });
+    const run = makeRun();
+    const rerender = vi.fn();
+
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+
+    globalThis.fetch.mockClear();
+    rerender.mockClear();
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('# My Plan'),
+    });
+
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(rerender).toHaveBeenCalled();
+
+    // Now it should be cached — no more fetches
+    globalThis.fetch.mockClear();
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('caches on success — does NOT re-fetch on next call', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('# Plan'),
+    });
+    const run = makeRun();
+    const rerender = vi.fn();
+
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    globalThis.fetch.mockClear();
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not cache on network error — re-fetches on next call', async () => {
+    globalThis.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
+    const run = makeRun();
+    const rerender = vi.fn();
+
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    globalThis.fetch.mockClear();
+    globalThis.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    _ensureRunPlanFetched(run, null, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _ensurePlanItersFetched (plan iterations)
+// ---------------------------------------------------------------------------
+describe('plan iterations cache (_ensurePlanItersFetched)', () => {
+  it('does not cache on 404 — re-fetches on next call', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({}),
+    });
+    const run = makeRun();
+    const rerender = vi.fn();
+
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    globalThis.fetch.mockClear();
+    rerender.mockClear();
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({}),
+    });
+
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches successfully after a prior 404', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({}),
+    });
+    const run = makeRun();
+    const rerender = vi.fn();
+
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+
+    globalThis.fetch.mockClear();
+    rerender.mockClear();
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ iterations: [{ n: 1, file: 'plan-001.md' }] }),
+    });
+
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    // Now cached
+    globalThis.fetch.mockClear();
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('caches on success — does NOT re-fetch on next call', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ iterations: [{ n: 1, file: 'plan-001.md' }] }),
+    });
+    const run = makeRun();
+    const rerender = vi.fn();
+
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    globalThis.fetch.mockClear();
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not cache on network error — re-fetches on next call', async () => {
+    globalThis.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
+    const run = makeRun();
+    const rerender = vi.fn();
+
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    globalThis.fetch.mockClear();
+    globalThis.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    _ensurePlanItersFetched(run, rerender);
+    await flush();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -45,8 +45,9 @@ import { stageTimelineView } from './stage-timeline.js';
 // W-061: plans are append-only numbered revisions (plan-001.md, …). The dialog
 // lists them and lets the user view any revision; the latest is the current
 // plan. Content is cached per (run, revision); the iteration list per run.
-const _runPlanText = new Map(); // `${runId}#${n|'latest'}` -> markdown | null (404)
+const _runPlanText = new Map(); // `${runId}#${n|'latest'}` -> markdown string
 const _runPlanTextFetching = new Set();
+export const _runPlanTextNotFound = new Set();
 const _runPlanIters = new Map(); // run_id -> [{n, file}]  (empty for legacy runs)
 const _runPlanItersFetching = new Set();
 let _planDialogRunId = null; // null when closed; run_id when open
@@ -69,7 +70,7 @@ function _planTextKey(runId, n) {
   return `${runId}#${n == null ? 'latest' : n}`;
 }
 
-function _ensurePlanItersFetched(run, rerender) {
+export function _ensurePlanItersFetched(run, rerender) {
   const runId = run?.id;
   if (!runId) return;
   if (_runPlanIters.has(runId) || _runPlanItersFetching.has(runId)) return;
@@ -79,28 +80,29 @@ function _ensurePlanItersFetched(run, rerender) {
   })
     .then(async (r) => {
       _runPlanItersFetching.delete(runId);
+      if (!r.ok) {
+        rerender?.();
+        return;
+      }
       let list = [];
-      if (r.ok) {
-        try {
-          const j = await r.json();
-          if (Array.isArray(j?.iterations)) list = j.iterations;
-        } catch {
-          list = [];
-        }
+      try {
+        const j = await r.json();
+        if (Array.isArray(j?.iterations)) list = j.iterations;
+      } catch {
+        list = [];
       }
       _runPlanIters.set(runId, list);
       rerender?.();
     })
     .catch(() => {
       _runPlanItersFetching.delete(runId);
-      _runPlanIters.set(runId, []);
       rerender?.();
     });
 }
 
 // n === null fetches the current (latest) plan via /plan; a number fetches a
 // specific revision via /plan?iteration=N.
-function _ensureRunPlanFetched(run, n, rerender) {
+export function _ensureRunPlanFetched(run, n, rerender) {
   const runId = run?.id;
   if (!runId) return;
   const key = _planTextKey(runId, n);
@@ -114,12 +116,16 @@ function _ensureRunPlanFetched(run, n, rerender) {
   fetch(url, { headers: { Accept: 'text/markdown' } })
     .then(async (r) => {
       _runPlanTextFetching.delete(key);
-      _runPlanText.set(key, r.ok ? await r.text() : null);
+      if (r.ok) {
+        _runPlanText.set(key, await r.text());
+        _runPlanTextNotFound.delete(key);
+      } else {
+        _runPlanTextNotFound.add(key);
+      }
       rerender?.();
     })
     .catch(() => {
       _runPlanTextFetching.delete(key);
-      _runPlanText.set(key, null);
       rerender?.();
     });
 }
@@ -147,6 +153,7 @@ function _planIterationButton(key, iter, run, rerender) {
   // it; in that case surface the editor's output here. Review-mode revisions
   // are produced by the NEXT planner iter, so plan_review iter N still ends
   // at plan-N.
+  if (iter?.status !== 'completed') return nothing;
   const iterNum = iter?.number || 1;
   const isEditOutput =
     key === 'plan_review' && iter?.outcome === 'approve_with_edits';
@@ -246,13 +253,22 @@ function _planArtifactDialog(run, rerender) {
       : nothing;
 
   const body = (() => {
-    if (planText === undefined) {
+    if (planText !== undefined) {
+      return html`<div class="markdown-body">${unsafeHTML(renderMarkdown(planText || ''))}</div>`;
+    }
+    if (_runPlanTextFetching.has(textKey)) {
       return html`<div class="plan-loading"><sl-spinner></sl-spinner> Loading plan…</div>`;
     }
-    if (planText === null) {
+    if (_runPlanTextNotFound.has(textKey)) {
+      const planInProgress =
+        run?.stages?.plan?.status === 'in_progress' ||
+        run?.stages?.plan_review?.status === 'in_progress';
+      if (planInProgress) {
+        return html`<div class="plan-loading">Planner is still writing this revision.</div>`;
+      }
       return html`<div class="plan-error">No plan file found for this run.</div>`;
     }
-    return html`<div class="markdown-body">${unsafeHTML(renderMarkdown(planText || ''))}</div>`;
+    return html`<div class="plan-loading"><sl-spinner></sl-spinner> Loading plan…</div>`;
   })();
   return html`
     <sl-dialog
@@ -698,7 +714,7 @@ function _issuesToMarkdown(issues, stageMode, baseHeading, iterNum) {
       i.suggestion ? `\n  - _Suggestion:_ ${i.suggestion}` : ''
     }`;
   if (stageMode !== 'review_and_edit') {
-    return head + issues.map(row).join('\n') + '\n';
+    return `${head}${issues.map(row).join('\n')}\n`;
   }
   const groups = _groupIssuesByResolution(issues, stageMode);
   const fmt = (h, rows) =>
@@ -1374,19 +1390,15 @@ function timingStripView(startedAt, completedAt, extra = nothing) {
   `;
 }
 
-// Render the Model: (alias) + ID: (resolved id) pair when an alias was
-// recorded on the stage/iteration. Backward-compatible: when model_alias is
-// missing (old runs, plain-model configs) or matches the resolved id, falls
-// back to the single "Model: <id>" label so existing runs render unchanged.
 function _modelInfoView(model, modelAlias) {
   if (!model) return nothing;
   const hasAlias = !!modelAlias && modelAlias !== model;
   if (!hasAlias) {
-    return html`<span class="stage-info-item"><span class="meta-label">Model:</span> <span class="meta-value">${model}</span></span>`;
+    return html`<span class="stage-info-item"><span class="meta-label">Model ID:</span> <span class="meta-value">${model}</span></span>`;
   }
   return html`
-    <span class="stage-info-item"><span class="meta-label">Model:</span> <span class="meta-value">${modelAlias}</span></span>
-    <span class="stage-info-item"><span class="meta-label">ID:</span> <span class="meta-value">${model}</span></span>
+    <span class="stage-info-item"><span class="meta-label">Model Alias:</span> <span class="meta-value">${modelAlias}</span></span>
+    <span class="stage-info-item"><span class="meta-label">Model ID:</span> <span class="meta-value">${model}</span></span>
   `;
 }
 

--- a/worca-ui/e2e/run-detail-model-alias.spec.js
+++ b/worca-ui/e2e/run-detail-model-alias.spec.js
@@ -6,10 +6,10 @@ const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
 // Pin the rendering of the Model / ID label pair end-to-end. The runner
 // records model_alias on each stage and per-iteration when the user-typed
 // alias resolves to a different id (e.g. "glm-ds" -> "opus"); the UI then
-// renders "Model: glm-ds  ID: opus" instead of a single "Model: opus" line.
+// renders "Model Alias: glm-ds  Model ID: opus" instead of a single "Model ID: opus" line.
 // Old runs without the field still render the original single-label form.
 test.describe('run-detail Model / ID rendering', () => {
-  test('renders Model: <alias>  ID: <id> when stage.model_alias is recorded', async ({
+  test('renders Model Alias: <alias>  Model ID: <id> when stage.model_alias is recorded', async ({
     page,
   }) => {
     const ctx = await startServer();
@@ -53,17 +53,17 @@ test.describe('run-detail Model / ID rendering', () => {
       const infoStrip = planPanel.locator('.stage-info-strip').first();
       // Two labels are rendered when the alias differs from the resolved id.
       const labels = infoStrip.locator('.meta-label');
-      await expect(labels.filter({ hasText: 'Model:' })).toHaveCount(1);
-      await expect(labels.filter({ hasText: 'ID:' })).toHaveCount(1);
-      // The alias is the primary "Model:" value, the resolved id is the "ID:" value.
-      await expect(infoStrip).toContainText('Model: glm-ds');
-      await expect(infoStrip).toContainText('ID: opus');
+      await expect(labels.filter({ hasText: 'Model Alias:' })).toHaveCount(1);
+      await expect(labels.filter({ hasText: 'Model ID:' })).toHaveCount(1);
+      // The alias is the primary "Model Alias:" value, the resolved id is the "Model ID:" value.
+      await expect(infoStrip).toContainText('Model Alias: glm-ds');
+      await expect(infoStrip).toContainText('Model ID: opus');
     } finally {
       await ctx.close();
     }
   });
 
-  test('renders only Model: <id> when no alias is recorded (backward-compatible)', async ({
+  test('renders only Model ID: <id> when no alias is recorded (backward-compatible)', async ({
     page,
   }) => {
     const ctx = await startServer();
@@ -107,9 +107,9 @@ test.describe('run-detail Model / ID rendering', () => {
 
       const infoStrip = planPanel.locator('.stage-info-strip').first();
       const labels = infoStrip.locator('.meta-label');
-      await expect(labels.filter({ hasText: 'Model:' })).toHaveCount(1);
-      await expect(labels.filter({ hasText: 'ID:' })).toHaveCount(0);
-      await expect(infoStrip).toContainText('Model: opus');
+      await expect(labels.filter({ hasText: 'Model ID:' })).toHaveCount(1);
+      await expect(labels.filter({ hasText: 'Model Alias:' })).toHaveCount(0);
+      await expect(infoStrip).toContainText('Model ID: opus');
     } finally {
       await ctx.close();
     }

--- a/worca-ui/e2e/run-detail-plan-transitions.spec.js
+++ b/worca-ui/e2e/run-detail-plan-transitions.spec.js
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+test.describe('run-detail PLAN stage transitions', () => {
+  test('no View plan button during in_progress; Model Alias + Model ID visible', async ({
+    page,
+  }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-plan-trans-inprog';
+      seedRun(ctx.worcaDir, runId, {
+        pipeline_status: 'running',
+        stage: 'plan',
+        stages: {
+          plan: {
+            status: 'in_progress',
+            agent: 'planner',
+            model: 'opus',
+            model_alias: 'glm-ds',
+            iterations: [
+              {
+                number: 1,
+                status: 'in_progress',
+                agent: 'planner',
+                model: 'opus',
+                model_alias: 'glm-ds',
+              },
+            ],
+          },
+        },
+      });
+
+      await page.goto(`${ctx.url}/#/history?run=${runId}`, GOTO_OPTS);
+      await expect(page.locator('.run-detail .stage-panels')).toBeVisible({
+        timeout: 8000,
+      });
+
+      const planPanel = page
+        .locator('.stage-panel', {
+          has: page.locator('.stage-panel-label', { hasText: 'PLAN' }),
+        })
+        .first();
+      // in_progress stages auto-expand (?open=${status === 'in_progress'})
+      await expect(planPanel).toHaveAttribute('open', '', { timeout: 5000 });
+
+      await expect(planPanel.locator('.btn-view-run-plan')).toHaveCount(0);
+
+      const infoStrip = planPanel.locator('.stage-info-strip').first();
+      await expect(infoStrip).toContainText('Model Alias:');
+      await expect(infoStrip).toContainText('glm-ds');
+      await expect(infoStrip).toContainText('Model ID:');
+      await expect(infoStrip).toContainText('opus');
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test('View plan button appears on completed; click opens dialog with plan content', async ({
+    page,
+  }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-plan-trans-done';
+      const runDir = join(ctx.worcaDir, 'runs', runId);
+      seedRun(ctx.worcaDir, runId, {
+        pipeline_status: 'running',
+        stage: 'coordinate',
+        stages: {
+          plan: {
+            status: 'completed',
+            agent: 'planner',
+            model: 'opus',
+            model_alias: 'glm-ds',
+            plan_file: join(runDir, 'plan-001.md'),
+            iterations: [
+              {
+                number: 1,
+                status: 'completed',
+                agent: 'planner',
+                model: 'opus',
+                model_alias: 'glm-ds',
+              },
+            ],
+          },
+        },
+      });
+      writeFileSync(
+        join(runDir, 'plan-001.md'),
+        '# Transition Test Plan\n\nThis is the plan content TRANSITIONMARKER.\n',
+        'utf8',
+      );
+
+      await page.goto(`${ctx.url}/#/history?run=${runId}`, GOTO_OPTS);
+      await expect(page.locator('.run-detail .stage-panels')).toBeVisible({
+        timeout: 8000,
+      });
+
+      const planPanel = page
+        .locator('.stage-panel', {
+          has: page.locator('.stage-panel-label', { hasText: 'PLAN' }),
+        })
+        .first();
+      await planPanel.locator('.stage-panel-header').click();
+      await expect(planPanel).toHaveAttribute('open', '', { timeout: 5000 });
+
+      const planBtn = planPanel.locator('.btn-view-run-plan').first();
+      await expect(planBtn).toContainText('plan-001.md');
+      await planBtn.click();
+
+      const dialog = page.locator('sl-dialog.run-plan-dialog');
+      await expect(dialog).toBeVisible({ timeout: 5000 });
+      await expect(dialog).toContainText('TRANSITIONMARKER', { timeout: 5000 });
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/package-lock.json
+++ b/worca-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worca/ui",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worca/ui",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.20.1",


### PR DESCRIPTION
## Summary

- **Plan button gating**: suppress "View plan" button while PLAN iteration is still `in_progress` — prevents clicking a confident filename that 404s and poisons the session cache
- **Model alias visibility**: widen `model_alias` recording from alt-endpoint-only to any `raw_model != model_id`, so the user's alias (e.g. `opus`) is visible in the UI. Introduce `cost_alias` for the pricing-override path (previously overloaded on `model_alias`). Relabel to `Model Alias:` / `Model ID:` for clarity
- **Plan cache poisoning**: stop caching 404s and fetch errors as `null` — only cache successful responses. Track not-found state in a separate `Set` so the dialog distinguishes "planner still writing" from "no plan exists"

## Test plan

- [x] Python tests pass (`pytest tests/test_stages.py` — 131 tests)
- [x] Vitest tests pass (43 tests across 4 test files: plan-button-gating, plan-cache, model-alias, dispatch)
- [x] Biome lint clean
- [x] Ruff lint clean
- [x] Playwright e2e (`run-detail-plan-transitions.spec.js`, `run-detail-model-alias.spec.js`) — CI green (ui-e2e-tests ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
