### PR TITLE
fix(ui): stop reading every project's events.jsonl twice on the sidebar hot path (#296)

### DIFF
--- a/worca-ui/server/dispatch-events-aggregator.js
+++ b/worca-ui/server/dispatch-events-aggregator.js
@@ -25,6 +25,31 @@ const DISPATCH_EVENT_TYPES = new Set([
 ]);
 
 /**
+ * Classify a single parsed events.jsonl line. Returns the normalised dispatch
+ * entry if the line is a dispatch event, or null otherwise. Extracted so a
+ * combined single-pass reader (events-jsonl-reader.js) can share the exact same
+ * normalisation as the standalone reader below.
+ *
+ * @param {object} e — a parsed events.jsonl object
+ * @returns {{type, section, candidate, via?, reason?, timestamp}|null}
+ */
+export function parseDispatchEventLine(e) {
+  if (!e || !DISPATCH_EVENT_TYPES.has(e.event_type)) return null;
+  const payload = e.payload || {};
+  const candidate = payload.candidate;
+  if (!candidate) return null;
+  const entry = {
+    type: e.event_type,
+    section: payload.section || 'subagents',
+    candidate,
+    timestamp: e.timestamp,
+  };
+  if (payload.reason) entry.reason = payload.reason;
+  if (payload.via) entry.via = payload.via;
+  return entry;
+}
+
+/**
  * Parse events.jsonl and return only the dispatch events, with normalised shape.
  * Malformed lines are silently skipped so a corrupt event doesn't break the run view.
  *
@@ -48,19 +73,8 @@ export function readDispatchEventsFromJsonl(eventsPath) {
     } catch {
       continue;
     }
-    if (!DISPATCH_EVENT_TYPES.has(e.event_type)) continue;
-    const payload = e.payload || {};
-    const candidate = payload.candidate;
-    if (!candidate) continue;
-    const entry = {
-      type: e.event_type,
-      section: payload.section || 'subagents',
-      candidate,
-      timestamp: e.timestamp,
-    };
-    if (payload.reason) entry.reason = payload.reason;
-    if (payload.via) entry.via = payload.via;
-    out.push(entry);
+    const entry = parseDispatchEventLine(e);
+    if (entry) out.push(entry);
   }
   return out;
 }

--- a/worca-ui/server/events-jsonl-reader.js
+++ b/worca-ui/server/events-jsonl-reader.js
@@ -1,0 +1,93 @@
+/**
+ * Combined single-pass reader for a run's events.jsonl.
+ *
+ * Previously enrichment read the same file TWICE — once for dispatch events
+ * (dispatch-events-aggregator) and once for graph-query events
+ * (graph-query-aggregator) — each its own readFileSync + split + per-line
+ * JSON.parse. This module reads + parses the file ONCE and dispatches each line
+ * to both classifiers, halving the cost wherever enrichment still runs
+ * (findRun, the detailed-view live-update path). See issue #296.
+ *
+ * Results are cached by file mtime+size so an unchanged events.jsonl is parsed
+ * at most once across repeated enrichment (multiple subscribe-run calls, the
+ * status watcher's debounced refresh). A live run appends to the file, changing
+ * mtime+size on every flush, so it always re-reads — exactly what we want for
+ * fresh per-iteration counts. The cache is bounded to avoid unbounded growth on
+ * a long-lived global-mode server.
+ */
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { parseDispatchEventLine } from './dispatch-events-aggregator.js';
+import { parseGraphQueryEventLine } from './graph-query-aggregator.js';
+
+const _parsedEventsCache = new Map(); // cacheKey → { dispatchEvents, graphEvents }
+const _MAX_CACHE_ENTRIES = 256;
+
+const EMPTY = Object.freeze({
+  dispatchEvents: Object.freeze([]),
+  graphEvents: Object.freeze([]),
+});
+
+/** Clear the events.jsonl parse cache (tests, or explicit invalidation). */
+export function _clearEventsJsonlCache() {
+  _parsedEventsCache.clear();
+}
+
+/**
+ * Read a run's events.jsonl ONCE and return both dispatch and graph-query
+ * events. No-op (empty arrays) when the file is missing or unreadable.
+ *
+ * @param {string} eventsPath — absolute path to events.jsonl
+ * @returns {{dispatchEvents: Array, graphEvents: Array}}
+ */
+export function readEventsForEnrichment(eventsPath) {
+  if (!eventsPath || !existsSync(eventsPath)) return EMPTY;
+
+  let stat;
+  try {
+    stat = statSync(eventsPath);
+  } catch {
+    return EMPTY;
+  }
+
+  const cacheKey = `${eventsPath}:${stat.mtimeMs}:${stat.size}`;
+  const cached = _parsedEventsCache.get(cacheKey);
+  if (cached) return cached;
+
+  let content;
+  try {
+    content = readFileSync(eventsPath, 'utf8');
+  } catch {
+    return EMPTY;
+  }
+
+  const dispatchEvents = [];
+  const graphEvents = [];
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    let e;
+    try {
+      e = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    // A line is at most one of these (distinct event_types) — classify once.
+    const d = parseDispatchEventLine(e);
+    if (d) {
+      dispatchEvents.push(d);
+      continue;
+    }
+    const g = parseGraphQueryEventLine(e);
+    if (g) graphEvents.push(g);
+  }
+
+  const result = { dispatchEvents, graphEvents };
+
+  // Bound cache growth — evict the oldest entry (insertion order) when full.
+  if (_parsedEventsCache.size >= _MAX_CACHE_ENTRIES) {
+    const oldest = _parsedEventsCache.keys().next().value;
+    _parsedEventsCache.delete(oldest);
+  }
+  _parsedEventsCache.set(cacheKey, result);
+  return result;
+}

