### PR TITLE
fix: restore pipeline_template from status.json on resume

### DIFF
--- a/src/worca/cli/main.py
+++ b/src/worca/cli/main.py
@@ -189,6 +189,12 @@ def create_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--resume", action="store_true", help="Resume from last checkpoint")
     run_parser.add_argument("--source", dest="source_arg", default=None, help="Work source")
     run_parser.add_argument("--template", default=None, help="Template ID to apply before running")
+    run_parser.add_argument(
+        "--force-template-change",
+        action="store_true",
+        default=False,
+        help="Allow switching to a different template when resuming a run",
+    )
     run_parser.add_argument("--param", action="append", metavar="KEY=VALUE", help="Template parameter override (repeatable)")
     run_parser.add_argument(
         "--worktree",

--- a/src/worca/cli/run_pipeline.py
+++ b/src/worca/cli/run_pipeline.py
@@ -86,6 +86,8 @@ def cmd_run(args: Namespace) -> None:
         cmd.extend(["--source", args.source_arg])
     if args.template:
         cmd.extend(["--template", args.template])
+    if args.force_template_change:
+        cmd.append("--force-template-change")
     for p in args.param or []:
         cmd.extend(["--param", p])
 

--- a/src/worca/events/types.py
+++ b/src/worca/events/types.py
@@ -123,6 +123,13 @@ PREFLIGHT_SKIPPED   = "pipeline.preflight.skipped"
 PLAN_EDITED = "pipeline.plan_review.edited"
 
 # ---------------------------------------------------------------------------
+# Template lifecycle (2 events)
+# ---------------------------------------------------------------------------
+
+TEMPLATE_APPLIED = "pipeline.template.applied"
+TEMPLATE_DROPPED = "pipeline.template.dropped"
+
+# ---------------------------------------------------------------------------
 # Learn stage events (2 events)
 # ---------------------------------------------------------------------------
 
@@ -874,6 +881,30 @@ def plan_edited_payload(
     if original_plan_path is not None:
         p["original_plan_path"] = original_plan_path
     return p
+
+
+# ---------------------------------------------------------------------------
+# Template lifecycle payload builders
+# ---------------------------------------------------------------------------
+
+def template_applied_payload(
+    template_id: str,
+    source: str,
+    tier: str = None,
+) -> dict:
+    """source: 'launch' | 'resume' | 'default'; tier: 'builtin' | 'project' | 'user'."""
+    p: dict = {"template_id": template_id, "source": source}
+    if tier is not None:
+        p["tier"] = tier
+    return p
+
+
+def template_dropped_payload(
+    template_id: str,
+    reason: str,
+) -> dict:
+    """reason: 'not_found' | 'resolve_error' | 'missing_on_resume'."""
+    return {"template_id": template_id, "reason": reason}
 
 
 # ---------------------------------------------------------------------------

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -95,6 +95,8 @@ from worca.events.types import (
     learn_completed_payload, learn_failed_payload,
     PLAN_EDITED, plan_edited_payload,
     GUIDE_CONFLICT, guide_conflict_payload,
+    TEMPLATE_APPLIED, TEMPLATE_DROPPED,
+    template_applied_payload, template_dropped_payload,
 )
 
 # Maps pipeline stages to their user-message block files. The stage's
@@ -2225,6 +2227,32 @@ def run_pipeline(
             if _branch_just_created:
                 emit_event(ctx, GIT_BRANCH_CREATED, git_branch_created_payload(
                     branch=branch_name,
+                ))
+
+            # Emit template lifecycle event now that EventContext is ready.
+            _persisted_tmpl = status.get("pipeline_template")
+            _is_resume = resume_stage is not None
+            if _is_resume and _persisted_tmpl and isinstance(_persisted_tmpl, str) and not pipeline_template:
+                # Regression guard: resumed run had a template persisted but
+                # the caller didn't pass pipeline_template (template wasn't
+                # restored). Shouldn't fire after the Phase 1 fix, but catches
+                # regressions where the template is silently dropped on resume.
+                _dropped_id = _persisted_tmpl.split(":", 1)[-1]
+                emit_event(ctx, TEMPLATE_DROPPED, template_dropped_payload(
+                    template_id=_dropped_id,
+                    reason="missing_on_resume",
+                ))
+            elif _persisted_tmpl and isinstance(_persisted_tmpl, str):
+                _source = "resume" if _is_resume else "launch"
+                _parts = _persisted_tmpl.split(":", 1)
+                if len(_parts) == 2:
+                    _tier, _tmpl_id = _parts
+                else:
+                    _tier, _tmpl_id = None, _parts[0]
+                emit_event(ctx, TEMPLATE_APPLIED, template_applied_payload(
+                    template_id=_tmpl_id,
+                    source=_source,
+                    tier=_tier,
                 ))
 
         context = {

--- a/src/worca/scripts/run_pipeline.py
+++ b/src/worca/scripts/run_pipeline.py
@@ -46,6 +46,8 @@ def create_parser():
     parser.add_argument("--worktree", action="store_true",
                         help="Worktree mode: skip branch creation and register in multi-pipeline registry")
     parser.add_argument("--template", help="Template ID to apply before running")
+    parser.add_argument("--force-template-change", action="store_true", default=False,
+                        help="Allow --template to override the persisted pipeline_template on resume")
     parser.add_argument("--param", action="append", metavar="KEY=VALUE",
                         help="Template parameter override (repeatable)")
     parser.add_argument("--guide", action="append", metavar="PATH",
@@ -211,6 +213,24 @@ def main():
         else:
             print(f"error: cannot resume — status file not found: {status_file}", file=sys.stderr)
             raise SystemExit(2)
+        # Restore pipeline_template from status.json when --template not explicitly passed.
+        _explicit_template = args.template
+        if not args.template:
+            _persisted_template = existing.get("pipeline_template")
+            if isinstance(_persisted_template, str) and _persisted_template:
+                args.template = _persisted_template.split(":")[1] if ":" in _persisted_template else _persisted_template
+        elif not args.force_template_change:
+            _persisted_template = existing.get("pipeline_template")
+            if isinstance(_persisted_template, str) and _persisted_template:
+                _persisted_bare = _persisted_template.split(":")[1] if ":" in _persisted_template else _persisted_template
+                if _explicit_template != _persisted_bare:
+                    print(
+                        f"error: --template {_explicit_template!r} conflicts with persisted "
+                        f"pipeline_template {_persisted_template!r}; "
+                        "use --force-template-change to override",
+                        file=sys.stderr,
+                    )
+                    raise SystemExit(2)
         plan_file = args.plan
         print(f"Resuming pipeline: {work_request.title}")
     else:
@@ -308,6 +328,22 @@ def main():
 
     effective_settings_path = _temp_settings_path if _template_id else args.settings
 
+    # On resume the run_dir is already known — write forensic snapshot before the run
+    # so crashes/kills don't leave the dir without template evidence.
+    if args.resume and _template_id and _resolver:
+        _resume_run_dir = os.path.dirname(os.path.abspath(status_file))
+        try:
+            _resolver.snapshot_to_run(_template_id, _resume_run_dir, _params)
+        except Exception as snap_err:
+            print(f"warning: template snapshot failed: {snap_err}", file=sys.stderr)
+        if _merged_settings:
+            try:
+                Path(_resume_run_dir, "settings.json").write_text(
+                    json.dumps(_merged_settings, indent=2), encoding="utf-8"
+                )
+            except OSError:
+                pass
+
     try:
         effective_status_path = os.path.join(args.status_dir, "status.json")
         status = run_pipeline(
@@ -326,8 +362,9 @@ def main():
             run_id=args.run_id,
         )
 
-        # Snapshot template to run dir and write merged settings for traceability
-        if _template_id and _resolver and status.get("run_id"):
+        # Snapshot template to run dir and write merged settings for traceability.
+        # Resume path: already written before run_pipeline() — skip here to avoid duplicates.
+        if not args.resume and _template_id and _resolver and status.get("run_id"):
             run_dir = os.path.join(args.status_dir, "runs", status["run_id"])
             try:
                 _resolver.snapshot_to_run(_template_id, run_dir, _params)

--- a/tests/integration/test_resume_e2e.py
+++ b/tests/integration/test_resume_e2e.py
@@ -262,3 +262,105 @@ def test_resume_emits_run_completed_in_run_dir_events(pipeline_env):
         f"final terminal event must be pipeline.run.completed; "
         f"got terminals: {[e.get('event_type') for e in terminals]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Resume preserves the template-pinned model alias for the implementer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.skipif(sys.platform == "win32", reason="signal-based tests require Unix")
+def test_resume_preserves_template_model_alias(pipeline_env):
+    """SIGKILL mid-implementer on a template-pinned run must result in the
+    resumed iteration using the *template's* model alias, not the project
+    default.
+
+    Reproduction scenario for the original bug: without the fix, resume
+    re-resolved the model from project settings (ignoring the persisted
+    ``pipeline_template`` in status.json), so the implementer ran with the
+    project default model alias instead of the template-pinned one.
+
+    Setup:
+    - Write a project-level template (``test-impl-alias``) that pins
+      ``agents.implementer.model`` to a custom alias ``"test-impl-alias"``
+      mapped to ``claude-sonnet-4-5`` in ``worca.models``.
+    - The project settings keep the default implementer model (``"sonnet"``
+      resolving to a different ID), so the alias divergence is detectable.
+    - Launch with ``--template test-impl-alias``, SIGKILL mid-implementer.
+    - Resume WITHOUT ``--template`` — the runner must restore the template
+      from ``status.json``'s ``pipeline_template`` field.
+    - Assert every implementer iteration recorded after resume carries
+      ``model_alias == "test-impl-alias"``.
+    """
+    # 1. Write the template into the project's .claude/templates/ directory.
+    tmpl_dir = pipeline_env.project / ".claude" / "templates" / "test-impl-alias"
+    tmpl_dir.mkdir(parents=True, exist_ok=True)
+    template_json = {
+        "id": "test-impl-alias",
+        "name": "Test Impl Alias",
+        "description": "Template that pins implementer to a custom model alias.",
+        "config": {
+            "agents": {
+                "implementer": {"model": "test-impl-alias", "max_turns": 5}
+            }
+        },
+    }
+    (tmpl_dir / "template.json").write_text(json.dumps(template_json))
+
+    # 2. Add the alias → real model-id mapping in settings so resolution
+    #    succeeds (mock_claude ignores the model flag, but the runner must be
+    #    able to resolve the alias to avoid an error at start-up).
+    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings = json.loads(settings_path.read_text())
+    settings.setdefault("worca", {}).setdefault("models", {})
+    # Map the alias to an actual Claude model ID
+    settings["worca"]["models"]["test-impl-alias"] = "claude-sonnet-4-5-20241022"
+    settings_path.write_text(json.dumps(settings, indent=2))
+
+    # 3. Crash mid-implementer on first run (template-pinned).
+    first = run_and_act(
+        pipeline_env,
+        _HANG_AT_IMPLEMENT,
+        send_sigkill,
+        act_after_stage="implement",
+        timeout=20,
+        extra_args=["--template", "test-impl-alias"],
+    )
+    assert first.status.get("pipeline_status") not in (
+        "completed", "failed", "interrupted"
+    ), (
+        f"first run should be non-terminal after SIGKILL; "
+        f"got {first.status.get('pipeline_status')!r}"
+    )
+    # Confirm template was recorded in status.json
+    assert "test-impl-alias" in (first.status.get("pipeline_template") or ""), (
+        f"pipeline_template not recorded; status: {first.status.get('pipeline_template')!r}"
+    )
+
+    # 4. Resume without --template — template must be restored from status.json.
+    resumed = pipeline_env.run(_ALL_SUCCEED, extra_args=["--resume"], timeout=60)
+    assert resumed.returncode == 0, (
+        f"resume should complete cleanly; rc={resumed.returncode}\n"
+        f"stderr: {resumed.stderr[:500]}"
+    )
+    assert resumed.status.get("pipeline_status") == "completed"
+
+    # 5. Every implementer iteration written during/after resume must carry
+    #    the template-pinned alias — not the project default ("sonnet" / None).
+    implement_stage = resumed.status.get("stages", {}).get("implement", {})
+    iterations = implement_stage.get("iterations") or []
+    assert iterations, "expected at least one implementer iteration after resume"
+
+    bad = [
+        it for it in iterations
+        if it.get("model_alias") != "test-impl-alias"
+    ]
+    assert not bad, (
+        f"resumed implementer iterations have wrong model_alias "
+        f"(expected 'test-impl-alias' for all):\n"
+        + "\n".join(
+            f"  iter {it.get('number')}: model_alias={it.get('model_alias')!r}"
+            for it in bad
+        )
+    )

--- a/tests/integration/test_resume_e2e.py
+++ b/tests/integration/test_resume_e2e.py
@@ -357,8 +357,8 @@ def test_resume_preserves_template_model_alias(pipeline_env):
         if it.get("model_alias") != "test-impl-alias"
     ]
     assert not bad, (
-        f"resumed implementer iterations have wrong model_alias "
-        f"(expected 'test-impl-alias' for all):\n"
+        "resumed implementer iterations have wrong model_alias "
+        "(expected 'test-impl-alias' for all):\n"
         + "\n".join(
             f"  iter {it.get('number')}: model_alias={it.get('model_alias')!r}"
             for it in bad

--- a/tests/test_cli_run_pipeline.py
+++ b/tests/test_cli_run_pipeline.py
@@ -182,3 +182,58 @@ class TestCmdRunWorktree:
         argv = mock_run.call_args[0][0]
         assert "run_pipeline.py" in argv[1]
         assert "run_worktree.py" not in argv[1]
+
+
+class TestForceTemplateChangeFlag:
+    """--force-template-change is accepted and forwarded to the subprocess."""
+
+    def _scaffold(self, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        scripts = tmp_path / ".claude" / "worca" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "run_pipeline.py").write_text("")
+        monkeypatch.chdir(tmp_path)
+
+    def test_force_template_change_accepted_by_parser(self):
+        from worca.cli.main import create_parser
+        parser = create_parser()
+        args = parser.parse_args(["run", "--template", "t1", "--force-template-change"])
+        assert args.force_template_change is True
+
+    def test_force_template_change_defaults_false(self):
+        from worca.cli.main import create_parser
+        parser = create_parser()
+        args = parser.parse_args(["run", "--template", "t1"])
+        assert args.force_template_change is False
+
+    def test_force_template_change_forwarded_to_subprocess(self, tmp_path, monkeypatch):
+        self._scaffold(tmp_path, monkeypatch)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            from worca.cli.main import main
+            with pytest.raises(SystemExit):
+                main(["run", "--template", "t1", "--force-template-change"])
+        argv = mock_run.call_args[0][0]
+        assert "--force-template-change" in argv
+
+    def test_force_template_change_not_forwarded_when_absent(self, tmp_path, monkeypatch):
+        self._scaffold(tmp_path, monkeypatch)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            from worca.cli.main import main
+            with pytest.raises(SystemExit):
+                main(["run", "--template", "t1"])
+        argv = mock_run.call_args[0][0]
+        assert "--force-template-change" not in argv
+
+    def test_template_still_forwarded_alongside_force_flag(self, tmp_path, monkeypatch):
+        self._scaffold(tmp_path, monkeypatch)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            from worca.cli.main import main
+            with pytest.raises(SystemExit):
+                main(["run", "--template", "bugfix", "--force-template-change"])
+        argv = mock_run.call_args[0][0]
+        assert "--template" in argv
+        assert argv[argv.index("--template") + 1] == "bugfix"
+        assert "--force-template-change" in argv

--- a/tests/test_event_types.py
+++ b/tests/test_event_types.py
@@ -95,6 +95,9 @@ PIPELINE_CONSTANTS = [
     # Learn stage uses generic STAGE_STARTED/COMPLETED/FAILED with stage="learn"
     # Plan review detail (1)
     ("PLAN_EDITED", "pipeline.plan_review.edited"),
+    # Template lifecycle (2)
+    ("TEMPLATE_APPLIED", "pipeline.template.applied"),
+    ("TEMPLATE_DROPPED", "pipeline.template.dropped"),
 ]
 
 CONTROL_CONSTANTS = [
@@ -134,18 +137,19 @@ def test_pipeline_constant_values_unique():
 
 
 def test_total_pipeline_constants():
-    """There must be exactly 53 pipeline.* outbound constants.
+    """There must be exactly 55 pipeline.* outbound constants.
 
     48 original + 2 dedicated learn events (pipeline.learn.completed/failed)
-    + 1 dispatch_allowed hook event + 1 RUN_CANCELLED + 1 PLAN_EDITED = 53.
+    + 1 dispatch_allowed hook event + 1 RUN_CANCELLED + 1 PLAN_EDITED
+    + 2 template lifecycle events = 55.
     """
     import worca.events.types as T
     pipeline_vals = [
         v for k, v in vars(T).items()
         if k.isupper() and isinstance(v, str) and v.startswith("pipeline.")
     ]
-    assert len(pipeline_vals) == 53, (
-        f"Expected 53 pipeline.* constants, found {len(pipeline_vals)}"
+    assert len(pipeline_vals) == 55, (
+        f"Expected 55 pipeline.* constants, found {len(pipeline_vals)}"
     )
 
 
@@ -229,6 +233,9 @@ EXPECTED_BUILDERS = [
     # pipeline.learn.* — removed; learn uses generic stage events
     # pipeline.plan_review.*
     "plan_edited_payload",
+    # pipeline.template.*
+    "template_applied_payload",
+    "template_dropped_payload",
     # control.*
     "control_milestone_approve_payload",
     "control_pipeline_pause_payload",
@@ -1105,3 +1112,55 @@ def test_plan_edited_payload_original_plan_path_omitted_when_none():
         issue_counts={"critical": 0, "major": 0, "minor": 0, "suggestion": 0},
     )
     assert "original_plan_path" not in p
+
+
+# ---------------------------------------------------------------------------
+# Template lifecycle payload builders
+# ---------------------------------------------------------------------------
+
+def test_template_applied_payload_required_fields():
+    from worca.events.types import template_applied_payload
+    p = template_applied_payload(
+        template_id="my-template",
+        source="launch",
+        tier="project",
+    )
+    assert p["template_id"] == "my-template"
+    assert p["source"] == "launch"
+    assert p["tier"] == "project"
+    assert isinstance(p, dict)
+
+
+def test_template_applied_payload_source_values():
+    from worca.events.types import template_applied_payload
+    for source in ("launch", "resume", "default"):
+        p = template_applied_payload(
+            template_id="tmpl", source=source, tier="builtin",
+        )
+        assert p["source"] == source
+
+
+def test_template_applied_payload_tier_optional():
+    from worca.events.types import template_applied_payload
+    p = template_applied_payload(template_id="tmpl", source="launch")
+    assert p["template_id"] == "tmpl"
+    assert p["source"] == "launch"
+    assert "tier" not in p
+
+
+def test_template_dropped_payload_required_fields():
+    from worca.events.types import template_dropped_payload
+    p = template_dropped_payload(
+        template_id="my-template",
+        reason="not_found",
+    )
+    assert p["template_id"] == "my-template"
+    assert p["reason"] == "not_found"
+    assert isinstance(p, dict)
+
+
+def test_template_dropped_payload_reason_values():
+    from worca.events.types import template_dropped_payload
+    for reason in ("not_found", "resolve_error", "missing_on_resume"):
+        p = template_dropped_payload(template_id="tmpl", reason=reason)
+        assert p["reason"] == reason

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -308,6 +308,16 @@ class TestTemplateArgs:
         args = parser.parse_args(["--prompt", "Fix"])
         assert args.param is None
 
+    def test_force_template_change_default_false(self):
+        parser = create_parser()
+        args = parser.parse_args(["--prompt", "Fix"])
+        assert args.force_template_change is False
+
+    def test_force_template_change_flag_sets_true(self):
+        parser = create_parser()
+        args = parser.parse_args(["--prompt", "Fix", "--force-template-change"])
+        assert args.force_template_change is True
+
 
 class TestParseParams:
     """Test the _parse_params helper."""
@@ -887,6 +897,503 @@ class TestPipelineTemplateFormatting:
 
         call_kwargs = mock_run_pipeline.call_args[1]
         assert call_kwargs.get("pipeline_template") is None
+
+
+class TestResumeRestoresPipelineTemplate:
+    """On resume, pipeline_template from status.json is restored when --template not passed."""
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_restores_template_from_status(self, mock_run_pipeline, tmp_path):
+        """When resuming without --template, persisted pipeline_template is applied."""
+        from worca.scripts.run_pipeline import main
+
+        worca_dir = tmp_path / ".worca"
+        run_id = "20260601-120000-000-abcd"
+        run_dir = worca_dir / "runs" / run_id
+        run_dir.mkdir(parents=True)
+        status = {
+            "pipeline_status": "paused",
+            "run_id": run_id,
+            "pipeline_template": "worca:bugfix",
+            "work_request": {
+                "source_type": "prompt",
+                "title": "Fix bug",
+                "description": "desc",
+            },
+        }
+        (run_dir / "status.json").write_text(json.dumps(status))
+        mock_run_pipeline.return_value = {"pipeline_status": "completed", "run_id": run_id}
+
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps({"worca": {}}))
+
+        mock_resolver = MagicMock()
+        mock_resolver.apply.return_value = {}
+        mock_tmpl = MagicMock()
+        mock_tmpl.agents_dir = None
+        mock_tmpl.tier = "builtin"
+        mock_resolver.get.return_value = mock_tmpl
+
+        with patch("sys.argv", [
+            "run_pipeline.py",
+            "--resume",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with patch("worca.scripts.run_pipeline._make_template_resolver", return_value=mock_resolver):
+                main()
+
+        call_kwargs = mock_run_pipeline.call_args[1]
+        assert call_kwargs.get("pipeline_template") == "worca:bugfix"
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_explicit_template_overrides_status_with_force(self, mock_run_pipeline, tmp_path):
+        """When resuming with --template and --force-template-change, explicit flag wins."""
+        from worca.scripts.run_pipeline import main
+
+        worca_dir = tmp_path / ".worca"
+        run_id = "20260601-120000-000-efgh"
+        run_dir = worca_dir / "runs" / run_id
+        run_dir.mkdir(parents=True)
+        status = {
+            "pipeline_status": "paused",
+            "run_id": run_id,
+            "pipeline_template": "worca:bugfix",
+            "work_request": {
+                "source_type": "prompt",
+                "title": "Fix bug",
+                "description": "desc",
+            },
+        }
+        (run_dir / "status.json").write_text(json.dumps(status))
+        mock_run_pipeline.return_value = {"pipeline_status": "completed", "run_id": run_id}
+
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps({"worca": {}}))
+
+        mock_resolver = MagicMock()
+        mock_resolver.apply.return_value = {}
+        mock_tmpl = MagicMock()
+        mock_tmpl.agents_dir = None
+        mock_tmpl.tier = "builtin"
+        mock_resolver.get.return_value = mock_tmpl
+
+        with patch("sys.argv", [
+            "run_pipeline.py",
+            "--resume",
+            "--template", "hotfix",
+            "--force-template-change",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with patch("worca.scripts.run_pipeline._make_template_resolver", return_value=mock_resolver):
+                main()
+
+        call_kwargs = mock_run_pipeline.call_args[1]
+        assert call_kwargs.get("pipeline_template") == "worca:hotfix"
+
+    def test_resume_conflicting_template_exits_2(self, tmp_path, capsys):
+        """Resuming with --template that conflicts with persisted template exits 2."""
+        from worca.scripts.run_pipeline import main
+
+        worca_dir = tmp_path / ".worca"
+        run_id = "20260601-120000-000-conf"
+        run_dir = worca_dir / "runs" / run_id
+        run_dir.mkdir(parents=True)
+        status = {
+            "pipeline_status": "paused",
+            "run_id": run_id,
+            "pipeline_template": "worca:bugfix",
+            "work_request": {
+                "source_type": "prompt",
+                "title": "Fix bug",
+                "description": "desc",
+            },
+        }
+        (run_dir / "status.json").write_text(json.dumps(status))
+
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps({"worca": {}}))
+
+        with patch("sys.argv", [
+            "run_pipeline.py",
+            "--resume",
+            "--template", "hotfix",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "hotfix" in captured.err
+        assert "bugfix" in captured.err
+
+    def test_resume_matching_template_no_conflict(self, tmp_path):
+        """Resuming with --template matching persisted bare ID does not exit."""
+        from worca.scripts.run_pipeline import main
+
+        worca_dir = tmp_path / ".worca"
+        run_id = "20260601-120000-000-match"
+        run_dir = worca_dir / "runs" / run_id
+        run_dir.mkdir(parents=True)
+        status = {
+            "pipeline_status": "paused",
+            "run_id": run_id,
+            "pipeline_template": "worca:bugfix",
+            "work_request": {
+                "source_type": "prompt",
+                "title": "Fix bug",
+                "description": "desc",
+            },
+        }
+        (run_dir / "status.json").write_text(json.dumps(status))
+
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps({"worca": {}}))
+
+        mock_resolver = MagicMock()
+        mock_resolver.apply.return_value = {}
+        mock_tmpl = MagicMock()
+        mock_tmpl.agents_dir = None
+        mock_tmpl.tier = "builtin"
+        mock_resolver.get.return_value = mock_tmpl
+
+        with patch("worca.scripts.run_pipeline.run_pipeline") as mock_run:
+            mock_run.return_value = {"pipeline_status": "completed", "run_id": run_id}
+            with patch("sys.argv", [
+                "run_pipeline.py",
+                "--resume",
+                "--template", "bugfix",
+                "--settings", str(settings_path),
+                "--status-dir", str(worca_dir),
+            ]):
+                with patch("worca.scripts.run_pipeline._make_template_resolver", return_value=mock_resolver):
+                    main()  # should not raise
+
+        mock_run.assert_called_once()
+
+    def test_resume_force_template_change_allows_different_template(self, tmp_path):
+        """--force-template-change bypasses conflict guard even when templates differ."""
+        from worca.scripts.run_pipeline import main
+
+        worca_dir = tmp_path / ".worca"
+        run_id = "20260601-120000-000-force"
+        run_dir = worca_dir / "runs" / run_id
+        run_dir.mkdir(parents=True)
+        status = {
+            "pipeline_status": "paused",
+            "run_id": run_id,
+            "pipeline_template": "project:special",
+            "work_request": {
+                "source_type": "prompt",
+                "title": "Fix bug",
+                "description": "desc",
+            },
+        }
+        (run_dir / "status.json").write_text(json.dumps(status))
+
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps({"worca": {}}))
+
+        mock_resolver = MagicMock()
+        mock_resolver.apply.return_value = {}
+        mock_tmpl = MagicMock()
+        mock_tmpl.agents_dir = None
+        mock_tmpl.tier = "builtin"
+        mock_resolver.get.return_value = mock_tmpl
+
+        with patch("worca.scripts.run_pipeline.run_pipeline") as mock_run:
+            mock_run.return_value = {"pipeline_status": "completed", "run_id": run_id}
+            with patch("sys.argv", [
+                "run_pipeline.py",
+                "--resume",
+                "--template", "hotfix",
+                "--force-template-change",
+                "--settings", str(settings_path),
+                "--status-dir", str(worca_dir),
+            ]):
+                with patch("worca.scripts.run_pipeline._make_template_resolver", return_value=mock_resolver):
+                    main()  # should not raise
+
+        mock_run.assert_called_once()
+
+
+class TestResumeTemplateRestoration:
+    """Unit tests for pipeline_template restoration and conflict guard on resume.
+
+    Tests use pipeline_template: "project:my-template" as the canonical persisted value.
+    """
+
+    def _make_status(self, base_dir, run_id, pipeline_template="project:my-template"):
+        """Write status.json with a paused run under base_dir/.worca/runs/run_id/."""
+        worca_dir = base_dir / ".worca"
+        run_dir = worca_dir / "runs" / run_id
+        run_dir.mkdir(parents=True)
+        status = {
+            "pipeline_status": "paused",
+            "run_id": run_id,
+            "work_request": {
+                "source_type": "prompt",
+                "title": "Template restore test",
+                "description": "test",
+            },
+        }
+        if pipeline_template is not None:
+            status["pipeline_template"] = pipeline_template
+        (run_dir / "status.json").write_text(json.dumps(status))
+        return worca_dir
+
+    def _make_settings(self, base_dir, worca_config=None):
+        settings_path = base_dir / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps({"worca": worca_config or {}}))
+        return settings_path
+
+    def _mock_resolver(self, tier="project"):
+        resolver = MagicMock()
+        resolver.apply.return_value = {}
+        tmpl = MagicMock()
+        tmpl.agents_dir = None
+        tmpl.tier = tier
+        resolver.get.return_value = tmpl
+        return resolver
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_restores_pipeline_template_from_status(self, mock_run_pipeline, tmp_path):
+        """Resume without --template reads pipeline_template from status.json and applies it."""
+        from worca.scripts.run_pipeline import main
+
+        run_id = "20260601-trt-0001-aaaa"
+        worca_dir = self._make_status(tmp_path, run_id, "project:my-template")
+        settings_path = self._make_settings(tmp_path)
+        mock_run_pipeline.return_value = {"pipeline_status": "completed", "run_id": run_id}
+        mock_resolver = self._mock_resolver("project")
+
+        with patch("sys.argv", [
+            "run_pipeline.py", "--resume",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with patch("worca.scripts.run_pipeline._make_template_resolver",
+                       return_value=mock_resolver):
+                main()
+
+        # Bare ID extracted from "project:my-template" and passed to apply()
+        mock_resolver.apply.assert_called_once()
+        assert mock_resolver.apply.call_args[0][0] == "my-template"
+        # Temp (merged) settings file was used, not the original
+        call_kwargs = mock_run_pipeline.call_args[1]
+        assert call_kwargs["settings_path"] != str(settings_path)
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_without_persisted_template_falls_back_to_default(
+        self, mock_run_pipeline, tmp_path
+    ):
+        """Resume with no pipeline_template in status.json falls back to worca.default_template."""
+        from worca.scripts.run_pipeline import main
+
+        run_id = "20260601-trt-0002-bbbb"
+        # pipeline_template=None → key absent from status.json
+        worca_dir = self._make_status(tmp_path, run_id, pipeline_template=None)
+        settings_path = self._make_settings(tmp_path, {"default_template": "quick-fix"})
+        mock_run_pipeline.return_value = {"pipeline_status": "completed", "run_id": run_id}
+        mock_resolver = self._mock_resolver("builtin")
+
+        with patch("sys.argv", [
+            "run_pipeline.py", "--resume",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with patch("worca.scripts.run_pipeline._make_template_resolver",
+                       return_value=mock_resolver):
+                main()
+
+        # Fell through to worca.default_template
+        mock_resolver.apply.assert_called_once()
+        assert mock_resolver.apply.call_args[0][0] == "quick-fix"
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_with_explicit_matching_template_succeeds(
+        self, mock_run_pipeline, tmp_path
+    ):
+        """--template my-template on resume matches persisted project:my-template — no error."""
+        from worca.scripts.run_pipeline import main
+
+        run_id = "20260601-trt-0003-cccc"
+        worca_dir = self._make_status(tmp_path, run_id, "project:my-template")
+        settings_path = self._make_settings(tmp_path)
+        mock_run_pipeline.return_value = {"pipeline_status": "completed", "run_id": run_id}
+        mock_resolver = self._mock_resolver("project")
+
+        with patch("sys.argv", [
+            "run_pipeline.py", "--resume",
+            "--template", "my-template",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with patch("worca.scripts.run_pipeline._make_template_resolver",
+                       return_value=mock_resolver):
+                main()  # must not raise
+
+        mock_run_pipeline.assert_called_once()
+
+    def test_resume_with_conflicting_template_errors(self, tmp_path, capsys):
+        """--template other-template conflicts with persisted project:my-template → SystemExit(2)."""
+        from worca.scripts.run_pipeline import main
+
+        run_id = "20260601-trt-0004-dddd"
+        worca_dir = self._make_status(tmp_path, run_id, "project:my-template")
+        settings_path = self._make_settings(tmp_path)
+
+        with patch("sys.argv", [
+            "run_pipeline.py", "--resume",
+            "--template", "other-template",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "other-template" in captured.err
+        assert "my-template" in captured.err
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_with_conflicting_template_force_override(
+        self, mock_run_pipeline, tmp_path
+    ):
+        """--force-template-change bypasses the conflict guard; explicit --template wins."""
+        from worca.scripts.run_pipeline import main
+
+        run_id = "20260601-trt-0005-eeee"
+        worca_dir = self._make_status(tmp_path, run_id, "project:my-template")
+        settings_path = self._make_settings(tmp_path)
+        mock_run_pipeline.return_value = {"pipeline_status": "completed", "run_id": run_id}
+        mock_resolver = self._mock_resolver("builtin")
+
+        with patch("sys.argv", [
+            "run_pipeline.py", "--resume",
+            "--template", "other-template",
+            "--force-template-change",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with patch("worca.scripts.run_pipeline._make_template_resolver",
+                       return_value=mock_resolver):
+                main()  # must not raise
+
+        # The override template was applied, not the persisted one
+        mock_resolver.apply.assert_called_once()
+        assert mock_resolver.apply.call_args[0][0] == "other-template"
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_handles_malformed_pipeline_template(self, mock_run_pipeline, tmp_path):
+        """Malformed pipeline_template (empty string, non-string) is ignored gracefully."""
+        from worca.scripts.run_pipeline import main
+
+        for bad_value, label in [("", "empty"), (42, "int"), (None, "null")]:
+            sub = tmp_path / label
+            sub.mkdir()
+            run_id = "20260601-trt-0006-ffff"
+            worca_dir = self._make_status(sub, run_id, pipeline_template=bad_value)
+            settings_path = self._make_settings(sub)
+            mock_run_pipeline.reset_mock()
+            mock_run_pipeline.return_value = {"pipeline_status": "completed", "run_id": run_id}
+
+            with patch("sys.argv", [
+                "run_pipeline.py", "--resume",
+                "--settings", str(settings_path),
+                "--status-dir", str(worca_dir),
+            ]):
+                main()  # must not raise
+
+            # No template applied — run_pipeline received the original settings path
+            call_kwargs = mock_run_pipeline.call_args[1]
+            assert call_kwargs["settings_path"] == str(settings_path), (
+                f"malformed pipeline_template {bad_value!r} should not trigger template application"
+            )
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_writes_snapshot_before_run_pipeline(self, mock_run_pipeline, tmp_path):
+        """On resume with a template, snapshot_to_run is called before run_pipeline()."""
+        from worca.scripts.run_pipeline import main
+
+        run_id = "20260601-trt-0007-gggg"
+        worca_dir = self._make_status(tmp_path, run_id, "project:my-template")
+        settings_path = self._make_settings(tmp_path)
+        run_dir = worca_dir / "runs" / run_id
+
+        call_order = []
+
+        def record_snapshot(*args, **kwargs):
+            call_order.append("snapshot")
+
+        def record_run_pipeline(*args, **kwargs):
+            call_order.append("run_pipeline")
+            return {"pipeline_status": "completed", "run_id": run_id}
+
+        mock_run_pipeline.side_effect = record_run_pipeline
+        mock_resolver = self._mock_resolver("project")
+        mock_resolver.snapshot_to_run.side_effect = record_snapshot
+
+        with patch("sys.argv", [
+            "run_pipeline.py", "--resume",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with patch("worca.scripts.run_pipeline._make_template_resolver",
+                       return_value=mock_resolver):
+                main()
+
+        assert call_order.index("snapshot") < call_order.index("run_pipeline"), (
+            "snapshot_to_run must be called before run_pipeline on resume"
+        )
+        mock_resolver.snapshot_to_run.assert_called_once_with("my-template", str(run_dir), {})
+
+    @patch("worca.scripts.run_pipeline.run_pipeline")
+    def test_resume_writes_merged_settings_before_run_pipeline(self, mock_run_pipeline, tmp_path):
+        """On resume with a template, merged settings.json is written before run_pipeline()."""
+        from worca.scripts.run_pipeline import main
+
+        run_id = "20260601-trt-0008-hhhh"
+        worca_dir = self._make_status(tmp_path, run_id, "project:my-template")
+        settings_path = self._make_settings(tmp_path, {"loops": {"test": 3}})
+        run_dir = worca_dir / "runs" / run_id
+
+        settings_written_before_run = []
+
+        def check_and_record_run(*args, **kwargs):
+            # Check if settings.json already exists in run_dir at the time run_pipeline is called
+            sf = run_dir / "settings.json"
+            settings_written_before_run.append(sf.exists())
+            return {"pipeline_status": "completed", "run_id": run_id}
+
+        mock_run_pipeline.side_effect = check_and_record_run
+        mock_resolver = self._mock_resolver("project")
+        mock_resolver.apply.return_value = {"loops": {"test": 9}}
+
+        with patch("sys.argv", [
+            "run_pipeline.py", "--resume",
+            "--settings", str(settings_path),
+            "--status-dir", str(worca_dir),
+        ]):
+            with patch("worca.scripts.run_pipeline._make_template_resolver",
+                       return_value=mock_resolver):
+                main()
+
+        assert settings_written_before_run == [True], (
+            "merged settings.json must exist in run_dir before run_pipeline is called"
+        )
+        written = json.loads((run_dir / "settings.json").read_text())
+        assert written["worca"]["loops"]["test"] == 9
 
 
 class TestResumeAmbiguousError:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4640,3 +4640,180 @@ class TestLogStageMetricsCostOverride:
         out = capsys.readouterr().err
         assert "cost=$2.50" in out, f"override cost not in log: {out}"
         assert "$4.09" not in out, f"raw envelope cost leaked into log: {out}"
+
+
+# --- Template lifecycle events ---
+
+def _make_template_event_settings(tmp_path):
+    """Minimal settings with only coordinate stage enabled (no plan needed)."""
+    cfg = {
+        "worca": {
+            "stages": {
+                "plan": {"agent": "planner", "enabled": False},
+                "coordinate": {"agent": "coordinator", "enabled": True},
+                "implement": {"agent": "implementer", "enabled": False},
+                "test": {"agent": "tester", "enabled": False},
+                "review": {"agent": "guardian", "enabled": False},
+                "pr": {"agent": "guardian", "enabled": False},
+            },
+            "agents": {"coordinator": {"model": "opus", "max_turns": 10}},
+            "loops": {},
+        }
+    }
+    p = tmp_path / "settings.json"
+    p.write_text(json.dumps(cfg))
+    return str(p)
+
+
+def _run_pipeline_with_template(tmp_path, pipeline_template=None, resume=False,
+                                 resume_status=None):
+    """Helper: run_pipeline with optional pipeline_template and resume support."""
+    from worca.orchestrator.work_request import WorkRequest
+
+    plan = tmp_path / "plan.md"
+    plan.write_text("# Plan\n")
+    wr = WorkRequest(source_type="prompt", title="Template event test")
+    settings_path = _make_template_event_settings(tmp_path)
+    worca_dir = tmp_path / ".worca"
+    worca_dir.mkdir(exist_ok=True)
+    status_path = str(worca_dir / "status.json")
+
+    if resume_status:
+        # Write status directly into per-run dir (resume reads from runs/<id>/)
+        run_id = resume_status["run_id"]
+        run_dir = worca_dir / "runs" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "status.json").write_text(json.dumps(resume_status))
+
+    def mock_run_stage(stage, context, settings_path, msize=1, iteration=1,
+                       prompt_override=None, **kwargs):
+        return {"beads_ids": [], "dependency_graph": {}}, {"type": "result"}
+
+    with patch("worca.orchestrator.runner.run_stage", side_effect=mock_run_stage), \
+         patch("worca.orchestrator.runner.create_branch"), \
+         patch("worca.orchestrator.runner._write_pid"), \
+         patch("worca.orchestrator.runner._remove_pid"):
+        return run_pipeline(
+            wr,
+            plan_file=str(plan),
+            settings_path=settings_path,
+            status_path=status_path,
+            pipeline_template=pipeline_template,
+            resume=resume,
+        )
+
+
+def _read_events(tmp_path, run_id):
+    """Read all events from events.jsonl for a run."""
+    events_path = tmp_path / ".worca" / "runs" / run_id / "events.jsonl"
+    return [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
+
+
+def test_run_pipeline_emits_template_applied_on_fresh_start(tmp_path, monkeypatch):
+    """pipeline.template.applied is emitted on fresh start when pipeline_template is set."""
+    monkeypatch.chdir(tmp_path)
+    result = _run_pipeline_with_template(tmp_path, pipeline_template="project:my-template")
+    events = _read_events(tmp_path, result["run_id"])
+    event_types = [e["event_type"] for e in events]
+    assert "pipeline.template.applied" in event_types
+
+
+def test_run_pipeline_template_applied_payload_launch_source(tmp_path, monkeypatch):
+    """TEMPLATE_APPLIED payload has source='launch' on fresh start."""
+    monkeypatch.chdir(tmp_path)
+    result = _run_pipeline_with_template(tmp_path, pipeline_template="project:my-template")
+    events = _read_events(tmp_path, result["run_id"])
+    evt = next(e for e in events if e["event_type"] == "pipeline.template.applied")
+    assert evt["payload"]["source"] == "launch"
+
+
+def test_run_pipeline_template_applied_payload_template_id_and_tier(tmp_path, monkeypatch):
+    """TEMPLATE_APPLIED payload correctly splits 'tier:id' into template_id and tier."""
+    monkeypatch.chdir(tmp_path)
+    result = _run_pipeline_with_template(tmp_path, pipeline_template="project:my-template")
+    events = _read_events(tmp_path, result["run_id"])
+    evt = next(e for e in events if e["event_type"] == "pipeline.template.applied")
+    assert evt["payload"]["template_id"] == "my-template"
+    assert evt["payload"]["tier"] == "project"
+
+
+def test_run_pipeline_no_template_event_when_no_template(tmp_path, monkeypatch):
+    """No pipeline.template.applied event when pipeline_template is None."""
+    monkeypatch.chdir(tmp_path)
+    result = _run_pipeline_with_template(tmp_path, pipeline_template=None)
+    events = _read_events(tmp_path, result["run_id"])
+    event_types = [e["event_type"] for e in events]
+    assert "pipeline.template.applied" not in event_types
+    assert "pipeline.template.dropped" not in event_types
+
+
+def test_run_pipeline_emits_template_applied_on_resume(tmp_path, monkeypatch):
+    """TEMPLATE_APPLIED is emitted with source='resume' when resuming a run that had a template."""
+    monkeypatch.chdir(tmp_path)
+    run_id = "20260101-000000-000-tmpl-resume"
+    resume_status = {
+        "run_id": run_id,
+        "pipeline_status": "failed",
+        "work_request": {"title": "Template event test"},
+        "branch": "feat/template-resume",
+        "pipeline_template": "project:my-template",
+        "stages": {
+            "plan": {"status": "completed"},
+            "plan_review": {"status": "pending"},
+            "coordinate": {"status": "pending"},
+            "implement": {"status": "pending"},
+            "test": {"status": "pending"},
+            "review": {"status": "pending"},
+            "pr": {"status": "pending"},
+        },
+        "milestones": {},
+        "loop_counters": {},
+    }
+    result = _run_pipeline_with_template(
+        tmp_path,
+        pipeline_template="my-template",
+        resume=True,
+        resume_status=resume_status,
+    )
+    events = _read_events(tmp_path, result["run_id"])
+    evt = next(e for e in events if e["event_type"] == "pipeline.template.applied")
+    assert evt["payload"]["source"] == "resume"
+    assert evt["payload"]["template_id"] == "my-template"
+    assert evt["payload"]["tier"] == "project"
+
+
+def test_run_pipeline_emits_template_dropped_on_resume_regression(tmp_path, monkeypatch):
+    """TEMPLATE_DROPPED is emitted when a resumed run has a persisted template
+    but the runner receives pipeline_template=None (regression guard)."""
+    monkeypatch.chdir(tmp_path)
+    run_id = "20260101-000000-000-tmpl-dropped"
+    resume_status = {
+        "run_id": run_id,
+        "pipeline_status": "failed",
+        "work_request": {"title": "Template event test"},
+        "branch": "feat/template-dropped",
+        "pipeline_template": "project:my-template",
+        "stages": {
+            "plan": {"status": "completed"},
+            "plan_review": {"status": "pending"},
+            "coordinate": {"status": "pending"},
+            "implement": {"status": "pending"},
+            "test": {"status": "pending"},
+            "review": {"status": "pending"},
+            "pr": {"status": "pending"},
+        },
+        "milestones": {},
+        "loop_counters": {},
+    }
+    result = _run_pipeline_with_template(
+        tmp_path,
+        pipeline_template=None,  # template not passed → regression scenario
+        resume=True,
+        resume_status=resume_status,
+    )
+    events = _read_events(tmp_path, result["run_id"])
+    event_types = [e["event_type"] for e in events]
+    assert "pipeline.template.dropped" in event_types
+    evt = next(e for e in events if e["event_type"] == "pipeline.template.dropped")
+    assert evt["payload"]["template_id"] == "my-template"
+    assert evt["payload"]["reason"] == "missing_on_resume"


### PR DESCRIPTION
## Summary

- **Resume was silently dropping the persisted `pipeline_template`**, falling back to `worca.default_template` (or none), which swapped every template-driven setting mid-run — most visibly the agent model (e.g. alt-endpoint `glm-ds` → Anthropic-native `opus`)
- Reads `existing["pipeline_template"]` in the resume branch of `run_pipeline.py` and feeds it into the existing template-resolution flow before any template merge happens
- Adds `--force-template-change` guard to reject conflicting `--template` on resume unless explicitly overridden
- Emits `pipeline.template.applied` / `pipeline.template.dropped` events for observability, with a defense-in-depth regression guard in `runner.py`
- Moves the forensic snapshot (template + `settings.json`) to before `run_pipeline()` on resume so crashed/killed runs leave evidence

## Test plan

- [x] Unit tests: `test_run_pipeline.py` — template restoration from `"tier:id"` format, bare ID fallback, conflict guard exit, `--force-template-change` override, snapshot timing for resume runs
- [x] Unit tests: `test_cli_run_pipeline.py` — `--force-template-change` flag forwarded through `worca run`
- [x] Unit tests: `test_event_types.py` — `template_applied_payload` and `template_dropped_payload` builders
- [x] Unit tests: `test_runner.py` — `TEMPLATE_APPLIED` emitted on launch/resume, `TEMPLATE_DROPPED` emitted when template missing on resume
- [x] Integration test: `test_resume_e2e.py` — launch with template, kill, resume, assert template persists across resume boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)