### PR TITLE
W-063: Run Timeline View

### DIFF
--- a/docs-site/src/content/docs/running-pipelines/monitoring-a-run.md
+++ b/docs-site/src/content/docs/running-pipelines/monitoring-a-run.md
@@ -29,6 +29,24 @@ The expanded **Agent Instructions** panel separates the resolved system prompt f
 An expanded Implement stage: per-iteration metrics, the effort badge, and the dispatch allow/deny rows.
 :::
 
+## The timeline view
+
+The stage pipeline answers "where is the run now?" The **timeline view** answers "how did it get here?" A **Timeline** button on the pipeline timing bar opens a Gantt-style swimlane chart: one row per stage, one bar per iteration, laid out along a shared time axis. Loopbacks — the moments when a downstream stage sent work back upstream — are drawn as arrows that connect the iteration that *caused* the loopback to the iteration that *resumed* it.
+
+:::note[Screenshot — coming soon]
+The timeline view: stage swimlanes with per-iteration bars, gap bands, and loopback arrows.
+:::
+
+The bars are color-coded per stage (the same hues used elsewhere in the UI) and their **fill darkness reflects the iteration's status** — success bars are saturated, failed bars are washed out, in-progress bars carry the active hue. **Gap bands** between iterations show where time was spent in *another* stage (with a tooltip naming that stage), so you can see at a glance which loopbacks bled into which downstream waits. For active runs, the view streams over the same WebSocket as the rest of the page — new bars and arrows appear as the pipeline advances.
+
+### Interacting with the timeline
+
+- **Zoom** — `+` / `−` / reset in the top-right toolbar; shift-wheel anywhere over the chart; or drag-select a window directly on the time axis at the bottom.
+- **Hover** — bars surface a tooltip with stage, iteration N of total, duration, started/ended, model, status, and cost. Gap bands surface the stage that owned the gap and how long it lasted.
+- **Click** — clicking a bar opens a drawer with the iteration's status pill, key metrics, and a collapsed **Raw JSON** block for full inspection. A footer link jumps to that iteration on the run-detail page.
+- **Keyboard** — bars and gaps are focusable; **Enter** or **Space** on a focused bar opens the same drawer.
+- **Dense rows** — when a single stage has more than 30 iterations, loopback arrows are suppressed and a hint appears so the row stays readable.
+
 ## The log viewer
 
 The log viewer streams real-time agent output with per-stage filtering — follow the Implementer's reasoning, the Tester's command output, or the Reviewer's verdict as it happens. Agent prompts, guides, context artifacts, and bead tooltips render as sanitized Markdown.