--- a/worca-ui/server/events-jsonl-reader.test.js
+++ b/worca-ui/server/events-jsonl-reader.test.js
@@ -1,0 +1,159 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  _clearEventsJsonlCache,
+  readEventsForEnrichment,
+} from './events-jsonl-reader.js';
+
+describe('events-jsonl-reader', () => {
+  let dir;
+  let eventsPath;
+
+  const writeEvents = (events) =>
+    writeFileSync(
+      eventsPath,
+      `${events.map((e) => JSON.stringify(e)).join('\n')}\n`,
+    );
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `worca-events-reader-${Date.now()}-${Math.random()}`);
+    mkdirSync(dir, { recursive: true });
+    eventsPath = join(dir, 'events.jsonl');
+    _clearEventsJsonlCache();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    _clearEventsJsonlCache();
+  });
+
+  it('returns empty arrays when the file is missing', () => {
+    const { dispatchEvents, graphEvents } = readEventsForEnrichment(eventsPath);
+    expect(dispatchEvents).toEqual([]);
+    expect(graphEvents).toEqual([]);
+  });
+
+  it('returns empty arrays for null/empty path', () => {
+    expect(readEventsForEnrichment('')).toEqual({
+      dispatchEvents: [],
+      graphEvents: [],
+    });
+    expect(readEventsForEnrichment(null)).toEqual({
+      dispatchEvents: [],
+      graphEvents: [],
+    });
+  });
+
+  it('reads BOTH dispatch and graph-query events in a single pass', () => {
+    writeEvents([
+      { event_type: 'pipeline.run.started', timestamp: 't0', payload: {} },
+      {
+        event_type: 'pipeline.hook.dispatch_allowed',
+        timestamp: 't1',
+        payload: { section: 'subagents', candidate: 'Explore' },
+      },
+      {
+        event_type: 'pipeline.hook.dispatch_blocked',
+        timestamp: 't2',
+        payload: { candidate: 'general-purpose', reason: 'denylist' },
+      },
+      {
+        event_type: 'pipeline.hook.graph_query',
+        timestamp: 't3',
+        payload: { engine: 'graphify', op: 'query' },
+      },
+      {
+        event_type: 'pipeline.hook.graph_query',
+        timestamp: 't4',
+        payload: { engine: 'crg', op: 'explain' },
+      },
+    ]);
+
+    const { dispatchEvents, graphEvents } = readEventsForEnrichment(eventsPath);
+    expect(dispatchEvents).toHaveLength(2);
+    expect(dispatchEvents[0]).toMatchObject({
+      type: 'pipeline.hook.dispatch_allowed',
+      section: 'subagents',
+      candidate: 'Explore',
+    });
+    expect(dispatchEvents[1]).toMatchObject({
+      type: 'pipeline.hook.dispatch_blocked',
+      candidate: 'general-purpose',
+      reason: 'denylist',
+    });
+    expect(graphEvents).toHaveLength(2);
+    expect(graphEvents[0]).toEqual({
+      engine: 'graphify',
+      op: 'query',
+      timestamp: 't3',
+    });
+    expect(graphEvents[1]).toEqual({
+      engine: 'crg',
+      op: 'explain',
+      timestamp: 't4',
+    });
+  });
+
+  it('skips malformed lines without throwing', () => {
+    writeFileSync(
+      eventsPath,
+      [
+        'not json',
+        JSON.stringify({
+          event_type: 'pipeline.hook.dispatch_allowed',
+          timestamp: 't1',
+          payload: { candidate: 'Explore' },
+        }),
+        '{ broken',
+        '',
+      ].join('\n'),
+    );
+    const { dispatchEvents } = readEventsForEnrichment(eventsPath);
+    expect(dispatchEvents).toHaveLength(1);
+    expect(dispatchEvents[0].candidate).toBe('Explore');
+  });
+
+  it('caches by mtime+size: an unchanged file returns the same object (no re-parse)', () => {
+    writeEvents([
+      {
+        event_type: 'pipeline.hook.dispatch_allowed',
+        timestamp: 't1',
+        payload: { candidate: 'Explore' },
+      },
+    ]);
+    const first = readEventsForEnrichment(eventsPath);
+    const second = readEventsForEnrichment(eventsPath);
+    // Same cached reference — the file was parsed at most once.
+    expect(second).toBe(first);
+  });
+
+  it('re-reads when the file changes (size/mtime key miss)', () => {
+    writeEvents([
+      {
+        event_type: 'pipeline.hook.dispatch_allowed',
+        timestamp: 't1',
+        payload: { candidate: 'Explore' },
+      },
+    ]);
+    const first = readEventsForEnrichment(eventsPath);
+    expect(first.dispatchEvents).toHaveLength(1);
+
+    // Append a second event — size changes, so the cache key misses.
+    writeEvents([
+      {
+        event_type: 'pipeline.hook.dispatch_allowed',
+        timestamp: 't1',
+        payload: { candidate: 'Explore' },
+      },
+      {
+        event_type: 'pipeline.hook.dispatch_allowed',
+        timestamp: 't2',
+        payload: { candidate: 'general-purpose' },
+      },
+    ]);
+    const second = readEventsForEnrichment(eventsPath);
+    expect(second).not.toBe(first);
+    expect(second.dispatchEvents).toHaveLength(2);
+  });
+});

