### PR TITLE
fix(tests): stop test_crg_validation_spike hangs (~2 min) on local pytest

### DIFF
--- a/src/worca/scripts/crg_validation_spike.py
+++ b/src/worca/scripts/crg_validation_spike.py
@@ -25,6 +25,7 @@ Fallback strategies (plan §5) are attached to each failing gate result.
 import json
 import os
 import re
+import select
 import shutil
 import subprocess
 import time
@@ -97,11 +98,30 @@ def _mcp_request(method: str, params: Optional[dict] = None, req_id: Optional[in
     return f"Content-Length: {len(body)}\r\n\r\n{body}".encode()
 
 
+def _wait_readable(stream, max_wait: float) -> bool:
+    """Block up to ``max_wait`` seconds for ``stream`` to be readable.
+
+    Why: ``read(1)`` on a subprocess pipe blocks indefinitely when the child
+    is silent — the surrounding deadline loop only checks between reads. On
+    POSIX, ``select`` enforces the wait. On Windows (no select-on-pipes),
+    fall back to letting the blocking read proceed.
+    """
+    if max_wait <= 0:
+        return False
+    try:
+        ready, _, _ = select.select([stream], [], [], max_wait)
+    except (OSError, ValueError):
+        return True
+    return bool(ready)
+
+
 def _read_mcp_response(proc, timeout: float = 10.0) -> Optional[dict]:
     """Read one JSON-RPC response from an MCP stdio server."""
     deadline = time.monotonic() + timeout
     header = b""
     while time.monotonic() < deadline:
+        if not _wait_readable(proc.stdout, deadline - time.monotonic()):
+            return None
         ch = proc.stdout.read(1)
         if not ch:
             return None
@@ -121,10 +141,15 @@ def _read_mcp_response(proc, timeout: float = 10.0) -> Optional[dict]:
 
     body = b""
     while len(body) < content_length and time.monotonic() < deadline:
+        if not _wait_readable(proc.stdout, deadline - time.monotonic()):
+            return None
         chunk = proc.stdout.read(content_length - len(body))
         if not chunk:
             return None
         body += chunk
+
+    if len(body) < content_length:
+        return None
 
     return json.loads(body.decode())
 

--- a/tests/test_crg_validation_spike.py
+++ b/tests/test_crg_validation_spike.py
@@ -14,6 +14,7 @@ import shutil
 
 import pytest
 
+import worca.scripts.crg_validation_spike as crg_spike
 from worca.scripts.crg_validation_spike import (
     MUTATING_TOOLS,
     READ_TOOLS,
@@ -29,6 +30,17 @@ requires_crg = pytest.mark.skipif(
     shutil.which("code-review-graph") is None,
     reason="code-review-graph not installed",
 )
+
+
+@pytest.fixture
+def crg_not_installed(monkeypatch):
+    """Force the skip path regardless of whether CRG is locally installed.
+
+    Without this, the "skip" tests below silently spawn ``code-review-graph
+    serve`` on dev machines that happen to have CRG installed, then hang on
+    the MCP read until pytest-timeout fires.
+    """
+    monkeypatch.setattr(crg_spike, "_crg_available", lambda: False)
 
 
 # ── is_dml classification ──────────────────────────────────────────
@@ -142,15 +154,15 @@ class TestValidationResult:
 # ── Gate 1: read tools no DML (unit, mocked) ───────────────────────
 
 class TestValidateReadToolsNoDml:
-    def test_returns_skip_when_crg_not_importable(self, tmp_path):
+    def test_returns_skip_when_crg_not_importable(self, tmp_path, crg_not_installed):
         db = tmp_path / "graph.db"
         db.touch()
         result = validate_read_tools_no_dml(str(db), str(tmp_path))
-        if shutil.which("code-review-graph") is None:
-            assert result.passed is True
-            assert "skip" in result.details.lower() or "not installed" in result.details.lower()
+        assert result.passed is True
+        assert "skip" in result.details.lower() or "not installed" in result.details.lower()
 
     @requires_crg
+    @pytest.mark.timeout(15)
     def test_real_read_tools_emit_no_dml(self, tmp_path):
         """When CRG is installed, build a graph and verify read tools emit no DML."""
         import os
@@ -182,13 +194,13 @@ class TestValidateReadToolsNoDml:
 # ── Gate 2: serve honors env vars (unit, mocked) ───────────────────
 
 class TestValidateEnvVarHonor:
-    def test_returns_skip_when_crg_not_installed(self, tmp_path):
+    def test_returns_skip_when_crg_not_installed(self, tmp_path, crg_not_installed):
         result = validate_env_var_honor(str(tmp_path), str(tmp_path))
-        if shutil.which("code-review-graph") is None:
-            assert result.passed is True
-            assert "skip" in result.details.lower() or "not installed" in result.details.lower()
+        assert result.passed is True
+        assert "skip" in result.details.lower() or "not installed" in result.details.lower()
 
     @requires_crg
+    @pytest.mark.timeout(15)
     def test_serve_reads_from_env_var_location(self, tmp_path):
         """When CRG installed, verify serve reads from CRG_DATA_DIR, not project default."""
         import os
@@ -219,13 +231,13 @@ class TestValidateEnvVarHonor:
 # ── Gate 3: startup latency (unit, mocked) ─────────────────────────
 
 class TestMeasureServeStartupLatency:
-    def test_returns_skip_when_crg_not_installed(self, tmp_path):
+    def test_returns_skip_when_crg_not_installed(self, tmp_path, crg_not_installed):
         result = measure_serve_startup_latency(str(tmp_path), str(tmp_path))
-        if shutil.which("code-review-graph") is None:
-            assert result.passed is True
-            assert "skip" in result.details.lower() or "not installed" in result.details.lower()
+        assert result.passed is True
+        assert "skip" in result.details.lower() or "not installed" in result.details.lower()
 
     @requires_crg
+    @pytest.mark.timeout(15)
     def test_measures_latency(self, tmp_path):
         """When CRG installed, startup latency should be under 10s (generous threshold)."""
         import os
@@ -268,8 +280,6 @@ class TestRunAllGates:
         gates = {r.gate for r in results}
         assert gates == {"read_tools_no_dml", "env_var_honor", "startup_latency"}
 
-    def test_when_crg_missing_all_skip_as_passed(self, tmp_path):
-        if shutil.which("code-review-graph") is not None:
-            pytest.skip("CRG is installed — skip-path not exercised")
+    def test_when_crg_missing_all_skip_as_passed(self, tmp_path, crg_not_installed):
         results = run_all_gates(str(tmp_path), str(tmp_path))
         assert all(r.passed for r in results)


### PR DESCRIPTION
## Summary

- `_read_mcp_response`'s blocking `proc.stdout.read(1)` made the `timeout=` parameter a lie — when CRG's `serve` is silent, the read sits indefinitely and only the global `pytest-timeout=30` unblocks it.
- Four tests in `test_crg_validation_spike.py` each burned 30 s on any dev machine with `code-review-graph` installed, adding ~**2 minutes** to every local `pytest tests/` run. CI is unaffected (CRG isn't installed there → `@requires_crg` tests skip).
- Surfaced from a worca pipeline run where the implementer kept backgrounding full-suite pytest invocations and the 2-min CRG tax stacked across iterations.

## Changes

- `_read_mcp_response` now waits via `select` so its `timeout` actually bounds the read; falls back to the existing blocking read on Windows (`select` doesn't support pipes there), unchanged from prior behavior.
- Three "skip when not installed" tests use a new `crg_not_installed` fixture (`monkeypatch` of `_crg_available`) so they exercise the skip path regardless of whether CRG is locally installed. The old `if shutil.which(...) is None:` guard silently no-op'd the assertion on dev boxes and let `validate_*` spawn `serve` and hang.
- The three `@requires_crg` tests get `pytest.mark.timeout(15)` so a broken local CRG install can't dominate suite wall time.

## Numbers

Full non-integration `pytest tests/` wall time on my machine:

| | Before | After |
|---|---|---|
| `test_crg_validation_spike.py` | 120 s | 35 s |
| Total suite | 198 s | 110 s |

The 3 `@requires_crg` tests still fail locally with clear errors (the local CRG install doesn't respond to MCP `initialize` — separate issue) but no longer hang. In CI they skip.

## Test plan

- [x] `ruff check .` — green
- [x] `pytest tests/test_crg_validation_spike.py` — locally: 33 pass, 3 fail fast with explicit errors (CRG-broken-locally), no hangs
- [x] `pytest tests/ --ignore=tests/integration` — 4 pre-existing `test_runner.py` failures unrelated to this branch (confirmed on master)
- [ ] CI green — should be the first time this file's been under 2 minutes locally without changing observable CI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)