### PR TITLE
feat(agents): bound execution-stage prompt scope to prevent wasted turns

### DIFF
--- a/src/worca/agents/core/coordinator.md
+++ b/src/worca/agents/core/coordinator.md
@@ -1,5 +1,23 @@
 # Coordinator Agent
 
+## Role Boundaries
+
+You do NOT discover or probe the Beads CLI — the pipeline runner has already initialized bd and the reference you need is below.
+
+**Do NOT run these commands (they waste turns on known-state probes):**
+
+<!-- governance -->
+- `which bd` — bd is already installed
+- `bd --help` — the reference is in the `## bd CLI Reference` section below
+- `bd create --help` — the reference is below
+- `bd dep --help` — the reference is below
+- `bd list --help` — the reference is below
+- `bd status` — you will run `bd list` to verify after creating tasks
+- `bd list --all` — you will run `bd list` to verify after creating tasks
+- `ls .beads/` — do not inspect the beads directory directly
+
+The CLI is already initialized for you. Your job is decomposition, not discovery.
+
 ## Role
 
 You are the Coordinator. You read the approved plan at `{{plan_file}}` and decompose it into fine-grained Beads tasks with dependencies.
@@ -8,11 +26,37 @@ You are the Coordinator. You read the approved plan at `{{plan_file}}` and decom
 
 You receive the approved plan and access to the Beads CLI (`bd`).
 
+## bd CLI Reference
+
+You will use the Beads CLI (`bd`) to create tasks and set dependencies. The runner has already initialized bd for you.
+
+**Create a task:**
+```bash
+bd create --title="..." --type=task --labels "run:{{run_id}},worca-effort:<level>" --silent
+```
+- `--title`: Required. Descriptive task title (100 chars or fewer).
+- `--type`: `task` or `bug` (always `task` for decomposition).
+- `--labels`: Required. `"run:{{run_id}},worca-effort:<level>"` — mandatory on every `bd create`.
+- `--silent`: Required. Prints only the bead ID on stdout (e.g., `beads-abc123`).
+
+**Add dependency:**
+```bash
+bd dep add <downstream> <upstream>
+```
+- `<downstream>` must complete after `<upstream>`.
+- Use to enforce ordering constraints.
+
+**List tasks to verify:**
+```bash
+bd list
+```
+- Run after all creations to confirm tasks were created correctly.
+
 ## Process
 
 1. Read `{{plan_file}}`
 2. Break down into atomic implementation tasks
-3. Create Beads tasks: `bd create --title="..." --type=task --labels "run:{{run_id}}"` — the `--labels "run:{{run_id}}"` flag is **required** on every `bd create` call
+3. Create Beads tasks: `bd create --title="..." --type=task --labels "run:{{run_id}},worca-effort:<level>" --silent` — the `--labels "run:{{run_id}}"` flag is **required** on every `bd create` call
 4. Set dependencies: `bd dep add <downstream> <upstream>`
 5. Identify parallel execution groups
 6. Output the coordination result
@@ -111,6 +155,10 @@ This run is revising an existing PR based on review feedback. The approved plan 
 - ALWAYS pass `--labels "run:{{run_id}}"` when creating tasks so they are linked to this pipeline run.
 - Verify tasks were created by running `bd list` before producing output
 - Create tasks one at a time (one `bd create` per tool call). Do NOT batch multiple bd commands in parallel.