--- a/worca-ui/server/graph-query-aggregator.js
+++ b/worca-ui/server/graph-query-aggregator.js
@@ -19,6 +19,23 @@ import { existsSync, readFileSync } from 'node:fs';
 const GRAPH_QUERY_EVENT_TYPE = 'pipeline.hook.graph_query';
 
 /**
+ * Classify a single parsed events.jsonl line. Returns the normalised graph-query
+ * entry if the line is a graph-query event, or null otherwise. Extracted so a
+ * combined single-pass reader (events-jsonl-reader.js) can share the exact same
+ * normalisation as the standalone reader below.
+ *
+ * @param {object} e — a parsed events.jsonl object
+ * @returns {{engine, op, timestamp}|null}
+ */
+export function parseGraphQueryEventLine(e) {
+  if (!e || e.event_type !== GRAPH_QUERY_EVENT_TYPE) return null;
+  const payload = e.payload || {};
+  const engine = payload.engine;
+  if (engine !== 'graphify' && engine !== 'crg') return null;
+  return { engine, op: payload.op || '', timestamp: e.timestamp };
+}
+
+/**
  * Parse events.jsonl and return only the graph-query events.
  * Malformed lines are skipped so a corrupt event doesn't break the run view.
  *
@@ -42,11 +59,8 @@ export function readGraphQueryEventsFromJsonl(eventsPath) {
     } catch {
       continue;
     }
-    if (e.event_type !== GRAPH_QUERY_EVENT_TYPE) continue;
-    const payload = e.payload || {};
-    const engine = payload.engine;
-    if (engine !== 'graphify' && engine !== 'crg') continue;
-    out.push({ engine, op: payload.op || '', timestamp: e.timestamp });
+    const entry = parseGraphQueryEventLine(e);
+    if (entry) out.push(entry);
   }
   return out;
 }

--- a/worca-ui/server/project-routes-beads-enrichment.test.js
+++ b/worca-ui/server/project-routes-beads-enrichment.test.js
@@ -24,8 +24,12 @@ vi.mock('./process-manager.js', async (importOriginal) => {
 });
 
 const mockDiscoverRuns = vi.fn().mockReturnValue([]);
+// /runs now scans via discoverRunsAsync (issue #296 — off the event loop, no
+// events.jsonl enrichment). Back both exports with the same mock so the
+// existing mockDiscoverRuns.mockReturnValue(...) setups still drive the route.
 vi.mock('./watcher.js', () => ({
   discoverRuns: (...args) => mockDiscoverRuns(...args),
+  discoverRunsAsync: (...args) => mockDiscoverRuns(...args),
 }));
 
 const { createProjectScopedRoutes, projectResolver } = await import(

--- a/worca-ui/server/project-routes.js
+++ b/worca-ui/server/project-routes.js
@@ -53,7 +53,7 @@ import { validateSettingsPayload } from './settings-validator.js';
 import { createTemplatesRoutes } from './templates-routes.js';
 import { isVersionBehind } from './version-check.js';
 import { getVersionInfo } from './versions.js';
-import { discoverRuns } from './watcher.js';
+import { discoverRuns, discoverRunsAsync } from './watcher.js';
 import {
   checkWorcaInstalled,
   readProjectWorcaVersion,
@@ -365,7 +365,12 @@ export function createProjectScopedRoutes({
   // GET /api/projects/:projectId/runs — list runs for this project
   router.get('/runs', requireWorcaDir, async (req, res) => {
     try {
-      const runs = discoverRuns(req.project.worcaDir);
+      // List/sidebar path: scan off the event loop (async) and skip
+      // events.jsonl enrichment entirely — neither the run list nor the sidebar
+      // render dispatch_events / graph-query counts (issue #296).
+      const runs = await discoverRunsAsync(req.project.worcaDir, {
+        enrich: false,
+      });
       const default_branch = getDefaultBranch(req.project.projectRoot);
 
       const { getBeadsCounts } = req.app.locals;
@@ -1715,7 +1720,9 @@ export function createProjectScopedRoutes({
   // Reads per-iteration token_usage from each run's status.json.
   router.get('/costs', requireWorcaDir, (req, res) => {
     const { worcaDir } = req.project;
-    const runs = discoverRuns(worcaDir);
+    // Costs read only per-iteration token_usage from status.json — no
+    // events.jsonl enrichment needed (issue #296).
+    const runs = discoverRuns(worcaDir, { enrich: false });
     const tokenData = {};
 
     for (const run of runs) {

--- a/worca-ui/server/watcher.js
+++ b/worca-ui/server/watcher.js
@@ -2,14 +2,9 @@ import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import {
-  assignEventsToIterations,
-  readDispatchEventsFromJsonl,
-} from './dispatch-events-aggregator.js';
-import {
-  assignGraphQueryCountsToIterations,
-  readGraphQueryEventsFromJsonl,
-} from './graph-query-aggregator.js';
+import { assignEventsToIterations } from './dispatch-events-aggregator.js';
+import { readEventsForEnrichment } from './events-jsonl-reader.js';
+import { assignGraphQueryCountsToIterations } from './graph-query-aggregator.js';
 import { readPipelineOverlay } from './run-dir-resolver.js';
 import { safeWatch } from './safe-watch.js';
 
@@ -25,11 +20,11 @@ import { safeWatch } from './safe-watch.js';
 function enrichWithDispatchEvents(status, runDir) {
   if (!status?.stages) return status;
   const eventsPath = join(runDir, 'events.jsonl');
-  const dispatchEvents = readDispatchEventsFromJsonl(eventsPath);
+  // Single read for both event kinds (issue #296) — was two full passes.
+  const { dispatchEvents, graphEvents } = readEventsForEnrichment(eventsPath);
   if (dispatchEvents.length > 0) {
     status.stages = assignEventsToIterations(dispatchEvents, status.stages);
   }
-  const graphEvents = readGraphQueryEventsFromJsonl(eventsPath);
   if (graphEvents.length > 0) {
     status.stages = assignGraphQueryCountsToIterations(
       graphEvents,
@@ -62,7 +57,7 @@ function isTerminal(status) {
   );
 }
 
-const _discoverRunsCache = new Map(); // worcaDir → { ts, runs }
+const _discoverRunsCache = new Map(); // `${worcaDir}|${enrich}` → { ts, runs }
 // TTL defaults to 0 under vitest (NODE_ENV=test) so the cache is a no-op in
 // tests — they build fixture dirs from Date.now() and a shared path could
 // otherwise serve a stale cached scan across tests. Production uses 1500ms;
@@ -82,14 +77,21 @@ export function _setDiscoverRunsTtlForTest(ms) {
  * single scan. Per-run handlers use findRun() instead. Live status changes
  * still reach clients via the statusWatcher broadcast, so TTL-window staleness
  * here is invisible in the UI.
+ *
+ * `enrich` (default false) controls events.jsonl enrichment. List/sidebar
+ * callers never render dispatch_events / graph-query counts (only the detailed
+ * run view does, fed by findRun), so they pass enrich:false and skip reading
+ * every project's events.jsonl entirely — the hot-path fix for issue #296. The
+ * cache is keyed on (worcaDir, enrich) since the two shapes differ.
  */
