### PR TITLE
fix(ui): make template deny tiers (Always Disallowed / Default Denied) visible & editable

### DIFF
--- a/worca-ui/app/views/dispatch-section.js
+++ b/worca-ui/app/views/dispatch-section.js
@@ -84,6 +84,69 @@ function tierView(title, items, { locked, warn, removable, onRemove }) {
   `;
 }
 
+/**
+ * Editable variant of tierView for the Always Disallowed / Default Denied
+ * tiers. Unlike tierView it ALWAYS renders (even when empty) so the user
+ * can add the first entry, and it carries a free-text add input (Enter to
+ * commit, Escape to clear). Used only when `denyTiersEditable` is set —
+ * i.e. the template editor, where these tiers are template-owned config.
+ */
+function editableTierView(
+  title,
+  items,
+  { locked, warn, tierState, placeholder, onAdd, onRemove, rerender },
+) {
+  return html`
+    <div class="dispatch-tier dispatch-tier--editable" data-tier="${title}">
+      <div class="dispatch-tier-label">${title}</div>
+      <div class="dispatch-tag-input-wrapper">
+        <div
+          class="dispatch-tag-input"
+          @click=${(e) => {
+            const input = e.currentTarget.querySelector(
+              '.dispatch-tag-input-field',
+            );
+            if (input && e.target !== input) input.focus();
+          }}
+        >
+          ${(items || []).map((tag) =>
+            chipView(tag, {
+              locked,
+              warn,
+              removable: true,
+              onRemove: () => onRemove(tag),
+            }),
+          )}
+          <input
+            class="dispatch-tag-input-field"
+            type="text"
+            .value=${tierState.input || ''}
+            placeholder=${(items || []).length === 0 ? placeholder : ''}
+            @input=${(e) => {
+              tierState.input = e.target.value;
+              rerender();
+            }}
+            @keydown=${(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                const value = (tierState.input || '').trim();
+                if (value) {
+                  tierState.input = '';
+                  onAdd(value);
+                  rerender();
+                }
+              } else if (e.key === 'Escape') {
+                tierState.input = '';
+                rerender();
+              }
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  `;
+}
+
 function filterSuggestions(input, knownItems, currentTags, deniedSet, warnSet) {
   const query = (input || '').trim().toLowerCase();
   const warns = warnSet || new Set();
@@ -348,6 +411,7 @@ export function dispatchSectionView({
   state,
   rerender,
   showTitle = true,
+  denyTiersEditable = false,
 }) {
   const alwaysDisallowed = config.always_disallowed || [];
   const defaultDenied = config.default_denied || [];
@@ -360,6 +424,15 @@ export function dispatchSectionView({
       editingState[agent] = { input: '', showSuggestions: false };
     }
     return editingState[agent];
+  }
+
+  // Tier-level add inputs (Always Disallowed / Default Denied) keep their
+  // own edit state under reserved keys so they don't collide with the
+  // per-agent rows ('_defaults' + agent names never start with '__tier').
+  function getTierState(tier) {
+    const key = `__tier_${tier}`;
+    if (!editingState[key]) editingState[key] = { input: '' };
+    return editingState[key];
   }
 
   function emit(newPerAgentAllow) {
@@ -427,6 +500,31 @@ export function dispatchSectionView({
     });
   }
 
+  function handleAddDefaultDenied(tag) {
+    const trimmed = (tag || '').trim();
+    if (!trimmed || defaultDenied.includes(trimmed)) return;
+    onChange({
+      ...config,
+      default_denied: [...defaultDenied, trimmed],
+    });
+  }
+
+  function handleAddAlwaysDisallowed(tag) {
+    const trimmed = (tag || '').trim();
+    if (!trimmed || alwaysDisallowed.includes(trimmed)) return;
+    onChange({
+      ...config,
+      always_disallowed: [...alwaysDisallowed, trimmed],
+    });
+  }
+
+  function handleRemoveAlwaysDisallowed(tag) {
+    onChange({
+      ...config,
+      always_disallowed: alwaysDisallowed.filter((t) => t !== tag),
+    });
+  }
+
   const allAgentKeys = ['_defaults', ...agentRoles];
 
   const sectionHint = _SECTION_HINTS[section];
@@ -482,18 +580,42 @@ export function dispatchSectionView({
       }
       ${wildcardWarning}
 
-      ${tierView('Always Disallowed', alwaysDisallowed, {
-        locked: true,
-        warn: false,
-        removable: false,
-      })}
+      ${
+        denyTiersEditable
+          ? editableTierView('Always Disallowed', alwaysDisallowed, {
+              locked: true,
+              warn: false,
+              tierState: getTierState('always_disallowed'),
+              placeholder: `Add hard-deny ${section.slice(0, -1)}…`,
+              onAdd: handleAddAlwaysDisallowed,
+              onRemove: handleRemoveAlwaysDisallowed,
+              rerender: triggerRerender,
+            })
+          : tierView('Always Disallowed', alwaysDisallowed, {
+              locked: true,
+              warn: false,
+              removable: false,
+            })
+      }
 
-      ${tierView('Default Denied', defaultDenied, {
-        locked: false,
-        warn: true,
-        removable: true,
-        onRemove: handleRemoveDefaultDenied,
-      })}
+      ${
+        denyTiersEditable
+          ? editableTierView('Default Denied', defaultDenied, {
+              locked: false,
+              warn: true,
+              tierState: getTierState('default_denied'),
+              placeholder: `Add default-denied ${section.slice(0, -1)}…`,
+              onAdd: handleAddDefaultDenied,
+              onRemove: handleRemoveDefaultDenied,
+              rerender: triggerRerender,
+            })
+          : tierView('Default Denied', defaultDenied, {
+              locked: false,
+              warn: true,
+              removable: true,
+              onRemove: handleRemoveDefaultDenied,
+            })
+      }
 
       <div class="dispatch-tier">
         <div class="dispatch-tier-label">Per-Agent Allow</div>

--- a/worca-ui/app/views/dispatch-section.test.js
+++ b/worca-ui/app/views/dispatch-section.test.js
@@ -738,4 +738,101 @@ describe('dispatch-section', () => {
       );
     });
   });
+
+  describe('denyTiersEditable — editable Always Disallowed / Default Denied', () => {
+    const baseConfig = () => ({
+      always_disallowed: ['EnterPlanMode'],
+      default_denied: ['general-purpose'],
+      per_agent_allow: { _defaults: ['*'] },
+    });
+
+    function render(extra = {}) {
+      return renderToString(
+        dispatchSectionView({
+          section: 'tools',
+          config: baseConfig(),
+          knownItems: [],
+          agentRoles: AGENT_ROLES,
+          defaults: DISPATCH_DEFAULTS.tools,
+          onChange: vi.fn(),
+          denyTiersEditable: true,
+          ...extra,
+        }),
+      );
+    }
+
+    it('renders an add input for both deny tiers when editable', () => {
+      const html = render();
+      expect(html).toContain('dispatch-tier--editable');
+      expect(html).toContain('data-tier="Always Disallowed"');
+      expect(html).toContain('data-tier="Default Denied"');
+    });
+
+    it('renders an empty Default Denied tier (add input) instead of hiding it', () => {
+      const html = renderToString(
+        dispatchSectionView({
+          section: 'tools',
+          config: {
+            always_disallowed: [],
+            default_denied: [],
+            per_agent_allow: { _defaults: ['*'] },
+          },
+          knownItems: [],
+          agentRoles: AGENT_ROLES,
+          defaults: DISPATCH_DEFAULTS.tools,
+          onChange: vi.fn(),
+          denyTiersEditable: true,
+        }),
+      );
+      // Both tiers present even when empty (non-editable mode would omit them).
+      expect(html).toContain('data-tier="Always Disallowed"');
+      expect(html).toContain('data-tier="Default Denied"');
+    });
+
+    it('non-editable mode keeps the locked, hide-when-empty behavior', () => {
+      const html = renderToString(
+        dispatchSectionView({
+          section: 'tools',
+          config: {
+            always_disallowed: ['EnterPlanMode'],
+            default_denied: [],
+            per_agent_allow: { _defaults: ['*'] },
+          },
+          knownItems: [],
+          agentRoles: AGENT_ROLES,
+          defaults: DISPATCH_DEFAULTS.tools,
+          onChange: vi.fn(),
+          // denyTiersEditable omitted → defaults false
+        }),
+      );
+      expect(html).not.toContain('dispatch-tier--editable');
+      // Empty Default Denied is hidden in the read-only variant.
+      expect(html).not.toContain('data-tier="Default Denied"');
+    });
+
+    it('renders existing deny-tier entries as removable chips', () => {
+      const html = render();
+      // The seeded entries appear inside the editable tier, and the input
+      // wrapper is present so the user can add more.
+      expect(html).toContain('EnterPlanMode');
+      expect(html).toContain('general-purpose');
+      expect(html).toContain('dispatch-tag-input-field');
+    });
+
+    it('does not call onChange on mount (render is side-effect free)', () => {
+      const onChange = vi.fn();
+      renderToString(
+        dispatchSectionView({
+          section: 'tools',
+          config: baseConfig(),
+          knownItems: [],
+          agentRoles: AGENT_ROLES,
+          defaults: DISPATCH_DEFAULTS.tools,
+          onChange,
+          denyTiersEditable: true,
+        }),
+      );
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/worca-ui/app/views/pipelines-editor-roundtrip.test.js
+++ b/worca-ui/app/views/pipelines-editor-roundtrip.test.js
@@ -28,6 +28,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { DISPATCH_DEFAULTS } from '../../server/dispatch-defaults.js';
 import { buildFormBuffer, formBufferToConfig } from './pipelines-editor.js';
 
 // --- 1a: effort block round-trips ---
@@ -234,6 +235,104 @@ describe('formBufferToConfig — governance.dispatch is template-owned but not p
       per_agent_allow: { planner: ['something'] },
     });
     expect(out.governance.dispatch.subagents).toBeUndefined();
+  });
+});
+
+// --- 1e: dispatch display is correctly sectioned + deny tiers editable ---
+
+describe('buildFormBuffer — display dispatch is keyed by section', () => {
+  it('produces tools/skills/subagents sections (not a single flat tier-set)', () => {
+    const form = buildFormBuffer({}, { worca: {} });
+    const d = form.governance.dispatch;
+    expect(d.tools).toBeDefined();
+    expect(d.skills).toBeDefined();
+    expect(d.subagents).toBeDefined();
+    // The pre-fix bug produced a flat {always_disallowed,...} at the top
+    // level; guard against its return.
+    expect(d.always_disallowed).toBeUndefined();
+  });
+
+  it('seeds each section deny tiers from the shipped DISPATCH_DEFAULTS floor', () => {
+    const form = buildFormBuffer({}, { worca: {} });
+    expect(form.governance.dispatch.tools.always_disallowed).toEqual(
+      DISPATCH_DEFAULTS.tools.always_disallowed,
+    );
+    expect(form.governance.dispatch.skills.default_denied).toEqual(
+      DISPATCH_DEFAULTS.skills.default_denied,
+    );
+  });
+
+  it("preserves the template's own per_agent_allow (regression: was dropped)", () => {
+    const config = {
+      governance: {
+        dispatch: { tools: { per_agent_allow: { planner: ['Read'] } } },
+      },
+    };
+    const form = buildFormBuffer(config, { worca: {} });
+    expect(form.governance.dispatch.tools.per_agent_allow).toEqual({
+      planner: ['Read'],
+    });
+  });
+
+  it('does NOT seed the project dispatch as the floor (templates are portable)', () => {
+    const config = {};
+    const projectSettings = {
+      worca: {
+        governance: {
+          dispatch: {
+            tools: { always_disallowed: ['ProjectOnlyTool'] },
+          },
+        },
+      },
+    };
+    const form = buildFormBuffer(config, projectSettings);
+    expect(form.governance.dispatch.tools.always_disallowed).not.toContain(
+      'ProjectOnlyTool',
+    );
+    expect(form.governance.dispatch.tools.always_disallowed).toEqual(
+      DISPATCH_DEFAULTS.tools.always_disallowed,
+    );
+  });
+});
+
+describe('formBufferToConfig — deny tiers strip-on-write vs persist-when-customized', () => {
+  it('strips deny tiers that equal the shipped defaults (per_agent_allow-only edit)', () => {
+    const config = {
+      governance: {
+        dispatch: { tools: { per_agent_allow: { planner: ['Read'] } } },
+      },
+    };
+    const form = buildFormBuffer(config, { worca: {} });
+    // dirty the section (deny tiers untouched = seeded defaults)
+    form._dispatchDirty.tools = true;
+    const out = formBufferToConfig(form);
+    expect(out.governance.dispatch.tools).toEqual({
+      per_agent_allow: { planner: ['Read'] },
+    });
+  });
+
+  it('persists an added always_disallowed entry', () => {
+    const form = buildFormBuffer({}, { worca: {} });
+    form.governance.dispatch.tools.always_disallowed = [
+      ...DISPATCH_DEFAULTS.tools.always_disallowed,
+      'CustomTool',
+    ];
+    form._dispatchDirty.tools = true;
+    const out = formBufferToConfig(form);
+    expect(out.governance.dispatch.tools.always_disallowed).toContain(
+      'CustomTool',
+    );
+  });
+
+  it('persists a pruned default_denied entry as the shorter list', () => {
+    const form = buildFormBuffer({}, { worca: {} });
+    form.governance.dispatch.skills.default_denied =
+      DISPATCH_DEFAULTS.skills.default_denied.filter((x) => x !== 'simplify');
+    form._dispatchDirty.skills = true;
+    const out = formBufferToConfig(form);
+    expect(out.governance.dispatch.skills.default_denied).not.toContain(
+      'simplify',
+    );
   });
 });
 

--- a/worca-ui/app/views/pipelines-editor.js
+++ b/worca-ui/app/views/pipelines-editor.js
@@ -305,12 +305,12 @@ export function buildFormBuffer(templateConfig, settings) {
 
 /**
  * Deep merge governance config with defaults.
+ *
+ * `dispatch` is rebuilt per-section by buildDisplayDispatch — the
+ * remaining keys (guards, test_gate_strikes, plan_review_enforce)
+ * fall back to project defaults then the shipped defaults.
  */
 function deepMergeGovernance(gov, defaultGov) {
-  const base = deepMergeGovernanceTiered(
-    gov?.dispatch || {},
-    defaultGov?.dispatch || {},
-  );
   const guards = {
     ...DEFAULT_GOVERNANCE.guards,
     ...(defaultGov?.guards || {}),
@@ -323,43 +323,81 @@ function deepMergeGovernance(gov, defaultGov) {
       gov?.test_gate_strikes ?? defaultGov?.test_gate_strikes ?? 2,
     plan_review_enforce:
       gov?.plan_review_enforce ?? defaultGov?.plan_review_enforce ?? 'auto',
-    dispatch: base,
+    dispatch: buildDisplayDispatch(gov?.dispatch),
   };
 }
 
 /**
- * Deep merge dispatch governance (3-tier + per-agent).
+ * Build the per-section dispatch view the editor form binds to.
+ *
+ * The result is keyed by section (tools / skills / subagents) — the
+ * shape `_governanceSection` reads via `dispatch[section]`. Each
+ * section's deny tiers (Always Disallowed / Default Denied) are seeded
+ * from the SHIPPED floor (DISPATCH_DEFAULTS) so the user can see and
+ * edit them even when the template overrides nothing; per_agent_allow
+ * carries the template's OWN entries (per-agent display fallback to the
+ * defaults happens inside dispatchSectionView).
+ *
+ * The project's own governance.dispatch is intentionally NOT used as the
+ * floor — templates are portable, so the baseline is the shipped default
+ * every project inherits, never the current project's tweaks. (An
+ * earlier version merged the whole `{tools,skills,subagents}` object as
+ * if it were a single tier-set, which collapsed every section to an
+ * empty view and silently dropped per_agent_allow on save.)
  */
-function deepMergeGovernanceTiered(dispatch, defaultDispatch) {
-  const tiered = {
-    always_disallowed: [...(defaultDispatch?.always_disallowed || [])],
-    default_denied: [...(defaultDispatch?.default_denied || [])],
-    per_agent_allow: {},
-  };
-
-  // Merge default per_agent entries
-  const perAgent = { ...(defaultDispatch?.per_agent_allow || {}) };
-  for (const [agent, defEntries] of Object.entries(perAgent)) {
-    tiered.per_agent_allow[agent] = [...(defEntries || [])];
+function buildDisplayDispatch(templateDispatch) {
+  const out = {};
+  for (const section of ['tools', 'skills', 'subagents']) {
+    const t = templateDispatch?.[section] || {};
+    const d = DISPATCH_DEFAULTS[section] || {};
+    out[section] = {
+      always_disallowed: [
+        ...(t.always_disallowed ?? d.always_disallowed ?? []),
+      ],
+      default_denied: [...(t.default_denied ?? d.default_denied ?? [])],
+      per_agent_allow: { ...(t.per_agent_allow || {}) },
+    };
   }
+  return out;
+}
 
-  // Overlay template dispatch settings
-  if (dispatch) {
-    if (dispatch.always_disallowed) {
-      tiered.always_disallowed = [...dispatch.always_disallowed];
-    }
-    if (dispatch.default_denied) {
-      tiered.default_denied = [...dispatch.default_denied];
-    }
-    if (dispatch.per_agent_allow) {
-      const overlay = dispatch.per_agent_allow;
-      for (const [agent, entries] of Object.entries(overlay)) {
-        tiered.per_agent_allow[agent] = [...(entries || [])];
-      }
-    }
+/**
+ * Order-insensitive membership equality for two string lists.
+ */
+function _sameMembers(a, b) {
+  const aa = a || [];
+  const bb = b || [];
+  if (aa.length !== bb.length) return false;
+  const seen = new Set(bb);
+  return aa.every((x) => seen.has(x));
+}
+
+/**
+ * Strip deny-tier entries that exactly match the shipped DISPATCH_DEFAULTS
+ * so a template only persists genuinely-customized tiers. Without this,
+ * any edit to a section (even just a per_agent_allow tweak) would freeze
+ * the shipped Always Disallowed / Default Denied lists into the template,
+ * so a future change to the shipped floor would never reach it.
+ */
+function _cleanSectionForWrite(section, cfg) {
+  const d = DISPATCH_DEFAULTS[section] || {};
+  const out = {};
+  if (
+    cfg.always_disallowed !== undefined &&
+    !_sameMembers(cfg.always_disallowed, d.always_disallowed)
+  ) {
+    out.always_disallowed = cfg.always_disallowed;
   }
-
-  return tiered;
+  if (
+    cfg.default_denied !== undefined &&
+    !_sameMembers(cfg.default_denied, d.default_denied)
+  ) {
+    out.default_denied = cfg.default_denied;
+  }
+  if (cfg.per_agent_allow && Object.keys(cfg.per_agent_allow).length > 0) {
+    out.per_agent_allow = cfg.per_agent_allow;
+  }
+  return out;
 }
 
 /**
@@ -439,7 +477,10 @@ export function formBufferToConfig(formBuffer) {
   let dispatchHasEntries = false;
   for (const section of ['tools', 'skills', 'subagents']) {
     if (dirty[section]) {
-      writtenDispatch[section] = mergedDispatch[section] || {};
+      writtenDispatch[section] = _cleanSectionForWrite(
+        section,
+        mergedDispatch[section] || {},
+      );
       dispatchHasEntries = true;
     } else if (original[section] !== undefined) {
       writtenDispatch[section] = original[section];
@@ -2036,9 +2077,14 @@ function _governanceSection(formBuffer, settings, projectId, rerender) {
 
       <h3 class="settings-section-title">Governance dispatch</h3>
       <p class="settings-section-desc">
-        Per-agent allow / deny lists for tools, skills, and subagents.
-        The project's <code>governance.guards</code> (hook gates) remain
-        cross-template and are edited in Project Settings.
+        Allow / deny lists for tools, skills, and subagents, per agent.
+        <strong>Always Disallowed</strong> is the hard-deny floor and
+        <strong>Default Denied</strong> is blocked under <code>*</code>
+        unless an agent opts in — both are seeded from the shipped
+        defaults and editable here; a tier left untouched stays inherited
+        rather than frozen into the template. The project's
+        <code>governance.guards</code> (hook gates) remain cross-template
+        and are edited in Project Settings.
       </p>
       <div class="governance-content">
         ${['tools', 'skills', 'subagents'].map((section) => {
@@ -2049,6 +2095,7 @@ function _governanceSection(formBuffer, settings, projectId, rerender) {
               section === 'tools' ? [] : section === 'skills' ? [] : [],
             agentRoles: AGENT_NAMES,
             defaults: DISPATCH_DEFAULTS[section],
+            denyTiersEditable: true,
             onChange: (newConfig) => {
               if (!editorState.formBuffer.governance) {
                 editorState.formBuffer.governance = { ...DEFAULT_GOVERNANCE };

--- a/worca-ui/e2e/pipelines-editor.spec.js
+++ b/worca-ui/e2e/pipelines-editor.spec.js
@@ -431,6 +431,27 @@ test('edit governance dispatch section', async ({ page }) => {
     const toolsSection = govSection.locator('.dispatch-section:has(.dispatch-section-title:has-text("Tools"))');
     await expect(toolsSection).toBeAttached();
 
+    // Deny tiers are now visible AND editable at the template level.
+    // They seed from the shipped DISPATCH_DEFAULTS floor, so the Tools
+    // "Always Disallowed" tier shows the hard-deny defaults even though
+    // this template overrides nothing in that tier.
+    const alwaysTier = toolsSection.locator(
+      '[data-tier="Always Disallowed"].dispatch-tier--editable',
+    );
+    const deniedTier = toolsSection.locator(
+      '[data-tier="Default Denied"].dispatch-tier--editable',
+    );
+    await expect(alwaysTier).toBeVisible();
+    await expect(deniedTier).toBeVisible();
+    await expect(alwaysTier).toContainText('EnterPlanMode');
+
+    // Add a new hard-deny entry via the tier's add input (Enter to commit).
+    const alwaysInput = alwaysTier.locator('.dispatch-tag-input-field');
+    await alwaysInput.click();
+    await alwaysInput.fill('CustomHardDeny');
+    await alwaysInput.press('Enter');
+    await expect(alwaysTier).toContainText('CustomHardDeny');
+
     // Find the planner row within tools section and its input
     const plannerInput = page.locator(
       '#dispatch-tools-planner .dispatch-tag-input-field',


### PR DESCRIPTION
## Problem

The template editor's Governance tab built `governance.dispatch` with the **wrong shape** — a single flat `{always_disallowed, default_denied, per_agent_allow}` instead of one keyed by `{tools, skills, subagents}`. So `dispatch[section]` was always `undefined`:

- the **Always Disallowed** / **Default Denied** tiers rendered nothing (empty → hidden),
- the template's own `per_agent_allow` was invisible, **and**
- editing + saving a section silently **dropped** that template's `per_agent_allow`.

Save round-trip tests masked this because the write path reads a separate raw clone (`_templateOriginalDispatch`). Since W-062 moved dispatch config out of Project Settings, the template editor is the *only* surface for it — so governance was effectively unconfigurable from the UI.

## Fix

- **`buildDisplayDispatch()`** — correct per-section view; seeds each section's deny tiers from the shipped `DISPATCH_DEFAULTS` floor (not project tweaks — templates are portable) and carries the template's own `per_agent_allow`.
- **`_cleanSectionForWrite()`** — strips deny-tier entries equal to the shipped defaults before save, so editing one tier doesn't freeze the whole shipped list into the template; genuine adds/removals persist.
- **`dispatch-section.js`** — new `editableTierView()` renders both deny tiers (even when empty) with removable chips + an Enter-to-add input, gated behind a new `denyTiersEditable` prop (default `false` — read-only behavior elsewhere untouched). Template editor passes `denyTiersEditable: true`, so both **user** and **project** templates are editable (built-in stays read-only).

## Tests

- Round-trip: corrected section shape, default seeding, `per_agent_allow` preservation, strip-on-write.
- Component: editable deny tiers render with add inputs.
- E2E: governance dispatch test now adds a hard-deny entry through the UI.

Full UI vitest (4624) + editor e2e green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

