### PR TITLE
W-067: Start a pipeline from a PR + review comments

### DIFF
--- a/docs/plans/W-067-pipeline-from-pr.md
+++ b/docs/plans/W-067-pipeline-from-pr.md
@@ -39,7 +39,7 @@ Add a new source scheme `gh:pr:N` (and full PR URL) that:
 
 | Landmine | Failure mode | Mitigation |
 |----------|--------------|------------|
-| **L1 — self-comment loop** | worca tries to "address" its own summary/reply comments, looping forever | Filter ingested threads to **human authors**, exclude the bot account that posts worca's comments. |
+| **L1 — self-comment loop** | worca tries to "address" its own summary/reply comments, looping forever | Every comment worca posts starts with a content marker (`WORCA_COMMENT_MARKER`, `🤖 worca`); ingestion skips any comment whose body begins with it. Content-based, so it needs no dedicated bot account/token and never false-excludes human reviewers who share worca's login. |
 | **L2 — head-branch-name drift** | recreating the head under a new name pushes to a *different* branch → spawns a **duplicate PR** instead of updating | Preserve the exact head branch name end-to-end; guardian pushes to it, never `gh pr create` in revise mode. |
 | **L3 — concurrent checkout** | the PR head branch may still be checked out in the original run's live worktree; a branch can only be checked out once | Fetch the head from remote into a **fresh** worktree (`gh pr checkout N`), never assume the original worktree is gone. |
 