--- a/worca-ui/app/main-header-buttons.test.js
+++ b/worca-ui/app/main-header-buttons.test.js
@@ -1,4 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { runDetailView } from './views/run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
 
 describe('header button pending-state scoping', () => {
   function resolvePending(controlPending, routeRunId) {
@@ -34,5 +54,75 @@ describe('header button pending-state scoping', () => {
     const controlPending = { action: 'stop', runId: runA };
     expect(resolvePending(controlPending, runA)).toBe('stop');
     expect(resolvePending(controlPending, runB)).toBeNull();
+  });
+});
+
+describe('Timeline button in run-detail overview', () => {
+  const baseRun = { run_id: 'run-1', stages: {}, active: false };
+
+  it('renders Timeline button after stage strip when onOpenTimeline is provided', () => {
+    const onOpenTimeline = vi.fn();
+    const out = renderToString(
+      runDetailView(baseRun, {}, { onOpenTimeline }).overview,
+    );
+    expect(out).toContain('run-stage-actions');
+    expect(out).toContain('Timeline');
+  });
+
+  it('does not render Timeline button when onOpenTimeline is absent', () => {
+    const out = renderToString(runDetailView(baseRun, {}).overview);
+    expect(out).not.toContain('run-stage-actions');
+  });
+
+  it('onOpenTimeline callback routes to timeline sub-view', () => {
+    const calls = [];
+    function navigate(section, runId, projectId, action) {
+      calls.push({ section, runId, projectId, action });
+    }
+    const route = { section: 'active', runId: 'run-1', projectId: null };
+    navigate(route.section, route.runId, route.projectId, 'timeline');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      section: 'active',
+      runId: 'run-1',
+      projectId: null,
+      action: 'timeline',
+    });
+  });
+});
+
+describe('back-arrow from timeline sub-view', () => {
+  function handleBack(route, navigate) {
+    if (route.action === 'timeline' && route.runId) {
+      navigate(route.section, route.runId, route.projectId, null);
+    } else if (route.runId) {
+      navigate(route.section, null, route.projectId);
+    }
+  }
+
+  it('navigates to run detail (not section root) when action is timeline', () => {
+    const calls = [];
+    const navigate = (...args) => calls.push(args);
+    handleBack(
+      {
+        section: 'active',
+        runId: 'run-1',
+        projectId: null,
+        action: 'timeline',
+      },
+      navigate,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(['active', 'run-1', null, null]);
+  });
+
+  it('navigates to section root (no runId) when on run detail view', () => {
+    const calls = [];
+    const navigate = (...args) => calls.push(args);
+    handleBack(
+      { section: 'active', runId: 'run-1', projectId: null, action: null },
+      navigate,
+    );
+    expect(calls[0]).toEqual(['active', null, null]);
   });
 });

--- a/worca-ui/app/main-header-buttons.test.js
+++ b/worca-ui/app/main-header-buttons.test.js
@@ -60,18 +60,18 @@ describe('header button pending-state scoping', () => {
 describe('Timeline button in run-detail overview', () => {
   const baseRun = { run_id: 'run-1', stages: {}, active: false };
 
-  it('renders Timeline button after stage strip when onOpenTimeline is provided', () => {
+  it('renders Timeline button above the pipeline timing bar when onOpenTimeline is provided', () => {
     const onOpenTimeline = vi.fn();
     const out = renderToString(
       runDetailView(baseRun, {}, { onOpenTimeline }).overview,
     );
-    expect(out).toContain('run-stage-actions');
+    expect(out).toContain('pipeline-timing-bar-actions');
     expect(out).toContain('Timeline');
   });
 
   it('does not render Timeline button when onOpenTimeline is absent', () => {
     const out = renderToString(runDetailView(baseRun, {}).overview);
-    expect(out).not.toContain('run-stage-actions');
+    expect(out).not.toContain('pipeline-timing-bar-actions');
   });
 
   it('onOpenTimeline callback routes to timeline sub-view', () => {

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -89,6 +89,7 @@ import {
   runDetailView,
 } from './views/run-detail.js';
 import { runListView } from './views/run-list.js';
+import { runTimelineView } from './views/run-timeline.js';
 import {
   loadSettings,
   projectSettingsView,
@@ -2973,6 +2974,83 @@ function handleCancelRun(runId) {
   );
 }
 
+// --- Shared run-page header helper ---
+
+function runPageHeaderParts(runId) {
+  const run = store.getRunById(runId);
+  const raw = run?.work_request?.title || 'Pipeline Details';
+  const firstLine = raw.split('\n')[0];
+  const title =
+    firstLine.length > 80 ? `${firstLine.slice(0, 80)}…` : firstLine;
+  let badge = null;
+  let actionButton = null;
+  if (run) {
+    const ps = run.pipeline_status || (run.active ? 'running' : 'completed');
+    const variantMap = {
+      running: 'primary',
+      paused: 'warning',
+      completed: 'success',
+      failed: 'danger',
+      cancelled: 'neutral',
+      interrupted: 'warning',
+    };
+    const variant = variantMap[ps] || 'neutral';
+    const label = ps.charAt(0).toUpperCase() + ps.slice(1);
+    badge = html`<sl-badge variant="${variant}" pill>
+      ${unsafeHTML(statusIcon(ps, 12))}
+      ${label}
+    </sl-badge>`;
+    const pending =
+      _controlPending?.runId === runId ? _controlPending.action : null;
+    if (pending === 'stop') {
+      actionButton = html`
+        <button class="action-btn action-btn--danger" disabled>
+          ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
+          Stopping…
+        </button>`;
+    } else if (pending === 'pause') {
+      actionButton = html`
+        <button class="action-btn action-btn--amber" disabled>
+          ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
+          Pausing…
+        </button>`;
+    } else if (pending === 'resume') {
+      actionButton = html`
+        <button class="action-btn action-btn--primary" disabled>
+          ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
+          Resuming…
+        </button>`;
+    } else {
+      const pauseBtn = actionAllowed('pause', ps)
+        ? html`<button class="action-btn action-btn--amber" @click=${() => handlePauseRun(runId)}>
+            ${unsafeHTML(iconSvg(Pause, 14))} Pause
+          </button>`
+        : nothing;
+      const stopBtn = actionAllowed('stop', ps)
+        ? html`<button class="action-btn action-btn--danger" @click=${() => handleStopRun(runId)}>
+            ${unsafeHTML(iconSvg(Square, 14))} Stop
+          </button>`
+        : nothing;
+      const resumeBtn = actionAllowed('resume', ps)
+        ? html`<button class="action-btn action-btn--primary" @click=${() => handleResumeRun(runId)}>
+            ${unsafeHTML(iconSvg(Play, 14))} Resume
+          </button>`
+        : nothing;
+      const cancelBtn =
+        stopBtn === nothing && actionAllowed('cancel', ps)
+          ? html`<button class="action-btn action-btn--danger" @click=${() => handleCancelRun(runId)}>
+              ${unsafeHTML(iconSvg(Square, 14))} Cancel
+            </button>`
+          : nothing;
+      const btns = [pauseBtn, stopBtn, resumeBtn, cancelBtn].filter(
+        (b) => b !== nothing,
+      );
+      if (btns.length) actionButton = html`${btns}`;
+    }
+  }
+  return { title, badge, actionButton };
+}
+
 // --- PR Approval ---
 
 async function handleApprovePR(runId) {
@@ -3227,7 +3305,9 @@ async function handleConfirmRestartStage() {
 }
 
 function handleBack() {
-  if (route.runId) {
+  if (route.action === 'timeline' && route.runId) {
+    navigate(route.section, route.runId, route.projectId, null);
+  } else if (route.runId) {
     navigate(route.section, null, route.projectId);
   } else if (route.section && route.section !== 'dashboard') {
     navigate('dashboard', null, route.projectId);
@@ -3690,82 +3770,16 @@ function contentHeaderView() {
     } else {
       title = 'Workspaces';
     }
+  } else if (route.action === 'timeline' && route.runId) {
+    showBack = true;
+    ({ title, badge, actionButton } = runPageHeaderParts(route.runId));
   } else if (route.runId && route.section !== 'templates') {
     // The templates section also encodes its tid in `route.runId` (e.g.
     // `#/templates/feature-glm-ds/edit`), so without the section guard
     // this generic "run detail" handler would overwrite the dedicated
     // "Edit Template" title below.
-    const run = store.getRunById(route.runId);
-    const raw = run?.work_request?.title || 'Pipeline Details';
-    const firstLine = raw.split('\n')[0];
-    title =
-      firstLine.length > 80 ? `${firstLine.slice(0, 80)}\u2026` : firstLine;
     showBack = true;
-    if (run) {
-      const ps = run.pipeline_status || (run.active ? 'running' : 'completed');
-      const variantMap = {
-        running: 'primary',
-        paused: 'warning',
-        completed: 'success',
-        failed: 'danger',
-        cancelled: 'neutral',
-        interrupted: 'warning',
-      };
-      const variant = variantMap[ps] || 'neutral';
-      const label = ps.charAt(0).toUpperCase() + ps.slice(1);
-      badge = html`<sl-badge variant="${variant}" pill>
-        ${unsafeHTML(statusIcon(ps, 12))}
-        ${label}
-      </sl-badge>`;
-
-      const pending =
-        _controlPending?.runId === route.runId ? _controlPending.action : null;
-      if (pending === 'stop') {
-        actionButton = html`
-          <button class="action-btn action-btn--danger" disabled>
-            ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
-            Stopping\u2026
-          </button>`;
-      } else if (pending === 'pause') {
-        actionButton = html`
-          <button class="action-btn action-btn--amber" disabled>
-            ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
-            Pausing\u2026
-          </button>`;
-      } else if (pending === 'resume') {
-        actionButton = html`
-          <button class="action-btn action-btn--primary" disabled>
-            ${unsafeHTML(iconSvg(Loader, 14, 'icon-spin'))}
-            Resuming\u2026
-          </button>`;
-      } else {
-        const pauseBtn = actionAllowed('pause', ps)
-          ? html`<button class="action-btn action-btn--amber" @click=${() => handlePauseRun(route.runId)}>
-              ${unsafeHTML(iconSvg(Pause, 14))} Pause
-            </button>`
-          : nothing;
-        const stopBtn = actionAllowed('stop', ps)
-          ? html`<button class="action-btn action-btn--danger" @click=${() => handleStopRun(route.runId)}>
-              ${unsafeHTML(iconSvg(Square, 14))} Stop
-            </button>`
-          : nothing;
-        const resumeBtn = actionAllowed('resume', ps)
-          ? html`<button class="action-btn action-btn--primary" @click=${() => handleResumeRun(route.runId)}>
-              ${unsafeHTML(iconSvg(Play, 14))} Resume
-            </button>`
-          : nothing;
-        const cancelBtn =
-          stopBtn === nothing && actionAllowed('cancel', ps)
-            ? html`<button class="action-btn action-btn--danger" @click=${() => handleCancelRun(run.id)}>
-                ${unsafeHTML(iconSvg(Square, 14))} Cancel
-              </button>`
-            : nothing;
-        const btns = [pauseBtn, stopBtn, resumeBtn, cancelBtn].filter(
-          (b) => b !== nothing,
-        );
-        if (btns.length) actionButton = html`${btns}`;
-      }
-    }
+    ({ title, badge, actionButton } = runPageHeaderParts(route.runId));
   } else if (route.section === 'active') {
     title = 'Running Pipelines';
     showBack = true;
@@ -4055,6 +4069,42 @@ function mainContentView() {
     });
   }
 
+  // Timeline sub-view for a run: short-circuit to runTimelineView.
+  if (route.action === 'timeline' && route.runId) {
+    const run = store.getRunById(route.runId);
+    if (!run) {
+      if (
+        state.runsLoaded &&
+        currentProjectId &&
+        (state.projects || []).length > 1
+      ) {
+        navigate(route.section, null, route.projectId);
+        return html``;
+      }
+      if (state.runsLoaded) {
+        return html`
+          <div class="run-detail run-detail-layout">
+            <div class="run-detail-layout__overview">
+              <sl-alert variant="warning" open>
+                <strong>Run not found.</strong>
+                No <code>status.json</code> exists for
+                <code>${route.runId}</code> — it may have been an orphan worktree
+                whose pipeline died before writing run state. Clean it up from the
+                <a href="#/worktrees" @click=${() => navigate('worktrees')}>Worktrees</a> view.
+              </sl-alert>
+            </div>
+          </div>
+        `;
+      }
+      return html``;
+    }
+    return runTimelineView(run, settings, {
+      section: route.section,
+      runId: route.runId,
+      projectId: route.projectId,
+    });
+  }
+
   // The runId catch-all renders the per-run pipeline detail view. Exclude
   // sections that own their own :id sub-route (fleet-runs, workspace-runs,
   // workspaces — the create-definition flow, pipelines for template editing).
@@ -4119,6 +4169,8 @@ function mainContentView() {
       onRestartStage: handleRestartStage,
       stageIterationTab,
       onStageTabChange: handleStageTabChange,
+      onOpenTimeline: () =>
+        navigate(route.section, route.runId, route.projectId, 'timeline'),
       // Plan-stage View plan dialog needs to redraw when the modal
       // toggles open/closed and when the lazy plan fetch resolves.
       rerender,

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -128,6 +128,7 @@ import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/divider/divider.js';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import '@shoelace-style/shoelace/dist/components/drawer/drawer.js';
 import '@shoelace-style/shoelace/dist/components/tab-group/tab-group.js';
 import '@shoelace-style/shoelace/dist/components/tab/tab.js';
 import '@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js';

--- a/worca-ui/app/router.test.js
+++ b/worca-ui/app/router.test.js
@@ -142,6 +142,29 @@ describe('router', () => {
     });
   });
 
+  it('parseHash handles timeline sub-view action', () => {
+    expect(parseHash('#/runs/abc123/timeline')).toEqual({
+      section: 'runs',
+      runId: 'abc123',
+      action: 'timeline',
+      projectId: null,
+      tier: null,
+    });
+  });
+
+  it('buildHash round-trips timeline sub-view', () => {
+    const hash = buildHash('runs', 'abc123', null, 'timeline');
+    expect(hash).toBe('#/runs/abc123/timeline');
+    const parsed = parseHash(hash);
+    expect(parsed).toEqual({
+      section: 'runs',
+      runId: 'abc123',
+      action: 'timeline',
+      projectId: null,
+      tier: null,
+    });
+  });
+
   it('buildHash includes action as 3rd segment when supplied', () => {
     expect(buildHash('workspaces', 'my-ws', null, 'edit')).toBe(
       '#/workspaces/my-ws/edit',

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -410,9 +410,189 @@ h1, h2, h3, h4, h5, h6 {
   color: #ffffff;
 }
 
+.action-btn--ghost {
+  border-color: transparent;
+  color: var(--text-muted);
+}
+
+.action-btn--ghost:hover {
+  border-color: var(--border);
+  color: var(--text);
+}
+
 .action-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.run-stage-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 0 0 4px;
+  flex-wrap: wrap;
+}
+
+/* --- Run Timeline --- */
+.run-timeline {
+  padding: 8px 0;
+  overflow-x: auto;
+}
+
+.timeline-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 0 0 6px;
+}
+
+.timeline-zoom-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 24px;
+  padding: 0 6px;
+  border: 1px solid var(--sl-color-neutral-300, #d1d5db);
+  border-radius: 4px;
+  background: var(--sl-color-neutral-0, #fff);
+  color: var(--sl-color-neutral-700, #374151);
+  font-size: 14px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.timeline-zoom-btn:hover {
+  background: var(--sl-color-neutral-100, #f3f4f6);
+}
+
+.timeline-zoom-btn:active {
+  background: var(--sl-color-neutral-200, #e5e7eb);
+}
+
+.timeline-bar {
+  cursor: pointer;
+}
+
+.timeline-bar:hover {
+  filter: brightness(1.15);
+}
+
+.timeline-bar:focus-visible {
+  outline: 2px solid var(--accent, #3b82f6);
+  outline-offset: 1px;
+}
+
+.timeline-gap {
+  cursor: default;
+}
+
+.timeline-gap:hover {
+  opacity: 0.75;
+}
+
+.loopback {
+  stroke-opacity: 0.15;
+  transition: stroke-opacity 0.1s;
+}
+
+.loopback.highlight {
+  stroke-opacity: 1;
+}
+
+.timeline-tooltip {
+  position: fixed;
+  z-index: 1000;
+  background: var(--sl-color-neutral-0, #fff);
+  border: 1px solid var(--sl-color-neutral-200, #e5e7eb);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 8px 10px;
+  pointer-events: none;
+  min-width: 160px;
+  max-width: 260px;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.tooltip-header {
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--fg, #1e293b);
+}
+
+.tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--fg, #1e293b);
+}
+
+.tooltip-label {
+  color: var(--muted, #94a3b8);
+}
+
+.tooltip-value {
+  font-family: var(--sl-font-mono, monospace);
+}
+
+/* --- Iteration drawer (click-to-drill) --- */
+.iteration-drawer::part(panel) {
+  width: 380px;
+  max-width: 90vw;
+}
+
+.drawer-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.drawer-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.drawer-label {
+  color: var(--muted, #94a3b8);
+  min-width: 64px;
+}
+
+.drawer-raw-json {
+  margin-top: 8px;
+}
+
+.drawer-raw-json summary {
+  cursor: pointer;
+  color: var(--muted, #94a3b8);
+  font-size: 12px;
+  user-select: none;
+}
+
+.drawer-raw-json pre {
+  font-size: 11px;
+  font-family: var(--sl-font-mono, monospace);
+  background: var(--bg-secondary, #f8fafc);
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 4px;
+  padding: 8px;
+  overflow-x: auto;
+  white-space: pre;
+  margin-top: 4px;
+}
+
+.drawer-run-detail-link {
+  color: var(--accent, #3b82f6);
+  text-decoration: none;
+  font-size: 13px;
+}
+
+.drawer-run-detail-link:hover {
+  text-decoration: underline;
 }
 
 .action-btn:disabled:hover {

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -434,165 +434,493 @@ h1, h2, h3, h4, h5, h6 {
   flex-wrap: wrap;
 }
 
-/* --- Run Timeline --- */
+/* --- Run Timeline ---
+   Local tokens layered on the global palette. --text-strong gives a
+   WCAG-AA-safe muted color for labels (4.5:1 on white at 12-13px), avoiding
+   the very pale --muted (#94a3b8). All other colors route through brand vars
+   so dark mode and theme tweaks land for free. */
 .run-timeline {
-  padding: 8px 0;
+  --tl-text-strong: #475569;
+  --tl-row-alt-bg: rgba(15, 23, 42, 0.04);
+  --tl-row-divider: rgba(15, 23, 42, 0.08);
+  --tl-grid-line: rgba(15, 23, 42, 0.05);
+  --tl-axis-line: rgba(15, 23, 42, 0.18);
+  --tl-axis-tick: rgba(15, 23, 42, 0.28);
+  --tl-axis-label: rgba(15, 23, 42, 0.62);
+  --tl-row-label: rgba(15, 23, 42, 0.78);
+  --tl-row-label-count: rgba(15, 23, 42, 0.45);
+  --tl-loopback-default-opacity: 0.7;
+  --tl-loopback-hint: rgba(15, 23, 42, 0.4);
+  --tl-bar-stroke: rgba(15, 23, 42, 0.22);
+  --tl-bar-shadow: rgba(15, 23, 42, 0.22);
+  --timeline-gap-fill: rgba(15, 23, 42, 0.04);
+  --timeline-gap-dot: rgba(15, 23, 42, 0.32);
+
+  padding: 16px 20px 24px;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border-subtle, rgba(226, 232, 240, 0.6));
+  border-radius: 10px;
   overflow-x: auto;
+  position: relative;
 }
 
-.timeline-toolbar {
+/* worca-ui drives dark mode via [data-theme="dark"] on the html element,
+   not via prefers-color-scheme. Both selectors here so the timeline tokens
+   flip with the rest of the chrome. */
+[data-theme="dark"] .run-timeline,
+.run-timeline[data-theme="dark"] {
+  --tl-text-strong: #cbd5e1;
+  --tl-row-alt-bg: rgba(255, 255, 255, 0.04);
+  --tl-row-divider: rgba(255, 255, 255, 0.1);
+  --tl-grid-line: rgba(255, 255, 255, 0.07);
+  --tl-axis-line: rgba(255, 255, 255, 0.22);
+  --tl-axis-tick: rgba(255, 255, 255, 0.35);
+  --tl-axis-label: rgba(255, 255, 255, 0.7);
+  --tl-row-label: rgba(255, 255, 255, 0.9);
+  --tl-row-label-count: rgba(255, 255, 255, 0.55);
+  --tl-loopback-hint: rgba(255, 255, 255, 0.5);
+  --tl-bar-stroke: rgba(255, 255, 255, 0.32);
+  --tl-bar-shadow: rgba(0, 0, 0, 0.45);
+  --timeline-gap-fill: rgba(255, 255, 255, 0.06);
+  --timeline-gap-dot: rgba(255, 255, 255, 0.4);
+}
+
+/* Top stats summary */
+.timeline-summary {
   display: flex;
-  justify-content: flex-end;
-  gap: 4px;
-  padding: 0 0 6px;
+  align-items: center;
+  gap: 28px;
+  /* Right-padding reserves space for the absolutely-positioned .timeline-toolbar
+     anchored at top:16px / right:20px so the stats never run under the buttons. */
+  padding: 4px 260px 16px 0;
+  flex-wrap: wrap;
+}
+.summary-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 64px;
+}
+.summary-stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--tl-text-strong);
+  font-weight: 500;
+}
+.summary-stat-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--fg, #0f172a);
+  font-variant-numeric: tabular-nums;
+}
+.summary-spacer {
+  flex: 1;
 }
 
+/* Toolbar — anchored to the top-right corner of the timeline box.
+   Stacks the zoom button group above the keyboard-hint text, both right-aligned. */
+.timeline-toolbar {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+.timeline-toolbar-group {
+  display: inline-flex;
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg, #fff);
+}
 .timeline-zoom-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 28px;
-  height: 24px;
-  padding: 0 6px;
-  border: 1px solid var(--sl-color-neutral-300, #d1d5db);
-  border-radius: 4px;
-  background: var(--sl-color-neutral-0, #fff);
-  color: var(--sl-color-neutral-700, #374151);
-  font-size: 14px;
+  min-width: 30px;
+  height: 28px;
+  padding: 0 8px;
+  border: none;
+  background: transparent;
+  color: var(--tl-text-strong);
   cursor: pointer;
   user-select: none;
+  border-right: 1px solid var(--border, #e2e8f0);
 }
-
+.timeline-zoom-btn:last-child {
+  border-right: none;
+}
 .timeline-zoom-btn:hover {
-  background: var(--sl-color-neutral-100, #f3f4f6);
+  background: var(--bg-secondary, #f8fafc);
+  color: var(--fg, #0f172a);
 }
-
 .timeline-zoom-btn:active {
-  background: var(--sl-color-neutral-200, #e5e7eb);
+  background: var(--bg-tertiary, #f1f5f9);
+}
+.timeline-zoom-btn:focus-visible {
+  outline: 2px solid var(--accent, #3b82f6);
+  outline-offset: -2px;
+  z-index: 1;
+}
+.timeline-toolbar-hint {
+  font-size: 11px;
+  color: var(--tl-text-strong);
+  text-align: right;
 }
 
+/* SVG wrapper */
+.timeline-svg-wrap {
+  position: relative;
+  overflow: visible;
+}
+
+/* Row backgrounds */
+.row-bg-alt {
+  fill: var(--tl-row-alt-bg);
+}
+.row-divider {
+  stroke: var(--tl-row-divider);
+  stroke-width: 1;
+  shape-rendering: crispEdges;
+}
+.grid-line {
+  stroke: var(--tl-grid-line);
+  stroke-width: 1;
+  shape-rendering: crispEdges;
+}
+
+/* Row labels — match the uppercase tracking used by .pipeline-stage-name so
+   timeline rows read like the stage section headers elsewhere in the UI. */
+.row-label {
+  font-size: 12px;
+  font-weight: 600;
+  fill: var(--tl-row-label);
+  font-family: var(--sl-font-sans, system-ui, sans-serif);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.row-label-count {
+  font-size: 11px;
+  font-weight: 500;
+  fill: var(--tl-row-label-count);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.loopback-hint {
+  font-size: 10px;
+  fill: var(--tl-loopback-hint);
+  pointer-events: none;
+}
+
+/* Bars
+   Default: thin contrasting hairline stroke so bar edges read clearly without
+   any per-bar divider. Hover/active: lift via translateY + drop-shadow so the
+   bar "raises" off the chart. Active state persists while the iteration drawer
+   is open (driven by the .is-active class). Reduced-motion drops the lift. */
 .timeline-bar {
   cursor: pointer;
+  stroke: var(--tl-bar-stroke);
+  stroke-width: 1;
+  transition:
+    filter 130ms ease,
+    transform 130ms ease,
+    stroke-width 130ms ease;
+  /* SVG rect transforms relative to the SVG viewport origin, not the rect
+     itself — fine for translateY since we want a small vertical lift. */
 }
-
-.timeline-bar:hover {
-  filter: brightness(1.15);
+.timeline-bar:hover,
+.timeline-bar.is-active {
+  filter: drop-shadow(0 3px 6px var(--tl-bar-shadow));
+  transform: translateY(-1px);
+  stroke-width: 1.25;
 }
-
 .timeline-bar:focus-visible {
-  outline: 2px solid var(--accent, #3b82f6);
-  outline-offset: 1px;
+  /* Subtle keyboard-focus indicator — no bold ring. The raised+shadow state
+     above also kicks in on focus via :focus-visible :is() below. */
+  outline: 1.5px dashed var(--accent, #3b82f6);
+  outline-offset: 2px;
+}
+.timeline-bar:focus-visible {
+  filter: drop-shadow(0 3px 6px var(--tl-bar-shadow));
+  transform: translateY(-1px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .timeline-bar,
+  .timeline-bar:hover,
+  .timeline-bar.is-active,
+  .timeline-bar:focus-visible {
+    transform: none;
+  }
+}
+.bar-label {
+  font-size: 10px;
+  font-weight: 600;
+  fill: #fff;
+  font-family: var(--sl-font-sans, system-ui, sans-serif);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
 }
 
+/* Gaps */
 .timeline-gap {
   cursor: default;
 }
-
-.timeline-gap:hover {
-  opacity: 0.75;
+.timeline-gap:focus-visible {
+  outline: 2px solid var(--accent, #3b82f6);
+  outline-offset: 1px;
+}
+.gap-bg {
+  fill: var(--timeline-gap-fill);
+}
+.gap-dot {
+  fill: var(--timeline-gap-dot);
 }
 
+/* Loopbacks */
 .loopback {
-  stroke-opacity: 0.15;
-  transition: stroke-opacity 0.1s;
+  stroke-opacity: var(--tl-loopback-default-opacity);
+  transition: stroke-opacity 120ms ease, stroke-width 120ms ease;
 }
-
 .loopback.highlight {
   stroke-opacity: 1;
+  stroke-width: 2.5;
 }
 
+/* Time axis */
+.axis-baseline {
+  stroke: var(--tl-axis-line);
+  stroke-width: 1;
+  shape-rendering: crispEdges;
+}
+.axis-tick {
+  stroke: var(--tl-axis-tick);
+  stroke-width: 1;
+  shape-rendering: crispEdges;
+}
+.axis-label {
+  font-size: 11px;
+  fill: var(--tl-axis-label);
+  font-family: var(--sl-font-sans, system-ui, sans-serif);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Legend */
+.timeline-legend {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 0 4px;
+  margin-top: 8px;
+  border-top: 1px solid var(--border-subtle, rgba(226, 232, 240, 0.6));
+  flex-wrap: wrap;
+}
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--tl-text-strong);
+}
+.legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: var(--muted);
+}
+.legend-swatch--gap {
+  background:
+    radial-gradient(circle, var(--timeline-gap-dot) 0.6px, transparent 1.2px),
+    var(--timeline-gap-fill);
+  background-size: 5px 5px;
+  border: 1px solid var(--tl-row-divider);
+}
+.legend-loopback {
+  /* Inline SVG arc + chevron; inherits color from the legend-item color, so
+     it tracks the rest of the legend chrome in both themes. */
+  color: var(--accent, #3b82f6);
+  flex-shrink: 0;
+}
+
+/* Tooltip */
 .timeline-tooltip {
   position: fixed;
   z-index: 1000;
-  background: var(--sl-color-neutral-0, #fff);
-  border: 1px solid var(--sl-color-neutral-200, #e5e7eb);
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  padding: 8px 10px;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border, #e2e8f0);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.12), 0 2px 6px rgba(15, 23, 42, 0.08);
+  padding: 10px 12px;
   pointer-events: none;
-  min-width: 160px;
-  max-width: 260px;
+  min-width: 200px;
+  max-width: 280px;
   font-size: 12px;
-  line-height: 1.5;
-  white-space: nowrap;
+  line-height: 1.55;
+  color: var(--fg, #0f172a);
 }
-
 .tooltip-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-weight: 600;
-  margin-bottom: 4px;
-  color: var(--fg, #1e293b);
+  margin-bottom: 6px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border-subtle, rgba(226, 232, 240, 0.6));
 }
-
+.tooltip-hue-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.tooltip-header-sub {
+  font-weight: 400;
+  color: var(--tl-text-strong);
+  font-size: 11px;
+}
 .tooltip-row {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
-  color: var(--fg, #1e293b);
+  gap: 14px;
 }
-
 .tooltip-label {
-  color: var(--muted, #94a3b8);
+  color: var(--tl-text-strong);
+  font-weight: 500;
 }
-
 .tooltip-value {
-  font-family: var(--sl-font-mono, monospace);
+  font-family: var(--sl-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-variant-numeric: tabular-nums;
+  color: var(--fg, #0f172a);
 }
+.tooltip-status {
+  text-transform: capitalize;
+}
+.tooltip-status.status-completed { color: var(--status-completed); }
+.tooltip-status.status-running, .tooltip-status.status-in_progress { color: var(--status-running); }
+.tooltip-status.status-failed { color: var(--status-failed); }
+.tooltip-status.status-paused { color: var(--status-paused); }
+.tooltip-status.status-interrupted { color: var(--status-interrupted); }
 
-/* --- Iteration drawer (click-to-drill) --- */
+/* --- Iteration drawer --- */
 .iteration-drawer::part(panel) {
-  width: 380px;
+  width: 420px;
   max-width: 90vw;
 }
-
+.iteration-drawer::part(header) {
+  border-bottom: 1px solid var(--border-subtle, rgba(226, 232, 240, 0.6));
+}
 .drawer-body {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 14px;
   font-size: 13px;
+  color: var(--fg, #0f172a);
 }
-
-.drawer-row {
+.drawer-title {
   display: flex;
   align-items: center;
   gap: 8px;
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fg, #0f172a);
+  outline: none;
 }
-
+.drawer-hue-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.drawer-title-sub {
+  font-weight: 400;
+  color: var(--tl-text-strong);
+  font-size: 13px;
+}
+.drawer-status-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--bg-secondary, #f8fafc);
+  align-self: flex-start;
+}
+.drawer-status-pill {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.drawer-status-text {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.drawer-status-text.status-completed { color: var(--status-completed); }
+.drawer-status-text.status-running, .drawer-status-text.status-in_progress { color: var(--status-running); }
+.drawer-status-text.status-failed { color: var(--status-failed); }
+.drawer-fields {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 18px;
+  margin: 0;
+}
 .drawer-label {
-  color: var(--muted, #94a3b8);
-  min-width: 64px;
+  color: var(--tl-text-strong);
+  font-weight: 500;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  align-self: center;
 }
-
+.drawer-value {
+  margin: 0;
+  font-family: var(--sl-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-variant-numeric: tabular-nums;
+  color: var(--fg, #0f172a);
+}
 .drawer-raw-json {
-  margin-top: 8px;
+  margin-top: 4px;
 }
-
 .drawer-raw-json summary {
   cursor: pointer;
-  color: var(--muted, #94a3b8);
+  color: var(--tl-text-strong);
   font-size: 12px;
   user-select: none;
 }
-
 .drawer-raw-json pre {
   font-size: 11px;
-  font-family: var(--sl-font-mono, monospace);
+  font-family: var(--sl-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   background: var(--bg-secondary, #f8fafc);
   border: 1px solid var(--border, #e2e8f0);
-  border-radius: 4px;
-  padding: 8px;
+  border-radius: 6px;
+  padding: 10px;
   overflow-x: auto;
   white-space: pre;
-  margin-top: 4px;
+  margin-top: 6px;
+  max-height: 280px;
 }
-
 .drawer-run-detail-link {
   color: var(--accent, #3b82f6);
   text-decoration: none;
   font-size: 13px;
+  font-weight: 500;
 }
-
 .drawer-run-detail-link:hover {
   text-decoration: underline;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline-bar,
+  .loopback {
+    transition: none;
+  }
 }
 
 .action-btn:disabled:hover {
@@ -748,6 +1076,12 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* Pipeline timing bar */
+.pipeline-timing-bar-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
 .pipeline-timing-bar-container {
   margin-top: 8px;
 }

--- a/worca-ui/app/utils/icons.js
+++ b/worca-ui/app/utils/icons.js
@@ -11,6 +11,7 @@ import ArrowLeft from 'lucide/dist/esm/icons/arrow-left';
 import ArrowRight from 'lucide/dist/esm/icons/arrow-right';
 import Bell from 'lucide/dist/esm/icons/bell';
 import Boxes from 'lucide/dist/esm/icons/boxes';
+import BarChart3 from 'lucide/dist/esm/icons/chart-bar';
 import ChevronDown from 'lucide/dist/esm/icons/chevron-down';
 import ChevronRight from 'lucide/dist/esm/icons/chevron-right';
 import Circle from 'lucide/dist/esm/icons/circle';
@@ -89,6 +90,7 @@ export {
   Activity,
   Archive,
   ArrowLeft,
+  BarChart3,
   ArrowRight,
   ArrowDown,
   Bell,

--- a/worca-ui/app/utils/icons.js
+++ b/worca-ui/app/utils/icons.js
@@ -61,6 +61,8 @@ import Users from 'lucide/dist/esm/icons/users';
 import Workflow from 'lucide/dist/esm/icons/workflow';
 import X from 'lucide/dist/esm/icons/x';
 import Zap from 'lucide/dist/esm/icons/zap';
+import ZoomIn from 'lucide/dist/esm/icons/zoom-in';
+import ZoomOut from 'lucide/dist/esm/icons/zoom-out';
 
 function renderChildren(nodes) {
   return nodes
@@ -144,4 +146,6 @@ export {
   Workflow,
   X,
   Zap,
+  ZoomIn,
+  ZoomOut,
 };

--- a/worca-ui/app/utils/stage-hues.js
+++ b/worca-ui/app/utils/stage-hues.js
@@ -1,0 +1,23 @@
+/** Canonical per-stage accent colors, keyed by Stage enum values from stages.py. */
+export const STAGE_HUES = {
+  preflight: '#64748b',
+  plan: '#4f46e5',
+  plan_review: '#7c3aed',
+  coordinate: '#0d9488',
+  implement: '#9333ea',
+  test: '#d97706',
+  review: '#059669',
+  pr: '#0891b2',
+  learn: '#e11d48',
+};
+
+/**
+ * Returns a CSS block that exposes each stage color as a custom property
+ * --stage-hue-<key> on :root (works in light and dark mode via CSS inheritance).
+ */
+export function applyStageCSSVars() {
+  const declarations = Object.entries(STAGE_HUES)
+    .map(([key, color]) => `  --stage-hue-${key}: ${color};`)
+    .join('\n');
+  return `:root {\n${declarations}\n}`;
+}

--- a/worca-ui/app/utils/stage-hues.test.js
+++ b/worca-ui/app/utils/stage-hues.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { applyStageCSSVars, STAGE_HUES } from './stage-hues.js';
+import { STAGE_ORDER } from './stage-order.js';
+
+describe('STAGE_HUES', () => {
+  it('has an entry for every Stage enum value from stages.py', () => {
+    for (const stage of STAGE_ORDER) {
+      expect(STAGE_HUES).toHaveProperty(stage);
+    }
+  });
+
+  it('has exactly the same keys as STAGE_ORDER', () => {
+    expect(Object.keys(STAGE_HUES).sort()).toEqual([...STAGE_ORDER].sort());
+  });
+
+  it('preflight is #64748b', () =>
+    expect(STAGE_HUES.preflight).toBe('#64748b'));
+  it('plan is #4f46e5', () => expect(STAGE_HUES.plan).toBe('#4f46e5'));
+  it('plan_review is #7c3aed', () =>
+    expect(STAGE_HUES.plan_review).toBe('#7c3aed'));
+  it('coordinate is #0d9488', () =>
+    expect(STAGE_HUES.coordinate).toBe('#0d9488'));
+  it('implement is #9333ea', () =>
+    expect(STAGE_HUES.implement).toBe('#9333ea'));
+  it('test is #d97706', () => expect(STAGE_HUES.test).toBe('#d97706'));
+  it('review is #059669', () => expect(STAGE_HUES.review).toBe('#059669'));
+  it('pr is #0891b2', () => expect(STAGE_HUES.pr).toBe('#0891b2'));
+  it('learn is #e11d48', () => expect(STAGE_HUES.learn).toBe('#e11d48'));
+});
+
+describe('applyStageCSSVars', () => {
+  it('returns a string containing all --stage-hue-<key> declarations', () => {
+    const css = applyStageCSSVars();
+    for (const key of STAGE_ORDER) {
+      expect(css).toContain(`--stage-hue-${key}:`);
+    }
+  });
+
+  it('includes the :root selector', () => {
+    expect(applyStageCSSVars()).toContain(':root');
+  });
+});

--- a/worca-ui/app/utils/timeline-layout.js
+++ b/worca-ui/app/utils/timeline-layout.js
@@ -1,0 +1,178 @@
+import { STAGE_ORDER } from './stage-order.js';
+
+/**
+ * Projects run.stages into the swimlane layout model used by the timeline view.
+ *
+ * @param {object|null} stages - run.stages from status.json
+ * @param {string} runEndTime - ISO timestamp for the right edge (pass now() for active runs)
+ * @returns {{ runStart, runEnd, totalMs, rows, loopbacks }}
+ */
+export function computeTimelineLayout(stages, runEndTime) {
+  if (!stages) {
+    return {
+      runStart: runEndTime,
+      runEnd: runEndTime,
+      totalMs: 0,
+      rows: [],
+      loopbacks: [],
+    };
+  }
+
+  // Collect all non-empty, non-all-skipped stage entries in pipeline order
+  const stageEntries = STAGE_ORDER.map((key) => [key, stages[key]]).filter(
+    ([, stage]) => {
+      if (!stage || !stage.iterations || stage.iterations.length === 0)
+        return false;
+      return stage.iterations.some((it) => it.status !== 'skipped');
+    },
+  );
+
+  if (stageEntries.length === 0) {
+    return {
+      runStart: runEndTime,
+      runEnd: runEndTime,
+      totalMs: 0,
+      rows: [],
+      loopbacks: [],
+    };
+  }
+
+  // Determine runStart: earliest started_at across all iterations
+  let runStartMs = Infinity;
+  for (const [, stage] of stageEntries) {
+    for (const it of stage.iterations) {
+      if (it.started_at) {
+        const t = new Date(it.started_at).getTime();
+        if (t < runStartMs) runStartMs = t;
+      }
+    }
+  }
+
+  const runEndMs = new Date(runEndTime).getTime();
+  const runStartIso = new Date(runStartMs).toISOString();
+  const totalMs = runEndMs - runStartMs;
+
+  // Build flat iteration lookup keyed by stageKey for gap/overlap queries
+  // itersByStage: Map<stageKey, [{startMs, endMs, number}]>
+  const itersByStage = new Map();
+  for (const [key, stage] of stageEntries) {
+    const list = stage.iterations
+      .filter((it) => it.started_at)
+      .map((it, idx) => ({
+        startMs: new Date(it.started_at).getTime() - runStartMs,
+        endMs: it.completed_at
+          ? new Date(it.completed_at).getTime() - runStartMs
+          : totalMs,
+        number: it.number ?? idx + 1,
+      }));
+    itersByStage.set(key, list);
+  }
+
+  // Build rows
+  const rows = stageEntries.map(([key, stage]) => {
+    const bars = stage.iterations
+      .filter((it) => it.started_at)
+      .map((it, idx) => {
+        const startMs = new Date(it.started_at).getTime() - runStartMs;
+        const endMs = it.completed_at
+          ? new Date(it.completed_at).getTime() - runStartMs
+          : totalMs;
+        return {
+          number: it.number ?? idx + 1,
+          startMs,
+          durMs: endMs - startMs,
+          status: it.status,
+          cost: it.cost_usd ?? 0,
+          model: it.model ?? null,
+          agent: it.agent ?? null,
+        };
+      });
+
+    // Compute gaps between consecutive bars
+    const gaps = [];
+    for (let i = 0; i < bars.length - 1; i++) {
+      const gapStart = bars[i].startMs + bars[i].durMs;
+      const gapEnd = bars[i + 1].startMs;
+      if (gapEnd <= gapStart) continue;
+
+      const inStage = findInStage(key, gapStart, gapEnd, itersByStage);
+      gaps.push({
+        afterIter: bars[i].number,
+        startMs: gapStart,
+        durMs: gapEnd - gapStart,
+        inStage,
+      });
+    }
+
+    return {
+      stageKey: key,
+      stageLabel: key.toUpperCase(),
+      iterationCount: bars.length,
+      bars,
+      gaps,
+    };
+  });
+
+  // Build loopbacks from gaps that have inStage — only backward arcs:
+  // inStage must be later in STAGE_ORDER than the row's stage, meaning a downstream
+  // stage ran and triggered this earlier stage to retry.
+  const loopbacks = [];
+  for (const row of rows) {
+    const rowIdx = STAGE_ORDER.indexOf(row.stageKey);
+    for (let g = 0; g < row.gaps.length; g++) {
+      const gap = row.gaps[g];
+      if (!gap.inStage) continue;
+      if (STAGE_ORDER.indexOf(gap.inStage) <= rowIdx) continue;
+
+      // Find which iteration of inStage overlapped this gap
+      const inStageIters = itersByStage.get(gap.inStage) ?? [];
+      const overlapping = inStageIters.filter(
+        (it) => it.startMs < gap.startMs + gap.durMs && it.endMs > gap.startMs,
+      );
+      const fromIter =
+        overlapping.length > 0
+          ? overlapping[overlapping.length - 1].number
+          : null;
+
+      loopbacks.push({
+        fromStage: gap.inStage,
+        fromIter,
+        toStage: row.stageKey,
+        toIter: row.bars[g + 1]?.number ?? null,
+      });
+    }
+  }
+
+  return {
+    runStart: runStartIso,
+    runEnd: runEndTime,
+    totalMs,
+    rows,
+    loopbacks,
+  };
+}
+
+/**
+ * Find which stage (other than excludeKey) occupied the gap window [gapStart, gapEnd].
+ * If multiple stages overlap, returns the one whose overlapping iteration ended closest to gapEnd.
+ * Returns null if no stage overlaps.
+ */
+function findInStage(excludeKey, gapStart, gapEnd, itersByStage) {
+  let bestKey = null;
+  let bestEndDelta = Infinity;
+
+  for (const [key, iters] of itersByStage) {
+    if (key === excludeKey) continue;
+    for (const it of iters) {
+      if (it.startMs < gapEnd && it.endMs > gapStart) {
+        const delta = Math.abs(it.endMs - gapEnd);
+        if (delta < bestEndDelta) {
+          bestEndDelta = delta;
+          bestKey = key;
+        }
+      }
+    }
+  }
+
+  return bestKey;
+}

--- a/worca-ui/app/utils/timeline-layout.js
+++ b/worca-ui/app/utils/timeline-layout.js
@@ -1,5 +1,15 @@
 import { STAGE_ORDER } from './stage-order.js';
 
+// "pr" → "PR" (acronym); "plan_review" → "Plan Review"; etc.
+const ACRONYM_KEYS = new Set(['pr']);
+function toDisplayLabel(key) {
+  if (ACRONYM_KEYS.has(key)) return key.toUpperCase();
+  return key
+    .split('_')
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : ''))
+    .join(' ');
+}
+
 /**
  * Projects run.stages into the swimlane layout model used by the timeline view.
  *
@@ -69,49 +79,51 @@ export function computeTimelineLayout(stages, runEndTime) {
   }
 
   // Build rows
-  const rows = stageEntries.map(([key, stage]) => {
-    const bars = stage.iterations
-      .filter((it) => it.started_at)
-      .map((it, idx) => {
-        const startMs = new Date(it.started_at).getTime() - runStartMs;
-        const endMs = it.completed_at
-          ? new Date(it.completed_at).getTime() - runStartMs
-          : totalMs;
-        return {
-          number: it.number ?? idx + 1,
-          startMs,
-          durMs: endMs - startMs,
-          status: it.status,
-          cost: it.cost_usd ?? 0,
-          model: it.model ?? null,
-          agent: it.agent ?? null,
-        };
-      });
+  const rows = stageEntries
+    .map(([key, stage]) => {
+      const bars = stage.iterations
+        .filter((it) => it.started_at)
+        .map((it, idx) => {
+          const startMs = new Date(it.started_at).getTime() - runStartMs;
+          const endMs = it.completed_at
+            ? new Date(it.completed_at).getTime() - runStartMs
+            : totalMs;
+          return {
+            number: it.number ?? idx + 1,
+            startMs,
+            durMs: endMs - startMs,
+            status: it.status,
+            cost: it.cost_usd ?? 0,
+            model: it.model ?? null,
+            agent: it.agent ?? null,
+          };
+        });
 
-    // Compute gaps between consecutive bars
-    const gaps = [];
-    for (let i = 0; i < bars.length - 1; i++) {
-      const gapStart = bars[i].startMs + bars[i].durMs;
-      const gapEnd = bars[i + 1].startMs;
-      if (gapEnd <= gapStart) continue;
+      // Compute gaps between consecutive bars
+      const gaps = [];
+      for (let i = 0; i < bars.length - 1; i++) {
+        const gapStart = bars[i].startMs + bars[i].durMs;
+        const gapEnd = bars[i + 1].startMs;
+        if (gapEnd <= gapStart) continue;
 
-      const inStage = findInStage(key, gapStart, gapEnd, itersByStage);
-      gaps.push({
-        afterIter: bars[i].number,
-        startMs: gapStart,
-        durMs: gapEnd - gapStart,
-        inStage,
-      });
-    }
+        const inStage = findInStage(key, gapStart, gapEnd, itersByStage);
+        gaps.push({
+          afterIter: bars[i].number,
+          startMs: gapStart,
+          durMs: gapEnd - gapStart,
+          inStage,
+        });
+      }
 
-    return {
-      stageKey: key,
-      stageLabel: key.toUpperCase(),
-      iterationCount: bars.length,
-      bars,
-      gaps,
-    };
-  });
+      return {
+        stageKey: key,
+        stageLabel: toDisplayLabel(key),
+        iterationCount: bars.length,
+        bars,
+        gaps,
+      };
+    })
+    .filter((row) => row.bars.length > 0);
 
   // Build loopbacks from gaps that have inStage — only backward arcs:
   // inStage must be later in STAGE_ORDER than the row's stage, meaning a downstream

--- a/worca-ui/app/utils/timeline-layout.test.js
+++ b/worca-ui/app/utils/timeline-layout.test.js
@@ -96,13 +96,18 @@ describe('computeTimelineLayout', () => {
       expect(keys.indexOf('plan')).toBeLessThan(keys.indexOf('implement'));
     });
 
-    it('includes stageLabel as uppercased stage key', () => {
+    it('includes stageLabel as Title Case of the stage key', () => {
       const stages = {
         implement: { iterations: [iter(T(0), T(5000))] },
+        plan_review: { iterations: [iter(T(0), T(5000))] },
       };
       const layout = computeTimelineLayout(stages, T(5000));
-      const row = layout.rows.find((r) => r.stageKey === 'implement');
-      expect(row.stageLabel).toBe('IMPLEMENT');
+      expect(
+        layout.rows.find((r) => r.stageKey === 'implement').stageLabel,
+      ).toBe('Implement');
+      expect(
+        layout.rows.find((r) => r.stageKey === 'plan_review').stageLabel,
+      ).toBe('Plan Review');
     });
 
     it('maps iterations to bars with startMs relative to runStart', () => {

--- a/worca-ui/app/utils/timeline-layout.test.js
+++ b/worca-ui/app/utils/timeline-layout.test.js
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest';
+import { computeTimelineLayout } from './timeline-layout.js';
+
+// Helper: build a minimal iteration entry
+function iter(startedAt, completedAt, opts = {}) {
+  return {
+    started_at: startedAt,
+    completed_at: completedAt,
+    status: opts.status ?? 'completed',
+    cost_usd: opts.cost ?? 0,
+    model: opts.model ?? 'sonnet',
+    agent: opts.agent ?? 'implementer',
+    number: opts.number ?? 1,
+    duration_ms:
+      opts.duration_ms ??
+      (completedAt ? new Date(completedAt) - new Date(startedAt) : null),
+  };
+}
+
+// Base timestamp helpers (all relative to T0 = '2024-01-01T00:00:00.000Z')
+const T0 = '2024-01-01T00:00:00.000Z';
+const T = (offsetMs) =>
+  new Date(new Date(T0).getTime() + offsetMs).toISOString();
+
+describe('computeTimelineLayout', () => {
+  describe('runStart from earliest iteration', () => {
+    it('picks the earliest started_at across all rows', () => {
+      const stages = {
+        plan: { iterations: [iter(T(5000), T(15000))] },
+        implement: { iterations: [iter(T(1000), T(10000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(20000));
+      expect(layout.runStart).toBe(T(1000));
+    });
+
+    it('uses the single iteration start when only one row exists', () => {
+      const stages = {
+        implement: { iterations: [iter(T(3000), T(8000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(10000));
+      expect(layout.runStart).toBe(T(3000));
+    });
+  });
+
+  describe('runEnd for active runs', () => {
+    it('uses provided runEndTime when passed', () => {
+      const stages = {
+        implement: { iterations: [iter(T(0), T(5000))] },
+      };
+      const endTime = T(9000);
+      const layout = computeTimelineLayout(stages, endTime);
+      expect(layout.runEnd).toBe(endTime);
+    });
+
+    it('runEnd from runEndTime is later than all completed_at', () => {
+      const stages = {
+        implement: { iterations: [iter(T(0), T(5000))] },
+      };
+      const endTime = T(10000);
+      const layout = computeTimelineLayout(stages, endTime);
+      expect(new Date(layout.runEnd).getTime()).toBe(
+        new Date(endTime).getTime(),
+      );
+    });
+  });
+
+  describe('totalMs', () => {
+    it('equals runEnd minus runStart in milliseconds', () => {
+      const stages = {
+        implement: { iterations: [iter(T(1000), T(6000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(11000));
+      expect(layout.totalMs).toBe(10000);
+    });
+  });
+
+  describe('rows', () => {
+    it('includes a row for each non-skipped stage', () => {
+      const stages = {
+        plan: { iterations: [iter(T(0), T(5000))] },
+        implement: { iterations: [iter(T(6000), T(10000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(10000));
+      const keys = layout.rows.map((r) => r.stageKey);
+      expect(keys).toContain('plan');
+      expect(keys).toContain('implement');
+    });
+
+    it('orders rows by STAGE_ORDER', () => {
+      const stages = {
+        implement: { iterations: [iter(T(6000), T(10000))] },
+        plan: { iterations: [iter(T(0), T(5000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(10000));
+      const keys = layout.rows.map((r) => r.stageKey);
+      expect(keys.indexOf('plan')).toBeLessThan(keys.indexOf('implement'));
+    });
+
+    it('includes stageLabel as uppercased stage key', () => {
+      const stages = {
+        implement: { iterations: [iter(T(0), T(5000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(5000));
+      const row = layout.rows.find((r) => r.stageKey === 'implement');
+      expect(row.stageLabel).toBe('IMPLEMENT');
+    });
+
+    it('maps iterations to bars with startMs relative to runStart', () => {
+      // plan starts at T(0), establishing runStart = T(0)
+      // implement starts at T(2000) → startMs = 2000 (offset from runStart)
+      const stages = {
+        plan: { iterations: [iter(T(0), T(1500))] },
+        implement: { iterations: [iter(T(2000), T(7000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(10000));
+      const row = layout.rows.find((r) => r.stageKey === 'implement');
+      expect(row.bars).toHaveLength(1);
+      expect(row.bars[0].startMs).toBe(2000);
+      expect(row.bars[0].durMs).toBe(5000);
+    });
+
+    it('bar carries status, cost, model, agent', () => {
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(5000), {
+              status: 'completed',
+              cost: 1.23,
+              model: 'opus',
+              agent: 'implementer',
+            }),
+          ],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(5000));
+      const bar = layout.rows[0].bars[0];
+      expect(bar.status).toBe('completed');
+      expect(bar.cost).toBe(1.23);
+      expect(bar.model).toBe('opus');
+      expect(bar.agent).toBe('implementer');
+    });
+
+    it('iterationCount equals the number of bars', () => {
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(5000), { number: 1 }),
+            iter(T(6000), T(10000), { number: 2 }),
+          ],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(10000));
+      const row = layout.rows.find((r) => r.stageKey === 'implement');
+      expect(row.iterationCount).toBe(2);
+      expect(row.bars).toHaveLength(2);
+    });
+  });
+
+  describe('skipped row hiding', () => {
+    it('excludes rows where all iterations are skipped', () => {
+      const stages = {
+        plan_review: {
+          iterations: [iter(T(0), T(1000), { status: 'skipped' })],
+        },
+        implement: { iterations: [iter(T(1000), T(5000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(5000));
+      const keys = layout.rows.map((r) => r.stageKey);
+      expect(keys).not.toContain('plan_review');
+      expect(keys).toContain('implement');
+    });
+
+    it('excludes stages with no iterations', () => {
+      const stages = {
+        plan_review: { iterations: [] },
+        implement: { iterations: [iter(T(0), T(5000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(5000));
+      const keys = layout.rows.map((r) => r.stageKey);
+      expect(keys).not.toContain('plan_review');
+    });
+
+    it('includes a row where at least one iteration is not skipped', () => {
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(3000), { status: 'skipped' }),
+            iter(T(4000), T(8000), { status: 'completed' }),
+          ],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(8000));
+      const keys = layout.rows.map((r) => r.stageKey);
+      expect(keys).toContain('implement');
+    });
+  });
+
+  describe('gap derivation', () => {
+    it('produces a gap between consecutive iterations on the same row', () => {
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(3000), { number: 1 }),
+            iter(T(5000), T(9000), { number: 2 }),
+          ],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(9000));
+      const row = layout.rows.find((r) => r.stageKey === 'implement');
+      expect(row.gaps).toHaveLength(1);
+      expect(row.gaps[0].afterIter).toBe(1);
+      expect(row.gaps[0].startMs).toBe(3000);
+      expect(row.gaps[0].durMs).toBe(2000);
+    });
+
+    it('gap inStage by overlap — attributes to stage overlapping the gap window', () => {
+      // implement iter1: T(0)–T(3000)
+      // test iter1:      T(3000)–T(5000)  ← overlaps the gap [3000, 5000]
+      // implement iter2: T(5000)–T(9000)
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(3000), { number: 1 }),
+            iter(T(5000), T(9000), { number: 2 }),
+          ],
+        },
+        test: {
+          iterations: [iter(T(3000), T(5000), { number: 1 })],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(9000));
+      const implRow = layout.rows.find((r) => r.stageKey === 'implement');
+      expect(implRow.gaps[0].inStage).toBe('test');
+    });
+
+    it('gap inStage is null when no other stage overlaps', () => {
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(3000), { number: 1 }),
+            iter(T(5000), T(9000), { number: 2 }),
+          ],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(9000));
+      const implRow = layout.rows.find((r) => r.stageKey === 'implement');
+      expect(implRow.gaps[0].inStage).toBeNull();
+    });
+
+    it('attributes gap to the overlapping stage whose iter ended closest to next iter start', () => {
+      // Two stages overlap the gap; the one that ended nearer to iter2.start wins
+      // implement iter1: T(0)–T(2000), iter2: T(8000)–T(12000)
+      // review iter1:    T(2000)–T(5000)  → ends at T(5000), gap is [2000, 8000]
+      // test iter1:      T(4000)–T(8000)  → ends at T(8000) — closer to T(8000) → wins
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(2000), { number: 1 }),
+            iter(T(8000), T(12000), { number: 2 }),
+          ],
+        },
+        review: {
+          iterations: [iter(T(2000), T(5000), { number: 1 })],
+        },
+        test: {
+          iterations: [iter(T(4000), T(8000), { number: 1 })],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(12000));
+      const implRow = layout.rows.find((r) => r.stageKey === 'implement');
+      expect(implRow.gaps[0].inStage).toBe('test');
+    });
+
+    it('produces no gaps for a row with a single iteration', () => {
+      const stages = {
+        implement: { iterations: [iter(T(0), T(5000))] },
+      };
+      const layout = computeTimelineLayout(stages, T(5000));
+      const row = layout.rows.find((r) => r.stageKey === 'implement');
+      expect(row.gaps).toHaveLength(0);
+    });
+  });
+
+  describe('loopback building', () => {
+    it('builds loopbacks from gap.inStage', () => {
+      // implement iter1 → gap inStage=test → implement iter2
+      // loopback: { fromStage: 'test', fromIter: 1, toStage: 'implement', toIter: 2 }
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(3000), { number: 1 }),
+            iter(T(5000), T(9000), { number: 2 }),
+          ],
+        },
+        test: {
+          iterations: [iter(T(3000), T(5000), { number: 1 })],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(9000));
+      expect(layout.loopbacks).toHaveLength(1);
+      const lb = layout.loopbacks[0];
+      expect(lb.fromStage).toBe('test');
+      expect(lb.toStage).toBe('implement');
+      expect(lb.toIter).toBe(2);
+    });
+
+    it('produces no loopbacks when there are no gaps with inStage', () => {
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(3000), { number: 1 }),
+            iter(T(3000), T(6000), { number: 2 }),
+          ],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(6000));
+      expect(layout.loopbacks).toHaveLength(0);
+    });
+
+    it('builds one loopback per gap that has inStage', () => {
+      // implement: 3 iters, test overlaps each gap
+      const stages = {
+        implement: {
+          iterations: [
+            iter(T(0), T(3000), { number: 1 }),
+            iter(T(5000), T(8000), { number: 2 }),
+            iter(T(10000), T(13000), { number: 3 }),
+          ],
+        },
+        test: {
+          iterations: [
+            iter(T(3000), T(5000), { number: 1 }),
+            iter(T(8000), T(10000), { number: 2 }),
+          ],
+        },
+      };
+      const layout = computeTimelineLayout(stages, T(13000));
+      expect(layout.loopbacks).toHaveLength(2);
+    });
+  });
+
+  describe('empty / edge cases', () => {
+    it('returns empty rows and loopbacks for empty stages', () => {
+      const layout = computeTimelineLayout({}, new Date().toISOString());
+      expect(layout.rows).toHaveLength(0);
+      expect(layout.loopbacks).toHaveLength(0);
+    });
+
+    it('handles stages object being null/undefined gracefully', () => {
+      const layout = computeTimelineLayout(null, new Date().toISOString());
+      expect(layout.rows).toHaveLength(0);
+    });
+  });
+});

--- a/worca-ui/app/utils/timeline-zoom.js
+++ b/worca-ui/app/utils/timeline-zoom.js
@@ -1,0 +1,51 @@
+export const SCALE_MIN = 1.0;
+export const SCALE_MAX = 32;
+
+export function clampScale(scale) {
+  return Math.max(SCALE_MIN, Math.min(SCALE_MAX, scale));
+}
+
+// panMs is bounded to [0, totalMs - totalMs/scale]
+export function clampPan(panMs, totalMs, scale) {
+  const visibleMs = totalMs / scale;
+  const maxPan = Math.max(0, totalMs - visibleMs);
+  return Math.max(0, Math.min(maxPan, panMs));
+}
+
+export function resetZoom() {
+  return { scale: 1.0, panMs: 0 };
+}
+
+// Wheel-anchored zoom: the time under the cursor stays fixed after scale change.
+// deltaY > 0 = zoom out, deltaY < 0 = zoom in.
+// cursorMs: time coordinate under the cursor (in ms from run start)
+export function wheelZoom(state, deltaY, cursorMs, totalMs) {
+  const factor = deltaY < 0 ? 2 : 0.5;
+  const newScale = clampScale(state.scale * factor);
+  if (newScale === state.scale) {
+    return state;
+  }
+  // Fraction of the visible window at which the cursor sits
+  const visibleMs = totalMs / state.scale;
+  const cursorFraction =
+    visibleMs > 0 ? (cursorMs - state.panMs) / visibleMs : 0;
+  const newPanMs = clampPan(
+    cursorMs - cursorFraction * (totalMs / newScale),
+    totalMs,
+    newScale,
+  );
+  return { scale: newScale, panMs: newPanMs };
+}
+
+// Drag-to-zoom: fit the [selStart, selEnd] window into the full view.
+export function dragToZoom(state, selStart, selEnd, totalMs) {
+  const lo = Math.min(selStart, selEnd);
+  const hi = Math.max(selStart, selEnd);
+  const windowMs = hi - lo;
+  if (windowMs <= 0) {
+    return state;
+  }
+  const newScale = clampScale(totalMs / windowMs);
+  const newPanMs = clampPan(lo, totalMs, newScale);
+  return { scale: newScale, panMs: newPanMs };
+}

--- a/worca-ui/app/utils/timeline-zoom.test.js
+++ b/worca-ui/app/utils/timeline-zoom.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampPan,
+  clampScale,
+  dragToZoom,
+  resetZoom,
+  wheelZoom,
+} from './timeline-zoom.js';
+
+const SCALE_MIN = 1.0;
+const SCALE_MAX = 32;
+
+describe('clampScale', () => {
+  it('clamps below min to 1.0', () => {
+    expect(clampScale(0.5)).toBe(SCALE_MIN);
+  });
+
+  it('clamps above max to 32', () => {
+    expect(clampScale(64)).toBe(SCALE_MAX);
+  });
+
+  it('passes through a value within range', () => {
+    expect(clampScale(4)).toBe(4);
+  });
+});
+
+describe('clampPan', () => {
+  it('clamps pan below 0 to 0', () => {
+    expect(clampPan(-100, 5000, 2.0)).toBe(0);
+  });
+
+  it('clamps pan beyond run window', () => {
+    // totalMs=10000, scale=2 → visible window = 10000/2 = 5000
+    // max panMs = 10000 - 5000 = 5000
+    expect(clampPan(9000, 10000, 2.0)).toBe(5000);
+  });
+
+  it('returns 0 when scale is 1 (fit-to-run)', () => {
+    expect(clampPan(500, 10000, 1.0)).toBe(0);
+  });
+
+  it('passes through valid pan', () => {
+    expect(clampPan(2000, 10000, 4.0)).toBe(2000);
+  });
+});
+
+describe('resetZoom', () => {
+  it('returns scale=1.0 and panMs=0', () => {
+    const state = resetZoom();
+    expect(state.scale).toBe(1.0);
+    expect(state.panMs).toBe(0);
+  });
+});
+
+describe('wheelZoom', () => {
+  it('zooms in (negative deltaY) and anchors the cursor time', () => {
+    // At scale=1, panMs=0, totalMs=10000, cursor at 50% → cursorMs=5000
+    // zoom in → scale doubles to 2
+    // anchor: panMs adjusted so time under cursor stays
+    // new panMs = cursorMs - cursorMs/newScale = 5000 - 5000/2 = 2500
+    const state = { scale: 1.0, panMs: 0 };
+    const next = wheelZoom(state, -1, 5000, 10000);
+    expect(next.scale).toBe(2.0);
+    expect(next.panMs).toBe(2500);
+  });
+
+  it('zooms out (positive deltaY) and anchors the cursor time', () => {
+    // At scale=2, panMs=2500, totalMs=10000, cursorMs=5000
+    // cursorFraction = (cursorMs - panMs) / (totalMs / scale) = (5000-2500)/(5000) = 0.5
+    // zoom out → scale halves to 1
+    // new panMs = cursorMs - cursorFraction * (totalMs / newScale) = 5000 - 0.5*10000 = 0
+    const state = { scale: 2.0, panMs: 2500 };
+    const next = wheelZoom(state, 1, 5000, 10000);
+    expect(next.scale).toBe(1.0);
+    expect(next.panMs).toBe(0);
+  });
+
+  it('does not zoom below scale=1.0', () => {
+    const state = { scale: 1.0, panMs: 0 };
+    const next = wheelZoom(state, 1, 5000, 10000);
+    expect(next.scale).toBe(1.0);
+    expect(next.panMs).toBe(0);
+  });
+
+  it('does not zoom above scale=32', () => {
+    const state = { scale: 32, panMs: 0 };
+    const next = wheelZoom(state, -1, 0, 10000);
+    expect(next.scale).toBe(32);
+  });
+
+  it('cursor time at left edge: panMs stays at left edge after zoom in', () => {
+    const state = { scale: 1.0, panMs: 0 };
+    const next = wheelZoom(state, -1, 0, 10000);
+    expect(next.panMs).toBe(0);
+  });
+});
+
+describe('dragToZoom', () => {
+  it('sets scale and panMs to fit the selected window', () => {
+    // totalMs=10000, select [2000, 4000] → window of 2000ms
+    // scale = totalMs / windowMs = 5
+    // panMs = selStart = 2000
+    const state = { scale: 1.0, panMs: 0 };
+    const next = dragToZoom(state, 2000, 4000, 10000);
+    expect(next.scale).toBe(5.0);
+    expect(next.panMs).toBe(2000);
+  });
+
+  it('clamps scale to 32 for very small selections', () => {
+    const state = { scale: 1.0, panMs: 0 };
+    const next = dragToZoom(state, 0, 100, 10000);
+    expect(next.scale).toBe(32);
+  });
+
+  it('handles reversed selection (selEnd < selStart)', () => {
+    const state = { scale: 1.0, panMs: 0 };
+    const next = dragToZoom(state, 4000, 2000, 10000);
+    expect(next.scale).toBe(5.0);
+    expect(next.panMs).toBe(2000);
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -1482,7 +1482,7 @@ function _agentPromptSection(_stageKey, promptData) {
       ${
         agentInstructions
           ? html`
-        <div class="agent-prompt-block agent-prompt-block--agent">
+        <div class="agent-prompt-block">
           <div class="agent-prompt-label-row">
             <span class="agent-prompt-label">Agent Prompt (resolved)</span>
             <button class="copy-btn" @click=${(e) => _copyToClipboard(agentInstructions, e.currentTarget)}>
@@ -1497,7 +1497,7 @@ function _agentPromptSection(_stageKey, promptData) {
       ${
         userPrompt
           ? html`
-        <div class="agent-prompt-block agent-prompt-block--user">
+        <div class="agent-prompt-block">
           <div class="agent-prompt-label-row">
             <span class="agent-prompt-label">User Message (-p)</span>
             <button class="copy-btn" @click=${(e) => _copyToClipboard(userPrompt, e.currentTarget)}>
@@ -1679,16 +1679,6 @@ export function runDetailView(run, settings = {}, options = {}) {
   const overview = html`
     <div class="run-detail-overview">
       ${stageTimelineView(stages, stageUi, run.active)}
-      ${
-        options.onOpenTimeline
-          ? html`<div class="run-stage-actions">
-              <button
-                class="action-btn action-btn--ghost"
-                @click=${options.onOpenTimeline}
-              >${unsafeHTML(iconSvg(BarChart3, 14))} Timeline</button>
-            </div>`
-          : nothing
-      }
       ${_circuitBreakerBannerView(run, settings)}
       ${prVerificationBannerView(run)}
       ${guideConflictsPanelView(run.guide_conflicts, options)}
@@ -1810,6 +1800,18 @@ export function runDetailView(run, settings = {}, options = {}) {
               <div class="pipeline-cost-strip">
                 ${pipelineCost > 0 ? html`<span class="pipeline-cost-item"><span class="meta-label">Cost:</span> <span class="meta-value">$${pipelineCost.toFixed(2)}</span></span>` : nothing}
                 ${pipelineTurns > 0 ? html`<span class="pipeline-cost-item"><span class="meta-label">Total Turns:</span> <span class="meta-value">${pipelineTurns}</span></span>` : nothing}
+              </div>
+            `
+                : nothing
+            }
+            ${
+              options.onOpenTimeline
+                ? html`
+              <div class="pipeline-timing-bar-actions">
+                <button
+                  class="action-btn action-btn--primary"
+                  @click=${options.onOpenTimeline}
+                ><span aria-hidden="true">${unsafeHTML(iconSvg(BarChart3, 14))}</span> Timeline</button>
               </div>
             `
                 : nothing

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -4,6 +4,7 @@ import { elapsed, formatDuration, formatTimestamp } from '../utils/duration.js';
 import { effortLevelBadge } from '../utils/effort-badge.js';
 import {
   AlertTriangle,
+  BarChart3,
   CircleCheck,
   ClipboardCopy,
   Clock,
@@ -1481,7 +1482,7 @@ function _agentPromptSection(_stageKey, promptData) {
       ${
         agentInstructions
           ? html`
-        <div class="agent-prompt-block">
+        <div class="agent-prompt-block agent-prompt-block--agent">
           <div class="agent-prompt-label-row">
             <span class="agent-prompt-label">Agent Prompt (resolved)</span>
             <button class="copy-btn" @click=${(e) => _copyToClipboard(agentInstructions, e.currentTarget)}>
@@ -1496,7 +1497,7 @@ function _agentPromptSection(_stageKey, promptData) {
       ${
         userPrompt
           ? html`
-        <div class="agent-prompt-block">
+        <div class="agent-prompt-block agent-prompt-block--user">
           <div class="agent-prompt-label-row">
             <span class="agent-prompt-label">User Message (-p)</span>
             <button class="copy-btn" @click=${(e) => _copyToClipboard(userPrompt, e.currentTarget)}>
@@ -1678,6 +1679,16 @@ export function runDetailView(run, settings = {}, options = {}) {
   const overview = html`
     <div class="run-detail-overview">
       ${stageTimelineView(stages, stageUi, run.active)}
+      ${
+        options.onOpenTimeline
+          ? html`<div class="run-stage-actions">
+              <button
+                class="action-btn action-btn--ghost"
+                @click=${options.onOpenTimeline}
+              >${unsafeHTML(iconSvg(BarChart3, 14))} Timeline</button>
+            </div>`
+          : nothing
+      }
       ${_circuitBreakerBannerView(run, settings)}
       ${prVerificationBannerView(run)}
       ${guideConflictsPanelView(run.guide_conflicts, options)}

--- a/worca-ui/app/views/run-timeline.js
+++ b/worca-ui/app/views/run-timeline.js
@@ -1,33 +1,32 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { iconSvg, RefreshCw, ZoomIn, ZoomOut } from '../utils/icons.js';
 import { STAGE_HUES } from '../utils/stage-hues.js';
 import { computeTimelineLayout } from '../utils/timeline-layout.js';
-import {
-  clampPan,
-  clampScale,
-  dragToZoom,
-  wheelZoom,
-} from '../utils/timeline-zoom.js';
+import { clampPan, clampScale, wheelZoom } from '../utils/timeline-zoom.js';
 
-const LABEL_WIDTH = 160;
-const ROW_HEIGHT = 32;
-const AXIS_HEIGHT = 24;
-const MIN_BAR_PX = 12;
-const LABEL_MIN_PX = 36;
+const LABEL_WIDTH = 168;
+const ROW_HEIGHT = 40;
+const ROW_BAR_INSET = 7;
+const AXIS_HEIGHT = 32;
+const AXIS_TOP_GAP = 6;
+const MIN_BAR_PX = 10;
+const LABEL_MIN_PX = 44;
+const MIN_TICK_PX = 90;
 const _LOOPBACK_HIDE_THRESHOLD = 30;
 
 const STATUS_FILL = {
-  completed: '#22c55e',
-  in_progress: '#3b82f6',
-  running: '#3b82f6',
-  failed: '#ef4444',
-  skipped: '#6b7280',
-  cancelled: '#6b7280',
-  pending: '#94a3b8',
+  completed: 'var(--status-completed)',
+  in_progress: 'var(--status-in-progress)',
+  running: 'var(--status-running)',
+  failed: 'var(--status-failed)',
+  skipped: 'var(--status-skipped)',
+  cancelled: 'var(--status-cancelled)',
+  pending: 'var(--status-pending)',
 };
 
 function statusFill(status) {
-  return STATUS_FILL[status] || '#94a3b8';
+  return STATUS_FILL[status] || 'var(--status-pending)';
 }
 
 // Escape values interpolated into the unsafeHTML SVG string to prevent attribute/text injection.
@@ -46,7 +45,28 @@ function formatDuration(ms) {
   if (s < 60) return `${s}s`;
   const m = Math.floor(s / 60);
   const rem = s % 60;
-  return `${m}m ${rem}s`;
+  if (m < 60) return rem ? `${m}m ${rem}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  const remm = m % 60;
+  return remm ? `${h}h ${remm}m` : `${h}h`;
+}
+
+function formatCost(cost) {
+  if (cost == null) return '—';
+  if (cost < 0.01) return '<$0.01';
+  return `$${cost.toFixed(2)}`;
+}
+
+// Pick the smallest "nice" tick interval (ms) that is >= minMs.
+const NICE_INTERVALS_MS = [
+  1000, 2000, 5000, 10000, 15000, 30000, 60000, 120000, 300000, 600000, 900000,
+  1800000, 3600000, 7200000, 10800000, 21600000, 43200000, 86400000,
+];
+function niceTickInterval(minMs) {
+  for (const t of NICE_INTERVALS_MS) {
+    if (t >= minMs) return t;
+  }
+  return NICE_INTERVALS_MS[NICE_INTERVALS_MS.length - 1];
 }
 
 // Format a run-relative ms offset as mm:ss (or hh:mm:ss when hours > 0)
@@ -76,11 +96,19 @@ function formatAxisLabel(ms, totalMs) {
 // --- Module-level zoom/pan state ---
 let _scale = 1.0;
 let _panMs = 0;
+// Chart-area drag → pan
 let _dragging = false;
 let _dragStartX = 0;
 let _dragStartPanMs = 0;
-let _selecting = false;
-let _selectStartMs = 0;
+let _dragMoved = false;
+// Axis-ribbon drag → zoom (anchored at click point)
+let _axisDragging = false;
+let _axisDragStartX = 0;
+let _axisDragStartScale = 1.0;
+let _axisDragAnchorMs = 0;
+let _axisDragAnchorScreenX = 0;
+// Track the bar whose drawer is open so it stays raised across re-renders.
+let _activeBar = null;
 
 export function _resetZoomStateForTests() {
   _scale = 1.0;
@@ -88,8 +116,13 @@ export function _resetZoomStateForTests() {
   _dragging = false;
   _dragStartX = 0;
   _dragStartPanMs = 0;
-  _selecting = false;
-  _selectStartMs = 0;
+  _dragMoved = false;
+  _axisDragging = false;
+  _axisDragStartX = 0;
+  _axisDragStartScale = 1.0;
+  _axisDragAnchorMs = 0;
+  _axisDragAnchorScreenX = 0;
+  _activeBar = null;
 }
 
 // Memoize layout per run object (WeakMap avoids stale cache on same id/updated_at with different stages)
@@ -136,64 +169,230 @@ function getLayout(run) {
 function buildAxisHtml(totalMs, swimlaneWidth, scale, panMs) {
   if (totalMs <= 0 || swimlaneWidth <= 0) return '';
 
-  let tickIntervalMs;
-  if (scale >= 16) {
-    tickIntervalMs = 1000;
-  } else if (scale >= 4) {
-    tickIntervalMs = 10000;
-  } else {
-    tickIntervalMs = 60000;
-  }
-
-  // Prevent runaway tick generation for very long visible ranges (e.g. active runs).
-  // Double the interval until the visible range would produce at most 200 ticks.
-  const visibleMsForTick = totalMs / scale;
-  while (visibleMsForTick / tickIntervalMs > 200) {
-    tickIntervalMs *= 10;
-  }
-
   const visibleMs = totalMs / scale;
+  const pxPerMs = swimlaneWidth / visibleMs;
+  const minTickMs = MIN_TICK_PX / pxPerMs;
+  const tickIntervalMs = niceTickInterval(minTickMs);
+
   const startMs = panMs;
   const endMs = panMs + visibleMs;
   const firstTickMs = Math.ceil(startMs / tickIntervalMs) * tickIntervalMs;
 
-  let out = `<line x1="${LABEL_WIDTH}" y1="0" x2="${LABEL_WIDTH + swimlaneWidth}" y2="0" stroke="currentColor" stroke-opacity="0.2"/>`;
+  let out = `<line x1="${LABEL_WIDTH}" y1="0" x2="${LABEL_WIDTH + swimlaneWidth}" y2="0" class="axis-baseline"/>`;
 
-  for (let tickMs = firstTickMs; tickMs <= endMs; tickMs += tickIntervalMs) {
+  for (
+    let tickMs = firstTickMs;
+    tickMs <= endMs + 1;
+    tickMs += tickIntervalMs
+  ) {
     const xInSwimlane = ((tickMs - panMs) / visibleMs) * swimlaneWidth;
     const tx = LABEL_WIDTH + xInSwimlane;
     if (tx < LABEL_WIDTH - 1 || tx > LABEL_WIDTH + swimlaneWidth + 1) continue;
     const label = esc(formatAxisLabel(tickMs, totalMs));
-    out += `<line x1="${tx}" y1="0" x2="${tx}" y2="5" stroke="currentColor" stroke-opacity="0.3"/>`;
-    out += `<text x="${tx}" y="16" text-anchor="middle" font-size="9" fill="currentColor" opacity="0.5">${label}</text>`;
+    out += `<line x1="${tx}" y1="0" x2="${tx}" y2="5" class="axis-tick"/>`;
+    out += `<text x="${tx}" y="20" text-anchor="middle" class="axis-label">${label}</text>`;
   }
 
   return out;
 }
 
+// Grid lines are rendered inside a <g transform="translate(LABEL_WIDTH, 0)">,
+// so x coords here are relative to the swimlane origin (0..swimlaneWidth).
+function buildGridHtml(totalMs, swimlaneWidth, contentHeight, scale, panMs) {
+  if (totalMs <= 0 || swimlaneWidth <= 0) return '';
+
+  const visibleMs = totalMs / scale;
+  const pxPerMs = swimlaneWidth / visibleMs;
+  const minTickMs = MIN_TICK_PX / pxPerMs;
+  const tickIntervalMs = niceTickInterval(minTickMs);
+
+  const endMs = panMs + visibleMs;
+  const firstTickMs = Math.ceil(panMs / tickIntervalMs) * tickIntervalMs;
+
+  let out = '';
+  for (
+    let tickMs = firstTickMs;
+    tickMs <= endMs + 1;
+    tickMs += tickIntervalMs
+  ) {
+    const x = ((tickMs - panMs) / visibleMs) * swimlaneWidth;
+    if (x < -1 || x > swimlaneWidth + 1) continue;
+    out += `<line x1="${x}" y1="0" x2="${x}" y2="${contentHeight}" class="grid-line"/>`;
+  }
+  return out;
+}
+
 // --- Apply zoom/pan directly to DOM (no full re-render) ---
 
-function applyZoomPan(container, totalMs, swimlaneWidth) {
+function applyZoomPan(container, layout, swimlaneWidth, contentHeight) {
   const swimG = container.querySelector('.swimlane-content');
   const axisG = container.querySelector('.axis');
+  const gridG = container.querySelector('.grid');
   if (!swimG || !axisG) return;
 
-  const panPx = totalMs > 0 ? (_panMs / totalMs) * swimlaneWidth : 0;
-  swimG.setAttribute(
-    'transform',
-    `translate(${LABEL_WIDTH}, 0) scale(${_scale}, 1) translate(${-panPx}, 0)`,
+  const { totalMs } = layout;
+  // Redraw the swimlane content at the new scale/pan so bar widths and
+  // text stay at their natural size (an SVG-transform-scale would visually
+  // stretch text and the left-edge accents).
+  swimG.innerHTML = buildSwimlaneLayerHtml(
+    layout,
+    swimlaneWidth,
+    _scale,
+    _panMs,
   );
 
   axisG.innerHTML = buildAxisHtml(totalMs, swimlaneWidth, _scale, _panMs);
+  if (gridG) {
+    gridG.innerHTML = buildGridHtml(
+      totalMs,
+      swimlaneWidth,
+      contentHeight,
+      _scale,
+      _panMs,
+    );
+  }
 }
 
 // --- SVG builder ---
 
+// Compute the swimlane innerHTML (bars, gaps, bar labels, loopbacks) for the
+// given scale + pan. The wrapping <g> uses ONLY translate(LABEL_WIDTH, 0) — no
+// SVG scale — so bar widths and text sizes stay correct at every zoom level.
+function buildSwimlaneLayerHtml(layout, swimlaneWidth, scale, panMs) {
+  const { totalMs, rows, loopbacks } = layout;
+  if (rows.length === 0 || totalMs <= 0) return '';
+
+  const visibleMs = totalMs / scale;
+  const pxPerMs = swimlaneWidth / visibleMs;
+
+  const highIterStages = new Set(
+    rows
+      .filter((r) => r.iterationCount > _LOOPBACK_HIDE_THRESHOLD)
+      .map((r) => r.stageKey),
+  );
+
+  const rowDataMap = new Map();
+  let swimlaneRowsStr = '';
+
+  rows.forEach((row, rowIdx) => {
+    const y = rowIdx * ROW_HEIGHT;
+    const cy = y + ROW_HEIGHT / 2;
+    const barY = y + ROW_BAR_INSET;
+    const barH = ROW_HEIGHT - ROW_BAR_INSET * 2;
+    const barInfos = [];
+
+    let gapsStr = '';
+    for (const gap of row.gaps) {
+      const rawX = (gap.startMs - panMs) * pxPerMs;
+      const rawW = gap.durMs * pxPerMs;
+      if (rawX + rawW < 0 || rawX > swimlaneWidth) continue;
+      const gapW = Math.max(2, rawW);
+      const tooltipText = gap.inStage
+        ? `Control in ${gap.inStage} for ${formatDuration(gap.durMs)}`
+        : `Idle gap for ${formatDuration(gap.durMs)}`;
+      const ariaLabel = `${row.stageLabel} gap: ${tooltipText}`;
+      gapsStr += `<rect class="timeline-gap" role="img" tabindex="0" aria-label="${esc(ariaLabel)}" x="${rawX}" y="${barY}" width="${gapW}" height="${barH}" fill="url(#gapDots)" data-tooltip="${esc(tooltipText)}" data-stage-label="${esc(row.stageLabel)}" data-dur-ms="${esc(gap.durMs)}" data-in-stage="${esc(gap.inStage ?? '')}" data-in-stage-count="1" data-returned-at-ms="${esc(gap.startMs + gap.durMs)}"/>`;
+    }
+
+    let barsStr = '';
+    for (const bar of row.bars) {
+      const rawX = (bar.startMs - panMs) * pxPerMs;
+      const rawW = bar.durMs * pxPerMs;
+      const barW = Math.max(MIN_BAR_PX, rawW);
+      // Always record bar info — loopback endpoints may reference off-screen bars
+      barInfos.push({ barX: rawX, barW, cy, number: bar.number });
+      if (rawX + barW < 0 || rawX > swimlaneWidth) continue;
+
+      const fill = statusFill(bar.status);
+      const isActive =
+        _activeBar &&
+        _activeBar.stageKey === row.stageKey &&
+        _activeBar.number === bar.number;
+      const ariaLabel = `${row.stageLabel} iteration ${bar.number} of ${row.iterationCount}, ${formatDuration(bar.durMs)}, ${bar.status}`;
+      barsStr += `<rect class="timeline-bar${isActive ? ' is-active' : ''}" role="button" aria-label="${esc(ariaLabel)}" tabindex="0" x="${rawX}" y="${barY}" width="${barW}" height="${barH}" fill="${fill}" data-stage-key="${esc(row.stageKey)}" data-bar-number="${esc(bar.number)}" data-stage-label="${esc(row.stageLabel)}" data-iter-total="${esc(row.iterationCount)}" data-start-ms="${esc(bar.startMs)}" data-dur-ms="${esc(bar.durMs)}" data-model="${esc(bar.model ?? '')}" data-status="${esc(bar.status)}" data-cost="${esc(bar.cost ?? 0)}"/>`;
+
+      // Center label over the VISIBLE portion of the bar so a bar that's
+      // clipped on the left keeps a readable label inside its on-screen area.
+      const visibleStart = Math.max(rawX, 0);
+      const visibleEnd = Math.min(rawX + barW, swimlaneWidth);
+      const visibleW = visibleEnd - visibleStart;
+      if (visibleW >= LABEL_MIN_PX) {
+        const labelX = (visibleStart + visibleEnd) / 2;
+        barsStr += `<text class="bar-label" x="${labelX}" y="${cy + 4}" text-anchor="middle" pointer-events="none">${esc(formatDuration(bar.durMs))}</text>`;
+      }
+    }
+
+    swimlaneRowsStr += `<g class="timeline-row" data-stage-key="${esc(row.stageKey)}">${gapsStr}${barsStr}</g>`;
+    rowDataMap.set(row.stageKey, { bars: barInfos, rowIdx });
+  });
+
+  let loopbackStr = '';
+  for (const lb of loopbacks) {
+    if (highIterStages.has(lb.fromStage) || highIterStages.has(lb.toStage))
+      continue;
+    const fromData = rowDataMap.get(lb.fromStage);
+    const toData = rowDataMap.get(lb.toStage);
+    if (!fromData || !toData) continue;
+
+    const fromBarInfo =
+      lb.fromIter != null
+        ? fromData.bars.find((b) => b.number === lb.fromIter)
+        : fromData.bars[fromData.bars.length - 1];
+    const toBarInfo =
+      lb.toIter != null
+        ? toData.bars.find((b) => b.number === lb.toIter)
+        : toData.bars[0];
+    if (!fromBarInfo || !toBarInfo) continue;
+
+    const x1 = fromBarInfo.barX + fromBarInfo.barW;
+    const y1 = fromBarInfo.cy;
+    const x2 = toBarInfo.barX;
+    const y2 = toBarInfo.cy;
+    if ((x1 < 0 && x2 < 0) || (x1 > swimlaneWidth && x2 > swimlaneWidth))
+      continue;
+    // Cubic-bezier S-curve. Control points pulled HORIZONTALLY only, so:
+    //  - the curve leaves the source going right (cp1 is right of source)
+    //  - the curve enters the target going right too (cp2 is left of target)
+    // — and the arrowhead always lands in the target bar's left edge moving
+    // rightward. Bulge scales with |dx| so loopbacks that span a wider time
+    // gap still feel proportional.
+    const stroke = STAGE_HUES[lb.fromStage] || 'currentColor';
+    const bulge = Math.max(30, Math.abs(x2 - x1) * 0.4);
+    const cp1x = x1 + bulge;
+    const cp1y = y1;
+    const cp2x = x2 - bulge;
+    const cp2y = y2;
+    const path = `M${x1},${y1} C${cp1x},${cp1y} ${cp2x},${cp2y} ${x2},${y2}`;
+    // Inline chevron arrowhead, oriented along the incoming tangent at (x2,y2).
+    // For our cubic the tangent direction = (x2,y2) - (cp2x,cp2y) = (bulge, 0),
+    // i.e. pure-right — but we compute it generically so other geometries work too.
+    const tx = x2 - cp2x;
+    const ty = y2 - cp2y;
+    const tlen = Math.hypot(tx, ty) || 1;
+    const ux = tx / tlen;
+    const uy = ty / tlen;
+    const ahSize = 6;
+    // Perpendicular vector (rotate (ux,uy) 90°)
+    const px = -uy;
+    const py = ux;
+    const baseX = x2 - ux * ahSize;
+    const baseY = y2 - uy * ahSize;
+    const aLx = baseX + px * (ahSize * 0.6);
+    const aLy = baseY + py * (ahSize * 0.6);
+    const aRx = baseX - px * (ahSize * 0.6);
+    const aRy = baseY - py * (ahSize * 0.6);
+    const arrowhead = `<path d="M${x2},${y2} L${aLx.toFixed(2)},${aLy.toFixed(2)} L${aRx.toFixed(2)},${aRy.toFixed(2)} Z" fill="${stroke}" aria-hidden="true"/>`;
+
+    loopbackStr += `<path class="loopback" data-from-stage="${esc(lb.fromStage)}" data-from-iter="${esc(lb.fromIter ?? '')}" data-to-stage="${esc(lb.toStage)}" data-to-iter="${esc(lb.toIter ?? '')}" d="${path}" fill="none" stroke="${stroke}" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"/>${arrowhead}`;
+  }
+
+  return swimlaneRowsStr + loopbackStr;
+}
+
 function buildSvg(layout, swimlaneWidth) {
-  const { totalMs, rows, loopbacks, runStart } = layout;
+  const { totalMs, rows, runStart } = layout;
   if (rows.length === 0) return null;
 
-  // Rows exceeding this threshold get loopbacks suppressed and a hint shown instead
   const highIterStages = new Set(
     rows
       .filter((r) => r.iterationCount > _LOOPBACK_HIDE_THRESHOLD)
@@ -202,136 +401,68 @@ function buildSvg(layout, swimlaneWidth) {
 
   const svgWidth = LABEL_WIDTH + swimlaneWidth;
   const contentHeight = ROW_HEIGHT * rows.length;
-  const svgHeight = contentHeight + AXIS_HEIGHT;
+  const svgHeight = contentHeight + AXIS_TOP_GAP + AXIS_HEIGHT;
 
-  // Map ms offset to x pixel within swimlane at scale=1
-  function msToX(ms) {
-    if (totalMs <= 0) return 0;
-    return (ms / totalMs) * swimlaneWidth;
-  }
-
-  const panPx = totalMs > 0 ? (_panMs / totalMs) * swimlaneWidth : 0;
-
+  // Fixed layer: row backgrounds, dividers, hue dots, row labels.
+  // These do not move with zoom/pan.
   let fixedStr = '';
-  let swimlaneRowsStr = '';
-  const rowDataMap = new Map();
-
   rows.forEach((row, rowIdx) => {
     const y = rowIdx * ROW_HEIGHT;
     const cy = y + ROW_HEIGHT / 2;
-    const stageHue = STAGE_HUES[row.stageKey] || '#94a3b8';
-    const barInfos = [];
 
-    // Fixed layer: row background stripe
-    const bgFill = rowIdx % 2 === 0 ? 'rgba(0,0,0,0.02)' : 'transparent';
-    fixedStr += `<rect x="0" y="${y}" width="${svgWidth}" height="${ROW_HEIGHT}" fill="${bgFill}"/>`;
-
-    // Fixed layer: row label
-    const iterBadge = row.iterationCount > 1 ? ` ↻×${row.iterationCount}` : '';
-    fixedStr += `<text class="row-label" x="${LABEL_WIDTH - 8}" y="${cy + 4}" text-anchor="end" font-size="11" fill="currentColor">${esc(row.stageLabel)}${iterBadge}</text>`;
-
-    // Swimlane bars — x coords relative to swimlane start (no LABEL_WIDTH offset)
-    let barsStr = '';
-    for (const bar of row.bars) {
-      const rawW = msToX(bar.durMs);
-      const barW = Math.max(MIN_BAR_PX, rawW);
-      const barX = msToX(bar.startMs);
-      const fill = statusFill(bar.status);
-
-      const ariaLabel = `${row.stageLabel} iteration ${bar.number} of ${row.iterationCount}, ${formatDuration(bar.durMs)}, ${bar.status}`;
-      barsStr += `<rect class="timeline-bar" role="img" aria-label="${esc(ariaLabel)}" tabindex="0" x="${barX}" y="${y + 4}" width="${barW}" height="${ROW_HEIGHT - 8}" rx="2" fill="${fill}" data-stage-key="${esc(row.stageKey)}" data-bar-number="${esc(bar.number)}" data-stage-label="${esc(row.stageLabel)}" data-iter-total="${esc(row.iterationCount)}" data-start-ms="${esc(bar.startMs)}" data-dur-ms="${esc(bar.durMs)}" data-model="${esc(bar.model ?? '')}" data-status="${esc(bar.status)}" data-cost="${esc(bar.cost ?? 0)}"/>`;
-      // 3px left-edge accent — pointer-events:none so hover always hits the bar rect
-      barsStr += `<rect class="bar-accent" x="${barX}" y="${y + 4}" width="3" height="${ROW_HEIGHT - 8}" rx="1" fill="${stageHue}" pointer-events="none"/>`;
-
-      if (barW >= LABEL_MIN_PX) {
-        barsStr += `<text class="bar-label" x="${barX + barW / 2}" y="${cy + 4}" text-anchor="middle" font-size="10" fill="white" pointer-events="none">${esc(formatDuration(bar.durMs))}</text>`;
-      }
-
-      barInfos.push({ barX, barW, cy });
+    if (rowIdx % 2 === 1) {
+      fixedStr += `<rect x="0" y="${y}" width="${svgWidth}" height="${ROW_HEIGHT}" class="row-bg-alt"/>`;
     }
-
-    // Swimlane gaps — hoverable via data-tooltip
-    let gapsStr = '';
-    for (const gap of row.gaps) {
-      const gapX = msToX(gap.startMs);
-      const gapW = Math.max(1, msToX(gap.durMs));
-      const tooltipText = gap.inStage
-        ? `Control in ${gap.inStage.toUpperCase()} for ${formatDuration(gap.durMs)}`
-        : `Idle gap for ${formatDuration(gap.durMs)}`;
-      gapsStr += `<rect class="timeline-gap" x="${gapX}" y="${y + 4}" width="${gapW}" height="${ROW_HEIGHT - 8}" fill="url(#gapHatch)" opacity="0.5" data-tooltip="${esc(tooltipText)}" data-stage-label="${esc(row.stageLabel)}" data-dur-ms="${esc(gap.durMs)}" data-in-stage="${esc(gap.inStage ?? '')}" data-in-stage-count="1" data-returned-at-ms="${esc(gap.startMs + gap.durMs)}" style="cursor:default"/>`;
+    // Draw a divider above the first row so the top of the chart matches the
+    // between-row separators (the bottom of the last row is drawn below).
+    if (rowIdx === 0) {
+      fixedStr += `<line x1="0" y1="${y}" x2="${svgWidth}" y2="${y}" class="row-divider"/>`;
     }
+    fixedStr += `<line x1="0" y1="${y + ROW_HEIGHT}" x2="${svgWidth}" y2="${y + ROW_HEIGHT}" class="row-divider"/>`;
 
-    swimlaneRowsStr += `<g class="timeline-row">${gapsStr}${barsStr}</g>`;
-    rowDataMap.set(row.stageKey, { bars: barInfos, rowIdx });
+    const iterBadge =
+      row.iterationCount > 1
+        ? ` <tspan class="row-label-count">×${row.iterationCount}</tspan>`
+        : '';
+    fixedStr += `<text class="row-label" x="14" y="${cy + 4}" text-anchor="start">${esc(row.stageLabel)}${iterBadge}</text>`;
 
-    // Hint text for rows where loopbacks are suppressed due to high iteration count
     if (highIterStages.has(row.stageKey)) {
-      fixedStr += `<text x="${LABEL_WIDTH + 8}" y="${cy + 4}" font-size="9" fill="currentColor" opacity="0.4" pointer-events="none">(loopbacks hidden — hover an iteration to highlight)</text>`;
+      fixedStr += `<text x="${LABEL_WIDTH + 8}" y="${cy + 4}" class="loopback-hint">loopbacks hidden — hover a bar</text>`;
     }
   });
 
-  // Loopback arrows (inside swimlane-content, same coordinate space as bars)
-  let loopbackStr = '';
-  for (const lb of loopbacks) {
-    // Skip arrows involving rows that exceeded the loopback hide threshold
-    if (highIterStages.has(lb.fromStage) || highIterStages.has(lb.toStage))
-      continue;
-    const fromData = rowDataMap.get(lb.fromStage);
-    const toData = rowDataMap.get(lb.toStage);
-    if (!fromData || !toData) continue;
-
-    const fromRow = rows.find((r) => r.stageKey === lb.fromStage);
-    const toRow = rows.find((r) => r.stageKey === lb.toStage);
-    if (!fromRow || !toRow) continue;
-
-    const fromBarIdx =
-      lb.fromIter != null
-        ? fromRow.bars.findIndex((b) => b.number === lb.fromIter)
-        : fromRow.bars.length - 1;
-    const toBarIdx =
-      lb.toIter != null
-        ? toRow.bars.findIndex((b) => b.number === lb.toIter)
-        : 0;
-
-    if (fromBarIdx < 0 || toBarIdx < 0) continue;
-
-    const fromBarInfo = fromData.bars[fromBarIdx];
-    const toBarInfo = toData.bars[toBarIdx];
-    if (!fromBarInfo || !toBarInfo) continue;
-
-    const x1 = fromBarInfo.barX + fromBarInfo.barW;
-    const y1 = fromBarInfo.cy;
-    const x2 = toBarInfo.barX;
-    const y2 = toBarInfo.cy;
-    const lift = 1.5 * ROW_HEIGHT;
-    const cpY = Math.min(y1, y2) - lift;
-
-    loopbackStr += `<path class="loopback" data-from-stage="${esc(lb.fromStage)}" data-from-iter="${esc(lb.fromIter ?? '')}" data-to-stage="${esc(lb.toStage)}" data-to-iter="${esc(lb.toIter ?? '')}" d="M${x1},${y1} C${x1},${cpY} ${x2},${cpY} ${x2},${y2}" fill="none" stroke="currentColor" stroke-opacity="0.15" stroke-width="1.5" marker-end="url(#arrowhead)" aria-hidden="true"/>`;
-  }
+  const swimlaneLayer = buildSwimlaneLayerHtml(
+    layout,
+    swimlaneWidth,
+    _scale,
+    _panMs,
+  );
 
   const defs = `<defs>
     <clipPath id="swimlane-clip">
-      <rect x="${LABEL_WIDTH}" y="-200" width="${swimlaneWidth}" height="${svgHeight + 400}"/>
+      <rect x="0" y="-200" width="${swimlaneWidth}" height="${svgHeight + 400}"/>
     </clipPath>
-    <pattern id="gapHatch" patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
-      <line x1="0" y1="0" x2="0" y2="6" stroke="#94a3b8" stroke-width="2"/>
+    <pattern id="gapDots" patternUnits="userSpaceOnUse" width="6" height="6">
+      <rect width="6" height="6" class="gap-bg"/>
+      <circle cx="2" cy="2" r="1" class="gap-dot"/>
     </pattern>
-    <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
-      <path d="M0,0 L6,3 L0,6 Z" fill="currentColor" opacity="0.3"/>
-    </marker>
   </defs>`;
 
   const axisHtml = buildAxisHtml(totalMs, swimlaneWidth, _scale, _panMs);
+  const gridHtml = buildGridHtml(
+    totalMs,
+    swimlaneWidth,
+    contentHeight,
+    _scale,
+    _panMs,
+  );
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}" style="display:block;width:100%;overflow:visible" data-total-ms="${totalMs}" data-swimlane-width="${swimlaneWidth}" data-run-start="${esc(runStart ?? '')}">
   ${defs}
   <g class="fixed-layer">${fixedStr}</g>
-  <g class="swimlane-content" clip-path="url(#swimlane-clip)" transform="translate(${LABEL_WIDTH}, 0) scale(${_scale}, 1) translate(${-panPx}, 0)">
-    ${swimlaneRowsStr}
-    ${loopbackStr}
-  </g>
-  <g class="axis" transform="translate(0, ${contentHeight})">${axisHtml}</g>
-  <rect class="zoom-selection" x="${LABEL_WIDTH}" y="0" width="0" height="${contentHeight}" fill="rgba(59,130,246,0.15)" stroke="#3b82f6" stroke-width="1" display="none" pointer-events="none"/>
+  <g class="grid" transform="translate(${LABEL_WIDTH}, 0)">${gridHtml}</g>
+  <g class="swimlane-content" clip-path="url(#swimlane-clip)" transform="translate(${LABEL_WIDTH}, 0)">${swimlaneLayer}</g>
+  <g class="axis" transform="translate(0, ${contentHeight + AXIS_TOP_GAP})">${axisHtml}</g>
 </svg>`;
 }
 
@@ -345,18 +476,19 @@ function buildBarTooltipHtml(target) {
   const durMs = parseFloat(target.getAttribute('data-dur-ms') || '0');
   const model = target.getAttribute('data-model') || '—';
   const status = target.getAttribute('data-status') || '—';
+  const stageKey = target.getAttribute('data-stage-key') || '';
   const cost = parseFloat(target.getAttribute('data-cost') || '0');
   const endMs = startMs + durMs;
-  const costStr = `$${cost.toFixed(2)}`;
+  const hue = STAGE_HUES[stageKey] || 'var(--muted)';
 
   return (
-    `<div class="tooltip-header">${esc(stageLabel)} · Iteration ${esc(iterNum)} of ${esc(iterTotal)}</div>` +
+    `<div class="tooltip-header"><span class="tooltip-hue-dot" style="background:${esc(hue)}"></span>${esc(stageLabel)} <span class="tooltip-header-sub">Iteration ${esc(iterNum)} of ${esc(iterTotal)}</span></div>` +
     `<div class="tooltip-row"><span class="tooltip-label">Duration</span><span class="tooltip-value">${esc(formatDuration(durMs))}</span></div>` +
     `<div class="tooltip-row"><span class="tooltip-label">Started</span><span class="tooltip-value">${esc(formatTimestamp(startMs))}</span></div>` +
     `<div class="tooltip-row"><span class="tooltip-label">Ended</span><span class="tooltip-value">${esc(formatTimestamp(endMs))}</span></div>` +
     `<div class="tooltip-row"><span class="tooltip-label">Model</span><span class="tooltip-value">${esc(model)}</span></div>` +
-    `<div class="tooltip-row"><span class="tooltip-label">Status</span><span class="tooltip-value">${esc(status)}</span></div>` +
-    `<div class="tooltip-row"><span class="tooltip-label">Cost</span><span class="tooltip-value">${esc(costStr)}</span></div>`
+    `<div class="tooltip-row"><span class="tooltip-label">Status</span><span class="tooltip-value tooltip-status status-${esc(status)}">${esc(status)}</span></div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Cost</span><span class="tooltip-value">${esc(formatCost(cost))}</span></div>`
   );
 }
 
@@ -369,7 +501,7 @@ function buildGapTooltipHtml(target) {
     target.getAttribute('data-returned-at-ms') || '0',
   );
   const controlStr = inStage
-    ? `${esc(inStage.toUpperCase())} (${esc(inStageCount)} iteration${inStageCount === '1' ? '' : 's'})`
+    ? `${esc(inStage)} (${esc(inStageCount)} iteration${inStageCount === '1' ? '' : 's'})`
     : '&mdash;';
 
   return (
@@ -414,43 +546,56 @@ function buildDrawerContent(run, stageKey, barNum, options) {
   const cost = iteration?.cost_usd ?? null;
   const model = iteration?.model ?? null;
   const agent = iteration?.agent ?? null;
-  const effort = iteration?.effort ?? null;
+  // effort may be a string (legacy) or an object like { level, requested }.
+  const effortRaw = iteration?.effort ?? null;
+  const effort =
+    effortRaw && typeof effortRaw === 'object'
+      ? (effortRaw.level ?? null)
+      : effortRaw;
   const inputTokens = iteration?.input_tokens ?? null;
   const outputTokens = iteration?.output_tokens ?? null;
   const cacheTokens = iteration?.cache_read_input_tokens ?? null;
+  const hue = STAGE_HUES[stageKey] || 'var(--muted)';
+  const stageLabelTitle = stageKey
+    .split('_')
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : ''))
+    .join(' ');
 
-  // Safe: all dynamic values are passed through esc() before insertion into innerHTML.
+  // Heading carries tabindex=-1 so we can move focus there when the drawer opens.
   let body = `<div class="drawer-body">`;
-  body += `<div class="drawer-row"><span class="status-pip" style="background:${esc(statusColor)};width:10px;height:10px;border-radius:50%;display:inline-block;margin-right:6px"></span><span>${esc(status)}</span></div>`;
+  body += `<h3 class="drawer-title" tabindex="-1"><span class="drawer-hue-dot" style="background:${esc(hue)}"></span>${esc(stageLabelTitle)} <span class="drawer-title-sub">Iteration ${esc(barNum)}</span></h3>`;
+  body += `<div class="drawer-status-row"><span class="drawer-status-pill" style="background:${esc(statusColor)}"></span><span class="drawer-status-text status-${esc(status)}">${esc(status)}</span></div>`;
+  body += `<dl class="drawer-fields">`;
   if (durMs != null) {
-    body += `<div class="drawer-row"><span class="drawer-label">Duration</span><span>${esc(formatDuration(durMs))}</span></div>`;
+    body += `<dt class="drawer-label">Duration</dt><dd class="drawer-value">${esc(formatDuration(durMs))}</dd>`;
   }
   if (cost != null) {
-    body += `<div class="drawer-row"><span class="drawer-label">Cost</span><span>$${esc(cost.toFixed(2))}</span></div>`;
+    body += `<dt class="drawer-label">Cost</dt><dd class="drawer-value">${esc(formatCost(cost))}</dd>`;
   }
   if (model) {
-    body += `<div class="drawer-row"><span class="drawer-label">Model</span><span>${esc(model)}</span></div>`;
+    body += `<dt class="drawer-label">Model</dt><dd class="drawer-value">${esc(model)}</dd>`;
   }
   if (agent) {
-    body += `<div class="drawer-row"><span class="drawer-label">Agent</span><span>${esc(agent)}</span></div>`;
+    body += `<dt class="drawer-label">Agent</dt><dd class="drawer-value">${esc(agent)}</dd>`;
   }
   if (effort) {
-    body += `<div class="drawer-row"><span class="drawer-label">Effort</span><span>${esc(effort)}</span></div>`;
+    body += `<dt class="drawer-label">Effort</dt><dd class="drawer-value">${esc(effort)}</dd>`;
   }
   if (inputTokens != null || outputTokens != null) {
     const inp = inputTokens ?? '—';
     const out = outputTokens ?? '—';
     const cache =
-      cacheTokens != null ? ` cache: ${esc(String(cacheTokens))}` : '';
-    body += `<div class="drawer-row"><span class="drawer-label">Tokens</span><span>in: ${esc(String(inp))} out: ${esc(String(out))}${cache}</span></div>`;
+      cacheTokens != null ? ` · cache: ${esc(String(cacheTokens))}` : '';
+    body += `<dt class="drawer-label">Tokens</dt><dd class="drawer-value">in: ${esc(String(inp))} · out: ${esc(String(out))}${cache}</dd>`;
   }
+  body += `</dl>`;
   const rawJson = iteration != null ? JSON.stringify(iteration, null, 2) : '{}';
   body += `<details class="drawer-raw-json"><summary>Raw JSON</summary><pre>${esc(rawJson)}</pre></details>`;
   body += `</div>`;
 
   if (options?.section && options?.runId) {
     const href = `#/${encodeURIComponent(options.section)}/${encodeURIComponent(options.runId)}`;
-    body += `<div slot="footer"><a href="${esc(href)}" class="drawer-run-detail-link">Open in run detail</a></div>`;
+    body += `<div slot="footer"><a href="${esc(href)}" class="drawer-run-detail-link">Open in run detail →</a></div>`;
   }
 
   return body;
@@ -467,6 +612,20 @@ function openIterationDrawer(
   const drawer = container.querySelector('sl-drawer');
   if (!drawer) return;
 
+  // Mark this bar as active so it stays raised until the drawer closes.
+  _activeBar = { stageKey, number: barNum };
+  applyActiveBarClass(container);
+
+  // Attach a single sl-after-hide listener so closing the drawer drops the
+  // active bar back to its rest state.
+  if (!drawer.__timelineCloseListenerAttached) {
+    drawer.addEventListener('sl-after-hide', () => {
+      _activeBar = null;
+      applyActiveBarClass(container);
+    });
+    drawer.__timelineCloseListenerAttached = true;
+  }
+
   drawer.setAttribute('label', `${stageLabel} · Iteration ${barNum}`);
   drawer.innerHTML = buildDrawerContent(run, stageKey, barNum, options);
 
@@ -474,6 +633,27 @@ function openIterationDrawer(
     drawer.show();
   } else {
     drawer.setAttribute('open', '');
+  }
+
+  // Move focus to the drawer's heading so screen readers announce the iteration.
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => {
+      const heading = drawer.querySelector('.drawer-title');
+      if (heading && typeof heading.focus === 'function') heading.focus();
+    });
+  }
+}
+
+// Reconciles `_activeBar` against the currently-rendered .timeline-bar nodes.
+// Called on open/close and (implicitly) after every zoom/pan re-render via the
+// is-active class baked into the swimlane HTML.
+function applyActiveBarClass(container) {
+  for (const bar of container.querySelectorAll('.timeline-bar.is-active')) {
+    bar.classList.remove('is-active');
+  }
+  if (_activeBar) {
+    const sel = `.timeline-bar[data-stage-key="${_activeBar.stageKey}"][data-bar-number="${_activeBar.number}"]`;
+    container.querySelector(sel)?.classList.add('is-active');
   }
 }
 
@@ -484,7 +664,7 @@ function onTimelineMouseover(e) {
   if (!target.classList || !target.classList.contains('timeline-bar')) return;
   const stageKey = target.getAttribute('data-stage-key');
   const barNum = target.getAttribute('data-bar-number');
-  const svg = e.currentTarget.querySelector('svg');
+  const svg = e.currentTarget.querySelector('.timeline-svg-wrap svg');
   if (!svg || !stageKey || !barNum) return;
   for (const lb of svg.querySelectorAll('.loopback')) {
     if (
@@ -501,7 +681,7 @@ function onTimelineMouseover(e) {
 function onTimelineMouseout(e) {
   const target = e.target;
   if (!target.classList || !target.classList.contains('timeline-bar')) return;
-  const svg = e.currentTarget.querySelector('svg');
+  const svg = e.currentTarget.querySelector('.timeline-svg-wrap svg');
   if (!svg) return;
   for (const lb of svg.querySelectorAll('.loopback.highlight')) {
     lb.classList.remove('highlight');
@@ -513,6 +693,42 @@ function onTimelineMouseleave(e) {
   if (tooltip) tooltip.style.display = 'none';
 }
 
+// --- Stats summary ---
+
+function buildStatsSummary(layout) {
+  const { totalMs, rows } = layout;
+  let totalCost = 0;
+  let totalIters = 0;
+  for (const row of rows) {
+    totalIters += row.iterationCount;
+    for (const bar of row.bars) {
+      totalCost += bar.cost || 0;
+    }
+  }
+  // Status pill omitted — the page header (contentHeaderView) already shows
+  // the run's status badge next to the title.
+  return html`
+    <div class="timeline-summary">
+      <div class="summary-stat">
+        <span class="summary-stat-label">Duration</span>
+        <span class="summary-stat-value">${formatDuration(totalMs)}</span>
+      </div>
+      <div class="summary-stat">
+        <span class="summary-stat-label">Stages</span>
+        <span class="summary-stat-value">${rows.length}</span>
+      </div>
+      <div class="summary-stat">
+        <span class="summary-stat-label">Iterations</span>
+        <span class="summary-stat-value">${totalIters}</span>
+      </div>
+      <div class="summary-stat">
+        <span class="summary-stat-label">Cost</span>
+        <span class="summary-stat-value">${formatCost(totalCost)}</span>
+      </div>
+    </div>
+  `;
+}
+
 // --- Main view ---
 
 export function runTimelineView(run, _settings, options = {}) {
@@ -520,12 +736,22 @@ export function runTimelineView(run, _settings, options = {}) {
 
   if (layout.rows.length === 0) {
     return html`<div class="run-timeline">
-      <div class="empty-state">Run has not started any stages yet</div>
+      <div class="empty-state" role="status" aria-live="polite">
+        Run has not started any stages yet
+      </div>
     </div>`;
   }
 
-  const swimlaneWidth = options.swimlaneWidth || 640;
+  // Pick a swimlane width that fits typical desktop content area (sidebar + padding
+  // ≈ 320px). Falls back to 800 in non-browser test environments. Tests pass an
+  // explicit value to stay deterministic.
+  const defaultSwimlaneWidth =
+    typeof window !== 'undefined' && window.innerWidth
+      ? Math.max(600, window.innerWidth - LABEL_WIDTH - 320)
+      : 800;
+  const swimlaneWidth = options.swimlaneWidth || defaultSwimlaneWidth;
   const { totalMs } = layout;
+  const contentHeight = ROW_HEIGHT * layout.rows.length;
   const svgStr = buildSvg(layout, swimlaneWidth);
 
   function handleZoomIn(e) {
@@ -533,7 +759,7 @@ export function runTimelineView(run, _settings, options = {}) {
     if (!container) return;
     _scale = clampScale(_scale * 2);
     _panMs = clampPan(_panMs, totalMs, _scale);
-    applyZoomPan(container, totalMs, swimlaneWidth);
+    applyZoomPan(container, layout, swimlaneWidth, contentHeight);
   }
 
   function handleZoomOut(e) {
@@ -541,7 +767,7 @@ export function runTimelineView(run, _settings, options = {}) {
     if (!container) return;
     _scale = clampScale(_scale * 0.5);
     _panMs = clampPan(_panMs, totalMs, _scale);
-    applyZoomPan(container, totalMs, swimlaneWidth);
+    applyZoomPan(container, layout, swimlaneWidth, contentHeight);
   }
 
   function handleReset(e) {
@@ -549,7 +775,7 @@ export function runTimelineView(run, _settings, options = {}) {
     if (!container) return;
     _scale = 1.0;
     _panMs = 0;
-    applyZoomPan(container, totalMs, swimlaneWidth);
+    applyZoomPan(container, layout, swimlaneWidth, contentHeight);
   }
 
   function handleWheel(e) {
@@ -557,12 +783,8 @@ export function runTimelineView(run, _settings, options = {}) {
     const container = e.currentTarget;
 
     if (e.shiftKey) {
-      // shift+wheel: horizontal pan
-      const panDeltaMs = (e.deltaY / swimlaneWidth) * (totalMs / _scale);
-      _panMs = clampPan(_panMs + panDeltaMs, totalMs, _scale);
-    } else {
-      // zoom anchored at cursor position
-      const svg = container.querySelector('svg');
+      // shift+wheel: zoom anchored at cursor position
+      const svg = container.querySelector('.timeline-svg-wrap svg');
       let cursorMs = _panMs;
       if (svg) {
         const rect = svg.getBoundingClientRect();
@@ -579,106 +801,109 @@ export function runTimelineView(run, _settings, options = {}) {
       );
       _scale = next.scale;
       _panMs = next.panMs;
+    } else {
+      // Default: horizontal pan. Trackpads emit deltaX on horizontal swipe;
+      // vertical-wheel mice emit deltaY. Use whichever is non-zero.
+      const wheelDelta = e.deltaX !== 0 ? e.deltaX : e.deltaY;
+      const panDeltaMs = (wheelDelta / swimlaneWidth) * (totalMs / _scale);
+      _panMs = clampPan(_panMs + panDeltaMs, totalMs, _scale);
     }
-    applyZoomPan(container, totalMs, swimlaneWidth);
+    applyZoomPan(container, layout, swimlaneWidth, contentHeight);
   }
 
   function handleMousedown(e) {
+    if (e.button !== 0 && e.button !== 1) return;
     const container = e.currentTarget;
-    const svg = container.querySelector('svg');
+    const svg = container.querySelector('.timeline-svg-wrap svg');
     if (!svg) return;
 
     const rect = svg.getBoundingClientRect();
     const svgH = parseFloat(svg.getAttribute('height') || '0');
     const mouseX = e.clientX - rect.left;
     const mouseY = e.clientY - rect.top;
-    const axisZoneY = svgH - AXIS_HEIGHT;
-    const inAxisZone = mouseY >= axisZoneY;
-    const isShiftCanvas = e.shiftKey && e.button === 0 && !inAxisZone;
+    const inAxisZone = mouseY >= svgH - AXIS_HEIGHT;
+    const inLabelColumn = mouseX < LABEL_WIDTH;
+    if (inLabelColumn) return;
 
-    if (e.button === 1) {
+    if (e.button === 0 && inAxisZone) {
+      // Drag on the time-axis ribbon → zoom anchored at the click point.
       e.preventDefault();
-      _dragging = true;
-      _dragStartX = e.clientX;
-      _dragStartPanMs = _panMs;
+      _axisDragging = true;
+      _axisDragStartX = e.clientX;
+      _axisDragStartScale = _scale;
+      _axisDragAnchorScreenX = mouseX - LABEL_WIDTH;
+      const visibleMs = totalMs / _scale;
+      const raw = _panMs + (_axisDragAnchorScreenX / swimlaneWidth) * visibleMs;
+      _axisDragAnchorMs = Math.max(0, Math.min(totalMs, raw));
       return;
     }
 
-    if (e.button === 0 && (inAxisZone || isShiftCanvas)) {
-      e.preventDefault();
-      _selecting = true;
-      const swimX = mouseX - LABEL_WIDTH;
-      const visibleMs = totalMs / _scale;
-      const raw = _panMs + (swimX / swimlaneWidth) * visibleMs;
-      _selectStartMs = Math.max(0, Math.min(totalMs, raw));
-
-      const selRect = svg.querySelector('.zoom-selection');
-      if (selRect) {
-        const startX =
-          LABEL_WIDTH + ((_selectStartMs - _panMs) / visibleMs) * swimlaneWidth;
-        selRect.setAttribute('x', String(startX));
-        selRect.setAttribute('width', '0');
-        selRect.removeAttribute('display');
-      }
-    }
+    // Anywhere else on the chart (including over a bar) → pan.
+    e.preventDefault();
+    _dragging = true;
+    _dragStartX = e.clientX;
+    _dragStartPanMs = _panMs;
+    _dragMoved = false;
   }
 
   function handleMousemove(e) {
     const container = e.currentTarget;
 
-    // Tooltip: show/reposition when over a bar or gap, hide otherwise
-    const tooltip = container.querySelector('.timeline-tooltip');
-    if (tooltip) {
-      const target = e.target;
-      if (target.classList && target.classList.contains('timeline-bar')) {
-        // Safe: all values passed through esc() — stage keys, model names, status, cost from local server
-        tooltip.innerHTML = buildBarTooltipHtml(target);
-        positionTooltip(tooltip, e);
-      } else if (
-        target.classList &&
-        target.classList.contains('timeline-gap')
-      ) {
-        // Safe: same escaping guarantee as bar tooltip
-        tooltip.innerHTML = buildGapTooltipHtml(target);
-        positionTooltip(tooltip, e);
-      } else {
-        tooltip.style.display = 'none';
+    // Tooltip — suppressed while dragging to avoid flicker.
+    if (!_dragging && !_axisDragging) {
+      const tooltip = container.querySelector('.timeline-tooltip');
+      if (tooltip) {
+        const target = e.target;
+        if (target.classList && target.classList.contains('timeline-bar')) {
+          tooltip.innerHTML = buildBarTooltipHtml(target);
+          positionTooltip(tooltip, e);
+        } else if (
+          target.classList &&
+          target.classList.contains('timeline-gap')
+        ) {
+          tooltip.innerHTML = buildGapTooltipHtml(target);
+          positionTooltip(tooltip, e);
+        } else {
+          tooltip.style.display = 'none';
+        }
       }
     }
 
-    if (!_dragging && !_selecting) return;
-    const svg = container.querySelector('svg');
-    if (!svg) return;
-
-    const rect = svg.getBoundingClientRect();
-    const mouseX = e.clientX - rect.left;
-
-    if (_dragging) {
-      const deltaX = e.clientX - _dragStartX;
-      const deltaMs = -(deltaX / swimlaneWidth) * (totalMs / _scale);
-      _panMs = clampPan(_dragStartPanMs + deltaMs, totalMs, _scale);
-      applyZoomPan(container, totalMs, swimlaneWidth);
+    if (_axisDragging) {
+      // 200px of horizontal drag ≈ one doubling (or halving) of scale.
+      // Exponential mapping so right-drag-zoom-in and left-drag-zoom-out feel
+      // symmetric — and so the anchor time stays glued to its starting x.
+      const deltaX = e.clientX - _axisDragStartX;
+      const factor = Math.exp(deltaX / 200);
+      const newScale = clampScale(_axisDragStartScale * factor);
+      _scale = newScale;
+      const newVisibleMs = totalMs / newScale;
+      _panMs = clampPan(
+        _axisDragAnchorMs -
+          (_axisDragAnchorScreenX / swimlaneWidth) * newVisibleMs,
+        totalMs,
+        newScale,
+      );
+      applyZoomPan(container, layout, swimlaneWidth, contentHeight);
       return;
     }
 
-    const swimX = mouseX - LABEL_WIDTH;
-    const visibleMs = totalMs / _scale;
-    const currentMs = Math.max(
-      0,
-      Math.min(totalMs, _panMs + (swimX / swimlaneWidth) * visibleMs),
-    );
-    const selRect = svg.querySelector('.zoom-selection');
-    if (selRect) {
-      const startX =
-        LABEL_WIDTH + ((_selectStartMs - _panMs) / visibleMs) * swimlaneWidth;
-      const endX =
-        LABEL_WIDTH + ((currentMs - _panMs) / visibleMs) * swimlaneWidth;
-      selRect.setAttribute('x', String(Math.min(startX, endX)));
-      selRect.setAttribute('width', String(Math.abs(endX - startX)));
+    if (_dragging) {
+      const deltaX = e.clientX - _dragStartX;
+      if (Math.abs(deltaX) > 3) _dragMoved = true;
+      const deltaMs = -(deltaX / swimlaneWidth) * (totalMs / _scale);
+      _panMs = clampPan(_dragStartPanMs + deltaMs, totalMs, _scale);
+      applyZoomPan(container, layout, swimlaneWidth, contentHeight);
     }
   }
 
   function handleClick(e) {
+    // Suppress the click that follows a pan-drag — otherwise dragging over a
+    // bar would also open its drawer at mouseup time.
+    if (_dragMoved) {
+      _dragMoved = false;
+      return;
+    }
     const bar =
       e.target.closest?.('.timeline-bar') ||
       (e.target.classList?.contains('timeline-bar') ? e.target : null);
@@ -699,13 +924,15 @@ export function runTimelineView(run, _settings, options = {}) {
   }
 
   function handleKeydown(e) {
-    if (e.key !== 'Enter') return;
+    // Accept Enter and Space as activation per the WAI-ARIA Button pattern.
+    if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar') return;
     const bar = e.target?.classList?.contains('timeline-bar') ? e.target : null;
     if (!bar) return;
+    // Space scrolls the page by default; suppress it when activating a bar.
+    e.preventDefault();
     const stageKey = bar.getAttribute('data-stage-key');
     const barNum = parseInt(bar.getAttribute('data-bar-number'), 10);
-    const stageLabel =
-      bar.getAttribute('data-stage-label') || stageKey?.toUpperCase() || '';
+    const stageLabel = bar.getAttribute('data-stage-label') || stageKey || '';
     if (!stageKey || Number.isNaN(barNum)) return;
     openIterationDrawer(
       e.currentTarget,
@@ -717,44 +944,9 @@ export function runTimelineView(run, _settings, options = {}) {
     );
   }
 
-  function handleMouseup(e) {
-    const container = e.currentTarget;
-
-    if (_dragging) {
-      _dragging = false;
-      return;
-    }
-
-    if (_selecting) {
-      _selecting = false;
-      const svg = container.querySelector('svg');
-      if (svg) {
-        const rect = svg.getBoundingClientRect();
-        const mouseX = e.clientX - rect.left;
-        const swimX = mouseX - LABEL_WIDTH;
-        const visibleMs = totalMs / _scale;
-        const endMs = Math.max(
-          0,
-          Math.min(totalMs, _panMs + (swimX / swimlaneWidth) * visibleMs),
-        );
-
-        // Only commit if selection is large enough to be intentional
-        if (Math.abs(endMs - _selectStartMs) > 100) {
-          const next = dragToZoom(
-            { scale: _scale, panMs: _panMs },
-            _selectStartMs,
-            endMs,
-            totalMs,
-          );
-          _scale = next.scale;
-          _panMs = next.panMs;
-          applyZoomPan(container, totalMs, swimlaneWidth);
-        }
-
-        const selRect = svg.querySelector('.zoom-selection');
-        if (selRect) selRect.setAttribute('display', 'none');
-      }
-    }
+  function handleMouseup() {
+    if (_dragging) _dragging = false;
+    if (_axisDragging) _axisDragging = false;
   }
 
   return html`<div
@@ -769,13 +961,35 @@ export function runTimelineView(run, _settings, options = {}) {
     @click=${handleClick}
     @keydown=${handleKeydown}
   >
-    <div class="timeline-toolbar">
-      <button class="timeline-zoom-btn" aria-label="Zoom out" @click=${handleZoomOut}>−</button>
-      <button class="timeline-zoom-btn" aria-label="Reset zoom" @click=${handleReset}>⤺</button>
-      <button class="timeline-zoom-btn" aria-label="Zoom in" @click=${handleZoomIn}>+</button>
+    ${buildStatsSummary(layout)}
+    <div class="timeline-toolbar" role="toolbar" aria-label="Timeline zoom">
+      <div class="timeline-toolbar-group">
+        <button class="timeline-zoom-btn" type="button" aria-label="Zoom out" title="Zoom out" @click=${handleZoomOut}>
+          ${unsafeHTML(iconSvg(ZoomOut, 14))}
+        </button>
+        <button class="timeline-zoom-btn" type="button" aria-label="Reset zoom" title="Reset zoom" @click=${handleReset}>
+          ${unsafeHTML(iconSvg(RefreshCw, 14))}
+        </button>
+        <button class="timeline-zoom-btn" type="button" aria-label="Zoom in" title="Zoom in" @click=${handleZoomIn}>
+          ${unsafeHTML(iconSvg(ZoomIn, 14))}
+        </button>
+      </div>
+      <span class="timeline-toolbar-hint">Drag chart to pan · Drag axis to zoom · Shift+wheel to zoom</span>
     </div>
-    ${svgStr ? unsafeHTML(svgStr) : nothing}
-    <div class="timeline-tooltip" style="display:none"></div>
+    <div class="timeline-svg-wrap">${svgStr ? unsafeHTML(svgStr) : nothing}</div>
+    <div class="timeline-legend" aria-hidden="true">
+      <span class="legend-item"><span class="legend-swatch" style="background:var(--status-completed)"></span>Completed</span>
+      <span class="legend-item"><span class="legend-swatch" style="background:var(--status-running)"></span>Running</span>
+      <span class="legend-item"><span class="legend-swatch" style="background:var(--status-failed)"></span>Failed</span>
+      <span class="legend-item"><span class="legend-swatch legend-swatch--gap"></span>Gap</span>
+      <span class="legend-item">${unsafeHTML(
+        `<svg class="legend-loopback" width="22" height="14" viewBox="0 0 22 14">
+          <path d="M2,11 Q11,1 20,11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          <path d="M20,11 L17,8 L17.5,12 Z" fill="currentColor"/>
+        </svg>`,
+      )}Loopback</span>
+    </div>
+    <div class="timeline-tooltip" style="display:none" role="tooltip"></div>
     <sl-drawer class="iteration-drawer" placement="end"></sl-drawer>
   </div>`;
 }

--- a/worca-ui/app/views/run-timeline.js
+++ b/worca-ui/app/views/run-timeline.js
@@ -1,0 +1,781 @@
+import { html, nothing } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { STAGE_HUES } from '../utils/stage-hues.js';
+import { computeTimelineLayout } from '../utils/timeline-layout.js';
+import {
+  clampPan,
+  clampScale,
+  dragToZoom,
+  wheelZoom,
+} from '../utils/timeline-zoom.js';
+
+const LABEL_WIDTH = 160;
+const ROW_HEIGHT = 32;
+const AXIS_HEIGHT = 24;
+const MIN_BAR_PX = 12;
+const LABEL_MIN_PX = 36;
+const _LOOPBACK_HIDE_THRESHOLD = 30;
+
+const STATUS_FILL = {
+  completed: '#22c55e',
+  in_progress: '#3b82f6',
+  running: '#3b82f6',
+  failed: '#ef4444',
+  skipped: '#6b7280',
+  cancelled: '#6b7280',
+  pending: '#94a3b8',
+};
+
+function statusFill(status) {
+  return STATUS_FILL[status] || '#94a3b8';
+}
+
+// Escape values interpolated into the unsafeHTML SVG string to prevent attribute/text injection.
+function esc(v) {
+  return String(v == null ? '' : v)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatDuration(ms) {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return `${m}m ${rem}s`;
+}
+
+// Format a run-relative ms offset as mm:ss (or hh:mm:ss when hours > 0)
+function formatTimestamp(ms) {
+  const totalSec = Math.round(ms / 1000);
+  const hours = Math.floor(totalSec / 3600);
+  const min = Math.floor((totalSec % 3600) / 60);
+  const sec = totalSec % 60;
+  if (hours > 0) {
+    return `${String(hours).padStart(2, '0')}:${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+  }
+  return `${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+}
+
+// Format a run-relative ms offset as m:ss (or h:mm:ss for runs > 1h)
+function formatAxisLabel(ms, totalMs) {
+  const totalSec = Math.round(ms / 1000);
+  const hours = Math.floor(totalSec / 3600);
+  const min = Math.floor((totalSec % 3600) / 60);
+  const sec = totalSec % 60;
+  if (totalMs > 3600000 || hours > 0) {
+    return `${hours}:${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+  }
+  return `${min}:${String(sec).padStart(2, '0')}`;
+}
+
+// --- Module-level zoom/pan state ---
+let _scale = 1.0;
+let _panMs = 0;
+let _dragging = false;
+let _dragStartX = 0;
+let _dragStartPanMs = 0;
+let _selecting = false;
+let _selectStartMs = 0;
+
+export function _resetZoomStateForTests() {
+  _scale = 1.0;
+  _panMs = 0;
+  _dragging = false;
+  _dragStartX = 0;
+  _dragStartPanMs = 0;
+  _selecting = false;
+  _selectStartMs = 0;
+}
+
+// Memoize layout per run object (WeakMap avoids stale cache on same id/updated_at with different stages)
+const _layoutCache = new WeakMap();
+
+function getLayout(run) {
+  if (_layoutCache.has(run)) return _layoutCache.get(run);
+
+  const isActive =
+    !run.completed_at &&
+    (run.status === 'in_progress' || run.status === 'running');
+
+  // Derive runEnd: prefer run.completed_at, then scan iteration ends, then updated_at
+  let runEnd = run.completed_at;
+  if (!runEnd && run.stages) {
+    let latestMs = 0;
+    for (const stage of Object.values(run.stages)) {
+      if (!stage?.iterations) continue;
+      for (const it of stage.iterations) {
+        if (it.completed_at) {
+          const t = new Date(it.completed_at).getTime();
+          if (t > latestMs) latestMs = t;
+        }
+      }
+    }
+    if (latestMs > 0) runEnd = new Date(latestMs).toISOString();
+  }
+
+  // Active runs use now() as right edge so it advances on each WS refresh.
+  // Don't cache active runs — they must recompute to keep the right edge current.
+  if (isActive) {
+    runEnd = new Date().toISOString();
+    return computeTimelineLayout(run.stages, runEnd);
+  }
+
+  runEnd = runEnd || run.updated_at || new Date().toISOString();
+  const layout = computeTimelineLayout(run.stages, runEnd);
+  _layoutCache.set(run, layout);
+  return layout;
+}
+
+// --- Adaptive time axis ---
+
+function buildAxisHtml(totalMs, swimlaneWidth, scale, panMs) {
+  if (totalMs <= 0 || swimlaneWidth <= 0) return '';
+
+  let tickIntervalMs;
+  if (scale >= 16) {
+    tickIntervalMs = 1000;
+  } else if (scale >= 4) {
+    tickIntervalMs = 10000;
+  } else {
+    tickIntervalMs = 60000;
+  }
+
+  // Prevent runaway tick generation for very long visible ranges (e.g. active runs).
+  // Double the interval until the visible range would produce at most 200 ticks.
+  const visibleMsForTick = totalMs / scale;
+  while (visibleMsForTick / tickIntervalMs > 200) {
+    tickIntervalMs *= 10;
+  }
+
+  const visibleMs = totalMs / scale;
+  const startMs = panMs;
+  const endMs = panMs + visibleMs;
+  const firstTickMs = Math.ceil(startMs / tickIntervalMs) * tickIntervalMs;
+
+  let out = `<line x1="${LABEL_WIDTH}" y1="0" x2="${LABEL_WIDTH + swimlaneWidth}" y2="0" stroke="currentColor" stroke-opacity="0.2"/>`;
+
+  for (let tickMs = firstTickMs; tickMs <= endMs; tickMs += tickIntervalMs) {
+    const xInSwimlane = ((tickMs - panMs) / visibleMs) * swimlaneWidth;
+    const tx = LABEL_WIDTH + xInSwimlane;
+    if (tx < LABEL_WIDTH - 1 || tx > LABEL_WIDTH + swimlaneWidth + 1) continue;
+    const label = esc(formatAxisLabel(tickMs, totalMs));
+    out += `<line x1="${tx}" y1="0" x2="${tx}" y2="5" stroke="currentColor" stroke-opacity="0.3"/>`;
+    out += `<text x="${tx}" y="16" text-anchor="middle" font-size="9" fill="currentColor" opacity="0.5">${label}</text>`;
+  }
+
+  return out;
+}
+
+// --- Apply zoom/pan directly to DOM (no full re-render) ---
+
+function applyZoomPan(container, totalMs, swimlaneWidth) {
+  const swimG = container.querySelector('.swimlane-content');
+  const axisG = container.querySelector('.axis');
+  if (!swimG || !axisG) return;
+
+  const panPx = totalMs > 0 ? (_panMs / totalMs) * swimlaneWidth : 0;
+  swimG.setAttribute(
+    'transform',
+    `translate(${LABEL_WIDTH}, 0) scale(${_scale}, 1) translate(${-panPx}, 0)`,
+  );
+
+  axisG.innerHTML = buildAxisHtml(totalMs, swimlaneWidth, _scale, _panMs);
+}
+
+// --- SVG builder ---
+
+function buildSvg(layout, swimlaneWidth) {
+  const { totalMs, rows, loopbacks, runStart } = layout;
+  if (rows.length === 0) return null;
+
+  // Rows exceeding this threshold get loopbacks suppressed and a hint shown instead
+  const highIterStages = new Set(
+    rows
+      .filter((r) => r.iterationCount > _LOOPBACK_HIDE_THRESHOLD)
+      .map((r) => r.stageKey),
+  );
+
+  const svgWidth = LABEL_WIDTH + swimlaneWidth;
+  const contentHeight = ROW_HEIGHT * rows.length;
+  const svgHeight = contentHeight + AXIS_HEIGHT;
+
+  // Map ms offset to x pixel within swimlane at scale=1
+  function msToX(ms) {
+    if (totalMs <= 0) return 0;
+    return (ms / totalMs) * swimlaneWidth;
+  }
+
+  const panPx = totalMs > 0 ? (_panMs / totalMs) * swimlaneWidth : 0;
+
+  let fixedStr = '';
+  let swimlaneRowsStr = '';
+  const rowDataMap = new Map();
+
+  rows.forEach((row, rowIdx) => {
+    const y = rowIdx * ROW_HEIGHT;
+    const cy = y + ROW_HEIGHT / 2;
+    const stageHue = STAGE_HUES[row.stageKey] || '#94a3b8';
+    const barInfos = [];
+
+    // Fixed layer: row background stripe
+    const bgFill = rowIdx % 2 === 0 ? 'rgba(0,0,0,0.02)' : 'transparent';
+    fixedStr += `<rect x="0" y="${y}" width="${svgWidth}" height="${ROW_HEIGHT}" fill="${bgFill}"/>`;
+
+    // Fixed layer: row label
+    const iterBadge = row.iterationCount > 1 ? ` ↻×${row.iterationCount}` : '';
+    fixedStr += `<text class="row-label" x="${LABEL_WIDTH - 8}" y="${cy + 4}" text-anchor="end" font-size="11" fill="currentColor">${esc(row.stageLabel)}${iterBadge}</text>`;
+
+    // Swimlane bars — x coords relative to swimlane start (no LABEL_WIDTH offset)
+    let barsStr = '';
+    for (const bar of row.bars) {
+      const rawW = msToX(bar.durMs);
+      const barW = Math.max(MIN_BAR_PX, rawW);
+      const barX = msToX(bar.startMs);
+      const fill = statusFill(bar.status);
+
+      const ariaLabel = `${row.stageLabel} iteration ${bar.number} of ${row.iterationCount}, ${formatDuration(bar.durMs)}, ${bar.status}`;
+      barsStr += `<rect class="timeline-bar" role="img" aria-label="${esc(ariaLabel)}" tabindex="0" x="${barX}" y="${y + 4}" width="${barW}" height="${ROW_HEIGHT - 8}" rx="2" fill="${fill}" data-stage-key="${esc(row.stageKey)}" data-bar-number="${esc(bar.number)}" data-stage-label="${esc(row.stageLabel)}" data-iter-total="${esc(row.iterationCount)}" data-start-ms="${esc(bar.startMs)}" data-dur-ms="${esc(bar.durMs)}" data-model="${esc(bar.model ?? '')}" data-status="${esc(bar.status)}" data-cost="${esc(bar.cost ?? 0)}"/>`;
+      // 3px left-edge accent — pointer-events:none so hover always hits the bar rect
+      barsStr += `<rect class="bar-accent" x="${barX}" y="${y + 4}" width="3" height="${ROW_HEIGHT - 8}" rx="1" fill="${stageHue}" pointer-events="none"/>`;
+
+      if (barW >= LABEL_MIN_PX) {
+        barsStr += `<text class="bar-label" x="${barX + barW / 2}" y="${cy + 4}" text-anchor="middle" font-size="10" fill="white" pointer-events="none">${esc(formatDuration(bar.durMs))}</text>`;
+      }
+
+      barInfos.push({ barX, barW, cy });
+    }
+
+    // Swimlane gaps — hoverable via data-tooltip
+    let gapsStr = '';
+    for (const gap of row.gaps) {
+      const gapX = msToX(gap.startMs);
+      const gapW = Math.max(1, msToX(gap.durMs));
+      const tooltipText = gap.inStage
+        ? `Control in ${gap.inStage.toUpperCase()} for ${formatDuration(gap.durMs)}`
+        : `Idle gap for ${formatDuration(gap.durMs)}`;
+      gapsStr += `<rect class="timeline-gap" x="${gapX}" y="${y + 4}" width="${gapW}" height="${ROW_HEIGHT - 8}" fill="url(#gapHatch)" opacity="0.5" data-tooltip="${esc(tooltipText)}" data-stage-label="${esc(row.stageLabel)}" data-dur-ms="${esc(gap.durMs)}" data-in-stage="${esc(gap.inStage ?? '')}" data-in-stage-count="1" data-returned-at-ms="${esc(gap.startMs + gap.durMs)}" style="cursor:default"/>`;
+    }
+
+    swimlaneRowsStr += `<g class="timeline-row">${gapsStr}${barsStr}</g>`;
+    rowDataMap.set(row.stageKey, { bars: barInfos, rowIdx });
+
+    // Hint text for rows where loopbacks are suppressed due to high iteration count
+    if (highIterStages.has(row.stageKey)) {
+      fixedStr += `<text x="${LABEL_WIDTH + 8}" y="${cy + 4}" font-size="9" fill="currentColor" opacity="0.4" pointer-events="none">(loopbacks hidden — hover an iteration to highlight)</text>`;
+    }
+  });
+
+  // Loopback arrows (inside swimlane-content, same coordinate space as bars)
+  let loopbackStr = '';
+  for (const lb of loopbacks) {
+    // Skip arrows involving rows that exceeded the loopback hide threshold
+    if (highIterStages.has(lb.fromStage) || highIterStages.has(lb.toStage))
+      continue;
+    const fromData = rowDataMap.get(lb.fromStage);
+    const toData = rowDataMap.get(lb.toStage);
+    if (!fromData || !toData) continue;
+
+    const fromRow = rows.find((r) => r.stageKey === lb.fromStage);
+    const toRow = rows.find((r) => r.stageKey === lb.toStage);
+    if (!fromRow || !toRow) continue;
+
+    const fromBarIdx =
+      lb.fromIter != null
+        ? fromRow.bars.findIndex((b) => b.number === lb.fromIter)
+        : fromRow.bars.length - 1;
+    const toBarIdx =
+      lb.toIter != null
+        ? toRow.bars.findIndex((b) => b.number === lb.toIter)
+        : 0;
+
+    if (fromBarIdx < 0 || toBarIdx < 0) continue;
+
+    const fromBarInfo = fromData.bars[fromBarIdx];
+    const toBarInfo = toData.bars[toBarIdx];
+    if (!fromBarInfo || !toBarInfo) continue;
+
+    const x1 = fromBarInfo.barX + fromBarInfo.barW;
+    const y1 = fromBarInfo.cy;
+    const x2 = toBarInfo.barX;
+    const y2 = toBarInfo.cy;
+    const lift = 1.5 * ROW_HEIGHT;
+    const cpY = Math.min(y1, y2) - lift;
+
+    loopbackStr += `<path class="loopback" data-from-stage="${esc(lb.fromStage)}" data-from-iter="${esc(lb.fromIter ?? '')}" data-to-stage="${esc(lb.toStage)}" data-to-iter="${esc(lb.toIter ?? '')}" d="M${x1},${y1} C${x1},${cpY} ${x2},${cpY} ${x2},${y2}" fill="none" stroke="currentColor" stroke-opacity="0.15" stroke-width="1.5" marker-end="url(#arrowhead)" aria-hidden="true"/>`;
+  }
+
+  const defs = `<defs>
+    <clipPath id="swimlane-clip">
+      <rect x="${LABEL_WIDTH}" y="-200" width="${swimlaneWidth}" height="${svgHeight + 400}"/>
+    </clipPath>
+    <pattern id="gapHatch" patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="6" stroke="#94a3b8" stroke-width="2"/>
+    </pattern>
+    <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="currentColor" opacity="0.3"/>
+    </marker>
+  </defs>`;
+
+  const axisHtml = buildAxisHtml(totalMs, swimlaneWidth, _scale, _panMs);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}" style="display:block;width:100%;overflow:visible" data-total-ms="${totalMs}" data-swimlane-width="${swimlaneWidth}" data-run-start="${esc(runStart ?? '')}">
+  ${defs}
+  <g class="fixed-layer">${fixedStr}</g>
+  <g class="swimlane-content" clip-path="url(#swimlane-clip)" transform="translate(${LABEL_WIDTH}, 0) scale(${_scale}, 1) translate(${-panPx}, 0)">
+    ${swimlaneRowsStr}
+    ${loopbackStr}
+  </g>
+  <g class="axis" transform="translate(0, ${contentHeight})">${axisHtml}</g>
+  <rect class="zoom-selection" x="${LABEL_WIDTH}" y="0" width="0" height="${contentHeight}" fill="rgba(59,130,246,0.15)" stroke="#3b82f6" stroke-width="1" display="none" pointer-events="none"/>
+</svg>`;
+}
+
+// --- Tooltip helpers ---
+
+function buildBarTooltipHtml(target) {
+  const stageLabel = target.getAttribute('data-stage-label') || '';
+  const iterNum = target.getAttribute('data-bar-number') || '';
+  const iterTotal = target.getAttribute('data-iter-total') || '';
+  const startMs = parseFloat(target.getAttribute('data-start-ms') || '0');
+  const durMs = parseFloat(target.getAttribute('data-dur-ms') || '0');
+  const model = target.getAttribute('data-model') || '—';
+  const status = target.getAttribute('data-status') || '—';
+  const cost = parseFloat(target.getAttribute('data-cost') || '0');
+  const endMs = startMs + durMs;
+  const costStr = `$${cost.toFixed(2)}`;
+
+  return (
+    `<div class="tooltip-header">${esc(stageLabel)} · Iteration ${esc(iterNum)} of ${esc(iterTotal)}</div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Duration</span><span class="tooltip-value">${esc(formatDuration(durMs))}</span></div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Started</span><span class="tooltip-value">${esc(formatTimestamp(startMs))}</span></div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Ended</span><span class="tooltip-value">${esc(formatTimestamp(endMs))}</span></div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Model</span><span class="tooltip-value">${esc(model)}</span></div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Status</span><span class="tooltip-value">${esc(status)}</span></div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Cost</span><span class="tooltip-value">${esc(costStr)}</span></div>`
+  );
+}
+
+function buildGapTooltipHtml(target) {
+  const stageLabel = target.getAttribute('data-stage-label') || '';
+  const durMs = parseFloat(target.getAttribute('data-dur-ms') || '0');
+  const inStage = target.getAttribute('data-in-stage') || '';
+  const inStageCount = target.getAttribute('data-in-stage-count') || '1';
+  const returnedAtMs = parseFloat(
+    target.getAttribute('data-returned-at-ms') || '0',
+  );
+  const controlStr = inStage
+    ? `${esc(inStage.toUpperCase())} (${esc(inStageCount)} iteration${inStageCount === '1' ? '' : 's'})`
+    : '&mdash;';
+
+  return (
+    `<div class="tooltip-header">Gap on ${esc(stageLabel)}</div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Duration</span><span class="tooltip-value">${esc(formatDuration(durMs))}</span></div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Control</span><span class="tooltip-value">${controlStr}</span></div>` +
+    `<div class="tooltip-row"><span class="tooltip-label">Returned at</span><span class="tooltip-value">${esc(formatTimestamp(returnedAtMs))}</span></div>`
+  );
+}
+
+function positionTooltip(tooltip, e) {
+  tooltip.style.display = '';
+  const offset = 14;
+  let left = e.clientX + offset;
+  let top = e.clientY - offset;
+  const w = tooltip.offsetWidth || 200;
+  const h = tooltip.offsetHeight || 120;
+  const vw = typeof window !== 'undefined' ? window.innerWidth : 0;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : 0;
+  if (vw > 0 && left + w > vw - 8) left = e.clientX - w - 4;
+  if (vh > 0 && top + h > vh - 8) top = e.clientY - h - 4;
+  if (top < 8) top = 8;
+  tooltip.style.left = `${left}px`;
+  tooltip.style.top = `${top}px`;
+}
+
+// --- Iteration drawer (click-to-drill) ---
+
+function buildDrawerContent(run, stageKey, barNum, options) {
+  const stage = run.stages?.[stageKey];
+  const iteration =
+    stage?.iterations?.find((it, idx) => (it.number ?? idx + 1) === barNum) ??
+    null;
+
+  const status = iteration?.status || 'unknown';
+  const statusColor = statusFill(status);
+  const durMs =
+    iteration?.started_at && iteration?.completed_at
+      ? new Date(iteration.completed_at).getTime() -
+        new Date(iteration.started_at).getTime()
+      : null;
+  const cost = iteration?.cost_usd ?? null;
+  const model = iteration?.model ?? null;
+  const agent = iteration?.agent ?? null;
+  const effort = iteration?.effort ?? null;
+  const inputTokens = iteration?.input_tokens ?? null;
+  const outputTokens = iteration?.output_tokens ?? null;
+  const cacheTokens = iteration?.cache_read_input_tokens ?? null;
+
+  // Safe: all dynamic values are passed through esc() before insertion into innerHTML.
+  let body = `<div class="drawer-body">`;
+  body += `<div class="drawer-row"><span class="status-pip" style="background:${esc(statusColor)};width:10px;height:10px;border-radius:50%;display:inline-block;margin-right:6px"></span><span>${esc(status)}</span></div>`;
+  if (durMs != null) {
+    body += `<div class="drawer-row"><span class="drawer-label">Duration</span><span>${esc(formatDuration(durMs))}</span></div>`;
+  }
+  if (cost != null) {
+    body += `<div class="drawer-row"><span class="drawer-label">Cost</span><span>$${esc(cost.toFixed(2))}</span></div>`;
+  }
+  if (model) {
+    body += `<div class="drawer-row"><span class="drawer-label">Model</span><span>${esc(model)}</span></div>`;
+  }
+  if (agent) {
+    body += `<div class="drawer-row"><span class="drawer-label">Agent</span><span>${esc(agent)}</span></div>`;
+  }
+  if (effort) {
+    body += `<div class="drawer-row"><span class="drawer-label">Effort</span><span>${esc(effort)}</span></div>`;
+  }
+  if (inputTokens != null || outputTokens != null) {
+    const inp = inputTokens ?? '—';
+    const out = outputTokens ?? '—';
+    const cache =
+      cacheTokens != null ? ` cache: ${esc(String(cacheTokens))}` : '';
+    body += `<div class="drawer-row"><span class="drawer-label">Tokens</span><span>in: ${esc(String(inp))} out: ${esc(String(out))}${cache}</span></div>`;
+  }
+  const rawJson = iteration != null ? JSON.stringify(iteration, null, 2) : '{}';
+  body += `<details class="drawer-raw-json"><summary>Raw JSON</summary><pre>${esc(rawJson)}</pre></details>`;
+  body += `</div>`;
+
+  if (options?.section && options?.runId) {
+    const href = `#/${encodeURIComponent(options.section)}/${encodeURIComponent(options.runId)}`;
+    body += `<div slot="footer"><a href="${esc(href)}" class="drawer-run-detail-link">Open in run detail</a></div>`;
+  }
+
+  return body;
+}
+
+function openIterationDrawer(
+  container,
+  run,
+  stageKey,
+  barNum,
+  stageLabel,
+  options,
+) {
+  const drawer = container.querySelector('sl-drawer');
+  if (!drawer) return;
+
+  drawer.setAttribute('label', `${stageLabel} · Iteration ${barNum}`);
+  drawer.innerHTML = buildDrawerContent(run, stageKey, barNum, options);
+
+  if (typeof drawer.show === 'function') {
+    drawer.show();
+  } else {
+    drawer.setAttribute('open', '');
+  }
+}
+
+// --- Mouseover/out handlers for loopback highlight ---
+
+function onTimelineMouseover(e) {
+  const target = e.target;
+  if (!target.classList || !target.classList.contains('timeline-bar')) return;
+  const stageKey = target.getAttribute('data-stage-key');
+  const barNum = target.getAttribute('data-bar-number');
+  const svg = e.currentTarget.querySelector('svg');
+  if (!svg || !stageKey || !barNum) return;
+  for (const lb of svg.querySelectorAll('.loopback')) {
+    if (
+      (lb.getAttribute('data-from-stage') === stageKey &&
+        lb.getAttribute('data-from-iter') === barNum) ||
+      (lb.getAttribute('data-to-stage') === stageKey &&
+        lb.getAttribute('data-to-iter') === barNum)
+    ) {
+      lb.classList.add('highlight');
+    }
+  }
+}
+
+function onTimelineMouseout(e) {
+  const target = e.target;
+  if (!target.classList || !target.classList.contains('timeline-bar')) return;
+  const svg = e.currentTarget.querySelector('svg');
+  if (!svg) return;
+  for (const lb of svg.querySelectorAll('.loopback.highlight')) {
+    lb.classList.remove('highlight');
+  }
+}
+
+function onTimelineMouseleave(e) {
+  const tooltip = e.currentTarget.querySelector('.timeline-tooltip');
+  if (tooltip) tooltip.style.display = 'none';
+}
+
+// --- Main view ---
+
+export function runTimelineView(run, _settings, options = {}) {
+  const layout = getLayout(run);
+
+  if (layout.rows.length === 0) {
+    return html`<div class="run-timeline">
+      <div class="empty-state">Run has not started any stages yet</div>
+    </div>`;
+  }
+
+  const swimlaneWidth = options.swimlaneWidth || 640;
+  const { totalMs } = layout;
+  const svgStr = buildSvg(layout, swimlaneWidth);
+
+  function handleZoomIn(e) {
+    const container = e.currentTarget.closest('.run-timeline');
+    if (!container) return;
+    _scale = clampScale(_scale * 2);
+    _panMs = clampPan(_panMs, totalMs, _scale);
+    applyZoomPan(container, totalMs, swimlaneWidth);
+  }
+
+  function handleZoomOut(e) {
+    const container = e.currentTarget.closest('.run-timeline');
+    if (!container) return;
+    _scale = clampScale(_scale * 0.5);
+    _panMs = clampPan(_panMs, totalMs, _scale);
+    applyZoomPan(container, totalMs, swimlaneWidth);
+  }
+
+  function handleReset(e) {
+    const container = e.currentTarget.closest('.run-timeline');
+    if (!container) return;
+    _scale = 1.0;
+    _panMs = 0;
+    applyZoomPan(container, totalMs, swimlaneWidth);
+  }
+
+  function handleWheel(e) {
+    e.preventDefault();
+    const container = e.currentTarget;
+
+    if (e.shiftKey) {
+      // shift+wheel: horizontal pan
+      const panDeltaMs = (e.deltaY / swimlaneWidth) * (totalMs / _scale);
+      _panMs = clampPan(_panMs + panDeltaMs, totalMs, _scale);
+    } else {
+      // zoom anchored at cursor position
+      const svg = container.querySelector('svg');
+      let cursorMs = _panMs;
+      if (svg) {
+        const rect = svg.getBoundingClientRect();
+        const mouseX = e.clientX - rect.left - LABEL_WIDTH;
+        const visibleMs = totalMs / _scale;
+        const raw = _panMs + (mouseX / swimlaneWidth) * visibleMs;
+        cursorMs = Math.max(0, Math.min(totalMs, raw));
+      }
+      const next = wheelZoom(
+        { scale: _scale, panMs: _panMs },
+        e.deltaY,
+        cursorMs,
+        totalMs,
+      );
+      _scale = next.scale;
+      _panMs = next.panMs;
+    }
+    applyZoomPan(container, totalMs, swimlaneWidth);
+  }
+
+  function handleMousedown(e) {
+    const container = e.currentTarget;
+    const svg = container.querySelector('svg');
+    if (!svg) return;
+
+    const rect = svg.getBoundingClientRect();
+    const svgH = parseFloat(svg.getAttribute('height') || '0');
+    const mouseX = e.clientX - rect.left;
+    const mouseY = e.clientY - rect.top;
+    const axisZoneY = svgH - AXIS_HEIGHT;
+    const inAxisZone = mouseY >= axisZoneY;
+    const isShiftCanvas = e.shiftKey && e.button === 0 && !inAxisZone;
+
+    if (e.button === 1) {
+      e.preventDefault();
+      _dragging = true;
+      _dragStartX = e.clientX;
+      _dragStartPanMs = _panMs;
+      return;
+    }
+
+    if (e.button === 0 && (inAxisZone || isShiftCanvas)) {
+      e.preventDefault();
+      _selecting = true;
+      const swimX = mouseX - LABEL_WIDTH;
+      const visibleMs = totalMs / _scale;
+      const raw = _panMs + (swimX / swimlaneWidth) * visibleMs;
+      _selectStartMs = Math.max(0, Math.min(totalMs, raw));
+
+      const selRect = svg.querySelector('.zoom-selection');
+      if (selRect) {
+        const startX =
+          LABEL_WIDTH + ((_selectStartMs - _panMs) / visibleMs) * swimlaneWidth;
+        selRect.setAttribute('x', String(startX));
+        selRect.setAttribute('width', '0');
+        selRect.removeAttribute('display');
+      }
+    }
+  }
+
+  function handleMousemove(e) {
+    const container = e.currentTarget;
+
+    // Tooltip: show/reposition when over a bar or gap, hide otherwise
+    const tooltip = container.querySelector('.timeline-tooltip');
+    if (tooltip) {
+      const target = e.target;
+      if (target.classList && target.classList.contains('timeline-bar')) {
+        // Safe: all values passed through esc() — stage keys, model names, status, cost from local server
+        tooltip.innerHTML = buildBarTooltipHtml(target);
+        positionTooltip(tooltip, e);
+      } else if (
+        target.classList &&
+        target.classList.contains('timeline-gap')
+      ) {
+        // Safe: same escaping guarantee as bar tooltip
+        tooltip.innerHTML = buildGapTooltipHtml(target);
+        positionTooltip(tooltip, e);
+      } else {
+        tooltip.style.display = 'none';
+      }
+    }
+
+    if (!_dragging && !_selecting) return;
+    const svg = container.querySelector('svg');
+    if (!svg) return;
+
+    const rect = svg.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+
+    if (_dragging) {
+      const deltaX = e.clientX - _dragStartX;
+      const deltaMs = -(deltaX / swimlaneWidth) * (totalMs / _scale);
+      _panMs = clampPan(_dragStartPanMs + deltaMs, totalMs, _scale);
+      applyZoomPan(container, totalMs, swimlaneWidth);
+      return;
+    }
+
+    const swimX = mouseX - LABEL_WIDTH;
+    const visibleMs = totalMs / _scale;
+    const currentMs = Math.max(
+      0,
+      Math.min(totalMs, _panMs + (swimX / swimlaneWidth) * visibleMs),
+    );
+    const selRect = svg.querySelector('.zoom-selection');
+    if (selRect) {
+      const startX =
+        LABEL_WIDTH + ((_selectStartMs - _panMs) / visibleMs) * swimlaneWidth;
+      const endX =
+        LABEL_WIDTH + ((currentMs - _panMs) / visibleMs) * swimlaneWidth;
+      selRect.setAttribute('x', String(Math.min(startX, endX)));
+      selRect.setAttribute('width', String(Math.abs(endX - startX)));
+    }
+  }
+
+  function handleClick(e) {
+    const bar =
+      e.target.closest?.('.timeline-bar') ||
+      (e.target.classList?.contains('timeline-bar') ? e.target : null);
+    if (!bar) return;
+    const stageKey = bar.getAttribute('data-stage-key');
+    const barNum = parseInt(bar.getAttribute('data-bar-number'), 10);
+    const stageLabel =
+      bar.getAttribute('data-stage-label') || stageKey?.toUpperCase() || '';
+    if (!stageKey || Number.isNaN(barNum)) return;
+    openIterationDrawer(
+      e.currentTarget,
+      run,
+      stageKey,
+      barNum,
+      stageLabel,
+      options,
+    );
+  }
+
+  function handleKeydown(e) {
+    if (e.key !== 'Enter') return;
+    const bar = e.target?.classList?.contains('timeline-bar') ? e.target : null;
+    if (!bar) return;
+    const stageKey = bar.getAttribute('data-stage-key');
+    const barNum = parseInt(bar.getAttribute('data-bar-number'), 10);
+    const stageLabel =
+      bar.getAttribute('data-stage-label') || stageKey?.toUpperCase() || '';
+    if (!stageKey || Number.isNaN(barNum)) return;
+    openIterationDrawer(
+      e.currentTarget,
+      run,
+      stageKey,
+      barNum,
+      stageLabel,
+      options,
+    );
+  }
+
+  function handleMouseup(e) {
+    const container = e.currentTarget;
+
+    if (_dragging) {
+      _dragging = false;
+      return;
+    }
+
+    if (_selecting) {
+      _selecting = false;
+      const svg = container.querySelector('svg');
+      if (svg) {
+        const rect = svg.getBoundingClientRect();
+        const mouseX = e.clientX - rect.left;
+        const swimX = mouseX - LABEL_WIDTH;
+        const visibleMs = totalMs / _scale;
+        const endMs = Math.max(
+          0,
+          Math.min(totalMs, _panMs + (swimX / swimlaneWidth) * visibleMs),
+        );
+
+        // Only commit if selection is large enough to be intentional
+        if (Math.abs(endMs - _selectStartMs) > 100) {
+          const next = dragToZoom(
+            { scale: _scale, panMs: _panMs },
+            _selectStartMs,
+            endMs,
+            totalMs,
+          );
+          _scale = next.scale;
+          _panMs = next.panMs;
+          applyZoomPan(container, totalMs, swimlaneWidth);
+        }
+
+        const selRect = svg.querySelector('.zoom-selection');
+        if (selRect) selRect.setAttribute('display', 'none');
+      }
+    }
+  }
+
+  return html`<div
+    class="run-timeline"
+    @mouseover=${onTimelineMouseover}
+    @mouseout=${onTimelineMouseout}
+    @mouseleave=${onTimelineMouseleave}
+    @wheel=${handleWheel}
+    @mousedown=${handleMousedown}
+    @mousemove=${handleMousemove}
+    @mouseup=${handleMouseup}
+    @click=${handleClick}
+    @keydown=${handleKeydown}
+  >
+    <div class="timeline-toolbar">
+      <button class="timeline-zoom-btn" aria-label="Zoom out" @click=${handleZoomOut}>−</button>
+      <button class="timeline-zoom-btn" aria-label="Reset zoom" @click=${handleReset}>⤺</button>
+      <button class="timeline-zoom-btn" aria-label="Zoom in" @click=${handleZoomIn}>+</button>
+    </div>
+    ${svgStr ? unsafeHTML(svgStr) : nothing}
+    <div class="timeline-tooltip" style="display:none"></div>
+    <sl-drawer class="iteration-drawer" placement="end"></sl-drawer>
+  </div>`;
+}

--- a/worca-ui/app/views/run-timeline.test.js
+++ b/worca-ui/app/views/run-timeline.test.js
@@ -1,0 +1,955 @@
+// @vitest-environment jsdom
+
+import { render } from 'lit-html';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { _resetZoomStateForTests, runTimelineView } from './run-timeline.js';
+
+// jsdom container helper
+function renderToString(templateResult) {
+  const el = document.createElement('div');
+  render(templateResult, el);
+  return el;
+}
+
+const T0 = '2024-01-01T00:00:00.000Z';
+const T = (ms) => new Date(new Date(T0).getTime() + ms).toISOString();
+
+function makeRun(overrides = {}) {
+  return {
+    id: 'run-1',
+    status: 'completed',
+    updated_at: T0,
+    stages: {
+      implement: {
+        iterations: [
+          {
+            number: 1,
+            started_at: T(0),
+            completed_at: T(60000),
+            status: 'completed',
+            cost_usd: 0.1,
+            model: 'sonnet',
+            agent: 'implementer',
+          },
+          {
+            number: 2,
+            started_at: T(90000),
+            completed_at: T(180000),
+            status: 'completed',
+            cost_usd: 0.2,
+            model: 'sonnet',
+            agent: 'implementer',
+          },
+        ],
+      },
+      test: {
+        iterations: [
+          {
+            number: 1,
+            started_at: T(60000),
+            completed_at: T(90000),
+            status: 'completed',
+            cost_usd: 0.05,
+            model: 'sonnet',
+            agent: 'tester',
+          },
+        ],
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('runTimelineView', () => {
+  it('renders an SVG element', () => {
+    const el = renderToString(runTimelineView(makeRun(), {}, {}));
+    const svg = el.querySelector('svg');
+    expect(svg).not.toBeNull();
+  });
+
+  it('renders one row per non-skipped stage', () => {
+    const el = renderToString(runTimelineView(makeRun(), {}, {}));
+    const rows = el.querySelectorAll('.timeline-row');
+    expect(rows.length).toBe(2);
+  });
+
+  it('renders bars with status fill rects', () => {
+    const el = renderToString(runTimelineView(makeRun(), {}, {}));
+    const bars = el.querySelectorAll('.timeline-bar');
+    expect(bars.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders 3px accent rects for each bar', () => {
+    const el = renderToString(runTimelineView(makeRun(), {}, {}));
+    const accents = el.querySelectorAll('.bar-accent');
+    expect(accents.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders duration badge text when bar is wide enough', () => {
+    // With 180s total and swimlaneWidth=800, implement iter 1 (60s = 1/3 * 800 = ~267px) should show label
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const labels = el.querySelectorAll('.bar-label');
+    expect(labels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('formats duration as "1m 0s" for 60000ms', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const labels = Array.from(el.querySelectorAll('.bar-label'));
+    const texts = labels.map((l) => l.textContent.trim());
+    expect(texts.some((t) => t === '1m 0s')).toBe(true);
+  });
+
+  it('renders row labels with stage name', () => {
+    const el = renderToString(runTimelineView(makeRun(), {}, {}));
+    const labelTexts = Array.from(el.querySelectorAll('.row-label')).map(
+      (t) => t.textContent,
+    );
+    expect(labelTexts.some((t) => t.includes('IMPLEMENT'))).toBe(true);
+  });
+
+  it('renders row label with iteration badge when count > 1', () => {
+    const el = renderToString(runTimelineView(makeRun(), {}, {}));
+    const labelTexts = Array.from(el.querySelectorAll('.row-label')).map(
+      (t) => t.textContent,
+    );
+    expect(labelTexts.some((t) => t.includes('×2') || t.includes('↻'))).toBe(
+      true,
+    );
+  });
+
+  it('renders empty-state when run has no stages', () => {
+    const run = makeRun({ stages: null });
+    const el = renderToString(runTimelineView(run, {}, {}));
+    expect(el.querySelector('.empty-state')).not.toBeNull();
+  });
+
+  it('renders gap hatch rects', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const gaps = el.querySelectorAll('.timeline-gap');
+    expect(gaps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('memoizes layout — returns same SVG when updated_at unchanged', () => {
+    const run = makeRun();
+    const el1 = renderToString(
+      runTimelineView(run, {}, { swimlaneWidth: 800 }),
+    );
+    const el2 = renderToString(
+      runTimelineView(run, {}, { swimlaneWidth: 800 }),
+    );
+    const bars1 = el1.querySelectorAll('.timeline-bar').length;
+    const bars2 = el2.querySelectorAll('.timeline-bar').length;
+    expect(bars1).toBe(bars2);
+  });
+
+  it('renders loopback path when test retry precedes implement retry', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const loopbacks = el.querySelectorAll('.loopback');
+    // test ran between implement iter 1 and iter 2 — one loopback expected
+    expect(loopbacks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('gap rects carry data-tooltip attribute for hoverable gap bands', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const gaps = el.querySelectorAll('.timeline-gap');
+    expect(gaps.length).toBeGreaterThanOrEqual(1);
+    for (const gap of gaps) {
+      const tooltip =
+        gap.getAttribute('data-tooltip') || gap.getAttribute('title');
+      expect(tooltip).toBeTruthy();
+    }
+  });
+
+  it('timeline bars have data-stage-key and data-bar-number attributes', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const bars = el.querySelectorAll('.timeline-bar');
+    expect(bars.length).toBeGreaterThanOrEqual(1);
+    for (const bar of bars) {
+      expect(bar.getAttribute('data-stage-key')).toBeTruthy();
+      expect(bar.getAttribute('data-bar-number')).toBeTruthy();
+    }
+  });
+
+  it('loopback paths have from/to stage and iter data attributes', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const lbs = el.querySelectorAll('.loopback');
+    expect(lbs.length).toBeGreaterThanOrEqual(1);
+    for (const lb of lbs) {
+      expect(lb.getAttribute('data-from-stage')).toBeTruthy();
+      expect(lb.getAttribute('data-to-stage')).toBeTruthy();
+    }
+  });
+
+  it('mouseover on implement bar 2 highlights matching loopback arrows', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const impl2 = container.querySelector(
+      '[data-stage-key="implement"][data-bar-number="2"]',
+    );
+    expect(impl2).not.toBeNull();
+
+    impl2.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    expect(
+      container.querySelectorAll('.loopback.highlight').length,
+    ).toBeGreaterThanOrEqual(1);
+
+    impl2.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+    expect(container.querySelectorAll('.loopback.highlight').length).toBe(0);
+
+    document.body.removeChild(container);
+  });
+});
+
+describe('runTimelineView Phase 3: toolbar and zoom state', () => {
+  beforeEach(() => {
+    _resetZoomStateForTests();
+  });
+
+  it('renders .timeline-toolbar with zoom-in, zoom-out, and reset buttons', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const toolbar = el.querySelector('.timeline-toolbar');
+    expect(toolbar).not.toBeNull();
+    expect(toolbar.querySelector('[aria-label="Zoom in"]')).not.toBeNull();
+    expect(toolbar.querySelector('[aria-label="Zoom out"]')).not.toBeNull();
+    expect(toolbar.querySelector('[aria-label="Reset zoom"]')).not.toBeNull();
+  });
+
+  it('swimlane-content <g> exists with initial scale(1, 1) transform', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const swimG = el.querySelector('.swimlane-content');
+    expect(swimG).not.toBeNull();
+    expect(swimG.getAttribute('transform')).toContain('scale(1, 1)');
+  });
+
+  it('zoom-in button doubles scale from 1 to 2', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    container.querySelector('[aria-label="Zoom in"]').click();
+    const swimG = container.querySelector('.swimlane-content');
+    expect(swimG.getAttribute('transform')).toContain('scale(2, 1)');
+
+    document.body.removeChild(container);
+  });
+
+  it('zoom-out at scale=1 stays clamped at scale=1', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    container.querySelector('[aria-label="Zoom out"]').click();
+    const swimG = container.querySelector('.swimlane-content');
+    expect(swimG.getAttribute('transform')).toContain('scale(1, 1)');
+
+    document.body.removeChild(container);
+  });
+
+  it('zoom-in twice then reset restores scale(1, 1)', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    container.querySelector('[aria-label="Zoom in"]').click();
+    container.querySelector('[aria-label="Zoom in"]').click();
+    container.querySelector('[aria-label="Reset zoom"]').click();
+    const swimG = container.querySelector('.swimlane-content');
+    expect(swimG.getAttribute('transform')).toContain('scale(1, 1)');
+
+    document.body.removeChild(container);
+  });
+
+  it('zoom-in 5 times caps at scale(32, 1)', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const btn = container.querySelector('[aria-label="Zoom in"]');
+    btn.click();
+    btn.click();
+    btn.click();
+    btn.click();
+    btn.click();
+    const swimG = container.querySelector('.swimlane-content');
+    expect(swimG.getAttribute('transform')).toContain('scale(32, 1)');
+
+    document.body.removeChild(container);
+  });
+});
+
+describe('runTimelineView Phase 3: adaptive axis', () => {
+  beforeEach(() => {
+    _resetZoomStateForTests();
+  });
+
+  it('axis <g class="axis"> renders tick lines at scale=1', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const axisG = el.querySelector('.axis');
+    expect(axisG).not.toBeNull();
+    expect(axisG.querySelectorAll('line').length).toBeGreaterThan(0);
+  });
+
+  it('axis has more tick lines at scale=16 than at scale=1', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const axisG = container.querySelector('.axis');
+    const ticksAtScale1 = axisG.querySelectorAll('line').length;
+
+    // Zoom in 4 times: 1 → 2 → 4 → 8 → 16
+    const zoomIn = container.querySelector('[aria-label="Zoom in"]');
+    zoomIn.click();
+    zoomIn.click();
+    zoomIn.click();
+    zoomIn.click();
+    const ticksAtScale16 = axisG.querySelectorAll('line').length;
+    expect(ticksAtScale16).toBeGreaterThan(ticksAtScale1);
+
+    document.body.removeChild(container);
+  });
+});
+
+describe('runTimelineView Phase 3: wheel zoom', () => {
+  beforeEach(() => {
+    _resetZoomStateForTests();
+  });
+
+  it('wheel event with deltaY<0 (zoom-in) doubles scale to 2', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const timeline = container.querySelector('.run-timeline');
+    timeline.dispatchEvent(
+      new WheelEvent('wheel', {
+        deltaY: -100,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    const swimG = container.querySelector('.swimlane-content');
+    expect(swimG.getAttribute('transform')).toContain('scale(2, 1)');
+
+    document.body.removeChild(container);
+  });
+
+  it('wheel event with deltaY>0 (zoom-out) at scale=1 stays at scale=1', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const timeline = container.querySelector('.run-timeline');
+    timeline.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 100, bubbles: true, cancelable: true }),
+    );
+    const swimG = container.querySelector('.swimlane-content');
+    expect(swimG.getAttribute('transform')).toContain('scale(1, 1)');
+
+    document.body.removeChild(container);
+  });
+});
+
+describe('runTimelineView Phase 4: tooltips', () => {
+  beforeEach(() => {
+    _resetZoomStateForTests();
+  });
+
+  it('renders a .timeline-tooltip div', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    expect(el.querySelector('.timeline-tooltip')).not.toBeNull();
+  });
+
+  it('tooltip is initially hidden via style="display:none"', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const tooltip = el.querySelector('.timeline-tooltip');
+    expect(tooltip.style.display).toBe('none');
+  });
+
+  it('bars carry tooltip data attributes (stage-label, iter-total, start-ms, dur-ms, model, status, cost)', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const bar = el.querySelector('.timeline-bar');
+    expect(bar.getAttribute('data-stage-label')).toBeTruthy();
+    expect(bar.getAttribute('data-iter-total')).toBeTruthy();
+    expect(bar.getAttribute('data-start-ms')).not.toBeNull();
+    expect(bar.getAttribute('data-dur-ms')).not.toBeNull();
+    expect(bar.getAttribute('data-status')).toBeTruthy();
+    expect(bar.getAttribute('data-cost')).not.toBeNull();
+  });
+
+  it('gaps carry tooltip data attributes (stage-label, dur-ms, in-stage, returned-at-ms)', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const gap = el.querySelector('.timeline-gap');
+    expect(gap.getAttribute('data-stage-label')).toBeTruthy();
+    expect(gap.getAttribute('data-dur-ms')).not.toBeNull();
+    expect(gap.getAttribute('data-returned-at-ms')).not.toBeNull();
+  });
+
+  it('mousemove over a bar shows tooltip (not display:none)', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector('.timeline-bar');
+    bar.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 50 }),
+    );
+
+    const tooltip = container.querySelector('.timeline-tooltip');
+    expect(tooltip.style.display).not.toBe('none');
+    document.body.removeChild(container);
+  });
+
+  it('bar tooltip header contains stage label and "Iteration N of TOTAL"', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector(
+      '[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    bar.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 50 }),
+    );
+
+    const tooltip = container.querySelector('.timeline-tooltip');
+    expect(tooltip.innerHTML).toContain('IMPLEMENT');
+    expect(tooltip.innerHTML).toContain('Iteration 1 of');
+    document.body.removeChild(container);
+  });
+
+  it('bar tooltip contains Duration, Started, Ended, Model, Status, Cost rows', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector('.timeline-bar');
+    bar.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 50 }),
+    );
+
+    const html = container.querySelector('.timeline-tooltip').innerHTML;
+    expect(html).toContain('Duration');
+    expect(html).toContain('Started');
+    expect(html).toContain('Ended');
+    expect(html).toContain('Status');
+    expect(html).toContain('Cost');
+    document.body.removeChild(container);
+  });
+
+  it('mousemove over a gap shows tooltip with "Gap on" header', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const gap = container.querySelector('.timeline-gap');
+    gap.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 50 }),
+    );
+
+    const tooltip = container.querySelector('.timeline-tooltip');
+    expect(tooltip.style.display).not.toBe('none');
+    expect(tooltip.innerHTML).toContain('Gap on');
+    document.body.removeChild(container);
+  });
+
+  it('gap tooltip contains Duration, Control, Returned at rows', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const gap = container.querySelector('.timeline-gap');
+    gap.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 50 }),
+    );
+
+    const html = container.querySelector('.timeline-tooltip').innerHTML;
+    expect(html).toContain('Duration');
+    expect(html).toContain('Control');
+    expect(html).toContain('Returned at');
+    document.body.removeChild(container);
+  });
+
+  it('mousemove over non-bar non-gap element hides tooltip', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    // First show the tooltip by hovering a bar
+    const bar = container.querySelector('.timeline-bar');
+    bar.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 50 }),
+    );
+    expect(container.querySelector('.timeline-tooltip').style.display).not.toBe(
+      'none',
+    );
+
+    // Then move to a non-bar element (the svg itself)
+    const svg = container.querySelector('svg');
+    svg.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, clientX: 100, clientY: 5 }),
+    );
+    expect(container.querySelector('.timeline-tooltip').style.display).toBe(
+      'none',
+    );
+    document.body.removeChild(container);
+  });
+
+  it('mouseleave on container hides tooltip', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    // Show tooltip
+    const bar = container.querySelector('.timeline-bar');
+    bar.dispatchEvent(
+      new MouseEvent('mousemove', { bubbles: true, clientX: 300, clientY: 50 }),
+    );
+
+    // Trigger mouseleave on the container
+    container
+      .querySelector('.run-timeline')
+      .dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+    expect(container.querySelector('.timeline-tooltip').style.display).toBe(
+      'none',
+    );
+    document.body.removeChild(container);
+  });
+
+  it('mousemove over loopback arrow does NOT show tooltip', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const loopback = container.querySelector('.loopback');
+    if (loopback) {
+      loopback.dispatchEvent(
+        new MouseEvent('mousemove', {
+          bubbles: true,
+          clientX: 300,
+          clientY: 50,
+        }),
+      );
+      expect(container.querySelector('.timeline-tooltip').style.display).toBe(
+        'none',
+      );
+    }
+    document.body.removeChild(container);
+  });
+});
+
+describe('runTimelineView Phase 3: drag-to-zoom selection rect', () => {
+  beforeEach(() => {
+    _resetZoomStateForTests();
+  });
+
+  it('zoom-selection rect is initially hidden', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const selRect = el.querySelector('.zoom-selection');
+    expect(selRect).not.toBeNull();
+    expect(selRect.getAttribute('display')).toBe('none');
+  });
+
+  it('mousedown on axis zone shows zoom-selection rect', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const timeline = container.querySelector('.run-timeline');
+    const svg = container.querySelector('svg');
+    const svgH = parseFloat(svg.getAttribute('height') || '0');
+
+    // Click in the axis zone (bottom 24px of SVG)
+    // getBoundingClientRect returns {top:0, left:0} in jsdom
+    timeline.dispatchEvent(
+      new MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        clientX: 300,
+        clientY: svgH - 5, // within axis zone
+      }),
+    );
+
+    const selRect = container.querySelector('.zoom-selection');
+    expect(selRect.getAttribute('display')).not.toBe('none');
+
+    document.body.removeChild(container);
+  });
+});
+
+describe('runTimelineView Phase 4: click-to-drill drawer', () => {
+  beforeEach(() => {
+    _resetZoomStateForTests();
+  });
+
+  it('renders an sl-drawer element', () => {
+    const el = renderToString(runTimelineView(makeRun(), {}, {}));
+    expect(el.querySelector('sl-drawer')).not.toBeNull();
+  });
+
+  it('sl-drawer is initially closed (no open attribute)', () => {
+    const el = renderToString(runTimelineView(makeRun(), {}, {}));
+    const drawer = el.querySelector('sl-drawer');
+    expect(drawer.hasAttribute('open')).toBe(false);
+  });
+
+  it('clicking a bar opens the drawer', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector('.timeline-bar');
+    bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const drawer = container.querySelector('sl-drawer');
+    expect(drawer.hasAttribute('open')).toBe(true);
+
+    document.body.removeChild(container);
+  });
+
+  it('drawer label contains stage label and iteration number', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector(
+      '[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const drawer = container.querySelector('sl-drawer');
+    expect(drawer.getAttribute('label')).toContain('IMPLEMENT');
+    expect(drawer.getAttribute('label')).toContain('Iteration 1');
+
+    document.body.removeChild(container);
+  });
+
+  it('drawer body contains status pip, Duration, Model, Agent rows', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector(
+      '[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const drawer = container.querySelector('sl-drawer');
+    expect(drawer.innerHTML).toContain('status-pip');
+    expect(drawer.innerHTML).toContain('Duration');
+    expect(drawer.innerHTML).toContain('Model');
+    expect(drawer.innerHTML).toContain('Agent');
+
+    document.body.removeChild(container);
+  });
+
+  it('drawer body contains a collapsed <details> block for raw JSON', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector('.timeline-bar');
+    bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const drawer = container.querySelector('sl-drawer');
+    const details = drawer.querySelector('details');
+    expect(details).not.toBeNull();
+    expect(details.querySelector('summary')).not.toBeNull();
+
+    document.body.removeChild(container);
+  });
+
+  it('raw JSON details block contains the iteration number', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector(
+      '[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const drawer = container.querySelector('sl-drawer');
+    const details = drawer.querySelector('details');
+    // The raw JSON should contain the iteration's number field
+    expect(details.textContent).toContain('"number"');
+
+    document.body.removeChild(container);
+  });
+
+  it('drawer footer contains "Open in run detail" link when section and runId provided', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(
+      runTimelineView(
+        makeRun(),
+        {},
+        {
+          swimlaneWidth: 800,
+          section: 'active',
+          runId: 'run-1',
+        },
+      ),
+      container,
+    );
+
+    const bar = container.querySelector('.timeline-bar');
+    bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const drawer = container.querySelector('sl-drawer');
+    const footer = drawer.querySelector('[slot="footer"]');
+    expect(footer).not.toBeNull();
+    expect(footer.textContent).toContain('Open in run detail');
+    const link = footer.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link.getAttribute('href')).toContain('active');
+    expect(link.getAttribute('href')).toContain('run-1');
+
+    document.body.removeChild(container);
+  });
+
+  it('clicking a gap does not open the drawer', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const gap = container.querySelector('.timeline-gap');
+    if (gap) {
+      gap.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    }
+
+    const drawer = container.querySelector('sl-drawer');
+    expect(drawer.hasAttribute('open')).toBe(false);
+
+    document.body.removeChild(container);
+  });
+
+  it('drawer shows cost formatted as $X.XX', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector(
+      '[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const drawer = container.querySelector('sl-drawer');
+    expect(drawer.innerHTML).toContain('$0.10');
+
+    document.body.removeChild(container);
+  });
+});
+
+describe('runTimelineView Phase 5: loopback hide threshold', () => {
+  beforeEach(() => {
+    _resetZoomStateForTests();
+  });
+
+  it('shows loopbacks normally when iterationCount <= 30', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const lbs = el.querySelectorAll('.loopback');
+    expect(lbs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('suppresses loopback arrows when a row has iterationCount > 30', () => {
+    const iterations = Array.from({ length: 31 }, (_, i) => ({
+      number: i + 1,
+      started_at: T(i * 2000),
+      completed_at: T(i * 2000 + 1000),
+      status: 'completed',
+    }));
+    const run = makeRun({ stages: { implement: { iterations } } });
+    const el = renderToString(runTimelineView(run, {}, { swimlaneWidth: 800 }));
+    const lbs = el.querySelectorAll('.loopback');
+    expect(lbs.length).toBe(0);
+  });
+
+  it('renders hint text when loopbacks are suppressed', () => {
+    const iterations = Array.from({ length: 31 }, (_, i) => ({
+      number: i + 1,
+      started_at: T(i * 2000),
+      completed_at: T(i * 2000 + 1000),
+      status: 'completed',
+    }));
+    const run = makeRun({ stages: { implement: { iterations } } });
+    const el = renderToString(runTimelineView(run, {}, { swimlaneWidth: 800 }));
+    expect(el.querySelector('svg').innerHTML).toContain('loopbacks hidden');
+  });
+});
+
+describe('runTimelineView Phase 5: accessibility', () => {
+  it('timeline bars have role="img" attribute', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const bars = el.querySelectorAll('.timeline-bar');
+    expect(bars.length).toBeGreaterThan(0);
+    for (const bar of bars) {
+      expect(bar.getAttribute('role')).toBe('img');
+    }
+  });
+
+  it('timeline bars have aria-label attribute', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const bars = el.querySelectorAll('.timeline-bar');
+    expect(bars.length).toBeGreaterThan(0);
+    for (const bar of bars) {
+      expect(bar.getAttribute('aria-label')).toBeTruthy();
+    }
+  });
+
+  it('timeline bars have tabindex="0" for keyboard navigation', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const bars = el.querySelectorAll('.timeline-bar');
+    expect(bars.length).toBeGreaterThan(0);
+    for (const bar of bars) {
+      expect(bar.getAttribute('tabindex')).toBe('0');
+    }
+  });
+
+  it('Enter key on a focused bar opens the drawer', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector(
+      '[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    bar.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+
+    const drawer = container.querySelector('sl-drawer');
+    expect(drawer.hasAttribute('open')).toBe(true);
+
+    document.body.removeChild(container);
+  });
+
+  it('loopback arrows have aria-hidden="true"', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const lbs = el.querySelectorAll('.loopback');
+    expect(lbs.length).toBeGreaterThan(0);
+    for (const lb of lbs) {
+      expect(lb.getAttribute('aria-hidden')).toBe('true');
+    }
+  });
+});
+
+describe('runTimelineView Phase 5: live update for active runs', () => {
+  it('active run uses now() as runEnd so totalMs exceeds updated_at gap', () => {
+    // T0 = 2024-01-01; updated_at is 60s after start; now() in test env is years later
+    const activeRun = {
+      id: 'run-1',
+      status: 'in_progress',
+      updated_at: T(60000),
+      stages: {
+        implement: {
+          iterations: [
+            {
+              number: 1,
+              started_at: T(0),
+              status: 'in_progress',
+            },
+          ],
+        },
+      },
+    };
+    const el = renderToString(
+      runTimelineView(activeRun, {}, { swimlaneWidth: 800 }),
+    );
+    const svg = el.querySelector('svg');
+    expect(svg).not.toBeNull();
+    const totalMs = parseFloat(svg.getAttribute('data-total-ms') || '0');
+    // Without now(): totalMs = 60000 (updated_at gap). With now(): totalMs >> 60000
+    expect(totalMs).toBeGreaterThan(60000);
+  });
+
+  it('active run layout recomputes on new run object (WS update adds a bar)', () => {
+    const run1 = makeRun({
+      status: 'completed',
+      stages: {
+        implement: {
+          iterations: [
+            {
+              number: 1,
+              started_at: T(0),
+              completed_at: T(60000),
+              status: 'completed',
+            },
+          ],
+        },
+      },
+    });
+    const run2 = {
+      ...run1,
+      stages: {
+        implement: {
+          iterations: [
+            {
+              number: 1,
+              started_at: T(0),
+              completed_at: T(60000),
+              status: 'completed',
+            },
+            {
+              number: 2,
+              started_at: T(70000),
+              completed_at: T(130000),
+              status: 'completed',
+            },
+          ],
+        },
+      },
+    };
+    const el1 = renderToString(
+      runTimelineView(run1, {}, { swimlaneWidth: 800 }),
+    );
+    const el2 = renderToString(
+      runTimelineView(run2, {}, { swimlaneWidth: 800 }),
+    );
+    const bars1 = el1.querySelectorAll('.timeline-bar').length;
+    const bars2 = el2.querySelectorAll('.timeline-bar').length;
+    expect(bars2).toBeGreaterThan(bars1);
+  });
+});

--- a/worca-ui/app/views/run-timeline.test.js
+++ b/worca-ui/app/views/run-timeline.test.js
@@ -79,12 +79,6 @@ describe('runTimelineView', () => {
     expect(bars.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('renders 3px accent rects for each bar', () => {
-    const el = renderToString(runTimelineView(makeRun(), {}, {}));
-    const accents = el.querySelectorAll('.bar-accent');
-    expect(accents.length).toBeGreaterThanOrEqual(2);
-  });
-
   it('renders duration badge text when bar is wide enough', () => {
     // With 180s total and swimlaneWidth=800, implement iter 1 (60s = 1/3 * 800 = ~267px) should show label
     const el = renderToString(
@@ -94,13 +88,13 @@ describe('runTimelineView', () => {
     expect(labels.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('formats duration as "1m 0s" for 60000ms', () => {
+  it('formats duration as "1m" for 60000ms', () => {
     const el = renderToString(
       runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
     );
     const labels = Array.from(el.querySelectorAll('.bar-label'));
     const texts = labels.map((l) => l.textContent.trim());
-    expect(texts.some((t) => t === '1m 0s')).toBe(true);
+    expect(texts.some((t) => t === '1m')).toBe(true);
   });
 
   it('renders row labels with stage name', () => {
@@ -108,7 +102,7 @@ describe('runTimelineView', () => {
     const labelTexts = Array.from(el.querySelectorAll('.row-label')).map(
       (t) => t.textContent,
     );
-    expect(labelTexts.some((t) => t.includes('IMPLEMENT'))).toBe(true);
+    expect(labelTexts.some((t) => t.includes('Implement'))).toBe(true);
   });
 
   it('renders row label with iteration badge when count > 1', () => {
@@ -232,23 +226,35 @@ describe('runTimelineView Phase 3: toolbar and zoom state', () => {
     expect(toolbar.querySelector('[aria-label="Reset zoom"]')).not.toBeNull();
   });
 
-  it('swimlane-content <g> exists with initial scale(1, 1) transform', () => {
+  // Bars are now redrawn (with new pixel widths) on every zoom change instead of
+  // being visually scaled by an SVG transform — so zoom assertions check bar
+  // widths rather than a `scale(N, 1)` transform attribute.
+  function bar1Width(container) {
+    const bar = container.querySelector(
+      '.timeline-bar[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    return bar ? parseFloat(bar.getAttribute('width')) : null;
+  }
+
+  it('swimlane-content <g> exists with translate-only transform at scale=1', () => {
     const el = renderToString(
       runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
     );
     const swimG = el.querySelector('.swimlane-content');
     expect(swimG).not.toBeNull();
-    expect(swimG.getAttribute('transform')).toContain('scale(1, 1)');
+    expect(swimG.getAttribute('transform')).not.toContain('scale');
+    expect(swimG.getAttribute('transform')).toContain('translate(168');
   });
 
-  it('zoom-in button doubles scale from 1 to 2', () => {
+  it('zoom-in button roughly doubles bar widths', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
 
+    const before = bar1Width(container);
     container.querySelector('[aria-label="Zoom in"]').click();
-    const swimG = container.querySelector('.swimlane-content');
-    expect(swimG.getAttribute('transform')).toContain('scale(2, 1)');
+    const after = bar1Width(container);
+    expect(after / before).toBeCloseTo(2, 1);
 
     document.body.removeChild(container);
   });
@@ -258,40 +264,45 @@ describe('runTimelineView Phase 3: toolbar and zoom state', () => {
     document.body.appendChild(container);
     render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
 
+    const before = bar1Width(container);
     container.querySelector('[aria-label="Zoom out"]').click();
-    const swimG = container.querySelector('.swimlane-content');
-    expect(swimG.getAttribute('transform')).toContain('scale(1, 1)');
+    const after = bar1Width(container);
+    expect(after).toBe(before);
 
     document.body.removeChild(container);
   });
 
-  it('zoom-in twice then reset restores scale(1, 1)', () => {
+  it('zoom-in twice then reset restores fit-to-run bar widths', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
 
+    const initial = bar1Width(container);
     container.querySelector('[aria-label="Zoom in"]').click();
     container.querySelector('[aria-label="Zoom in"]').click();
     container.querySelector('[aria-label="Reset zoom"]').click();
-    const swimG = container.querySelector('.swimlane-content');
-    expect(swimG.getAttribute('transform')).toContain('scale(1, 1)');
+    const after = bar1Width(container);
+    expect(after).toBe(initial);
 
     document.body.removeChild(container);
   });
 
-  it('zoom-in 5 times caps at scale(32, 1)', () => {
+  it('zoom-in caps at scale=32 (bar width grows ~32x from fit-to-run)', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
 
+    const initial = bar1Width(container);
     const btn = container.querySelector('[aria-label="Zoom in"]');
     btn.click();
     btn.click();
     btn.click();
     btn.click();
     btn.click();
-    const swimG = container.querySelector('.swimlane-content');
-    expect(swimG.getAttribute('transform')).toContain('scale(32, 1)');
+    btn.click();
+    const after = bar1Width(container);
+    // 6 doublings would be 64×, but clamped to 32×.
+    expect(after / initial).toBeCloseTo(32, 0);
 
     document.body.removeChild(container);
   });
@@ -311,22 +322,38 @@ describe('runTimelineView Phase 3: adaptive axis', () => {
     expect(axisG.querySelectorAll('line').length).toBeGreaterThan(0);
   });
 
-  it('axis has more tick lines at scale=16 than at scale=1', () => {
+  it('axis tick interval gets finer as scale increases', () => {
+    // With pixel-density-based tick selection, total tick count stays roughly
+    // similar across zoom levels — what changes is the *interval*. Verify the
+    // tick-interval shrinks (in ms) as scale grows, which is what prevents
+    // label overlap regardless of zoom.
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
 
-    const axisG = container.querySelector('.axis');
-    const ticksAtScale1 = axisG.querySelectorAll('line').length;
+    function tickIntervalMs() {
+      const axisG = container.querySelector('.axis');
+      const labels = Array.from(axisG.querySelectorAll('text.axis-label'));
+      if (labels.length < 2) return Infinity;
+      // Labels are formatted m:ss or h:mm:ss — parse to seconds.
+      const toSec = (t) => {
+        const parts = t.split(':').map(Number);
+        return parts.length === 2
+          ? parts[0] * 60 + parts[1]
+          : parts[0] * 3600 + parts[1] * 60 + parts[2];
+      };
+      const secs = labels.map((l) => toSec(l.textContent.trim()));
+      return (secs[1] - secs[0]) * 1000;
+    }
 
-    // Zoom in 4 times: 1 → 2 → 4 → 8 → 16
+    const intervalAt1 = tickIntervalMs();
     const zoomIn = container.querySelector('[aria-label="Zoom in"]');
     zoomIn.click();
     zoomIn.click();
     zoomIn.click();
     zoomIn.click();
-    const ticksAtScale16 = axisG.querySelectorAll('line').length;
-    expect(ticksAtScale16).toBeGreaterThan(ticksAtScale1);
+    const intervalAt16 = tickIntervalMs();
+    expect(intervalAt16).toBeLessThan(intervalAt1);
 
     document.body.removeChild(container);
   });
@@ -337,11 +364,63 @@ describe('runTimelineView Phase 3: wheel zoom', () => {
     _resetZoomStateForTests();
   });
 
-  it('wheel event with deltaY<0 (zoom-in) doubles scale to 2', () => {
+  function bar1Width(container) {
+    const bar = container.querySelector(
+      '.timeline-bar[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    return bar ? parseFloat(bar.getAttribute('width')) : null;
+  }
+
+  it('shift+wheel with deltaY<0 (zoom-in) roughly doubles bar widths', () => {
+    // Wheel default is now horizontal-pan (matches Mac trackpad two-finger
+    // swipe). Zoom requires the shift modifier.
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
 
+    const before = bar1Width(container);
+    const timeline = container.querySelector('.run-timeline');
+    timeline.dispatchEvent(
+      new WheelEvent('wheel', {
+        deltaY: -100,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    const after = bar1Width(container);
+    expect(after / before).toBeCloseTo(2, 1);
+
+    document.body.removeChild(container);
+  });
+
+  it('shift+wheel with deltaY>0 (zoom-out) at scale=1 stays at scale=1', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const before = bar1Width(container);
+    const timeline = container.querySelector('.run-timeline');
+    timeline.dispatchEvent(
+      new WheelEvent('wheel', {
+        deltaY: 100,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    const after = bar1Width(container);
+    expect(after).toBe(before);
+
+    document.body.removeChild(container);
+  });
+
+  it('plain wheel (no shift) pans, does not change scale', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const before = bar1Width(container);
     const timeline = container.querySelector('.run-timeline');
     timeline.dispatchEvent(
       new WheelEvent('wheel', {
@@ -350,23 +429,9 @@ describe('runTimelineView Phase 3: wheel zoom', () => {
         cancelable: true,
       }),
     );
-    const swimG = container.querySelector('.swimlane-content');
-    expect(swimG.getAttribute('transform')).toContain('scale(2, 1)');
-
-    document.body.removeChild(container);
-  });
-
-  it('wheel event with deltaY>0 (zoom-out) at scale=1 stays at scale=1', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
-
-    const timeline = container.querySelector('.run-timeline');
-    timeline.dispatchEvent(
-      new WheelEvent('wheel', { deltaY: 100, bubbles: true, cancelable: true }),
-    );
-    const swimG = container.querySelector('.swimlane-content');
-    expect(swimG.getAttribute('transform')).toContain('scale(1, 1)');
+    const after = bar1Width(container);
+    // No scale change → bar width is identical.
+    expect(after).toBe(before);
 
     document.body.removeChild(container);
   });
@@ -443,7 +508,7 @@ describe('runTimelineView Phase 4: tooltips', () => {
     );
 
     const tooltip = container.querySelector('.timeline-tooltip');
-    expect(tooltip.innerHTML).toContain('IMPLEMENT');
+    expect(tooltip.innerHTML).toContain('Implement');
     expect(tooltip.innerHTML).toContain('Iteration 1 of');
     document.body.removeChild(container);
   });
@@ -568,42 +633,53 @@ describe('runTimelineView Phase 4: tooltips', () => {
   });
 });
 
-describe('runTimelineView Phase 3: drag-to-zoom selection rect', () => {
+describe('runTimelineView Phase 3: axis-drag zoom', () => {
   beforeEach(() => {
     _resetZoomStateForTests();
   });
 
-  it('zoom-selection rect is initially hidden', () => {
-    const el = renderToString(
-      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
-    );
-    const selRect = el.querySelector('.zoom-selection');
-    expect(selRect).not.toBeNull();
-    expect(selRect.getAttribute('display')).toBe('none');
-  });
-
-  it('mousedown on axis zone shows zoom-selection rect', () => {
+  it('mousedown + mousemove on the time-axis ribbon changes scale', () => {
+    // Drag-to-zoom region select was replaced by continuous axis-drag zoom:
+    // horizontal drag on the axis ribbon scales the chart in place.
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
 
+    function bar1Width() {
+      const bar = container.querySelector(
+        '.timeline-bar[data-stage-key="implement"][data-bar-number="1"]',
+      );
+      return bar ? parseFloat(bar.getAttribute('width')) : null;
+    }
+    const before = bar1Width();
+
     const timeline = container.querySelector('.run-timeline');
-    const svg = container.querySelector('svg');
+    const svg = container.querySelector('.timeline-svg-wrap svg');
     const svgH = parseFloat(svg.getAttribute('height') || '0');
 
-    // Click in the axis zone (bottom 24px of SVG)
-    // getBoundingClientRect returns {top:0, left:0} in jsdom
+    // Mousedown in the axis ribbon (bottom AXIS_HEIGHT band of the SVG)
     timeline.dispatchEvent(
       new MouseEvent('mousedown', {
         bubbles: true,
         button: 0,
         clientX: 300,
-        clientY: svgH - 5, // within axis zone
+        clientY: svgH - 5,
       }),
     );
+    // Drag right by 140px → scale grows by ~exp(140/200) ≈ 2.01×
+    timeline.dispatchEvent(
+      new MouseEvent('mousemove', {
+        bubbles: true,
+        clientX: 440,
+        clientY: svgH - 5,
+      }),
+    );
+    timeline.dispatchEvent(
+      new MouseEvent('mouseup', { bubbles: true, button: 0 }),
+    );
 
-    const selRect = container.querySelector('.zoom-selection');
-    expect(selRect.getAttribute('display')).not.toBe('none');
+    const after = bar1Width();
+    expect(after / before).toBeGreaterThan(1.5);
 
     document.body.removeChild(container);
   });
@@ -650,13 +726,13 @@ describe('runTimelineView Phase 4: click-to-drill drawer', () => {
     bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     const drawer = container.querySelector('sl-drawer');
-    expect(drawer.getAttribute('label')).toContain('IMPLEMENT');
+    expect(drawer.getAttribute('label')).toContain('Implement');
     expect(drawer.getAttribute('label')).toContain('Iteration 1');
 
     document.body.removeChild(container);
   });
 
-  it('drawer body contains status pip, Duration, Model, Agent rows', () => {
+  it('drawer body contains status pill, Duration, Model, Agent rows', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
@@ -667,7 +743,7 @@ describe('runTimelineView Phase 4: click-to-drill drawer', () => {
     bar.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     const drawer = container.querySelector('sl-drawer');
-    expect(drawer.innerHTML).toContain('status-pip');
+    expect(drawer.innerHTML).toContain('drawer-status-pill');
     expect(drawer.innerHTML).toContain('Duration');
     expect(drawer.innerHTML).toContain('Model');
     expect(drawer.innerHTML).toContain('Agent');
@@ -808,19 +884,53 @@ describe('runTimelineView Phase 5: loopback hide threshold', () => {
     }));
     const run = makeRun({ stages: { implement: { iterations } } });
     const el = renderToString(runTimelineView(run, {}, { swimlaneWidth: 800 }));
-    expect(el.querySelector('svg').innerHTML).toContain('loopbacks hidden');
+    expect(el.querySelector('.timeline-svg-wrap svg').innerHTML).toContain(
+      'loopbacks hidden',
+    );
   });
 });
 
 describe('runTimelineView Phase 5: accessibility', () => {
-  it('timeline bars have role="img" attribute', () => {
+  it('timeline bars have role="button" attribute', () => {
+    // Bars are interactive (Enter/Space opens the drawer). They are announced
+    // as buttons, not images, per the WAI-ARIA Button pattern.
     const el = renderToString(
       runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
     );
     const bars = el.querySelectorAll('.timeline-bar');
     expect(bars.length).toBeGreaterThan(0);
     for (const bar of bars) {
-      expect(bar.getAttribute('role')).toBe('img');
+      expect(bar.getAttribute('role')).toBe('button');
+    }
+  });
+
+  it('Space key on a focused bar also opens the drawer', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }), container);
+
+    const bar = container.querySelector(
+      '[data-stage-key="implement"][data-bar-number="1"]',
+    );
+    bar.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ' ', bubbles: true }),
+    );
+
+    const drawer = container.querySelector('sl-drawer');
+    expect(drawer.hasAttribute('open')).toBe(true);
+
+    document.body.removeChild(container);
+  });
+
+  it('timeline gaps are focusable and carry an aria-label', () => {
+    const el = renderToString(
+      runTimelineView(makeRun(), {}, { swimlaneWidth: 800 }),
+    );
+    const gaps = el.querySelectorAll('.timeline-gap');
+    expect(gaps.length).toBeGreaterThan(0);
+    for (const gap of gaps) {
+      expect(gap.getAttribute('tabindex')).toBe('0');
+      expect(gap.getAttribute('aria-label')).toBeTruthy();
     }
   });
 
@@ -898,7 +1008,7 @@ describe('runTimelineView Phase 5: live update for active runs', () => {
     const el = renderToString(
       runTimelineView(activeRun, {}, { swimlaneWidth: 800 }),
     );
-    const svg = el.querySelector('svg');
+    const svg = el.querySelector('.timeline-svg-wrap svg');
     expect(svg).not.toBeNull();
     const totalMs = parseFloat(svg.getAttribute('data-total-ms') || '0');
     // Without now(): totalMs = 60000 (updated_at gap). With now(): totalMs >> 60000

--- a/worca-ui/e2e/run-timeline-active-run-updates.spec.js
+++ b/worca-ui/e2e/run-timeline-active-run-updates.spec.js
@@ -77,7 +77,7 @@ test.describe('run timeline active run updates', () => {
       seedActiveRun(ctx.worcaDir, runId);
 
       await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
-      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+      await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible({ timeout: 8000 });
 
       // Read initial bar count to confirm SVG rendered
       const initialBarCount = await page.locator('.timeline-bar').count();
@@ -88,7 +88,7 @@ test.describe('run timeline active run updates', () => {
 
       // Active runs skip the WeakMap cache so SVG re-renders on each WS refresh.
       // After the update, the SVG should still be visible and have bars.
-      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible({ timeout: 5000 });
       await expect(page.locator('.timeline-bar').first()).toBeAttached({ timeout: 5000 });
 
       // The rightmost bar (implement iter 1) should still be present after update

--- a/worca-ui/e2e/run-timeline-active-run-updates.spec.js
+++ b/worca-ui/e2e/run-timeline-active-run-updates.spec.js
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+const BASE_START = '2026-01-01T10:00:00.000Z';
+
+function seedActiveRun(worcaDir, runId) {
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'running',
+    stage: 'implement',
+    started_at: BASE_START,
+    stages: {
+      plan: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: BASE_START,
+            completed_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+      implement: {
+        status: 'in_progress',
+        iterations: [
+          {
+            number: 1,
+            status: 'running',
+            started_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+    },
+  });
+}
+
+function advanceActiveRun(worcaDir, runId) {
+  // Advance time: implement iter 1 still running but more time elapsed
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'running',
+    stage: 'implement',
+    started_at: BASE_START,
+    updated_at: '2026-01-01T10:20:00.000Z',
+    stages: {
+      plan: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: BASE_START,
+            completed_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+      implement: {
+        status: 'in_progress',
+        iterations: [
+          {
+            number: 1,
+            status: 'running',
+            started_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+    },
+  });
+}
+
+test.describe('run timeline active run updates', () => {
+  test('WS update advancing time causes SVG to refresh with updated data-total-ms', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-timeline-active';
+      seedActiveRun(ctx.worcaDir, runId);
+
+      await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
+      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+
+      // Read initial bar count to confirm SVG rendered
+      const initialBarCount = await page.locator('.timeline-bar').count();
+      expect(initialBarCount).toBeGreaterThan(0);
+
+      // Trigger a WS update by writing updated status
+      advanceActiveRun(ctx.worcaDir, runId);
+
+      // Active runs skip the WeakMap cache so SVG re-renders on each WS refresh.
+      // After the update, the SVG should still be visible and have bars.
+      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('.timeline-bar').first()).toBeAttached({ timeout: 5000 });
+
+      // The rightmost bar (implement iter 1) should still be present after update
+      const implementBar = page.locator('.timeline-bar[data-stage-key="implement"]').first();
+      await expect(implementBar).toBeAttached({ timeout: 5000 });
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/e2e/run-timeline-back-nav.spec.js
+++ b/worca-ui/e2e/run-timeline-back-nav.spec.js
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+function seedTimelineRun(worcaDir, runId) {
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'completed',
+    stage: 'pr',
+    completed_at: '2026-01-01T10:15:00.000Z',
+    stages: {
+      plan: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:00:00.000Z',
+            completed_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+      implement: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:05:00.000Z',
+            completed_at: '2026-01-01T10:15:00.000Z',
+          },
+        ],
+      },
+    },
+  });
+}
+
+test.describe('run timeline back navigation', () => {
+  test('clicking back arrow from timeline drops /timeline suffix and shows run detail', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-timeline-nav-back';
+      seedTimelineRun(ctx.worcaDir, runId);
+
+      await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
+      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+
+      await page.locator('.content-header-back').click();
+
+      await expect(page).toHaveURL(new RegExp(`#/history/${runId}$`), { timeout: 5000 });
+
+      await expect(page.locator('.run-detail .stage-panels')).toBeVisible({ timeout: 8000 });
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/e2e/run-timeline-back-nav.spec.js
+++ b/worca-ui/e2e/run-timeline-back-nav.spec.js
@@ -43,7 +43,7 @@ test.describe('run timeline back navigation', () => {
       seedTimelineRun(ctx.worcaDir, runId);
 
       await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
-      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+      await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible({ timeout: 8000 });
 
       await page.locator('.content-header-back').click();
 

--- a/worca-ui/e2e/run-timeline-click-drill.spec.js
+++ b/worca-ui/e2e/run-timeline-click-drill.spec.js
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+function seedDrillRun(worcaDir, runId) {
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'completed',
+    stage: 'pr',
+    completed_at: '2026-01-01T10:15:00.000Z',
+    stages: {
+      plan: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            model: 'claude-opus-4-5',
+            cost_usd: 0.12,
+            input_tokens: 1000,
+            output_tokens: 500,
+            started_at: '2026-01-01T10:00:00.000Z',
+            completed_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+      implement: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            model: 'claude-sonnet-4-5',
+            started_at: '2026-01-01T10:05:00.000Z',
+            completed_at: '2026-01-01T10:15:00.000Z',
+          },
+        ],
+      },
+    },
+  });
+}
+
+test.describe('run timeline click drill', () => {
+  test('clicking a bar opens sl-drawer with iteration header and raw JSON details', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-timeline-drill';
+      seedDrillRun(ctx.worcaDir, runId);
+
+      await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
+      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+
+      const bar = page.locator('.timeline-bar').first();
+      await expect(bar).toBeAttached({ timeout: 5000 });
+
+      // Dispatch click directly: Playwright's actionability check fails for SVG rects
+      // behind fixed-layer backgrounds; dispatching on the bar bubbles to the container
+      // with e.target = bar so the click-drill handler fires correctly.
+      await page.evaluate(() => {
+        const b = document.querySelector('.timeline-bar');
+        const r = b.getBoundingClientRect();
+        const cx = r.left + r.width / 2;
+        const cy = r.top + r.height / 2;
+        b.dispatchEvent(
+          new MouseEvent('click', { bubbles: true, cancelable: true, clientX: cx, clientY: cy }),
+        );
+      });
+
+      // sl-drawer should open
+      const drawer = page.locator('sl-drawer.iteration-drawer');
+      await expect(drawer).toHaveAttribute('open', { timeout: 5000 });
+
+      // Drawer label should contain iteration info
+      const label = await drawer.getAttribute('label');
+      expect(label).toMatch(/Iteration \d+/);
+
+      // Raw JSON section should be present
+      await expect(drawer.locator('details.drawer-raw-json')).toBeAttached({ timeout: 3000 });
+      await expect(drawer.locator('details.drawer-raw-json summary')).toContainText('Raw JSON');
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/e2e/run-timeline-click-drill.spec.js
+++ b/worca-ui/e2e/run-timeline-click-drill.spec.js
@@ -48,7 +48,7 @@ test.describe('run timeline click drill', () => {
       seedDrillRun(ctx.worcaDir, runId);
 
       await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
-      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+      await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible({ timeout: 8000 });
 
       const bar = page.locator('.timeline-bar').first();
       await expect(bar).toBeAttached({ timeout: 5000 });

--- a/worca-ui/e2e/run-timeline-loopback-highlight.spec.js
+++ b/worca-ui/e2e/run-timeline-loopback-highlight.spec.js
@@ -60,7 +60,7 @@ test.describe('run timeline loopback highlight', () => {
       seedLoopbackRun(ctx.worcaDir, runId);
 
       await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
-      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+      await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible({ timeout: 8000 });
 
       // Find implement iteration 2 bar
       const implementBars = page.locator('.timeline-bar[data-stage-key="implement"]');
@@ -93,7 +93,7 @@ test.describe('run timeline loopback highlight', () => {
         // No loopbacks rendered — still verify the bar is present and hoverable
         await iter2Bar.hover();
         // Just confirm no errors occurred
-        await expect(page.locator('.run-timeline svg')).toBeVisible();
+        await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible();
       }
     } finally {
       await ctx.close();

--- a/worca-ui/e2e/run-timeline-loopback-highlight.spec.js
+++ b/worca-ui/e2e/run-timeline-loopback-highlight.spec.js
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+function seedLoopbackRun(worcaDir, runId) {
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'completed',
+    stage: 'pr',
+    completed_at: '2026-01-01T10:30:00.000Z',
+    stages: {
+      plan: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:00:00.000Z',
+            completed_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+      implement: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:05:00.000Z',
+            completed_at: '2026-01-01T10:10:00.000Z',
+          },
+          {
+            number: 2,
+            status: 'completed',
+            started_at: '2026-01-01T10:15:00.000Z',
+            completed_at: '2026-01-01T10:25:00.000Z',
+          },
+        ],
+      },
+      test: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:10:00.000Z',
+            completed_at: '2026-01-01T10:15:00.000Z',
+          },
+        ],
+      },
+    },
+  });
+}
+
+test.describe('run timeline loopback highlight', () => {
+  test('hovering IMPLEMENT iter 2 bar changes loopback arrow opacity', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-timeline-loopback';
+      seedLoopbackRun(ctx.worcaDir, runId);
+
+      await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
+      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+
+      // Find implement iteration 2 bar
+      const implementBars = page.locator('.timeline-bar[data-stage-key="implement"]');
+      await expect(implementBars).toHaveCount(2, { timeout: 5000 });
+      const iter2Bar = implementBars.nth(1);
+
+      // Check loopback arrows exist
+      const loopbacks = page.locator('.loopback');
+      const loopbackCount = await loopbacks.count();
+
+      if (loopbackCount > 0) {
+        // Before hover: no .highlight class
+        const highlightedBefore = await loopbacks.first().evaluate((el) =>
+          el.classList.contains('highlight'),
+        );
+        expect(highlightedBefore).toBe(false);
+
+        // Hover implement iter 2
+        await iter2Bar.hover();
+
+        // After hover: at least one loopback should have .highlight
+        await expect(async () => {
+          const anyHighlighted = await page.evaluate(() => {
+            const lbs = document.querySelectorAll('.loopback');
+            return Array.from(lbs).some((lb) => lb.classList.contains('highlight'));
+          });
+          expect(anyHighlighted).toBe(true);
+        }).toPass({ timeout: 3000 });
+      } else {
+        // No loopbacks rendered — still verify the bar is present and hoverable
+        await iter2Bar.hover();
+        // Just confirm no errors occurred
+        await expect(page.locator('.run-timeline svg')).toBeVisible();
+      }
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/e2e/run-timeline-navigation.spec.js
+++ b/worca-ui/e2e/run-timeline-navigation.spec.js
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+function seedTimelineRun(worcaDir, runId) {
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'completed',
+    stage: 'pr',
+    completed_at: '2026-01-01T10:15:00.000Z',
+    stages: {
+      plan: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:00:00.000Z',
+            completed_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+      implement: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:05:00.000Z',
+            completed_at: '2026-01-01T10:15:00.000Z',
+          },
+        ],
+      },
+    },
+  });
+}
+
+test.describe('run timeline navigation', () => {
+  test('clicking Timeline button navigates to timeline URL and renders SVG', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-timeline-nav-fwd';
+      seedTimelineRun(ctx.worcaDir, runId);
+
+      await page.goto(`${ctx.url}/#/history?run=${runId}`, GOTO_OPTS);
+      await expect(page.locator('.run-detail .stage-panels')).toBeVisible({ timeout: 8000 });
+
+      const timelineBtn = page.locator('.run-stage-actions button.action-btn--ghost');
+      await expect(timelineBtn).toBeVisible({ timeout: 5000 });
+      await timelineBtn.click();
+
+      await expect(page).toHaveURL(new RegExp(`#/history/${runId}/timeline$`), { timeout: 5000 });
+
+      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 5000 });
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/e2e/run-timeline-navigation.spec.js
+++ b/worca-ui/e2e/run-timeline-navigation.spec.js
@@ -45,13 +45,15 @@ test.describe('run timeline navigation', () => {
       await page.goto(`${ctx.url}/#/history?run=${runId}`, GOTO_OPTS);
       await expect(page.locator('.run-detail .stage-panels')).toBeVisible({ timeout: 8000 });
 
-      const timelineBtn = page.locator('.run-stage-actions button.action-btn--ghost');
+      const timelineBtn = page.locator(
+        '.pipeline-timing-bar-actions button.action-btn--primary',
+      );
       await expect(timelineBtn).toBeVisible({ timeout: 5000 });
       await timelineBtn.click();
 
       await expect(page).toHaveURL(new RegExp(`#/history/${runId}/timeline$`), { timeout: 5000 });
 
-      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible({ timeout: 5000 });
     } finally {
       await ctx.close();
     }

--- a/worca-ui/e2e/run-timeline-tooltip-hover.spec.js
+++ b/worca-ui/e2e/run-timeline-tooltip-hover.spec.js
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+function seedTooltipRun(worcaDir, runId) {
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'completed',
+    stage: 'pr',
+    completed_at: '2026-01-01T10:15:00.000Z',
+    stages: {
+      plan: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            model: 'claude-opus-4-5',
+            started_at: '2026-01-01T10:00:00.000Z',
+            completed_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+      implement: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            model: 'claude-sonnet-4-5',
+            started_at: '2026-01-01T10:05:00.000Z',
+            completed_at: '2026-01-01T10:15:00.000Z',
+          },
+        ],
+      },
+    },
+  });
+}
+
+test.describe('run timeline tooltip hover', () => {
+  test('hovering an iteration bar shows tooltip with stage label, iteration, duration, model, status', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-timeline-tooltip';
+      seedTooltipRun(ctx.worcaDir, runId);
+
+      await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
+      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+
+      // Hover the first timeline bar
+      const bar = page.locator('.timeline-bar').first();
+      await expect(bar).toBeAttached({ timeout: 5000 });
+
+      // Use JavaScript dispatch: Playwright's actionability check fails for SVG rects
+      // behind fixed-layer backgrounds; dispatching directly sets e.target correctly.
+      await page.evaluate(() => {
+        const b = document.querySelector('.timeline-bar');
+        const r = b.getBoundingClientRect();
+        const cx = r.left + r.width / 2;
+        const cy = r.top + r.height / 2;
+        const container = b.closest('.run-timeline');
+        container.dispatchEvent(
+          new MouseEvent('mousemove', { bubbles: true, cancelable: true, clientX: cx, clientY: cy }),
+        );
+        b.dispatchEvent(
+          new MouseEvent('mousemove', { bubbles: true, cancelable: true, clientX: cx, clientY: cy }),
+        );
+      });
+
+      const tooltip = page.locator('.timeline-tooltip');
+      await expect(tooltip).toBeVisible({ timeout: 3000 });
+
+      // Tooltip header: stage label + iteration N of total
+      await expect(tooltip.locator('.tooltip-header')).toContainText('Iteration');
+      await expect(tooltip.locator('.tooltip-header')).toContainText('of');
+
+      // Duration row
+      await expect(tooltip).toContainText('Duration');
+
+      // Model row
+      await expect(tooltip).toContainText('Model');
+
+      // Status row
+      await expect(tooltip).toContainText('Status');
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/e2e/run-timeline-tooltip-hover.spec.js
+++ b/worca-ui/e2e/run-timeline-tooltip-hover.spec.js
@@ -45,7 +45,7 @@ test.describe('run timeline tooltip hover', () => {
       seedTooltipRun(ctx.worcaDir, runId);
 
       await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
-      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+      await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible({ timeout: 8000 });
 
       // Hover the first timeline bar
       const bar = page.locator('.timeline-bar').first();

--- a/worca-ui/e2e/run-timeline-zoom-controls.spec.js
+++ b/worca-ui/e2e/run-timeline-zoom-controls.spec.js
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+function seedZoomRun(worcaDir, runId) {
+  return seedRun(worcaDir, runId, {
+    pipeline_status: 'completed',
+    stage: 'pr',
+    completed_at: '2026-01-01T10:15:00.000Z',
+    stages: {
+      plan: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:00:00.000Z',
+            completed_at: '2026-01-01T10:05:00.000Z',
+          },
+        ],
+      },
+      implement: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            started_at: '2026-01-01T10:05:00.000Z',
+            completed_at: '2026-01-01T10:15:00.000Z',
+          },
+        ],
+      },
+    },
+  });
+}
+
+test.describe('run timeline zoom controls', () => {
+  test('clicking + zooms in (bars widen) and reset restores fit-to-run', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-timeline-zoom';
+      seedZoomRun(ctx.worcaDir, runId);
+
+      await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
+      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+
+      const bar = page.locator('.timeline-bar').first();
+      await expect(bar).toBeAttached({ timeout: 5000 });
+
+      // Measure initial bar width from SVG attribute
+      const widthBefore = await bar.evaluate((el) => parseFloat(el.getAttribute('width') || '0'));
+
+      // Click zoom-in button
+      const zoomInBtn = page.locator('button[aria-label="Zoom in"]');
+      await expect(zoomInBtn).toBeVisible({ timeout: 3000 });
+      await zoomInBtn.click();
+
+      // The swimlane-content transform scale changes — verify via transform attribute
+      const swimlane = page.locator('.swimlane-content');
+      const transformAfterZoom = await swimlane.getAttribute('transform');
+      expect(transformAfterZoom).toMatch(/scale\(2/);
+
+      // Click reset button
+      const resetBtn = page.locator('button[aria-label="Reset zoom"]');
+      await resetBtn.click();
+
+      const transformAfterReset = await swimlane.getAttribute('transform');
+      expect(transformAfterReset).toMatch(/scale\(1/);
+
+      // Bar width is stored in SVG attribute — should still be the original value
+      const widthAfterReset = await bar.evaluate((el) => parseFloat(el.getAttribute('width') || '0'));
+      expect(widthAfterReset).toBeCloseTo(widthBefore, 1);
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/e2e/run-timeline-zoom-controls.spec.js
+++ b/worca-ui/e2e/run-timeline-zoom-controls.spec.js
@@ -43,7 +43,7 @@ test.describe('run timeline zoom controls', () => {
       seedZoomRun(ctx.worcaDir, runId);
 
       await page.goto(`${ctx.url}/#/history/${runId}/timeline`, GOTO_OPTS);
-      await expect(page.locator('.run-timeline svg')).toBeVisible({ timeout: 8000 });
+      await expect(page.locator('.timeline-svg-wrap > svg')).toBeVisible({ timeout: 8000 });
 
       const bar = page.locator('.timeline-bar').first();
       await expect(bar).toBeAttached({ timeout: 5000 });
@@ -56,20 +56,23 @@ test.describe('run timeline zoom controls', () => {
       await expect(zoomInBtn).toBeVisible({ timeout: 3000 });
       await zoomInBtn.click();
 
-      // The swimlane-content transform scale changes — verify via transform attribute
-      const swimlane = page.locator('.swimlane-content');
-      const transformAfterZoom = await swimlane.getAttribute('transform');
-      expect(transformAfterZoom).toMatch(/scale\(2/);
+      // Zoom redraws bars at the new pxPerMs (no SVG-level scale transform),
+      // so the first bar's width attribute should ~double.
+      const widthAfterZoom = await page
+        .locator('.timeline-bar')
+        .first()
+        .evaluate((el) => parseFloat(el.getAttribute('width') || '0'));
+      expect(widthAfterZoom / widthBefore).toBeCloseTo(2, 1);
 
       // Click reset button
       const resetBtn = page.locator('button[aria-label="Reset zoom"]');
       await resetBtn.click();
 
-      const transformAfterReset = await swimlane.getAttribute('transform');
-      expect(transformAfterReset).toMatch(/scale\(1/);
-
-      // Bar width is stored in SVG attribute — should still be the original value
-      const widthAfterReset = await bar.evaluate((el) => parseFloat(el.getAttribute('width') || '0'));
+      // After reset, bar width returns to the fit-to-run baseline.
+      const widthAfterReset = await page
+        .locator('.timeline-bar')
+        .first()
+        .evaluate((el) => parseFloat(el.getAttribute('width') || '0'));
       expect(widthAfterReset).toBeCloseTo(widthBefore, 1);
     } finally {
       await ctx.close();


### PR DESCRIPTION
## Summary

- Adds a `/run/:runId/timeline` page with a Gantt-style swimlanes chart: one row per pipeline stage, one bar per iteration positioned by wall-clock time, with loopback arrows, zoom controls, hover tooltips (duration/cost/model/status), and a click-to-drill iteration drawer.
- Entry via a ghost "Timeline" button below the stage strip on run detail; back arrow returns to run detail (not section root). Timeline page mirrors the run page header so Pause/Stop/Resume remain accessible.
- Extracts `runPageHeaderParts()` shared helper from `contentHeaderView()` to avoid duplicating header/action-button logic between run detail and timeline pages.

### New modules
| Module | Purpose |
|---|---|
| `stage-hues.js` | Deterministic HSL hue assignment per pipeline stage |
| `timeline-layout.js` | Bar positions, gap bands, loopback arc geometry |
| `timeline-zoom.js` | Zoom in/out/reset + wheel + drag-to-zoom region |
| `run-timeline.js` | SVG Gantt chart view with adaptive time-axis ticks |

## Test plan

- [x] 955-line vitest suite for `run-timeline.js` (rendering, tooltips, zoom, loopbacks, active-run updates, drawer)
- [x] Unit tests for `stage-hues` (42 lines), `timeline-layout` (354 lines), `timeline-zoom` (121 lines)
- [x] 7 Playwright e2e specs: navigation, back-nav, tooltip hover, click drill, zoom controls, loopback highlight, active-run updates
- [x] Router tests for `timeline` action round-trip
- [x] Header-button tests for Timeline button presence/absence and back-arrow routing
- [x] `npm run lint` clean (no new warnings)
- [x] `npx vitest run` — 4441 tests pass

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)