### PR TITLE
feat(ui): new-run Max Beads dropdown passthrough sentinel

### DIFF
--- a/worca-ui/app/views/new-run-max-beads.test.js
+++ b/worca-ui/app/views/new-run-max-beads.test.js
@@ -453,7 +453,7 @@ describe('new-run — maxBeads seeding from template', () => {
     expect(newMod.maxBeads).toBeNull();
   });
 
-  it('reseeds maxBeads when template is switched', async () => {
+  it('leaves maxBeads null after fetchTemplates (passthrough preserved until user acts)', async () => {
     const templates = [
       {
         id: 'tmpl-a',
@@ -487,13 +487,11 @@ describe('new-run — maxBeads seeding from template', () => {
     newRunView({ currentProjectId: 'proj-abc' }, { rerender: vi.fn() });
     await new Promise((r) => setTimeout(r, 100));
 
+    // fetchTemplates must NOT seed maxBeads — passthrough stays null
     let newMod = await import('./new-run.js');
-    expect(newMod.maxBeads).toBe(4);
+    expect(newMod.maxBeads).toBeNull();
 
-    // Switch template — simulate sl-change event on the select
-    const rerender = vi.fn();
-    newRunView({ currentProjectId: 'proj-abc' }, { rerender });
-    // Directly call seedMaxBeadsFromTemplate for the new template
+    // Explicit user template switch via seedMaxBeadsFromTemplate does seed it
     newMod = await import('./new-run.js');
     newMod.seedMaxBeadsFromTemplate('tmpl-b');
 

--- a/worca-ui/app/views/new-run-max-beads.test.js
+++ b/worca-ui/app/views/new-run-max-beads.test.js
@@ -1,24 +1,9 @@
 /**
- * Tests: new-run.js Max Beads dropdown — seed from template, reseed on switch,
- * and maxBeads always present in submit body.
+ * Tests: new-run.js Max Beads dropdown — passthrough sentinel, seed from
+ * project/template, reseed on switch, and conditional submit body inclusion.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-vi.mock('lit-html', () => ({ html: () => null, nothing: null }));
-vi.mock('lit-html/directives/unsafe-html.js', () => ({
-  unsafeHTML: () => null,
-}));
-vi.mock('../utils/icons.js', () => ({
-  iconSvg: () => '',
-  FileText: 'FileText',
-  Circle: 'Circle',
-  CircleAlert: 'CircleAlert',
-  CircleCheck: 'CircleCheck',
-  CircleSlash: 'CircleSlash',
-  Loader: 'Loader',
-  Pause: 'Pause',
-}));
 
 function createDocStub() {
   const elements = {};
@@ -33,9 +18,8 @@ function createDocStub() {
   };
 }
 
-describe('new-run — maxBeads seeding from template', () => {
+describe('new-run — maxBeads passthrough sentinel', () => {
   let origFetch;
-  let newRunView, resetNewRunState;
 
   beforeEach(async () => {
     origFetch = globalThis.fetch;
@@ -54,36 +38,133 @@ describe('new-run — maxBeads seeding from template', () => {
       CircleSlash: 'CircleSlash',
       Loader: 'Loader',
       Pause: 'Pause',
+      Play: 'Play',
+      Square: 'Square',
+      Home: 'Home',
+      Settings: 'Settings',
+      GitBranch: 'GitBranch',
+      ChevronDown: 'ChevronDown',
+      ChevronRight: 'ChevronRight',
+      X: 'X',
+      Plus: 'Plus',
+      GitMerge: 'GitMerge',
+      AlertTriangle: 'AlertTriangle',
+      Shield: 'Shield',
+      Activity: 'Activity',
+      Clock: 'Clock',
+      CheckCircle: 'CheckCircle',
+      Info: 'Info',
+      Zap: 'Zap',
+    }));
+    vi.doMock('./sidebar.js', () => ({
+      projectStatus: () => 'idle',
     }));
     vi.doMock('./settings.js', () => ({
       getDefaults: () => ({ msize: 1, mloops: 1 }),
     }));
+    vi.doMock('../utils/status-badge.js', () => ({
+      statusDotClass: () => 'status-pending',
+    }));
+    vi.doMock('../utils/help-links.js', () => ({
+      helpFor: () => null,
+    }));
 
-    const mod = await import('./new-run.js');
-    newRunView = mod.newRunView;
-    resetNewRunState = mod.resetNewRunState;
+    await import('./new-run.js');
   });
 
   afterEach(() => {
     globalThis.fetch = origFetch;
   });
 
-  it('seeds maxBeads from template.config.agents.coordinator.max_beads on template fetch', async () => {
+  it('imports export null and projectLevelMaxBeads as module-level variables', async () => {
+    const mod = await import('./new-run.js');
+    // After resetNewRunState() default, both should be null
+    expect(mod.maxBeads).toBeNull();
+    expect(mod.projectLevelMaxBeads).toBeNull();
+  });
+
+  it('resetNewRunState() respects explicit maxBeads override', async () => {
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({ maxBeads: 3 });
+    expect(mod.maxBeads).toBe(3);
+  });
+
+  it('resetNewRunState() defaults maxBeads to null when not specified', async () => {
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({ someOtherKey: 'value' });
+    expect(mod.maxBeads).toBeNull();
+  });
+});
+
+describe('new-run — project-level maxBeads caching', () => {
+  let origFetch;
+
+  beforeEach(async () => {
+    origFetch = globalThis.fetch;
+
+    vi.resetModules();
+    vi.doMock('lit-html', () => ({ html: () => null, nothing: null }));
+    vi.doMock('lit-html/directives/unsafe-html.js', () => ({
+      unsafeHTML: () => null,
+    }));
+    vi.doMock('../utils/icons.js', () => ({
+      iconSvg: () => '',
+      FileText: 'FileText',
+      Circle: 'Circle',
+      CircleAlert: 'CircleAlert',
+      CircleCheck: 'CircleCheck',
+      CircleSlash: 'CircleSlash',
+      Loader: 'Loader',
+      Pause: 'Pause',
+      Play: 'Play',
+      Square: 'Square',
+      Home: 'Home',
+      Settings: 'Settings',
+      GitBranch: 'GitBranch',
+      ChevronDown: 'ChevronDown',
+      ChevronRight: 'ChevronRight',
+      X: 'X',
+      Plus: 'Plus',
+      GitMerge: 'GitMerge',
+      AlertTriangle: 'AlertTriangle',
+      Shield: 'Shield',
+      Activity: 'Activity',
+      Clock: 'Clock',
+      CheckCircle: 'CheckCircle',
+      Info: 'Info',
+      Zap: 'Zap',
+    }));
+    vi.doMock('./sidebar.js', () => ({
+      projectStatus: () => 'idle',
+    }));
+    vi.doMock('./settings.js', () => ({
+      getDefaults: () => ({ msize: 1, mloops: 1 }),
+    }));
+    vi.doMock('../utils/status-badge.js', () => ({
+      statusDotClass: () => 'status-pending',
+    }));
+    vi.doMock('../utils/help-links.js', () => ({
+      helpFor: () => null,
+    }));
+
+    await import('./new-run.js');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('caches projectLevelMaxBeads from /settings response', async () => {
     globalThis.fetch = vi.fn((url) => {
-      if (url.includes('/templates')) {
+      if (url.includes('/settings')) {
         return Promise.resolve({
           ok: true,
           json: () =>
             Promise.resolve({
               ok: true,
-              templates: [
-                {
-                  id: 'fast-track',
-                  name: 'Fast Track',
-                  tier: 'builtin',
-                  config: { agents: { coordinator: { max_beads: 3 } } },
-                },
-              ],
+              worca: {
+                agents: { coordinator: { max_beads: 5 } },
+              },
             }),
         });
       }
@@ -93,16 +174,251 @@ describe('new-run — maxBeads seeding from template', () => {
       });
     });
 
-    resetNewRunState({ selectedTemplate: 'fast-track' });
-    newRunView({ currentProjectId: 'proj-abc' }, { rerender: vi.fn() });
-
-    await new Promise((r) => setTimeout(r, 100));
-
     const mod = await import('./new-run.js');
-    expect(mod.maxBeads).toBe(3);
+    mod.resetNewRunState({ selectedTemplate: 'default' });
+
+    // Trigger fetch
+    await mod.fetchDefaultTemplate('proj-abc');
+
+    expect(mod.projectLevelMaxBeads).toBe(5);
   });
 
-  it('seeds maxBeads to 0 when template has no max_beads config', async () => {
+  it('caches null when project has no coordinator.max_beads config', async () => {
+    globalThis.fetch = vi.fn((url) => {
+      if (url.includes('/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              worca: {
+                agents: {},
+              },
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, branches: [] }),
+      });
+    });
+
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({ selectedTemplate: 'default' });
+    await mod.fetchDefaultTemplate('proj-abc');
+
+    expect(mod.projectLevelMaxBeads).toBeNull();
+  });
+
+  it('resets projectLevelMaxBeads cache on project switch', async () => {
+    globalThis.fetch = vi.fn((url) => {
+      if (url.includes('/settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ok: true,
+              worca: {
+                agents: { coordinator: { max_beads: 7 } },
+              },
+            }),
+        });
+      }
+      if (url.includes('/branches')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, branches: [] }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, templates: [] }),
+      });
+    });
+
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({ selectedTemplate: 'default' });
+    await mod.fetchDefaultTemplate('proj-abc');
+    expect(mod.projectLevelMaxBeads).toBe(7);
+
+    // Reset state via resetNewRunState, which resets the cache
+    mod.resetNewRunState({ selectedTemplate: 'default' });
+
+    // After reset, both should be back to null
+    expect(mod.projectLevelMaxBeads).toBeNull();
+    expect(mod.maxBeads).toBeNull();
+  });
+});
+
+describe('new-run — resolveEffectiveMaxBeads helper', () => {
+  let origFetch;
+
+  beforeEach(async () => {
+    origFetch = globalThis.fetch;
+
+    vi.resetModules();
+    vi.doMock('lit-html', () => ({ html: () => null, nothing: null }));
+    vi.doMock('lit-html/directives/unsafe-html.js', () => ({
+      unsafeHTML: () => null,
+    }));
+    vi.doMock('../utils/icons.js', () => ({
+      iconSvg: () => '',
+      FileText: 'FileText',
+      Circle: 'Circle',
+      CircleAlert: 'CircleAlert',
+      CircleCheck: 'CircleCheck',
+      CircleSlash: 'CircleSlash',
+      Loader: 'Loader',
+      Pause: 'Pause',
+      Play: 'Play',
+      Square: 'Square',
+      Home: 'Home',
+      Settings: 'Settings',
+      GitBranch: 'GitBranch',
+      ChevronDown: 'ChevronDown',
+      ChevronRight: 'ChevronRight',
+      X: 'X',
+      Plus: 'Plus',
+      GitMerge: 'GitMerge',
+      AlertTriangle: 'AlertTriangle',
+      Shield: 'Shield',
+      Activity: 'Activity',
+      Clock: 'Clock',
+      CheckCircle: 'CheckCircle',
+      Info: 'Info',
+      Zap: 'Zap',
+    }));
+    vi.doMock('./sidebar.js', () => ({
+      projectStatus: () => 'idle',
+    }));
+    vi.doMock('./settings.js', () => ({
+      getDefaults: () => ({ msize: 1, mloops: 1 }),
+    }));
+    vi.doMock('../utils/status-badge.js', () => ({
+      statusDotClass: () => 'status-pending',
+    }));
+    vi.doMock('../utils/help-links.js', () => ({
+      helpFor: () => null,
+    }));
+
+    await import('./new-run.js');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('resolves template max_beads when selected', async () => {
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({
+      selectedTemplate: 'tmpl-with-beads',
+      templates: [
+        {
+          id: 'tmpl-with-beads',
+          config: { agents: { coordinator: { max_beads: 3 } } },
+        },
+      ],
+    });
+
+    const result = mod.resolveEffectiveMaxBeads();
+    expect(result).toBe(3);
+  });
+
+  it('resolves project-level max_beads when no template selected', async () => {
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({
+      selectedTemplate: 'default',
+      projectLevelMaxBeads: 5,
+    });
+
+    const result = mod.resolveEffectiveMaxBeads();
+    expect(result).toBe(5);
+  });
+
+  it('returns null when neither template nor project has max_beads', async () => {
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({
+      selectedTemplate: 'default',
+      projectLevelMaxBeads: null,
+    });
+
+    const result = mod.resolveEffectiveMaxBeads();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when template has no max_beads config', async () => {
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({
+      selectedTemplate: 'tmpl-no-beads',
+      templates: [{ id: 'tmpl-no-beads', config: {} }],
+    });
+
+    const result = mod.resolveEffectiveMaxBeads();
+    expect(result).toBeNull();
+  });
+});
+
+describe('new-run — maxBeads seeding from template', () => {
+  let origFetch;
+  let newRunView;
+
+  beforeEach(async () => {
+    origFetch = globalThis.fetch;
+
+    vi.resetModules();
+    vi.doMock('lit-html', () => ({ html: () => null, nothing: null }));
+    vi.doMock('lit-html/directives/unsafe-html.js', () => ({
+      unsafeHTML: () => null,
+    }));
+    vi.doMock('../utils/icons.js', () => ({
+      iconSvg: () => '',
+      FileText: 'FileText',
+      Circle: 'Circle',
+      CircleAlert: 'CircleAlert',
+      CircleCheck: 'CircleCheck',
+      CircleSlash: 'CircleSlash',
+      Loader: 'Loader',
+      Pause: 'Pause',
+      Play: 'Play',
+      Square: 'Square',
+      Home: 'Home',
+      Settings: 'Settings',
+      GitBranch: 'GitBranch',
+      ChevronDown: 'ChevronDown',
+      ChevronRight: 'ChevronRight',
+      X: 'X',
+      Plus: 'Plus',
+      GitMerge: 'GitMerge',
+      AlertTriangle: 'AlertTriangle',
+      Shield: 'Shield',
+      Activity: 'Activity',
+      Clock: 'Clock',
+      CheckCircle: 'CheckCircle',
+      Info: 'Info',
+      Zap: 'Zap',
+    }));
+    vi.doMock('./sidebar.js', () => ({
+      projectStatus: () => 'idle',
+    }));
+    vi.doMock('./settings.js', () => ({
+      getDefaults: () => ({ msize: 1, mloops: 1 }),
+    }));
+    vi.doMock('../utils/status-badge.js', () => ({
+      statusDotClass: () => 'status-pending',
+    }));
+    vi.doMock('../utils/help-links.js', () => ({
+      helpFor: () => null,
+    }));
+
+    const mod = await import('./new-run.js');
+    newRunView = mod.newRunView;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('seeds maxBeads to null when template has no max_beads config', async () => {
     globalThis.fetch = vi.fn((url) => {
       if (url.includes('/templates')) {
         return Promise.resolve({
@@ -127,13 +443,14 @@ describe('new-run — maxBeads seeding from template', () => {
       });
     });
 
-    resetNewRunState({ selectedTemplate: 'plain', maxBeads: 5 });
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({ selectedTemplate: 'plain', maxBeads: 5 });
     newRunView({ currentProjectId: 'proj-abc' }, { rerender: vi.fn() });
 
     await new Promise((r) => setTimeout(r, 100));
 
-    const mod = await import('./new-run.js');
-    expect(mod.maxBeads).toBe(0);
+    const newMod = await import('./new-run.js');
+    expect(newMod.maxBeads).toBeNull();
   });
 
   it('reseeds maxBeads when template is switched', async () => {
@@ -165,21 +482,22 @@ describe('new-run — maxBeads seeding from template', () => {
       });
     });
 
-    resetNewRunState({ selectedTemplate: 'tmpl-a' });
+    const mod = await import('./new-run.js');
+    mod.resetNewRunState({ selectedTemplate: 'tmpl-a' });
     newRunView({ currentProjectId: 'proj-abc' }, { rerender: vi.fn() });
     await new Promise((r) => setTimeout(r, 100));
 
-    let mod = await import('./new-run.js');
-    expect(mod.maxBeads).toBe(4);
+    let newMod = await import('./new-run.js');
+    expect(newMod.maxBeads).toBe(4);
 
     // Switch template — simulate sl-change event on the select
     const rerender = vi.fn();
     newRunView({ currentProjectId: 'proj-abc' }, { rerender });
     // Directly call seedMaxBeadsFromTemplate for the new template
-    mod = await import('./new-run.js');
-    mod.seedMaxBeadsFromTemplate('tmpl-b');
+    newMod = await import('./new-run.js');
+    newMod.seedMaxBeadsFromTemplate('tmpl-b');
 
-    expect(mod.maxBeads).toBe(7);
+    expect(newMod.maxBeads).toBe(7);
   });
 });
 
@@ -207,9 +525,35 @@ describe('new-run — maxBeads in submit body', () => {
       CircleSlash: 'CircleSlash',
       Loader: 'Loader',
       Pause: 'Pause',
+      Play: 'Play',
+      Square: 'Square',
+      Home: 'Home',
+      Settings: 'Settings',
+      GitBranch: 'GitBranch',
+      ChevronDown: 'ChevronDown',
+      ChevronRight: 'ChevronRight',
+      X: 'X',
+      Plus: 'Plus',
+      GitMerge: 'GitMerge',
+      AlertTriangle: 'AlertTriangle',
+      Shield: 'Shield',
+      Activity: 'Activity',
+      Clock: 'Clock',
+      CheckCircle: 'CheckCircle',
+      Info: 'Info',
+      Zap: 'Zap',
+    }));
+    vi.doMock('./sidebar.js', () => ({
+      projectStatus: () => 'idle',
     }));
     vi.doMock('./settings.js', () => ({
       getDefaults: () => ({ msize: 1, mloops: 1 }),
+    }));
+    vi.doMock('../utils/status-badge.js', () => ({
+      statusDotClass: () => 'status-pending',
+    }));
+    vi.doMock('../utils/help-links.js', () => ({
+      helpFor: () => null,
     }));
 
     const mod = await import('./new-run.js');
@@ -240,6 +584,28 @@ describe('new-run — maxBeads in submit body', () => {
     return () => capturedBody;
   }
 
+  it('omits maxBeads from POST body when null (passthrough)', async () => {
+    const getBody = mockFetch();
+    setupDOM();
+    resetNewRunState({ maxBeads: null });
+
+    await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
+
+    const body = getBody();
+    expect(body.maxBeads).toBeUndefined();
+  });
+
+  it('omits maxBeads from POST body by default (fresh state is null)', async () => {
+    const getBody = mockFetch();
+    setupDOM();
+    resetNewRunState();
+
+    await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
+
+    const body = getBody();
+    expect(body.maxBeads).toBeUndefined();
+  });
+
   it('includes maxBeads=5 in POST body when set', async () => {
     const getBody = mockFetch();
     setupDOM();
@@ -251,7 +617,7 @@ describe('new-run — maxBeads in submit body', () => {
     expect(body.maxBeads).toBe(5);
   });
 
-  it('includes maxBeads=0 in POST body when set to 0 (Auto)', async () => {
+  it('includes maxBeads=0 in POST body when explicitly set to 0 (Auto)', async () => {
     const getBody = mockFetch();
     setupDOM();
     resetNewRunState({ maxBeads: 0 });
@@ -262,14 +628,30 @@ describe('new-run — maxBeads in submit body', () => {
     expect(body.maxBeads).toBe(0);
   });
 
-  it('includes maxBeads=0 in POST body by default (fresh state)', async () => {
+  it('reads maxBeads from DOM select when present and module state is null', async () => {
     const getBody = mockFetch();
     setupDOM();
-    resetNewRunState();
+    docStub._set('new-run-max-beads', '3'); // DOM says 3
+
+    // Module state is null (passthrough) but DOM select has explicit value
+    resetNewRunState({ maxBeads: null });
 
     await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
 
     const body = getBody();
-    expect(body.maxBeads).toBe(0);
+    expect(body.maxBeads).toBe(3);
+  });
+
+  it('reads empty string from DOM select as null (passthrough)', async () => {
+    const getBody = mockFetch();
+    setupDOM();
+    docStub._set('new-run-max-beads', ''); // DOM says passthrough (empty string)
+
+    resetNewRunState({ maxBeads: null });
+
+    await submitNewRun({ rerender: vi.fn(), onStarted: vi.fn() });
+
+    const body = getBody();
+    expect(body.maxBeads).toBeUndefined();
   });
 });

--- a/worca-ui/app/views/new-run.js
+++ b/worca-ui/app/views/new-run.js
@@ -232,9 +232,6 @@ function fetchTemplates(projectId) {
             selectedTemplate = defaultTemplateId;
           }
         }
-
-        // Seed maxBeads from the currently selected template's config
-        seedMaxBeadsFromTemplate(selectedTemplate);
       }
       return templates || [];
     })

--- a/worca-ui/app/views/new-run.js
+++ b/worca-ui/app/views/new-run.js
@@ -23,7 +23,8 @@ export let prBaseBranch = '';
 export let prBaseBranchError = '';
 export let selectedProject = null; // project picked in All Projects mode
 export let projectEditable = false; // Change link toggles read-only → editable
-export let maxBeads = 0; // 0 = Auto (no cap)
+export let maxBeads = null; // null = passthrough (use template/project default), 0 = Auto, N = explicit cap
+export let projectLevelMaxBeads = null; // cached from /settings endpoint
 
 // Dismissable worktree info banner — persisted via localStorage
 export let bannerDismissed = (() => {
@@ -40,6 +41,48 @@ export let bannerDismissed = (() => {
 export function invalidateTemplateCache() {
   templates = null;
   defaultTemplateId = '';
+  projectLevelMaxBeads = null;
+  maxBeads = null;
+}
+
+/**
+ * exposed for testing
+ */
+export function fetchDefaultTemplate(projectId) {
+  const url = projectId
+    ? `/api/projects/${projectId}/settings`
+    : '/api/settings';
+  return fetch(url)
+    .then((r) => r.json())
+    .then((data) => {
+      // Accept both forms: legacy bare-string `"bugfix"` and the
+      // new structured `{tier: "project", id: "bugfix"}` shape.
+      const raw = data?.worca?.default_template;
+      defaultTemplateId =
+        typeof raw === 'string'
+          ? raw
+          : raw && typeof raw === 'object'
+            ? raw.id || ''
+            : '';
+
+      // Cache project-level max_beads for the default option label
+      projectLevelMaxBeads =
+        data?.worca?.agents?.coordinator?.max_beads ?? null;
+
+      // Auto-select the default template if it's present in the templates list
+      if (defaultTemplateId && templates) {
+        const found = templates.find((t) => t.id === defaultTemplateId);
+        if (found && selectedTemplate === 'default') {
+          selectedTemplate = defaultTemplateId;
+        }
+      }
+
+      return defaultTemplateId;
+    })
+    .catch(() => {
+      defaultTemplateId = '';
+      return '';
+    });
 }
 
 export function resetNewRunState(overrides = {}) {
@@ -61,12 +104,32 @@ export function resetNewRunState(overrides = {}) {
   if ('planDropdownOpen' in overrides)
     planDropdownOpen = overrides.planDropdownOpen;
   if ('branches' in overrides) branches = overrides.branches;
-  maxBeads = overrides.maxBeads ?? 0;
+  maxBeads = 'maxBeads' in overrides ? overrides.maxBeads : null;
+  projectLevelMaxBeads =
+    'projectLevelMaxBeads' in overrides ? overrides.projectLevelMaxBeads : null;
+}
+
+/**
+ * Resolve effective max beads for display labels.
+ * Precedence: selected template → project settings → null.
+ */
+export function resolveEffectiveMaxBeads() {
+  // If an explicit template is selected, use its config
+  if (selectedTemplate && selectedTemplate !== 'default') {
+    const tmpl = (templates || []).find((t) => t.id === selectedTemplate);
+    const tmplMaxBeads = tmpl?.config?.agents?.coordinator?.max_beads;
+    if (tmplMaxBeads !== undefined && tmplMaxBeads !== null)
+      return tmplMaxBeads;
+  }
+  // Fall back to project-level setting
+  return projectLevelMaxBeads;
 }
 
 export function seedMaxBeadsFromTemplate(templateId) {
   const tmpl = (templates || []).find((t) => t.id === templateId);
-  maxBeads = tmpl?.config?.agents?.coordinator?.max_beads ?? 0;
+  const tmplMaxBeads = tmpl?.config?.agents?.coordinator?.max_beads;
+  maxBeads =
+    tmplMaxBeads !== undefined && tmplMaxBeads !== null ? tmplMaxBeads : null; // passthrough when template has no config
 }
 
 function sourceLabel(type) {
@@ -181,42 +244,6 @@ function fetchTemplates(projectId) {
     });
 }
 
-// Phase 1: fetch the project's worca.default_template so the "default" option
-// in the dropdown can name what will actually run when no explicit template
-// is picked at launch.
-function fetchDefaultTemplate(projectId) {
-  const url = projectId
-    ? `/api/projects/${projectId}/settings`
-    : '/api/settings';
-  return fetch(url)
-    .then((r) => r.json())
-    .then((data) => {
-      // Accept both forms: legacy bare-string `"bugfix"` and the
-      // new structured `{tier: "project", id: "bugfix"}` shape.
-      const raw = data?.worca?.default_template;
-      defaultTemplateId =
-        typeof raw === 'string'
-          ? raw
-          : raw && typeof raw === 'object'
-            ? raw.id || ''
-            : '';
-
-      // Auto-select the default template if it's present in the templates list
-      if (defaultTemplateId && templates) {
-        const found = templates.find((t) => t.id === defaultTemplateId);
-        if (found && selectedTemplate === 'default') {
-          selectedTemplate = defaultTemplateId;
-        }
-      }
-
-      return defaultTemplateId;
-    })
-    .catch(() => {
-      defaultTemplateId = '';
-      return '';
-    });
-}
-
 // Build the label for the "default" dropdown option. With Phase 1 in play,
 // picking this option does not always mean "raw settings.json" — if
 // worca.default_template is set, the runtime resolves it and applies that
@@ -306,9 +333,19 @@ export async function submitNewRun({
   const maxBeadsEl = document.getElementById('new-run-max-beads');
   const msize = msizeEl ? parseInt(msizeEl.value, 10) || 1 : 1;
   const mloops = mloopsEl ? parseInt(mloopsEl.value, 10) || 1 : 1;
-  const maxBeadsValue = maxBeadsEl
-    ? parseInt(maxBeadsEl.value, 10) || 0
-    : maxBeads;
+
+  // Parse maxBeads: empty string → null (passthrough), "0" → 0 (explicit Auto), numeric → cap
+  let maxBeadsValue = maxBeads;
+  if (maxBeadsEl) {
+    const val = maxBeadsEl.value;
+    if (val === '') {
+      // Empty string from dropdown means passthrough
+      maxBeadsValue = null;
+    } else {
+      // Parse as number
+      maxBeadsValue = parseInt(val, 10) || 0;
+    }
+  }
 
   const PR_BRANCH_RE = /^[a-zA-Z0-9._/-]+$/;
   if (prBaseBranch && !PR_BRANCH_RE.test(prBaseBranch)) {
@@ -333,8 +370,11 @@ export async function submitNewRun({
       sourceType: wireSourceType,
       msize: Math.max(1, Math.min(10, msize)),
       mloops: Math.max(1, Math.min(10, mloops)),
-      maxBeads: maxBeadsValue,
     };
+    // Conditionally include maxBeads only when explicitly set (not null/passthrough)
+    if (maxBeadsValue !== null) {
+      body.maxBeads = maxBeadsValue;
+    }
     if (hasSource) body.sourceValue = sourceValue;
     if (hasPrompt) body.prompt = promptValue;
     if (hasPlan) body.planFile = selectedPlan;
@@ -422,6 +462,8 @@ export function newRunView(_state, { rerender }) {
     templates = null;
     defaultTemplateId = '';
     planFiles = null;
+    projectLevelMaxBeads = null;
+    maxBeads = null;
     const newId = selectedProject;
     if (newId) {
       fetchBranches(newId).then(() => rerender());
@@ -441,6 +483,8 @@ export function newRunView(_state, { rerender }) {
   // Reset caches when effective project changes (before fetchBranches updates _lastProjectId)
   if (_lastProjectId !== effectiveId) {
     templates = null;
+    projectLevelMaxBeads = null;
+    maxBeads = null;
   }
 
   // Fetch branches once (null = not yet fetched, or project changed)
@@ -469,7 +513,14 @@ export function newRunView(_state, { rerender }) {
     // Persist the choice to module state so a rerender (async branch/template
     // fetch resolving before submit) doesn't snap the select back to the
     // template-seeded value via the `value=${String(maxBeads)}` binding.
-    maxBeads = parseInt(e.target.value, 10) || 0;
+    const val = e.target.value;
+    if (val === '') {
+      // Empty string means passthrough (use template/project default)
+      maxBeads = null;
+    } else {
+      // Parse as number
+      maxBeads = parseInt(val, 10) || 0;
+    }
     rerender();
   }
 
@@ -781,13 +832,39 @@ export function newRunView(_state, { rerender }) {
 
               <div class="settings-field">
                 <label class="settings-label">Max Beads</label>
-                <sl-select id="new-run-max-beads" value=${String(maxBeads)} @sl-change=${handleMaxBeadsChange}>
-                  <sl-option value="0">Auto</sl-option>
-                  ${[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(
-                    (n) => html`<sl-option value=${String(n)}>${n}</sl-option>`,
+                <sl-select id="new-run-max-beads" value=${maxBeads === null ? '' : String(maxBeads)} @sl-change=${handleMaxBeadsChange}>
+                  ${(() => {
+                    const effective = resolveEffectiveMaxBeads();
+                    const defaultLabel =
+                      effective !== null
+                        ? `Template/project default (${effective})`
+                        : 'Template/project default (Auto)';
+                    return html`<sl-option value="">${defaultLabel}</sl-option>`;
+                  })()}
+                  <sl-option value="0">Auto (force even if template/project has a cap)</sl-option>
+                  ${[1, 2, 3, 5, 10].map(
+                    (n) =>
+                      html`<sl-option value=${String(n)}>${n} beads</sl-option>`,
                   )}
                 </sl-select>
-                <span class="settings-field-hint">Cap on coordinator beads (0 = no cap)</span>
+                ${(() => {
+                  const effective = resolveEffectiveMaxBeads();
+                  let hintText = 'Cap on coordinator beads.';
+                  if (maxBeads === null) {
+                    if (effective !== null) {
+                      hintText = `Using template/project default (${effective}). Explicit selection overrides this.`;
+                    } else {
+                      hintText =
+                        'Using template/project default (Auto). Explicit selection overrides this.';
+                    }
+                  } else if (maxBeads === 0) {
+                    hintText =
+                      'Explicitly set to Auto (no cap), overrides template/project default.';
+                  } else {
+                    hintText = `Explicitly set to ${maxBeads} bead${maxBeads === 1 ? '' : 's'}, overrides template/project default.`;
+                  }
+                  return html`<span class="settings-field-hint">${hintText}</span>`;
+                })()}
               </div>
             </div>
 


### PR DESCRIPTION
## Problem

The Max Beads dropdown in worca-ui's New Run launcher always sent a `maxBeads` value in the POST body (even when the user left it at `0` / Auto). This meant the UI value always overrode both **template** `agents.coordinator.max_beads` and **project-level** `worca.agents.coordinator.max_beads` from `settings.json` — the value was recorded as `explicit` even when it was actually template- or project-derived.

## Solution

Replace the default-`Auto` behavior with a passthrough sentinel that **omits** `maxBeads` from the POST body when left at default, allowing the proper precedence chain to remain intact:

1. **Template/project default (n)** — the new default. Resolved client-side from:
   - Selected template's `agents.coordinator.max_beads`, else
   - Project-level `worca.agents.coordinator.max_beads` from settings, else
   - Auto

   Selecting this option omits `maxBeads` from the POST body entirely.

2. **Auto** — explicit `0` override (forces Auto even when template/project sets a cap)

3. **Narrowed explicit ladder** — `1, 2, 3, 5, 10` (covers typical use cases without clutter)

## Changes

- **Server**: No backend changes needed — the server already supports omitting `maxBeads` from the body
- **Client** (`worca-ui/app/views/new-run.js`):
  - Module state: `maxBeads = null` (passthrough) instead of `0`
  - Added `projectLevelMaxBeads` cache from `/api/projects/:id/settings`
  - New `resolveEffectiveMaxBeads()` helper for display label resolution
  - Conditional POST body: only include `maxBeads` when explicitly set (not `null`)
  - Dropdown options restructured with passthrough as first option
  - Updated hint text to reflect current selection state

- **Tests** (`worca-ui/app/views/new-run-max-beads.test.js`):
  - Added test suites for passthrough sentinel, project-level caching, and `resolveEffectiveMaxBeads()`
  - Updated existing tests for the new behavior

## Result

The preflight badge now correctly shows `max_beads_source: "template"` when the user leaves the dropdown at default, rather than falsely showing `explicit`. The precedence chain flows correctly without UI interference.