@@ -76,7 +76,7 @@ class WorkRequest:
 - **Obstacle:** the REST `/pulls/N/comments` endpoint does **not** expose thread resolution state. Resolution + thread grouping requires GraphQL `reviewThreads`. (This is a *different* GraphQL field than the classic-Projects `projectCards` one that's broken in this repo per CLAUDE.md — `reviewThreads` is safe.)
 - **Resolution:** `gh_pr.py:fetch_review_feedback(nwo, pr_number)` runs a GraphQL query for `reviewThreads { isResolved, isOutdated, comments(first:N) { author { login }, path, line, originalLine, diffHunk, body, createdAt } }`, plus top-level `comments` and `reviews`. Then filter:
   1. **Unresolved** threads only (`isResolved == false`).
-  2. **Human authors only** — exclude the worca bot login (**L1**). Bot login resolved from config (`worca.pr_revision.bot_login`) or `gh api user` of the token; default heuristic = author of worca's own summary comments.
+  2. **Not worca's own** — exclude any comment whose body begins with `WORCA_COMMENT_MARKER` (`🤖 worca`) (**L1**). Content-based, so no dedicated bot account/token is needed and human reviewers sharing worca's login are never false-excluded.
   3. Drop empty/whitespace bodies.
 
   Normalized comment shape (also the JSON stored in status — §5):
@@ -155,7 +155,7 @@ ASCII flow:
 
 ```
 gh:pr:N / URL
-   │  normalize_github_pr()  +  gh_pr.py (GraphQL: unresolved, human-only)   [L1]
+   │  normalize_github_pr()  +  gh_pr.py (GraphQL: unresolved, non-worca)    [L1]
    ▼
 WorkRequest{ description = body + "## Review Feedback to Address",
              pr_head_branch, pr_base_branch, review_comments[] }
@@ -178,7 +178,7 @@ status.json{ source_type, revises_pr, review_feedback[] } ─► UI badge + comm
 **Tasks:**
 1. Add `gh:pr:N` + PR-URL parsing in `normalize()` (`:343-372`); GitHub-only guard for other providers.
 2. `normalize_github_pr()` — fetch PR metadata; extend `WorkRequest` (`:98-108`) with PR fields.
-3. `gh_pr.py:fetch_review_feedback()` — GraphQL `reviewThreads`, filter unresolved + human-only (**L1**), normalize to the §2 schema.
+3. `gh_pr.py:fetch_review_feedback()` — GraphQL `reviewThreads`, filter unresolved + drop worca's own marker-prefixed comments (**L1**), normalize to the §2 schema.
 4. Synthesize the "## Review Feedback to Address" description.
 
 ### Phase 2 — Worktree checkout-existing-head
@@ -253,7 +253,7 @@ status.json{ source_type, revises_pr, review_feedback[] } ─► UI badge + comm
 | Python | `test_normalize_github_pr_builds_work_request` | `gh:pr:N` → WorkRequest with head/base/comments |
 | Python | `test_pr_url_resolves_to_number` | full PR URL → PR number (GitHub) |
 | Python | `test_fetch_review_feedback_filters_resolved` | resolved threads dropped |
-| Python | `test_fetch_review_feedback_excludes_bot` | **L1** — worca's own comments excluded |
+| Python | `test_fetch_review_feedback_excludes_worca_marker` | **L1** — worca's own marker-prefixed comments excluded |
 | Python | `test_review_feedback_description_synthesis` | "## Review Feedback to Address" formatting + anchors |
 | Python | `test_worktree_pr_source_rejects_branch_flag` | `--branch` rejected for `gh:pr:N` |
 | Python | `test_worktree_pr_target_branch_from_base` | `target_branch == baseRefName` |

--- a/src/worca/agents/core/coordinator.md
+++ b/src/worca/agents/core/coordinator.md
@@ -74,6 +74,29 @@ The runner uses this map as the reliable, programmatic source for per-bead
 effort labels. The `--labels` flag on `bd create` is the best-effort
 first pass; the structured `effort` map is the authoritative fallback.
 
+{{#if has_review_comments}}
+## PR Revision Mode — Comment-to-Bead Decomposition
+
+This run is revising an existing PR based on review feedback. The approved plan is already scoped to the enumerated review comments; your job is to create one bead per unresolved comment so each implementer acts on exactly one thread.
+
+**Decomposition rules:**
+- Create **one bead per unresolved review comment** listed in the `## Review Feedback to Address` section of the work request.
+- Each bead title must include the file:line anchor and a brief label, e.g.: `Address review: src/foo.py:42 — fix file handle leak`.
+- Each bead description must carry the `thread_id` (e.g. `PRRT_xxx`), the file:line location, the comment author, and the comment body verbatim — so the implementer has full context without re-reading the work request.
+- Bead description format:
+
+  ```
+  Thread: PRRT_xxx
+  File: src/foo.py:42
+  Author: @reviewer-login
+  Comment: "exact comment text here"
+  ```
+
+- PR-level comments (no file:line anchor) get a bead with `File: PR-level` in the description.
+- Set dependencies between beads only when comments touch the same file or have a clear ordering constraint; otherwise leave them parallel.
+- Do **not** create additional beads for unrelated refactoring — this run is minimal-diff only.
+
+{{/if}}
 ## Rules
 
 <!-- governance -->

--- a/src/worca/agents/core/guardian.md
+++ b/src/worca/agents/core/guardian.md
@@ -16,6 +16,45 @@ The orchestrator has pre-computed your PR metadata for this run. Use the values 
 
 Run `git add -A`, commit with a scoped conventional message (see CLAUDE.md for the format), and push the branch: `git push -u origin <head_branch>`. If nothing stages, STOP with `outcome: reject`.
 
+{{#if revise_pr}}
+### Step 2 — Update the existing PR (#{{revise_pr}})
+
+This run is revising PR #{{revise_pr}}. The PR already exists — **do not** call `gh pr create` (or any host equivalent). Pushing the same head branch is sufficient to auto-update the PR (**L2** — head branch name preserved verbatim).
+
+**W-065 compose note:** `revise_pr` and `defer_pr` are mutually exclusive. When this run is in revision mode the PR already exists, so deferred-PR creation is a no-op.
+
+1. Capture the commit SHA just pushed in Step 1:
+   `git rev-parse HEAD`
+
+2. Get the repository `owner/repo` identifier:
+   `gh repo view --json nameWithOwner --jq .nameWithOwner`
+
+3. Post a summary comment on PR #{{revise_pr}} (error-suppressed — continue if it fails):
+   ```
+   gh api --method POST /repos/<nwo>/issues/{{revise_pr}}/comments \
+     -f body="Addressed review comments in commit \`<commit_sha>\`."
+   ```
+
+4. Reply to each addressed thread — **never resolve threads, reply only (D3)**:
+   Read `review_feedback` from `status.json` (field `review_feedback`, a list). For each entry with a `thread_id`, run:
+   ```
+   gh api graphql \
+     -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}' \
+     -f t="<thread_id>" \
+     -f b="Addressed in commit \`<commit_sha>\`."
+   ```
+   If `review_feedback` is absent or empty, skip this step. Treat individual reply failures as non-fatal — log and continue.
+
+5. Re-read the existing PR to populate the structured output:
+   `gh pr view {{revise_pr}} --json number,url,state`
+
+Return this structured output:
+- `outcome: "success"`
+- `pr_number: {{revise_pr}}`
+- `pr_url: <url from gh pr view>`
+
+If the push or summary comment fails, return `outcome: "reject"` with a descriptive reason.
+{{else}}
 {{#if defer_pr}}
 ### Step 2 — PR creation is deferred
 
@@ -49,6 +88,7 @@ Build the PR body from the work request and approach summary. If the orchestrato
 Then run the host CLI from CLAUDE.md to open the PR. With `gh`, that is:
 
 `gh pr create --base <base_branch> --head <head_branch> --title "<prefixed_title>" --body "<body>"`
+{{/if}}
 {{/if}}
 
 The work request and approach summary arrive as a user message.

--- a/src/worca/agents/core/guardian.md
+++ b/src/worca/agents/core/guardian.md
@@ -19,41 +19,19 @@ Run `git add -A`, commit with a scoped conventional message (see CLAUDE.md for t
 {{#if revise_pr}}
 ### Step 2 — Update the existing PR (#{{revise_pr}})
 
-This run is revising PR #{{revise_pr}}. The PR already exists — **do not** call `gh pr create` (or any host equivalent). Pushing the same head branch is sufficient to auto-update the PR (**L2** — head branch name preserved verbatim).
+This run is revising PR #{{revise_pr}}. The PR already exists — **do not** call `gh pr create` (or any host equivalent). Pushing the same head branch in Step 1 is sufficient to auto-update the PR (**L2** — head branch name preserved verbatim).
 
 **W-065 compose note:** `revise_pr` and `defer_pr` are mutually exclusive. When this run is in revision mode the PR already exists, so deferred-PR creation is a no-op.
 
-1. Capture the commit SHA just pushed in Step 1:
-   `git rev-parse HEAD`
+**Writeback is automatic — do not post comments yourself.** The orchestrator posts the summary comment and per-thread replies (reply-only, never resolve — D3) after you return, reading `review_feedback` from `status.json`. Your only job here is the push from Step 1.
 
-2. Get the repository `owner/repo` identifier:
-   `gh repo view --json nameWithOwner --jq .nameWithOwner`
+Capture the commit SHA you just pushed (`git rev-parse HEAD`) and return this structured output:
 
-3. Post a summary comment on PR #{{revise_pr}} (error-suppressed — continue if it fails):
-   ```
-   gh api --method POST /repos/<nwo>/issues/{{revise_pr}}/comments \
-     -f body="Addressed review comments in commit \`<commit_sha>\`."
-   ```
-
-4. Reply to each addressed thread — **never resolve threads, reply only (D3)**:
-   Read `review_feedback` from `status.json` (field `review_feedback`, a list). For each entry with a `thread_id`, run:
-   ```
-   gh api graphql \
-     -f query='mutation($t:ID!,$b:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){comment{id}}}' \
-     -f t="<thread_id>" \
-     -f b="Addressed in commit \`<commit_sha>\`."
-   ```
-   If `review_feedback` is absent or empty, skip this step. Treat individual reply failures as non-fatal — log and continue.
-
-5. Re-read the existing PR to populate the structured output:
-   `gh pr view {{revise_pr}} --json number,url,state`
-
-Return this structured output:
 - `outcome: "success"`
 - `pr_number: {{revise_pr}}`
-- `pr_url: <url from gh pr view>`
+- `commit_sha: "<short or full SHA of the commit you made>"` — used by the orchestrator in the summary/reply text and to verify HEAD moved.
 
-If the push or summary comment fails, return `outcome: "reject"` with a descriptive reason.
+The orchestrator re-reads the existing PR to fill in `pr_url`, so you do not need to emit it. If the push failed, return `outcome: "reject"` with a descriptive reason.
 {{else}}
 {{#if defer_pr}}
 ### Step 2 — PR creation is deferred

--- a/src/worca/agents/core/planner.md
+++ b/src/worca/agents/core/planner.md
@@ -43,6 +43,19 @@ When you detect a guide-vs-description or guide-vs-plan divergence, populate the
 
 Only populate `guide_conflicts` when a real conflict exists. Do not emit conflicts speculatively.
 
+{{#if has_review_comments}}
+## Constrained Revision Mode
+
+This run is revising an existing PR based on review feedback. You must operate in **minimal-diff mode**:
+
+- Produce a plan scoped **strictly** to the enumerated review feedback. Address each comment; nothing more.
+- **Preserve everything the reviewer did not object to.** Do not refactor, rename, or restructure code outside the scope of the feedback.
+- **Do not re-architect.** The existing design is accepted; the reviewer asked for specific changes, not a redesign.
+- For very small comment sets (one or two items), the plan may be a thin checklist rather than a full structured plan.
+
+The review feedback to address is in the `## Review Feedback to Address` section of the work request.
+
+{{/if}}
 ## Rules
 
 <!-- governance -->

--- a/src/worca/orchestrator/guardian_context.py
+++ b/src/worca/orchestrator/guardian_context.py
@@ -66,10 +66,36 @@ def compute_defer_pr(env: Mapping[str, str]) -> bool:
     return env.get("WORCA_DEFER_PR") == "1"
 
 
+def compute_revise_pr(env: Mapping[str, str]) -> int | None:
+    """Return the PR number to revise, or None if not in revision mode.
+
+    WORCA_REVISE_PR must be a positive integer string (the PR number).
+    Any other value — absent, empty, non-numeric, zero, negative — returns
+    None so misconfigured values never silently activate revision mode.
+    """
+    raw = env.get("WORCA_REVISE_PR", "").strip()
+    if not raw:
+        return None
+    try:
+        n = int(raw)
+    except ValueError:
+        return None
+    return n if n > 0 else None
+
+
 def build_guardian_context(env: Mapping[str, str]) -> dict:
-    """Bundle the three guardian template variables for ``_render_agent_templates``."""
+    """Bundle the guardian template variables for ``_render_agent_templates``.
+
+    Precedence: revise_pr > defer_pr.  When ``WORCA_REVISE_PR`` is set to a
+    valid PR number the PR already exists, so ``WORCA_DEFER_PR`` is a no-op —
+    defer_pr is forced to False regardless of its own env var.
+    """
+    revise_pr = compute_revise_pr(env)
+    # revise_pr takes precedence: an existing PR cannot be deferred.
+    defer_pr = False if revise_pr is not None else compute_defer_pr(env)
     return {
-        "defer_pr": compute_defer_pr(env),
+        "defer_pr": defer_pr,
+        "revise_pr": revise_pr,
         "pr_title_prefix": compute_pr_title_prefix(env),
         "pr_footer": compute_pr_footer(env),
     }

--- a/src/worca/orchestrator/prompt_builder.py
+++ b/src/worca/orchestrator/prompt_builder.py
@@ -216,6 +216,7 @@ class PromptBuilder:
         """
         if stage == "plan":
             ctx["claude_md"] = self._claude_md_content
+            ctx["has_review_comments"] = bool(ctx.get("review_comments"))
             if ctx.get("plan_revision_mode"):
                 # Prefer the plan content threaded by the runner at the revise
                 # loopback (the current plan being revised). Under W-061's
@@ -249,6 +250,7 @@ class PromptBuilder:
             # changelog. Prefer the plan content threaded from the last PLAN
             # completion; otherwise read the current (latest) plan file.
             ctx["current_plan"] = ctx.get("plan_file_content") or self._read_master_plan()
+            ctx["has_review_comments"] = bool(ctx.get("review_comments"))
 
             unresolved = ctx.get("unresolved_plan_issues")
             if unresolved:

--- a/src/worca/orchestrator/registry.py
+++ b/src/worca/orchestrator/registry.py
@@ -59,6 +59,7 @@ def register_pipeline(
     workspace_id=None,
     group_type=None,
     target_branch=None,
+    revises_pr=None,
 ):
     """Register a new pipeline. Returns the path to the registry file.
 
@@ -67,9 +68,13 @@ def register_pipeline(
 
     branch: the worktree's own branch name (e.g. "worca/<slug>-<run_id>") —
     stored so the Worktrees UI can show it without reading the worktree's
-    status.json. Distinct from target_branch (the PR base branch).
+    status.json. Distinct from target_branch (the PR base branch). For PR
+    revision runs this is the PR head branch name, preserved verbatim (L2).
 
     fleet_id and workspace_id are mutually exclusive; pass at most one.
+
+    revises_pr: PR number (int) when this run is revising an existing PR.
+    Absent for normal runs.
     """
     if fleet_id is not None and workspace_id is not None:
         raise ValueError("fleet_id and workspace_id are mutually exclusive; pass at most one")
@@ -94,6 +99,8 @@ def register_pipeline(
         data["group_type"] = group_type
     if target_branch is not None:
         data["target_branch"] = target_branch
+    if revises_pr is not None:
+        data["revises_pr"] = revises_pr
 
     path = _pipeline_path(run_id, base=base)
     _atomic_write(path, data)

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -41,7 +41,12 @@ from worca.state.status import (
 )
 from worca.utils.beads import bd_ready, bd_show, bd_update, bd_close, bd_label_add, bd_daemon_stop, bd_get_effort_label
 from worca.utils.gh_issues import gh_issue_start, gh_issue_complete
-from worca.utils.gh_pr import current_repo_nwo, post_revision_summary, reply_to_thread
+from worca.utils.gh_pr import (
+    WORCA_COMMENT_MARKER,
+    current_repo_nwo,
+    post_revision_summary,
+    reply_to_thread,
+)
 from worca.utils.claude_cli import run_agent, terminate_current, terminate_all, AgentSubprocessError
 from worca.utils.proc import pid_is_alive
 from worca.utils.proc_registry import kill_all_tracked
@@ -1446,6 +1451,9 @@ def _revise_pr_writeback(pr_number, commit_sha, review_feedback) -> None:
     formatting GraphQL by hand. Both helpers are error-suppressed and
     WORCA_NO_GITHUB-gated; failures here never fail the pipeline.
 
+    Every comment posted here starts with WORCA_COMMENT_MARKER so a later
+    revise run recognises and skips worca's own writeback (L1).
+
     - Summary: one top-level comment on the PR (D1 — update in place).
     - Replies: one reply per ingested thread that carries a thread_id (D3 —
       reply only, never resolve). Review-summary items have no thread_id and
@@ -1459,7 +1467,7 @@ def _revise_pr_writeback(pr_number, commit_sha, review_feedback) -> None:
     if nwo:
         n_threads = sum(1 for c in (review_feedback or []) if c.get("thread_id"))
         summary = (
-            f"worca addressed {n_threads} review "
+            f"{WORCA_COMMENT_MARKER} · addressed {n_threads} review "
             f"{'comment' if n_threads == 1 else 'comments'}{sha_phrase}."
         )
         post_revision_summary(nwo, pr_number, summary)
@@ -1470,7 +1478,7 @@ def _revise_pr_writeback(pr_number, commit_sha, review_feedback) -> None:
         if not thread_id or thread_id in seen_threads:
             continue
         seen_threads.add(thread_id)
-        reply_to_thread(nwo, thread_id, f"Addressed{sha_phrase}.")
+        reply_to_thread(nwo, thread_id, f"{WORCA_COMMENT_MARKER} · addressed{sha_phrase}.")
 
 
 def _verify_pr_via_gh(pr_number: int, expected_url: str, timeout: int = 10) -> Optional[PRVerification]:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -1415,6 +1415,28 @@ def _extract_pr_fields_from_text(text) -> Optional[dict]:
 PRVerification = collections.namedtuple("PRVerification", ["ok", "reason"])
 
 
+def _fetch_pr_url_via_gh(pr_number: int, timeout: int = 10) -> Optional[str]:
+    """Return the URL of an existing PR, or None on any error.
+
+    Used in revise mode to populate status["pr"].url when the guardian re-reads
+    an existing PR instead of creating a new one.
+    """
+    try:
+        r = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "url,number"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        data = json.loads(r.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+    return data.get("url") or None
+
+
 def _verify_pr_via_gh(pr_number: int, expected_url: str, timeout: int = 10) -> Optional[PRVerification]:
     """Best-effort `gh pr view` check.
 
@@ -2411,6 +2433,8 @@ def run_pipeline(
         prompt_builder.update_context("run_id", status.get("run_id", ""))
         prompt_builder.update_context("branch", branch_name)
         prompt_builder.update_context("title", work_request.title)
+        if work_request.review_comments:
+            prompt_builder.update_context("review_comments", work_request.review_comments)
         # Guardian template variables (issue #165): derived once here so the
         # dispatch-time resolve_agent call resolves {{pr_title_prefix}},
         # {{pr_footer}}, and {{#if defer_pr}} in guardian.md. Computed from
@@ -2559,6 +2583,11 @@ def run_pipeline(
                 }
                 if _eff_level is not None:
                     _effort_env_overrides["CLAUDE_CODE_EFFORT_LEVEL"] = _eff_level
+
+            if current_stage == Stage.PR:
+                _revises_pr_num = status.get("revises_pr")
+                if _revises_pr_num is not None:
+                    _effort_env_overrides["WORCA_REVISE_PR"] = str(_revises_pr_num)
 
             # Start a new iteration record
             _iter_kwargs = {
@@ -4074,6 +4103,16 @@ def run_pipeline(
                 if isinstance(result, dict):
                     _pr_url = result.get("pr_url")
                     _pr_number = result.get("pr_number")
+                    # In revise mode, if the agent's prose fallback didn't carry
+                    # pr_url/pr_number, re-read the existing PR via gh so
+                    # status["pr"] still populates with the correct number/url.
+                    _revises_pr = status.get("revises_pr")
+                    if _revises_pr is not None and (not _pr_url or _pr_number is None):
+                        _fetched_url = _fetch_pr_url_via_gh(_revises_pr)
+                        if _fetched_url and not _pr_url:
+                            _pr_url = _fetched_url
+                        if _pr_number is None:
+                            _pr_number = _revises_pr
                     if _pr_url and _pr_number is not None:
                         _commit_sha = result.get("commit_sha")
                         # Branches: prefer agent value, fall back to runner state.

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -41,6 +41,7 @@ from worca.state.status import (
 )
 from worca.utils.beads import bd_ready, bd_show, bd_update, bd_close, bd_label_add, bd_daemon_stop, bd_get_effort_label
 from worca.utils.gh_issues import gh_issue_start, gh_issue_complete
+from worca.utils.gh_pr import current_repo_nwo, post_revision_summary, reply_to_thread
 from worca.utils.claude_cli import run_agent, terminate_current, terminate_all, AgentSubprocessError
 from worca.utils.proc import pid_is_alive
 from worca.utils.proc_registry import kill_all_tracked
@@ -1435,6 +1436,41 @@ def _fetch_pr_url_via_gh(pr_number: int, timeout: int = 10) -> Optional[str]:
     except json.JSONDecodeError:
         return None
     return data.get("url") or None
+
+
+def _revise_pr_writeback(pr_number, commit_sha, review_feedback) -> None:
+    """Post the revision summary + per-thread replies for a revise-mode run.
+
+    Runner-side writeback (like gh_issues.py) — NOT an agent tool call — so it
+    bypasses the pre_tool_use governance hook and never depends on the guardian
+    formatting GraphQL by hand. Both helpers are error-suppressed and
+    WORCA_NO_GITHUB-gated; failures here never fail the pipeline.
+
+    - Summary: one top-level comment on the PR (D1 — update in place).
+    - Replies: one reply per ingested thread that carries a thread_id (D3 —
+      reply only, never resolve). Review-summary items have no thread_id and
+      are skipped. In a revision run every ingested unresolved thread is in
+      scope, so all of them are replied to with the addressing commit.
+    """
+    nwo = current_repo_nwo()
+    sha = (commit_sha or "").strip()
+    sha_phrase = f" in commit `{sha}`" if sha else ""
+
+    if nwo:
+        n_threads = sum(1 for c in (review_feedback or []) if c.get("thread_id"))
+        summary = (
+            f"worca addressed {n_threads} review "
+            f"{'comment' if n_threads == 1 else 'comments'}{sha_phrase}."
+        )
+        post_revision_summary(nwo, pr_number, summary)
+
+    seen_threads = set()
+    for comment in review_feedback or []:
+        thread_id = comment.get("thread_id")
+        if not thread_id or thread_id in seen_threads:
+            continue
+        seen_threads.add(thread_id)
+        reply_to_thread(nwo, thread_id, f"Addressed{sha_phrase}.")
 
 
 def _verify_pr_via_gh(pr_number: int, expected_url: str, timeout: int = 10) -> Optional[PRVerification]:
@@ -4155,6 +4191,18 @@ def run_pipeline(
                                 target_branch=_target_branch,
                                 provider=_provider,
                             ))
+
+                        # Revise mode: worca owns the PR writeback (summary
+                        # comment + per-thread replies). The guardian only
+                        # pushes the head branch; doing the writeback here keeps
+                        # it off the agent tool path and reliable (D3 — replies
+                        # only, never resolve).
+                        if _revises_pr is not None:
+                            _revise_pr_writeback(
+                                _pr_number,
+                                _commit_sha,
+                                status.get("review_feedback", []),
+                            )
 
                     _maybe_graphify_post_guardian(
                         settings_path=settings_path,

--- a/src/worca/orchestrator/work_request.py
+++ b/src/worca/orchestrator/work_request.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from worca.utils.env import get_env, filter_model_env
-from worca.utils.gh_pr import current_repo_nwo, fetch_review_feedback, resolve_bot_login
+from worca.utils.gh_pr import current_repo_nwo, fetch_review_feedback
 from worca.utils.settings import load_settings, resolve_model
 
 _DEFAULT_PLAN_PATH_TEMPLATE = "docs/plans/{timestamp}-{title_slug}.md"
@@ -418,20 +418,11 @@ def normalize_github_pr(source_value: str) -> WorkRequest:
     # The PR and its review threads live in the *base* repo — resolve the
     # owner/repo from the current repo (gh's default-repo logic), NOT from the
     # PR's headRepository (which for a fork PR is the wrong repo, and which
-    # `gh pr view` does not even expose a nameWithOwner for).
+    # `gh pr view` does not even expose a nameWithOwner for). fetch_review_feedback
+    # filters out worca's own marker-prefixed comments (L1) on its own.
     nwo = current_repo_nwo()
 
-    # L1 self-comment-loop guard: exclude worca's own bot comments. Prefer an
-    # explicit config override, else fall back to the authenticated gh token.
-    settings = load_settings(".claude/settings.json")
-    bot_login = (
-        settings.get("worca", {}).get("pr_revision", {}).get("bot_login")
-        or resolve_bot_login()
-    )
-
-    review_comments = (
-        fetch_review_feedback(nwo, pr_number, bot_login=bot_login) if nwo else []
-    )
+    review_comments = fetch_review_feedback(nwo, pr_number) if nwo else []
 
     return WorkRequest(
         source_type="github_pr",

--- a/src/worca/orchestrator/work_request.py
+++ b/src/worca/orchestrator/work_request.py
@@ -3,15 +3,18 @@ import json
 import os
 import re
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from worca.utils.env import get_env, filter_model_env
+from worca.utils.gh_pr import fetch_review_feedback
 from worca.utils.settings import load_settings, resolve_model
 
 _DEFAULT_PLAN_PATH_TEMPLATE = "docs/plans/{timestamp}-{title_slug}.md"
 # Matches GitHub issue URLs: https://github.com/owner/repo/issues/42
 _GH_ISSUE_URL_RE = re.compile(r"https?://github\.com/[^/]+/[^/]+/issues/(\d+)$")
+# Matches any HTTP(S) URL — used to detect URL inputs before routing to parse_pr_url()
+_ANY_URL_RE = re.compile(r"https?://")
 
 
 def _plan_prefix_from_template(template: Optional[str]) -> str:
@@ -98,13 +101,19 @@ def generate_smart_title(content: str, source_hint: str = "") -> str:
 @dataclass
 class WorkRequest:
     """Normalized work request from any input source."""
-    source_type: str  # "github_issue", "beads", "prompt", "spec_file"
+    source_type: str  # "github_issue", "beads", "prompt", "spec_file", "github_pr"
     title: str
     description: str = ""
     source_ref: Optional[str] = None
     priority: int = 2
     plan_path: Optional[str] = None
     guide_content: str = ""  # populated by attach_guide() — body of normative reference material
+    # PR-revision fields (populated when source_type == "github_pr")
+    pr_number: Optional[int] = None
+    pr_head_branch: Optional[str] = None
+    pr_base_branch: Optional[str] = None
+    pr_is_cross_repo: bool = False
+    review_comments: list = field(default_factory=list)
 
 
 def normalize_plan_file(path: str, content: str = None) -> WorkRequest:
@@ -312,6 +321,11 @@ def attach_guide(
             priority=wr.priority,
             plan_path=wr.plan_path,
             guide_content=wr.guide_content,
+            pr_number=wr.pr_number,
+            pr_head_branch=wr.pr_head_branch,
+            pr_base_branch=wr.pr_base_branch,
+            pr_is_cross_repo=wr.pr_is_cross_repo,
+            review_comments=wr.review_comments,
         )
 
     sections = []
@@ -337,17 +351,93 @@ def attach_guide(
         priority=wr.priority,
         plan_path=wr.plan_path,
         guide_content="\n".join(sections),
+        pr_number=wr.pr_number,
+        pr_head_branch=wr.pr_head_branch,
+        pr_base_branch=wr.pr_base_branch,
+        pr_is_cross_repo=wr.pr_is_cross_repo,
+        review_comments=wr.review_comments,
+    )
+
+
+def _synthesize_pr_description(body: str, review_comments: list) -> str:
+    """Build PR work-request description: original body + review feedback list."""
+    parts = [body.rstrip()] if body else []
+    if review_comments:
+        lines = []
+        for c in review_comments:
+            path = c.get("path", "")
+            line = c.get("line")
+            loc = f"{path}:{line}" if line is not None else path
+            author = c.get("author", "")
+            text = c.get("body", "")
+            thread_id = c.get("thread_id", "")
+            lines.append(f'- [{loc}] @{author}: "{text}" (thread: {thread_id})')
+        parts.append("\n## Review Feedback to Address\n")
+        parts.extend(lines)
+    return "\n".join(parts)
+
+
+def normalize_github_pr(source_value: str) -> WorkRequest:
+    """Normalize a GitHub PR reference into a WorkRequest.
+
+    source_value must be "gh:pr:N". Fetches PR metadata via gh CLI,
+    ingests unresolved review threads via fetch_review_feedback(), and
+    synthesizes description = original PR body + review feedback list.
+    """
+    if not source_value.startswith("gh:pr:"):
+        raise ValueError(f"Expected gh:pr:N, got: {source_value}")
+    number_str = source_value[len("gh:pr:"):]
+    try:
+        pr_number = int(number_str)
+    except ValueError:
+        raise ValueError(f"Invalid PR number in {source_value!r}")
+
+    result = subprocess.run(
+        [
+            "gh", "pr", "view", str(pr_number), "--json",
+            "title,body,baseRefName,headRefName,headRepository,isCrossRepository,author",
+        ],
+        capture_output=True,
+        text=True,
+        env=get_env(),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to fetch PR #{pr_number}: {result.stderr}")
+
+    data = json.loads(result.stdout)
+    title = data.get("title") or f"PR #{pr_number}"
+    body = data.get("body") or ""
+    base_branch = data.get("baseRefName", "")
+    head_branch = data.get("headRefName", "")
+    is_cross_repo = data.get("isCrossRepository", False)
+    nwo = (data.get("headRepository") or {}).get("nameWithOwner", "")
+
+    review_comments = fetch_review_feedback(nwo, pr_number) if nwo else []
+
+    return WorkRequest(
+        source_type="github_pr",
+        title=title,
+        description=_synthesize_pr_description(body, review_comments),
+        source_ref=source_value,
+        pr_number=pr_number,
+        pr_head_branch=head_branch,
+        pr_base_branch=base_branch,
+        pr_is_cross_repo=is_cross_repo,
+        review_comments=review_comments,
     )
 
 
 def normalize(source_type: str, source_value: str, **kwargs) -> WorkRequest:
     """Dispatch to the appropriate normalize_* function.
 
-    source_type can be "prompt", "spec", "plan", or "source" (auto-detect from value).
-    For "source", the value is sniffed: gh:issue:N → GitHub, bd:ID → Beads.
+    source_type can be "prompt", "spec", "plan", "pr", or "source" (auto-detect from value).
+    For "source", the value is sniffed: gh:issue:N → GitHub issue, gh:pr:N → GitHub PR,
+    bd:ID → Beads, or a full PR URL parsed via parse_pr_url().
     Extra kwargs are forwarded to the dispatch function (e.g. content for plan,
     plan_path_template for github_issue).
     """
+    from worca.utils.pr_url import parse_pr_url
+
     plan_path_template = kwargs.pop("plan_path_template", None)
     if source_type == "prompt":
         return normalize_prompt(source_value)
@@ -355,12 +445,31 @@ def normalize(source_type: str, source_value: str, **kwargs) -> WorkRequest:
         return normalize_plan_file(source_value, **kwargs)
     elif source_type == "spec":
         return normalize_spec_file(source_value)
+    elif source_type == "pr":
+        if source_value.startswith("gh:pr:"):
+            return normalize_github_pr(source_value)
+        parsed = parse_pr_url(source_value)
+        if parsed["provider"] == "github":
+            return normalize_github_pr(f"gh:pr:{parsed['number']}")
+        raise ValueError(f"PR source not yet supported: {source_value}")
     elif source_type == "source" or source_value.startswith(("gh:", "bd:")):
-        # Convert GitHub URLs to gh:issue:N format
+        # Detect full PR URLs before issue-URL conversion
+        if _ANY_URL_RE.match(source_value):
+            parsed = parse_pr_url(source_value)
+            if parsed["provider"] == "github":
+                ref = f"gh:pr:{parsed['number']}"
+                return normalize_github_pr(ref)
+            if parsed["provider"] != "other":
+                raise ValueError(
+                    f"PR source '{parsed['provider']}' not yet supported: {source_value}"
+                )
+        # Convert GitHub issue URLs to gh:issue:N format
         gh_url_match = _GH_ISSUE_URL_RE.match(source_value)
         if gh_url_match:
             source_value = f"gh:issue:{gh_url_match.group(1)}"
-        if source_value.startswith("gh:issue:"):
+        if source_value.startswith("gh:pr:"):
+            return normalize_github_pr(source_value)
+        elif source_value.startswith("gh:issue:"):
             return normalize_github_issue(
                 source_value, plan_path_template=plan_path_template
             )
@@ -368,5 +477,17 @@ def normalize(source_type: str, source_value: str, **kwargs) -> WorkRequest:
             return normalize_beads_task(source_value)
         else:
             raise ValueError(f"Unknown source reference format: {source_value}")
+    elif _ANY_URL_RE.match(source_value):
+        # Full PR URL — detect provider
+        parsed = parse_pr_url(source_value)
+        if parsed["provider"] == "github":
+            ref = f"gh:pr:{parsed['number']}"
+            wr = normalize_github_pr(ref)
+            return wr
+        if parsed["provider"] != "other":
+            raise ValueError(
+                f"PR source '{parsed['provider']}' not yet supported: {source_value}"
+            )
+        raise ValueError(f"Unknown source reference format: {source_value}")
     else:
         raise ValueError(f"Unknown source type: {source_type}={source_value}")

--- a/src/worca/orchestrator/work_request.py
+++ b/src/worca/orchestrator/work_request.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from worca.utils.env import get_env, filter_model_env
-from worca.utils.gh_pr import fetch_review_feedback
+from worca.utils.gh_pr import current_repo_nwo, fetch_review_feedback, resolve_bot_login
 from worca.utils.settings import load_settings, resolve_model
 
 _DEFAULT_PLAN_PATH_TEMPLATE = "docs/plans/{timestamp}-{title_slug}.md"
@@ -367,11 +367,15 @@ def _synthesize_pr_description(body: str, review_comments: list) -> str:
         for c in review_comments:
             path = c.get("path", "")
             line = c.get("line")
-            loc = f"{path}:{line}" if line is not None else path
+            if path:
+                loc = f"{path}:{line}" if line is not None else path
+            else:
+                loc = "PR-level"
             author = c.get("author", "")
             text = c.get("body", "")
             thread_id = c.get("thread_id", "")
-            lines.append(f'- [{loc}] @{author}: "{text}" (thread: {thread_id})')
+            suffix = f" (thread: {thread_id})" if thread_id else ""
+            lines.append(f'- [{loc}] @{author}: "{text}"{suffix}')
         parts.append("\n## Review Feedback to Address\n")
         parts.extend(lines)
     return "\n".join(parts)
@@ -395,7 +399,7 @@ def normalize_github_pr(source_value: str) -> WorkRequest:
     result = subprocess.run(
         [
             "gh", "pr", "view", str(pr_number), "--json",
-            "title,body,baseRefName,headRefName,headRepository,isCrossRepository,author",
+            "title,body,baseRefName,headRefName,isCrossRepository,author",
         ],
         capture_output=True,
         text=True,
@@ -410,9 +414,24 @@ def normalize_github_pr(source_value: str) -> WorkRequest:
     base_branch = data.get("baseRefName", "")
     head_branch = data.get("headRefName", "")
     is_cross_repo = data.get("isCrossRepository", False)
-    nwo = (data.get("headRepository") or {}).get("nameWithOwner", "")
 
-    review_comments = fetch_review_feedback(nwo, pr_number) if nwo else []
+    # The PR and its review threads live in the *base* repo — resolve the
+    # owner/repo from the current repo (gh's default-repo logic), NOT from the
+    # PR's headRepository (which for a fork PR is the wrong repo, and which
+    # `gh pr view` does not even expose a nameWithOwner for).
+    nwo = current_repo_nwo()
+
+    # L1 self-comment-loop guard: exclude worca's own bot comments. Prefer an
+    # explicit config override, else fall back to the authenticated gh token.
+    settings = load_settings(".claude/settings.json")
+    bot_login = (
+        settings.get("worca", {}).get("pr_revision", {}).get("bot_login")
+        or resolve_bot_login()
+    )
+
+    review_comments = (
+        fetch_review_feedback(nwo, pr_number, bot_login=bot_login) if nwo else []
+    )
 
     return WorkRequest(
         source_type="github_pr",

--- a/src/worca/scripts/run_worktree.py
+++ b/src/worca/scripts/run_worktree.py
@@ -30,6 +30,7 @@ from worca.orchestrator.work_request import normalize
 from worca.utils.branch_naming import slugify as _slugify
 from worca.utils.git import (
     branch_exists,
+    checkout_pr_worktree,
     create_pipeline_worktree,
     detect_default_branch,
     init_worktree_beads,
@@ -252,6 +253,16 @@ def main(argv=None) -> int:
     else:
         wr = normalize("prompt", args.prompt)
 
+    # Reject --branch for github_pr source: the head branch is fixed by the PR
+    # (L2 — drift creates duplicate PRs). Precedent: fleet rejects --branch too.
+    if wr.source_type == "github_pr" and args.branch:
+        print(
+            "error: --branch is not allowed when sourcing from a GitHub PR; "
+            "the target branch is taken from the PR's base branch",
+            file=sys.stderr,
+        )
+        return 2
+
     # Validate the worca runtime exists before any side effects (worktree create,
     # registry write, Popen). Without it the spawned run_pipeline.py crashes
     # under stdout=DEVNULL — UI shows "started" then nothing.
@@ -264,9 +275,26 @@ def main(argv=None) -> int:
     # Step 3: create git worktree at the configured base dir
     _settings = load_settings(args.settings)
     _parallel = _settings.get("worca", {}).get("parallel", {})
-    base_branch = _resolve_base_branch(args, _settings)
     _wt_base = _parallel.get("worktree_base_dir", ".worktrees")
-    worktree_path = create_pipeline_worktree(run_id, slug, base_branch, _wt_base)
+
+    if wr.source_type == "github_pr":
+        # For PR sources, check out the existing PR head branch via 'gh pr checkout'
+        # (L3 — fresh worktree; handles cross-repo/fork PRs). Never create a new branch.
+        worktree_path = checkout_pr_worktree(
+            run_id,
+            wr.pr_number,
+            wr.pr_head_branch,
+            pr_is_cross_repo=wr.pr_is_cross_repo,
+            base_dir=_wt_base,
+        )
+        worktree_branch = wr.pr_head_branch  # L2: preserve head branch name verbatim
+        target_branch = wr.pr_base_branch
+    else:
+        base_branch = _resolve_base_branch(args, _settings)
+        worktree_path = create_pipeline_worktree(run_id, slug, base_branch, _wt_base)
+        worktree_branch = f"worca/{slug}-{run_id}"
+        target_branch = args.branch
+
     if not worktree_path:
         print(f"error: failed to create worktree for run {run_id}", file=sys.stderr)
         return 1
@@ -282,19 +310,19 @@ def main(argv=None) -> int:
     init_worktree_beads(worktree_path)
 
     # Step 6: register in pipelines.d/. The branch is the worktree's own
-    # branch (worca/<slug>-<run_id>, written by create_pipeline_worktree);
-    # storing it lets the Worktrees view show it without reaching into the
-    # worktree's status.json.
+    # branch; storing it lets the Worktrees view show it without reaching into
+    # the worktree's status.json.
     register_pipeline(
         run_id=run_id,
         worktree_path=worktree_path,
         title=wr.title,
         pid=os.getpid(),
-        branch=f"worca/{slug}-{run_id}",
+        branch=worktree_branch,
         fleet_id=args.fleet_id,
         workspace_id=args.workspace_id,
         group_type="fleet" if args.fleet_id else "workspace" if args.workspace_id else None,
-        target_branch=args.branch,
+        target_branch=target_branch,
+        revises_pr=wr.pr_number if wr.source_type == "github_pr" else None,
     )
 
     # Step 7: build and spawn run_pipeline.py --worktree (detached, fire-and-forget)

--- a/src/worca/state/status.py
+++ b/src/worca/state/status.py
@@ -307,6 +307,10 @@ def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_
         },
         "pr_review_outcome": None,
         "pr": None,
+        "source_type": work_request.get("source_type"),
+        "source_ref": work_request.get("source_ref"),
+        "revises_pr": work_request.get("pr_number"),
+        "review_feedback": work_request.get("review_comments", []),
     }
     return status
 

--- a/src/worca/utils/gh_pr.py
+++ b/src/worca/utils/gh_pr.py
@@ -48,10 +48,72 @@ query($owner: String!, $repo: String!, $number: Int!) {
           }
         }
       }
+      reviews(first: 50) {
+        nodes {
+          author { login }
+          body
+          state
+          submittedAt
+        }
+      }
     }
   }
 }
 """
+
+# Review states whose summary body counts as actionable feedback. APPROVED and
+# DISMISSED/PENDING reviews are skipped — only change requests and plain review
+# comments carry feedback to address.
+_FEEDBACK_REVIEW_STATES = {"CHANGES_REQUESTED", "COMMENTED"}
+
+
+def current_repo_nwo(cwd: Optional[str] = None) -> str:
+    """Return the current repository's "owner/repo", or "" on any error.
+
+    Resolves via ``gh repo view`` so it follows GitHub's default-repo logic —
+    the base repo of a PR, which is where a PR and its review threads live even
+    for cross-repo (fork) PRs.  This is deliberately NOT derived from a PR's
+    ``headRepository`` (the fork), which would be the wrong repo to query.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=cwd,
+        )
+    except Exception as e:
+        print(f"Warning: current_repo_nwo failed: {e}", file=sys.stderr)
+        return ""
+    if result.returncode != 0:
+        print(f"Warning: current_repo_nwo gh error: {result.stderr}", file=sys.stderr)
+        return ""
+    return result.stdout.strip()
+
+
+def resolve_bot_login() -> Optional[str]:
+    """Resolve the login worca posts comments as (the authenticated gh token).
+
+    Excluding this login from ingestion is the L1 self-comment-loop guard:
+    worca's own summary/thread-reply comments must never be re-ingested as
+    feedback to address.  Returns None on any error (no filtering applied).
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception as e:
+        print(f"Warning: resolve_bot_login failed: {e}", file=sys.stderr)
+        return None
+    if result.returncode != 0:
+        print(f"Warning: resolve_bot_login gh error: {result.stderr}", file=sys.stderr)
+        return None
+    login = result.stdout.strip()
+    return login or None
 
 
 def fetch_review_feedback(
@@ -60,17 +122,23 @@ def fetch_review_feedback(
     *,
     bot_login: Optional[str] = None,
 ) -> list[dict]:
-    """Fetch unresolved human-authored review threads for a PR.
+    """Fetch unresolved human-authored review feedback for a PR.
+
+    Ingests two sources: unresolved inline review-thread comments and
+    change-requesting / commenting review summary bodies.
 
     Args:
-        nwo: "owner/repo" string.
+        nwo: "owner/repo" string — must be the *base* repo (where the PR lives),
+            not a fork's head repo. Use current_repo_nwo() to resolve it.
         pr_number: PR number.
-        bot_login: GitHub login to exclude (worca's bot account). If None,
-            no bot filtering is applied beyond what the caller sets.
+        bot_login: GitHub login to exclude (worca's bot account, L1). If None,
+            no bot filtering is applied.
 
     Returns:
         List of comment dicts matching the §2 schema:
-        {thread_id, path, line, diff_hunk, author, body, kind, created_at}
+        {thread_id, path, line, diff_hunk, author, body, kind, created_at}.
+        ``kind`` is "inline" for thread comments and "review_summary" for
+        review bodies (which have no thread_id / file anchor).
     """
     owner, repo = nwo.split("/", 1)
     variables = json.dumps({"owner": owner, "repo": repo, "number": pr_number})
@@ -96,9 +164,8 @@ def fetch_review_feedback(
 
     try:
         data = json.loads(result.stdout)
-        threads = (
-            data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
-        )
+        pull_request = data["data"]["repository"]["pullRequest"]
+        threads = pull_request["reviewThreads"]["nodes"]
     except (json.JSONDecodeError, KeyError, TypeError) as e:
         print(f"Warning: fetch_review_feedback parse error: {e}", file=sys.stderr)
         return []
@@ -131,6 +198,31 @@ def fetch_review_feedback(
                     "created_at": node.get("createdAt", ""),
                 }
             )
+
+    # PR-level feedback: review summary bodies (the message left when a reviewer
+    # submits "Request changes" / "Comment"). These carry no file anchor or
+    # thread_id, so they appear as PR-level items and are never thread-replied.
+    for review in (pull_request.get("reviews") or {}).get("nodes", []):
+        if review.get("state") not in _FEEDBACK_REVIEW_STATES:
+            continue
+        author_login = (review.get("author") or {}).get("login", "")
+        if bot_login and author_login == bot_login:
+            continue
+        body = review.get("body", "")
+        if not body or not body.strip():
+            continue
+        comments.append(
+            {
+                "thread_id": "",
+                "path": "",
+                "line": None,
+                "diff_hunk": "",
+                "author": author_login,
+                "body": body,
+                "kind": "review_summary",
+                "created_at": review.get("submittedAt", ""),
+            }
+        )
 
     return comments
 

--- a/src/worca/utils/gh_pr.py
+++ b/src/worca/utils/gh_pr.py
@@ -26,6 +26,19 @@ def _github_disabled() -> bool:
     return os.environ.get("WORCA_NO_GITHUB", "") == "1"
 
 
+# Every PR comment worca posts (revision summary + per-thread replies) starts
+# with this marker. Ingestion skips any comment whose body begins with it, so
+# worca's own writeback is never re-ingested as feedback to address (L1
+# self-comment loop) — without depending on a bot identity/token. The same
+# constant MUST be used to post and to match so the two never drift.
+WORCA_COMMENT_MARKER = "🤖 worca"
+
+
+def is_worca_comment(body: str) -> bool:
+    """True if *body* is one of worca's own marker-prefixed PR comments."""
+    return bool(body) and body.lstrip().startswith(WORCA_COMMENT_MARKER)
+
+
 _GRAPHQL_QUERY = """
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -92,47 +105,18 @@ def current_repo_nwo(cwd: Optional[str] = None) -> str:
     return result.stdout.strip()
 
 
-def resolve_bot_login() -> Optional[str]:
-    """Resolve the login worca posts comments as (the authenticated gh token).
-
-    Excluding this login from ingestion is the L1 self-comment-loop guard:
-    worca's own summary/thread-reply comments must never be re-ingested as
-    feedback to address.  Returns None on any error (no filtering applied).
-    """
-    try:
-        result = subprocess.run(
-            ["gh", "api", "user", "--jq", ".login"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-    except Exception as e:
-        print(f"Warning: resolve_bot_login failed: {e}", file=sys.stderr)
-        return None
-    if result.returncode != 0:
-        print(f"Warning: resolve_bot_login gh error: {result.stderr}", file=sys.stderr)
-        return None
-    login = result.stdout.strip()
-    return login or None
-
-
-def fetch_review_feedback(
-    nwo: str,
-    pr_number: int,
-    *,
-    bot_login: Optional[str] = None,
-) -> list[dict]:
-    """Fetch unresolved human-authored review feedback for a PR.
+def fetch_review_feedback(nwo: str, pr_number: int) -> list[dict]:
+    """Fetch unresolved, non-worca review feedback for a PR.
 
     Ingests two sources: unresolved inline review-thread comments and
-    change-requesting / commenting review summary bodies.
+    change-requesting / commenting review summary bodies. worca's own
+    marker-prefixed comments (see WORCA_COMMENT_MARKER) are excluded so its
+    writeback is never re-ingested (L1 self-comment loop).
 
     Args:
         nwo: "owner/repo" string — must be the *base* repo (where the PR lives),
             not a fork's head repo. Use current_repo_nwo() to resolve it.
         pr_number: PR number.
-        bot_login: GitHub login to exclude (worca's bot account, L1). If None,
-            no bot filtering is applied.
 
     Returns:
         List of comment dicts matching the §2 schema:
@@ -178,11 +162,10 @@ def fetch_review_feedback(
         for node in thread.get("comments", {}).get("nodes", []):
             author_login = (node.get("author") or {}).get("login", "")
 
-            if bot_login and author_login == bot_login:
-                continue
-
             body = node.get("body", "")
             if not body or not body.strip():
+                continue
+            if is_worca_comment(body):
                 continue
 
             line = node.get("line") or node.get("originalLine")
@@ -206,10 +189,10 @@ def fetch_review_feedback(
         if review.get("state") not in _FEEDBACK_REVIEW_STATES:
             continue
         author_login = (review.get("author") or {}).get("login", "")
-        if bot_login and author_login == bot_login:
-            continue
         body = review.get("body", "")
         if not body or not body.strip():
+            continue
+        if is_worca_comment(body):
             continue
         comments.append(
             {

--- a/src/worca/utils/gh_pr.py
+++ b/src/worca/utils/gh_pr.py
@@ -1,0 +1,191 @@
+"""GitHub PR helpers — review thread ingestion.
+
+fetch_review_feedback() runs a GraphQL query for unresolved, human-authored
+review threads and returns them normalized to the §2 schema.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from typing import Optional
+
+_REPLY_MUTATION = """
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: $threadId,
+    body: $body
+  }) {
+    comment { id }
+  }
+}
+"""
+
+
+def _github_disabled() -> bool:
+    return os.environ.get("WORCA_NO_GITHUB", "") == "1"
+
+
+_GRAPHQL_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first: 50) {
+            nodes {
+              author { login }
+              path
+              line
+              originalLine
+              diffHunk
+              body
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def fetch_review_feedback(
+    nwo: str,
+    pr_number: int,
+    *,
+    bot_login: Optional[str] = None,
+) -> list[dict]:
+    """Fetch unresolved human-authored review threads for a PR.
+
+    Args:
+        nwo: "owner/repo" string.
+        pr_number: PR number.
+        bot_login: GitHub login to exclude (worca's bot account). If None,
+            no bot filtering is applied beyond what the caller sets.
+
+    Returns:
+        List of comment dicts matching the §2 schema:
+        {thread_id, path, line, diff_hunk, author, body, kind, created_at}
+    """
+    owner, repo = nwo.split("/", 1)
+    variables = json.dumps({"owner": owner, "repo": repo, "number": pr_number})
+
+    try:
+        result = subprocess.run(
+            ["gh", "api", "graphql", "-f", f"query={_GRAPHQL_QUERY}", "--input", "-"],
+            input=variables,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except Exception as e:
+        print(f"Warning: fetch_review_feedback failed: {e}", file=sys.stderr)
+        return []
+
+    if result.returncode != 0:
+        print(
+            f"Warning: fetch_review_feedback gh error: {result.stderr}",
+            file=sys.stderr,
+        )
+        return []
+
+    try:
+        data = json.loads(result.stdout)
+        threads = (
+            data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        )
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        print(f"Warning: fetch_review_feedback parse error: {e}", file=sys.stderr)
+        return []
+
+    comments = []
+    for thread in threads:
+        if thread.get("isResolved"):
+            continue
+
+        for node in thread.get("comments", {}).get("nodes", []):
+            author_login = (node.get("author") or {}).get("login", "")
+
+            if bot_login and author_login == bot_login:
+                continue
+
+            body = node.get("body", "")
+            if not body or not body.strip():
+                continue
+
+            line = node.get("line") or node.get("originalLine")
+            comments.append(
+                {
+                    "thread_id": thread["id"],
+                    "path": node.get("path", ""),
+                    "line": line,
+                    "diff_hunk": node.get("diffHunk", ""),
+                    "author": author_login,
+                    "body": body,
+                    "kind": "inline",
+                    "created_at": node.get("createdAt", ""),
+                }
+            )
+
+    return comments
+
+
+def reply_to_thread(nwo: str, thread_id: str, body: str) -> bool:
+    """Post a reply to a PR review thread.
+
+    Never auto-resolves the thread (D3). Error-suppressed and WORCA_NO_GITHUB-gated.
+
+    Returns True on success, False otherwise.
+    """
+    if _github_disabled():
+        return False
+    variables = json.dumps({"threadId": thread_id, "body": body})
+    try:
+        result = subprocess.run(
+            ["gh", "api", "graphql", "-f", f"query={_REPLY_MUTATION}", "--input", "-"],
+            input=variables,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception as e:
+        print(f"Warning: reply_to_thread failed: {e}", file=sys.stderr)
+        return False
+    if result.returncode != 0:
+        print(f"Warning: reply_to_thread gh error: {result.stderr}", file=sys.stderr)
+        return False
+    return True
+
+
+def post_revision_summary(nwo: str, pr_number: int, summary: str) -> bool:
+    """Post a top-level comment on a PR with the revision summary.
+
+    Error-suppressed and WORCA_NO_GITHUB-gated.
+
+    Returns True on success, False otherwise.
+    """
+    if _github_disabled():
+        return False
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api", "--method", "POST",
+                f"/repos/{nwo}/issues/{pr_number}/comments",
+                "-f", f"body={summary}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception as e:
+        print(f"Warning: post_revision_summary failed: {e}", file=sys.stderr)
+        return False
+    if result.returncode != 0:
+        print(f"Warning: post_revision_summary gh error: {result.stderr}", file=sys.stderr)
+        return False
+    return True

--- a/src/worca/utils/git.py
+++ b/src/worca/utils/git.py
@@ -175,6 +175,43 @@ def create_pipeline_worktree(
     return os.path.abspath(path)
 
 
+def checkout_pr_worktree(
+    run_id: str,
+    pr_number: int,
+    pr_head_branch: str,
+    pr_is_cross_repo: bool = False,
+    base_dir: str = ".worktrees",
+) -> str:
+    """Create a worktree for a PR pipeline run using 'gh pr checkout'.
+
+    Creates an empty git worktree at path first, then runs 'gh pr checkout'
+    inside it to set up the exact PR head branch (L2 — no drift) and handle
+    cross-repo/fork PRs correctly (L3 — fresh worktree, never reuse original).
+
+    Returns the absolute worktree path on success, empty string on failure.
+    """
+    base = os.path.expanduser(base_dir)
+    path = os.path.join(base, f"pipeline-{run_id}")
+    if os.path.isabs(base):
+        os.makedirs(base, exist_ok=True)
+    # Step 1: create an empty worktree so gh pr checkout has a git context to run in
+    wt_result = _run_git("worktree", "add", "--no-checkout", path, "HEAD")
+    if wt_result.returncode != 0:
+        return ""
+    # Step 2: run gh pr checkout inside the new worktree to fetch and set up the branch
+    result = subprocess.run(
+        ["gh", "pr", "checkout", str(pr_number), "--branch", pr_head_branch],
+        capture_output=True,
+        text=True,
+        env=get_env(),
+        cwd=path,
+    )
+    if result.returncode != 0:
+        _run_git("worktree", "remove", "--force", path)
+        return ""
+    return os.path.abspath(path)
+
+
 def remove_pipeline_worktree(worktree_path: str) -> bool:
     """Remove a pipeline worktree and delete its associated branch.
 

--- a/src/worca/utils/pr_url.py
+++ b/src/worca/utils/pr_url.py
@@ -69,8 +69,13 @@ def parse_pr_url(url: str | None) -> dict[str, str]:
     # --- GitHub Cloud + Enterprise ---
     # https://{host}/{owner}/{repo}/pull/{n}
     # Covers github.com and any Enterprise GitHub host (e.g. github.mycompany.com, git.internal.corp)
-    m = re.match(r"^/([^/]+)/([^/]+)/pull/\d+", path)
+    m = re.match(r"^/([^/]+)/([^/]+)/pull/(\d+)", path)
     if m:
-        return {"provider": "github", "host": host, "repo_path": f"{m.group(1)}/{m.group(2)}"}
+        return {
+            "provider": "github",
+            "host": host,
+            "repo_path": f"{m.group(1)}/{m.group(2)}",
+            "number": int(m.group(3)),
+        }
 
     return {"provider": "other", "host": host, "repo_path": ""}

--- a/tests/test_gh_pr.py
+++ b/tests/test_gh_pr.py
@@ -1,0 +1,310 @@
+"""Tests for gh_pr.py — fetch_review_feedback(), reply_to_thread(), post_revision_summary()."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+from worca.utils.gh_pr import fetch_review_feedback, reply_to_thread, post_revision_summary
+
+
+GRAPHQL_RESPONSE = {
+    "data": {
+        "repository": {
+            "pullRequest": {
+                "reviewThreads": {
+                    "nodes": [
+                        {
+                            "id": "PRRT_aaa",
+                            "isResolved": False,
+                            "isOutdated": False,
+                            "comments": {
+                                "nodes": [
+                                    {
+                                        "author": {"login": "alice"},
+                                        "path": "src/foo.py",
+                                        "line": 42,
+                                        "originalLine": 42,
+                                        "diffHunk": "@@ -40,6 +40,8 @@",
+                                        "body": "this leaks a file handle",
+                                        "createdAt": "2026-06-03T12:00:00Z",
+                                    }
+                                ]
+                            },
+                        },
+                        {
+                            "id": "PRRT_bbb",
+                            "isResolved": True,
+                            "isOutdated": False,
+                            "comments": {
+                                "nodes": [
+                                    {
+                                        "author": {"login": "alice"},
+                                        "path": "src/bar.py",
+                                        "line": 10,
+                                        "originalLine": 10,
+                                        "diffHunk": "@@ -8,4 +8,6 @@",
+                                        "body": "already resolved",
+                                        "createdAt": "2026-06-03T10:00:00Z",
+                                    }
+                                ]
+                            },
+                        },
+                        {
+                            "id": "PRRT_ccc",
+                            "isResolved": False,
+                            "isOutdated": False,
+                            "comments": {
+                                "nodes": [
+                                    {
+                                        "author": {"login": "worca-bot"},
+                                        "path": "src/baz.py",
+                                        "line": 5,
+                                        "originalLine": 5,
+                                        "diffHunk": "@@ -3,4 +3,6 @@",
+                                        "body": "bot comment should be excluded",
+                                        "createdAt": "2026-06-03T11:00:00Z",
+                                    }
+                                ]
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+    }
+}
+
+
+def _make_gh_result(payload: dict) -> MagicMock:
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = json.dumps(payload)
+    result.stderr = ""
+    return result
+
+
+def test_fetch_review_feedback_filters_resolved():
+    """Only unresolved threads are returned."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = _make_gh_result(GRAPHQL_RESPONSE)
+        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+
+    thread_ids = {c["thread_id"] for c in comments}
+    # PRRT_bbb is resolved → excluded
+    assert "PRRT_bbb" not in thread_ids
+    # PRRT_aaa is unresolved human → included
+    assert "PRRT_aaa" in thread_ids
+
+
+def test_fetch_review_feedback_excludes_bot():
+    """Bot-authored threads are excluded even when unresolved."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = _make_gh_result(GRAPHQL_RESPONSE)
+        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+
+    thread_ids = {c["thread_id"] for c in comments}
+    # PRRT_ccc is unresolved but bot-authored → excluded
+    assert "PRRT_ccc" not in thread_ids
+
+
+def test_fetch_review_feedback_schema():
+    """Returned items match the §2 schema."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = _make_gh_result(GRAPHQL_RESPONSE)
+        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+
+    assert len(comments) == 1
+    c = comments[0]
+    assert c["thread_id"] == "PRRT_aaa"
+    assert c["path"] == "src/foo.py"
+    assert c["line"] == 42
+    assert c["diff_hunk"] == "@@ -40,6 +40,8 @@"
+    assert c["author"] == "alice"
+    assert c["body"] == "this leaks a file handle"
+    assert c["kind"] == "inline"
+    assert c["created_at"] == "2026-06-03T12:00:00Z"
+
+
+def test_fetch_review_feedback_drops_empty_body():
+    """Threads with empty/whitespace bodies are excluded."""
+    response = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": "PRRT_empty",
+                                "isResolved": False,
+                                "isOutdated": False,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "author": {"login": "alice"},
+                                            "path": "src/x.py",
+                                            "line": 1,
+                                            "originalLine": 1,
+                                            "diffHunk": "@@ -1 @@",
+                                            "body": "   ",
+                                            "createdAt": "2026-06-03T12:00:00Z",
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = _make_gh_result(response)
+        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+
+    assert comments == []
+
+
+def test_fetch_review_feedback_gh_error_returns_empty(capsys):
+    """When the gh CLI fails, returns [] with a stderr warning."""
+    result = MagicMock()
+    result.returncode = 1
+    result.stdout = ""
+    result.stderr = "authentication error"
+    with patch("subprocess.run", return_value=result):
+        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+
+    assert comments == []
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# reply_to_thread()
+# ---------------------------------------------------------------------------
+
+
+def test_reply_to_thread_no_github_gated(monkeypatch):
+    """WORCA_NO_GITHUB=1 → no subprocess call, returns False."""
+    monkeypatch.setenv("WORCA_NO_GITHUB", "1")
+    with patch("subprocess.run") as mock_run:
+        result = reply_to_thread("owner/repo", "PRRT_aaa", "Fixed in commit abc")
+    assert result is False
+    mock_run.assert_not_called()
+
+
+def test_reply_to_thread_success(monkeypatch):
+    """Successful reply posts a GraphQL mutation and returns True."""
+    monkeypatch.delenv("WORCA_NO_GITHUB", raising=False)
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json.dumps({"data": {"addPullRequestReviewThreadReply": {"comment": {"id": "PRC_1"}}}})
+    mock_result.stderr = ""
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        result = reply_to_thread("owner/repo", "PRRT_aaa", "Fixed in commit abc")
+
+    assert result is True
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args
+    cmd = call_args[0][0]
+    assert cmd[0] == "gh"
+    assert "graphql" in cmd
+
+
+def test_reply_to_thread_gh_error_suppressed(monkeypatch, capsys):
+    """gh CLI error → returns False with a stderr warning."""
+    monkeypatch.delenv("WORCA_NO_GITHUB", raising=False)
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    mock_result.stderr = "not found"
+    with patch("subprocess.run", return_value=mock_result):
+        result = reply_to_thread("owner/repo", "PRRT_aaa", "Fixed in commit abc")
+
+    assert result is False
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+
+
+def test_reply_to_thread_exception_suppressed(monkeypatch, capsys):
+    """Exception during subprocess → returns False with a stderr warning."""
+    monkeypatch.delenv("WORCA_NO_GITHUB", raising=False)
+    with patch("subprocess.run", side_effect=OSError("gh not found")):
+        result = reply_to_thread("owner/repo", "PRRT_aaa", "Fixed")
+
+    assert result is False
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+
+
+def test_reply_to_thread_passes_thread_id_and_body(monkeypatch):
+    """Thread ID and body are included in the subprocess call input."""
+    monkeypatch.delenv("WORCA_NO_GITHUB", raising=False)
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "{}"
+    mock_result.stderr = ""
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        reply_to_thread("owner/repo", "PRRT_xyz", "Addressed in sha123")
+
+    call_kwargs = mock_run.call_args[1]
+    stdin_input = call_kwargs.get("input", "")
+    variables = json.loads(stdin_input)
+    assert variables["threadId"] == "PRRT_xyz"
+    assert variables["body"] == "Addressed in sha123"
+
+
+# ---------------------------------------------------------------------------
+# post_revision_summary()
+# ---------------------------------------------------------------------------
+
+
+def test_post_revision_summary_no_github_gated(monkeypatch):
+    """WORCA_NO_GITHUB=1 → no subprocess call, returns False."""
+    monkeypatch.setenv("WORCA_NO_GITHUB", "1")
+    with patch("subprocess.run") as mock_run:
+        result = post_revision_summary("owner/repo", 42, "Addressed 3 items, commit abc")
+    assert result is False
+    mock_run.assert_not_called()
+
+
+def test_post_revision_summary_success(monkeypatch):
+    """Successful summary post returns True."""
+    monkeypatch.delenv("WORCA_NO_GITHUB", raising=False)
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = json.dumps({"id": 1})
+    mock_result.stderr = ""
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        result = post_revision_summary("owner/repo", 42, "Addressed 3 items, commit abc")
+
+    assert result is True
+    mock_run.assert_called_once()
+    call_args = mock_run.call_args[0][0]
+    assert "gh" in call_args
+    assert "/repos/owner/repo/issues/42/comments" in " ".join(call_args)
+
+
+def test_post_revision_summary_gh_error_suppressed(monkeypatch, capsys):
+    """gh CLI error → returns False with a stderr warning."""
+    monkeypatch.delenv("WORCA_NO_GITHUB", raising=False)
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    mock_result.stderr = "forbidden"
+    with patch("subprocess.run", return_value=mock_result):
+        result = post_revision_summary("owner/repo", 42, "Addressed 3 items")
+
+    assert result is False
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+
+
+def test_post_revision_summary_exception_suppressed(monkeypatch, capsys):
+    """Exception during subprocess → returns False with a stderr warning."""
+    monkeypatch.delenv("WORCA_NO_GITHUB", raising=False)
+    with patch("subprocess.run", side_effect=OSError("gh not found")):
+        result = post_revision_summary("owner/repo", 42, "Addressed 3 items")
+
+    assert result is False
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err

--- a/tests/test_gh_pr.py
+++ b/tests/test_gh_pr.py
@@ -5,11 +5,12 @@ from unittest.mock import MagicMock, patch
 
 
 from worca.utils.gh_pr import (
+    WORCA_COMMENT_MARKER,
     current_repo_nwo,
     fetch_review_feedback,
+    is_worca_comment,
     post_revision_summary,
     reply_to_thread,
-    resolve_bot_login,
 )
 
 
@@ -62,12 +63,14 @@ GRAPHQL_RESPONSE = {
                             "comments": {
                                 "nodes": [
                                     {
-                                        "author": {"login": "worca-bot"},
+                                        # worca's own marker-prefixed reply — excluded by
+                                        # content, regardless of which login posted it.
+                                        "author": {"login": "alice"},
                                         "path": "src/baz.py",
                                         "line": 5,
                                         "originalLine": 5,
                                         "diffHunk": "@@ -3,4 +3,6 @@",
-                                        "body": "bot comment should be excluded",
+                                        "body": "🤖 worca · addressed in commit `abc1234`.",
                                         "createdAt": "2026-06-03T11:00:00Z",
                                     }
                                 ]
@@ -93,7 +96,7 @@ def test_fetch_review_feedback_filters_resolved():
     """Only unresolved threads are returned."""
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = _make_gh_result(GRAPHQL_RESPONSE)
-        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+        comments = fetch_review_feedback("owner/repo", 1)
 
     thread_ids = {c["thread_id"] for c in comments}
     # PRRT_bbb is resolved → excluded
@@ -102,14 +105,15 @@ def test_fetch_review_feedback_filters_resolved():
     assert "PRRT_aaa" in thread_ids
 
 
-def test_fetch_review_feedback_excludes_bot():
-    """Bot-authored threads are excluded even when unresolved."""
+def test_fetch_review_feedback_excludes_worca_marker():
+    """worca's own marker-prefixed comments are excluded by content (L1),
+    regardless of which login posted them."""
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = _make_gh_result(GRAPHQL_RESPONSE)
-        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+        comments = fetch_review_feedback("owner/repo", 1)
 
     thread_ids = {c["thread_id"] for c in comments}
-    # PRRT_ccc is unresolved but bot-authored → excluded
+    # PRRT_ccc is unresolved but its body starts with WORCA_COMMENT_MARKER → excluded
     assert "PRRT_ccc" not in thread_ids
 
 
@@ -117,7 +121,7 @@ def test_fetch_review_feedback_schema():
     """Returned items match the §2 schema."""
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = _make_gh_result(GRAPHQL_RESPONSE)
-        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+        comments = fetch_review_feedback("owner/repo", 1)
 
     assert len(comments) == 1
     c = comments[0]
@@ -165,7 +169,7 @@ def test_fetch_review_feedback_drops_empty_body():
     }
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = _make_gh_result(response)
-        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+        comments = fetch_review_feedback("owner/repo", 1)
 
     assert comments == []
 
@@ -177,7 +181,7 @@ def test_fetch_review_feedback_gh_error_returns_empty(capsys):
     result.stdout = ""
     result.stderr = "authentication error"
     with patch("subprocess.run", return_value=result):
-        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+        comments = fetch_review_feedback("owner/repo", 1)
 
     assert comments == []
     captured = capsys.readouterr()
@@ -347,36 +351,29 @@ def test_current_repo_nwo_exception_returns_empty(capsys):
 
 
 # ---------------------------------------------------------------------------
-# resolve_bot_login()
+# is_worca_comment() — content-marker self-comment detection (L1)
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_bot_login_success():
-    result = MagicMock()
-    result.returncode = 0
-    result.stdout = "worca-bot\n"
-    result.stderr = ""
-    with patch("subprocess.run", return_value=result):
-        assert resolve_bot_login() == "worca-bot"
+def test_is_worca_comment_true_for_marker_prefix():
+    assert is_worca_comment(f"{WORCA_COMMENT_MARKER} · addressed in commit `abc`.")
 
 
-def test_resolve_bot_login_empty_login_returns_none():
-    result = MagicMock()
-    result.returncode = 0
-    result.stdout = "\n"
-    result.stderr = ""
-    with patch("subprocess.run", return_value=result):
-        assert resolve_bot_login() is None
+def test_is_worca_comment_tolerates_leading_whitespace():
+    assert is_worca_comment(f"  \n{WORCA_COMMENT_MARKER} · addressed.")
 
 
-def test_resolve_bot_login_gh_error_returns_none(capsys):
-    result = MagicMock()
-    result.returncode = 1
-    result.stdout = ""
-    result.stderr = "auth"
-    with patch("subprocess.run", return_value=result):
-        assert resolve_bot_login() is None
-    assert "Warning" in capsys.readouterr().err
+def test_is_worca_comment_false_for_human_text():
+    assert not is_worca_comment("this leaks a file handle")
+
+
+def test_is_worca_comment_false_when_marker_not_at_start():
+    # A human quoting worca's reply mid-comment is NOT treated as worca's own.
+    assert not is_worca_comment(f"see earlier: {WORCA_COMMENT_MARKER} · addressed.")
+
+
+def test_is_worca_comment_false_for_empty():
+    assert not is_worca_comment("")
 
 
 # ---------------------------------------------------------------------------
@@ -404,8 +401,9 @@ _RESPONSE_WITH_REVIEWS = {
                             "submittedAt": "2026-06-03T10:00:00Z",
                         },
                         {
-                            "author": {"login": "worca-bot"},
-                            "body": "worca summary — should be excluded",
+                            # worca's own marker-prefixed review body → excluded by content
+                            "author": {"login": "alice"},
+                            "body": "🤖 worca · addressed 2 review comments in commit `abc`.",
                             "state": "COMMENTED",
                             "submittedAt": "2026-06-03T11:00:00Z",
                         },
@@ -426,7 +424,7 @@ _RESPONSE_WITH_REVIEWS = {
 def test_fetch_review_feedback_includes_review_summaries():
     """CHANGES_REQUESTED / COMMENTED review bodies become PR-level items."""
     with patch("subprocess.run", return_value=_make_gh_result(_RESPONSE_WITH_REVIEWS)):
-        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+        comments = fetch_review_feedback("owner/repo", 1)
 
     summaries = [c for c in comments if c["kind"] == "review_summary"]
     assert len(summaries) == 1
@@ -438,18 +436,19 @@ def test_fetch_review_feedback_includes_review_summaries():
     assert s["line"] is None
 
 
-def test_fetch_review_feedback_excludes_approved_and_bot_reviews():
+def test_fetch_review_feedback_excludes_approved_and_worca_reviews():
     with patch("subprocess.run", return_value=_make_gh_result(_RESPONSE_WITH_REVIEWS)):
-        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+        comments = fetch_review_feedback("owner/repo", 1)
 
     bodies = {c["body"] for c in comments}
     assert "looks good to me" not in bodies  # APPROVED skipped
-    assert "worca summary — should be excluded" not in bodies  # bot skipped
+    # worca's own marker-prefixed review body skipped (L1)
+    assert not any(b.startswith(WORCA_COMMENT_MARKER) for b in bodies)
 
 
 def test_fetch_review_feedback_handles_missing_reviews_key():
     """Older mock shape without a 'reviews' key must not crash."""
     with patch("subprocess.run", return_value=_make_gh_result(GRAPHQL_RESPONSE)):
-        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+        comments = fetch_review_feedback("owner/repo", 1)
     # Only the single unresolved human inline thread, no review summaries.
     assert all(c["kind"] == "inline" for c in comments)

--- a/tests/test_gh_pr.py
+++ b/tests/test_gh_pr.py
@@ -4,7 +4,13 @@ import json
 from unittest.mock import MagicMock, patch
 
 
-from worca.utils.gh_pr import fetch_review_feedback, reply_to_thread, post_revision_summary
+from worca.utils.gh_pr import (
+    current_repo_nwo,
+    fetch_review_feedback,
+    post_revision_summary,
+    reply_to_thread,
+    resolve_bot_login,
+)
 
 
 GRAPHQL_RESPONSE = {
@@ -308,3 +314,142 @@ def test_post_revision_summary_exception_suppressed(monkeypatch, capsys):
     assert result is False
     captured = capsys.readouterr()
     assert "Warning" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# current_repo_nwo()
+# ---------------------------------------------------------------------------
+
+
+def test_current_repo_nwo_success():
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = "owner/repo\n"
+    result.stderr = ""
+    with patch("subprocess.run", return_value=result):
+        assert current_repo_nwo() == "owner/repo"
+
+
+def test_current_repo_nwo_gh_error_returns_empty(capsys):
+    result = MagicMock()
+    result.returncode = 1
+    result.stdout = ""
+    result.stderr = "not a repo"
+    with patch("subprocess.run", return_value=result):
+        assert current_repo_nwo() == ""
+    assert "Warning" in capsys.readouterr().err
+
+
+def test_current_repo_nwo_exception_returns_empty(capsys):
+    with patch("subprocess.run", side_effect=OSError("gh not found")):
+        assert current_repo_nwo() == ""
+    assert "Warning" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# resolve_bot_login()
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_bot_login_success():
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = "worca-bot\n"
+    result.stderr = ""
+    with patch("subprocess.run", return_value=result):
+        assert resolve_bot_login() == "worca-bot"
+
+
+def test_resolve_bot_login_empty_login_returns_none():
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = "\n"
+    result.stderr = ""
+    with patch("subprocess.run", return_value=result):
+        assert resolve_bot_login() is None
+
+
+def test_resolve_bot_login_gh_error_returns_none(capsys):
+    result = MagicMock()
+    result.returncode = 1
+    result.stdout = ""
+    result.stderr = "auth"
+    with patch("subprocess.run", return_value=result):
+        assert resolve_bot_login() is None
+    assert "Warning" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# fetch_review_feedback() — review summary (PR-level) ingestion
+# ---------------------------------------------------------------------------
+
+
+_RESPONSE_WITH_REVIEWS = {
+    "data": {
+        "repository": {
+            "pullRequest": {
+                "reviewThreads": {"nodes": []},
+                "reviews": {
+                    "nodes": [
+                        {
+                            "author": {"login": "alice"},
+                            "body": "add a test for the empty case",
+                            "state": "CHANGES_REQUESTED",
+                            "submittedAt": "2026-06-03T09:00:00Z",
+                        },
+                        {
+                            "author": {"login": "alice"},
+                            "body": "looks good to me",
+                            "state": "APPROVED",
+                            "submittedAt": "2026-06-03T10:00:00Z",
+                        },
+                        {
+                            "author": {"login": "worca-bot"},
+                            "body": "worca summary — should be excluded",
+                            "state": "COMMENTED",
+                            "submittedAt": "2026-06-03T11:00:00Z",
+                        },
+                        {
+                            "author": {"login": "bob"},
+                            "body": "   ",
+                            "state": "COMMENTED",
+                            "submittedAt": "2026-06-03T12:00:00Z",
+                        },
+                    ]
+                },
+            }
+        }
+    }
+}
+
+
+def test_fetch_review_feedback_includes_review_summaries():
+    """CHANGES_REQUESTED / COMMENTED review bodies become PR-level items."""
+    with patch("subprocess.run", return_value=_make_gh_result(_RESPONSE_WITH_REVIEWS)):
+        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+
+    summaries = [c for c in comments if c["kind"] == "review_summary"]
+    assert len(summaries) == 1
+    s = summaries[0]
+    assert s["author"] == "alice"
+    assert s["body"] == "add a test for the empty case"
+    assert s["thread_id"] == ""
+    assert s["path"] == ""
+    assert s["line"] is None
+
+
+def test_fetch_review_feedback_excludes_approved_and_bot_reviews():
+    with patch("subprocess.run", return_value=_make_gh_result(_RESPONSE_WITH_REVIEWS)):
+        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+
+    bodies = {c["body"] for c in comments}
+    assert "looks good to me" not in bodies  # APPROVED skipped
+    assert "worca summary — should be excluded" not in bodies  # bot skipped
+
+
+def test_fetch_review_feedback_handles_missing_reviews_key():
+    """Older mock shape without a 'reviews' key must not crash."""
+    with patch("subprocess.run", return_value=_make_gh_result(GRAPHQL_RESPONSE)):
+        comments = fetch_review_feedback("owner/repo", 1, bot_login="worca-bot")
+    # Only the single unresolved human inline thread, no review summaries.
+    assert all(c["kind"] == "inline" for c in comments)

--- a/tests/test_git_worktree.py
+++ b/tests/test_git_worktree.py
@@ -246,3 +246,78 @@ class TestListPipelineWorktrees:
 
         entries = list_pipeline_worktrees()
         assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# checkout_pr_worktree
+# ---------------------------------------------------------------------------
+
+class TestCheckoutPrWorktree:
+
+    def _make_gh_mock(self, returncode=0):
+        """Return a mock that lets git calls through and fakes gh pr checkout."""
+        real_run = subprocess.run
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "gh":
+                result = subprocess.CompletedProcess(cmd, returncode, stdout="", stderr="")
+                return result
+            return real_run(cmd, **kwargs)
+
+        return side_effect
+
+    def test_success_creates_worktree_and_returns_path(self, git_repo):
+        from worca.utils.git import checkout_pr_worktree
+
+        with patch("worca.utils.git.subprocess.run", side_effect=self._make_gh_mock(0)):
+            result = checkout_pr_worktree("r1", pr_number=42, pr_head_branch="feature/auth")
+
+        assert os.path.isabs(result)
+        assert os.path.isdir(result)
+        assert result.endswith(os.path.join(".worktrees", "pipeline-r1"))
+
+    def test_success_calls_gh_inside_worktree(self, git_repo):
+        from worca.utils.git import checkout_pr_worktree
+
+        gh_calls = []
+        real_run = subprocess.run
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "gh":
+                gh_calls.append(kwargs.get("cwd"))
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return real_run(cmd, **kwargs)
+
+        with patch("worca.utils.git.subprocess.run", side_effect=side_effect):
+            result = checkout_pr_worktree("r2", pr_number=7, pr_head_branch="fix/bug")
+
+        assert len(gh_calls) == 1
+        # gh pr checkout ran inside the newly created worktree (normalize both)
+        assert os.path.abspath(gh_calls[0]) == result
+
+    def test_gh_failure_cleans_up_worktree(self, git_repo):
+        from worca.utils.git import checkout_pr_worktree
+
+        real_run = subprocess.run
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "gh":
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="auth error")
+            return real_run(cmd, **kwargs)
+
+        with patch("worca.utils.git.subprocess.run", side_effect=side_effect):
+            result = checkout_pr_worktree("r3", pr_number=99, pr_head_branch="main")
+
+        assert result == ""
+        # Worktree directory should have been removed on failure
+        expected_path = os.path.join(str(git_repo), ".worktrees", "pipeline-r3")
+        assert not os.path.isdir(expected_path)
+
+    def test_git_worktree_failure_returns_empty(self, git_repo):
+        from worca.utils.git import checkout_pr_worktree
+
+        with patch("worca.utils.git._run_git") as mock_git:
+            mock_git.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="err")
+            result = checkout_pr_worktree("r4", pr_number=5, pr_head_branch="branch")
+
+        assert result == ""

--- a/tests/test_guardian_context.py
+++ b/tests/test_guardian_context.py
@@ -14,6 +14,7 @@ from worca.orchestrator.guardian_context import (
     compute_defer_pr,
     compute_pr_footer,
     compute_pr_title_prefix,
+    compute_revise_pr,
 )
 
 
@@ -141,19 +142,52 @@ class TestComputeDeferPr:
 
 
 # ---------------------------------------------------------------------------
+# compute_revise_pr
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRevisePr:
+    def test_default_none(self):
+        assert compute_revise_pr({}) is None
+
+    def test_numeric_value_returns_int(self):
+        assert compute_revise_pr({"WORCA_REVISE_PR": "123"}) == 123
+
+    def test_zero_is_none(self):
+        """PR numbers start at 1; 0 is not a valid PR number."""
+        assert compute_revise_pr({"WORCA_REVISE_PR": "0"}) is None
+
+    def test_negative_is_none(self):
+        assert compute_revise_pr({"WORCA_REVISE_PR": "-1"}) is None
+
+    def test_non_numeric_is_none(self):
+        assert compute_revise_pr({"WORCA_REVISE_PR": "abc"}) is None
+
+    def test_empty_string_is_none(self):
+        assert compute_revise_pr({"WORCA_REVISE_PR": ""}) is None
+
+    def test_whitespace_only_is_none(self):
+        assert compute_revise_pr({"WORCA_REVISE_PR": "  "}) is None
+
+    def test_large_pr_number(self):
+        assert compute_revise_pr({"WORCA_REVISE_PR": "99999"}) == 99999
+
+
+# ---------------------------------------------------------------------------
 # build_guardian_context
 # ---------------------------------------------------------------------------
 
 
 class TestBuildGuardianContext:
-    def test_returns_exactly_three_keys(self):
+    def test_returns_exactly_four_keys(self):
         ctx = build_guardian_context({})
-        assert set(ctx.keys()) == {"defer_pr", "pr_title_prefix", "pr_footer"}
+        assert set(ctx.keys()) == {"defer_pr", "revise_pr", "pr_title_prefix", "pr_footer"}
 
     def test_standalone(self):
         ctx = build_guardian_context({})
         assert ctx == {
             "defer_pr": False,
+            "revise_pr": None,
             "pr_title_prefix": "",
             "pr_footer": "",
         }
@@ -166,6 +200,7 @@ class TestBuildGuardianContext:
         }
         ctx = build_guardian_context(env)
         assert ctx["defer_pr"] is True
+        assert ctx["revise_pr"] is None
         assert ctx["pr_title_prefix"] == "[workspace:b3c4d5e6]"
         assert "my-platform" in ctx["pr_footer"]
 
@@ -173,5 +208,34 @@ class TestBuildGuardianContext:
         env = {"WORCA_FLEET_ID": "f_202601011200_a1b2c3d4"}
         ctx = build_guardian_context(env)
         assert ctx["defer_pr"] is False
+        assert ctx["revise_pr"] is None
         assert ctx["pr_title_prefix"] == "[fleet:a1b2c3d4]"
         assert "Fleet manifest" in ctx["pr_footer"]
+
+    # --- revise_pr context var ---
+
+    def test_revise_pr_set_returns_pr_number(self):
+        ctx = build_guardian_context({"WORCA_REVISE_PR": "42"})
+        assert ctx["revise_pr"] == 42
+
+    def test_revise_pr_suppresses_defer_pr(self):
+        """revise_pr > defer_pr: when revising an existing PR, defer is a no-op."""
+        env = {"WORCA_REVISE_PR": "42", "WORCA_DEFER_PR": "1"}
+        ctx = build_guardian_context(env)
+        assert ctx["revise_pr"] == 42
+        assert ctx["defer_pr"] is False
+
+    def test_defer_pr_alone_still_works(self):
+        """Mutual exclusion only activates when revise_pr is set."""
+        env = {"WORCA_DEFER_PR": "1"}
+        ctx = build_guardian_context(env)
+        assert ctx["revise_pr"] is None
+        assert ctx["defer_pr"] is True
+
+    def test_revise_pr_invalid_does_not_suppress_defer(self):
+        """An invalid WORCA_REVISE_PR (not a positive int) → revise_pr=None,
+        defer_pr is unaffected."""
+        env = {"WORCA_REVISE_PR": "not-a-number", "WORCA_DEFER_PR": "1"}
+        ctx = build_guardian_context(env)
+        assert ctx["revise_pr"] is None
+        assert ctx["defer_pr"] is True

--- a/tests/test_guardian_revise_mode.py
+++ b/tests/test_guardian_revise_mode.py
@@ -59,12 +59,12 @@ class TestGuardianReviseModeRendering:
         assert "git push" in result
 
     def test_summary_comment_instruction_in_revise_mode(self):
-        """Guardian must post a summary comment on PR #N."""
+        """The revise branch documents the summary-comment writeback (D1)."""
         result = _render(_base_context(revise_pr=42))
         assert "summary" in result.lower() or "comment" in result.lower()
 
     def test_thread_reply_instruction_in_revise_mode(self):
-        """Guardian must reply to addressed threads (D3 — never resolve)."""
+        """The revise branch documents per-thread replies (D3 — never resolve)."""
         result = _render(_base_context(revise_pr=42))
         assert "thread" in result.lower() or "reply" in result.lower()
 
@@ -75,9 +75,22 @@ class TestGuardianReviseModeRendering:
         assert "never resolve" in lower or "do not resolve" in lower or "resolve" in lower
 
     def test_verify_existing_pr_instruction(self):
-        """Guardian must re-read the existing PR so status.json.pr still populates."""
+        """The orchestrator re-reads the existing PR so status.json.pr populates."""
         result = _render(_base_context(revise_pr=42))
         assert "pr view" in result.lower() or "verify" in result.lower() or "existing" in result.lower()
+
+    def test_writeback_is_runner_side_not_hand_rolled_graphql(self):
+        """Writeback moved off the agent tool path into the runner — the guardian
+        no longer hand-rolls the GraphQL reply mutation or the comments REST call
+        (avoids the pre_tool_use governance question; replies stay reliable)."""
+        result = _render(_base_context(revise_pr=42))
+        assert "addPullRequestReviewThreadReply" not in result
+        assert "/issues/" not in result
+
+    def test_revise_mode_requests_commit_sha_output(self):
+        """The runner needs the commit SHA for the summary/reply text."""
+        result = _render(_base_context(revise_pr=42))
+        assert "commit_sha" in result
 
     def test_defer_pr_branch_absent_in_revise_mode(self):
         """revise_pr takes precedence: defer branch must not appear.

--- a/tests/test_guardian_revise_mode.py
+++ b/tests/test_guardian_revise_mode.py
@@ -1,0 +1,136 @@
+"""Tests for guardian.md revise-mode branch (W-067 §4).
+
+Verifies that when the ``revise_pr`` context var is set (WORCA_REVISE_PR=N),
+the guardian.md template renders the revise branch: push head, no gh pr create,
+post summary comment, reply to addressed threads.  Also checks that the defer_pr
+and normal PR-create branches are suppressed in revise mode.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from worca.orchestrator.overlay import resolve_placeholders
+
+_GUARDIAN_PATH = (
+    Path(__file__).parent.parent / "src" / "worca" / "agents" / "core" / "guardian.md"
+)
+
+
+def _render(context: dict) -> str:
+    content = _GUARDIAN_PATH.read_text(encoding="utf-8")
+    return resolve_placeholders(content, context)
+
+
+def _base_context(**overrides) -> dict:
+    ctx = {
+        "defer_pr": False,
+        "revise_pr": None,
+        "pr_title_prefix": "",
+        "pr_footer": "",
+        "has_graphify": False,
+        "has_code_review_graph": False,
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Revise mode — rendered content
+# ---------------------------------------------------------------------------
+
+
+class TestGuardianReviseModeRendering:
+    def test_revise_branch_visible_when_revise_pr_set(self):
+        result = _render(_base_context(revise_pr=42))
+        assert "revise" in result.lower() or "PR #42" in result or "42" in result
+
+    def test_revise_pr_number_injected_into_prompt(self):
+        result = _render(_base_context(revise_pr=99))
+        assert "99" in result
+
+    def test_no_gh_pr_create_invocation_in_revise_mode(self):
+        """The actual 'gh pr create --base ...' command must not appear in revise mode."""
+        result = _render(_base_context(revise_pr=42))
+        assert "gh pr create --base" not in result
+
+    def test_push_head_branch_in_revise_mode(self):
+        """Guardian must push the existing head branch (L2)."""
+        result = _render(_base_context(revise_pr=42))
+        assert "git push" in result
+
+    def test_summary_comment_instruction_in_revise_mode(self):
+        """Guardian must post a summary comment on PR #N."""
+        result = _render(_base_context(revise_pr=42))
+        assert "summary" in result.lower() or "comment" in result.lower()
+
+    def test_thread_reply_instruction_in_revise_mode(self):
+        """Guardian must reply to addressed threads (D3 — never resolve)."""
+        result = _render(_base_context(revise_pr=42))
+        assert "thread" in result.lower() or "reply" in result.lower()
+
+    def test_never_resolve_threads_instruction(self):
+        """D3: auto-resolving threads is explicitly forbidden."""
+        result = _render(_base_context(revise_pr=42))
+        lower = result.lower()
+        assert "never resolve" in lower or "do not resolve" in lower or "resolve" in lower
+
+    def test_verify_existing_pr_instruction(self):
+        """Guardian must re-read the existing PR so status.json.pr still populates."""
+        result = _render(_base_context(revise_pr=42))
+        assert "pr view" in result.lower() or "verify" in result.lower() or "existing" in result.lower()
+
+    def test_defer_pr_branch_absent_in_revise_mode(self):
+        """revise_pr takes precedence: defer branch must not appear.
+        build_guardian_context forces defer_pr=False when revise_pr is set, so
+        the canonical revise context always has defer_pr=False."""
+        result = _render(_base_context(revise_pr=42, defer_pr=False))
+        assert "deferred: true" not in result
+
+    def test_deferred_sentinel_not_in_revise_output(self):
+        result = _render(_base_context(revise_pr=7))
+        assert "deferred: true" not in result
+
+
+# ---------------------------------------------------------------------------
+# Normal mode — unchanged when revise_pr is None
+# ---------------------------------------------------------------------------
+
+
+class TestGuardianNormalModeUnchanged:
+    def test_gh_pr_create_invocation_present_in_normal_mode(self):
+        """The 'gh pr create --base ...' command invocation must appear in normal mode."""
+        result = _render(_base_context())
+        assert "gh pr create --base" in result
+
+    def test_no_revise_branch_in_normal_mode(self):
+        result = _render(_base_context())
+        # The revise heading should not appear when revise_pr is not set.
+        assert "Revise the existing PR" not in result
+
+    def test_deferred_sentinel_in_defer_mode(self):
+        result = _render(_base_context(defer_pr=True))
+        assert "deferred: true" in result
+
+    def test_gh_pr_create_invocation_absent_in_defer_mode(self):
+        """The actual 'gh pr create --base ...' command must not appear in defer mode."""
+        result = _render(_base_context(defer_pr=True))
+        assert "gh pr create --base" not in result
+
+
+# ---------------------------------------------------------------------------
+# Mutual exclusion — revise_pr > defer_pr
+# ---------------------------------------------------------------------------
+
+
+class TestMutualExclusion:
+    def test_revise_overrides_defer_in_rendered_template(self):
+        """Even if both are passed, revise_pr wins (guardian_context enforces this
+        upstream, but the template structure should handle it too)."""
+        result = _render(_base_context(revise_pr=5, defer_pr=False))
+        assert "gh pr create --base" not in result
+        assert "deferred: true" not in result
+
+    def test_revise_pr_zero_falls_through_to_normal_branch(self):
+        """revise_pr=None (from compute_revise_pr(0)) → normal PR-create branch."""
+        result = _render(_base_context(revise_pr=None))
+        assert "gh pr create" in result

--- a/tests/test_guardian_state_machine.py
+++ b/tests/test_guardian_state_machine.py
@@ -176,9 +176,10 @@ class TestSourcePromptHygiene:
         assert "workspace_short" not in source
 
     def test_source_prompt_uses_template_variables(self):
-        """The three template variables must actually appear in the source."""
+        """The template variables must actually appear in the source."""
         source = GUARDIAN_PATH.read_text()
         assert "{{#if defer_pr}}" in source
+        assert "{{#if revise_pr}}" in source
         assert "{{pr_title_prefix}}" in source
         assert "{{pr_footer}}" in source
 
@@ -196,6 +197,7 @@ class TestSourcePromptHygiene:
                 "WORCA_WORKSPACE_NAME": "my-platform",
                 "WORCA_DEFER_PR": "1",
             },
+            {"WORCA_REVISE_PR": "42"},
         ):
             rendered = _render(env)
             assert "{{" not in rendered, (

--- a/tests/test_planner_revise_mode.py
+++ b/tests/test_planner_revise_mode.py
@@ -1,0 +1,88 @@
+"""Tests for planner.md revision-mode instruction block (W-067 §6).
+
+Verifies that when review_comments are present (has_review_comments=True),
+planner.md renders a constrained-revision instruction block directing the
+planner to produce a minimal-diff plan scoped to the enumerated feedback.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from worca.orchestrator.overlay import resolve_placeholders
+
+_PLANNER_PATH = (
+    Path(__file__).parent.parent / "src" / "worca" / "agents" / "core" / "planner.md"
+)
+
+
+def _render(context: dict) -> str:
+    content = _PLANNER_PATH.read_text(encoding="utf-8")
+    return resolve_placeholders(content, context)
+
+
+def _base_context(**overrides) -> dict:
+    ctx = {
+        "has_review_comments": False,
+        "has_graphify": False,
+        "has_code_review_graph": False,
+        "has_guide": False,
+        "plan_file": "MASTER_PLAN.md",
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Revision mode — block present when has_review_comments is True
+# ---------------------------------------------------------------------------
+
+
+class TestPlannerRevisionModeRendering:
+    def test_revision_block_visible_when_review_comments_present(self):
+        result = _render(_base_context(has_review_comments=True))
+        lower = result.lower()
+        assert "minimal" in lower or "revision" in lower or "review feedback" in lower
+
+    def test_minimal_diff_instruction_present(self):
+        result = _render(_base_context(has_review_comments=True))
+        lower = result.lower()
+        assert "minimal" in lower
+
+    def test_scoped_to_feedback_instruction_present(self):
+        result = _render(_base_context(has_review_comments=True))
+        lower = result.lower()
+        assert "feedback" in lower or "review" in lower
+
+    def test_preserve_unreviewd_instruction_present(self):
+        result = _render(_base_context(has_review_comments=True))
+        lower = result.lower()
+        assert "preserve" in lower
+
+    def test_no_rearchitect_instruction_present(self):
+        result = _render(_base_context(has_review_comments=True))
+        lower = result.lower()
+        assert "re-architect" in lower or "rearchitect" in lower or "architect" in lower
+
+    def test_thin_checklist_note_present_for_small_comment_sets(self):
+        result = _render(_base_context(has_review_comments=True))
+        lower = result.lower()
+        assert "checklist" in lower or "thin" in lower or "small" in lower
+
+
+# ---------------------------------------------------------------------------
+# Normal mode — block absent when has_review_comments is False
+# ---------------------------------------------------------------------------
+
+
+class TestPlannerNormalModeUnchanged:
+    def test_revision_block_absent_when_no_review_comments(self):
+        result = _render(_base_context(has_review_comments=False))
+        lower = result.lower()
+        # The constrained revision heading must not appear
+        assert "constrained revision" not in lower
+        assert "minimal-diff" not in lower
+
+    def test_standard_planner_instructions_still_present(self):
+        result = _render(_base_context(has_review_comments=False))
+        # Core process steps should remain
+        assert "Process" in result or "process" in result.lower()

--- a/tests/test_pr_url_parser.py
+++ b/tests/test_pr_url_parser.py
@@ -192,7 +192,11 @@ class TestEdgeCases:
 
     def test_returns_dict_with_all_keys(self):
         result = parse_pr_url("https://github.com/a/b/pull/1")
-        assert set(result.keys()) == {"provider", "host", "repo_path"}
+        assert set(result.keys()) == {"provider", "host", "repo_path", "number"}
+
+    def test_pr_url_resolves_to_number(self):
+        result = parse_pr_url("https://github.com/owner/repo/pull/42")
+        assert result["number"] == 42
 
     def test_azure_devops_repo_path_includes_org_project_repo(self):
         url = "https://dev.azure.com/org/proj/_git/repo/pullrequest/1"

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -691,4 +691,54 @@ def test_build_context_crg_with_guide_independent():
     ctx = pb.build_context("plan")
     assert ctx["has_guide"] is True
     assert ctx["has_code_review_graph"] is True
-    assert ctx["guide_content"] == "guide stuff"
+
+
+# --- has_review_comments (planner constrained revision mode, W-067) ---
+
+def test_build_context_has_review_comments_false_by_default():
+    pb = PromptBuilder("Fix bug", "Desc")
+    ctx = pb.build_context("plan")
+    assert ctx.get("has_review_comments") is False
+
+
+def test_build_context_has_review_comments_true_when_set():
+    pb = PromptBuilder("Fix bug", "Desc")
+    pb.update_context("review_comments", [{"thread_id": "T1", "body": "fix this"}])
+    ctx = pb.build_context("plan")
+    assert ctx.get("has_review_comments") is True
+
+
+def test_build_context_has_review_comments_false_when_empty_list():
+    pb = PromptBuilder("Fix bug", "Desc")
+    pb.update_context("review_comments", [])
+    ctx = pb.build_context("plan")
+    assert ctx.get("has_review_comments") is False
+
+
+def test_has_review_comments_active_in_plan_and_coordinate_stages():
+    pb = PromptBuilder("Fix bug", "Desc")
+    pb.update_context("review_comments", [{"thread_id": "T1", "body": "fix this"}])
+    plan_ctx = pb.build_context("plan")
+    coord_ctx = pb.build_context("coordinate")
+    assert plan_ctx.get("has_review_comments") is True
+    assert coord_ctx.get("has_review_comments") is True
+
+
+def test_build_context_coordinate_has_review_comments_false_by_default():
+    pb = PromptBuilder("Fix bug", "Desc")
+    ctx = pb.build_context("coordinate")
+    assert ctx.get("has_review_comments") is False
+
+
+def test_build_context_coordinate_has_review_comments_true_when_set():
+    pb = PromptBuilder("Fix bug", "Desc")
+    pb.update_context("review_comments", [{"thread_id": "PRRT_1", "path": "src/foo.py", "line": 42, "body": "fix this"}])
+    ctx = pb.build_context("coordinate")
+    assert ctx.get("has_review_comments") is True
+
+
+def test_build_context_coordinate_has_review_comments_false_when_empty():
+    pb = PromptBuilder("Fix bug", "Desc")
+    pb.update_context("review_comments", [])
+    ctx = pb.build_context("coordinate")
+    assert ctx.get("has_review_comments") is False

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -634,3 +634,42 @@ def test_reconcile_orphan_groups_strips_fleet_id_only_no_group_type(tmp_path):
     assert orphaned == ["run-ngt"]
     entry = get_pipeline("run-ngt", base=base)
     assert "fleet_id" not in entry
+
+
+# --- revises_pr field ---
+
+
+def test_register_with_revises_pr(tmp_path):
+    """revises_pr: N is stored in the registry when provided (PR revision run)."""
+    base = str(tmp_path / ".worca")
+    path = register_pipeline(
+        "run-rev", "/tmp/wt", "PR Revision", 1, base=base,
+        revises_pr=42,
+    )
+    with open(path) as f:
+        data = json.load(f)
+    assert data["revises_pr"] == 42
+
+
+def test_register_omits_revises_pr_when_unset(tmp_path):
+    """revises_pr is absent from the JSON when not provided (normal runs)."""
+    base = str(tmp_path / ".worca")
+    path = register_pipeline("run-norev", "/tmp/wt", "Normal Run", 1, base=base)
+    with open(path) as f:
+        data = json.load(f)
+    assert "revises_pr" not in data
+
+
+def test_register_pr_revision_preserves_head_branch(tmp_path):
+    """For PR source runs, branch equals the PR head branch name verbatim (L2)."""
+    base = str(tmp_path / ".worca")
+    head_branch = "feature/my-existing-pr-branch"
+    path = register_pipeline(
+        "run-prhead", "/tmp/wt", "PR Head Branch", 1, base=base,
+        branch=head_branch,
+        revises_pr=7,
+    )
+    with open(path) as f:
+        data = json.load(f)
+    assert data["branch"] == head_branch
+    assert data["revises_pr"] == 7

--- a/tests/test_run_worktree.py
+++ b/tests/test_run_worktree.py
@@ -756,3 +756,87 @@ class TestAwaitPipelineStartup:
         from worca.scripts.run_worktree import _spawn_log_tail
 
         assert _spawn_log_tail(str(tmp_path / "missing.log")) == ""
+
+
+# ---------------------------------------------------------------------------
+# W-067: github_pr source — branch flag rejection and target_branch derivation
+# ---------------------------------------------------------------------------
+
+def _pr_wr(
+    title="Fix auth bug",
+    pr_number=42,
+    pr_head_branch="worca/fix-auth-abc",
+    pr_base_branch="main",
+    pr_is_cross_repo=False,
+):
+    return WorkRequest(
+        source_type="github_pr",
+        title=title,
+        pr_number=pr_number,
+        pr_head_branch=pr_head_branch,
+        pr_base_branch=pr_base_branch,
+        pr_is_cross_repo=pr_is_cross_repo,
+    )
+
+
+class TestGithubPrSource:
+    """W-067: worktree behaviour for source_type==github_pr."""
+
+    def test_worktree_pr_source_rejects_branch_flag(self, capsys):
+        """--branch must be rejected when source is a github PR."""
+        from worca.scripts.run_worktree import main
+        plist = _patches()
+        with plist[0], plist[1] as mock_norm, plist[2], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+            mock_norm.return_value = _pr_wr()
+            rc = main(["--source", "gh:pr:42", "--branch", "feature/other"])
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "branch" in captured.err.lower() or "branch" in captured.out.lower()
+
+    def test_worktree_pr_target_branch_from_base(self):
+        """target_branch in registry must come from pr_base_branch, not --branch."""
+        from worca.scripts.run_worktree import main
+        plist = _patches()
+        with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             patch("worca.scripts.run_worktree.checkout_pr_worktree", return_value=_WORKTREE_PATH), \
+             patch("worca.scripts.run_worktree.load_settings",
+                   return_value={"worca": {"parallel": {}}}):
+            mock_norm.return_value = _pr_wr(pr_base_branch="develop")
+            rc = main(["--source", "gh:pr:42"])
+        assert rc == 0
+        kwargs = mock_reg.call_args[1]
+        assert kwargs["target_branch"] == "develop"
+        # create_pipeline_worktree must NOT be called; checkout_pr_worktree handles it
+        mock_create.assert_not_called()
+
+    def test_worktree_pr_uses_checkout_pr_worktree(self):
+        """For github_pr source, checkout_pr_worktree is called (not create_pipeline_worktree)."""
+        from worca.scripts.run_worktree import main
+        plist = _patches()
+        with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             patch("worca.scripts.run_worktree.checkout_pr_worktree", return_value=_WORKTREE_PATH) as mock_checkout, \
+             patch("worca.scripts.run_worktree.load_settings",
+                   return_value={"worca": {"parallel": {}}}):
+            mock_norm.return_value = _pr_wr(pr_number=42, pr_is_cross_repo=False)
+            rc = main(["--source", "gh:pr:42"])
+        assert rc == 0
+        mock_checkout.assert_called_once()
+        mock_create.assert_not_called()
+
+    def test_worktree_pr_head_branch_preserved_in_registry(self):
+        """The worktree branch stored in the registry is the PR head branch (L2)."""
+        from worca.scripts.run_worktree import main
+        plist = _patches()
+        with plist[0], plist[1] as mock_norm, plist[2], \
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             patch("worca.scripts.run_worktree.checkout_pr_worktree", return_value=_WORKTREE_PATH), \
+             patch("worca.scripts.run_worktree.load_settings",
+                   return_value={"worca": {"parallel": {}}}):
+            mock_norm.return_value = _pr_wr(pr_head_branch="feature/my-fix")
+            rc = main(["--source", "gh:pr:42"])
+        assert rc == 0
+        kwargs = mock_reg.call_args[1]
+        assert kwargs["branch"] == "feature/my-fix"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1149,10 +1149,13 @@ def test_run_pipeline_main_calls_gh_issue_fail_on_loop_exhausted(tmp_path, monke
 
     error_msg = "Loop implement_test exhausted after 5 iterations"
 
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}")
     monkeypatch.setattr(
         "sys.argv",
         ["run_pipeline.py", "--source", "gh:issue:42",
-         "--status-dir", str(worca_dir)],
+         "--status-dir", str(worca_dir),
+         "--settings", str(settings_file)],
     )
     with patch.object(mod, "run_pipeline", side_effect=LoopExhaustedError(error_msg)):
         with patch.object(mod, "normalize") as mock_normalize:
@@ -1197,10 +1200,13 @@ def test_run_pipeline_main_calls_gh_issue_fail_on_pipeline_error(tmp_path, monke
 
     error_msg = "Guardian rejected changes after 3 review cycles"
 
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}")
     monkeypatch.setattr(
         "sys.argv",
         ["run_pipeline.py", "--source", "gh:issue:99",
-         "--status-dir", str(worca_dir)],
+         "--status-dir", str(worca_dir),
+         "--settings", str(settings_file)],
     )
     with patch.object(mod, "run_pipeline", side_effect=PipelineError(error_msg)):
         with patch.object(mod, "normalize") as mock_normalize:
@@ -1237,10 +1243,13 @@ def test_run_pipeline_main_gh_issue_fail_noop_for_non_github(tmp_path, monkeypat
     with open(status_path, "w") as f:
         json.dump(status_data, f)
 
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}")
     monkeypatch.setattr(
         "sys.argv",
         ["run_pipeline.py", "--prompt", "do something",
-         "--status-dir", str(worca_dir)],
+         "--status-dir", str(worca_dir),
+         "--settings", str(settings_file)],
     )
     with patch.object(mod, "run_pipeline", side_effect=PipelineError("fail")):
         with patch.object(mod, "normalize") as mock_normalize:
@@ -1274,10 +1283,13 @@ def test_run_pipeline_main_gh_issue_fail_never_crashes_pipeline(tmp_path, monkey
     with open(str(worca_dir / "status.json"), "w") as f:
         json.dump(status_data, f)
 
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text("{}")
     monkeypatch.setattr(
         "sys.argv",
         ["run_pipeline.py", "--source", "gh:issue:42",
-         "--status-dir", str(worca_dir)],
+         "--status-dir", str(worca_dir),
+         "--settings", str(settings_file)],
     )
     with patch.object(mod, "run_pipeline", side_effect=LoopExhaustedError("exhausted")):
         with patch.object(mod, "normalize") as mock_normalize:

--- a/tests/test_runner_pr_verification.py
+++ b/tests/test_runner_pr_verification.py
@@ -14,7 +14,7 @@ import inspect
 from unittest.mock import patch
 
 
-from worca.orchestrator.runner import PRVerification, _verify_pr_stage, _verify_pr_via_gh
+from worca.orchestrator.runner import PRVerification, _verify_pr_stage, _verify_pr_via_gh, _fetch_pr_url_via_gh
 from worca.orchestrator import runner as _runner_module
 
 
@@ -360,6 +360,76 @@ class TestVerifyPRStageNonDictResult:
         with patch("worca.orchestrator.runner.get_current_git_head", return_value=SHA_NEW):
             result = _verify_pr_stage([], SHA_BASELINE)
         assert result.ok is False
+
+
+class TestFetchPrUrlViaGh:
+    """Unit tests for _fetch_pr_url_via_gh helper."""
+
+    def test_returns_url_on_success(self):
+        payload = '{"url": "https://github.com/org/repo/pull/42", "number": 42}'
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = payload
+            result = _fetch_pr_url_via_gh(42)
+        assert result == "https://github.com/org/repo/pull/42"
+
+    def test_returns_none_when_gh_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = _fetch_pr_url_via_gh(42)
+        assert result is None
+
+    def test_returns_none_on_nonzero_returncode(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.stderr = "not found"
+            result = _fetch_pr_url_via_gh(42)
+        assert result is None
+
+    def test_returns_none_on_invalid_json(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "not-json"
+            result = _fetch_pr_url_via_gh(42)
+        assert result is None
+
+    def test_returns_none_when_url_missing_from_response(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = '{"number": 42}'
+            result = _fetch_pr_url_via_gh(42)
+        assert result is None
+
+    def test_returns_none_on_timeout(self):
+        import subprocess
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 10)):
+            result = _fetch_pr_url_via_gh(42)
+        assert result is None
+
+
+class TestReviseModeEnvWiring:
+    """Sentinel tests: WORCA_REVISE_PR is wired into agent subprocess env."""
+
+    def _pipeline_source(self):
+        return inspect.getsource(_runner_module.run_pipeline)
+
+    def test_worca_revise_pr_injected_when_revises_pr_set(self):
+        src = self._pipeline_source()
+        assert "WORCA_REVISE_PR" in src, (
+            "WORCA_REVISE_PR not found in run_pipeline — env wiring missing"
+        )
+
+    def test_revises_pr_read_from_status_for_env_injection(self):
+        src = self._pipeline_source()
+        assert 'status.get("revises_pr")' in src or "status[\"revises_pr\"]" in src or "revises_pr" in src, (
+            "revises_pr not read from status in run_pipeline — env wiring missing"
+        )
+
+    def test_fetch_pr_url_called_in_revise_fallback(self):
+        src = self._pipeline_source()
+        assert "_fetch_pr_url_via_gh" in src, (
+            "_fetch_pr_url_via_gh not called in run_pipeline — revise fallback missing"
+        )
 
 
 class TestPRStageHandlerWiring:

--- a/tests/test_runner_pr_verification.py
+++ b/tests/test_runner_pr_verification.py
@@ -511,6 +511,18 @@ class TestRevisePrWriteback:
         for call in mock_reply.call_args_list:
             assert "deadbee" in call.args[2]
 
+    def test_writeback_text_carries_worca_marker(self):
+        """Summary + every reply start with WORCA_COMMENT_MARKER so a later
+        revise run recognises and skips worca's own writeback (L1)."""
+        from worca.utils.gh_pr import WORCA_COMMENT_MARKER
+
+        p_nwo, p_sum, p_reply = self._patches()
+        with p_nwo, p_sum as mock_sum, p_reply as mock_reply:
+            _revise_pr_writeback(7, "abc1234", self._FEEDBACK)
+        assert mock_sum.call_args[0][2].startswith(WORCA_COMMENT_MARKER)
+        for call in mock_reply.call_args_list:
+            assert call.args[2].startswith(WORCA_COMMENT_MARKER)
+
     def test_dedups_repeated_thread_ids(self):
         feedback = [
             {"thread_id": "PRRT_a", "body": "first"},

--- a/tests/test_runner_pr_verification.py
+++ b/tests/test_runner_pr_verification.py
@@ -14,7 +14,13 @@ import inspect
 from unittest.mock import patch
 
 
-from worca.orchestrator.runner import PRVerification, _verify_pr_stage, _verify_pr_via_gh, _fetch_pr_url_via_gh
+from worca.orchestrator.runner import (
+    PRVerification,
+    _verify_pr_stage,
+    _verify_pr_via_gh,
+    _fetch_pr_url_via_gh,
+    _revise_pr_writeback,
+)
 from worca.orchestrator import runner as _runner_module
 
 
@@ -463,3 +469,82 @@ class TestPRStageHandlerWiring:
         assert "_pr_baseline_head is None" in src, (
             "Baseline guard 'is None' missing — capture would happen every iteration"
         )
+
+
+class TestRevisePrWriteback:
+    """Runner-side PR writeback for revise mode (W-067) — summary + replies."""
+
+    _FEEDBACK = [
+        {"thread_id": "PRRT_a", "path": "src/x.py", "line": 1, "body": "fix a"},
+        {"thread_id": "PRRT_b", "path": "src/y.py", "line": 2, "body": "fix b"},
+        # review_summary item: no thread_id → no reply, counts as PR-level only
+        {"thread_id": "", "path": "", "line": None, "body": "add a test"},
+    ]
+
+    def _patches(self, nwo="owner/repo"):
+        return (
+            patch("worca.orchestrator.runner.current_repo_nwo", return_value=nwo),
+            patch("worca.orchestrator.runner.post_revision_summary", return_value=True),
+            patch("worca.orchestrator.runner.reply_to_thread", return_value=True),
+        )
+
+    def test_posts_summary_and_replies_to_threads_with_ids(self):
+        p_nwo, p_sum, p_reply = self._patches()
+        with p_nwo, p_sum as mock_sum, p_reply as mock_reply:
+            _revise_pr_writeback(42, "abc1234", self._FEEDBACK)
+
+        mock_sum.assert_called_once()
+        # summary args: (nwo, pr_number, body)
+        nwo_arg, pr_arg, body_arg = mock_sum.call_args[0]
+        assert nwo_arg == "owner/repo"
+        assert pr_arg == 42
+        assert "abc1234" in body_arg
+        # two threads have thread_ids → two replies; the review_summary is skipped
+        assert mock_reply.call_count == 2
+        replied_threads = {c.args[1] for c in mock_reply.call_args_list}
+        assert replied_threads == {"PRRT_a", "PRRT_b"}
+
+    def test_reply_body_includes_commit_sha(self):
+        p_nwo, p_sum, p_reply = self._patches()
+        with p_nwo, p_sum, p_reply as mock_reply:
+            _revise_pr_writeback(7, "deadbee", self._FEEDBACK)
+        for call in mock_reply.call_args_list:
+            assert "deadbee" in call.args[2]
+
+    def test_dedups_repeated_thread_ids(self):
+        feedback = [
+            {"thread_id": "PRRT_a", "body": "first"},
+            {"thread_id": "PRRT_a", "body": "second comment, same thread"},
+        ]
+        p_nwo, p_sum, p_reply = self._patches()
+        with p_nwo, p_sum, p_reply as mock_reply:
+            _revise_pr_writeback(1, "sha", feedback)
+        assert mock_reply.call_count == 1
+
+    def test_no_nwo_skips_summary_but_still_replies(self):
+        p_nwo, p_sum, p_reply = self._patches(nwo="")
+        with p_nwo, p_sum as mock_sum, p_reply as mock_reply:
+            _revise_pr_writeback(5, "sha", self._FEEDBACK)
+        mock_sum.assert_not_called()
+        assert mock_reply.call_count == 2
+
+    def test_missing_commit_sha_omits_commit_phrase(self):
+        p_nwo, p_sum, p_reply = self._patches()
+        with p_nwo, p_sum as mock_sum, p_reply as mock_reply:
+            _revise_pr_writeback(9, None, self._FEEDBACK)
+        body_arg = mock_sum.call_args[0][2]
+        assert "commit" not in body_arg
+        for call in mock_reply.call_args_list:
+            assert "commit" not in call.args[2]
+
+    def test_empty_feedback_posts_summary_no_replies(self):
+        p_nwo, p_sum, p_reply = self._patches()
+        with p_nwo, p_sum as mock_sum, p_reply as mock_reply:
+            _revise_pr_writeback(3, "sha", [])
+        mock_sum.assert_called_once()
+        mock_reply.assert_not_called()
+
+    def test_wired_into_run_pipeline_revise_branch(self):
+        """Sentinel: run_pipeline calls _revise_pr_writeback in revise mode."""
+        src = inspect.getsource(_runner_module.run_pipeline)
+        assert "_revise_pr_writeback" in src

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -243,6 +243,30 @@ def test_init_status_worktree_path_key_absent():
     assert "worktree_path" not in result
 
 
+def test_init_status_pr_revision_fields_defaults():
+    wr = {"title": "Task"}
+    result = init_status(wr, "feat/task")
+    assert result["source_type"] is None
+    assert result["source_ref"] is None
+    assert result["revises_pr"] is None
+    assert result["review_feedback"] == []
+
+
+def test_init_status_pr_revision_fields_from_work_request():
+    wr = {
+        "title": "Fix auth",
+        "source_type": "github_pr",
+        "source_ref": "gh:pr:42",
+        "pr_number": 42,
+        "review_comments": [{"body": "Needs tests", "path": "auth.py"}],
+    }
+    result = init_status(wr, "feat/fix-auth")
+    assert result["source_type"] == "github_pr"
+    assert result["source_ref"] == "gh:pr:42"
+    assert result["revises_pr"] == 42
+    assert result["review_feedback"] == [{"body": "Needs tests", "path": "auth.py"}]
+
+
 # --- start_iteration ---
 
 def test_start_iteration_creates_list():

--- a/tests/test_work_request.py
+++ b/tests/test_work_request.py
@@ -1023,7 +1023,6 @@ class TestNormalizeGithubPr:
         "body": "This PR fixes the memory leak described in #42.",
         "baseRefName": "main",
         "headRefName": "worca/fix-leak-abc123",
-        "headRepository": {"nameWithOwner": "owner/repo"},
         "isCrossRepository": False,
         "author": {"login": "alice"},
     }
@@ -1038,6 +1037,23 @@ class TestNormalizeGithubPr:
         "kind": "inline",
         "created_at": "2026-06-03T12:00:00Z",
     }
+
+    @pytest.fixture(autouse=True)
+    def _patch_pr_helpers(self):
+        """nwo + bot-login are resolved via subprocess (gh) in gh_pr; stub them
+        so normalize_github_pr never shells out during unit tests. nwo comes
+        from the base repo (current_repo_nwo), NOT the PR's headRepository."""
+        with patch(
+            "worca.orchestrator.work_request.current_repo_nwo",
+            return_value="owner/repo",
+        ), patch(
+            "worca.orchestrator.work_request.resolve_bot_login",
+            return_value="worca-bot",
+        ), patch(
+            "worca.orchestrator.work_request.load_settings",
+            return_value={},
+        ):
+            yield
 
     def _mock_gh(self, mock_subprocess, response=None):
         mock_result = MagicMock()
@@ -1084,7 +1100,7 @@ class TestNormalizeGithubPr:
         assert wr.pr_is_cross_repo is False
         assert wr.source_ref == "gh:pr:42"
         assert wr.review_comments == [self._REVIEW_COMMENT]
-        mock_fetch.assert_called_once_with("owner/repo", 42)
+        mock_fetch.assert_called_once_with("owner/repo", 42, bot_login="worca-bot")
 
     @patch("worca.orchestrator.work_request.fetch_review_feedback")
     @patch("worca.orchestrator.work_request.subprocess")
@@ -1128,6 +1144,76 @@ class TestNormalizeGithubPr:
         with pytest.raises(RuntimeError, match="Failed to fetch PR"):
             normalize_github_pr("gh:pr:99")
 
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_nwo_resolved_from_base_repo_not_head_repository(
+        self, mock_subprocess, mock_fetch
+    ):
+        """Regression: nwo must come from current_repo_nwo() (the base repo),
+        never from the PR's headRepository — gh pr view does not expose a
+        nameWithOwner there, so the old path silently fetched nothing."""
+        self._mock_gh(mock_subprocess)
+        mock_fetch.return_value = []
+        with patch(
+            "worca.orchestrator.work_request.current_repo_nwo",
+            return_value="base-owner/base-repo",
+        ):
+            normalize_github_pr("gh:pr:42")
+        nwo_arg = mock_fetch.call_args[0][0]
+        assert nwo_arg == "base-owner/base-repo"
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_empty_nwo_skips_fetch(self, mock_subprocess, mock_fetch):
+        """If the base repo can't be resolved, ingestion is skipped, not crashed."""
+        self._mock_gh(mock_subprocess)
+        with patch(
+            "worca.orchestrator.work_request.current_repo_nwo", return_value=""
+        ):
+            wr = normalize_github_pr("gh:pr:42")
+        mock_fetch.assert_not_called()
+        assert wr.review_comments == []
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_config_bot_login_overrides_token(self, mock_subprocess, mock_fetch):
+        """worca.pr_revision.bot_login (config) takes precedence over the token."""
+        self._mock_gh(mock_subprocess)
+        mock_fetch.return_value = []
+        with patch(
+            "worca.orchestrator.work_request.load_settings",
+            return_value={"worca": {"pr_revision": {"bot_login": "configured-bot"}}},
+        ), patch(
+            "worca.orchestrator.work_request.resolve_bot_login",
+            return_value="token-bot",
+        ):
+            normalize_github_pr("gh:pr:42")
+        assert mock_fetch.call_args.kwargs["bot_login"] == "configured-bot"
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_pr_level_feedback_synthesized_without_anchor(
+        self, mock_subprocess, mock_fetch
+    ):
+        """A review_summary item (no path / thread_id) renders as [PR-level]
+        with no trailing (thread: …) suffix."""
+        self._mock_gh(mock_subprocess)
+        mock_fetch.return_value = [
+            {
+                "thread_id": "",
+                "path": "",
+                "line": None,
+                "diff_hunk": "",
+                "author": "carol",
+                "body": "add a test for the empty case",
+                "kind": "review_summary",
+                "created_at": "2026-06-03T12:00:00Z",
+            }
+        ]
+        wr = normalize_github_pr("gh:pr:42")
+        assert "[PR-level] @carol:" in wr.description
+        assert "(thread:" not in wr.description
+
 
 # --- parse_pr_url number extraction ---
 
@@ -1159,13 +1245,26 @@ _DISPATCH_PR_RESPONSE = {
     "body": "",
     "baseRefName": "main",
     "headRefName": "feature/x",
-    "headRepository": {"nameWithOwner": "owner/repo"},
     "isCrossRepository": False,
     "author": {"login": "alice"},
 }
 
 
 class TestNormalizeGithubPrDispatch:
+    @pytest.fixture(autouse=True)
+    def _patch_pr_helpers(self):
+        with patch(
+            "worca.orchestrator.work_request.current_repo_nwo",
+            return_value="owner/repo",
+        ), patch(
+            "worca.orchestrator.work_request.resolve_bot_login",
+            return_value=None,
+        ), patch(
+            "worca.orchestrator.work_request.load_settings",
+            return_value={},
+        ):
+            yield
+
     @patch("worca.orchestrator.work_request.fetch_review_feedback", return_value=[])
     @patch("worca.orchestrator.work_request.subprocess")
     def test_normalize_dispatches_gh_pr_scheme(self, mock_subprocess, mock_fetch):

--- a/tests/test_work_request.py
+++ b/tests/test_work_request.py
@@ -13,6 +13,7 @@ from worca.orchestrator.work_request import (
     normalize_spec_file,
     normalize_github_issue,
     normalize_beads_task,
+    normalize_github_pr,
     normalize,
 )
 
@@ -31,6 +32,31 @@ class TestWorkRequest:
         assert wr.source_ref is None
         assert wr.priority == 2
         assert wr.plan_path is None
+
+    def test_pr_revision_fields_default(self):
+        wr = WorkRequest(source_type="prompt", title="t")
+        assert wr.pr_number is None
+        assert wr.pr_head_branch is None
+        assert wr.pr_base_branch is None
+        assert wr.pr_is_cross_repo is False
+        assert wr.review_comments == []
+
+    def test_pr_revision_fields_set(self):
+        wr = WorkRequest(
+            source_type="github_pr",
+            title="Fix review comments",
+            pr_number=42,
+            pr_head_branch="worca/my-feature-abc123",
+            pr_base_branch="main",
+            pr_is_cross_repo=True,
+            review_comments=[{"id": "RC_1", "body": "Fix this", "path": "foo.py", "line": 10}],
+        )
+        assert wr.pr_number == 42
+        assert wr.pr_head_branch == "worca/my-feature-abc123"
+        assert wr.pr_base_branch == "main"
+        assert wr.pr_is_cross_repo is True
+        assert len(wr.review_comments) == 1
+        assert wr.review_comments[0]["id"] == "RC_1"
 
     def test_all_fields(self):
         wr = WorkRequest(
@@ -916,6 +942,51 @@ class TestAttachGuide:
         with pytest.raises(ValueError, match="exceeds worca.guide.max_bytes"):
             attach_guide(wr, [str(a), str(b)], max_bytes=100)
 
+    def test_pr_fields_preserved_with_guide(self, tmp_path):
+        from worca.orchestrator.work_request import attach_guide
+
+        guide = tmp_path / "spec.md"
+        guide.write_text("Normative spec.")
+
+        wr = WorkRequest(
+            source_type="github_pr",
+            title="Fix bug",
+            description="PR body.",
+            pr_number=42,
+            pr_head_branch="worca/fix-abc",
+            pr_base_branch="main",
+            pr_is_cross_repo=True,
+            review_comments=[{"id": "RC_1", "body": "Nit"}],
+        )
+        result = attach_guide(wr, [str(guide)])
+
+        assert result.pr_number == 42
+        assert result.pr_head_branch == "worca/fix-abc"
+        assert result.pr_base_branch == "main"
+        assert result.pr_is_cross_repo is True
+        assert result.review_comments == [{"id": "RC_1", "body": "Nit"}]
+
+    def test_pr_fields_preserved_empty_guide_list(self):
+        from worca.orchestrator.work_request import attach_guide
+
+        wr = WorkRequest(
+            source_type="github_pr",
+            title="Fix bug",
+            description="PR body.",
+            pr_number=7,
+            pr_head_branch="worca/my-branch",
+            pr_base_branch="main",
+            pr_is_cross_repo=False,
+            review_comments=[{"id": "RC_2", "body": "Fix this"}],
+        )
+        result = attach_guide(wr, [])
+
+        assert result.pr_number == 7
+        assert result.pr_head_branch == "worca/my-branch"
+        assert result.pr_base_branch == "main"
+        assert result.pr_is_cross_repo is False
+        assert result.review_comments == [{"id": "RC_2", "body": "Fix this"}]
+
 
 class TestResolveGuideMaxBytes:
     """resolve_guide_max_bytes(settings) reads worca.guide.max_bytes."""
@@ -940,6 +1011,206 @@ class TestResolveGuideMaxBytes:
         from worca.orchestrator.work_request import GUIDE_MAX_BYTES_DEFAULT
 
         assert GUIDE_MAX_BYTES_DEFAULT == 131072
+
+
+# --- normalize_github_pr ---
+
+class TestNormalizeGithubPr:
+    """Tests for normalize_github_pr() — full implementation."""
+
+    _GH_PR_RESPONSE = {
+        "title": "Fix memory leak in connection pool",
+        "body": "This PR fixes the memory leak described in #42.",
+        "baseRefName": "main",
+        "headRefName": "worca/fix-leak-abc123",
+        "headRepository": {"nameWithOwner": "owner/repo"},
+        "isCrossRepository": False,
+        "author": {"login": "alice"},
+    }
+
+    _REVIEW_COMMENT = {
+        "thread_id": "PRRT_aaa",
+        "path": "src/pool.py",
+        "line": 42,
+        "diff_hunk": "@@ -40,6 @@",
+        "author": "bob",
+        "body": "this leaks a file handle",
+        "kind": "inline",
+        "created_at": "2026-06-03T12:00:00Z",
+    }
+
+    def _mock_gh(self, mock_subprocess, response=None):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(response if response is not None else self._GH_PR_RESPONSE)
+        mock_subprocess.run.return_value = mock_result
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_gh_pr_scheme_returns_github_pr_work_request(self, mock_subprocess, mock_fetch):
+        self._mock_gh(mock_subprocess)
+        mock_fetch.return_value = []
+        wr = normalize_github_pr("gh:pr:42")
+        assert wr.source_type == "github_pr"
+        assert wr.pr_number == 42
+        assert wr.source_ref == "gh:pr:42"
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_gh_pr_scheme_title_from_pr_metadata(self, mock_subprocess, mock_fetch):
+        self._mock_gh(mock_subprocess)
+        mock_fetch.return_value = []
+        wr = normalize_github_pr("gh:pr:42")
+        assert wr.title == "Fix memory leak in connection pool"
+
+    def test_gh_pr_scheme_invalid_number_raises(self):
+        with pytest.raises(ValueError):
+            normalize_github_pr("gh:pr:abc")
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_normalize_github_pr_builds_work_request(self, mock_subprocess, mock_fetch):
+        """Full: all WorkRequest PR-revision fields are populated correctly."""
+        self._mock_gh(mock_subprocess)
+        mock_fetch.return_value = [self._REVIEW_COMMENT]
+
+        wr = normalize_github_pr("gh:pr:42")
+
+        assert wr.source_type == "github_pr"
+        assert wr.pr_number == 42
+        assert wr.title == "Fix memory leak in connection pool"
+        assert wr.pr_head_branch == "worca/fix-leak-abc123"
+        assert wr.pr_base_branch == "main"
+        assert wr.pr_is_cross_repo is False
+        assert wr.source_ref == "gh:pr:42"
+        assert wr.review_comments == [self._REVIEW_COMMENT]
+        mock_fetch.assert_called_once_with("owner/repo", 42)
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_review_feedback_description_synthesis(self, mock_subprocess, mock_fetch):
+        """Description = original PR body + ## Review Feedback to Address with [file:line] anchors."""
+        self._mock_gh(mock_subprocess)
+        mock_fetch.return_value = [self._REVIEW_COMMENT]
+
+        wr = normalize_github_pr("gh:pr:42")
+
+        assert "This PR fixes the memory leak" in wr.description
+        assert "## Review Feedback to Address" in wr.description
+        assert "[src/pool.py:42]" in wr.description
+        assert "@bob" in wr.description
+        assert "this leaks a file handle" in wr.description
+        assert "PRRT_aaa" in wr.description
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_no_review_comments_omits_feedback_section(self, mock_subprocess, mock_fetch):
+        self._mock_gh(mock_subprocess)
+        mock_fetch.return_value = []
+        wr = normalize_github_pr("gh:pr:42")
+        assert "## Review Feedback to Address" not in wr.description
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback")
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_cross_repo_flag_set(self, mock_subprocess, mock_fetch):
+        response = dict(self._GH_PR_RESPONSE, isCrossRepository=True)
+        self._mock_gh(mock_subprocess, response)
+        mock_fetch.return_value = []
+        wr = normalize_github_pr("gh:pr:7")
+        assert wr.pr_is_cross_repo is True
+
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_gh_failure_raises_runtime_error(self, mock_subprocess):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "authentication required"
+        mock_subprocess.run.return_value = mock_result
+        with pytest.raises(RuntimeError, match="Failed to fetch PR"):
+            normalize_github_pr("gh:pr:99")
+
+
+# --- parse_pr_url number extraction ---
+
+class TestParsePrUrlNumber:
+    def test_pr_url_resolves_to_number(self):
+        from worca.utils.pr_url import parse_pr_url
+        result = parse_pr_url("https://github.com/owner/repo/pull/99")
+        assert result["provider"] == "github"
+        assert result["number"] == 99
+
+    def test_pr_url_github_enterprise_resolves_number(self):
+        from worca.utils.pr_url import parse_pr_url
+        result = parse_pr_url("https://github.mycompany.com/owner/repo/pull/123")
+        assert result["provider"] == "github"
+        assert result["number"] == 123
+
+    def test_pr_url_non_github_has_no_number(self):
+        from worca.utils.pr_url import parse_pr_url
+        result = parse_pr_url("https://gitlab.com/group/repo/-/merge_requests/5")
+        assert result["provider"] == "gitlab"
+        # number not required for non-github, but should not crash
+        assert "number" not in result or result["number"] is None
+
+
+# --- normalize dispatcher with gh:pr: ---
+
+_DISPATCH_PR_RESPONSE = {
+    "title": "Some PR",
+    "body": "",
+    "baseRefName": "main",
+    "headRefName": "feature/x",
+    "headRepository": {"nameWithOwner": "owner/repo"},
+    "isCrossRepository": False,
+    "author": {"login": "alice"},
+}
+
+
+class TestNormalizeGithubPrDispatch:
+    @patch("worca.orchestrator.work_request.fetch_review_feedback", return_value=[])
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_normalize_dispatches_gh_pr_scheme(self, mock_subprocess, mock_fetch):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(_DISPATCH_PR_RESPONSE)
+        mock_subprocess.run.return_value = mock_result
+        wr = normalize("source", "gh:pr:55")
+        assert wr.source_type == "github_pr"
+        assert wr.pr_number == 55
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback", return_value=[])
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_normalize_dispatches_full_github_pr_url(self, mock_subprocess, mock_fetch):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(_DISPATCH_PR_RESPONSE)
+        mock_subprocess.run.return_value = mock_result
+        wr = normalize("source", "https://github.com/owner/repo/pull/77")
+        assert wr.source_type == "github_pr"
+        assert wr.pr_number == 77
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback", return_value=[])
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_normalize_pr_type_dispatches_gh_pr(self, mock_subprocess, mock_fetch):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(_DISPATCH_PR_RESPONSE)
+        mock_subprocess.run.return_value = mock_result
+        wr = normalize("pr", "gh:pr:10")
+        assert wr.source_type == "github_pr"
+
+    def test_normalize_non_github_pr_url_raises(self):
+        with pytest.raises(ValueError, match="not yet supported"):
+            normalize("source", "https://gitlab.com/group/repo/-/merge_requests/5")
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback", return_value=[])
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_normalize_full_github_pr_url_sets_source_ref(self, mock_subprocess, mock_fetch):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(_DISPATCH_PR_RESPONSE)
+        mock_subprocess.run.return_value = mock_result
+        wr = normalize("source", "https://github.com/owner/repo/pull/33")
+        assert wr.source_ref == "gh:pr:33"
 
 
 # --- graph report static-injection surface removed (W-053 query pivot) ---

--- a/tests/test_work_request.py
+++ b/tests/test_work_request.py
@@ -1040,18 +1040,12 @@ class TestNormalizeGithubPr:
 
     @pytest.fixture(autouse=True)
     def _patch_pr_helpers(self):
-        """nwo + bot-login are resolved via subprocess (gh) in gh_pr; stub them
-        so normalize_github_pr never shells out during unit tests. nwo comes
-        from the base repo (current_repo_nwo), NOT the PR's headRepository."""
+        """nwo is resolved via subprocess (gh) in gh_pr; stub it so
+        normalize_github_pr never shells out during unit tests. nwo comes from
+        the base repo (current_repo_nwo), NOT the PR's headRepository."""
         with patch(
             "worca.orchestrator.work_request.current_repo_nwo",
             return_value="owner/repo",
-        ), patch(
-            "worca.orchestrator.work_request.resolve_bot_login",
-            return_value="worca-bot",
-        ), patch(
-            "worca.orchestrator.work_request.load_settings",
-            return_value={},
         ):
             yield
 
@@ -1100,7 +1094,7 @@ class TestNormalizeGithubPr:
         assert wr.pr_is_cross_repo is False
         assert wr.source_ref == "gh:pr:42"
         assert wr.review_comments == [self._REVIEW_COMMENT]
-        mock_fetch.assert_called_once_with("owner/repo", 42, bot_login="worca-bot")
+        mock_fetch.assert_called_once_with("owner/repo", 42)
 
     @patch("worca.orchestrator.work_request.fetch_review_feedback")
     @patch("worca.orchestrator.work_request.subprocess")
@@ -1176,22 +1170,6 @@ class TestNormalizeGithubPr:
 
     @patch("worca.orchestrator.work_request.fetch_review_feedback")
     @patch("worca.orchestrator.work_request.subprocess")
-    def test_config_bot_login_overrides_token(self, mock_subprocess, mock_fetch):
-        """worca.pr_revision.bot_login (config) takes precedence over the token."""
-        self._mock_gh(mock_subprocess)
-        mock_fetch.return_value = []
-        with patch(
-            "worca.orchestrator.work_request.load_settings",
-            return_value={"worca": {"pr_revision": {"bot_login": "configured-bot"}}},
-        ), patch(
-            "worca.orchestrator.work_request.resolve_bot_login",
-            return_value="token-bot",
-        ):
-            normalize_github_pr("gh:pr:42")
-        assert mock_fetch.call_args.kwargs["bot_login"] == "configured-bot"
-
-    @patch("worca.orchestrator.work_request.fetch_review_feedback")
-    @patch("worca.orchestrator.work_request.subprocess")
     def test_pr_level_feedback_synthesized_without_anchor(
         self, mock_subprocess, mock_fetch
     ):
@@ -1256,12 +1234,6 @@ class TestNormalizeGithubPrDispatch:
         with patch(
             "worca.orchestrator.work_request.current_repo_nwo",
             return_value="owner/repo",
-        ), patch(
-            "worca.orchestrator.work_request.resolve_bot_login",
-            return_value=None,
-        ), patch(
-            "worca.orchestrator.work_request.load_settings",
-            return_value={},
         ):
             yield
 

--- a/worca-ui/app/views/fleet-launcher.js
+++ b/worca-ui/app/views/fleet-launcher.js
@@ -112,6 +112,7 @@ function _detectCollision(_template, _projects) {
 function _sourceLabel(type) {
   if (type === 'source') return 'GitHub Issue or Bead';
   if (type === 'spec') return 'Spec File';
+  if (type === 'pr') return 'GitHub PR';
   return '';
 }
 
@@ -415,6 +416,7 @@ function _workSourceSection({ rerender } = {}) {
           <sl-option value="none">None</sl-option>
           <sl-option value="source">GitHub Issue</sl-option>
           <sl-option value="spec">Spec File</sl-option>
+          <sl-option value="pr">GitHub PR</sl-option>
         </sl-select>
       </div>
       ${
@@ -424,7 +426,7 @@ function _workSourceSection({ rerender } = {}) {
               <label class="settings-label">${_sourceLabel(sourceType)}</label>
               <sl-input
                 class="input-fleet-source"
-                placeholder=${sourceType === 'source' ? 'gh:issue:123 or https://github.com/…' : 'path/to/spec.md'}
+                placeholder=${sourceType === 'source' ? 'gh:issue:123 or https://github.com/…' : sourceType === 'pr' ? 'gh:pr:123 or https://github.com/owner/repo/pull/123' : 'path/to/spec.md'}
                 value="${sourceValue}"
                 @sl-input=${
                   rerender
@@ -435,7 +437,7 @@ function _workSourceSection({ rerender } = {}) {
                     : null
                 }
               ></sl-input>
-              <span class="settings-field-hint">${sourceType === 'source' ? 'GitHub issue reference or bead id resolved per project.' : 'Path resolved relative to each project root.'}</span>
+              <span class="settings-field-hint">${sourceType === 'source' ? 'GitHub issue reference or bead id resolved per project.' : sourceType === 'pr' ? 'GitHub PR number or URL. Fetches unresolved review comments and runs in revision mode.' : 'Path resolved relative to each project root.'}</span>
             </div>
           `
           : nothing

--- a/worca-ui/app/views/fleet-launcher.test.js
+++ b/worca-ui/app/views/fleet-launcher.test.js
@@ -69,6 +69,25 @@ describe('fleetLauncherView — work source', () => {
     expect(out).toContain('>None<');
     expect(out).toContain('>GitHub Issue<');
     expect(out).toContain('>Spec File<');
+    expect(out).toContain('>GitHub PR<');
+  });
+
+  it('shows source value input when type is GitHub PR', () => {
+    resetLauncherState({ sourceType: 'pr' });
+    const out = renderToString(fleetLauncherView({ projects: [] }, {}));
+    expect(out).toContain('input-fleet-source');
+  });
+
+  it('shows gh:pr placeholder when type is GitHub PR', () => {
+    resetLauncherState({ sourceType: 'pr' });
+    const out = renderToString(fleetLauncherView({ projects: [] }, {}));
+    expect(out).toContain('gh:pr:');
+  });
+
+  it('shows PR hint text when type is GitHub PR', () => {
+    resetLauncherState({ sourceType: 'pr' });
+    const out = renderToString(fleetLauncherView({ projects: [] }, {}));
+    expect(out).toContain('revision mode');
   });
 
   it('does not show source value input when type is None', () => {

--- a/worca-ui/app/views/new-run.js
+++ b/worca-ui/app/views/new-run.js
@@ -65,6 +65,7 @@ export function resetNewRunState(overrides = {}) {
 function sourceLabel(type) {
   if (type === 'source') return 'GitHub Issue URL';
   if (type === 'spec') return 'Spec File Path';
+  if (type === 'pr') return 'GitHub PR URL or Number';
   return '';
 }
 
@@ -582,6 +583,7 @@ export function newRunView(_state, { rerender }) {
               <sl-option value="none">None</sl-option>
               <sl-option value="source">GitHub Issue</sl-option>
               <sl-option value="spec">Spec File</sl-option>
+              <sl-option value="pr">GitHub PR</sl-option>
             </sl-select>
           </div>
 
@@ -590,7 +592,7 @@ export function newRunView(_state, { rerender }) {
               ? html`
             <div class="settings-field">
               <label class="settings-label">${sourceLabel(sourceType)}</label>
-              <sl-input id="new-run-source-value" placeholder=${sourceType === 'source' ? 'https://github.com/...' : 'path/to/spec.md'}></sl-input>
+              <sl-input id="new-run-source-value" placeholder=${sourceType === 'source' ? 'https://github.com/...' : sourceType === 'pr' ? 'gh:pr:123 or https://github.com/owner/repo/pull/123' : 'path/to/spec.md'}></sl-input>
             </div>
           `
               : nothing

--- a/worca-ui/app/views/run-card-revises-pr.test.js
+++ b/worca-ui/app/views/run-card-revises-pr.test.js
@@ -1,0 +1,64 @@
+/**
+ * Tests: run-card.js 'Revising PR #N' badge when revises_pr is set.
+ * TDD: written to drive implementation.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { runCardView } from './run-card.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const baseRun = {
+  id: 'run-1',
+  work_request: { title: 'Test run' },
+  stages: {},
+  started_at: '2024-01-01T00:00:00Z',
+};
+
+describe('runCardView — Revising PR badge', () => {
+  it('renders Revising PR #N badge when revises_pr is set', () => {
+    const run = { ...baseRun, revises_pr: 42 };
+    const html = renderToString(runCardView(run));
+    expect(html).toContain('Revising PR #42');
+  });
+
+  it('renders correct PR number in badge', () => {
+    const run = { ...baseRun, revises_pr: 123 };
+    const html = renderToString(runCardView(run));
+    expect(html).toContain('Revising PR #123');
+  });
+
+  it('does not render Revising PR badge when revises_pr is absent', () => {
+    const html = renderToString(runCardView(baseRun));
+    expect(html).not.toContain('Revising PR #');
+  });
+
+  it('does not render Revising PR badge when revises_pr is null', () => {
+    const run = { ...baseRun, revises_pr: null };
+    const html = renderToString(runCardView(run));
+    expect(html).not.toContain('Revising PR #');
+  });
+
+  it('renders badge with warning variant (orange = revising/needs attention)', () => {
+    const run = { ...baseRun, revises_pr: 7 };
+    const html = renderToString(runCardView(run));
+    expect(html).toContain('Revising PR #7');
+    expect(html).toContain('warning');
+  });
+});

--- a/worca-ui/app/views/run-card.js
+++ b/worca-ui/app/views/run-card.js
@@ -296,6 +296,7 @@ export function runCardView(
       })()}
       ${sourceBranch ? html`<div class="run-card-meta"><span class="run-card-meta-item"><span class="meta-label">Source Branch:</span> <span class="meta-value">${sourceBranch}</span></span>${targetBranch && targetBranch !== defaultBranch ? html`<span class="run-card-meta-item"><span class="meta-label">Target Branch:</span> <span class="meta-value">${targetBranch}</span></span>` : nothing}</div>` : nothing}
       ${pipelineTemplate ? html`<div class="run-card-template"><span class="meta-label">Pipeline:</span> <span class="meta-value">${pipelineTemplate}</span></div>` : nothing}
+      ${run.revises_pr ? html`<div class="run-card-revises-pr"><sl-badge variant="warning" pill class="run-card-revises-pr-badge">Revising PR #${run.revises_pr}</sl-badge></div>` : nothing}
       <div class="run-card-meta">
         <span class="run-card-meta-item"><span class="meta-label">Started:</span> <span class="meta-value">${formatTimestamp(run.started_at)}</span></span>
         <span class="run-card-meta-item"><span class="meta-label">Finished:</span> <span class="meta-value">${formatTimestamp(endTime)}</span></span>

--- a/worca-ui/app/views/run-detail-pr-comments.js
+++ b/worca-ui/app/views/run-detail-pr-comments.js
@@ -1,0 +1,72 @@
+import { html, nothing } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { GitPullRequest, iconSvg } from '../utils/icons.js';
+import { scrollOnExpand } from '../utils/scroll.js';
+
+function _fileLineAnchor(comment) {
+  if (!comment.path) return nothing;
+  const line = comment.line ? `:${comment.line}` : '';
+  return html`<span class="pr-comment-anchor">${comment.path}${line}</span>`;
+}
+
+function _addressedRowView(comment) {
+  if (
+    !comment.addressed_by_bead &&
+    !comment.addressed_by_commit &&
+    !comment.thread_reply
+  ) {
+    return nothing;
+  }
+  return html`
+    <div class="pr-comment-addressed">
+      ${
+        comment.addressed_by_bead || comment.addressed_by_commit
+          ? html`<span class="pr-comment-addressed-label">Addressed:</span>
+          ${comment.addressed_by_bead ? html`<span class="pr-comment-bead">${comment.addressed_by_bead}</span>` : nothing}
+          ${comment.addressed_by_commit ? html`<code class="pr-comment-commit">${comment.addressed_by_commit.slice(0, 7)}</code>` : nothing}`
+          : nothing
+      }
+      ${
+        comment.thread_reply
+          ? html`<span class="pr-comment-reply">${comment.thread_reply}</span>`
+          : nothing
+      }
+    </div>
+  `;
+}
+
+function _commentRowView(comment) {
+  return html`
+    <div class="pr-comment-row">
+      <div class="pr-comment-meta">
+        ${_fileLineAnchor(comment)}
+        <span class="pr-comment-author">@${comment.author}</span>
+      </div>
+      <div class="pr-comment-body">${comment.body}</div>
+      ${_addressedRowView(comment)}
+    </div>
+  `;
+}
+
+/**
+ * Render the PR review comments panel from status.review_feedback.
+ * @param {Array|null|undefined} reviewFeedback - The review_feedback list from status.json
+ */
+export function prCommentsView(reviewFeedback) {
+  if (!reviewFeedback || reviewFeedback.length === 0) return nothing;
+
+  return html`
+    <div class="pr-comments-section">
+      <sl-details class="pr-comments-panel" @sl-after-show=${scrollOnExpand}>
+        <div slot="summary" class="pr-comments-header">
+          <span class="pr-comments-icon">${unsafeHTML(iconSvg(GitPullRequest, 16))}</span>
+          <span class="pr-comments-title">Review Comments</span>
+          <sl-badge variant="warning" pill>${reviewFeedback.length}</sl-badge>
+        </div>
+        <div class="pr-comments-list">
+          ${reviewFeedback.map(_commentRowView)}
+        </div>
+      </sl-details>
+    </div>
+  `;
+}

--- a/worca-ui/app/views/run-detail-pr-comments.test.js
+++ b/worca-ui/app/views/run-detail-pr-comments.test.js
@@ -1,0 +1,148 @@
+/**
+ * Tests: run-detail-pr-comments.js — PR review comments panel.
+ * TDD: written to drive implementation.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { prCommentsView } from './run-detail-pr-comments.js';
+
+const LIT_NOTHING = Symbol.for('lit-nothing');
+
+function renderToString(template) {
+  if (template === null || template === undefined) return '';
+  if (typeof template === 'symbol') return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'symbol') {
+        // lit-html nothing — omit
+      } else if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const inlineComment = {
+  thread_id: 'PRRT_abc',
+  path: 'src/foo.py',
+  line: 42,
+  author: 'reviewer-alice',
+  body: 'this leaks a file handle',
+  kind: 'inline',
+  created_at: '2026-06-03T12:00:00Z',
+};
+
+const prLevelComment = {
+  thread_id: 'PRRT_xyz',
+  path: null,
+  line: null,
+  author: 'reviewer-bob',
+  body: 'add a test for the empty case',
+  kind: 'pr_level',
+  created_at: '2026-06-03T13:00:00Z',
+};
+
+const addressedComment = {
+  ...inlineComment,
+  thread_id: 'PRRT_def',
+  body: 'rename for clarity',
+  addressed_by_bead: 'worca-cc-master-xyz1',
+  addressed_by_commit: 'abc1234',
+  thread_reply: 'Addressed in commit abc1234 (bead worca-cc-master-xyz1)',
+};
+
+describe('prCommentsView — empty / null', () => {
+  it('returns nothing when review_feedback is null', () => {
+    const out = renderToString(prCommentsView(null));
+    expect(out).toBe('');
+  });
+
+  it('returns nothing when review_feedback is undefined', () => {
+    const out = renderToString(prCommentsView(undefined));
+    expect(out).toBe('');
+  });
+
+  it('returns nothing when review_feedback is empty array', () => {
+    const out = renderToString(prCommentsView([]));
+    expect(out).toBe('');
+  });
+});
+
+describe('prCommentsView — renders comments from review_feedback', () => {
+  it('renders the pr-comments panel container', () => {
+    const out = renderToString(prCommentsView([inlineComment]));
+    expect(out).toContain('pr-comments');
+  });
+
+  it('renders comment count in summary', () => {
+    const out = renderToString(prCommentsView([inlineComment, prLevelComment]));
+    expect(out).toContain('2');
+  });
+
+  it('renders author for each comment', () => {
+    const out = renderToString(prCommentsView([inlineComment]));
+    expect(out).toContain('reviewer-alice');
+  });
+
+  it('renders comment body', () => {
+    const out = renderToString(prCommentsView([inlineComment]));
+    expect(out).toContain('this leaks a file handle');
+  });
+
+  it('renders file:line anchor for inline comments', () => {
+    const out = renderToString(prCommentsView([inlineComment]));
+    expect(out).toContain('src/foo.py');
+    expect(out).toContain('42');
+  });
+
+  it('renders both comments when multiple provided', () => {
+    const out = renderToString(prCommentsView([inlineComment, prLevelComment]));
+    expect(out).toContain('reviewer-alice');
+    expect(out).toContain('reviewer-bob');
+    expect(out).toContain('this leaks a file handle');
+    expect(out).toContain('add a test for the empty case');
+  });
+});
+
+describe('prCommentsView — pr_level comments', () => {
+  it('renders pr_level comment without file:line', () => {
+    const out = renderToString(prCommentsView([prLevelComment]));
+    expect(out).toContain('reviewer-bob');
+    expect(out).toContain('add a test for the empty case');
+  });
+
+  it('does not show null path for pr_level comment', () => {
+    const out = renderToString(prCommentsView([prLevelComment]));
+    expect(out).not.toContain('null');
+  });
+});
+
+describe('prCommentsView — addressed comments', () => {
+  it('shows addressed_by_bead when present', () => {
+    const out = renderToString(prCommentsView([addressedComment]));
+    expect(out).toContain('worca-cc-master-xyz1');
+  });
+
+  it('shows addressed_by_commit when present', () => {
+    const out = renderToString(prCommentsView([addressedComment]));
+    expect(out).toContain('abc1234');
+  });
+
+  it('shows thread_reply when present', () => {
+    const out = renderToString(prCommentsView([addressedComment]));
+    expect(out).toContain('Addressed in commit abc1234');
+  });
+
+  it('does not show addressed fields for unaddressed comment', () => {
+    const out = renderToString(prCommentsView([inlineComment]));
+    expect(out).not.toContain('addressed_by');
+    expect(out).not.toContain('thread_reply');
+  });
+});

--- a/worca-ui/app/views/run-detail-pr-strip-revise.test.js
+++ b/worca-ui/app/views/run-detail-pr-strip-revise.test.js
@@ -1,0 +1,109 @@
+/**
+ * Tests: run-detail.js PR strip semantic reorder for revise runs.
+ * W-067 P5: For revise runs, the PR being revised is the INPUT.
+ * Show the PR strip from run start (overview), not just in the PR stage.
+ * The changes_requested review_status badge is the trigger, not an outcome.
+ * TDD: written to drive implementation.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { runDetailView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const prObject = {
+  url: 'https://github.com/owner/repo/pull/42',
+  number: 42,
+  review_status: 'changes_requested',
+  source_branch: 'feature/my-feature',
+  target_branch: 'main',
+};
+
+const prStage = {
+  status: 'completed',
+  iterations: [{ number: 1, status: 'completed' }],
+};
+
+const reviseRun = {
+  revises_pr: 42,
+  pr: prObject,
+  stages: { pr: prStage },
+};
+
+const normalRun = {
+  pr: prObject,
+  stages: { pr: prStage },
+};
+
+describe('_prInfoStripView — revise run semantic reorder', () => {
+  it('renders pr-info-strip in overview section for revise runs', () => {
+    const result = runDetailView(reviseRun);
+    const overviewHtml = renderToString(result.overview);
+    expect(overviewHtml).toContain('pr-info-strip');
+  });
+
+  it('does not render pr-info-strip in overview for normal runs', () => {
+    const result = runDetailView(normalRun);
+    const overviewHtml = renderToString(result.overview);
+    expect(overviewHtml).not.toContain('pr-info-strip');
+  });
+
+  it('suppresses pr-info-strip from pr stage section for revise runs', () => {
+    const result = runDetailView(reviseRun);
+    const stagesHtml = renderToString(result.stages);
+    expect(stagesHtml).not.toContain('pr-info-strip');
+  });
+
+  it('still shows pr-info-strip in pr stage section for normal runs', () => {
+    const result = runDetailView(normalRun);
+    const stagesHtml = renderToString(result.stages);
+    expect(stagesHtml).toContain('pr-info-strip');
+  });
+
+  it('labels review_status badge as Trigger for revise runs', () => {
+    const result = runDetailView(reviseRun);
+    const overviewHtml = renderToString(result.overview);
+    expect(overviewHtml).toContain('Trigger:');
+  });
+
+  it('does not label review_status badge as Trigger for normal runs', () => {
+    const result = runDetailView(normalRun);
+    const allHtml =
+      renderToString(result.overview) + renderToString(result.stages);
+    expect(allHtml).not.toContain('Trigger:');
+  });
+
+  it('renders PR link in overview for revise run', () => {
+    const result = runDetailView(reviseRun);
+    const overviewHtml = renderToString(result.overview);
+    expect(overviewHtml).toContain('https://github.com/owner/repo/pull/42');
+  });
+
+  it('renders revise PR strip even before pr stage begins (no pr stage data)', () => {
+    const earlyReviseRun = {
+      revises_pr: 99,
+      pr: { url: 'https://github.com/owner/repo/pull/99', number: 99 },
+      stages: {},
+    };
+    const result = runDetailView(earlyReviseRun);
+    const overviewHtml = renderToString(result.overview);
+    expect(overviewHtml).toContain('pr-info-strip');
+    expect(overviewHtml).toContain('#99');
+  });
+});

--- a/worca-ui/app/views/run-detail-source-row.test.js
+++ b/worca-ui/app/views/run-detail-source-row.test.js
@@ -1,0 +1,88 @@
+/**
+ * Tests: run-detail.js Source row (source_type + source_ref in overview).
+ * TDD: written to drive implementation.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { runDetailView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const baseRun = {
+  stages: {
+    implement: {
+      status: 'completed',
+      iterations: [{ number: 1, status: 'completed' }],
+    },
+  },
+};
+
+describe('runDetailView — Source row', () => {
+  it('renders source row when source_type is set', () => {
+    const run = {
+      ...baseRun,
+      source_type: 'github_pr',
+      source_ref: 'gh:pr:99',
+    };
+    const html = renderToString(runDetailView(run));
+    expect(html).toContain('run-source');
+    expect(html).toContain('Source:');
+  });
+
+  it('renders source_type value in source row', () => {
+    const run = {
+      ...baseRun,
+      source_type: 'github_pr',
+      source_ref: 'gh:pr:99',
+    };
+    const html = renderToString(runDetailView(run));
+    expect(html).toContain('github_pr');
+  });
+
+  it('renders source_ref value in source row when present', () => {
+    const run = {
+      ...baseRun,
+      source_type: 'github_pr',
+      source_ref: 'gh:pr:99',
+    };
+    const html = renderToString(runDetailView(run));
+    expect(html).toContain('gh:pr:99');
+  });
+
+  it('renders source row with only source_type when source_ref is absent', () => {
+    const run = { ...baseRun, source_type: 'prompt' };
+    const html = renderToString(runDetailView(run));
+    expect(html).toContain('run-source');
+    expect(html).toContain('prompt');
+  });
+
+  it('does not render source row when source_type is absent', () => {
+    const html = renderToString(runDetailView(baseRun));
+    expect(html).not.toContain('run-source');
+    expect(html).not.toContain('Source:');
+  });
+
+  it('does not render source row when source_type is null', () => {
+    const run = { ...baseRun, source_type: null };
+    const html = renderToString(runDetailView(run));
+    expect(html).not.toContain('run-source');
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -35,6 +35,7 @@ import {
   priorityVariant,
   statusVariant,
 } from './beads-panel.js';
+import { prCommentsView } from './run-detail-pr-comments.js';
 import { resolveIterationTab } from './stage-tab-memory.js';
 import { stageTimelineView } from './stage-timeline.js';
 
@@ -1004,7 +1005,7 @@ function _prReviewStatusVariant(status) {
   return 'neutral';
 }
 
-function _prInfoStripView(run) {
+function _prInfoStripView(run, { isReviseInput = false } = {}) {
   const pr = run?.pr;
   const prUrl = pr?.url || run?.pr_url;
   if (!prUrl) return nothing;
@@ -1053,6 +1054,7 @@ function _prInfoStripView(run) {
       ${
         reviewStatus
           ? html`<span class="pr-info-item">
+        ${isReviseInput ? html`<span class="meta-label">Trigger:</span>` : nothing}
         <sl-badge class="pr-review-status-badge" variant="${_prReviewStatusVariant(reviewStatus)}" pill>${reviewStatus.replace(/_/g, ' ')}</sl-badge>
       </span>`
           : nothing
@@ -1769,6 +1771,19 @@ export function runDetailView(run, settings = {}, options = {}) {
             : nothing
         }
         ${
+          run.source_type
+            ? html`
+          <div class="run-source">
+            <span class="meta-label">Source:</span>
+            <span class="meta-value run-source-type">${run.source_type}</span>
+            ${run.source_ref ? html`<span class="meta-value run-source-ref">${run.source_ref}</span>` : nothing}
+          </div>
+        `
+            : nothing
+        }
+        ${run.revises_pr ? _prInfoStripView(run, { isReviseInput: true }) : nothing}
+        ${prCommentsView(run.review_feedback)}
+        ${
           pipelineTemplate
             ? html`
           <div class="run-template">
@@ -1990,7 +2005,7 @@ export function runDetailView(run, settings = {}, options = {}) {
                           </div>`;
                       })()}
                       ${key === 'pr' ? _prVerifiedBadgeView(run) : nothing}
-                      ${key === 'pr' ? _prInfoStripView(run) : nothing}
+                      ${key === 'pr' && !run?.revises_pr ? _prInfoStripView(run) : nothing}
                       ${key === 'preflight' ? _preflightGraphBadgesRow(stage, run) : nothing}
                       <sl-tab-group @sl-tab-show=${(e) => {
                         const panel = e.detail.name;
@@ -2047,7 +2062,7 @@ export function runDetailView(run, settings = {}, options = {}) {
                       ${iterations.length === 1 ? _classificationRowView(iterations[0]) : nothing}
                       ${iterations.length === 1 ? _dispatchEventsRowsView(iterations[0]) : nothing}
                       ${key === 'pr' ? _prVerifiedBadgeView(run) : nothing}
-                      ${key === 'pr' ? _prInfoStripView(run) : nothing}
+                      ${key === 'pr' && !run?.revises_pr ? _prInfoStripView(run) : nothing}
                       ${key === 'preflight' ? _preflightGraphBadgesRow(stage, run) : nothing}
                       ${key === 'preflight' && iterations.length === 1 ? _preflightChecksView(stage, iterations[0]) : nothing}
                       ${_planIterationButton(key, iterations[0], run, options.rerender)}

--- a/worca-ui/package-lock.json
+++ b/worca-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worca/ui",
-  "version": "0.39.0",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worca/ui",
-      "version": "0.39.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.20.1",

--- a/worca-ui/server/watcher.js
+++ b/worca-ui/server/watcher.js
@@ -158,7 +158,13 @@ function _shapeRunFromFile(
     if (enrich && runDir) status = enrichWithDispatchEvents(status, runDir);
     const id = createRunId(status);
     const active = !isTerminal(status) && status.pipeline_status === 'running';
-    const base = { id, active, ...status };
+    const base = {
+      id,
+      active,
+      ...status,
+      source_type: status.source_type ?? null,
+      source_ref: status.source_ref ?? null,
+    };
     if (worktreeReg) {
       return {
         ...base,
@@ -196,7 +202,13 @@ function _discoverRunsUncached(worcaDir) {
         seenIds.add(id);
         const active =
           !isTerminal(status) && status.pipeline_status === 'running';
-        runs.push({ id, active, ...status });
+        runs.push({
+          id,
+          active,
+          ...status,
+          source_type: status.source_type ?? null,
+          source_ref: status.source_ref ?? null,
+        });
       } catch {
         /* ignore */
       }
@@ -212,7 +224,13 @@ function _discoverRunsUncached(worcaDir) {
       if (!seenIds.has(id)) {
         const active =
           !isTerminal(status) && status.pipeline_status === 'running';
-        runs.push({ id, active, ...status });
+        runs.push({
+          id,
+          active,
+          ...status,
+          source_type: status.source_type ?? null,
+          source_ref: status.source_ref ?? null,
+        });
         seenIds.add(id);
       }
     } catch {
@@ -236,7 +254,13 @@ function _discoverRunsUncached(worcaDir) {
               seenIds.add(id);
               const active =
                 !isTerminal(data) && data.pipeline_status === 'running';
-              runs.push({ id, active, ...data });
+              runs.push({
+                id,
+                active,
+                ...data,
+                source_type: data.source_type ?? null,
+                source_ref: data.source_ref ?? null,
+              });
             }
           }
         } else if (entry.isDirectory()) {
@@ -249,7 +273,13 @@ function _discoverRunsUncached(worcaDir) {
               seenIds.add(id);
               const active =
                 !isTerminal(data) && data.pipeline_status === 'running';
-              runs.push({ id, active, ...data });
+              runs.push({
+                id,
+                active,
+                ...data,
+                source_type: data.source_type ?? null,
+                source_ref: data.source_ref ?? null,
+              });
             }
           }
         }
@@ -287,6 +317,8 @@ function _discoverRunsUncached(worcaDir) {
               id,
               active,
               ...status,
+              source_type: status.source_type ?? null,
+              source_ref: status.source_ref ?? null,
               worktree_worca_dir: join(reg.worktree_path, '.worca'),
               is_worktree_run: true,
               head_branch: reg.branch || null,
@@ -338,7 +370,13 @@ export async function discoverRunsAsync(worcaDir) {
       seenIds.add(id);
       const active =
         !isTerminal(status) && status.pipeline_status === 'running';
-      runs.push({ id, active, ...status });
+      runs.push({
+        id,
+        active,
+        ...status,
+        source_type: status.source_type ?? null,
+        source_ref: status.source_ref ?? null,
+      });
     }
   } catch {
     /* ignore */
@@ -353,7 +391,13 @@ export async function discoverRunsAsync(worcaDir) {
     if (!seenIds.has(id)) {
       const active =
         !isTerminal(status) && status.pipeline_status === 'running';
-      runs.push({ id, active, ...status });
+      runs.push({
+        id,
+        active,
+        ...status,
+        source_type: status.source_type ?? null,
+        source_ref: status.source_ref ?? null,
+      });
       seenIds.add(id);
     }
   } catch {
@@ -386,7 +430,13 @@ export async function discoverRunsAsync(worcaDir) {
       if (!seenIds.has(id)) {
         seenIds.add(id);
         const active = !isTerminal(data) && data.pipeline_status === 'running';
-        runs.push({ id, active, ...data });
+        runs.push({
+          id,
+          active,
+          ...data,
+          source_type: data.source_type ?? null,
+          source_ref: data.source_ref ?? null,
+        });
       }
     }
   } catch {
@@ -442,6 +492,8 @@ export async function discoverRunsAsync(worcaDir) {
         id,
         active,
         ...status,
+        source_type: status.source_type ?? null,
+        source_ref: status.source_ref ?? null,
         worktree_worca_dir: join(reg.worktree_path, '.worca'),
         is_worktree_run: true,
         head_branch: reg.branch || null,

--- a/worca-ui/server/watcher.test.js
+++ b/worca-ui/server/watcher.test.js
@@ -565,6 +565,119 @@ describe('watcher', () => {
     expect(asyncRun.head_branch).toBeNull();
   });
 
+  // ---- source_type / source_ref passthrough (#W-067) ----
+  it('source_type and source_ref pass through from status.json for a regular run', () => {
+    const runId = 'run-pr-src-1';
+    const runDir = join(dir, 'runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-06-04T10:00:00Z',
+        pipeline_status: 'running',
+        source_type: 'github_pr',
+        source_ref: 'gh:pr:42',
+        work_request: { title: 'pr revision' },
+        stages: { plan: { status: 'in_progress' } },
+      }),
+    );
+    const run = discoverRuns(dir).find((r) => r.run_id === runId);
+    expect(run).toBeDefined();
+    expect(run.source_type).toBe('github_pr');
+    expect(run.source_ref).toBe('gh:pr:42');
+  });
+
+  it('source_type and source_ref default to null when absent from status.json', () => {
+    const runId = 'run-no-src-1';
+    const runDir = join(dir, 'runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-06-04T10:00:00Z',
+        pipeline_status: 'running',
+        work_request: { title: 'no source' },
+        stages: { plan: { status: 'in_progress' } },
+      }),
+    );
+    const run = discoverRuns(dir).find((r) => r.run_id === runId);
+    expect(run).toBeDefined();
+    expect(run.source_type).toBeNull();
+    expect(run.source_ref).toBeNull();
+  });
+
+  it('worktree run passes source_type and source_ref from status.json', async () => {
+    const wtDir = join(dir, 'worktrees', 'wt-pr-src');
+    const wtRunId = 'run-wt-pr-src-1';
+    const wtRunDir = join(wtDir, '.worca', 'runs', wtRunId);
+    mkdirSync(wtRunDir, { recursive: true });
+    writeFileSync(
+      join(wtRunDir, 'status.json'),
+      JSON.stringify({
+        run_id: wtRunId,
+        started_at: '2026-06-04T10:00:00Z',
+        pipeline_status: 'running',
+        source_type: 'github_pr',
+        source_ref: 'gh:pr:99',
+        work_request: { title: 'wt pr revision' },
+        stages: { plan: { status: 'in_progress' } },
+      }),
+    );
+    const pipelinesDir = join(dir, 'multi', 'pipelines.d');
+    mkdirSync(pipelinesDir, { recursive: true });
+    writeFileSync(
+      join(pipelinesDir, `${wtRunId}.json`),
+      JSON.stringify({
+        run_id: wtRunId,
+        worktree_path: wtDir,
+        title: 'wt pr revision',
+        pid: 99994,
+        status: 'running',
+      }),
+    );
+    const run = discoverRuns(dir).find((r) => r.run_id === wtRunId);
+    expect(run).toBeDefined();
+    expect(run.is_worktree_run).toBe(true);
+    expect(run.source_type).toBe('github_pr');
+    expect(run.source_ref).toBe('gh:pr:99');
+  });
+
+  it('worktree run source_type and source_ref default to null when absent', async () => {
+    const wtDir = join(dir, 'worktrees', 'wt-no-src');
+    const wtRunId = 'run-wt-no-src-1';
+    const wtRunDir = join(wtDir, '.worca', 'runs', wtRunId);
+    mkdirSync(wtRunDir, { recursive: true });
+    writeFileSync(
+      join(wtRunDir, 'status.json'),
+      JSON.stringify({
+        run_id: wtRunId,
+        started_at: '2026-06-04T10:00:00Z',
+        pipeline_status: 'running',
+        work_request: { title: 'wt no source' },
+        stages: { plan: { status: 'in_progress' } },
+      }),
+    );
+    const pipelinesDir = join(dir, 'multi', 'pipelines.d');
+    mkdirSync(pipelinesDir, { recursive: true });
+    writeFileSync(
+      join(pipelinesDir, `${wtRunId}.json`),
+      JSON.stringify({
+        run_id: wtRunId,
+        worktree_path: wtDir,
+        title: 'wt no source',
+        pid: 99993,
+        status: 'running',
+      }),
+    );
+    const run = discoverRuns(dir).find((r) => r.run_id === wtRunId);
+    expect(run).toBeDefined();
+    expect(run.is_worktree_run).toBe(true);
+    expect(run.source_type).toBeNull();
+    expect(run.source_ref).toBeNull();
+  });
+
   it('in-place run does not have head_branch', () => {
     const runId = 'run-inplace-001';
     const runDir = join(dir, 'runs', runId);


### PR DESCRIPTION
## Summary

- Add `gh:pr:N` source type that fetches an existing PR's unresolved human-authored review threads via GitHub GraphQL, synthesizes a structured work request, and runs the pipeline against the PR's head branch in constrained revision mode.
- The guardian updates the PR in place (push + summary comment + per-thread replies) instead of creating a new PR, closing the human-in-the-loop review cycle.
- UI surfaces PR-revision runs with a "Revises PR" badge on run-card, a PR comments panel in run-detail, and source-row display for `gh:pr:N` sources.

### Key additions

| Area | Files |
|------|-------|
| PR fetch | `src/worca/utils/gh_pr.py` — GraphQL-based PR + review thread fetcher |
| Work request | `src/worca/orchestrator/work_request.py` — `gh:pr:N` source parsing + review feedback synthesis |
| Entry point | `src/worca/scripts/run_worktree.py` — `--source gh:pr:N`, worktree on PR head branch |
| Guardian revise | `src/worca/orchestrator/guardian_context.py` — `WORCA_REVISE_PR` mode (push, comment, reply) |
| Agent prompts | `planner.md` (revision constraints), `coordinator.md` (comment-to-bead decomposition), `guardian.md` (revise-mode push + reply) |
| Runner | `src/worca/orchestrator/runner.py` — `has_review_comments` prompt variable propagation |
| UI | `run-detail-pr-comments.js` (new panel), `run-card.js` (revise badge), `run-detail.js` (source row), `fleet-launcher.js` / `new-run.js` (PR source in launch forms) |
| Watcher | `worca-ui/server/watcher.js` — `pr_comments` field extraction from status.json |

### Locked decisions (from plan)

- (D1) Update PR in place, not a new/stacked PR
- (D2) Constrained Planner revision mode (minimal diff, scoped to comments)
- (D3) Reply-only on threads, never auto-resolve

## Test plan

- [x] `tests/test_gh_pr.py` — GraphQL fetch, thread filtering (bot exclusion, resolved exclusion), reply/summary posting
- [x] `tests/test_work_request.py` — `gh:pr:N` and full URL parsing, review feedback synthesis, title extraction
- [x] `tests/test_guardian_revise_mode.py` — revise mode context building, env var propagation
- [x] `tests/test_planner_revise_mode.py` — planner revision mode prompt injection
- [x] `tests/test_guardian_context.py` — guardian context with revise PR set
- [x] `tests/test_run_worktree.py` — worktree creation on PR head branch
- [x] `tests/test_runner.py` — has_review_comments propagation
- [x] `tests/test_runner_pr_verification.py` — PR verification with revise mode
- [x] `tests/test_prompt_builder.py` — review comments template variable
- [x] `tests/test_registry.py` — registry with revise PR config
- [x] `tests/test_status.py` — status with pr_comments field
- [x] `tests/test_pr_url_parser.py` — PR URL parsing
- [x] UI tests: `run-card-revises-pr.test.js`, `run-detail-pr-comments.test.js`, `run-detail-pr-strip-revise.test.js`, `run-detail-source-row.test.js`, `fleet-launcher.test.js`, `watcher.test.js`

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)