### PR TITLE
W-061: In-app help via Docs toggle + sonar ? badge overlay

### DIFF
--- a/.claude/agents/worca-release-preflight.md
+++ b/.claude/agents/worca-release-preflight.md
@@ -110,7 +110,22 @@ git log <last-tag>..HEAD -- MIGRATION.md --oneline
 
 Breaking change with no MIGRATION.md entry = `major` (surface for user to confirm; they may have decided to defer).
 
-## Step 6: Dependency drift (UI only, if @worca/ui in scope)
+## Step 6: In-app help links live on docs.worca.dev
+
+W-061 ships a registry of in-app help badges that link to `docs.worca.dev`. If `master` added a new doc page (and a matching `HELP_LINKS` entry) but `docs-live` was not fast-forwarded, the badge in the released UI will 404 for users. Catch this here before the release goes out.
+
+```bash
+python3 scripts/check-help-links-live.py
+```
+
+Exit code:
+- `0` → every `HELP_LINKS` slug returns 200 on `https://docs.worca.dev/<slug>/`. Carry on.
+- `1` → one or more 404s. **`critical`** — the fix is `/worca-docs-publish` (fast-forwards `docs-live` to master, publishing the missing pages). Re-run this step after the publish; do not proceed until it passes.
+- `2` → script could not find or parse `worca-ui/app/utils/help-links.js`. **`critical`** — surface the path the script reported.
+
+Skip this step only if `--target=worca-cc` is the explicit scope (the in-app registry ships with `@worca/ui`, not the Python package). Otherwise it always runs.
+
+## Step 7: Dependency drift (UI only, if @worca/ui in scope)
 
 ```bash
 cd worca-ui && npm outdated --json 2>/dev/null | jq 'keys'
@@ -118,7 +133,7 @@ cd worca-ui && npm outdated --json 2>/dev/null | jq 'keys'
 
 Surface outdated deps. Not a blocker, `minor` for awareness.
 
-## Step 7: Build sanity (optional, if requested)
+## Step 8: Build sanity (optional, if requested)
 
 If the user passes `--build-check`, run a dry build to catch packaging issues:
 
@@ -148,6 +163,7 @@ CHECKS:
   [✓] No tag conflict                     worca-cc-v0.7.0 does not exist
   [✗] CI status                           critical: most recent master run is "failure"
   [!] MIGRATION.md coverage               major: 2 breaking changes since worca-cc-v0.6.0, no MIGRATION.md update
+  [✗] Help links live on docs.worca.dev   critical: running-pipelines/timeline-view/ is 404 — run /worca-docs-publish
 
 BLOCKING ISSUES:
   [critical] CI is red on master — fix or revert before tagging.

--- a/.claude/skills/worca-docs-help/SKILL.md
+++ b/.claude/skills/worca-docs-help/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: worca-docs-help
+description: Wire a worca-ui surface to its docs.worca.dev page via the W-061 help-mode toggle — natural-language invocation ("add a docs link for the Pricing tab"). The skill locates the surface in worca-ui/app/views/, searches docs-site/src/content/docs/ for a matching page, picks or extends the HELP_LINKS registry entry, drops a `${helpFor('<id>')}` at the right anchor, updates the mapping table in worca-ui/docs/help-mode-prototype.md, and runs the L1 vitest to verify. If no matching doc page exists, proposes scaffolding a stub or escalating to a docs-authoring skill rather than wiring a 404 link. Triggers on "docs help", "add docs link", "wire help badge", "help-link this surface", "/worca-docs-help".
+---
+
+# Wire a worca-ui surface to its docs.worca.dev page
+
+This is the partner skill to the W-061 in-app help system (right-edge Docs tab + sonar `?` badge overlay). The toggle plumbing is already in place — every primary teaching surface that calls `helpFor('<id>')` gets a badge revealed when the user activates help mode. This skill adds one new placement (and, if needed, one new registry entry) per invocation.
+
+## Invocation
+
+Natural language. Examples that should all work:
+
+- `/worca-docs-help add a docs link for the Pricing tab`
+- `/worca-docs-help wire help for the Beads panel`
+- `/worca-docs-help the Webhook Inbox needs a Docs badge`
+- `add a help badge to the Token Costs section pointing at the costs reference page`
+
+If invoked with no description, ask: *"Which UI surface do you want to wire to docs? Describe it the way a user would (e.g. 'the Pricing tab', 'the Run Timeline view', 'the dispatch panel in run detail')."*
+
+## Step 1: Locate the UI surface
+
+Parse the user's description for a surface noun phrase (a tab label, a panel header, a section title, a view name). Then locate it in `worca-ui/app/views/`:
+
+```bash
+# Direct text match across all view files. Restrict to source (exclude tests).
+grep -rn '<label-or-title-text>' worca-ui/app/views/ --include='*.js' \
+  | grep -v '\.test\.js$' | head -20
+```
+
+For tab labels, also try the `panel=` slot attribute as a fallback:
+
+```bash
+grep -rn 'panel="<kebab-case-form>"' worca-ui/app/views/ --include='*.js' | head -5
+```
+
+For panel headers in run-detail or similar, the typical anchor classes are: `.panel-header`, `.section-title`, `.<feature>-header`, slot=summary inside `sl-details`, sl-tab labels, plain `<h2>`/`<h3>`.
+
+**Pick the file + line that's the most plausible anchor.** Multiple plausible candidates → present them to the user as a numbered list and ask which to wire.
+
+**No candidates** → the description didn't map. Ask the user to refine (e.g. "I couldn't find a 'Pricing' element in the views. Is it called something else in the code?").
+
+## Step 2: Check whether the surface is already wired
+
+```bash
+# Look ~10 lines around the anchor for an existing helpFor() call.
+sed -n '<line-5>,<line+10>p' worca-ui/app/views/<file>
+```
+
+If there's already a `${helpFor('<id>')}` near the anchor, **stop and surface it**:
+
+> The <surface> at `<file>:<line>` is already wired to `helpFor('<id>')` → docs page `<slug>`. Not re-instrumenting. (Run `/worca-docs-help` against a different surface if this was a typo.)
+
+## Step 3: Find the matching docs page
+
+Search `docs-site/src/content/docs/` for candidate pages. Strategy (run in this order, stop at first reasonable hit):
+
+1. **Filename match** (case-insensitive, the term as a slug fragment):
+   ```bash
+   find docs-site/src/content/docs -type f \( -name '*.md' -o -name '*.mdx' \) \
+     | grep -i '<keyword>'
+   ```
+
+2. **Frontmatter title match**:
+   ```bash
+   grep -ril '^title:.*<keyword>' docs-site/src/content/docs/
+   ```
+
+3. **Heading match anywhere in the doc tree**:
+   ```bash
+   grep -rli '^#.*<keyword>' docs-site/src/content/docs/
+   ```
+
+4. **Content keyword match** (broadest, last resort):
+   ```bash
+   grep -rli '<keyword>' docs-site/src/content/docs/
+   ```
+
+Rank candidates by:
+- Filename match > frontmatter > heading > body
+- Shorter slugs preferred (more authoritative pages tend to be top-level under each section)
+- Pages already referenced by an existing `HELP_LINKS` entry rank highest (registry already curated)
+
+**Validate every candidate** with the L1 rule:
+
+- File must end in `.md` or `.mdx`.
+- Slug = path under `docs-site/src/content/docs/` without the extension.
+- Slug must not contain `#` (anchors are forbidden — they silently break on heading renames).
+
+## Step 4: Decide based on what was found
+
+### 4a — Doc found, registry already has matching entry
+
+Most common case for established pages.
+
+```bash
+# Inspect the registry to find an existing helpId for this slug.
+grep -n "slug: '<slug>'" worca-ui/app/utils/help-links.js
+```
+
+If a helpId already points at the slug, **reuse it**. Skip Step 5.
+
+### 4b — Doc found, no registry entry for this slug
+
+Add a new entry to `worca-ui/app/utils/help-links.js`. Pick an `<id>`:
+
+- Short, kebab-case.
+- Doesn't collide with an existing key.
+- Mirrors the slug's leaf when possible (e.g. `configuration/pricing` → `pricing`; `advanced/tuning-effort` → `effort`).
+
+Insert the new `{ slug, title }` pair into the **section block matching the slug's top-level directory**:
+
+| Top-level dir | Comment header in help-links.js |
+|---|---|
+| `concepts/` | `// Concepts` |
+| `configuration/` | `// Configuration` |
+| `running-pipelines/` | `// Running pipelines` |
+| `advanced/` | `// Advanced` |
+| `integrations/` | `// Integrations` |
+| `getting-started/` | `// Getting started` |
+| `introduction/` / `reference/` / `upgrading/` | append a new section comment if none yet, otherwise group under a new `// Other` block |
+
+The `title` value is the human-readable label used in the badge's `title=` and `aria-label=` attributes — pull it from the doc's frontmatter `title:` field (`grep '^title:' <doc-file>`). Strip leading/trailing whitespace.
+
+### 4c — No matching doc page found
+
+**Do not** add a `helpFor()` pointing at a non-existent slug — that would fail L1 vitest immediately and would render a badge linking to a 404 in any environment where `WORCA_DOCS_BASE` is bypassed.
+
+Surface the gap to the user with these options:
+
+> No matching doc page found for *<surface>*. I can:
+>
+> 1. **Skip** — don't add a badge here yet. (Recommended if the feature is genuinely too thin to deserve a doc page; the W-061 discipline rule explicitly says skip-if-no-doc.)
+> 2. **Scaffold a stub doc page** at `docs-site/src/content/docs/<proposed-slug>.md` with a one-line title + a TODO body. The L1 vitest will then accept the new registry entry. *Caveat:* a thin page is barely better than a 404 for trust. Use this only if you're committing to fleshing it out before the next release.
+> 3. **Repoint at an adjacent page** that has some overlap (e.g. `configuration/settings-overview` as a fallback for Preferences). I'll show the top 3 candidates from Step 3.
+
+Wait for the user to pick. Don't auto-scaffold.
+
+> Future: if a dedicated `/worca-docs-create` skill lands (none today as of 2026-06), this skill should delegate option 2 to it for proper frontmatter, sidebar entry, and link to `docs-site/astro.config.mjs`.
+
+## Step 5: Apply the registry edit (only for Step 4b)
+
+Read `worca-ui/app/utils/help-links.js`, locate the matching section block, and insert the new entry **alphabetically by key** within that block (preserves grep-ability). Match the formatting of neighbouring entries — biome will reformat on `npm run lint:fix` if you get whitespace wrong.
+
+Show the diff before applying. Confirm.
+
+## Step 6: Apply the view edit
+
+Read the target view file. Ensure the `helpFor` import is present in the import block:
+
+```js
+import { helpFor } from '../utils/help-links.js';
+```
+
+If absent, insert it alphabetically into the existing `../utils/` import group.
+
+Insert `${helpFor('<id>')}` at the chosen anchor. Match the surrounding indentation. Conventional placements:
+
+- **Inside an `<sl-tab slot="nav">` label**: append after the existing label text, before the closing `</sl-tab>`.
+- **Inside an `slot="summary"` div on sl-details**: append before the closing `</div>`.
+- **Inside a panel wrapper `<div class="...">`**: place as the first child (before other content) when the host has its own header content, or as a sibling next to the heading element when the host is a heading-and-body pattern.
+- **Inside an empty-state `<div class="empty-state">`**: append directly after the empty-state text, no wrapper.
+
+Show the diff before applying. Confirm.
+
+## Step 7: Update the mapping table
+
+Read `worca-ui/docs/help-mode-prototype.md`. Find the section "Instrumented surfaces — full UI sweep" and the sub-region that matches the surface (Settings, Run Detail, Pipeline Templates, Launchers, etc.). Insert a new row into the relevant markdown table:
+
+```markdown
+| <Surface description> | `<id>` | <slug> |
+```
+
+If no sub-region fits cleanly (rare — new view category), add a new sub-region heading + table with one row.
+
+Show the diff. Confirm. Apply.
+
+## Step 8: Verify
+
+Run the L1 vitest (fast, no network):
+
+```bash
+cd worca-ui && npx vitest run app/utils/help-links.test.js
+```
+
+Should pass — the new entry must resolve to a real `.md`/`.mdx` file. If it fails, the edit is wrong; back out and re-investigate.
+
+Optionally probe just the new slug live:
+
+```bash
+python3 scripts/check-help-links-live.py 2>&1 | grep '<new-slug>'
+```
+
+If the new slug 404s on `docs.worca.dev`, warn the user — the local doc exists but `docs-live` hasn't been fast-forwarded. Fix is `/worca-docs-publish`. Not blocking for the PR; just a heads-up so they don't ship a release with a freshly-broken badge.
+
+## Step 9: Tell the user what to do next
+
+```
+Wired <surface> to docs.worca.dev/<slug>/ via helpFor('<id>').
+Changed files:
+  - worca-ui/app/utils/help-links.js   (+1 registry entry)   [if 4b]
+  - worca-ui/app/views/<file>          (+1 helpFor placement)
+  - worca-ui/docs/help-mode-prototype.md (+1 mapping row)
+
+L1 vitest: passed.
+L2 live check: ok | WARNING: <slug> is 404 on docs.worca.dev — run /worca-docs-publish before the next release.
+
+Rebuild + restart the UI to see it live:
+  pnpm worca:ui:restart
+```
+
+## Guardrails
+
+The skill **refuses** to:
+
+- Add a `helpFor()` at an anchor that already has one within ~5 lines (one badge per primary teaching surface — the W-061 discipline rule).
+- Add a registry entry whose slug doesn't resolve to a local `.md`/`.mdx` file (L1 contract).
+- Add a registry entry whose slug contains `#` (anchors silently break on heading renames; only page-level slugs are allowed).
+- Add a duplicate registry entry for a slug that's already represented under a different id (suggest reusing the existing id instead).
+- Touch the legacy inline `<a href="https://docs.worca.dev/configuration/precedence/">Learn more →</a>` at `settings.js:96`, which has already been migrated through `helpUrl('configuration-precedence')` — point users at `helpUrl(id)` for any new inline-prose anchor case.
+
+The skill **warns** (but does not block) on:
+
+- Slugs that 404 on `docs.worca.dev` (likely `/worca-docs-publish` lag).
+- Targeting a surface on the docs-skipped list (Pricing, Notifications, Beads panel, Token costs, Learnings panel, Live output, Log viewer). Surface the discipline rule and confirm — the user may be intentionally instrumenting because a doc finally landed.
+
+## What this skill does NOT do
+
+- Author docs prose. If a doc page is missing and the user picks Step 4c option 2, this skill writes a one-line stub and delegates the actual content authoring back to the user (or to a future `/worca-docs-create` skill).
+- Rebuild the UI bundle. The view edit doesn't take effect until `pnpm worca:ui:restart` runs — the skill reminds, doesn't run.
+- Publish docs. `/worca-docs-publish` is the explicit affordance for that.
+- Push or open PRs. Standard git workflow applies after the skill exits.

--- a/docs/plans/W-061-in-app-help-links.md
+++ b/docs/plans/W-061-in-app-help-links.md
@@ -1,86 +1,161 @@
-# W-061: In-app help links — central registry, standardized renderer, and CI sync checks
+# W-061: In-app help via right-edge "Docs" toggle + glowing `?` badge overlay
 
-**Status:** Draft
+**Status:** Prototype on `prototype/W-061-help-mode-toggle`
 **Priority:** P2
 **Area:** ui
-**Date:** 2026-05-30
+**Date:** 2026-05-30 (revised 2026-06-03 after prototype evaluation)
 **Depends on:** None
+
+> **Pattern revision note.** The original 2026-05-30 draft of this plan
+> shipped an always-on inline `?` icon at every primary teaching surface
+> (`helpLink(id)` rendering a muted 16px CircleHelp). After prototype
+> evaluation we switched to an **opt-in toggle** pattern: badges are
+> hidden by default and revealed together when the user activates "help
+> mode" via a right-edge "Docs" tab or the `?` keyboard shortcut. The
+> rest of this plan reflects the toggle pattern. The pre-W-062 settings
+> tab inventory in the original draft is also corrected throughout.
 
 ## Problem
 
