### PR TITLE
fix(env): strip stale WORCA_*/CLAUDECODE from subprocess env for nested invocations

### DIFF
--- a/src/worca/scripts/crg_validation_spike.py
+++ b/src/worca/scripts/crg_validation_spike.py
@@ -98,6 +98,24 @@ def _mcp_request(method: str, params: Optional[dict] = None, req_id: Optional[in
     return f"Content-Length: {len(body)}\r\n\r\n{body}".encode()
 
 
+def _clean_subprocess_env(**extra: str) -> dict[str, str]:
+    """Create a clean subprocess environment without worca-specific vars.
+
+    When spawning CRG serve tests, we must not inherit WORCA_* vars that
+    trigger governance guards (e.g., WORCA_AGENT causes CRG mutation guard
+    violations). Tests run the binary directly, not through agent tool use.
+    """
+    env = os.environ.copy()
+    # Remove worca-specific environment variables that trigger guards
+    worca_keys = [k for k in env if k.startswith("WORCA_")]
+    for key in worca_keys:
+        del env[key]
+    # Also remove CLAUDECODE to avoid any nested CLI interference
+    env.pop("CLAUDECODE", None)
+    env.update(extra)
+    return env
+
+
 def _wait_readable(stream, max_wait: float) -> bool:
     """Block up to ``max_wait`` seconds for ``stream`` to be readable.
 
@@ -193,11 +211,10 @@ def validate_read_tools_no_dml(db_path: str, repo_root: str) -> ValidationResult
     wal_path = db_path + "-wal"
     shm_path = db_path + "-shm"
 
-    env = {
-        **os.environ,
-        "CRG_REPO_ROOT": os.path.abspath(repo_root),
-        "CRG_DATA_DIR": data_dir,
-    }
+    env = _clean_subprocess_env(
+        CRG_REPO_ROOT=os.path.abspath(repo_root),
+        CRG_DATA_DIR=data_dir,
+    )
 
     proc = subprocess.Popen(
         ["code-review-graph", "serve"],
@@ -306,11 +323,10 @@ def validate_env_var_honor(data_dir: str, repo_root: str) -> ValidationResult:
             details=f"graph.db not found at {db_path}",
         )
 
-    env = {
-        **os.environ,
-        "CRG_REPO_ROOT": os.path.abspath(repo_root),
-        "CRG_DATA_DIR": os.path.abspath(data_dir),
-    }
+    env = _clean_subprocess_env(
+        CRG_REPO_ROOT=os.path.abspath(repo_root),
+        CRG_DATA_DIR=os.path.abspath(data_dir),
+    )
 
     proc = subprocess.Popen(
         ["code-review-graph", "serve"],
@@ -392,11 +408,10 @@ def measure_serve_startup_latency(
             details=f"graph.db not found at {db_path}",
         )
 
-    env = {
-        **os.environ,
-        "CRG_REPO_ROOT": os.path.abspath(repo_root),
-        "CRG_DATA_DIR": os.path.abspath(data_dir),
-    }
+    env = _clean_subprocess_env(
+        CRG_REPO_ROOT=os.path.abspath(repo_root),
+        CRG_DATA_DIR=os.path.abspath(data_dir),
+    )
 
     latencies_ms: list[float] = []
     errors: list[str] = []

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -580,8 +580,14 @@ def run_agent(
     agent_env = get_env(WORCA_AGENT=agent_name, **safe_env)
     if stage is not None:
         agent_env["WORCA_STAGE"] = stage
+    else:
+        # Explicitly remove to avoid inheriting from os.environ.copy()
+        agent_env.pop("WORCA_STAGE", None)
     if iteration is not None:
         agent_env["WORCA_ITERATION"] = str(iteration)
+    else:
+        # Explicitly remove to avoid inheriting from os.environ.copy()
+        agent_env.pop("WORCA_ITERATION", None)
     if bead_id is not None:
         agent_env["WORCA_BEAD_ID"] = bead_id
     if graphify_out:

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -421,6 +421,31 @@ def test_run_agent_omits_stage_and_iteration_when_not_provided():
     assert "WORCA_ITERATION" not in env
 
 
+def test_run_agent_strips_stale_stage_and_iteration_from_parent_env(monkeypatch):
+    """When the parent process already has WORCA_STAGE / WORCA_ITERATION set
+    (nested invocation, leftover from an earlier stage in the same pipeline,
+    or operator shell), they must NOT leak through to a child invoked with
+    ``stage=None`` / ``iteration=None``.
+
+    get_env() returns ``os.environ.copy()``, so without explicit removal the
+    parent's values silently win and the file-access hook records the child's
+    activity under the wrong stage/iteration column in the Access Map.
+    """
+    monkeypatch.setenv("WORCA_STAGE", "plan")
+    monkeypatch.setenv("WORCA_ITERATION", "5")
+    result_event = {"ok": True}
+    mock_proc = _make_mock_popen(result_event)
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc) as mock_popen:
+        run_agent(
+            "prompt", agent="planner",
+            stage=None, iteration=None,
+            settings={},
+        )
+    env = mock_popen.call_args[1]["env"]
+    assert "WORCA_STAGE" not in env
+    assert "WORCA_ITERATION" not in env
+
+
 def test_run_agent_sets_worca_agent_always():
     """WORCA_AGENT is always set, regardless of stage/iteration."""
     result_event = {"ok": True}


### PR DESCRIPTION
## Summary

Two defensive env-isolation fixes:

- **`src/worca/utils/claude_cli.py`** — `run_agent` now explicitly removes `WORCA_STAGE` / `WORCA_ITERATION` from the agent's subprocess env when the caller passes `stage=None` / `iteration=None`. `get_env()` is `os.environ.copy()` underneath, so a parent process that already has these vars set silently leaks them through to the child, and the file-access hook records the child's activity under the wrong stage/iteration column in the Access Map.
- **`src/worca/scripts/crg_validation_spike.py`** — extract a `_clean_subprocess_env()` helper that strips `WORCA_*` and `CLAUDECODE` before spawning `code-review-graph serve`. The CRG mutation guard refuses to initialize if `WORCA_AGENT` is set; the spike runs the binary directly (not via agent tool-use), so the guard fires as a false positive in this path.

## Provenance

These edits arrived as off-task working-tree drift from pipeline `20260607-065207-741-575c047d` / bead `worca-cc-h9zg` (originating from GH #302 — "Execution-stage prompts wander outside role"). That bead's actual scope was agent-prompt edits to `coordinator.md` / `guardian.md`. In `implement-2` the implementer wandered into CRG validation work and wrote to absolute paths under the **main checkout** (`/Volumes/.../worca-cc/src/...`) instead of its worktree (`/Volumes/.../worca-cc/.worktrees/pipeline-.../src/...`), so the writes never landed in that pipeline's merged PR ([`ae29dafb`](https://github.com/SinishaDjukic/worca-cc/commit/ae29dafb)) and were sitting orphaned in the main repo's working tree. Same root-cause pattern as the Access Map fix in [`5304b97b`](https://github.com/SinishaDjukic/worca-cc/commit/5304b97b), but with destructive consequences here.

Reviewed and salvaged with proper provenance rather than dropped silently.

## What this does NOT fix

`tests/test_crg_validation_spike.py::test_real_read_tools_emit_no_dml` still fails on master with `"serve did not respond to initialize"`. The fallback hint blames a CRG / fastmcp version mismatch, but `fastmcp 3.3.1` (>= 3.2.4) is installed locally — so the root cause sits in CRG itself or its MCP handshake timing. The env-scrub here is correct hygiene for the cases the guard does block but does not change the observable test outcome in this repo's env.

## Test plan

- [x] New unit test `test_run_agent_strips_stale_stage_and_iteration_from_parent_env` (in `tests/test_claude_cli.py`):
  - Sets `WORCA_STAGE=plan` and `WORCA_ITERATION=5` on the parent via `monkeypatch`.
  - Calls `run_agent(stage=None, iteration=None, ...)`.
  - Asserts neither key is present in the child's env dict.
  - Verified to **FAIL on master** without the `claude_cli.py` patch and **PASS** with it (regression guard).
- [x] `pytest tests/ --ignore=tests/integration --deselect tests/test_crg_validation_spike.py` — 6252 pass.
- [x] `ruff check .` — clean.
- [ ] CI green (Linux 3.10/3.12, macOS, Windows, UI unit, UI E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)