### PR TITLE
feat(ui): surface effective coordinator bead cap + source on the preflight row

### DIFF
--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -2223,6 +2223,29 @@ def launch_param_status(
     return out
 
 
+def effective_bead_cap_status(
+    effective_cap: int, max_beads_override: Optional[int], has_review_comments: bool
+) -> dict:
+    """Status keys recording the RESOLVED coordinator bead cap and where it came from.
+
+    Surfaced on the UI preflight row alongside ``max_beads_override``.
+    ``max_beads_effective`` is the cap prompt_builder actually resolved (0 = Auto,
+    and 0 under PR-revision suppression). ``max_beads_source`` is ``"explicit"``
+    only when a launch override genuinely drove the cap; config/template caps —
+    and PR-revision suppression, which forces the cap to 0 regardless of any
+    override — record ``"template"`` since neither is a launch-time choice.
+    """
+    source = (
+        "explicit"
+        if (max_beads_override is not None and not has_review_comments)
+        else "template"
+    )
+    return {
+        "max_beads_effective": int(effective_cap or 0),
+        "max_beads_source": source,
+    }
+
+
 def run_pipeline(
     work_request: WorkRequest,
     plan_file: Optional[str] = None,
@@ -2981,6 +3004,19 @@ def run_pipeline(
                     prompt_builder.update_context("max_beads_config", stage_config["max_beads"])
 
                 ctx_dict = prompt_builder.build_context(current_stage.value, pb_iteration)
+
+                # W-069: persist the resolved coordinator bead cap + its source so
+                # the UI preflight row can surface the EFFECTIVE cap (not just the
+                # launch override). Written before COORDINATE executes, so it's
+                # visible even if the stage later fails.
+                if current_stage == Stage.COORDINATE:
+                    status.update(effective_bead_cap_status(
+                        int(ctx_dict.get("max_beads", 0) or 0),
+                        max_beads_override,
+                        bool(ctx_dict.get("has_review_comments")),
+                    ))
+                    save_status(status, actual_status_path)
+
                 _stage_agent_name = stage_config["agent"]
                 if current_stage == Stage.PLAN_REVIEW:
                     _pr_mode, _pr_mode_reason = resolve_plan_review_mode(

--- a/tests/test_coordinator_max_beads.py
+++ b/tests/test_coordinator_max_beads.py
@@ -474,3 +474,84 @@ class TestLaunchParamStatus:
         from worca.orchestrator.runner import launch_param_status
 
         assert launch_param_status(None, 4, 1) == {"size_multiplier": 4}
+
+
+class TestEffectiveBeadCapStatus:
+    """effective_bead_cap_status maps (resolved cap, override, PR-revision) to the
+    two persisted fields the preflight UI reads: max_beads_effective + source."""
+
+    def test_explicit_override(self):
+        from worca.orchestrator.runner import effective_bead_cap_status
+
+        assert effective_bead_cap_status(5, 5, False) == {
+            "max_beads_effective": 5,
+            "max_beads_source": "explicit",
+        }
+
+    def test_template_config_no_override(self):
+        from worca.orchestrator.runner import effective_bead_cap_status
+
+        assert effective_bead_cap_status(3, None, False) == {
+            "max_beads_effective": 3,
+            "max_beads_source": "template",
+        }
+
+    def test_auto_run(self):
+        from worca.orchestrator.runner import effective_bead_cap_status
+
+        assert effective_bead_cap_status(0, None, False) == {
+            "max_beads_effective": 0,
+            "max_beads_source": "template",
+        }
+
+    def test_pr_revision_records_template_even_with_override(self):
+        from worca.orchestrator.runner import effective_bead_cap_status
+
+        # Override was passed, but PR-revision suppression forced the cap to 0;
+        # that isn't a launch-time choice, so source is "template".
+        assert effective_bead_cap_status(0, 1, True) == {
+            "max_beads_effective": 0,
+            "max_beads_source": "template",
+        }
+
+    # --- end-to-end: resolution (PromptBuilder) + status mapping together ---
+
+    def test_e2e_explicit_override(self):
+        from worca.orchestrator.runner import effective_bead_cap_status
+
+        pb = _make_pb(max_beads_override=4, max_beads_config=7)
+        ctx = pb.build_context("coordinate")
+        out = effective_bead_cap_status(
+            ctx["max_beads"], 4, bool(ctx.get("has_review_comments"))
+        )
+        assert out == {"max_beads_effective": 4, "max_beads_source": "explicit"}
+
+    def test_e2e_template_config(self):
+        from worca.orchestrator.runner import effective_bead_cap_status
+
+        pb = _make_pb(max_beads_config=6)
+        ctx = pb.build_context("coordinate")
+        out = effective_bead_cap_status(
+            ctx["max_beads"], None, bool(ctx.get("has_review_comments"))
+        )
+        assert out == {"max_beads_effective": 6, "max_beads_source": "template"}
+
+    def test_e2e_auto(self):
+        from worca.orchestrator.runner import effective_bead_cap_status
+
+        pb = _make_pb()
+        ctx = pb.build_context("coordinate")
+        out = effective_bead_cap_status(
+            ctx["max_beads"], None, bool(ctx.get("has_review_comments"))
+        )
+        assert out == {"max_beads_effective": 0, "max_beads_source": "template"}
+
+    def test_e2e_pr_revision_suppresses(self):
+        from worca.orchestrator.runner import effective_bead_cap_status
+
+        pb = _make_pb(max_beads_override=2, review_comments="please split this")
+        ctx = pb.build_context("coordinate")
+        out = effective_bead_cap_status(
+            ctx["max_beads"], 2, bool(ctx.get("has_review_comments"))
+        )
+        assert out == {"max_beads_effective": 0, "max_beads_source": "template"}

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -4666,6 +4666,12 @@ sl-details.learnings-panel::part(content) {
   color: var(--muted);
 }
 
+/* Secondary pill on the preflight params row (e.g. the Max Beads source:
+   "explicit" / "template"). Same font as the value pill, visually subordinated. */
+.preflight-param-source-badge {
+  opacity: 0.72;
+}
+
 .circuit-breaker-banner {
   margin: 8px 0 4px;
 }

--- a/worca-ui/app/views/run-detail-preflight.test.js
+++ b/worca-ui/app/views/run-detail-preflight.test.js
@@ -262,11 +262,10 @@ describe('runDetailView preflight stage', () => {
     expect(html).not.toContain('preflight-summary');
   });
 
-  it('shows launch-param pills only when explicitly set', () => {
-    const run = {
-      size_multiplier: 3,
-      loop_multiplier: 2,
-      max_beads_override: 12,
+  // Helper: wrap top-level run fields around a minimal completed preflight stage.
+  function _runWith(fields) {
+    return {
+      ...fields,
       stages: {
         preflight: {
           status: 'completed',
@@ -281,7 +280,19 @@ describe('runDetailView preflight stage', () => {
         },
       },
     };
-    const html = renderToString(runDetailView(run));
+  }
+
+  it('shows Size/Loop multiplier pills only when explicitly set', () => {
+    const html = renderToString(
+      runDetailView(
+        _runWith({
+          size_multiplier: 3,
+          loop_multiplier: 2,
+          max_beads_effective: 12,
+          max_beads_source: 'explicit',
+        }),
+      ),
+    );
     expect(html).toContain('preflight-params-row');
     expect(html).toContain('Size Multiplier:');
     expect(html).toContain('Loop Multiplier:');
@@ -289,29 +300,76 @@ describe('runDetailView preflight stage', () => {
     expect(html).toContain('preflight-param-badge');
   });
 
-  it('omits the params row when no launch param is set (or at defaults)', () => {
-    const run = {
-      // size/loop default to 1, max_beads 0 → none "explicitly set"
-      size_multiplier: 1,
-      loop_multiplier: 1,
-      max_beads_override: 0,
-      stages: {
-        preflight: {
-          status: 'completed',
-          iterations: [
-            {
-              number: 1,
-              status: 'completed',
-              outcome: 'success',
-              output: { status: 'pass', checks: [], summary },
-            },
-          ],
-        },
-      },
-    };
-    const html = renderToString(runDetailView(run));
-    expect(html).not.toContain('preflight-params-row');
+  it('still renders the params row (Max Beads always shown) with Size/Loop omitted at defaults', () => {
+    const html = renderToString(
+      runDetailView(
+        _runWith({
+          // size/loop default to 1 → omitted; Max Beads is always present.
+          size_multiplier: 1,
+          loop_multiplier: 1,
+          max_beads_effective: 0,
+          max_beads_source: 'template',
+        }),
+      ),
+    );
+    expect(html).toContain('preflight-params-row');
+    expect(html).toContain('Max Beads:');
+    // Size/Loop are still gated on > 1.
     expect(html).not.toContain('Size Multiplier:');
-    expect(html).not.toContain('Max Beads:');
+    expect(html).not.toContain('Loop Multiplier:');
+  });
+
+  // --- Max Beads resolution: three branches + (Auto)/source-omitted ---
+
+  it('branch 1: new fields → effective value pill + source pill', () => {
+    const html = renderToString(
+      runDetailView(
+        _runWith({ max_beads_effective: 1, max_beads_source: 'template' }),
+      ),
+    );
+    expect(html).toContain('Max Beads:');
+    expect(html).toContain('>1<'); // value pill text
+    expect(html).toContain('preflight-param-source-badge');
+    expect(html).toContain('template'); // source pill text
+  });
+
+  it('branch 1: explicit source renders "explicit" pill', () => {
+    const html = renderToString(
+      runDetailView(
+        _runWith({ max_beads_effective: 4, max_beads_source: 'explicit' }),
+      ),
+    );
+    expect(html).toContain('>4<');
+    expect(html).toContain('preflight-param-source-badge');
+    expect(html).toContain('explicit');
+  });
+
+  it('branch 2 (legacy): max_beads_override only → value + "explicit" source', () => {
+    const html = renderToString(
+      runDetailView(_runWith({ max_beads_override: 7 })),
+    );
+    expect(html).toContain('Max Beads:');
+    expect(html).toContain('>7<');
+    expect(html).toContain('preflight-param-source-badge');
+    expect(html).toContain('explicit');
+  });
+
+  it('branch 3 (legacy auto): neither field → "0 (Auto)" and NO source pill', () => {
+    const html = renderToString(runDetailView(_runWith({})));
+    expect(html).toContain('Max Beads:');
+    expect(html).toContain('0 (Auto)');
+    // Source is unknown for legacy auto runs → source pill omitted.
+    expect(html).not.toContain('preflight-param-source-badge');
+  });
+
+  it('renders "0 (Auto)" for an effective cap of 0 (with known source)', () => {
+    const html = renderToString(
+      runDetailView(
+        _runWith({ max_beads_effective: 0, max_beads_source: 'template' }),
+      ),
+    );
+    expect(html).toContain('0 (Auto)');
+    expect(html).toContain('preflight-param-source-badge');
+    expect(html).toContain('template');
   });
 });

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -1279,10 +1279,11 @@ function _preflightParamsRow(run) {
   if (!run) return nothing;
   const pill = (text, tip) =>
     html`<sl-tooltip content="${tip}"><sl-badge class="preflight-param-badge" variant="neutral" pill>${text}</sl-badge></sl-tooltip>`;
+  const sourcePill = (text, tip) =>
+    html`<sl-tooltip content="${tip}"><sl-badge class="preflight-param-badge preflight-param-source-badge" variant="neutral" pill>${text}</sl-badge></sl-tooltip>`;
   const items = [];
   const size = run.size_multiplier;
   const loops = run.loop_multiplier;
-  const maxBeads = run.max_beads_override;
   if (typeof size === 'number' && size > 1) {
     items.push(
       html`<span class="meta-label">Size Multiplier:</span> ${pill(`${size}×`, 'Turn multiplier (msize) set at launch — multiplies each agent’s max_turns.')}`,
@@ -1293,12 +1294,43 @@ function _preflightParamsRow(run) {
       html`<span class="meta-label">Loop Multiplier:</span> ${pill(`${loops}×`, 'Loop multiplier (mloops) set at launch — multiplies the test/review/plan retry-loop limits.')}`,
     );
   }
-  if (typeof maxBeads === 'number' && maxBeads > 0) {
-    items.push(
-      html`<span class="meta-label">Max Beads:</span> ${pill(String(maxBeads), 'Maximum beads the coordinator may create, set at launch (0 / unset = Auto).')}`,
+
+  // Max Beads is ALWAYS shown — the EFFECTIVE resolved cap plus a second pill
+  // for where it came from. Resolution degrades gracefully on old runs:
+  //   1. new fields present → effective value + its persisted source
+  //   2. legacy max_beads_override only → that value, source "explicit"
+  //   3. neither (legacy auto run) → 0 (Auto), source unknown (pill omitted)
+  let beadValue;
+  let beadSource;
+  if (typeof run.max_beads_effective === 'number') {
+    beadValue = run.max_beads_effective;
+    beadSource = run.max_beads_source;
+  } else if (typeof run.max_beads_override === 'number') {
+    beadValue = run.max_beads_override;
+    beadSource = 'explicit';
+  } else {
+    beadValue = 0;
+    beadSource = undefined;
+  }
+  const beadText = beadValue > 0 ? String(beadValue) : '0 (Auto)';
+  const beadPills = [
+    pill(
+      beadText,
+      'Effective cap on the number of beads the coordinator may create (0 = Auto / no cap).',
+    ),
+  ];
+  if (beadSource !== undefined) {
+    beadPills.push(
+      sourcePill(
+        beadSource,
+        beadSource === 'explicit'
+          ? 'Cap set explicitly at launch via --max-beads.'
+          : 'Cap came from the template / project config (or was suppressed for a PR-revision run).',
+      ),
     );
   }
-  if (!items.length) return nothing;
+  items.push(html`<span class="meta-label">Max Beads:</span> ${beadPills}`);
+
   return html`<div class="iteration-tags-row preflight-params-row">${items}</div>`;
 }
 
@@ -1311,7 +1343,10 @@ function _preflightChecksView(stage, iter, run) {
   const checks = output.checks || [];
   const summary = output.summary || '';
   const paramsRow = _preflightParamsRow(run);
-  if (!checks.length && !summary && paramsRow === nothing) return nothing;
+  // The params row now always carries the Max Beads cap (value + source) for any
+  // real run, so it renders even with no checks/summary. Only collapse when
+  // there is genuinely nothing to show — no params row, no checks, no summary.
+  if (paramsRow === nothing && !checks.length && !summary) return nothing;
   return html`
     <div class="preflight-checks-view">
       ${paramsRow}


### PR DESCRIPTION
Surfaces the **effective** coordinator bead cap on the run-detail preflight row, with a second pill showing where the cap came from:

```
Max Beads: [0 (Auto)] [explicit]
Max Beads: [1] [template]
```

## Part 1 — Backend: persist the effective cap + its source

Previously only `max_beads_override` was persisted (and only when `--max-beads` was passed). The template/config cap and the resolved effective cap were computed in-memory at COORDINATE and discarded.

- New `effective_bead_cap_status()` helper in `runner.py` maps `(resolved cap, override, has_review_comments)` → `{max_beads_effective, max_beads_source}`.
- `max_beads_source` is `"explicit"` only when a launch override genuinely drove the cap; config/template caps — and PR-revision suppression (cap forced to 0) — record `"template"`.
- Written to `status.json` right after the COORDINATE context is built (before the stage executes), so it's visible even if COORDINATE later fails.
- `max_beads_override` left unchanged (UI legacy fallback relies on it).

## Part 2 — UI: value pill + source pill, always shown

`_preflightParamsRow` now **always** renders Max Beads. Resolution degrades gracefully on old runs:
1. new fields present → `max_beads_effective` + its source
2. legacy `max_beads_override` only → that value, source `"explicit"`
3. neither → `0 (Auto)`, source pill omitted

Value pill: `> 0` → the number; `<= 0` → `"0 (Auto)"`. `_preflightChecksView` collapse logic updated so the always-present row still renders for auto runs. Optional muted `.preflight-param-source-badge` styling (same font).

## Tests / verification
- Python: `effective_bead_cap_status` unit + end-to-end (PromptBuilder) cases — explicit/template/auto/PR-revision.
- UI: run-detail preflight tests cover all three resolution branches + the `"0 (Auto)"`/source-omitted case.
- Full suites green: ruff, 6215 Python unit tests, UI 4898 tests + lint, integration suite (one fleet-circuit-breaker e2e flaked under load, passes 3/3 in isolation — unrelated to this change).
- Verified live in-browser: `Max Beads: 1 template` (new fields) and legacy `Max Beads: 0 (Auto)` with source pill omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
