### PR TITLE
fix(ui): repair template editor round-trip + iteration view (#273)

### DIFF
--- a/worca-ui/app/views/effort-badge.test.js
+++ b/worca-ui/app/views/effort-badge.test.js
@@ -174,8 +174,8 @@ describe('effort source qualifier chip', () => {
   });
 });
 
-describe('effort bead classified row', () => {
-  it('renders bead row when bead_classified exists and applied is false', () => {
+describe('effort bead classified chip (inline on Effort row)', () => {
+  it('renders bead chip when bead level diverges from effort level (explicit_override)', () => {
     const html = renderToString(
       runDetailView(
         makeRun({
@@ -197,7 +197,7 @@ describe('effort bead classified row', () => {
     expect(html).toContain('overridden');
   });
 
-  it('renders ignored divergence chip for mode_reactive skip_reason', () => {
+  it('renders ignored divergence chip for mode_reactive when levels differ', () => {
     const html = renderToString(
       runDetailView(
         makeRun({
@@ -217,7 +217,7 @@ describe('effort bead classified row', () => {
     expect(html).toMatch(/variant="warning"/);
   });
 
-  it('renders ignored divergence chip for mode_disabled skip_reason', () => {
+  it('SUPPRESSES bead chip for mode_disabled even when levels differ (label was never going to be consulted)', () => {
     const html = renderToString(
       runDetailView(
         makeRun({
@@ -232,11 +232,49 @@ describe('effort bead classified row', () => {
         }),
       ),
     );
-    expect(html).toContain('Bead:');
-    expect(html).toContain('ignored');
+    expect(html).not.toContain('Bead:');
+    expect(html).not.toContain('ignored');
   });
 
-  it('does not render bead row when bead_classified is absent', () => {
+  it('SUPPRESSES bead chip when bead level matches effort level (no divergence to show)', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'medium',
+          source: 'disabled',
+          base: 'medium',
+          bead_classified: {
+            level: 'medium',
+            applied: false,
+            skip_reason: 'explicit_override',
+          },
+        }),
+      ),
+    );
+    expect(html).not.toContain('Bead:');
+    expect(html).not.toContain('overridden');
+  });
+
+  it('SUPPRESSES bead chip when bead level matches effort level under mode_reactive', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          level: 'high',
+          source: 'reactive',
+          base: 'high',
+          bead_classified: {
+            level: 'high',
+            applied: false,
+            skip_reason: 'mode_reactive',
+          },
+        }),
+      ),
+    );
+    expect(html).not.toContain('Bead:');
+    expect(html).not.toContain('ignored');
+  });
+
+  it('does not render bead chip when bead_classified is absent', () => {
     const html = renderToString(
       runDetailView(
         makeRun({ level: 'high', source: 'explicit', base: 'high' }),
@@ -245,7 +283,7 @@ describe('effort bead classified row', () => {
     expect(html).not.toContain('Bead:');
   });
 
-  it('does not render bead row when applied is true and levels match', () => {
+  it('does not render bead chip when applied is true and levels match', () => {
     const html = renderToString(
       runDetailView(
         makeRun({
@@ -260,12 +298,11 @@ describe('effort bead classified row', () => {
         }),
       ),
     );
-    // When applied=true and level matches, no divergence to show
     expect(html).not.toContain('overridden');
     expect(html).not.toContain('ignored');
   });
 
-  it('does not render bead row when bead_classified level is null', () => {
+  it('does not render bead chip when bead_classified level is null', () => {
     const html = renderToString(
       runDetailView(
         makeRun({
@@ -281,6 +318,35 @@ describe('effort bead classified row', () => {
       ),
     );
     expect(html).not.toContain('Bead:');
+  });
+
+  it('renders bead chip on the SAME iteration-tags-row as the Effort label', () => {
+    // The bead chip merged into the Effort row in the W-273 fix —
+    // no second iteration-tags-row should appear for the bead.
+    const result = runDetailView(
+      makeRun({
+        level: 'high',
+        source: 'explicit',
+        base: 'high',
+        bead_classified: {
+          level: 'medium',
+          applied: false,
+          skip_reason: 'explicit_override',
+        },
+      }),
+    );
+    const html = renderToString(result);
+    // The effort + bead section should sit in ONE row (the second
+    // row is now suppressed). Effort and Bead labels appear in the
+    // same row so an iteration-tags-row containing Effort also
+    // contains Bead.
+    const effortIdx = html.indexOf('Effort:');
+    const beadIdx = html.indexOf('Bead:');
+    expect(effortIdx).toBeGreaterThan(-1);
+    expect(beadIdx).toBeGreaterThan(effortIdx);
+    // No new iteration-tags-row introduced between them.
+    const between = html.slice(effortIdx, beadIdx);
+    expect(between).not.toContain('iteration-tags-row');
   });
 });
 

--- a/worca-ui/app/views/pipelines-editor-roundtrip.test.js
+++ b/worca-ui/app/views/pipelines-editor-roundtrip.test.js
@@ -1,0 +1,286 @@
+/**
+ * Round-trip tests for `buildFormBuffer` / `formBufferToConfig` —
+ * the editor's read-and-write boundary on the template config.
+ *
+ * Regressions covered (issue #273):
+ *
+ *   1a. `config.effort` (`auto_mode` / `auto_cap`) must seed
+ *       `form.effort`. Without this, a template with
+ *       `auto_mode: disabled` opens as the default `adaptive` and a
+ *       casual touch in the Agents tab silently overwrites disk.
+ *
+ *   1b. `config.governance.guards` is cross-template (NOT in
+ *       TEMPLATE_OWNED_KEYS) and must be stripped before write.
+ *       Saving any template otherwise captures the project's
+ *       hook-gate snapshot, which then wins over later project
+ *       edits.
+ *
+ *   1c. `config.governance.dispatch` is template-owned but the
+ *       form buffer pre-merges project dispatch for the display
+ *       view. The buffer's dirty flag per section controls what's
+ *       actually written: untouched sections fall back to the
+ *       template-original snapshot, never the merged view.
+ *
+ *   1d. Unknown per-agent fields (anything beyond
+ *       `model / max_turns / effort`) must survive the round-trip.
+ *       Currently no built-in template uses extra keys, but adding
+ *       one shouldn't silently drop on save.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildFormBuffer, formBufferToConfig } from './pipelines-editor.js';
+
+// --- 1a: effort block round-trips ---
+
+describe('buildFormBuffer / formBufferToConfig — effort block', () => {
+  it('seeds form.effort from config.effort', () => {
+    const config = {
+      effort: { auto_mode: 'disabled', auto_cap: 'high' },
+    };
+    const form = buildFormBuffer(config, { worca: {} });
+    expect(form.effort).toEqual({
+      auto_mode: 'disabled',
+      auto_cap: 'high',
+    });
+  });
+
+  it('round-trips auto_mode: disabled without silent corruption', () => {
+    const config = {
+      effort: { auto_mode: 'disabled', auto_cap: 'medium' },
+    };
+    const form = buildFormBuffer(config, { worca: {} });
+    const out = formBufferToConfig(form);
+    expect(out.effort.auto_mode).toBe('disabled');
+    expect(out.effort.auto_cap).toBe('medium');
+  });
+
+  it('preserves a non-default auto_cap when seeded', () => {
+    const config = {
+      effort: { auto_mode: 'reactive', auto_cap: 'low' },
+    };
+    const form = buildFormBuffer(config, { worca: {} });
+    expect(form.effort.auto_cap).toBe('low');
+    expect(formBufferToConfig(form).effort).toEqual({
+      auto_mode: 'reactive',
+      auto_cap: 'low',
+    });
+  });
+
+  it('seeds an empty form.effort when config has no effort block', () => {
+    const config = {};
+    const form = buildFormBuffer(config, { worca: {} });
+    expect(form.effort).toEqual({});
+    // formBufferToConfig should omit the key entirely so the
+    // Python loader uses its own defaults.
+    const out = formBufferToConfig(form);
+    expect(out).not.toHaveProperty('effort');
+  });
+});
+
+// --- 1b: governance.guards must NOT leak into the template ---
+
+describe('formBufferToConfig — governance.guards is cross-template', () => {
+  it('drops governance.guards from the written config (clean form buffer)', () => {
+    const config = {};
+    const settings = {
+      worca: {
+        governance: {
+          guards: {
+            block_rm_rf: true,
+            block_env_write: true,
+            block_force_push: false, // a project-local tweak
+            restrict_git_commit: true,
+          },
+        },
+      },
+    };
+    const form = buildFormBuffer(config, settings);
+    // buildFormBuffer hydrates form.governance.guards from project
+    // settings for the display view…
+    expect(form.governance.guards).toBeDefined();
+    // …but formBufferToConfig must drop it on write.
+    const out = formBufferToConfig(form);
+    expect(out.governance).toBeDefined();
+    expect(out.governance.guards).toBeUndefined();
+  });
+
+  it('drops governance.guards even when the template originally had no guards', () => {
+    const config = { governance: { dispatch: {} } };
+    const settings = {
+      worca: { governance: { guards: { block_rm_rf: true } } },
+    };
+    const form = buildFormBuffer(config, settings);
+    const out = formBufferToConfig(form);
+    expect(out.governance.guards).toBeUndefined();
+  });
+
+  it('keeps template-owned governance keys (test_gate_strikes, plan_review_enforce)', () => {
+    const config = {
+      governance: {
+        test_gate_strikes: 1,
+        plan_review_enforce: 'review',
+        dispatch: {},
+      },
+    };
+    const form = buildFormBuffer(config, { worca: {} });
+    const out = formBufferToConfig(form);
+    expect(out.governance.test_gate_strikes).toBe(1);
+    expect(out.governance.plan_review_enforce).toBe('review');
+  });
+});
+
+// --- 1c: dispatch must not capture project snapshot ---
+
+describe('formBufferToConfig — governance.dispatch is template-owned but not project-leaked', () => {
+  function projectSettingsWithDispatch() {
+    return {
+      worca: {
+        governance: {
+          dispatch: {
+            tools: {
+              always_disallowed: [],
+              default_denied: [],
+              per_agent_allow: { coordinator: ['Read', 'Grep'] },
+            },
+            skills: {
+              per_agent_allow: { planner: ['some-project-skill'] },
+            },
+            subagents: {
+              per_agent_allow: { _defaults: ['*'] },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  it('preserves a clean template (no edits) exactly as the template originally had it', () => {
+    // Template has only ONE narrow dispatch entry; project has more.
+    const config = {
+      governance: {
+        dispatch: {
+          tools: {
+            per_agent_allow: { planner: ['Read'] },
+          },
+        },
+      },
+    };
+    const form = buildFormBuffer(config, projectSettingsWithDispatch());
+    const out = formBufferToConfig(form);
+
+    // Tools: template original wins (no widening from project).
+    expect(out.governance.dispatch.tools).toEqual({
+      per_agent_allow: { planner: ['Read'] },
+    });
+    // Skills + subagents: template never declared them; project's
+    // snapshot must NOT leak into the saved template.
+    expect(out.governance.dispatch.skills).toBeUndefined();
+    expect(out.governance.dispatch.subagents).toBeUndefined();
+  });
+
+  it('omits dispatch entirely when the template had no dispatch and the user never touched it', () => {
+    const config = {};
+    const form = buildFormBuffer(config, projectSettingsWithDispatch());
+    const out = formBufferToConfig(form);
+    expect(out.governance.dispatch).toBeUndefined();
+  });
+
+  it('writes the user-edited section when its dirty flag is set', () => {
+    const config = {
+      governance: {
+        dispatch: {
+          tools: { per_agent_allow: { planner: ['Read'] } },
+        },
+      },
+    };
+    const form = buildFormBuffer(config, projectSettingsWithDispatch());
+
+    // Simulate a UI edit to the tools section: update the merged
+    // view AND set the dirty flag.
+    form.governance.dispatch.tools = {
+      per_agent_allow: { planner: ['Read', 'Grep'] },
+    };
+    form._dispatchDirty.tools = true;
+
+    const out = formBufferToConfig(form);
+    expect(out.governance.dispatch.tools).toEqual({
+      per_agent_allow: { planner: ['Read', 'Grep'] },
+    });
+    // Other sections still untouched — no project leakage.
+    expect(out.governance.dispatch.skills).toBeUndefined();
+    expect(out.governance.dispatch.subagents).toBeUndefined();
+  });
+
+  it('treats sections independently — dirty tools does not flush clean skills', () => {
+    const config = {
+      governance: {
+        dispatch: {
+          skills: { per_agent_allow: { planner: ['something'] } },
+        },
+      },
+    };
+    const form = buildFormBuffer(config, projectSettingsWithDispatch());
+    form.governance.dispatch.tools = {
+      per_agent_allow: { coordinator: ['Read'] },
+    };
+    form._dispatchDirty.tools = true;
+
+    const out = formBufferToConfig(form);
+    expect(out.governance.dispatch.tools).toEqual({
+      per_agent_allow: { coordinator: ['Read'] },
+    });
+    // Skills was in the template's original — preserved exactly.
+    expect(out.governance.dispatch.skills).toEqual({
+      per_agent_allow: { planner: ['something'] },
+    });
+    expect(out.governance.dispatch.subagents).toBeUndefined();
+  });
+});
+
+// --- 1d: unknown per-agent fields survive round-trip ---
+
+describe('formBufferToConfig — per-agent unknown keys survive round-trip', () => {
+  it('preserves an arbitrary future per-agent key', () => {
+    const config = {
+      agents: {
+        planner: {
+          model: 'opus',
+          max_turns: 100,
+          effort: 'high',
+          // A hypothetical future key that the editor UI does not
+          // know about. Must NOT be silently dropped on save.
+          custom_future_knob: 'enabled',
+        },
+      },
+    };
+    const form = buildFormBuffer(config, { worca: {} });
+    const out = formBufferToConfig(form);
+    expect(out.agents.planner.model).toBe('opus');
+    expect(out.agents.planner.max_turns).toBe(100);
+    expect(out.agents.planner.effort).toBe('high');
+    expect(out.agents.planner.custom_future_knob).toBe('enabled');
+  });
+
+  it('drops effort when the user explicitly cleared it (null in form buffer)', () => {
+    const config = {
+      agents: {
+        planner: { model: 'opus', max_turns: 100, effort: 'high' },
+      },
+    };
+    const form = buildFormBuffer(config, { worca: {} });
+    form.agents.planner.effort = null; // user cleared the dropdown
+    const out = formBufferToConfig(form);
+    expect(out.agents.planner).not.toHaveProperty('effort');
+    expect(out.agents.planner.model).toBe('opus');
+    expect(out.agents.planner.max_turns).toBe(100);
+  });
+
+  it('preserves model/max_turns when the template had no agents block at all', () => {
+    const config = {};
+    const form = buildFormBuffer(config, { worca: {} });
+    const out = formBufferToConfig(form);
+    // Every agent in AGENT_NAMES gets defaults.
+    expect(out.agents.planner.model).toBe('sonnet');
+    expect(out.agents.planner.max_turns).toBe(30);
+  });
+});

--- a/worca-ui/app/views/pipelines-editor.js
+++ b/worca-ui/app/views/pipelines-editor.js
@@ -220,19 +220,26 @@ function normalizeStageConfig(stages) {
 
 /**
  * Merge template config with built-in defaults for form editing.
+ *
+ * Exported for tests; lives here so the test surface mirrors the
+ * editor's actual entry/exit points.
  */
-function buildFormBuffer(templateConfig, settings) {
+export function buildFormBuffer(templateConfig, settings) {
   const config = templateConfig || {};
   const form = {};
 
   // Stages
   form.stages = normalizeStageConfig(config.stages);
 
-  // Agents
+  // Agents — stash the original per-agent map so unknown keys
+  // (anything beyond model/max_turns/effort) survive the
+  // round-trip. formBufferToConfig overlays edited fields on top
+  // of _original on save.
   form.agents = {};
   for (const name of AGENT_NAMES) {
     const agentConfig = config.agents?.[name] || {};
     form.agents[name] = {
+      _original: { ...agentConfig },
       model: agentConfig.model || 'sonnet',
       max_turns: agentConfig.max_turns || 30,
       effort: agentConfig.effort || null,
@@ -248,11 +255,27 @@ function buildFormBuffer(templateConfig, settings) {
     ...(config.circuit_breaker || {}),
   };
 
-  // Governance
+  // Effort (auto_mode + auto_cap). Seed from the template so the
+  // Agents tab dropdowns show the saved value rather than the
+  // generic 'adaptive' / 'xhigh' fallback — without this, opening
+  // an `auto_mode: disabled` template and touching anything in
+  // the Agents tab silently overwrites the template back to
+  // 'adaptive' on save.
+  form.effort = { ...(config.effort || {}) };
+
+  // Governance — display-time merge of project defaults so the
+  // user sees the effective dispatch. The original template
+  // dispatch is stashed under _templateOriginalDispatch and a
+  // per-section dirty flag tracks user edits; formBufferToConfig
+  // emits only template-original + dirty sections, never the
+  // project's snapshot.
   form.governance = deepMergeGovernance(
     config.governance,
     settings?.worca?.governance,
   );
+  form._templateOriginalDispatch =
+    deepClone(config.governance?.dispatch || {}) || {};
+  form._dispatchDirty = { tools: false, skills: false, subagents: false };
 
   // Approval gates — milestones is template-owned. Defaults match
   // the server-side defaults (plan approval required, PR approval
@@ -327,8 +350,12 @@ function deepMergeGovernanceTiered(dispatch, defaultDispatch) {
 
 /**
  * Convert form buffer back to template config shape.
+ *
+ * Exported for tests; the round-trip (buildFormBuffer →
+ * formBufferToConfig) is the contract the W-062 editor must
+ * preserve, so it's worth exercising directly.
  */
-function formBufferToConfig(formBuffer) {
+export function formBufferToConfig(formBuffer) {
   const config = {};
 
   // Stages
@@ -344,22 +371,26 @@ function formBufferToConfig(formBuffer) {
     }
   }
 
-  // Agents
+  // Agents — overlay edited fields on top of the original per-agent
+  // map so unknown keys (anything beyond model/max_turns/effort)
+  // survive round-trip. Without _original, any new key added to the
+  // template's agent block would be silently dropped on save.
   config.agents = {};
   for (const name of AGENT_NAMES) {
     const agent = formBuffer.agents[name] || {};
+    const merged = {
+      ...(agent._original || {}),
+      model: agent.model,
+      max_turns: agent.max_turns,
+    };
     if (agent.effort) {
-      config.agents[name] = {
-        model: agent.model,
-        max_turns: agent.max_turns,
-        effort: agent.effort,
-      };
+      merged.effort = agent.effort;
     } else {
-      config.agents[name] = {
-        model: agent.model,
-        max_turns: agent.max_turns,
-      };
+      // User explicitly cleared effort — don't carry the original
+      // value through.
+      delete merged.effort;
     }
+    config.agents[name] = merged;
   }
 
   // Loops
@@ -373,8 +404,39 @@ function formBufferToConfig(formBuffer) {
   // Circuit breaker
   config.circuit_breaker = formBuffer.circuit_breaker;
 
-  // Governance
-  config.governance = formBuffer.governance;
+  // Governance — strip cross-template keys (guards) before write so
+  // the template doesn't capture the project's hook-gate snapshot.
+  // `guards` is NOT in TEMPLATE_OWNED_KEYS (see
+  // src/worca/orchestrator/templates.py); it stays cross-template
+  // and is edited in Project Settings.
+  const { guards: _drop_guards, ...templateOwnedGov } =
+    formBuffer.governance || {};
+  config.governance = templateOwnedGov;
+
+  // Governance dispatch — write template-original entries for
+  // sections the user never touched; write the merged form buffer
+  // only for sections marked dirty. This prevents a template from
+  // silently capturing the project's dispatch snapshot just because
+  // it was opened in the editor.
+  const dirty = formBuffer._dispatchDirty || {};
+  const original = formBuffer._templateOriginalDispatch || {};
+  const mergedDispatch = formBuffer.governance?.dispatch || {};
+  const writtenDispatch = {};
+  let dispatchHasEntries = false;
+  for (const section of ['tools', 'skills', 'subagents']) {
+    if (dirty[section]) {
+      writtenDispatch[section] = mergedDispatch[section] || {};
+      dispatchHasEntries = true;
+    } else if (original[section] !== undefined) {
+      writtenDispatch[section] = original[section];
+      dispatchHasEntries = true;
+    }
+  }
+  if (dispatchHasEntries) {
+    config.governance.dispatch = writtenDispatch;
+  } else {
+    delete config.governance.dispatch;
+  }
 
   // Effort (auto_mode + auto_cap). Only persist if the buffer has
   // either field — empty/default templates skip the key entirely so
@@ -1838,9 +1900,9 @@ function _governanceSection(formBuffer, settings, projectId, rerender) {
       </p>
       <div class="settings-grid">
         <div class="settings-field">
-          <label class="settings-label" for="governance-plan-review-enforce">Enforce mode</label>
           <sl-select
             id="governance-plan-review-enforce"
+            aria-label="Plan review enforce mode"
             .value=${planReviewEnforce}
             size="small"
             hoist
@@ -1889,6 +1951,16 @@ function _governanceSection(formBuffer, settings, projectId, rerender) {
                 };
               }
               editorState.formBuffer.governance.dispatch[section] = newConfig;
+              // Mark the section dirty so formBufferToConfig writes the
+              // user-edited config rather than the template original.
+              if (!editorState.formBuffer._dispatchDirty) {
+                editorState.formBuffer._dispatchDirty = {
+                  tools: false,
+                  skills: false,
+                  subagents: false,
+                };
+              }
+              editorState.formBuffer._dispatchDirty[section] = true;
               rerender();
             },
             state: dispatchEditState[section],

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -757,8 +757,20 @@ function _effortRowView(iter, graphifyEnabled, crgEnabled) {
     ? html`<sl-badge class="effort-source-chip" variant="neutral" pill>capped</sl-badge>`
     : nothing;
 
+  // Bead chip — only surface when it conveys real divergence info.
+  // Suppress when the coordinator's bead label matches the resolved
+  // effort level (no divergence) or when the run is in
+  // `mode_disabled` (the label was never going to be consulted, so
+  // showing "ignored" is noise). The chip also stays suppressed
+  // when bead_classified.applied is true (level already matches and
+  // is implied by the source chip).
   const bc = e.bead_classified;
-  const showBeadRow = bc && bc.level != null && bc.applied === false;
+  const showBeadChip =
+    bc &&
+    bc.level != null &&
+    bc.applied === false &&
+    bc.level !== e.level &&
+    bc.skip_reason !== 'mode_disabled';
   const divergenceLabel =
     bc?.skip_reason === 'explicit_override' ? 'overridden' : 'ignored';
 
@@ -769,20 +781,19 @@ function _effortRowView(iter, graphifyEnabled, crgEnabled) {
       <sl-badge class="effort-source-chip" variant="neutral" pill>${sourceLabel}</sl-badge>
       ${escalationChips}
       ${cappedChip}
-      ${gfx}
-      ${crg}
-    </div>
-    ${
-      showBeadRow
-        ? html`
-      <div class="iteration-tags-row">
+      ${
+        showBeadChip
+          ? html`
+        <span class="iteration-tags-sep">·</span>
         <span class="meta-label">Bead:</span>
         ${unsafeHTML(effortLevelBadge(bc.level))}
         <sl-badge class="effort-divergence-chip" variant="warning" pill>${divergenceLabel}</sl-badge>
-      </div>
-    `
-        : nothing
-    }
+      `
+          : nothing
+      }
+      ${gfx}
+      ${crg}
+    </div>
   `;
 }
 


### PR DESCRIPTION
Fixes the three independent issues in #273 from the W-062 template editor review.

## What's in here

### 1. Editor round-trip in `pipelines-editor.js`

| # | Fix | One-line |
|---|---|---|
| **1a** | seed `form.effort` in `buildFormBuffer` | `auto_mode: disabled` no longer opens as `adaptive` and overwrites on save |
| **1b** | strip `governance.guards` in `formBufferToConfig` | template no longer captures the project's hook-gate snapshot |
| **1c** | dirty-flag per dispatch section | clean templates stop silently absorbing project dispatch (tools/skills/subagents) |
| **1d** | stash `_original` + overlay on save | unknown per-agent fields (anything beyond `model/max_turns/effort`) survive the round-trip |

`buildFormBuffer` and `formBufferToConfig` are now exported so the round-trip is exercised directly in tests.

### 2. Governance tab — redundant "Enforce mode" label removed

The "Plan review enforcement" section title + description already establish the context; the dropdown is the only control in the section. Replaced with an `aria-label` on the `<sl-select>` so screen readers still get a name.

### 3. Iteration view — Bead row merged into Effort row

`_effortRowView` in `run-detail.js` no longer renders a separate Bead row. The bead chip sits inline on the Effort row and is suppressed when:

- `bc.level === e.level` (no divergence)
- `bc.skip_reason === 'mode_disabled'` (label was never going to be consulted)
- `bc.applied === true` (already implied by the source chip)

The common case (`fast` template with `auto_mode: disabled` + bead label matching effort) now renders one compact row instead of two near-identical ones.

## Tests

- New `pipelines-editor-roundtrip.test.js` — 13 cases covering 1a/1b/1c/1d directly against `buildFormBuffer` / `formBufferToConfig`.
- `effort-badge.test.js` updated — dropped the assertions that required a separate Bead row, added cases for the two new suppression rules, and asserts the bead chip sits in the same `iteration-tags-row` as Effort.

Locally green:
- `npx vitest run` (worca-ui): 269 files / 4338 tests passing
- `npx vitest run server/`: 132 files / 2028 tests passing
- `npx playwright test e2e/pipelines-editor.spec.js --workers=1`: 4 passed, 2 skipped (pre-existing)
- `npx playwright test e2e/pipelines-templates.spec.js --workers=1`: 16 passed
- `npm run lint`: 25 warnings (one fewer than baseline; no errors)

## Out of scope (per #273)

1e/1f/1g — UI controls for `plan_review.mode` and circuit-breaker transient-retry knobs are not added here; they belong in separate enhancement issues. The round-trip already preserves these values today via spread-then-write.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
