### PR TITLE
fix(ui): persist Max Beads dropdown selection across rerenders in the run launcher

### DIFF
--- a/worca-ui/app/views/new-run.js
+++ b/worca-ui/app/views/new-run.js
@@ -459,6 +459,14 @@ export function newRunView(_state, { rerender }) {
     rerender();
   }
 
+  function handleMaxBeadsChange(e) {
+    // Persist the choice to module state so a rerender (async branch/template
+    // fetch resolving before submit) doesn't snap the select back to the
+    // template-seeded value via the `value=${String(maxBeads)}` binding.
+    maxBeads = parseInt(e.target.value, 10) || 0;
+    rerender();
+  }
+
   function handlePlanFocus() {
     fetchPlanFiles(effectiveId).then(() => {
       planDropdownOpen = true;
@@ -767,7 +775,7 @@ export function newRunView(_state, { rerender }) {
 
               <div class="settings-field">
                 <label class="settings-label">Max Beads</label>
-                <sl-select id="new-run-max-beads" value=${String(maxBeads)}>
+                <sl-select id="new-run-max-beads" value=${String(maxBeads)} @sl-change=${handleMaxBeadsChange}>
                   <sl-option value="0">Auto</sl-option>
                   ${[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(
                     (n) => html`<sl-option value=${String(n)}>${n}</sl-option>`,


### PR DESCRIPTION
## Problem

In the run launcher (`worca-ui/app/views/new-run.js`), the **Max Beads** `<sl-select id="new-run-max-beads">` was bound to `value=${String(maxBeads)}` but had **no `@sl-change` handler**. The user's selection only lived in the DOM — it never updated the `maxBeads` module var. Any rerender before submit (e.g. an async branch/template fetch resolving) re-applied the `value` binding and snapped the select back to the template-seeded value, silently discarding the choice.

## Fix

Add `handleMaxBeadsChange` (mirroring the adjacent `handleBranchChange`) to persist the selection to module state and rerender, and wire it onto the select:

```js
function handleMaxBeadsChange(e) {
  maxBeads = parseInt(e.target.value, 10) || 0;
  rerender();
}
// on the select:
@sl-change=${handleMaxBeadsChange}
```

## Verification

- Live browser check: selected Max Beads = 5, then triggered an independent rerender (source-type change) — the select **stays at 5** (previously reset to Auto).
- Unit: full app-layer suite green (2756 passed), incl. `new-run-max-beads.test.js`.
- E2e: launcher/template specs green (22 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