-export function discoverRuns(worcaDir) {
-  const cached = _discoverRunsCache.get(worcaDir);
+export function discoverRuns(worcaDir, { enrich = false } = {}) {
+  const cacheKey = `${worcaDir}|${enrich ? 1 : 0}`;
+  const cached = _discoverRunsCache.get(cacheKey);
   if (cached && Date.now() - cached.ts < _discoverRunsTtlMs) {
     return cached.runs;
   }
-  const runs = _discoverRunsUncached(worcaDir);
-  _discoverRunsCache.set(worcaDir, { ts: Date.now(), runs });
+  const runs = _discoverRunsUncached(worcaDir, { enrich });
+  _discoverRunsCache.set(cacheKey, { ts: Date.now(), runs });
   return runs;
 }
 
@@ -154,8 +156,12 @@ export function findRun(worcaDir, runId) {
 
   // Fallback for legacy layouts where the on-disk name != the computed id
   // (flat .worca/status.json, hashed legacy ids). Rare — pay one (TTL-cached)
-  // full scan rather than regress correctness vs discoverRuns().find().
-  return discoverRuns(worcaDir).find((r) => r.id === runId) || null;
+  // full scan rather than regress correctness vs discoverRuns().find(). Pass
+  // enrich:true so findRun stays fully enriched in every branch (its contract),
+  // even though discoverRuns now defaults enrichment off for the list path.
+  return (
+    discoverRuns(worcaDir, { enrich: true }).find((r) => r.id === runId) || null
+  );
 }
 
 function _shapeRunFromFile(
@@ -198,7 +204,7 @@ function _shapeRunFromFile(
   }
 }
 
-function _discoverRunsUncached(worcaDir) {
+function _discoverRunsUncached(worcaDir, { enrich = false } = {}) {
   const runs = [];
   const seenIds = new Set();
 
@@ -211,7 +217,7 @@ function _discoverRunsUncached(worcaDir) {
       if (!existsSync(statusPath)) continue;
       try {
         let status = JSON.parse(readFileSync(statusPath, 'utf8'));
-        status = enrichWithDispatchEvents(status, runDir);
+        if (enrich) status = enrichWithDispatchEvents(status, runDir);
         const id = createRunId(status);
         if (seenIds.has(id)) continue;
         seenIds.add(id);
@@ -319,10 +325,12 @@ function _discoverRunsUncached(worcaDir) {
           if (!existsSync(sp)) continue;
           try {
             let status = JSON.parse(readFileSync(sp, 'utf8'));
-            status = enrichWithDispatchEvents(
-              status,
-              join(wtRunsDir, runEntry),
-            );
+            if (enrich) {
+              status = enrichWithDispatchEvents(
+                status,
+                join(wtRunsDir, runEntry),
+              );
+            }
             const id = createRunId(status);
             if (seenIds.has(id)) continue;
             seenIds.add(id);
@@ -356,10 +364,13 @@ function _discoverRunsUncached(worcaDir) {
 }
 
 /**
- * Async version of discoverRuns — avoids blocking the event loop.
- * Used by the status watcher's debounced refresh.
+ * Async version of discoverRuns — avoids blocking the event loop. Used by the
+ * status watcher's debounced refresh (enrich:true, since it broadcasts
+ * run-snapshot to the detailed view's live update) and by the list-path REST /
+ * WS handlers (enrich:false — issue #296, keeps the all-projects scan off the
+ * event loop without reading every events.jsonl).
  */
-export async function discoverRunsAsync(worcaDir) {
+export async function discoverRunsAsync(worcaDir, { enrich = false } = {}) {
   const runs = [];
   const seenIds = new Set();
 
@@ -379,7 +390,9 @@ export async function discoverRunsAsync(worcaDir) {
     });
     for (const result of await Promise.all(readPromises)) {
       if (!result) continue;
-      const status = enrichWithDispatchEvents(result.status, result.runDir);
+      const status = enrich
+        ? enrichWithDispatchEvents(result.status, result.runDir)
+        : result.status;
       const id = createRunId(status);
       if (seenIds.has(id)) continue;
       seenIds.add(id);
@@ -482,10 +495,12 @@ export async function discoverRunsAsync(worcaDir) {
             try {
               const sp = join(wtRunsDir, runEntry, 'status.json');
               let status = JSON.parse(await readFile(sp, 'utf8'));
-              status = enrichWithDispatchEvents(
-                status,
-                join(wtRunsDir, runEntry),
-              );
+              if (enrich) {
+                status = enrichWithDispatchEvents(
+                  status,
+                  join(wtRunsDir, runEntry),
+                );
+              }
               results.push({ status, reg });
             } catch {
               /* ignore */

--- a/worca-ui/server/watcher.test.js
+++ b/worca-ui/server/watcher.test.js
@@ -255,7 +255,7 @@ describe('watcher', () => {
     ]);
   });
 
-  it('enriches iterations with aggregated dispatch_events when events.jsonl is present', () => {
+  it('enriches iterations with aggregated dispatch_events when events.jsonl is present (enrich:true)', () => {
     const runId = 'run-disp-1';
     const runDir = join(dir, 'runs', runId);
     mkdirSync(runDir, { recursive: true });
@@ -329,7 +329,7 @@ describe('watcher', () => {
       `${events.map((e) => JSON.stringify(e)).join('\n')}\n`,
     );
 
-    const runs = discoverRuns(dir);
+    const runs = discoverRuns(dir, { enrich: true });
     const run = runs.find((r) => r.id === runId);
     expect(run).toBeDefined();
     const iter = run.stages.implement.iterations[0];
@@ -349,6 +349,75 @@ describe('watcher', () => {
     expect(blocked.candidate).toBe('general-purpose');
     expect(blocked.count).toBe(1);
     expect(blocked.reason).toBe('Blocked: denylist');
+  });
+
+  // ---- list-path enrichment opt-out (#296) ----
+  // The run list / sidebar never render dispatch_events, so discoverRuns
+  // defaults to enrich:false and skips reading every project's events.jsonl —
+  // the hot-path fix. findRun (detailed view) still enriches.
+  const _writeRunWithEvents = (runId) => {
+    const runDir = join(dir, 'runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-04-13T11:00:00.000Z',
+        completed_at: '2026-04-13T11:05:00.000Z',
+        pipeline_status: 'completed',
+        stages: {
+          implement: {
+            status: 'completed',
+            iterations: [
+              {
+                number: 1,
+                started_at: '2026-04-13T11:00:00.000Z',
+                completed_at: '2026-04-13T11:05:00.000Z',
+              },
+            ],
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(runDir, 'events.jsonl'),
+      `${JSON.stringify({
+        event_type: 'pipeline.hook.dispatch_allowed',
+        timestamp: '2026-04-13T11:01:00.000Z',
+        payload: { section: 'subagents', candidate: 'Explore' },
+      })}\n`,
+    );
+  };
+
+  it('discoverRuns defaults to enrich:false — no dispatch_events even when events.jsonl is present', () => {
+    // Enrichment is the only thing that reads events.jsonl in discoverRuns, so
+    // the absence of dispatch_events here transitively proves the list path
+    // performs no events.jsonl read (the #296 hot-path fix).
+    const runId = 'run-optout-1';
+    _writeRunWithEvents(runId);
+    const run = discoverRuns(dir).find((r) => r.id === runId);
+    expect(run).toBeDefined();
+    expect(run.stages.implement.iterations[0].dispatch_events).toBeUndefined();
+  });
+
+  it('discoverRuns({ enrich: true }) DOES enrich the same run (parity counterpart)', () => {
+    const runId = 'run-optout-enriched';
+    _writeRunWithEvents(runId);
+    const run = discoverRuns(dir, { enrich: true }).find((r) => r.id === runId);
+    expect(run.stages.implement.iterations[0].dispatch_events).toBeDefined();
+  });
+
+  it('findRun still enriches a runs/ run while discoverRuns (default) does not', () => {
+    const runId = 'run-optout-2';
+    _writeRunWithEvents(runId);
+    const viaFind = findRun(dir, runId);
+    const viaListScan = discoverRuns(dir).find((r) => r.id === runId);
+    expect(
+      viaFind.stages.implement.iterations[0].dispatch_events,
+    ).toBeDefined();
+    expect(
+      viaListScan.stages.implement.iterations[0].dispatch_events,
+    ).toBeUndefined();
   });
 
   it('discoverRuns_no_active_run: finds runs in runs/ without active_run file present', () => {

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -34,7 +34,7 @@ import {
 } from './process-manager.js';
 import { resolveRunDir } from './run-dir-resolver.js';
 import { readSettings } from './settings-reader.js';
-import { discoverRuns, findRun } from './watcher.js';
+import { discoverRunsAsync, findRun } from './watcher.js';
 import { resolveBeadsCounts } from './ws-beads-watcher.js';
 
 /**
@@ -143,7 +143,8 @@ export function createMessageRouter({
     // list-runs
     if (req.type === 'list-runs') {
       const proj = resolveProject(ws, req.payload);
-      const runs = discoverRuns(proj.worcaDir);
+      // List/sidebar path: async scan, no events.jsonl enrichment (issue #296).
+      const runs = await discoverRunsAsync(proj.worcaDir, { enrich: false });
       const settings = readSettings(proj.settingsPath);
       ws.send(JSON.stringify(makeOk(req, { runs, settings })));
       return;

--- a/worca-ui/server/ws-status-watcher.js
+++ b/worca-ui/server/ws-status-watcher.js
@@ -247,7 +247,11 @@ export function createStatusWatcher({
         /* ignore */
       }
       try {
-        const runs = await discoverRunsAsync(worcaDir);
+        // enrich:true — run-snapshot broadcasts below feed the detailed run
+        // view's live update, which renders dispatch_events / graph-query counts
+        // for the still-running iteration (issue #296 keeps the list path lean,
+        // not this one).
+        const runs = await discoverRunsAsync(worcaDir, { enrich: true });
         reconcileWorktreeWatchers();
         const subscribedIds = new Set();
         for (const ws of wss.clients) {


### PR DESCRIPTION
Fixes #296.

In global (multi-project) mode the sidebar blocked for seconds because the run-list path read + JSON-parsed **every** registered project's `events.jsonl` **twice** on the Node event loop — just to populate data the list/sidebar never render. With 11 projects (~99MB of `events.jsonl`) that was ~200MB of synchronous JSON parsing before the sidebar dots appeared, even when the viewed project was 539KB.

## Fixes (worca-ui only — no Python)

**1. Skip `events.jsonl` enrichment on the list path (biggest win).** Threaded `{ enrich = false }` through `discoverRuns` / `_discoverRunsUncached` / `discoverRunsAsync`. Only the detailed run view enriches — fed by `findRun` and the status watcher's `run-snapshot` broadcast, both of which keep `enrich: true`. `/runs`, `/costs`, and the `list-runs` WS handler opt out, removing the entire all-projects `events.jsonl` read from the hot path. `findRun`'s legacy fallback passes `enrich: true` to preserve its full-enrichment contract.

**2. Single-read aggregation.** New `events-jsonl-reader.js` reads + parses each `events.jsonl` **once**, dispatching lines to both the dispatch-event and graph-query collectors (was two independent full passes). The aggregators now expose `parseDispatchEventLine` / `parseGraphQueryEventLine`; their standalone readers delegate to them, so behavior is unchanged.

**3. Async list scan.** `/runs` and `list-runs` now `await discoverRunsAsync` so even a necessary scan stays off the event loop.

**4. Bound the giant files.** The combined reader caches parsed events keyed by `path:mtime:size` (bounded to 256 entries) — repeated enrichment of an unchanged file is parsed at most once; live runs re-read naturally as the file grows.

## Tests
- `events-jsonl-reader.test.js` — single-pass reads both event kinds, malformed-line skip, mtime+size cache hit/miss.
- `watcher.test.js` — enrichment test now uses `{ enrich: true }`; added opt-out/parity tests proving `findRun` still enriches while the default list scan does not.
- `project-routes-beads-enrichment.test.js` — mock now exports `discoverRunsAsync` (route's dependency changed).
- Server suite: 2145/2146 pass (the one failure, `keys-schema > PROJECT_DEFAULTS matches JSON`, is pre-existing on master — unrelated).
- Playwright: sidebar (7) + file-access (8) specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