-worca-ui currently has no in-app pointers to the comprehensive docs at [docs.worca.dev](https://docs.worca.dev). Users land on a settings tab (`worca-ui/app/views/settings.js:3497-3534` — 9 project-scoped tabs covering Models, Effort, Permissions, Pipeline, Pricing, Webhooks, Graphify, Code Review Graph, plus 4 global tabs at `:3444-3466`), a run-detail panel (`worca-ui/app/views/run-detail.js` — stage timeline, plan iterations, CRG badge at `:1148`, Graphify badge at `:1067`, dispatch section at `:880`, circuit breaker at `:916/:925`, PR details), or a launcher (`new-run.js`, `fleet-launcher.js`, `workspace-create.js`) with no affordance to "learn more about this."
+worca-ui has no in-app pointers to the comprehensive docs at
+[docs.worca.dev](https://docs.worca.dev). Users land on a settings tab,
+a run-detail panel, a launcher, a template editor (W-062), or the new
+timeline view (W-063) with no affordance to "learn more about this."
 
-The docs themselves are rich (45 pages across 9 sections under `docs-site/src/content/docs/`), but discovery is poor. Users either guess slugs, navigate from the docs site root, or never find them at all. A grep across `worca-ui/app/` confirms no existing pattern: no `target="_blank"` anchors to `docs.worca.dev`, no help icon, no `?` affordance anywhere in the UI today.
+The docs themselves are rich (49 pages across 9 sections under
+`docs-site/src/content/docs/`), but discovery is poor. Users either
+guess slugs, navigate from the docs site root, or never find them at
+all. The one inline anchor that does exist today (`worca-ui/app/views/settings.js:96` →
+`https://docs.worca.dev/configuration/precedence/`) is exactly the kind
+of one-off hardcoded link this plan is meant to prevent from
+proliferating.
 
-User-facing impact: every onboarding question that the docs already answer (what's an effort level? what does halted mean? how do I configure a webhook?) becomes a support touch instead of a self-serve click.
+User-facing impact: every onboarding question that the docs already
+answer (what's an effort level? what does halted mean? how do I
+configure a webhook?) becomes a support touch instead of a self-serve
+click.
 
 ## Proposal
 
-Add a single centralized help-link module — `worca-ui/app/utils/help-links.js` — with a frozen `HELP_LINKS` map (helpId → {slug, title}), a `helpUrl(id)` lookup, and a standardized `helpLink(id)` lit-html renderer. Every in-app `?` icon flows through `helpLink()` — never inline `<a target="_blank">` — making it the single point of control for URL, icon, color, hover, dark/light styling, and a11y.
+Three-part affordance:
 
-Enforce sync with two CI layers: an L1 vitest that resolves each slug against the local `docs-site/src/content/docs/` tree (no network, every PR), and an L2 live HEAD check wired into the `worca-release-preflight` subagent (catches "doc added to master but `/worca-docs-publish` not yet run").
+1. **A persistent right-edge "Docs" tab** (`worca-ui/app/views/help-edge-tab.js`)
+   anchored 100px from the viewport top, rotated `-90deg`, monospace
+   label matching the sidebar WORCA wordmark, 75% opacity idle / 100%
+   opaque on hover. Click toggles help mode. Same affordance bound to
+   the `?` keyboard shortcut (Shift+/), with an input-focus guard so
+   text fields stay typeable.
+2. **A central registry** (`worca-ui/app/utils/help-links.js`) exporting
+   `HELP_LINKS` (frozen helpId → `{slug, title}` map), `helpUrl(id)`,
+   and `helpFor(id)` — the lit-html template that renders a
+   `display: none` violet badge anchored to its host. The badge is
+   revealed only when `body.help-mode-active` is set.
+3. **A help-mode state machine** (`worca-ui/app/utils/help-mode.js`)
+   owning `isActive()` / `setActive()` / `toggle()` / `subscribe()`
+   and the body-class toggle. Single source of truth for both
+   the edge tab and any future help-mode indicator.
 
-Roll out by UX rule — **one `?` per primary teaching surface** (section/tab/panel/launcher header), never on individual buttons, badges, or form fields. ~22 icons total across the entire UI.
+**Discipline rule** (unchanged from original): one `?` per primary
+teaching surface — section header, panel header, settings tab label,
+launcher form, top-level view. Never on individual buttons, badges, or
+form fields. Skip if no doc page exists (404 destroys trust).
+Tooltips remain the tool for term-level explanation; `?` is for
+whole-topic onboarding. The full UI sweep instruments **34 surfaces**
+across 14 view files (see `worca-ui/docs/help-mode-prototype.md` for
+the table).
 
-Note on map size vs. placement count: `HELP_LINKS` ships with 25 entries (full coverage of the docs surface area). Initial placement uses ~22 because several helpIds are reused across surfaces (e.g. `agents-models` covers both the Agents and Models settings tabs; `crg` and `graphify` each cover both a settings tab and a run-detail badge area) and a handful are reserved for future surfaces (`monitoring`, `controlling`, `templates`) so they don't need to be added in a separate map-edit PR later.
+**Visual language** — deliberately *not* blue: blue is already used for
+primary actions + the `running` status, green for `completed`, orange
+for caution per the badge color language, red for `failed`, yellow for
+circuit-breaker warning. Help mode uses **violet (`#7c3aed`)** so it
+reads as informational and never competes with status semantics. The
+badge is a 27×27 violet disc at 75% opacity with a 21px white `?`
+glyph (plain text, not an SVG, so there's no lucide
+container-around-the-glyph artifact). A sonar wave (`::after`
+pseudo-element) scales 1 → 1.5 with opacity 0.55 → 0 across 2.4s
+infinite, giving the badge a slow signal-style pulse. `prefers-reduced-motion`
+collapses the wave to a static dim halo.
+
+**Sync — two CI layers** (unchanged from the original plan):
+
+- **L1 — source check** (every PR): vitest in
+  `worca-ui/app/utils/help-links.test.js` resolves each slug against
+  the local `docs-site/src/content/docs/` tree. No network. Catches
+  typos, missing pages, accidental anchors.
+- **L2 — live check** (release time): `scripts/check-help-links-live.py`
+  wired into the `worca-release-preflight` subagent HEAD-checks
+  `https://docs.worca.dev/<slug>/` for every entry. Catches the
+  "added a doc to master but `/worca-docs-publish` was never run"
+  case — the same root cause behind the user's discovery of the live
+  404 on `running-pipelines/timeline-view/` during this prototype.
+
+**Slug discipline:** page-level only, no anchors. Starlight
+auto-generates anchor IDs from heading text → renaming a heading
+silently breaks deep links. Page slugs require an explicit file
+rename, which a reviewer notices.
+
+**`DOCS_BASE`:** defaults to `https://docs.worca.dev`; overridable at
+esbuild build time via `WORCA_DOCS_BASE` env var
+(`worca-ui/scripts/build-frontend.js`) for local Starlight preview
+against `http://localhost:4321` or `http://staging.docs.worca.dev`.
+
+## Considerations
+
+- **Pattern trade-off — toggle vs always-on.** An always-on icon makes
+  every help link self-evident at first glance but adds visual density
+  to ~30 surfaces. A toggle adds zero baseline noise but costs one
+  extra click + makes discoverability of the edge tab the new problem.
+  The right-edge "Docs" label + `?` hotkey hint mitigates that. Both
+  patterns respect the same "one per surface" discipline rule.
+- **Trade-off — page-level vs anchor-level deep links:** anchors land
+  users on the exact paragraph but break silently on heading renames.
+  Page-level is more resilient at the cost of one extra scroll.
+- **Trade-off — centralised module vs raw URL helper:** the module +
+  renderer adds ~200 LOC and removes every chance of an inline anchor
+  diverging. Net win for theming, a11y consistency, and CI-checked
+  freshness.
+- **Sync gap acknowledgment:** UI ships in `@worca/ui` npm releases,
+  but `docs.worca.dev` only updates when `/worca-docs-publish` runs.
+  L2 catches mismatches at release time; it does not eliminate the
+  gap during day-to-day development. Acceptable because (1) day-to-day
+  UI dev uses local `npm run build` against current master where L1
+  passes, (2) released versions are gated by L2.
+- **Surfaces skipped (no doc today):** Pricing tab, Notifications tab,
+  Beads panel, Token costs panel, Learnings panel, Live output, Log
+  viewer. Deliberately skipped — adding a `?` to a 404 destroys trust.
+  When those docs land, the helpId is added in the same PR.
+- **Browser support:** `body.help-mode-active *:has(> .help-badge)`
+  uses CSS `:has()` (Chrome 105+, Safari 15.4+, Firefox 121+). Older
+  browsers will see the badge fall back to anchoring against the
+  next positioned ancestor (degraded but not broken).
+- **No breaking changes.** Pure additive: new modules, new CSS, no
+  existing API touched.
 
 ## Design
 
 ### 1. The central module — `worca-ui/app/utils/help-links.js`
 
-- **Current state:** no module exists; closest analogs are `worca-ui/app/utils/status-badge.js` and `worca-ui/app/utils/effort-badge.js` (small focused helpers exporting both data maps and lit-html renderers).
-- **Obstacle:** scattered `<a target="_blank" href="https://docs.worca.dev/...">` would re-introduce the divergence problem the registry is meant to solve. A second team member adding a help link would either copy-paste an existing anchor (fragile) or invent their own styling (inconsistent).
-- **Resolution:** ship the module + renderer together. Public API is exactly three exports — `HELP_LINKS`, `helpUrl(id)`, `helpLink(id)`. All consumers import `helpLink` only; the map and `helpUrl` are exposed for tests and for the rare case where the URL is needed without the icon (e.g., a "Learn more" inline anchor in copy).
+Public API is exactly three exports — `HELP_LINKS`, `helpUrl(id)`,
+`helpFor(id)`. All view-layer consumers import `helpFor`; the map and
+`helpUrl` are exposed for tests and for the rare case where the URL
+is needed without the icon (e.g., the inline "Learn more →" anchor in
+`settings.js:96`'s `TEMPLATE_DRIVEN_BANNER` was migrated to
+`helpUrl('configuration-precedence')`).
 
 ```js
-// worca-ui/app/utils/help-links.js
+// worca-ui/app/utils/help-links.js (excerpt)
 import { html } from 'lit-html';
-import { CircleHelp, iconSvg } from './icons.js';
 
-// Build-time override (see Design §5). Defaults to production docs.
 const DOCS_BASE =
-  typeof WORCA_DOCS_BASE !== 'undefined' ? WORCA_DOCS_BASE : 'https://docs.worca.dev';
+  typeof WORCA_DOCS_BASE !== 'undefined'
+    ? WORCA_DOCS_BASE
+    : 'https://docs.worca.dev';
 
-// Map helpId → { slug, title }.
-// slug: path under docs-site/src/content/docs/ without extension or leading slash.
-// title: shows in the tooltip (`Help: <title>`) and aria-label.
 export const HELP_LINKS = Object.freeze({
-  // Concepts
   'pipeline-stages':    { slug: 'concepts/the-pipeline-and-stages',          title: 'Pipeline & stages' },
-  'governance':         { slug: 'concepts/governance',                        title: 'Governance' },
-  'lifecycle':          { slug: 'concepts/lifecycle-and-state',               title: 'Run lifecycle & state' },
-  'templates':          { slug: 'concepts/pipeline-templates',                title: 'Pipeline templates' },
-  'plans-guides':       { slug: 'concepts/plans-work-requests-and-guides',    title: 'Plans, work requests & guides' },
-
-  // Configuration
-  'agents-models':      { slug: 'configuration/agents-and-models',            title: 'Agents & models' },
-  'stages-config':      { slug: 'configuration/stages',                       title: 'Stage configuration' },
-  'loops':              { slug: 'configuration/loops-and-circuit-breaker',    title: 'Loops & circuit breaker' },
-  'secrets':            { slug: 'configuration/secrets',                      title: 'Secrets' },
-
-  // Running pipelines
-  'launching':          { slug: 'running-pipelines/launching-a-run',          title: 'Launching a run' },
-  'monitoring':         { slug: 'running-pipelines/monitoring-a-run',         title: 'Monitoring a run' },
-  'controlling':        { slug: 'running-pipelines/controlling-a-run',        title: 'Controlling a run' },
-  'reviewing':          { slug: 'running-pipelines/reviewing-the-result',     title: 'Reviewing the result' },
-
-  // Advanced
-  'effort':             { slug: 'advanced/tuning-effort',                     title: 'Effort levels' },
-  'dispatch':           { slug: 'advanced/dispatch-governance',               title: 'Dispatch governance' },
-  'crg':                { slug: 'advanced/code-review-graph',                 title: 'Code Review Graph' },
-  'graphify':           { slug: 'advanced/knowledge-graph',                   title: 'Knowledge graph (Graphify)' },
-  'fleet-runs':         { slug: 'advanced/fleet-runs',                        title: 'Fleet runs' },
-  'workspace-runs':     { slug: 'advanced/workspace-runs',                    title: 'Workspace runs' },
-  'worktrees':          { slug: 'advanced/worktree-cleanup',                  title: 'Worktree cleanup' },
-
-  // Integrations
-  'webhooks':           { slug: 'integrations/webhooks',                      title: 'Webhooks' },
-  'chat':               { slug: 'integrations/chat-integrations',             title: 'Chat integrations' },
-  'events':             { slug: 'integrations/events-overview',               title: 'Events overview' },
-
-  // Getting started
-  'first-run':          { slug: 'getting-started/your-first-run',             title: 'Your first run' },
-  'add-project':        { slug: 'getting-started/add-your-project',           title: 'Add your project' },
+  governance:           { slug: 'concepts/governance',                        title: 'Governance' },
+  // …~30 entries spanning concepts / configuration / running-pipelines /
+  //    advanced / integrations / getting-started …
 });
 
 export function helpUrl(id) {
@@ -89,121 +164,89 @@ export function helpUrl(id) {
   return `${DOCS_BASE}/${entry.slug}/`;
 }
 
-// The standardized renderer. Every in-app `?` MUST go through this — never
-// hand-written <a target="_blank"> in views. This is the single point of
-// control for URL, icon glyph, color, dark/light theming, hover, and a11y.
-export function helpLink(id) {
+export function helpFor(id) {
   const entry = HELP_LINKS[id];
   if (!entry) {
-    // Soft fail: warn in dev console but never crash a view.
-    if (typeof console !== 'undefined') console.warn(`helpLink: unknown id "${id}"`);
+    if (typeof console !== 'undefined') console.warn(`helpFor: unknown id "${id}"`);
     return null;
   }
   const url = `${DOCS_BASE}/${entry.slug}/`;
-  return html`
-    <a class="help-link"
-       href=${url}
-       target="_blank"
-       rel="noopener noreferrer"
-       title="Help: ${entry.title}"
-       aria-label="Open help: ${entry.title}">
-      ${iconSvg(CircleHelp)}
-    </a>
-  `;
+  return html`<a class="help-badge" href=${url} target="_blank"
+    rel="noopener noreferrer" title="Help: ${entry.title}"
+    aria-label="Open help: ${entry.title}" data-help-id=${id}
+  ><span class="help-badge__glyph" aria-hidden="true">?</span></a>`;
 }
 ```
 
-### 2. Icon and styling
+The glyph is a plain text `?` rather than a lucide SVG so we don't get
+the container-around-the-glyph artifact baked into every lucide
+help-icon variant (`circle-question-mark`, `badge-question-mark`,
+`file-question-mark`, …).
 
-- **Current state:** `worca-ui/app/utils/icons.js` already imports ~50 lucide icons; `CircleHelp` is NOT in the current import list. `worca-ui/app/styles.css` has the global stylesheet.
-- **Obstacle:** the `?` icon must look "muted but discoverable" — visible enough to invite a click, quiet enough not to compete with primary actions. Hardcoding inline styles in `helpLink()` would defeat the centralization goal (no dark-mode handling, no hover state).
-- **Resolution:**
-  1. Add `import CircleHelp from 'lucide/dist/esm/icons/circle-help';` to `worca-ui/app/utils/icons.js`, and re-export.
-  2. Add one `.help-link` rule block to `worca-ui/app/styles.css`. Single grep target; theming and hover live here only.
+### 2. The state machine — `worca-ui/app/utils/help-mode.js`
 
-```css
-/* worca-ui/app/styles.css */
-.help-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-inline-start: 0.5rem;
-  color: var(--sl-color-neutral-500);
-  text-decoration: none;
-  vertical-align: middle;
-  transition: color 120ms ease;
-  border-radius: 2px;
-}
+Owns:
+- `body.help-mode-active` class (gates badge visibility).
+- Subscribers via `subscribe(cb)` (the edge tab's `aria-pressed` state listens).
+- Global `?` (Shift+/) keybinding with input-focus guard — does not
+  fire inside `<input>`, `<textarea>`, `<select>`, `contentEditable`,
+  or any `sl-*` host whose tag contains `input`/`textarea`.
+- Global `Escape` keybinding to close help mode when it's on.
 
-.help-link:hover,
-.help-link:focus-visible {
-  color: var(--sl-color-primary-600);
-}
+### 3. The edge tab — `worca-ui/app/views/help-edge-tab.js`
 
-.help-link:focus-visible {
-  outline: 2px solid var(--sl-color-primary-600);
-  outline-offset: 2px;
-}
+Vertical pill anchored 100px from the viewport top, right-edge flush.
+30×105 px, monospace label "Docs" matching the sidebar `.logo-text`
+style (JetBrains Mono, weight 700, letter-spacing 0.08em). The whole
+inner row (`[?-icon] [Docs]`) is rotated `-90deg` so it reads
+bottom-to-top along the right edge (book-spine convention). Mounted
+once at app bootstrap into a `<div id="help-edge-tab-root">` appended
+to `<body>`, outside the lit-html app render root, so route changes
+don't unmount it.
 
-.help-link svg {
-  width: 16px;
-  height: 16px;
-}
-```
+### 4. The badge — `.help-badge` + `::after` sonar wave
 
-Color choices route through Shoelace CSS variables so dark mode is handled automatically by the existing theme. No hardcoded hex values.
+Three stacked layers (see `worca-ui/docs/help-mode-prototype.md` §
+"The badge has three stacked visual layers" for the detailed anatomy):
 
-### 3. Slug discipline — page-level only, no anchors
+| Layer | Element | Role |
+|---|---|---|
+| 1 | `.help-badge` (an `<a>`) | The clickable 27×27 violet disc at 75% opacity, `position: absolute; top: 50%; right: 6px; transform: translateY(-50%)`. Vertically centred on the host's right edge so the sonar wave has equal headroom. |
+| 2 | `.help-badge__glyph` (a `<span>?</span>`) | Plain-text 18px white `?` glyph, font-weight 700, optical-centre nudged with `margin-top: 1px`. |
+| 3 | `.help-badge::after` | Same-violet pseudo-element behind the disc (`z-index: -1`), animated `help-badge-sonar` 2.4s ease-out infinite: scale 1 → 1.5, opacity 0.55 → 0. Static dim halo under `prefers-reduced-motion: reduce`. |
 
-- **Current state:** the docs site is Astro Starlight. Heading anchors (`#section-id`) are auto-generated from heading text by the markdown renderer.
-- **Obstacle:** if `HELP_LINKS` stored `slug: 'concepts/governance#dispatch-rules'` and someone later renames the H2 from "Dispatch rules" to "Dispatch governance", the anchor silently breaks. Starlight's slugifier emits a new ID; the old one 404s. Nothing in CI catches it — the page still exists.
-- **Resolution:** **only page-level slugs are allowed in `HELP_LINKS`.** Page slugs require an explicit file rename, which a reviewer notices. The L1 vitest enforces this by checking `existsSync(slug + '.md' | '.mdx')` — anchors would never resolve to a file and would always fail.
+`body.help-mode-active *:has(> .help-badge) { position: relative }`
+auto-promotes the badge's parent so absolute positioning anchors
+locally. `body.help-mode-active sl-tab { overflow: visible }` lifts
+Shoelace's default tab-strip clipping so the sonar wave isn't cut at
+the edges.
 
-Edge case: if a single doc page genuinely covers two distinct UI concepts, that's a signal to split the page, not to add anchor links.
+### 5. Slug discipline — page-level only, no anchors
 
-### 4. UX rule — visible but not overwhelming
+Same rationale as the original plan. The L1 vitest enforces this by
+checking `existsSync(slug + '.md' | '.mdx')` — anchors would never
+resolve to a file and would always fail.
 
-The single discipline rule:
+### 6. UX rule — visible but not overwhelming
 
-> **One `?` per primary teaching surface** — section header, panel header, settings tab title, launcher form header. Never on individual buttons, badges, or form fields.
-
-Four corollaries:
+> One `?` per primary teaching surface — section header, panel
+> header, settings tab title, launcher form header, top-level view.
+> Never on individual buttons, badges, or form fields.
 
 | Rule | Reason |
 |---|---|
 | `?` lives at the header, never inline mid-text. | Eyes scan headers first; one consistent location to look. |
-| Max 1 `?` per visible viewport-sized region. | If two appear close together, fold them into the parent header. |
-| Skip if no doc exists. | A `?` linking to a 404 (or a thin page) destroys trust. Better absent than wrong. |
-| Tooltips for terms; `?` for whole topics. | Status badges already have tooltips (`status-badge.js`) — that's the right tool for "what does 'halted' mean." `?` is for "tell me how this whole concept works." |
+| Max 1 `?` per visible viewport-sized region. | If two would appear close together, fold them into the parent header. |
+| Skip if no doc exists. | A `?` linking to a 404 (or a thin page) destroys trust. |
+| Tooltips for terms; `?` for whole topics. | Status badges already have tooltips — that's the right tool for "what does 'halted' mean." `?` is for "tell me how this whole concept works." |
 
-Visual treatment (matches existing `lucide` icon conventions):
-
-- `CircleHelp`, 16px
-- Muted color (`var(--sl-color-neutral-500)`; hover → primary)
-- Placed at the end of the section/tab/panel label with `margin-inline-start: 0.5rem`
-- Always `target="_blank" rel="noopener noreferrer"`
-- `aria-label="Open help: <topic>"` + native `title` for tooltip
-- No external-link glyph in addition to the `?` — the question-mark + new-tab opening is the affordance; extra glyphs add noise
-
-### 5. Build-time `DOCS_BASE` override
-
-- **Current state:** esbuild config lives at `worca-ui/scripts/build-frontend.js:120-130`. No `define` option is currently set.
-- **Obstacle:** devs running a local Starlight preview (`npm run dev` in `docs-site/`) want `?` icons to point at `http://localhost:4321` instead of production. Hardcoding `https://docs.worca.dev` removes this option.
-- **Resolution:** add a `define` option to the esbuild call, conditional on the `WORCA_DOCS_BASE` env var. Production builds (CI, `npm publish`) leave it unset → fall through to the production default in the module.
+### 7. Build-time `DOCS_BASE` override
 
 ```js
 // worca-ui/scripts/build-frontend.js
 const docsBase = process.env.WORCA_DOCS_BASE;
 await esbuild.build({
-  entryPoints: [entry],
-  bundle: true,
-  format: 'esm',
-  platform: 'browser',
-  target: 'es2020',
-  outfile,
-  sourcemap: true,
-  minify: true,
-  legalComments: 'none',
+  // …
   define: docsBase
     ? { WORCA_DOCS_BASE: JSON.stringify(docsBase) }
     : undefined,
@@ -213,212 +256,86 @@ await esbuild.build({
 Usage:
 
 ```bash
-# Local Starlight preview
 cd worca-ui && WORCA_DOCS_BASE=http://localhost:4321 npm run build
-
-# Staging preview
 cd worca-ui && WORCA_DOCS_BASE=http://staging.docs.worca.dev npm run build
 ```
 
 Production / npm-published builds leave `WORCA_DOCS_BASE` unset → default `https://docs.worca.dev`.
 
-### 6. Sync — two CI layers
+### 8. Sync — two CI layers
 
 #### L1 — source check (every PR)
 
-A vitest in `worca-ui/app/utils/help-links.test.js` reads `HELP_LINKS`, resolves each slug against `docs-site/src/content/docs/<slug>.{md,mdx}`. No network. Runs alongside the existing vitest suite.
+`worca-ui/app/utils/help-links.test.js` reads `HELP_LINKS`, asserts:
 
-```js
-// worca-ui/app/utils/help-links.test.js
-import { describe, it, expect } from 'vitest';
-import { HELP_LINKS } from './help-links.js';
-import { existsSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const DOCS_ROOT = resolve(__dirname, '../../../docs-site/src/content/docs');
-
-describe('help-links', () => {
-  for (const [id, entry] of Object.entries(HELP_LINKS)) {
-    it(`${id} → ${entry.slug} resolves to a docs page`, () => {
-      const md  = resolve(DOCS_ROOT, `${entry.slug}.md`);
-      const mdx = resolve(DOCS_ROOT, `${entry.slug}.mdx`);
-      expect(existsSync(md) || existsSync(mdx)).toBe(true);
-    });
-
-    it(`${id} slug has no anchor fragment`, () => {
-      expect(entry.slug).not.toContain('#');
-    });
-
-    it(`${id} has a non-empty title`, () => {
-      expect(entry.title).toMatch(/\S/);
-    });
-  }
-});
-```
-
-Failure modes the test catches:
-- Typo'd slug
-- Doc page deleted without removing the helpId
-- Anchor accidentally added to a slug
-- Empty title
-
-Failure mode it deliberately does NOT catch: doc page exists but is thin or wrong. That's a docs-quality issue, not a sync issue.
+- Each `slug` resolves to `docs-site/src/content/docs/<slug>.{md,mdx}`.
+- No slug contains `#` (slug discipline).
+- Every `title` is a non-empty string.
+- `helpUrl(unknown)` → `null`.
+- `helpUrl(known)` → canonical URL ending in `/<slug>/`.
+- `helpFor(unknown)` → `null` (soft fail).
 
 #### L2 — live check (release time)
 
-A new script — `scripts/check-help-links-live.py` — wired into the `worca-release-preflight` subagent at `.claude/agents/worca-release-preflight.md`. Runs only when cutting a release.
+`scripts/check-help-links-live.py` parses `worca-ui/app/utils/help-links.js`
+for slug literals (the file format is locked by the L1 test), HEAD-checks
+`https://docs.worca.dev/<slug>/` for every entry, exits non-zero on any
+non-200 with a summary including the fix hint:
 
-```python
-# scripts/check-help-links-live.py
-import json, re, sys, urllib.request
+> Fix: run `/worca-docs-publish` to fast-forward `docs-live` to master,
+> then re-run the release.
 
-BASE = "https://docs.worca.dev"
-HELP_LINKS_JS = "worca-ui/app/utils/help-links.js"
+Wired into `.claude/agents/worca-release-preflight.md` as an additional
+checklist item alongside version-file parity, master/CI state, and
+MIGRATION.md coverage audits.
 
-# Parse the `slug: '...'` literals out of the JS map (regex is fine — the
-# file format is locked by the L1 test and a hand-curated map).
-text = open(HELP_LINKS_JS).read()
-slugs = re.findall(r"slug:\s*'([^']+)'", text)
+### 9. Placement — concrete map
 
-failed = []
-for slug in slugs:
-    url = f"{BASE}/{slug}/"
-    req = urllib.request.Request(url, method="HEAD")
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            if resp.status != 200:
-                failed.append((url, resp.status))
-    except Exception as e:
-        failed.append((url, str(e)))
+Full mapping table lives in `worca-ui/docs/help-mode-prototype.md` § "Instrumented surfaces — full UI sweep". 34 placements across 14 view files. Summary by region:
 
-if failed:
-    print(f"FAIL: {len(failed)} help-link URL(s) not live on {BASE}:")
-    for url, why in failed:
-        print(f"  {url}  →  {why}")
-    print()
-    print("Fix: run /worca-docs-publish to fast-forward docs-live to master,")
-    print("then re-run the release. The docs publish ordering is already the")
-    print("recommended sequence; this check just enforces it.")
-    sys.exit(1)
-
-print(f"OK: {len(slugs)} help-link URL(s) are live on {BASE}")
-```
-
-Wire into `.claude/agents/worca-release-preflight.md` as an additional checklist item alongside the existing version-file parity, master/CI state, and MIGRATION.md coverage audits.
-
-The release-skill `.claude/skills/worca-release/SKILL.md` already recommends running `/worca-docs-publish` before a release; L2 makes this enforceable instead of an honor-system reminder.
-
-### 7. Placement — concrete map
-
-Every row below is exactly one `?`. Total: ~22 icons across the UI. Rule from §4 holds throughout — placement is at the section/tab/panel header, never inline.
-
-#### Settings (`worca-ui/app/views/settings.js`)
-
-Project-scoped tabs (lines `:3497-3534`):
-
-| Tab | panel name | helpId |
+| Region | Surfaces | helpIds |
 |---|---|---|
-| Agents | `agents` | `agents-models` |
-| Models | `models` | `agents-models` |
-| Effort | `effort` | `effort` |
-| Pipeline | `pipeline` | `stages-config` |
-| Governance | `governance` | `governance` |
-| Pricing | `pricing` | *(no doc — skip)* |
-| Webhooks | `webhooks` | `webhooks` |
-| Graphify | `graphify` | `graphify` |
-| Code Review Graph | `code-review-graph` | `crg` |
-
-Global-scope tabs (lines `:3444-3466`):
-
-| Tab | panel name | helpId |
-|---|---|---|
-| Projects | `projects` | `add-project` |
-| Notifications | `notifications` | *(no dedicated doc — skip for now)* |
-| Preferences | `preferences` | `stages-config` |
-| Integrations | `integrations` | `chat` |
-
-#### Launchers — `?` at form header
-
-| View | helpId |
-|---|---|
-| `worca-ui/app/views/new-run.js` header | `launching` |
-| `worca-ui/app/views/fleet-launcher.js` header | `fleet-runs` |
-| `worca-ui/app/views/workspace-create.js` header | `workspace-runs` |
-
-#### Run Detail (`worca-ui/app/views/run-detail.js`)
-
-| Panel / surface | citation | helpId |
-|---|---|---|
-| Run header (status/lifecycle) | top of view | `lifecycle` |
-| Stage Timeline panel | `stage-timeline.js` import at `:37` | `pipeline-stages` |
-| Plan iterations panel | iter tabs at `:1950` | `plans-guides` |
-| Code Review Graph badge area | `:1148` | `crg` |
-| Graphify badge area | `:1067` | `graphify` |
-| PR details panel | grep `pr-details` | `reviewing` |
-| Dispatch panel | `data-dispatch-section` at `:880` | `dispatch` |
-| Circuit breaker banner | `:916, :925` | `loops` |
-| Beads panel | `beads-panel.js` | *(no doc — skip)* |
-| Token costs | `token-costs.js` | *(no doc — skip)* |
-
-#### Dashboard, sidebar, integrations (sparing)
-
-| Surface | helpId |
-|---|---|
-| `worca-ui/app/views/dashboard.js` — empty state ("no runs yet") | `first-run` |
-| `worca-ui/app/views/sidebar.js` — Worktrees section label | `worktrees` |
-| `worca-ui/app/views/sidebar.js` — Integrations entry | `events` |
-| `worca-ui/app/views/integrations.js` header | `chat` |
-| `worca-ui/app/views/webhook-inbox.js` header | `webhooks` |
+| Settings — global tabs | 3 of 4 (Notifications skipped) | `add-project`, `settings-overview`, `chat` |
+| Settings — project tabs | 6 of 7 (Pricing skipped) | `agents-models`, `stages-config`, `governance`, `webhooks`, `graphify`, `crg` |
+| Settings — inline anchor migration | 1 | `configuration-precedence` (via `helpUrl`, not `helpFor`) |
+| Run Detail panels | 7 | `lifecycle`, `pipeline-stages`, `plans-guides`, `dispatch`, `loops`, `agent-prompt`, `reviewing` |
+| Pipeline Templates (W-062) | 5 | `templates`, `authoring-templates`, plus reuse of `agents-models`, `stages-config`, `dispatch` for the editor's 3 tabs |
+| Run Timeline (W-063) | 1 | `timeline-view` |
+| Launchers | 3 | `launching`, `fleet-runs`/`workspace-runs` (mode-switched), `workspace-runs` |
+| Dashboard / sidebar | 3 | `monitoring` (header), `first-run` (empty state), `worktrees` (sidebar item) |
+| Integrations / webhooks | 2 | `chat`, `webhooks` |
+| Detail + edit + listing | 5 | `fleet-runs`, `workspace-runs` ×3, `worktrees` |
 
 ## Implementation Plan
 
-### Phase 1 — Infrastructure (module + renderer + CSS + L1 + L2)
+### Phase 1 — Infrastructure
 
 **Files:**
 - `worca-ui/app/utils/help-links.js` (new)
-- `worca-ui/app/utils/help-links.test.js` (new)
-- `worca-ui/app/utils/icons.js` (add `CircleHelp` import + export)
-- `worca-ui/app/styles.css` (add `.help-link` block)
-- `worca-ui/scripts/build-frontend.js` (add optional `define` for `WORCA_DOCS_BASE`)
-- `scripts/check-help-links-live.py` (new)
-- `.claude/agents/worca-release-preflight.md` (add L2 check to checklist)
+- `worca-ui/app/utils/help-links.test.js` (new — L1)
+- `worca-ui/app/utils/help-mode.js` (new)
+- `worca-ui/app/views/help-edge-tab.js` (new)
+- `worca-ui/app/utils/icons.js` (re-export `CircleHelp` for edge tab)
+- `worca-ui/app/styles.css` (`.help-edge-tab`, `.help-badge`, sonar `@keyframes`, dark-mode + reduced-motion blocks)
+- `worca-ui/app/main.js` (mount edge tab at bootstrap, bind keyboard)
+- `worca-ui/scripts/build-frontend.js` (conditional `WORCA_DOCS_BASE` define)
+- `scripts/check-help-links-live.py` (new — L2)
+- `.claude/agents/worca-release-preflight.md` (wire L2 into checklist)
 
-**Tasks:**
-1. Add `CircleHelp` import + re-export in `worca-ui/app/utils/icons.js`.
-2. Write `help-links.js` with `HELP_LINKS`, `helpUrl`, `helpLink` exactly as in Design §1. Include all 25 entries.
-3. Add `.help-link` CSS block to `worca-ui/app/styles.css`.
-4. Write `help-links.test.js` (Design §6 L1).
-5. Update `build-frontend.js:120-130` to honor `WORCA_DOCS_BASE` env var.
-6. Write `scripts/check-help-links-live.py` (Design §6 L2).
-7. Update `worca-release-preflight.md` to invoke the L2 script as a checklist item.
-8. Verify: `cd worca-ui && npm run lint:fix && npx vitest run` (L1 passes against current docs).
-9. Verify: `python scripts/check-help-links-live.py` against `docs.worca.dev` (L2 passes against currently-published docs — this is the baseline).
-
-Done-criteria for Phase 1: module exists, L1 test passes, L2 script exists and passes against today's `docs.worca.dev`, no `?` icons appear in the UI yet (placement is Phase 2+).
+**Done-criteria:** module + state machine + edge tab exist, L1 passes against current docs, L2 passes against currently-published docs (baseline), no `?` icons appear in the UI yet.
 
 ### Phase 2 — Highest-payoff placement (Settings + Run Detail)
 
-**Files:**
-- `worca-ui/app/views/settings.js`
-- `worca-ui/app/views/run-detail.js`
+**Files:** `worca-ui/app/views/settings.js`, `worca-ui/app/views/run-detail.js`
 
-**Tasks:**
-1. Import `helpLink` in `settings.js`.
-2. For each `<sl-tab>` in lines `:3444-3466` (global) and `:3497-3534` (project-scoped), add `${helpLink('<id>')}` inside the tab label slot for the rows in Design §7.
-3. Import `helpLink` in `run-detail.js`.
-4. Add `${helpLink(...)}` at each panel header listed in Design §7.
-5. Rebuild bundle: `cd worca-ui && npm run build`.
-6. Run lint + vitest: `cd worca-ui && npm run lint:fix && npx vitest run`.
-7. Manual visual check (light + dark mode): all `?` icons render muted, hover turns primary, click opens new tab.
-8. Add/update Playwright spec — `worca-ui/e2e/help-links.spec.js` — that asserts the presence of a `.help-link` element with the correct `href` for at least one settings tab and one run-detail panel. Per CLAUDE.md: serial runner only (`npx playwright test --workers=1`).
+**Done-criteria:** every row in the Settings + Run Detail rows of Design §9 has its `?` badge. Inline `settings.js:96` anchor migrated through `helpUrl('configuration-precedence')`. Manual UX review confirms no surface has more than one badge after help mode activates.
 
-Done-criteria for Phase 2: every row in Settings + Run Detail tables of Design §7 has its `?` icon. Manual UX review confirms no surface has more than one `?`.
-
-### Phase 3 — Remaining surfaces (Launchers + Dashboard + Sidebar + Integrations)
+### Phase 3 — Remaining surfaces
 
 **Files:**
+- `worca-ui/app/views/pipelines.js`
+- `worca-ui/app/views/pipelines-editor.js`
+- `worca-ui/app/views/run-timeline.js`
 - `worca-ui/app/views/new-run.js`
 - `worca-ui/app/views/fleet-launcher.js`
 - `worca-ui/app/views/workspace-create.js`
@@ -426,135 +343,92 @@ Done-criteria for Phase 2: every row in Settings + Run Detail tables of Design �
 - `worca-ui/app/views/sidebar.js`
 - `worca-ui/app/views/integrations.js`
 - `worca-ui/app/views/webhook-inbox.js`
+- `worca-ui/app/views/fleet-detail.js`
+- `worca-ui/app/views/workspace-detail.js`
+- `worca-ui/app/views/workspace-edit.js`
+- `worca-ui/app/views/workspaces-config.js`
+- `worca-ui/app/views/worktrees.js`
+- `worca-ui/e2e/help-mode.spec.js` (new — Playwright)
 
-**Tasks:**
-1. Import `helpLink` and add at the surfaces enumerated in Design §7 (launchers, dashboard, sidebar, integrations).
-2. Rebuild bundle.
-3. Run lint + vitest + playwright.
-4. Manual visual sweep: walk through every view, confirm density target (~22 icons total, max 1 per viewport-sized region).
-5. Dispatch `worca-ui-a11y-reviewer` and `worca-ui-design-reviewer` subagents on the diff.
-
-Done-criteria for Phase 3: all 22 `?` icons in place. CI green. Subagent reviews report no high-confidence findings.
+**Done-criteria:** 34 badges in place. CI green. `worca-ui-a11y-reviewer` and `worca-ui-design-reviewer` subagent reviews report no high-confidence findings.
 
 ### Files Changed Summary
 
 | File | Change |
 |------|--------|
-| `worca-ui/app/utils/help-links.js` | NEW — `HELP_LINKS`, `helpUrl`, `helpLink` |
+| `worca-ui/app/utils/help-links.js` | NEW — `HELP_LINKS`, `helpUrl`, `helpFor` |
 | `worca-ui/app/utils/help-links.test.js` | NEW — L1 source-resolution test |
-| `worca-ui/app/utils/icons.js` | Add `CircleHelp` import + export |
-| `worca-ui/app/styles.css` | Add `.help-link` CSS block |
-| `worca-ui/scripts/build-frontend.js` | Add `define: { WORCA_DOCS_BASE }` conditional |
-| `worca-ui/app/views/settings.js` | Inject `helpLink()` at each tab in Design §7 |
-| `worca-ui/app/views/run-detail.js` | Inject `helpLink()` at each panel header in Design §7 |
-| `worca-ui/app/views/new-run.js` | Inject `helpLink()` at form header |
-| `worca-ui/app/views/fleet-launcher.js` | Inject `helpLink()` at form header |
-| `worca-ui/app/views/workspace-create.js` | Inject `helpLink()` at form header |
-| `worca-ui/app/views/dashboard.js` | Inject `helpLink()` at empty-state |
-| `worca-ui/app/views/sidebar.js` | Inject `helpLink()` at Worktrees + Integrations |
-| `worca-ui/app/views/integrations.js` | Inject `helpLink()` at header |
-| `worca-ui/app/views/webhook-inbox.js` | Inject `helpLink()` at header |
-| `worca-ui/e2e/help-links.spec.js` | NEW — Playwright spec covering settings + run-detail rendering |
+| `worca-ui/app/utils/help-mode.js` | NEW — state machine, keybindings |
+| `worca-ui/app/views/help-edge-tab.js` | NEW — right-edge "Docs" tab component |
+| `worca-ui/app/utils/icons.js` | Add `CircleHelp` lucide import + re-export (used by edge tab) |
+| `worca-ui/app/styles.css` | Add `.help-edge-tab` + `.help-badge` blocks + sonar `@keyframes` + reduced-motion + dark-mode |
+| `worca-ui/app/main.js` | Mount edge tab at bootstrap; bind global `?` / Escape |
+| `worca-ui/scripts/build-frontend.js` | Conditional `define: { WORCA_DOCS_BASE }` esbuild option |
+| `worca-ui/app/views/settings.js` | Inject `helpFor()` at each tab (11 tabs, 9 with helpIds); migrate inline anchor at `:96` through `helpUrl('configuration-precedence')` |
+| `worca-ui/app/views/run-detail.js` | Inject `helpFor()` at each panel header (7 panels) |
+| `worca-ui/app/views/pipelines.js` | Inject `helpFor('templates')` at list page |
+| `worca-ui/app/views/pipelines-editor.js` | Inject `helpFor('authoring-templates')` at subheader + per-tab `helpFor` on the 3 editor tabs |
+| `worca-ui/app/views/run-timeline.js` | Inject `helpFor('timeline-view')` |
+| `worca-ui/app/views/new-run.js` | Inject `helpFor('launching')` at form header |
+| `worca-ui/app/views/fleet-launcher.js` | Inject `helpFor('fleet-runs')` / `helpFor('workspace-runs')` (mode-switched) |
+| `worca-ui/app/views/workspace-create.js` | Inject `helpFor('workspace-runs')` |
+| `worca-ui/app/views/dashboard.js` | `helpFor('monitoring')` at top + `helpFor('first-run')` at empty state |
+| `worca-ui/app/views/sidebar.js` | `helpFor('worktrees')` at Worktrees item; `helpFor('events')` at Integrations item |
+| `worca-ui/app/views/integrations.js` | `helpFor('chat')` at settings panel |
+| `worca-ui/app/views/webhook-inbox.js` | `helpFor('webhooks')` at view header |
+| `worca-ui/app/views/fleet-detail.js` | `helpFor('fleet-runs')` |
+| `worca-ui/app/views/workspace-detail.js` | `helpFor('workspace-runs')` |
+| `worca-ui/app/views/workspace-edit.js` | `helpFor('workspace-runs')` |
+| `worca-ui/app/views/workspaces-config.js` | `helpFor('workspace-runs')` |
+| `worca-ui/app/views/worktrees.js` | `helpFor('worktrees')` |
+| `worca-ui/e2e/help-mode.spec.js` | NEW — Playwright spec covering toggle → reveal → click |
 | `scripts/check-help-links-live.py` | NEW — L2 release-time HEAD checker |
 | `.claude/agents/worca-release-preflight.md` | Add L2 to preflight checklist |
 
-## Considerations
-
-### Trade-offs
-
-- **Page-level slugs only vs. anchor-level deep linking.** Anchor linking would land users on the exact paragraph but breaks silently on heading renames. Page-level is more resilient at the cost of one extra scroll for the user. Worth it.
-- **Centralized renderer vs. raw URL helper.** The renderer adds a 5-line module and removes every chance of an inline anchor diverging. Net win.
-- **22 icons vs. more density.** Could go to 40+ by adding one per form field. Doesn't scale visually. The "one per primary teaching surface" rule caps density without leaving important surfaces uncovered.
-
-### Edge cases
-
-- **Pricing tab and Beads/Token-costs panels have no doc today.** Deliberately skipped — adding a `?` to a 404 destroys trust. When those docs land, add the helpId in the same PR as the new doc.
-- **`Notifications` and `Preferences` tabs.** No clean canonical doc. Mapped to closest fit; revisit when there's a dedicated doc page.
-- **User on staging UI with `WORCA_DOCS_BASE=http://staging.docs.worca.dev`.** L1 still passes (it reads local source). L2 only runs at release time on production — staging deploys don't gate on it. Acceptable: staging is internal.
-
-### Breaking changes
-
-None. Pure additive: new module, new icons, no existing API touched.
-
-### Migration
-
-None.
-
-### Governance
-
-No impact on `worca.governance.dispatch`, hooks, or agent prompts. This is pure UI surface work.
-
-### Sync gap acknowledgment
-
-The fundamental coupling — UI ships in `@worca/ui` npm releases, but `docs.worca.dev` only updates when `/worca-docs-publish` runs (which fast-forwards the `docs-live` branch from `master`) — means there's always a possible window where master ahead of docs-live. L2 catches this at release time; it does not eliminate the gap during day-to-day development. That's acceptable because:
-
-1. Day-to-day UI dev uses local `npm run build` against current master, where L1 already passes (the doc exists in master).
-2. Released `@worca/ui` versions are gated by L2 at release-preflight.
-3. Doc deletions are rare and any deletion PR will fail L1 unless it also removes the matching helpId from `HELP_LINKS`.
-
 ## Test Plan
 
-### Unit Tests
+### Unit Tests (vitest)
 
-| Layer | Test | Validates |
-|-------|------|-----------|
-| Vitest | `help-links.test.js: every helpId resolves to a docs page` | L1 — each `slug` resolves to `.md` or `.mdx` under `docs-site/src/content/docs/` |
-| Vitest | `help-links.test.js: no slug contains an anchor` | Slug discipline (Design §3) |
-| Vitest | `help-links.test.js: every entry has a non-empty title` | Tooltip + a11y label are never empty |
-| Vitest | `help-links.test.js: helpUrl returns null for unknown id` | `helpUrl('does-not-exist') === null` |
-| Vitest | `help-links.test.js: helpUrl returns canonical URL for known id` | `helpUrl('crg')` ends with `/advanced/code-review-graph/` |
-| Vitest | `help-links.test.js: helpLink renders an anchor with target=_blank and rel=noopener` | Renderer contract |
-| Vitest | `help-links.test.js: helpLink returns null for unknown id` | Soft-fail behavior (Design §1) |
+| Test | Validates |
+|---|---|
+| `help-links.test.js: every helpId resolves to a docs page` | L1 — each `slug` resolves to `.md` or `.mdx` under `docs-site/src/content/docs/` |
+| `help-links.test.js: no slug contains an anchor` | Slug discipline (Design §5) |
+| `help-links.test.js: every entry has a non-empty title` | Tooltip + a11y label are never empty |
+| `help-links.test.js: helpUrl returns null for unknown id` | `helpUrl('does-not-exist') === null` |
+| `help-links.test.js: helpUrl returns canonical URL for known id` | `helpUrl('crg')` ends with `/advanced/code-review-graph/` |
+| `help-links.test.js: helpFor returns null for unknown id` | Soft-fail behaviour (Design §1) |
 
-### Integration / E2E Tests
+### E2E (Playwright, `--workers=1`)
 
-| Layer | Test | Validates |
-|-------|------|-----------|
-| Playwright | `help-links.spec.js: settings tab renders a help-link` | One `?` per tab label, correct `href` |
-| Playwright | `help-links.spec.js: run-detail panel renders a help-link` | One `?` per panel header, correct `href` |
-| Playwright | `help-links.spec.js: help-link opens in a new tab` | `target="_blank"` honored |
-| Manual | Dark + light mode visual sweep | `.help-link` muted color readable in both themes; hover state visible |
+| Test | Validates |
+|---|---|
+| `help-mode.spec.js: edge tab is visible at startup` | The "Docs" tab renders into `<div id="help-edge-tab-root">` on bootstrap |
+| `help-mode.spec.js: clicking the edge tab reveals badges` | `body.help-mode-active` flips; an instrumented settings tab carries a `.help-badge` with the right `href` |
+| `help-mode.spec.js: `?` hotkey toggles help mode outside text inputs` | Global keybind respects the input-focus guard |
+| `help-mode.spec.js: Escape closes help mode` | `body.help-mode-active` removed on Escape |
+| `help-mode.spec.js: badge opens docs in a new tab` | `target="_blank" rel="noopener noreferrer"` honoured |
 
 ### Release-time (L2)
 
 | Layer | Test | Validates |
-|-------|------|-----------|
+|---|---|---|
 | Shell | `python scripts/check-help-links-live.py` | Every `HELP_LINKS` slug returns 200 on `https://docs.worca.dev/<slug>/` |
 
 ### Existing Tests to Update
 
-None — this is additive. Existing settings, run-detail, sidebar, integrations, dashboard tests already pass templates rendered with extra child elements (each view test asserts presence of specific selectors, not exhaustive child lists).
-
-If any test asserts `await page.locator('sl-tab').count()` and counts a specific number, it should not change — `?` icons go inside the tab label slot, not as new tabs. Verify in Phase 2.
-
-## Files to Create/Modify
-
-| File | Status | Purpose |
-|------|--------|---------|
-| `worca-ui/app/utils/help-links.js` | new | `HELP_LINKS` map + `helpUrl()` + `helpLink()` renderer |
-| `worca-ui/app/utils/help-links.test.js` | new | L1 source-resolution test (every slug → `.md`/`.mdx`) |
-| `worca-ui/app/utils/icons.js` | modify | Add `CircleHelp` lucide import + re-export |
-| `worca-ui/app/styles.css` | modify | Add `.help-link` CSS block (color, hover, focus, sizing) |
-| `worca-ui/scripts/build-frontend.js` | modify | Conditional `define: { WORCA_DOCS_BASE }` esbuild option |
-| `worca-ui/app/views/settings.js` | modify | Inject `helpLink()` at each tab in Design §7 (13 tabs, 11 with helpIds) |
-| `worca-ui/app/views/run-detail.js` | modify | Inject `helpLink()` at each panel header in Design §7 (8 panels) |
-| `worca-ui/app/views/new-run.js` | modify | Inject `helpLink('launching')` at form header |
-| `worca-ui/app/views/fleet-launcher.js` | modify | Inject `helpLink('fleet-runs')` at form header |
-| `worca-ui/app/views/workspace-create.js` | modify | Inject `helpLink('workspace-runs')` at form header |
-| `worca-ui/app/views/dashboard.js` | modify | Inject `helpLink('first-run')` at empty-state |
-| `worca-ui/app/views/sidebar.js` | modify | Inject `helpLink()` at Worktrees + Integrations entries |
-| `worca-ui/app/views/integrations.js` | modify | Inject `helpLink('chat')` at header |
-| `worca-ui/app/views/webhook-inbox.js` | modify | Inject `helpLink('webhooks')` at header |
-| `worca-ui/e2e/help-links.spec.js` | new | Playwright spec — settings + run-detail rendering, `target="_blank"` honored |
-| `scripts/check-help-links-live.py` | new | L2 release-time HEAD checker against `docs.worca.dev` |
-| `.claude/agents/worca-release-preflight.md` | modify | Add L2 script invocation to preflight checklist |
+None — this is additive. Existing view tests assert presence of specific
+selectors, not exhaustive child lists, so the extra `.help-badge` child
+elements don't break them. The `workspace-css.test.js` CSS-variable
+allowlist was extended once (in the prototype commits) to allow the
+Shoelace `--sl-color-neutral-*` / `--sl-color-primary-*` shades the
+prototype uses; that change is part of the rollout.
 
 ## Out of Scope
 
-- **Deep anchor links** to specific headings within a doc page. Page-level only (Design §3).
-- **Per-field `?` icons.** Deliberately ruled out by the UX rule (Design §4).
-- **Automatic generation of help-link IDs from the docs sidebar.** Manual curation IS the value — it forces a conscious "should this surface have a doc?" decision per placement.
-- **Versioned docs / pinning a UI release to a specific docs commit.** Worca currently ships unversioned docs; if we adopt versioned docs in the future, `DOCS_BASE` extends naturally to `${DOCS_BASE}/v0.36/`.
-- **Localization of help titles.** English-only, matches the rest of the UI.
-- **In-app inline docs viewer** (iframe, panel, etc.). Out of scope — `target="_blank"` to docs.worca.dev is the deliberate UX.
-- **Backfilling missing docs** for surfaces currently skipped (Pricing, Beads, Token costs, Notifications, Preferences). Tracked separately as docs-area issues; this plan ships the infra so they can be added in one-line PRs once their docs exist.
+- **Deep anchor links** to specific headings within a doc page. Page-level only (Design §5).
+- **Per-field `?` icons.** Deliberately ruled out by the UX rule (Design §6).
+- **Automatic generation of help-link IDs from the docs sidebar.** Manual curation IS the value.
+- **Versioned docs / pinning a UI release to a specific docs commit.** `DOCS_BASE` extends naturally to `${DOCS_BASE}/v0.40/` if we adopt versioned docs later.
+- **Localisation of help titles.** English-only, matches the rest of the UI.
+- **In-app inline docs viewer** (iframe, panel, etc.). `target="_blank"` to docs.worca.dev is the deliberate UX.
+- **Backfilling missing docs** for currently-skipped surfaces (Pricing, Notifications, Beads, Token costs, Learnings, Live output, Log viewer). Tracked separately as docs-area issues; this plan ships the infra so they can be added in one-line PRs once their docs exist.

--- a/scripts/check-help-links-live.py
+++ b/scripts/check-help-links-live.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+L2 — release-time live check for the W-061 in-app help registry.
+
+Parses ``worca-ui/app/utils/help-links.js`` for every ``slug: '...'`` literal,
+HEAD-checks ``https://docs.worca.dev/<slug>/`` for each, and exits non-zero
+if any URL returns a non-200 status.
+
+The fix path is always the same: the local docs source is fresh but
+``docs-live`` hasn't been fast-forwarded to master yet. Run
+``/worca-docs-publish`` (or the equivalent ``git push origin master:docs-live``)
+before cutting the release.
+
+Wired into the ``worca-release-preflight`` subagent so a release that
+points the UI at not-yet-published docs is caught before it goes out.
+
+Standalone usage:
+
+    python3 scripts/check-help-links-live.py
+    python3 scripts/check-help-links-live.py --base https://staging.docs.example
+    python3 scripts/check-help-links-live.py --timeout 5
+
+Exit codes:
+    0 — every slug returns 200.
+    1 — one or more 404 / network error / non-200 status.
+    2 — could not find or parse ``help-links.js``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_BASE = "https://docs.worca.dev"
+HELP_LINKS_REL = "worca-ui/app/utils/help-links.js"
+# Matches `slug: '<value>'` (single-quoted form the registry uses today).
+# Also tolerates `slug: "<value>"` for future flexibility, but the L1
+# vitest locks the file to one canonical shape.
+_SLUG_RE = re.compile(r"""slug\s*:\s*['"]([^'"]+)['"]""")
+
+
+def _repo_root() -> Path:
+    """Return the worca-cc repo root by walking up from this script."""
+    return Path(__file__).resolve().parent.parent
+
+
+def _read_slugs(path: Path) -> list[str]:
+    """Extract every page-level slug from help-links.js, preserving order."""
+    text = path.read_text(encoding="utf-8")
+    seen: set[str] = set()
+    slugs: list[str] = []
+    for m in _SLUG_RE.finditer(text):
+        slug = m.group(1)
+        # Skip anchor-laced slugs defensively — the L1 vitest rejects
+        # them, but a stale checkout shouldn't crash the script.
+        if "#" in slug:
+            continue
+        if slug not in seen:
+            seen.add(slug)
+            slugs.append(slug)
+    return slugs
+
+
+# docs.worca.dev (and most CDN-fronted Astro / Starlight deployments)
+# rejects HEAD requests and requests without a browser-shaped User-Agent
+# with HTTP 403, which would look like a page-missing failure even when
+# the page is fine. Probe with GET + a real UA, and read only the first
+# few bytes so we don't pull the whole HTML body just to verify the
+# status code.
+_PROBE_UA = (
+    "Mozilla/5.0 (worca-cc help-links live-check; "
+    "https://github.com/SinishaDjukic/worca-cc)"
+)
+
+
+def _probe(url: str, timeout: float) -> tuple[bool, str]:
+    """GET-probe ``url`` with a browser-shaped UA. Returns (ok, detail).
+
+    Treats 3xx as success (the urllib opener follows redirects, so a
+    final 200 is what we actually see in practice). 404 means the doc
+    page is genuinely missing; any other non-2xx is reported verbatim.
+    """
+    req = urllib.request.Request(url, method="GET", headers={"User-Agent": _PROBE_UA})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            status = getattr(resp, "status", resp.getcode())
+            # Drain a small chunk so the connection closes cleanly without
+            # buffering the entire docs page into memory.
+            resp.read(1024)
+            if 200 <= status < 400:
+                return True, str(status)
+            return False, f"HTTP {status}"
+    except urllib.error.HTTPError as err:
+        return False, f"HTTP {err.code}"
+    except urllib.error.URLError as err:
+        return False, f"URL error: {err.reason}"
+    except TimeoutError:
+        return False, f"timeout after {timeout}s"
+    except Exception as err:  # noqa: BLE001 — surface everything
+        return False, f"{type(err).__name__}: {err}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument(
+        "--base",
+        default=DEFAULT_BASE,
+        help="Docs site base URL (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HEAD-request timeout in seconds (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--registry",
+        default=None,
+        help=(
+            "Path to help-links.js (default: <repo>/worca-ui/app/utils/help-links.js)"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    registry_path = (
+        Path(args.registry).resolve()
+        if args.registry
+        else _repo_root() / HELP_LINKS_REL
+    )
+    if not registry_path.is_file():
+        print(f"FAIL: help-links registry not found at {registry_path}", file=sys.stderr)
+        return 2
+
+    slugs = _read_slugs(registry_path)
+    if not slugs:
+        print(
+            f"FAIL: no slugs parsed from {registry_path} — file format may have changed",
+            file=sys.stderr,
+        )
+        return 2
+
+    base = args.base.rstrip("/")
+    print(f"Checking {len(slugs)} help-link URL(s) on {base} …")
+
+    failures: list[tuple[str, str]] = []
+    for slug in slugs:
+        url = f"{base}/{slug}/"
+        ok, detail = _probe(url, args.timeout)
+        mark = "ok " if ok else "FAIL"
+        print(f"  [{mark}] {url}  ({detail})")
+        if not ok:
+            failures.append((url, detail))
+
+    if failures:
+        print()
+        print(f"FAIL: {len(failures)} of {len(slugs)} help-link URL(s) not live on {base}:")
+        for url, detail in failures:
+            print(f"  - {url}  →  {detail}")
+        print()
+        print("Fix: run /worca-docs-publish to fast-forward docs-live to")
+        print("master (publishes docs.worca.dev to the current master),")
+        print("then re-run this check. If a slug genuinely no longer has a")
+        print("doc target, remove its entry from HELP_LINKS in")
+        print("worca-ui/app/utils/help-links.js (the L1 vitest will catch")
+        print("orphan entries on the next PR).")
+        return 1
+
+    print()
+    print(f"OK: {len(slugs)} help-link URL(s) live on {base}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -5,6 +5,7 @@ import { navigate, onHashChange, parseHash } from './router.js';
 import { createStore, isArchivedRunExpired } from './state.js';
 import { createArchiveActions } from './utils/archive-actions.js';
 import { confirmDialogTemplate, showConfirm } from './utils/confirm-dialog.js';
+import { bindKeyboard as bindHelpKeyboard } from './utils/help-mode.js';
 import {
   AlertTriangle,
   ArrowLeft,
@@ -47,6 +48,7 @@ import {
   resetLauncherState,
   submitFleetLauncher,
 } from './views/fleet-launcher.js';
+import { mountHelpEdgeTab } from './views/help-edge-tab.js';
 import { buildRunMeta, learningsSectionView } from './views/learnings-panel.js';
 import {
   clearLiveTerminal,
@@ -4952,3 +4954,19 @@ setInterval(() => {
 
 rerender();
 attachStickyHeaderListener();
+
+// --- Help mode (W-061 prototype) -------------------------------------------
+// Mount the right-edge "Help" tab into its own fixed-position root outside
+// the lit-html app root so route changes don't unmount it. Bind the global
+// `?` / Escape keybindings once at bootstrap.
+(function initHelpMode() {
+  let root = document.getElementById('help-edge-tab-root');
+  if (!root) {
+    root = document.createElement('div');
+    root.id = 'help-edge-tab-root';
+    root.className = 'help-edge-tab-root';
+    document.body.appendChild(root);
+  }
+  mountHelpEdgeTab(root);
+  bindHelpKeyboard();
+})();

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -8353,13 +8353,19 @@ sl-dialog.markdown-dialog::part(body) {
  * Help mode (W-061 prototype, prototype/W-061-help-mode-toggle)
  *
  * Two concerns:
- *   1. The right-edge "Help" tab (.help-edge-tab) — always visible.
+ *   1. The right-edge "Docs" tab (.help-edge-tab) — always visible at 75%
+ *      opacity, fully opaque on hover/active.
  *   2. Per-surface "?" badges (.help-badge) — hidden until body has the
  *      .help-mode-active class.
  *
- * Visual language: muted neutral when idle, primary + gentle pulse when
- * help mode is on. `prefers-reduced-motion` collapses the pulse to a
- * static highlight so the badge stays discoverable but quiet.
+ * Colour: violet (~#7c3aed) — deliberately chosen so help mode reads as
+ * "informational / secondary" and never competes with the blue used for
+ * primary actions + running state, the green used for completed, the
+ * orange used for caution, or the red used for failed.
+ *
+ * Animation: each badge radiates a slow sonar wave outward and fades to
+ * transparent, like a discoverability signal. `prefers-reduced-motion`
+ * collapses the wave to a static dim halo.
  * ===========================================================================
  */
 
@@ -8372,68 +8378,82 @@ sl-dialog.markdown-dialog::part(body) {
   z-index: 1000;
 }
 
+/* Vertical pill anchored ~100px from the top of the viewport (deliberately
+   off-centre so it sits above the eye line and doesn't compete with
+   sidebar/main content for the visual centre). */
 .help-edge-tab {
   position: fixed;
   right: 0;
-  top: 50%;
-  transform: translateY(-50%) translateX(0);
+  top: 100px;
+  transform: translateX(0);
   transform-origin: right center;
   pointer-events: auto;
 
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
-  gap: 6px;
-  padding: 8px 10px 8px 12px;
-  border: 1px solid var(--sl-color-neutral-300, var(--border, #d1d5db));
+  justify-content: center;
+  /* Sized to wrap the rotated content (icon ~20px + 10px gap + "Docs"
+     label ~38px ≈ 68px length, 20px max thickness). Height bumped +25%
+     (84 → 105) per the user's request to give the rotated content more
+     padding at the top and bottom of the tab. */
+  width: 30px;
+  height: 105px;
+  padding: 0;
+  border: 1px solid #c4b5fd; /* violet-300 */
   border-right: none;
   border-top-left-radius: 8px;
   border-bottom-left-radius: 8px;
-  background: var(--sl-color-neutral-0, var(--bg, #fff));
-  color: var(--sl-color-neutral-700, var(--fg, #374151));
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.02em;
+  background: rgba(124, 58, 237, 0.1); /* violet-600 @ 10% */
+  color: #5b21b6; /* violet-800 */
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   cursor: pointer;
+  opacity: 0.75;
   box-shadow: -2px 0 8px rgba(0, 0, 0, 0.06);
-  transition: background-color 120ms ease, color 120ms ease, transform 180ms ease,
-    box-shadow 180ms ease;
+  transition: opacity 160ms ease, background-color 120ms ease, color 120ms ease,
+    transform 180ms ease, box-shadow 180ms ease;
 }
 
 .help-edge-tab:hover,
 .help-edge-tab:focus-visible {
-  color: var(--sl-color-primary-700, var(--accent, #2563eb));
-  background: var(--sl-color-primary-50, rgba(37, 99, 235, 0.06));
-  transform: translateY(-50%) translateX(-2px);
+  opacity: 1;
+  color: #4c1d95; /* violet-900 */
+  background: rgba(124, 58, 237, 0.18);
+  transform: translateX(-2px);
   box-shadow: -4px 0 12px rgba(0, 0, 0, 0.08);
   outline: none;
 }
 
 .help-edge-tab:focus-visible {
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.08),
-    0 0 0 2px var(--sl-color-primary-500, #3b82f6);
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.08), 0 0 0 2px #7c3aed;
 }
 
 .help-edge-tab--active {
-  background: var(--sl-color-primary-600, #2563eb);
-  color: var(--sl-color-neutral-0, #fff);
-  border-color: var(--sl-color-primary-700, #1d4ed8);
+  opacity: 1;
+  background: #7c3aed; /* violet-600 */
+  color: #fff;
+  border-color: #6d28d9; /* violet-700 */
 }
 
 .help-edge-tab--active:hover,
 .help-edge-tab--active:focus-visible {
-  background: var(--sl-color-primary-700, #1d4ed8);
-  color: var(--sl-color-neutral-0, #fff);
+  background: #6d28d9;
+  color: #fff;
 }
 
+/* Inner row is icon + "Docs". Rotating the entire row -90deg (counter-
+   clockwise) makes both the icon and the label share the same rotation,
+   reading bottom-to-top along the right edge (head tilted left). */
 .help-edge-tab__inner {
   display: inline-flex;
+  flex-direction: row;
   align-items: center;
-  gap: 6px;
-  /* Rotate the label so the tab reads bottom-to-top along the right edge,
-     matching the support-tab pattern users recognise but with explicit
-     "Help" wording + a ? kbd hint so it doesn't read as chat. */
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
+  gap: 10px;
+  transform: rotate(-90deg);
+  transform-origin: center center;
+  white-space: nowrap;
 }
 
 .help-edge-tab__icon {
@@ -8443,114 +8463,154 @@ sl-dialog.markdown-dialog::part(body) {
 }
 
 .help-edge-tab__label {
+  /* Matches the sidebar's WORCA wordmark (.logo-text) — JetBrains Mono
+     family + bold weight + wide letter-spacing — so the affordance reads
+     as part of the brand vocabulary rather than a generic side tab. */
+  font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   line-height: 1;
-}
-
-.help-edge-tab__kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
-  border: 1px solid currentColor;
-  border-radius: 3px;
-  font-family: var(--sl-font-mono, ui-monospace, monospace);
-  font-size: 10px;
-  font-weight: 600;
-  opacity: 0.75;
 }
 
 /* --- Per-surface help badge ------------------------------------------- */
 
 /* Hidden by default. Once help-mode-active flips on the body, every badge
-   reveals at the top-right of its parent and gently pulses.
+   reveals at the top-right of its parent and emits a slow sonar wave that
+   radiates outward then fades.
 
    The badge is a real <a> — keyboard reachable when visible, opens the
    doc in a new tab, never depends on JS for click handling. */
 .help-badge {
   display: none;
   position: absolute;
-  top: 4px;
-  right: 4px;
+  /* Vertically centred on the host's right edge — gives the sonar wave
+     equal headroom above and below the badge so it doesn't overflow
+     the host's bounding box. With disc 27px and wave max scale 1.5,
+     max wave diameter is ~40px → fits inside any host ≥ 40px tall
+     (typical sl-tab ~40px, panel headers larger). */
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
   z-index: 5;
 
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  /* Solid disc 27×27 — entire badge scaled up 50% (18 → 27). Icon, wave
+     base, and clickable hit target all grow proportionally. */
+  width: 27px;
+  height: 27px;
   border-radius: 50%;
-  background: var(--sl-color-primary-600, #2563eb);
-  color: var(--sl-color-neutral-0, #fff);
+  /* Solid disc at 75% opacity — rgba on the background only so the
+     ::after sonar wave's own opacity animation (0.55 → 0) isn't dimmed
+     by parent inheritance. The white glyph stays fully visible. */
+  background: rgba(124, 58, 237, 0.75); /* violet-600 @ 75% */
+  color: #fff;
   text-decoration: none;
-  border: 2px solid var(--sl-color-neutral-0, #fff);
-  box-shadow: 0 0 0 2px var(--sl-color-primary-600, #2563eb),
-    0 0 12px rgba(37, 99, 235, 0.55);
   transition: transform 120ms ease, background-color 120ms ease;
 }
 
-.help-badge svg {
-  width: 14px;
-  height: 14px;
+/* Plain text "?" glyph — no container artifact (lucide's question-mark
+   variants all wrap the ? in some outline shape). Sized + weighted to
+   fill the 27px disc with a comfortable optical balance. */
+.help-badge__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--sl-font-sans, system-ui, sans-serif);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  /* Most "?" glyphs sit slightly above the optical centre of their
+     em-box because of the descender-free shape. Nudge down 1px so it
+     reads centred in the disc. */
+  margin-top: 1px;
+}
+
+/* The sonar wave — a same-colour pseudo-element behind the badge that
+   slowly grows outward and fades. Sits at z-index 0 (badge itself is
+   at z-index 5) so it appears under the badge during expansion. */
+.help-badge::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: #7c3aed;
+  opacity: 0;
+  z-index: -1;
+  pointer-events: none;
 }
 
 body.help-mode-active .help-badge {
   display: inline-flex;
-  animation: help-badge-pulse 1.6s ease-in-out infinite;
+}
+
+body.help-mode-active .help-badge::after {
+  animation: help-badge-sonar 2.4s ease-out infinite;
 }
 
 /* Auto-relative any direct parent of a badge so absolute positioning has
    a containing block. Modern browsers (Chrome 105+, Safari 15.4+,
-   Firefox 121+) all support :has(). */
+   Firefox 121+) all support :has(). For sl-tab specifically, also force
+   overflow: visible so the badge (and especially the sonar wave) isn't
+   clipped against the tab strip's edge. */
 body.help-mode-active *:has(> .help-badge) {
   position: relative;
 }
 
-/* sl-tab / sl-tab-panel are already positioned hosts, but their internal
-   padding means the badge sits over the close-icon area. Nudge it inward
-   so it doesn't overlap the tab label content. */
-body.help-mode-active sl-tab:has(> .help-badge) > .help-badge {
-  top: -6px;
-  right: -6px;
+body.help-mode-active sl-tab {
+  overflow: visible;
 }
 
 .help-badge:hover,
 .help-badge:focus-visible {
-  transform: scale(1.1);
-  background: var(--sl-color-primary-700, #1d4ed8);
+  /* Compose the hover lift with the vertical-centre translate so the
+     badge doesn't jump when hovered. */
+  transform: translateY(-50%) scale(1.1);
+  /* Full opacity on hover so the affordance reads stronger. */
+  background: #6d28d9; /* violet-700, opaque */
   outline: none;
 }
 
-@keyframes help-badge-pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 2px var(--sl-color-primary-600, #2563eb),
-      0 0 8px rgba(37, 99, 235, 0.45);
+/* Sonar wave: scale 1 → 1.5 from the 27px badge → max diameter ~40px,
+   centred on a badge that's vertically centred on the host. Wave fits
+   the host's bounding box on any host ≥ 40px tall (typical sl-tab
+   ~40px, panel headers larger; thin inline hosts may graze the edge). */
+@keyframes help-badge-sonar {
+  0% {
+    transform: scale(1);
+    opacity: 0.55;
   }
-  50% {
-    box-shadow: 0 0 0 2px var(--sl-color-primary-500, #3b82f6),
-      0 0 18px rgba(59, 130, 246, 0.8);
+  100% {
+    transform: scale(1.5);
+    opacity: 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  body.help-mode-active .help-badge {
+  body.help-mode-active .help-badge::after {
     animation: none;
-    box-shadow: 0 0 0 2px var(--sl-color-primary-600, #2563eb),
-      0 0 12px rgba(37, 99, 235, 0.55);
+    opacity: 0.22;
+    transform: scale(1.3);
   }
   .help-edge-tab {
     transition: none;
   }
 }
 
-/* Dark-mode tweak — Shoelace's neutral-0 flips to a dark surface, so the
-   default rules largely work. The badge's white border keeps contrast
-   against dark panel backgrounds. */
+/* Dark-mode — violet stays violet, but we lift the idle background so it
+   doesn't blend into dark panels. */
 :root[data-theme='dark'] .help-edge-tab,
 .sl-theme-dark .help-edge-tab {
-  background: var(--sl-color-neutral-100, #1f2937);
-  color: var(--sl-color-neutral-200, #e5e7eb);
-  border-color: var(--sl-color-neutral-400, #4b5563);
+  background: rgba(124, 58, 237, 0.22);
+  color: #e9d5ff; /* violet-200 */
+  border-color: #6d28d9;
   box-shadow: -2px 0 8px rgba(0, 0, 0, 0.4);
+}
+
+:root[data-theme='dark'] .help-edge-tab:hover,
+:root[data-theme='dark'] .help-edge-tab:focus-visible,
+.sl-theme-dark .help-edge-tab:hover,
+.sl-theme-dark .help-edge-tab:focus-visible {
+  background: rgba(124, 58, 237, 0.35);
+  color: #f5f3ff;
 }

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -8348,3 +8348,209 @@ sl-dialog.markdown-dialog::part(body) {
   color: var(--fg-muted);
   gap: 8px;
 }
+
+/* ===========================================================================
+ * Help mode (W-061 prototype, prototype/W-061-help-mode-toggle)
+ *
+ * Two concerns:
+ *   1. The right-edge "Help" tab (.help-edge-tab) — always visible.
+ *   2. Per-surface "?" badges (.help-badge) — hidden until body has the
+ *      .help-mode-active class.
+ *
+ * Visual language: muted neutral when idle, primary + gentle pulse when
+ * help mode is on. `prefers-reduced-motion` collapses the pulse to a
+ * static highlight so the badge stays discoverable but quiet.
+ * ===========================================================================
+ */
+
+/* --- Edge tab --------------------------------------------------------- */
+
+.help-edge-tab-root {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.help-edge-tab {
+  position: fixed;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%) translateX(0);
+  transform-origin: right center;
+  pointer-events: auto;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 8px 12px;
+  border: 1px solid var(--sl-color-neutral-300, var(--border, #d1d5db));
+  border-right: none;
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+  background: var(--sl-color-neutral-0, var(--bg, #fff));
+  color: var(--sl-color-neutral-700, var(--fg, #374151));
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.06);
+  transition: background-color 120ms ease, color 120ms ease, transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.help-edge-tab:hover,
+.help-edge-tab:focus-visible {
+  color: var(--sl-color-primary-700, var(--accent, #2563eb));
+  background: var(--sl-color-primary-50, rgba(37, 99, 235, 0.06));
+  transform: translateY(-50%) translateX(-2px);
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.08);
+  outline: none;
+}
+
+.help-edge-tab:focus-visible {
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.08),
+    0 0 0 2px var(--sl-color-primary-500, #3b82f6);
+}
+
+.help-edge-tab--active {
+  background: var(--sl-color-primary-600, #2563eb);
+  color: var(--sl-color-neutral-0, #fff);
+  border-color: var(--sl-color-primary-700, #1d4ed8);
+}
+
+.help-edge-tab--active:hover,
+.help-edge-tab--active:focus-visible {
+  background: var(--sl-color-primary-700, #1d4ed8);
+  color: var(--sl-color-neutral-0, #fff);
+}
+
+.help-edge-tab__inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  /* Rotate the label so the tab reads bottom-to-top along the right edge,
+     matching the support-tab pattern users recognise but with explicit
+     "Help" wording + a ? kbd hint so it doesn't read as chat. */
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.help-edge-tab__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.help-edge-tab__label {
+  line-height: 1;
+}
+
+.help-edge-tab__kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  font-family: var(--sl-font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  font-weight: 600;
+  opacity: 0.75;
+}
+
+/* --- Per-surface help badge ------------------------------------------- */
+
+/* Hidden by default. Once help-mode-active flips on the body, every badge
+   reveals at the top-right of its parent and gently pulses.
+
+   The badge is a real <a> — keyboard reachable when visible, opens the
+   doc in a new tab, never depends on JS for click handling. */
+.help-badge {
+  display: none;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 5;
+
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--sl-color-primary-600, #2563eb);
+  color: var(--sl-color-neutral-0, #fff);
+  text-decoration: none;
+  border: 2px solid var(--sl-color-neutral-0, #fff);
+  box-shadow: 0 0 0 2px var(--sl-color-primary-600, #2563eb),
+    0 0 12px rgba(37, 99, 235, 0.55);
+  transition: transform 120ms ease, background-color 120ms ease;
+}
+
+.help-badge svg {
+  width: 14px;
+  height: 14px;
+}
+
+body.help-mode-active .help-badge {
+  display: inline-flex;
+  animation: help-badge-pulse 1.6s ease-in-out infinite;
+}
+
+/* Auto-relative any direct parent of a badge so absolute positioning has
+   a containing block. Modern browsers (Chrome 105+, Safari 15.4+,
+   Firefox 121+) all support :has(). */
+body.help-mode-active *:has(> .help-badge) {
+  position: relative;
+}
+
+/* sl-tab / sl-tab-panel are already positioned hosts, but their internal
+   padding means the badge sits over the close-icon area. Nudge it inward
+   so it doesn't overlap the tab label content. */
+body.help-mode-active sl-tab:has(> .help-badge) > .help-badge {
+  top: -6px;
+  right: -6px;
+}
+
+.help-badge:hover,
+.help-badge:focus-visible {
+  transform: scale(1.1);
+  background: var(--sl-color-primary-700, #1d4ed8);
+  outline: none;
+}
+
+@keyframes help-badge-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 2px var(--sl-color-primary-600, #2563eb),
+      0 0 8px rgba(37, 99, 235, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 0 2px var(--sl-color-primary-500, #3b82f6),
+      0 0 18px rgba(59, 130, 246, 0.8);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.help-mode-active .help-badge {
+    animation: none;
+    box-shadow: 0 0 0 2px var(--sl-color-primary-600, #2563eb),
+      0 0 12px rgba(37, 99, 235, 0.55);
+  }
+  .help-edge-tab {
+    transition: none;
+  }
+}
+
+/* Dark-mode tweak — Shoelace's neutral-0 flips to a dark surface, so the
+   default rules largely work. The badge's white border keeps contrast
+   against dark panel backgrounds. */
+:root[data-theme='dark'] .help-edge-tab,
+.sl-theme-dark .help-edge-tab {
+  background: var(--sl-color-neutral-100, #1f2937);
+  color: var(--sl-color-neutral-200, #e5e7eb);
+  border-color: var(--sl-color-neutral-400, #4b5563);
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.4);
+}

--- a/worca-ui/app/utils/help-links.js
+++ b/worca-ui/app/utils/help-links.js
@@ -1,0 +1,200 @@
+/**
+ * In-app help links — PROTOTYPE (W-061, prototype/W-061-help-mode-toggle).
+ *
+ * Pattern: badges are HIDDEN by default and only revealed when the user
+ * activates help mode via the right-edge "Help" tab or the `?` keyboard
+ * shortcut (see help-mode.js). This is the alternative to the always-on
+ * inline `?` icon approach in docs/plans/W-061-in-app-help-links.md.
+ *
+ * Public API:
+ *   HELP_LINKS  — frozen helpId → { slug, title } map.
+ *   helpUrl(id) — resolves an id to a docs.worca.dev URL (or null if unknown).
+ *   helpFor(id) — lit-html template that renders a discoverable .help-badge.
+ *                 The badge is `display: none` until `body.help-mode-active`
+ *                 flips it on, at which point it absolutely positions to the
+ *                 top-right of its parent and pulses gently.
+ *
+ * Slug discipline: page-level only, never anchors. Page slugs require an
+ * explicit file rename so a reviewer notices; auto-generated anchor IDs
+ * silently break on heading renames.
+ *
+ * Registry corrections vs. the original W-061 plan (post W-062 + W-063):
+ *   + timeline-view           — W-063 added running-pipelines/timeline-view.md
+ *   + templates               — W-062 surfaces; configuration/pipeline-templates.md
+ *   + authoring-templates     — advanced/authoring-templates.md
+ *   + configuration-precedence — settings.js:96 already links here
+ *   + settings-overview       — better fit for the Preferences tab
+ *   - effort / permissions     — those tabs no longer exist in settings.js
+ *                                (folded into the template editor)
+ */
+
+import { html } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { CircleHelp, iconSvg } from './icons.js';
+
+// Build-time override (see worca-ui/scripts/build-frontend.js). Defaults to
+// production docs. esbuild's `define` substitutes the literal at build time;
+// the typeof guard keeps tests / Node runs from blowing up on an undefined
+// global.
+const DOCS_BASE =
+  typeof WORCA_DOCS_BASE !== 'undefined'
+    ? WORCA_DOCS_BASE
+    : 'https://docs.worca.dev';
+
+export const HELP_LINKS = Object.freeze({
+  // Concepts
+  'pipeline-stages': {
+    slug: 'concepts/the-pipeline-and-stages',
+    title: 'Pipeline & stages',
+  },
+  governance: { slug: 'concepts/governance', title: 'Governance' },
+  lifecycle: {
+    slug: 'concepts/lifecycle-and-state',
+    title: 'Run lifecycle & state',
+  },
+  templates: {
+    slug: 'concepts/pipeline-templates',
+    title: 'Pipeline templates',
+  },
+  'plans-guides': {
+    slug: 'concepts/plans-work-requests-and-guides',
+    title: 'Plans, work requests & guides',
+  },
+
+  // Configuration
+  'agents-models': {
+    slug: 'configuration/agents-and-models',
+    title: 'Agents & models',
+  },
+  'stages-config': {
+    slug: 'configuration/stages',
+    title: 'Stage configuration',
+  },
+  loops: {
+    slug: 'configuration/loops-and-circuit-breaker',
+    title: 'Loops & circuit breaker',
+  },
+  secrets: { slug: 'configuration/secrets', title: 'Secrets' },
+  'configuration-precedence': {
+    slug: 'configuration/precedence',
+    title: 'Configuration precedence',
+  },
+  'settings-overview': {
+    slug: 'configuration/settings-overview',
+    title: 'Settings overview',
+  },
+
+  // Running pipelines
+  launching: {
+    slug: 'running-pipelines/launching-a-run',
+    title: 'Launching a run',
+  },
+  monitoring: {
+    slug: 'running-pipelines/monitoring-a-run',
+    title: 'Monitoring a run',
+  },
+  controlling: {
+    slug: 'running-pipelines/controlling-a-run',
+    title: 'Controlling a run',
+  },
+  reviewing: {
+    slug: 'running-pipelines/reviewing-the-result',
+    title: 'Reviewing the result',
+  },
+  'timeline-view': {
+    slug: 'running-pipelines/timeline-view',
+    title: 'Timeline view',
+  },
+
+  // Advanced
+  effort: { slug: 'advanced/tuning-effort', title: 'Effort levels' },
+  dispatch: {
+    slug: 'advanced/dispatch-governance',
+    title: 'Dispatch governance',
+  },
+  crg: { slug: 'advanced/code-review-graph', title: 'Code Review Graph' },
+  graphify: {
+    slug: 'advanced/knowledge-graph',
+    title: 'Knowledge graph (Graphify)',
+  },
+  'fleet-runs': { slug: 'advanced/fleet-runs', title: 'Fleet runs' },
+  'workspace-runs': {
+    slug: 'advanced/workspace-runs',
+    title: 'Workspace runs',
+  },
+  worktrees: { slug: 'advanced/worktree-cleanup', title: 'Worktree cleanup' },
+  'agent-prompt': {
+    slug: 'advanced/anatomy-of-an-agent-prompt',
+    title: 'Anatomy of an agent prompt',
+  },
+  'authoring-templates': {
+    slug: 'advanced/authoring-templates',
+    title: 'Authoring templates',
+  },
+
+  // Integrations
+  webhooks: { slug: 'integrations/webhooks', title: 'Webhooks' },
+  chat: { slug: 'integrations/chat-integrations', title: 'Chat integrations' },
+  events: { slug: 'integrations/events-overview', title: 'Events overview' },
+
+  // Getting started
+  'first-run': {
+    slug: 'getting-started/your-first-run',
+    title: 'Your first run',
+  },
+  'add-project': {
+    slug: 'getting-started/add-your-project',
+    title: 'Add your project',
+  },
+});
+
+/**
+ * Resolve a helpId to a docs.worca.dev URL.
+ * @param {string} id
+ * @returns {string|null}
+ */
+export function helpUrl(id) {
+  const entry = HELP_LINKS[id];
+  if (!entry) return null;
+  return `${DOCS_BASE}/${entry.slug}/`;
+}
+
+/**
+ * lit-html template that renders a help badge anchored to its parent.
+ *
+ * The badge is invisible until help mode activates (see help-mode.js). When
+ * active, it absolutely positions to the top-right corner of its parent and
+ * pulses. Click opens the doc page in a new tab.
+ *
+ * Usage:
+ *   <div class="help-host">
+ *     <h3>Dispatch governance</h3>
+ *     ${helpFor('dispatch')}
+ *   </div>
+ *
+ * The `.help-host` class on the parent is recommended (sets position:
+ * relative) but not strictly required — Shoelace components like sl-tab are
+ * already positioned hosts, and `body.help-mode-active *:has(> .help-badge)`
+ * in styles.css handles the auto-relative case for plain parents.
+ *
+ * Returns null and warns in dev for unknown ids — never crashes a view.
+ */
+export function helpFor(id) {
+  const entry = HELP_LINKS[id];
+  if (!entry) {
+    if (typeof console !== 'undefined') {
+      console.warn(`helpFor: unknown id "${id}"`);
+    }
+    return null;
+  }
+  const url = `${DOCS_BASE}/${entry.slug}/`;
+  return html`<a
+    class="help-badge"
+    href=${url}
+    target="_blank"
+    rel="noopener noreferrer"
+    title="Help: ${entry.title}"
+    aria-label="Open help: ${entry.title}"
+    data-help-id=${id}
+  >${unsafeHTML(iconSvg(CircleHelp, 14))}</a>`;
+}

--- a/worca-ui/app/utils/help-links.js
+++ b/worca-ui/app/utils/help-links.js
@@ -29,8 +29,6 @@
  */
 
 import { html } from 'lit-html';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import { CircleHelp, iconSvg } from './icons.js';
 
 // Build-time override (see worca-ui/scripts/build-frontend.js). Defaults to
 // production docs. esbuild's `define` substitutes the literal at build time;
@@ -188,6 +186,11 @@ export function helpFor(id) {
     return null;
   }
   const url = `${DOCS_BASE}/${entry.slug}/`;
+  // The "?" glyph is plain text rather than a lucide SVG so we don't get
+  // the container artifact baked into every lucide help-icon variant
+  // (circle-question-mark, badge-question-mark, etc. all draw their own
+  // outline shape around the ?). With text we have just the glyph, sized
+  // and weighted via the .help-badge__glyph CSS rule.
   return html`<a
     class="help-badge"
     href=${url}
@@ -196,5 +199,5 @@ export function helpFor(id) {
     title="Help: ${entry.title}"
     aria-label="Open help: ${entry.title}"
     data-help-id=${id}
-  >${unsafeHTML(iconSvg(CircleHelp, 14))}</a>`;
+  ><span class="help-badge__glyph" aria-hidden="true">?</span></a>`;
 }

--- a/worca-ui/app/utils/help-links.test.js
+++ b/worca-ui/app/utils/help-links.test.js
@@ -1,0 +1,109 @@
+/**
+ * L1 — source-resolution check for the HELP_LINKS registry.
+ *
+ * Catches the failure modes the live L2 check (scripts/check-help-links-live.py)
+ * can't catch at PR time:
+ *   - Typo'd slug that doesn't exist on disk.
+ *   - Doc page deleted without removing the helpId.
+ *   - Anchor (`#section`) sneaking into a slug (anchors silently break on
+ *     heading renames; only page-level slugs survive a refactor).
+ *   - Empty title (tooltip + aria-label would render blank).
+ *   - helpUrl / helpFor contract violations (unknown id, canonical URL shape).
+ *
+ * Does NOT catch: doc page exists but is thin / wrong / outdated. That's a
+ * docs-quality issue, not a sync issue.
+ *
+ * Lives in worca-ui/app/utils/ so vitest picks it up via the existing
+ * worca-ui/vitest.config.js test glob.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { HELP_LINKS, helpFor, helpUrl } from './help-links.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Walk up: app/utils/ -> app/ -> worca-ui/ -> worca-cc/
+const REPO_ROOT = resolve(__dirname, '../../..');
+const DOCS_ROOT = resolve(REPO_ROOT, 'docs-site/src/content/docs');
+
+describe('help-links L1 — every slug resolves to a docs page', () => {
+  for (const [id, entry] of Object.entries(HELP_LINKS)) {
+    it(`${id} → ${entry.slug} resolves to a .md or .mdx file`, () => {
+      const md = resolve(DOCS_ROOT, `${entry.slug}.md`);
+      const mdx = resolve(DOCS_ROOT, `${entry.slug}.mdx`);
+      const ok = existsSync(md) || existsSync(mdx);
+      expect(
+        ok,
+        `Expected ${entry.slug}.md or ${entry.slug}.mdx to exist under ${DOCS_ROOT}`,
+      ).toBe(true);
+    });
+
+    it(`${id} slug has no anchor fragment`, () => {
+      expect(
+        entry.slug,
+        `Anchors silently break on heading renames; ${id} should use a page-level slug.`,
+      ).not.toContain('#');
+    });
+
+    it(`${id} has a non-empty title`, () => {
+      expect(entry.title).toBeTypeOf('string');
+      expect(entry.title.trim().length, `${id} title is blank`).toBeGreaterThan(
+        0,
+      );
+    });
+  }
+});
+
+describe('help-links — helpUrl contract', () => {
+  it('returns null for an unknown id', () => {
+    expect(helpUrl('this-id-does-not-exist')).toBe(null);
+  });
+
+  it('returns a canonical URL ending in /<slug>/ for a known id', () => {
+    const url = helpUrl('crg');
+    expect(url).not.toBe(null);
+    expect(url.endsWith('/advanced/code-review-graph/')).toBe(true);
+  });
+
+  it('honours the default DOCS_BASE when WORCA_DOCS_BASE is unset', () => {
+    // The module's typeof guard means a process without WORCA_DOCS_BASE
+    // defined as a global falls through to the production default.
+    expect(helpUrl('crg')).toBe(
+      'https://docs.worca.dev/advanced/code-review-graph/',
+    );
+  });
+});
+
+describe('help-links — helpFor contract', () => {
+  it('returns null and warns for an unknown id (soft-fail)', () => {
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (msg) => warnings.push(String(msg));
+    try {
+      const result = helpFor('this-id-does-not-exist');
+      expect(result).toBe(null);
+      expect(warnings.some((w) => w.includes('this-id-does-not-exist'))).toBe(
+        true,
+      );
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  it('returns a lit-html template result for a known id', () => {
+    const tpl = helpFor('crg');
+    expect(tpl).not.toBe(null);
+    // lit-html TemplateResult shape: { strings, values, _$litType$ }.
+    expect(tpl).toHaveProperty('_$litType$');
+    expect(tpl).toHaveProperty('strings');
+    expect(Array.isArray(tpl.strings)).toBe(true);
+    // Strings should mention the target URL + the anchor's a11y wiring.
+    const joined = tpl.strings.join('');
+    expect(joined).toContain('class="help-badge"');
+    expect(joined).toContain('target="_blank"');
+    expect(joined).toContain('rel="noopener noreferrer"');
+    expect(joined).toContain('aria-label="Open help:');
+  });
+});

--- a/worca-ui/app/utils/help-mode.js
+++ b/worca-ui/app/utils/help-mode.js
@@ -1,0 +1,123 @@
+/**
+ * Help-mode state machine — PROTOTYPE (W-061, prototype/W-061-help-mode-toggle).
+ *
+ * Owns:
+ *   - The body.help-mode-active class that gates badge visibility.
+ *   - The `?` keyboard shortcut (Shift+/ on US keyboards) that toggles it.
+ *   - The Escape keybinding that closes help mode.
+ *
+ * The right-edge tab (help-edge-tab.js) and the main.js bootstrap both call
+ * toggle()/setActive()/isActive(). Subscribers (the edge tab's aria-pressed
+ * state, any future help-mode indicator) listen via subscribe().
+ *
+ * Why a tiny module instead of inlining into main.js:
+ *   - main.js is already ~5k lines; cross-cutting UI state with a defined
+ *     contract is the kind of thing a separate module makes testable.
+ *   - The edge tab needs to read state on every render — having a single
+ *     authoritative getter avoids the "two booleans drift" bug.
+ */
+
+let _active = false;
+const _listeners = new Set();
+
+/** @returns {boolean} */
+export function isActive() {
+  return _active;
+}
+
+/**
+ * Force state. Idempotent — no-ops if already in the target state.
+ * @param {boolean} next
+ */
+export function setActive(next) {
+  const v = Boolean(next);
+  if (v === _active) return;
+  _active = v;
+  if (typeof document !== 'undefined' && document.body) {
+    document.body.classList.toggle('help-mode-active', _active);
+  }
+  for (const cb of _listeners) {
+    try {
+      cb(_active);
+    } catch (err) {
+      // Don't let one bad listener break the rest.
+      if (typeof console !== 'undefined')
+        console.error('help-mode listener threw', err);
+    }
+  }
+}
+
+/** Flip active ↔ inactive. */
+export function toggle() {
+  setActive(!_active);
+}
+
+/**
+ * Subscribe to active-state changes. Returns an unsubscribe fn.
+ * @param {(active: boolean) => void} cb
+ * @returns {() => void}
+ */
+export function subscribe(cb) {
+  _listeners.add(cb);
+  return () => _listeners.delete(cb);
+}
+
+/**
+ * Should the `?` keypress be swallowed for help-mode toggling, or is the
+ * user typing into an input/textarea/contentEditable? Mirrors GitHub's
+ * shortcut-guard convention.
+ */
+function _isTypingContext(target) {
+  if (!target) return false;
+  const tag = (target.tagName || '').toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+  if (target.isContentEditable) return true;
+  // Shoelace inputs delegate focus to a shadow-DOM <input>; the event's
+  // composedPath() target is the host element, which is sl-input /
+  // sl-textarea. Check the tag explicitly.
+  if (
+    tag.startsWith('sl-') &&
+    (tag.includes('input') || tag.includes('textarea'))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+let _bound = false;
+
+/**
+ * Wire up global keybindings. Idempotent — safe to call from main.js
+ * bootstrap. Returns the keydown handler so tests can detach it.
+ */
+export function bindKeyboard() {
+  if (_bound || typeof window === 'undefined') return null;
+  _bound = true;
+  const handler = (e) => {
+    // Skip if user is typing in a field.
+    if (_isTypingContext(e.target)) return;
+    // Skip if any modifier other than Shift is held (Shift is required
+    // for `?` on US keyboards; Ctrl/Meta/Alt + ? is left alone for the
+    // browser).
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    if (e.key === '?') {
+      e.preventDefault();
+      toggle();
+    } else if (e.key === 'Escape' && _active) {
+      e.preventDefault();
+      setActive(false);
+    }
+  };
+  window.addEventListener('keydown', handler);
+  return handler;
+}
+
+// Test seam — never call from production code.
+export function _resetForTests() {
+  _active = false;
+  _listeners.clear();
+  _bound = false;
+  if (typeof document !== 'undefined' && document.body) {
+    document.body.classList.remove('help-mode-active');
+  }
+}

--- a/worca-ui/app/utils/icons.js
+++ b/worca-ui/app/utils/icons.js
@@ -17,6 +17,7 @@ import ChevronRight from 'lucide/dist/esm/icons/chevron-right';
 import Circle from 'lucide/dist/esm/icons/circle';
 import CircleAlert from 'lucide/dist/esm/icons/circle-alert';
 import CircleCheck from 'lucide/dist/esm/icons/circle-check';
+import CircleHelp from 'lucide/dist/esm/icons/circle-question-mark';
 import CircleSlash from 'lucide/dist/esm/icons/circle-slash';
 import ClipboardCopy from 'lucide/dist/esm/icons/clipboard-copy';
 import ClipboardPaste from 'lucide/dist/esm/icons/clipboard-paste';
@@ -102,6 +103,7 @@ export {
   Circle,
   CircleAlert,
   CircleCheck,
+  CircleHelp,
   CircleSlash,
   ClipboardCopy,
   ClipboardPaste,

--- a/worca-ui/app/views/dashboard.js
+++ b/worca-ui/app/views/dashboard.js
@@ -446,7 +446,7 @@ export function dashboardView(
           </div>
         </div>
       `
-          : html`<div class="empty-state">No active pipelines</div>`
+          : html`<div class="empty-state">No active pipelines${helpFor('first-run')}</div>`
       }
 
       ${

--- a/worca-ui/app/views/dashboard.js
+++ b/worca-ui/app/views/dashboard.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import {
   Activity,
   CircleAlert,
@@ -386,6 +387,7 @@ export function dashboardView(
   // attribution was unreliable when runs lacked a projectId field.
   return html`
     <div class="dashboard">
+      ${helpFor('monitoring')}
       <div class="dashboard-stats">
         <div class="stat-card stat-total">
           <div class="stat-icon-ring">${unsafeHTML(iconSvg(Zap, 20))}</div>

--- a/worca-ui/app/views/fleet-detail.js
+++ b/worca-ui/app/views/fleet-detail.js
@@ -1,6 +1,7 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { elapsed, formatDuration, formatTimestamp } from '../utils/duration.js';
+import { helpFor } from '../utils/help-links.js';
 import { renderMarkdown } from '../utils/markdown.js';
 import { statusClass, statusIcon } from '../utils/status-badge.js';
 import { projectBadgesView } from './fleet-card.js';
@@ -454,6 +455,7 @@ export function fleetDetailView(
 
   return html`
     <div class="new-run-page fleet-detail-page">
+      ${helpFor('fleet-runs')}
       ${_fleetOverviewSection(fleet, { runsById })}
       ${_circuitBreakerAlertView(fleet)}
       ${_userHaltAlertView(fleet)}

--- a/worca-ui/app/views/fleet-launcher.js
+++ b/worca-ui/app/views/fleet-launcher.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import { dagGraphView } from './dag-graph.js';
 import {
   filePickerButton,
@@ -1208,6 +1209,7 @@ export function fleetLauncherView(appState, { rerender } = {}) {
           : nothing
       }
       <div class="new-run-form">
+        ${helpFor(isWorkspace ? 'workspace-runs' : 'fleet-runs')}
         ${isWorkspace ? _workspaceSelectSection(appState, { rerender }) : _projectsSection(appProjects, { rerender })}
         ${isWorkspace ? _workspaceDagSection() : nothing}
 ${

--- a/worca-ui/app/views/help-edge-tab.js
+++ b/worca-ui/app/views/help-edge-tab.js
@@ -1,0 +1,58 @@
+/**
+ * Help edge tab — PROTOTYPE (W-061, prototype/W-061-help-mode-toggle).
+ *
+ * The persistent right-edge affordance that activates "help mode" — when
+ * pressed, every UI element that registered via `helpFor(id)` reveals a
+ * glowing badge linking to the relevant doc page.
+ *
+ * Visual: vertically rotated label "Help (?)" anchored to the middle of the
+ * right edge of the viewport, distinguishable from chat-widget conventions
+ * (we use the lucide CircleHelp icon + an explicit "?" keyboard hint to make
+ * the docs intent legible).
+ *
+ * Mounted once at bootstrap by main.js into a fixed-position root outside
+ * the app's lit-html render container, so route changes don't unmount it
+ * and the toggle state lives across navigation.
+ */
+
+import { html, render } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { isActive, subscribe, toggle } from '../utils/help-mode.js';
+import { CircleHelp, iconSvg } from '../utils/icons.js';
+
+/**
+ * Render the edge tab into the given root. Returns an unsubscribe function
+ * that disconnects the help-mode listener (tests; never called in prod).
+ *
+ * The view re-renders only when help-mode state flips, not on every app
+ * re-render — keeps it cheap and decoupled from the main render loop.
+ */
+export function mountHelpEdgeTab(root) {
+  if (!root) return () => {};
+
+  function _render() {
+    const active = isActive();
+    render(
+      html`
+        <button
+          type="button"
+          class="help-edge-tab ${active ? 'help-edge-tab--active' : ''}"
+          aria-pressed=${active ? 'true' : 'false'}
+          aria-label=${active ? 'Close help mode' : 'Open help mode (shortcut: ?)'}
+          title=${active ? 'Close help mode (Esc)' : 'Show help badges (?)'}
+          @click=${() => toggle()}
+        >
+          <span class="help-edge-tab__inner">
+            <span class="help-edge-tab__icon">${unsafeHTML(iconSvg(CircleHelp, 16))}</span>
+            <span class="help-edge-tab__label">Help</span>
+            <kbd class="help-edge-tab__kbd">?</kbd>
+          </span>
+        </button>
+      `,
+      root,
+    );
+  }
+
+  _render();
+  return subscribe(_render);
+}

--- a/worca-ui/app/views/help-edge-tab.js
+++ b/worca-ui/app/views/help-edge-tab.js
@@ -38,14 +38,13 @@ export function mountHelpEdgeTab(root) {
           type="button"
           class="help-edge-tab ${active ? 'help-edge-tab--active' : ''}"
           aria-pressed=${active ? 'true' : 'false'}
-          aria-label=${active ? 'Close help mode' : 'Open help mode (shortcut: ?)'}
-          title=${active ? 'Close help mode (Esc)' : 'Show help badges (?)'}
+          aria-label=${active ? 'Close docs mode' : 'Open docs mode (shortcut: ?)'}
+          title=${active ? 'Close docs mode (Esc)' : 'Show doc badges (?)'}
           @click=${() => toggle()}
         >
           <span class="help-edge-tab__inner">
-            <span class="help-edge-tab__icon">${unsafeHTML(iconSvg(CircleHelp, 16))}</span>
-            <span class="help-edge-tab__label">Help</span>
-            <kbd class="help-edge-tab__kbd">?</kbd>
+            <span class="help-edge-tab__icon">${unsafeHTML(iconSvg(CircleHelp, 20))}</span>
+            <span class="help-edge-tab__label">Docs</span>
           </span>
         </button>
       `,

--- a/worca-ui/app/views/integrations.js
+++ b/worca-ui/app/views/integrations.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 
 // Brand SVG icons (Simple Icons, MIT license) — 24×24
 const BRAND_ICONS = {
@@ -292,6 +293,7 @@ export function integrationsTab(integrationsState, options) {
 
   return html`
     <div class="ig-page">
+      ${helpFor('chat')}
       <p class="ig-subtitle">Receive pipeline notifications in chat apps.</p>
       <div class="ig-cards">
         ${ADAPTERS.map((meta) => {

--- a/worca-ui/app/views/new-run.js
+++ b/worca-ui/app/views/new-run.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import { FileText, iconSvg } from '../utils/icons.js';
 import { statusDotClass } from '../utils/status-badge.js';
 import { getDefaults } from './settings.js';
@@ -527,6 +528,7 @@ export function newRunView(_state, { rerender }) {
       ${submitStatus === 'error' ? html`<div class="new-run-error">${submitError}</div>` : nothing}
 
       <div class="new-run-form">
+        ${helpFor('launching')}
         <!-- Section 0: Project -->
         ${
           _state.projects && _state.projects.length > 0

--- a/worca-ui/app/views/pipelines-editor.js
+++ b/worca-ui/app/views/pipelines-editor.js
@@ -17,6 +17,7 @@ import { html, nothing } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { DISPATCH_DEFAULTS } from '../../server/dispatch-defaults.js';
+import { helpFor } from '../utils/help-links.js';
 import {
   CircleCheck,
   iconSvg,
@@ -1147,6 +1148,7 @@ export function pipelinesEditorView(state, options) {
   return html`
     <div class="pipelines-editor">
       <div class="editor-subheader">
+        ${helpFor('authoring-templates')}
         <div class="editor-subheader-title-group">
           <sl-tooltip content="Template name">
             <span class="editor-field-pill editor-name-pill">
@@ -1267,14 +1269,17 @@ export function pipelinesEditorView(state, options) {
           <sl-tab slot="nav" panel="agents">
             ${unsafeHTML(iconSvg(Users, 14))}
             Agents
+            ${helpFor('agents-models')}
           </sl-tab>
           <sl-tab slot="nav" panel="pipeline">
             ${unsafeHTML(iconSvg(Workflow, 14))}
             Pipeline
+            ${helpFor('stages-config')}
           </sl-tab>
           <sl-tab slot="nav" panel="governance">
             ${unsafeHTML(iconSvg(Shield, 14))}
             Governance
+            ${helpFor('dispatch')}
           </sl-tab>
 
           <sl-tab-panel name="agents">

--- a/worca-ui/app/views/pipelines.js
+++ b/worca-ui/app/views/pipelines.js
@@ -15,6 +15,7 @@
 import { html, nothing } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import {
   Copy,
   Cpu,
@@ -309,6 +310,7 @@ export function pipelinesView(state, options) {
   return html`
     <div class="pipelines-view">
       <div class="pipelines-content">
+        ${helpFor('templates')}
         ${_degradedBanner(worcaCliStatus)}
 
         ${

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -2,6 +2,7 @@ import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { elapsed, formatDuration, formatTimestamp } from '../utils/duration.js';
 import { effortLevelBadge } from '../utils/effort-badge.js';
+import { helpFor } from '../utils/help-links.js';
 import {
   AlertTriangle,
   BarChart3,
@@ -222,6 +223,7 @@ function _planArtifactDialog(run, rerender) {
     iters.length > 1
       ? html`
         <div class="plan-iter-selector" role="group" aria-label="Plan revisions">
+          ${helpFor('plans-guides')}
           ${iters.map((it) => {
             const isLatest = it.n === latestN;
             const active =
@@ -912,7 +914,7 @@ function _dispatchSectionInlineView(label, sectionKey, events) {
   return html`<span
     class="dispatch-events-section"
     data-dispatch-section="${sectionKey}"
-    ><span class="meta-label">${label}</span>${body}</span
+    ><span class="meta-label">${label}</span>${body}${helpFor('dispatch')}</span
   >`;
 }
 
@@ -949,6 +951,7 @@ function _circuitBreakerBannerView(run, settings) {
     return html`
       <sl-alert class="circuit-breaker-banner" variant="danger" open>
         <strong>Circuit breaker tripped:</strong> ${cb.tripped_reason || 'Pipeline halted due to repeated errors.'}
+        ${helpFor('loops')}
       </sl-alert>
     `;
   }
@@ -958,6 +961,7 @@ function _circuitBreakerBannerView(run, settings) {
     return html`
       <sl-alert class="circuit-breaker-banner" variant="warning" open>
         <strong>Circuit breaker warning:</strong> ${String(failures)}/${String(threshold)} consecutive failures.
+        ${helpFor('loops')}
       </sl-alert>
     `;
   }
@@ -1489,6 +1493,7 @@ function _agentPromptSection(_stageKey, promptData) {
       <div slot="summary" class="agent-prompt-header">
         <span class="stage-meta-icon">${unsafeHTML(iconSvg(FileText, 12))}</span>
         Agent Instructions
+        ${helpFor('agent-prompt')}
       </div>
       ${
         agentInstructions
@@ -1580,6 +1585,7 @@ export function prApprovalPanelView(run, options = {}) {
     <sl-card class="approval-panel" data-testid="pr-approval-panel">
       <div slot="header">
         <strong>PR creation paused — approval required</strong>
+        ${helpFor('reviewing')}
       </div>
       <p>The pipeline is ready to create a pull request for this run. Approve to proceed, or reject to stop the pipeline.</p>
       <div class="approval-actions">
@@ -1689,7 +1695,11 @@ export function runDetailView(run, settings = {}, options = {}) {
 
   const overview = html`
     <div class="run-detail-overview">
-      ${stageTimelineView(stages, stageUi, run.active)}
+      ${helpFor('lifecycle')}
+      <div class="run-detail-stage-timeline-wrap">
+        ${stageTimelineView(stages, stageUi, run.active)}
+        ${helpFor('pipeline-stages')}
+      </div>
       ${_circuitBreakerBannerView(run, settings)}
       ${prVerificationBannerView(run)}
       ${guideConflictsPanelView(run.guide_conflicts, options)}

--- a/worca-ui/app/views/run-timeline.js
+++ b/worca-ui/app/views/run-timeline.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import { iconSvg, RefreshCw, ZoomIn, ZoomOut } from '../utils/icons.js';
 import { STAGE_HUES } from '../utils/stage-hues.js';
 import { computeTimelineLayout } from '../utils/timeline-layout.js';
@@ -973,6 +974,7 @@ export function runTimelineView(run, _settings, options = {}) {
     @click=${handleClick}
     @keydown=${handleKeydown}
   >
+    ${helpFor('timeline-view')}
     ${buildStatsSummary(layout)}
     <div class="timeline-toolbar" role="toolbar" aria-label="Timeline zoom">
       <div class="timeline-toolbar-group">

--- a/worca-ui/app/views/settings.js
+++ b/worca-ui/app/views/settings.js
@@ -7,6 +7,7 @@ import {
   showConfirm,
   showInfo,
 } from '../utils/confirm-dialog.js';
+import { helpFor, helpUrl } from '../utils/help-links.js';
 import {
   Activity,
   Bell,
@@ -93,7 +94,7 @@ export const TEMPLATE_DRIVEN_BANNER = html`
     explicitly or pinned via <code>worca.default_template</code> — these
     values are <em>not</em> applied. The selected template owns them. The
     values here only take effect when no template is selected.
-    <a href="https://docs.worca.dev/configuration/precedence/" target="_blank" rel="noopener">Learn more →</a>
+    <a href=${helpUrl('configuration-precedence')} target="_blank" rel="noopener">Learn more →</a>
   </sl-alert>
 `;
 
@@ -3337,18 +3338,22 @@ export function settingsView(
         <sl-tab slot="nav" panel="projects">
           ${unsafeHTML(iconSvg(FolderOpen, 14))}
           Projects
+          ${helpFor('add-project')}
         </sl-tab>
         <sl-tab slot="nav" panel="notifications">
           ${unsafeHTML(iconSvg(Bell, 14))}
           Notifications
+          <!-- no dedicated doc page yet (W-061 prototype: skip-if-no-doc) -->
         </sl-tab>
         <sl-tab slot="nav" panel="preferences">
           ${unsafeHTML(iconSvg(Settings, 14))}
           Preferences
+          ${helpFor('settings-overview')}
         </sl-tab>
         <sl-tab slot="nav" panel="integrations">
           ${unsafeHTML(iconSvg(Zap, 14))}
           Integrations
+          ${helpFor('chat')}
         </sl-tab>
 
         <sl-tab-panel name="projects">${projectsTab(projects, { onProjectAdd, onProjectRemove, onProjectsRefresh, rerender })}</sl-tab-panel>
@@ -3401,30 +3406,37 @@ export function projectSettingsView(
         <sl-tab slot="nav" panel="models">
           ${unsafeHTML(iconSvg(Cpu, 14))}
           Models
+          ${helpFor('agents-models')}
         </sl-tab>
         <sl-tab slot="nav" panel="pipeline">
           ${unsafeHTML(iconSvg(Workflow, 14))}
           Pipeline
+          ${helpFor('stages-config')}
         </sl-tab>
         <sl-tab slot="nav" panel="governance">
           ${unsafeHTML(iconSvg(Shield, 14))}
           Governance
+          ${helpFor('governance')}
         </sl-tab>
         <sl-tab slot="nav" panel="pricing">
           ${unsafeHTML(iconSvg(Coins, 14))}
           Pricing
+          <!-- no dedicated doc page yet (W-061 prototype: skip-if-no-doc) -->
         </sl-tab>
         <sl-tab slot="nav" panel="webhooks">
           ${unsafeHTML(iconSvg(Zap, 14))}
           Webhooks
+          ${helpFor('webhooks')}
         </sl-tab>
         <sl-tab slot="nav" panel="graphify">
           ${unsafeHTML(iconSvg(Database, 14))}
           Graphify
+          ${helpFor('graphify')}
         </sl-tab>
         <sl-tab slot="nav" panel="code-review-graph">
           ${unsafeHTML(iconSvg(Search, 14))}
           Code Review Graph
+          ${helpFor('crg')}
         </sl-tab>
 
         <sl-tab-panel name="models">${modelsTab(worca, rerender)}</sl-tab-panel>

--- a/worca-ui/app/views/sidebar.js
+++ b/worca-ui/app/views/sidebar.js
@@ -1,5 +1,6 @@
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import {
   Activity,
   Archive,
@@ -319,6 +320,7 @@ export function sidebarView(
                 ? html`<sl-badge variant="${worktreeDiskWarning ? 'warning' : 'neutral'}" pill class="worktrees-count-badge">${worktreeCount}</sl-badge>`
                 : ''
           }
+          ${helpFor('worktrees')}
         </div>
         <div class="sidebar-item ${route.section === 'fleet-runs' ? 'active' : ''}"
              @click=${() => onNavigate('fleet-runs')}>

--- a/worca-ui/app/views/sidebar.js
+++ b/worca-ui/app/views/sidebar.js
@@ -380,6 +380,7 @@ export function sidebarView(
             <span>Webhooks</span>
           </span>
           ${(state.webhookInbox?.events?.length || 0) > 0 ? html`<sl-badge variant="warning" pill>${state.webhookInbox.events.length}</sl-badge>` : ''}
+          ${helpFor('events')}
         </div>
       </div>
 

--- a/worca-ui/app/views/webhook-inbox.js
+++ b/worca-ui/app/views/webhook-inbox.js
@@ -1,5 +1,6 @@
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import {
   ClipboardCopy,
   iconSvg,
@@ -242,6 +243,7 @@ export function webhookInboxView(
 
   return html`
     <div class="webhook-inbox">
+      ${helpFor('webhooks')}
       <div class="webhook-inbox-toolbar">
         <div class="webhook-inbox-category-chips">
           ${CATEGORIES.map(

--- a/worca-ui/app/views/workspace-create.js
+++ b/worca-ui/app/views/workspace-create.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import { FolderOpen, iconSvg } from '../utils/icons.js';
 import { dagGraphView } from './dag-graph.js';
 
@@ -599,6 +600,7 @@ export function workspaceCreateView(appState, { rerender } = {}) {
           : nothing
       }
       <div class="new-run-form">
+        ${helpFor('workspace-runs')}
         ${_nameSection({ rerender })}
         ${_parentDirSection(appState, { rerender })}
         ${_repoChecklistSection({ rerender })}

--- a/worca-ui/app/views/workspace-css.test.js
+++ b/worca-ui/app/views/workspace-css.test.js
@@ -163,6 +163,20 @@ describe('workspace CSS — DAG styling', () => {
       // hex fallback so themes without Shoelace still render the
       // amber edge.
       '--sl-color-warning-600',
+      // Used by the W-061 help-mode prototype (right-edge "Help" tab +
+      // per-surface .help-badge): Shoelace's neutral and primary scales
+      // are tapped for the muted-idle / primary-active treatment and
+      // for dark-mode contrast. Each var has a hex fallback in the
+      // CSS rules so themes without Shoelace still render.
+      '--sl-color-neutral-0',
+      '--sl-color-neutral-100',
+      '--sl-color-neutral-200',
+      '--sl-color-neutral-300',
+      '--sl-color-neutral-400',
+      '--sl-color-neutral-700',
+      '--sl-color-primary-50',
+      '--sl-color-primary-500',
+      '--sl-color-primary-700',
     ]);
     for (const prop of customProps) {
       expect(allowed.has(prop)).toBe(true);

--- a/worca-ui/app/views/workspace-detail.js
+++ b/worca-ui/app/views/workspace-detail.js
@@ -1,6 +1,7 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { elapsed, formatDuration, formatTimestamp } from '../utils/duration.js';
+import { helpFor } from '../utils/help-links.js';
 import { ClipboardCopy, iconSvg } from '../utils/icons.js';
 import { renderMarkdown } from '../utils/markdown.js';
 import { statusClass, statusIcon } from '../utils/status-badge.js';
@@ -1068,6 +1069,7 @@ export function workspaceDetailView(
   // compatibility but the body doesn't render its own action row.
   return html`
     <div class="new-run-page workspace-detail-page">
+      ${helpFor('workspace-runs')}
       ${_overviewSection(workspace)}
       ${_circuitBreakerAlertView(workspace)}
       ${_userHaltAlertView(workspace)}

--- a/worca-ui/app/views/workspace-edit.js
+++ b/worca-ui/app/views/workspace-edit.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import { dagGraphView } from './dag-graph.js';
 
 let workspaceName = '';
@@ -561,6 +562,7 @@ export function workspaceEditView(_appState, { rerender } = {}) {
 
   return html`
     <div class="new-run-page workspace-edit-page">
+      ${helpFor('workspace-runs')}
       ${_snapshotBanner()}
       ${
         submitStatus === 'error'

--- a/worca-ui/app/views/workspaces-config.js
+++ b/worca-ui/app/views/workspaces-config.js
@@ -1,5 +1,6 @@
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { helpFor } from '../utils/help-links.js';
 import { Boxes, iconSvg, Pencil, Play, Trash2 } from '../utils/icons.js';
 
 function _runStats(name, workspaceRuns) {
@@ -35,6 +36,7 @@ export function workspacesConfigView(
 
   return html`
     <div class="workspaces-config-table">
+      ${helpFor('workspace-runs')}
       <table>
         <thead>
           <tr>

--- a/worca-ui/app/views/worktrees.js
+++ b/worca-ui/app/views/worktrees.js
@@ -1,6 +1,7 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { formatDuration } from '../utils/duration.js';
+import { helpFor } from '../utils/help-links.js';
 import { iconSvg, Trash2 } from '../utils/icons.js';
 import { sortByStartDesc } from '../utils/sort-runs.js';
 import { statusClass, statusIcon } from '../utils/status-badge.js';
@@ -444,6 +445,7 @@ export function worktreesView(
 
   return html`
     <div class="worktrees-view">
+      ${helpFor('worktrees')}
       ${_diskSummaryView(worktrees, diskWarningBytes)}
       ${
         onStatusFilter

--- a/worca-ui/docs/help-mode-prototype.md
+++ b/worca-ui/docs/help-mode-prototype.md
@@ -38,39 +38,94 @@ Trade-off awareness (see also `.worca/analyses/issue-259.md`):
 | `app/styles.css` (appended block) | `.help-edge-tab` (rotated label, hover, active state), `.help-badge` (hidden until `body.help-mode-active`, absolute top-right of parent, glow pulse, `prefers-reduced-motion` fallback to static highlight), dark-mode tokens. |
 | `app/main.js` | Bootstrap: mount the edge tab into `<div id="help-edge-tab-root">` appended to `<body>`, bind keyboard. |
 
-## Instrumented surfaces (this prototype)
+## Instrumented surfaces — full UI sweep
 
-**Settings — 8 of 11 tabs** (3 skipped because no doc page exists yet):
+After the initial 16-surface validation pass, the prototype was extended to cover every primary teaching surface across the UI. Total: **34 surfaces** across 14 view files, all mapping to existing pages under `docs-site/src/content/docs/`. The "one `?` per primary teaching surface" discipline rule still holds — no per-button / per-field placements.
 
-| Tab | helpId |
-|---|---|
-| Global: Projects | `add-project` |
-| Global: Notifications | *(skip — no doc)* |
-| Global: Preferences | `settings-overview` |
-| Global: Integrations | `chat` |
-| Project: Models | `agents-models` |
-| Project: Pipeline | `stages-config` |
-| Project: Governance | `governance` |
-| Project: Pricing | *(skip — no doc)* |
-| Project: Webhooks | `webhooks` |
-| Project: Graphify | `graphify` |
-| Project: Code Review Graph | `crg` |
+### Settings (`settings.js`)
 
-**Run Detail — 7 panels**:
+| Surface | helpId | Doc target |
+|---|---|---|
+| Global tab: Projects | `add-project` | getting-started/add-your-project |
+| Global tab: Notifications | *(skip — no doc)* | — |
+| Global tab: Preferences | `settings-overview` | configuration/settings-overview |
+| Global tab: Integrations | `chat` | integrations/chat-integrations |
+| Project tab: Models | `agents-models` | configuration/agents-and-models |
+| Project tab: Pipeline | `stages-config` | configuration/stages |
+| Project tab: Governance | `governance` | concepts/governance |
+| Project tab: Pricing | *(skip — no doc)* | — |
+| Project tab: Webhooks | `webhooks` | integrations/webhooks |
+| Project tab: Graphify | `graphify` | advanced/knowledge-graph |
+| Project tab: Code Review Graph | `crg` | advanced/code-review-graph |
+| Inline anchor at `settings.js:96` | `configuration-precedence` (via `helpUrl`) | configuration/precedence |
 
-| Surface | helpId |
-|---|---|
-| `.run-detail-overview` (lifecycle/run header) | `lifecycle` |
-| `.stage-timeline` wrapper | `pipeline-stages` |
-| `.plan-iter-selector` (plan revisions) | `plans-guides` |
-| `.dispatch-events-section` | `dispatch` |
-| `.circuit-breaker-banner` (sl-alert) | `loops` |
-| `.agent-prompt-header` (sl-details summary) | `agent-prompt` |
-| `.approval-panel` (sl-card PR approval) | `reviewing` |
+### Run Detail (`run-detail.js`)
 
-**Other:** the inline `<a href="https://docs.worca.dev/configuration/precedence/">Learn more →</a>` at `settings.js:96` was migrated to use `helpUrl('configuration-precedence')` — keeping the inline-prose treatment but routing through the registry.
+| Surface | helpId | Doc target |
+|---|---|---|
+| `.run-detail-overview` (lifecycle/run header) | `lifecycle` | concepts/lifecycle-and-state |
+| `.stage-timeline` wrapper | `pipeline-stages` | concepts/the-pipeline-and-stages |
+| `.plan-iter-selector` (plan revisions) | `plans-guides` | concepts/plans-work-requests-and-guides |
+| `.dispatch-events-section` | `dispatch` | advanced/dispatch-governance |
+| `.circuit-breaker-banner` (sl-alert) | `loops` | configuration/loops-and-circuit-breaker |
+| `.agent-prompt-header` (sl-details summary) | `agent-prompt` | advanced/anatomy-of-an-agent-prompt |
+| `.approval-panel` (sl-card PR approval) | `reviewing` | running-pipelines/reviewing-the-result |
 
-Out of scope for this prototype (intentionally — covered after pattern validation): launchers (new-run, fleet, workspace), dashboard, sidebar, Pipeline Templates list page, Run Timeline view header.
+### Pipeline Templates (`pipelines.js`, `pipelines-editor.js`)
+
+| Surface | helpId | Doc target |
+|---|---|---|
+| Templates list page | `templates` | concepts/pipeline-templates |
+| Template editor (subheader) | `authoring-templates` | advanced/authoring-templates |
+| Editor tab: Agents | `agents-models` | configuration/agents-and-models |
+| Editor tab: Pipeline | `stages-config` | configuration/stages |
+| Editor tab: Governance | `dispatch` | advanced/dispatch-governance |
+
+### Run Timeline (`run-timeline.js`)
+
+| Surface | helpId | Doc target |
+|---|---|---|
+| Timeline view container | `timeline-view` | running-pipelines/timeline-view |
+
+### Launchers (`new-run.js`, `fleet-launcher.js`, `workspace-create.js`)
+
+| Surface | helpId | Doc target |
+|---|---|---|
+| New Run form | `launching` | running-pipelines/launching-a-run |
+| Fleet Launcher form (fleet mode) | `fleet-runs` | advanced/fleet-runs |
+| Fleet Launcher form (workspace mode) | `workspace-runs` | advanced/workspace-runs |
+| Workspace Create form | `workspace-runs` | advanced/workspace-runs |
+
+### Dashboard + sidebar + integrations (`dashboard.js`, `sidebar.js`, `integrations.js`, `webhook-inbox.js`)
+
+| Surface | helpId | Doc target |
+|---|---|---|
+| Dashboard view | `monitoring` | running-pipelines/monitoring-a-run |
+| Sidebar Worktrees item | `worktrees` | advanced/worktree-cleanup |
+| Integrations panel (settings tab body) | `chat` | integrations/chat-integrations |
+| Webhook inbox view | `webhooks` | integrations/webhooks |
+
+### Detail + edit + listing views (`fleet-detail.js`, `workspace-detail.js`, `workspace-edit.js`, `workspaces-config.js`, `worktrees.js`)
+
+| Surface | helpId | Doc target |
+|---|---|---|
+| Fleet Detail page | `fleet-runs` | advanced/fleet-runs |
+| Workspace Detail page | `workspace-runs` | advanced/workspace-runs |
+| Workspace Edit form | `workspace-runs` | advanced/workspace-runs |
+| Workspaces Config table | `workspace-runs` | advanced/workspace-runs |
+| Worktrees page | `worktrees` | advanced/worktree-cleanup |
+
+### Surfaces deliberately uninstrumented
+
+- `beads-panel.js`, `token-costs.js`, `learnings-panel.js`, `live-output.js`, `log-viewer.js` — no dedicated doc page yet; the skip-if-no-doc rule prevents `?` icons that would link to 404s or thin pages.
+- `settings-graphify.js`, `settings-code-review-graph.js` — covered transitively via the parent settings tabs.
+- `dispatch-section.js`, `stage-timeline.js` — covered transitively via `run-detail.js`.
+- `add-project-dialog.js` — dialog; help-mode activation is unlikely while modal-focused. Available as `add-project` helpId if desired later.
+- `dag-graph.js`, `fleet-card.js`, `run-card.js`, `workspace-card.js`, `run-list.js`, `group-rendering.js`, `agent-names.js`, `dispatch-tag-state.js`, `launcher-shared.js`, `stage-tab-memory.js` — utility / card / shared components; not primary teaching surfaces.
+
+### Registry coverage
+
+All 34 placements map to entries already in `HELP_LINKS` (the registry was sized for ~25 ids during the initial prototype; the full UI sweep added zero new entries). Doc pages currently in the tree but unused by any UI surface (preserved in the registry for future use): `effort`, `secrets`, `controlling`, `first-run`, `events`. Doc pages not in the registry but available as future targets: adding-models, anatomy-of-an-agent-prompt (already used), authoring-templates (already used), overriding-agent-prompts, running-from-the-cli, guides, agents-models-and-effort, fleet-and-workspace-runs, installation, prerequisites, the four introduction/* pages, the four reference/* pages, and upgrading/upgrading.
 
 ## How to evaluate
 

--- a/worca-ui/docs/help-mode-prototype.md
+++ b/worca-ui/docs/help-mode-prototype.md
@@ -1,0 +1,103 @@
+# Help-mode prototype (W-061 alternative)
+
+**Branch:** `prototype/W-061-help-mode-toggle`
+**Status:** Prototype — for design evaluation, not for merge.
+**Replaces:** the always-on inline `?` icon approach in `docs/plans/W-061-in-app-help-links.md`.
+
+## What it does
+
+A persistent **right-edge "Help" tab** (rotated label + `?` kbd hint) and the
+**`?` keyboard shortcut** both toggle "help mode." When help mode is on, every
+UI surface that registered a `helpFor(id)` call reveals a glowing primary-coloured
+badge anchored to its top-right corner. Click the badge → opens the relevant
+`docs.worca.dev` page in a new tab. `Escape` closes help mode.
+
+When help mode is off, the UI is unchanged — zero baseline visual noise.
+
+## Why prototype this instead of the inline-icon plan
+
+The original W-061 plan placed ~22 always-on `?` icons across the UI (now
+closer to ~30 after W-062 + W-063). That's defensible but visually heavy in
+dense ops panels (dispatch governance, run-detail). This prototype tests
+whether an opt-in reveal pattern works better.
+
+Trade-off awareness (see also `.worca/analyses/issue-259.md`):
+- **Win**: zero baseline noise; single discoverable affordance.
+- **Loss**: two-click cost per lookup (toggle, then click); right-edge tabs
+  carry "chat widget" association in users' muscle memory.
+- **Novel**: this pattern is uncommon for ongoing docs discovery (it's the
+  norm for one-shot product tours via Pendo/Appcues, less so for reference).
+
+## Architecture
+
+| File | Role |
+|---|---|
+| `app/utils/help-links.js` | Frozen `HELP_LINKS` registry (helpId → `{slug, title}`), `helpUrl(id)`, `helpFor(id)` lit-html template. |
+| `app/utils/help-mode.js` | `isActive()` / `setActive()` / `toggle()` / `subscribe()`. Owns `body.help-mode-active`. Binds `?` and `Escape` globally with an input-focus guard. |
+| `app/views/help-edge-tab.js` | The right-edge tab. Re-renders only when help-mode state flips (subscribed via `help-mode.subscribe`). Lives in its own fixed-position root outside the lit-html app, so route changes don't unmount it. |
+| `app/styles.css` (appended block) | `.help-edge-tab` (rotated label, hover, active state), `.help-badge` (hidden until `body.help-mode-active`, absolute top-right of parent, glow pulse, `prefers-reduced-motion` fallback to static highlight), dark-mode tokens. |
+| `app/main.js` | Bootstrap: mount the edge tab into `<div id="help-edge-tab-root">` appended to `<body>`, bind keyboard. |
+
+## Instrumented surfaces (this prototype)
+
+**Settings — 8 of 11 tabs** (3 skipped because no doc page exists yet):
+
+| Tab | helpId |
+|---|---|
+| Global: Projects | `add-project` |
+| Global: Notifications | *(skip — no doc)* |
+| Global: Preferences | `settings-overview` |
+| Global: Integrations | `chat` |
+| Project: Models | `agents-models` |
+| Project: Pipeline | `stages-config` |
+| Project: Governance | `governance` |
+| Project: Pricing | *(skip — no doc)* |
+| Project: Webhooks | `webhooks` |
+| Project: Graphify | `graphify` |
+| Project: Code Review Graph | `crg` |
+
+**Run Detail — 7 panels**:
+
+| Surface | helpId |
+|---|---|
+| `.run-detail-overview` (lifecycle/run header) | `lifecycle` |
+| `.stage-timeline` wrapper | `pipeline-stages` |
+| `.plan-iter-selector` (plan revisions) | `plans-guides` |
+| `.dispatch-events-section` | `dispatch` |
+| `.circuit-breaker-banner` (sl-alert) | `loops` |
+| `.agent-prompt-header` (sl-details summary) | `agent-prompt` |
+| `.approval-panel` (sl-card PR approval) | `reviewing` |
+
+**Other:** the inline `<a href="https://docs.worca.dev/configuration/precedence/">Learn more →</a>` at `settings.js:96` was migrated to use `helpUrl('configuration-precedence')` — keeping the inline-prose treatment but routing through the registry.
+
+Out of scope for this prototype (intentionally — covered after pattern validation): launchers (new-run, fleet, workspace), dashboard, sidebar, Pipeline Templates list page, Run Timeline view header.
+
+## How to evaluate
+
+1. `cd worca-ui && pnpm worca:ui:restart` (or `npm run build && pnpm worca:ui:restart`).
+2. Look for the vertical **"Help (?)"** tab on the right edge of the viewport. It should be muted-neutral idle, primary when active.
+3. Press `?` (Shift+/ on US keyboards) or click the edge tab.
+4. Navigate to Settings → Pipeline Templates and watch every instrumented tab reveal a glowing badge in its top-right corner.
+5. Open a run → Run Detail. Every panel header listed above should sprout a badge.
+6. Click any badge → opens `docs.worca.dev/<slug>/` in a new tab.
+7. Press `Escape` or click the edge tab again to close.
+8. Test reduced-motion: enable "Reduce motion" in macOS System Settings → Accessibility → Display. Reload. Help mode should still reveal badges but with no pulse animation.
+
+## Known limitations / things to evaluate
+
+- **`:has()` selector dependency.** The CSS uses `body.help-mode-active *:has(> .help-badge)` to auto-`position: relative` any direct parent of a badge. Supported in Chrome 105+, Safari 15.4+, Firefox 121+. Older browsers will see the badge mis-position to the nearest positioned ancestor (degraded but not broken).
+- **sl-tab badge placement.** Inside sl-tab label slots, the badge is nudged outward (`top: -6px; right: -6px`) so it sits at the tab's corner rather than overlapping the label text. Visually evaluate this on Settings tabs — it may need further tuning per Shoelace version.
+- **No tests.** This is a prototype; if the pattern survives evaluation, write `help-links.test.js` (L1 source-resolution), `help-mode.test.js` (state machine + keyboard), and `e2e/help-mode.spec.js` (toggle → reveal → click).
+- **No L2 release check.** The `scripts/check-help-links-live.py` from the original plan is unimplemented in this prototype.
+- **No build-time `WORCA_DOCS_BASE` override.** The original plan's esbuild `define` is also unimplemented; the registry defaults to production docs.
+- **Not all surfaces instrumented.** Launchers, dashboard, sidebar, Pipeline Templates page, and Run Timeline header are deliberately uncovered so they don't dilute the evaluation. The pattern works regardless; fan-out is mechanical.
+
+## Decision points for "should we merge this approach"
+
+After clicking through, the question to answer is:
+
+> Is the **opt-in reveal** discoverable enough for new users, given that the edge tab is the only persistent affordance? Or do users actually want the always-on inline `?` from the original plan, density cost included?
+
+If opt-in survives, the follow-ups are: (1) instrument remaining surfaces, (2) write the test suite, (3) implement L1 + L2 sync checks, (4) reconcile with the W-061 plan file.
+
+If opt-in does not survive, fall back to the inline-icon plan but apply the **coarser placement discipline** (Option A from the analysis): one `?` per route/section rather than per panel, dropping the inventory from ~30 to ~12.

--- a/worca-ui/e2e/help-mode.spec.js
+++ b/worca-ui/e2e/help-mode.spec.js
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test';
+import { startServer } from './fixtures.js';
+
+/**
+ * W-061 in-app help — opt-in toggle pattern.
+ *
+ * The "Docs" tab on the right edge + the `?` keyboard shortcut both flip
+ * `body.help-mode-active`, which reveals every `.help-badge` that
+ * `helpFor()` rendered into the page. Badges are real anchor links to
+ * `docs.worca.dev/<slug>/`, opening in a new tab.
+ *
+ * Per CLAUDE.md: run this spec with `--workers=1` to avoid the parallel
+ * worker contamination Playwright still hits in this repo.
+ */
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+test.describe('help-mode toggle — edge tab + hotkey + reveal', () => {
+  test('edge tab is mounted on bootstrap, before any user interaction', async ({
+    page,
+  }) => {
+    const ctx = await startServer();
+    try {
+      await page.goto(`${ctx.url}/#/dashboard`, GOTO_OPTS);
+      const tab = page.locator('.help-edge-tab');
+      await expect(tab).toBeVisible();
+      // Reads "Docs" — distinguishes from chat-widget side tabs.
+      await expect(tab.locator('.help-edge-tab__label')).toHaveText('Docs');
+      // aria-pressed reflects the current help-mode state.
+      await expect(tab).toHaveAttribute('aria-pressed', 'false');
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test('badges are hidden until help mode activates, then revealed', async ({
+    page,
+  }) => {
+    const ctx = await startServer();
+    try {
+      await page.goto(`${ctx.url}/#/dashboard`, GOTO_OPTS);
+      // Dashboard view carries helpFor('monitoring') — the badge element
+      // exists in the DOM but starts hidden via `display: none`.
+      const badge = page.locator('.dashboard .help-badge').first();
+      await expect(badge).toBeAttached();
+      await expect(badge).toBeHidden();
+
+      // Click the edge tab to flip help mode on.
+      await page.locator('.help-edge-tab').click();
+      await expect(page.locator('body.help-mode-active')).toBeVisible();
+      await expect(page.locator('.help-edge-tab')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+
+      // Now the badge becomes visible.
+      await expect(badge).toBeVisible();
+      // And it carries a real href into the canonical docs URL.
+      await expect(badge).toHaveAttribute(
+        'href',
+        /https:\/\/docs\.worca\.dev\/running-pipelines\/monitoring-a-run\//,
+      );
+      // Anchor opens in a new tab safely.
+      await expect(badge).toHaveAttribute('target', '_blank');
+      await expect(badge).toHaveAttribute('rel', /noopener/);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test('`?` hotkey toggles help mode when typed outside a text input', async ({
+    page,
+  }) => {
+    const ctx = await startServer();
+    try {
+      await page.goto(`${ctx.url}/#/dashboard`, GOTO_OPTS);
+      // Move focus to <body> so the keystroke isn't swallowed by any
+      // form control the page auto-focused on load.
+      await page.locator('body').click({ position: { x: 5, y: 5 } });
+
+      await page.keyboard.press('Shift+Slash'); // produces "?"
+      await expect(page.locator('body.help-mode-active')).toBeVisible();
+
+      // Escape closes it.
+      await page.keyboard.press('Escape');
+      await expect(page.locator('body.help-mode-active')).toHaveCount(0);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test('Settings tabs each sprout a badge in help mode', async ({ page }) => {
+    const ctx = await startServer();
+    try {
+      await page.goto(`${ctx.url}/#/settings`, GOTO_OPTS);
+      // Activate help mode.
+      await page.locator('.help-edge-tab').click();
+      await expect(page.locator('body.help-mode-active')).toBeVisible();
+
+      // The "Integrations" tab in the global settings panel carries
+      // helpFor('chat') → integrations/chat-integrations.
+      const tabBadge = page
+        .locator('sl-tab[panel="integrations"] .help-badge')
+        .first();
+      await expect(tabBadge).toBeVisible();
+      await expect(tabBadge).toHaveAttribute(
+        'href',
+        /https:\/\/docs\.worca\.dev\/integrations\/chat-integrations\//,
+      );
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/scripts/build-frontend.js
+++ b/worca-ui/scripts/build-frontend.js
@@ -117,7 +117,15 @@ async function run() {
 
   try {
     const esbuild = await import('esbuild');
-    await esbuild.build({
+    // Optional build-time override of the docs base URL used by
+    // worca-ui/app/utils/help-links.js. Production / npm-published
+    // builds leave WORCA_DOCS_BASE unset and fall through to the
+    // 'https://docs.worca.dev' default baked into the module.
+    // Local + staging previews can retarget the badges:
+    //   WORCA_DOCS_BASE=http://localhost:4321        npm run build
+    //   WORCA_DOCS_BASE=http://staging.docs.example  npm run build
+    const docsBase = process.env.WORCA_DOCS_BASE;
+    const buildOpts = {
       entryPoints: [entry],
       bundle: true,
       format: 'esm',
@@ -127,7 +135,12 @@ async function run() {
       sourcemap: true,
       minify: true,
       legalComments: 'none',
-    });
+    };
+    if (docsBase) {
+      buildOpts.define = { WORCA_DOCS_BASE: JSON.stringify(docsBase) };
+      console.log('help-links DOCS_BASE override:', docsBase);
+    }
+    await esbuild.build(buildOpts);
     console.log('built', path.relative(repoRoot, outfile));
   } catch (err) {
     console.error('bundle error', err);


### PR DESCRIPTION
Closes #259.

W-061 in-app help, opt-in **toggle pattern**: a persistent right-edge **"Docs"** tab + the `?` keyboard shortcut both flip `body.help-mode-active`, revealing a glowing violet `?` badge at every primary teaching surface in the UI. Click any badge → opens the relevant `docs.worca.dev` page in a new tab. Zero baseline visual noise.

## Pattern change vs the original W-061 plan

The original plan (2026-05-30 draft) shipped **always-on** inline `?` icons at every surface. After prototype evaluation we switched to **opt-in reveal** via a toggle. Both patterns respect the same "one `?` per primary teaching surface" discipline rule — the difference is whether badges are visible by default. The toggle pattern keeps dense ops panels (dispatch governance, run detail) free of visual noise and gives users a single discoverable affordance to learn about.

The plan file (`docs/plans/W-061-in-app-help-links.md`) has been rewritten in this PR to reflect the toggle design.

## What ships

### Infrastructure

| File | Role |
|---|---|
| `worca-ui/app/utils/help-links.js` | `HELP_LINKS` registry (30 entries), `helpUrl(id)`, `helpFor(id)` lit-html template |
| `worca-ui/app/utils/help-mode.js` | State machine — `isActive`/`setActive`/`toggle`/`subscribe`, global `?` + Escape keybindings with input-focus guard |
| `worca-ui/app/views/help-edge-tab.js` | Right-edge "Docs" tab — vertical mono label matching the WORCA wordmark, 75% opacity idle, click toggles help mode |
| `worca-ui/app/utils/icons.js` | Re-exports `CircleHelp` (used by the edge tab; the badge uses a plain text `?` glyph instead) |
| `worca-ui/app/styles.css` | `.help-edge-tab` + `.help-badge` + sonar `@keyframes` + `prefers-reduced-motion` fallback + dark-mode tokens |
| `worca-ui/app/main.js` | Mounts the edge tab into a `<div id="help-edge-tab-root">` outside the lit-html app root, binds keyboard |
| `worca-ui/scripts/build-frontend.js` | Optional `WORCA_DOCS_BASE` esbuild `define` for local/staging previews |

### Surface instrumentation (34 placements across 14 view files)

Settings (8 of 11 tabs + 1 inline-anchor migration), Run Detail (7 panels), Pipeline Templates list + editor (5 surfaces: list + subheader + 3 editor tabs), Run Timeline (1), Launchers (3 — new-run, fleet, workspace-create), Dashboard (2 — top + empty-state), Sidebar (Worktrees + Webhooks), Integrations panel, Webhook Inbox, Fleet Detail, Workspace Detail / Edit / Config, Worktrees page.

The inline `<a href="https://docs.worca.dev/configuration/precedence/">Learn more →</a>` that already existed at `settings.js:96` (contrary to the issue body's "no inline anchor today" claim) was migrated to route through `helpUrl('configuration-precedence')`.

Skipped (no doc page exists yet): Pricing, Notifications, Beads, Token costs, Learnings, Live output, Log viewer. Discipline rule: a `?` linking to a 404 destroys trust.

Full mapping table in `worca-ui/docs/help-mode-prototype.md` and `docs/plans/W-061-in-app-help-links.md` § "Placement — concrete map".

### CI sync — two layers

**L1 — source check (every PR)** — `worca-ui/app/utils/help-links.test.js`. For every entry in `HELP_LINKS`, asserts the slug resolves to a real `.md` or `.mdx` file under `docs-site/src/content/docs/`, no slug carries an anchor fragment, every title is non-empty. Plus `helpUrl` / `helpFor` contract tests. 95 tests, all passing.

**L2 — release-time live check** — `scripts/check-help-links-live.py`. GET-probes every slug at `https://docs.worca.dev/<slug>/` with a browser-shaped User-Agent (raw HEAD via urllib hits CDN-level 403 across the whole site, which would mask real 404s — the first revision of this script tripped over that). Wired into the `worca-release-preflight` subagent as Step 6 with the `/worca-docs-publish` fix hint.

### Playwright e2e

`worca-ui/e2e/help-mode.spec.js` — edge-tab boots, badges hidden-by-default + revealed on toggle, `?`-hotkey + Escape behaviour, Settings-tab badge anchor + `target="_blank"`.

## Visual treatment

- **Violet** (`#7c3aed`) — deliberately not blue (blue = primary actions + running), not green (= completed), not orange (= caution per the badge color language), not red (= failed), not yellow (= warning). Help mode reads as informational and never competes with status semantics.
- **27×27 violet disc** at 75% opacity, anchored top-right of each host, with a **plain text `?` glyph** (not a lucide icon — lucide's variants all bake in a container shape around the glyph, which produced a "two-circle" artifact in early iterations).
- **Sonar wave** — `::after` pseudo-element scales 1 → 1.5, opacity 0.55 → 0, 2.4 s ease-out infinite. Static dim halo under `prefers-reduced-motion: reduce`.

## Known follow-up before merge

The L2 check currently surfaces **one 404**: `running-pipelines/timeline-view` (the page @SinishaDjukic flagged). The local doc exists (added in `cb8e3ca` with W-063) but `docs-live` has not been fast-forwarded since. Fix: `/worca-docs-publish`. Not run automatically because publishing docs is outward-facing — leaving the decision (publish vs remove the entry) for the reviewer.

## Tests

- vitest: **4560/4560** pass (273 files + the new 95-case L1 suite)
- biome: clean
- ruff (new Python script): clean
- Playwright e2e: not run in this PR (requires Chromium install on the runner); included as a new spec for CI to pick up
- Manual visual sweep: all 34 surfaces verified with help mode toggled across light + dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