+
+<!-- governance -->
+- Merge plan sub-tasks that share a correctness invariant into one bead. For example, if a plan lists "update X" and "update Y" where X and Y must be consistent, create a single bead.
+- Do NOT create a bead whose sole purpose is running the build or test suite — the Tester stage owns that. If a plan step says "run tests", incorporate it into the implementation bead it validates.
 
 {{#if has_graphify}}
 ## Knowledge graph (use for orientation)

--- a/src/worca/agents/core/guardian.md
+++ b/src/worca/agents/core/guardian.md
@@ -1,5 +1,27 @@
 # Guardian Agent
 
+## You Are Not Starting From Zero
+
+The orchestrator invokes you only after the Implementer, Tester, and Reviewer stages have all passed. The working tree is final — you are NOT re-verifying work, you are shipping it.
+
+**Do NOT do these things (the orchestrator already did them):**
+
+<!-- governance -->
+- Read source, test, config, or documentation files from the working tree
+- Run any build, test, lint, or verification command: `mvn`, `gradle`, `npm`, `npm test`, `npm run lint`, `pytest`, `cargo`, `make`, etc.
+- Run `git diff` or `git show` to inspect changes — per-file inspection is prohibited
+- Use `TaskCreate` or `TaskUpdate` — task tracking is for implementers, not you
+
+**You MUST only do these things:**
+
+- `git add -A` — stage all changes
+- `git commit` — commit with a scoped conventional message
+- `git push -u origin <head_branch>` — push the branch
+- `gh pr create` (or host equivalent) — open the PR (unless `defer_pr` is set or `revise_pr` is set)
+- `git status` and `git log --oneline -5` — the ONLY pre-commit reads permitted (for commit messages only)
+
+Your job is to ship final, verified work — not to re-implement or re-test it.
+
 ## Role
 
 You ship the work: commit, push, and (when appropriate) open the PR.
@@ -86,6 +108,13 @@ Produce a structured result following the `pr.json` schema.
 - Do NOT modify source or test files. Hooks block writes.
 - Do NOT invoke skills (superpowers, executing-plans, etc.).
 - Do NOT read `WORCA_FLEET_ID`, `WORCA_WORKSPACE_ID`, `WORCA_DEFER_PR`, or `WORCA_WORKSPACE_NAME` — the orchestrator has already resolved them above.
+
+<!-- governance -->
+- Never read source, test, config, or doc files from the working tree
+- Never run build, test, lint, verification, or any dev command
+- Never run `git diff` or `git show` — per-file inspection is forbidden
+- Never use `TaskCreate` or `TaskUpdate`
+- Only read `git status` and `git log --oneline -5` before committing (for message context)
 
 {{#if has_graphify}}
 ## Knowledge graph (use for orientation)

--- a/src/worca/agents/core/pr.block.md
+++ b/src/worca/agents/core/pr.block.md
@@ -1,3 +1,7 @@
+The following describes what was already implemented, tested, and reviewed — use it as background to write the PR title and body, not as instructions to re-verify.
+
+---
+
 Ship this work: stage, commit, push, and open the PR. Use the host CLI documented in CLAUDE.md.
 
 ## Work Request

--- a/tests/test_coordinator_agent.py
+++ b/tests/test_coordinator_agent.py
@@ -1,0 +1,59 @@
+"""Source-prompt content tests for the coordinator agent.
+
+These tests verify that the coordinator.md prompt contains the required
+role-scope guard sections and CLI reference documentation.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+from worca.orchestrator.overlay import resolve_placeholders
+
+
+COORDINATOR_PATH = (
+    pathlib.Path(__file__).parent.parent
+    / "src"
+    / "worca"
+    / "agents"
+    / "core"
+    / "coordinator.md"
+)
+
+
+class TestCoordinatorRoleBoundaries:
+    """Acceptance: coordinator.md must forbid probed commands and provide CLI reference."""
+
+    def test_banned_commands_listed_in_prompt(self):
+        """coordinator.md must list the wasted-turn commands in the guard section."""
+        source = COORDINATOR_PATH.read_text()
+        for cmd in ("which bd", "bd --help", "bd create --help", "bd dep --help",
+                    "bd list --help", "bd status", "bd list --all", "ls .beads/"):
+            assert cmd in source, f"coordinator.md must forbid {cmd}"
+
+    def test_bd_reference_section_exists(self):
+        """coordinator.md must have a ## bd CLI Reference section."""
+        source = COORDINATOR_PATH.read_text()
+        assert "## bd CLI Reference" in source
+
+    def test_silent_flag_in_create_command(self):
+        """coordinator.md must include --silent in the bd create invocation."""
+        source = COORDINATOR_PATH.read_text()
+        patterns = [
+            r"bd create.*--silent",
+            r"bd create.*--title.*--type.*--labels.*--silent",
+        ]
+        assert any(re.search(p, source) for p in patterns), "bd create must include --silent"
+
+    def test_bead_merging_rules_present(self):
+        """coordinator.md must include bead-merging / test-ownership rules."""
+        source = COORDINATOR_PATH.read_text()
+        assert "share a correctness invariant" in source.lower()
+        assert "Tester stage owns" in source or "Test stage owns" in source
+
+    def test_bd_create_invocations_use_silent_in_rendered_output(self):
+        """Rendered coordinator must include --silent in the bd create example."""
+        template = COORDINATOR_PATH.read_text()
+        ctx = {"plan_file": "plan.md", "run_id": "test-run"}
+        rendered = resolve_placeholders(template, ctx)
+        assert "--silent" in rendered

--- a/tests/test_guardian_state_machine.py
+++ b/tests/test_guardian_state_machine.py
@@ -30,6 +30,15 @@ GUARDIAN_PATH = (
     / "guardian.md"
 )
 
+PR_BLOCK_PATH = (
+    pathlib.Path(__file__).parent.parent
+    / "src"
+    / "worca"
+    / "agents"
+    / "core"
+    / "pr.block.md"
+)
+
 RUNNER_PATH = (
     pathlib.Path(__file__).parent.parent
     / "src"
@@ -383,3 +392,28 @@ class TestBehaviorPreservation:
         assert "target_branch" in rendered_no_defer
         assert "**Workspace:** my-platform" in rendered_no_defer
         assert "gh pr create --base" in rendered_no_defer
+
+
+class TestGuardianRoleBoundaries:
+    """Acceptance: guardian.md must forbid re-verification actions and mirror in Rules."""
+
+    def test_not_starting_from_zero_section_exists(self):
+        """guardian.md must have a ## You Are Not Starting From Zero section."""
+        source = GUARDIAN_PATH.read_text()
+        assert "You Are Not Starting From Zero" in source or "You are not starting from zero" in source
+
+    def test_banned_command_list_explicit(self):
+        """guardian.md must list build/test/git diff/TaskCreate in the guard."""
+        source = GUARDIAN_PATH.read_text()
+        banned = ("git diff", "git show", "TaskCreate", "TaskUpdate",
+                  "source, test, config, or documentation files")
+        # Check for broader phrases that might appear instead of exact terms
+        assert ("build" in source and "test" in source and "lint" in source and "verification" in source), \
+            "guardian.md must forbid build/test/lint/verification commands"
+        for term in banned:
+            assert term in source or term.lower() in source.lower(), f"guardian.md must forbid {term}"
+
+    def test_pr_block_prepend_guard(self):
+        """pr.block.md must prepend the 'already implemented' guard."""
+        source = PR_BLOCK_PATH.read_text()
+        assert "already implemented" in source.lower() or "already implemented, tested, and reviewed" in source.lower()


### PR DESCRIPTION
Add role-scope guard sections to coordinator, guardian, and pr.block prompts to prevent execution-stage agents from wasting turns on discovery/verification actions outside their narrow role.

## Problem

Two prompts in `src/worca/agents/core/` let execution-stage agents waste turns on actions outside their narrow role:

- **Coordinator**: Runs discovery commands like `which bd`, `bd --help`, `bd status`, `ls .beads/` — even though the CLI is initialized by the runner and the reference doc lives in `coordinator.md`. Each `--help` invocation is a wasted turn on a known-state probe.

- **Guardian**: The role is `git add` / `git commit` / `git push` / `gh pr create` against an already-verified working tree. In practice it runs `git diff`, project build/test commands, and occasionally `TaskCreate` — re-verifying work the orchestrator already verified.

## Changes

**coordinator.md**:
- Add "Role Boundaries" section forbidding `bd --help`/`bd status`/`ls .beads/` commands
- Add inline "bd CLI Reference" section (create / dep / verify)
- Add `--silent` to `bd create` invocation (outputs only the bead ID)
- Add bead-merging rules: merge sub-tasks sharing correctness invariants; don't create build/test beads (Tester owns that)

**guardian.md**:
- Add "You Are Not Starting From Zero" section with explicit deny list (no source reads, no build/test/lint commands, no `git diff`/`git show`, no `TaskCreate`/`TaskUpdate`)
- Mirror deny rules in Rules section (survive prompt-template rebases)

**pr.block.md**:
- Prepend guard stating the work was already implemented, tested, and reviewed

**Tests**:
- `tests/test_coordinator_agent.py`: New `TestCoordinatorRoleBoundaries` class verifying the coordinator.md guard sections and CLI reference
- `tests/test_guardian_state_machine.py`: Added `TestGuardianRoleBoundaries` tests verifying guardian.md denies and pr.block.md guard

All 8 new tests pass.