### PR TITLE
feat(templates): v3 bundle layout, two-phase import with collision dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,10 @@ htmlcov/
 worca-ui/app/utils/status-constants.js
 .playwright-mcp/
 watch-page-live.png
+
+# Local screenshots from Playwright debugging
+collision-dialog.png
+collision-dialog-fixed.png
+dual-collision-dialog.png
+import-complete.png
+legacy-settings-picker-with-aliases.png

--- a/docs-site/.astro/content-assets.mjs
+++ b/docs-site/.astro/content-assets.mjs
@@ -1,1 +1,4 @@
-export default new Map();
+
+
+export default new Map([]);
+		

--- a/docs-site/src/content/docs/advanced/authoring-templates.md
+++ b/docs-site/src/content/docs/advanced/authoring-templates.md
@@ -65,10 +65,14 @@ When you ask to import or load a bundle, the skill walks you through three steps
 
    Before fetching, the skill reminds you that bundles are config-as-data and warns about the [trust boundary](#trust-boundary).
 
-2. **Target scope.** Either **project** (writes to `.claude/templates/`, merges models/pricing into `settings.json`) or **user** (writes to `~/.worca/templates/`; models and pricing are skipped because there's no user-level `settings.json`).
+2. **Target scope.** Either **project** (writes templates to `.claude/templates/`) or **user** (writes templates to `~/.worca/templates/`). **Model aliases and pricing always land in user-global `~/.worca/settings.json` regardless of the template scope** — this keeps the project's committed settings free of per-developer env scaffolds and secret placeholders. If you share the bundle with a teammate via the repo, each collaborator runs the import on their machine to pick up the alias definitions.
 
-3. **Run the import, handle collisions, and follow up on placeholders.** For each template ID that already exists in the target scope, the skill asks **replace / skip / abort** — unrecognized input re-prompts, never silently skips. After the import:
-   - If any `<YOUR-SECRET-HERE>` placeholder values landed, it lists every path needing a real secret and points you at [Secrets](/configuration/secrets/) for where to put them.
+3. **Run the import, handle collisions, and follow up on placeholders.** Imports run in two phases: a passive **preview** that detects every collision before any write, then a **commit** that respects the resolutions you picked. The skill prompts:
+   - For each template id that already exists in the target scope, **replace / skip / abort** — unrecognized input re-prompts, never silently skips.
+   - For each model alias whose incoming definition differs from the existing one in user-global, **rename / overwrite / skip / abort**. The default for rename is a zero-padded `-NN` suffix (e.g. `glm-ds` → `glm-ds-01`, probing `-01..-99` for the first free slot). When you rename, the imported template's `config.agents.*.model` references are rewritten to point at the new alias name transactionally with the alias write, so the template never lands referencing a missing alias.
+
+   After the import:
+   - If any `<YOUR-SECRET-HERE>` placeholder values landed, the skill lists every path needing a real secret and points you at [Secrets](/configuration/secrets/) for where to put them.
    - If the import landed templates that shadow built-ins, you get an `info:` line per shadow so it's visible, not silent.
    - On any failure, the rollback restores every replaced template and `settings.json` from the snapshots taken before mutation; nothing partial is ever committed.
 
@@ -98,12 +102,17 @@ A single-template zip bundle has this structure:
 ```
 <id>-bundle.zip
   template.json         # required — the template config (same schema as the on-disk file)
+  models.json           # optional (v3) — { "models": {...}, "pricing": {...} }
   agents/               # optional — present only when overlays exist
     planner.md
     coordinator.md
     plan.block.md
     …any other *.md or *.block.md files
 ```
+
+`models.json` carries any `worca.models` alias definition that the template references, alongside its pricing entry. The importer lifts both back to the manifest top-level `models` and `pricing` keys at parse time, so they participate in the same redaction and collision flow as JSON bundles.
+
+When a zip bundle includes `models.json` the synthesized `worca_bundle_version` is `3`; otherwise it stays at `2`. The importer accepts versions `1`, `2`, and `3`.
 
 One template per zip. There is no multi-template zip — if you export multiple templates, only those with overlays become `.zip`; the rest stay `.json`.
 
@@ -194,7 +203,7 @@ Flags:
 # From a local JSON bundle:
 worca templates import --from ./team-bundle.json
 
-# From a local zip bundle (carries config + overlays):
+# From a local zip bundle (carries config + overlays + optional models.json):
 worca templates import --from ./bugfix-bundle.zip
 
 # From an HTTPS URL (JSON or zip — hardened, see Trust boundary below):
@@ -206,8 +215,17 @@ worca templates import --from https://gist.github.com/alice/abc123def456...
 # Into the user scope instead of project:
 worca templates import --from ./bundle.json --scope user
 
-# CI / non-interactive: skip all collisions instead of prompting:
-worca templates import --from ./bundle.json --non-interactive
+# Non-interactive policies for the two collision dimensions:
+worca templates import --from ./bundle.json --non-interactive \
+  --on-template-conflict replace \
+  --on-model-conflict rename
+
+# Preview-only: print collisions JSON and exit without writing anything.
+worca templates import --from ./bundle.json --preview
+
+# Drive resolutions programmatically (used by the worca-ui import dialog):
+worca templates import --from ./bundle.json --non-interactive \
+  --resolutions ./resolutions.json
 ```
 
 Flags:
@@ -215,10 +233,14 @@ Flags:
 | Flag | Effect |
 |---|---|
 | `--from <src>` | Source: file path, HTTPS URL, or gist URL/ID. Required. |
-| `--scope project\|user` | Where to install. Default `project`. User scope skips models/pricing (no user-level `settings.json`). |
-| `--non-interactive` | Auto-skip every collision; never prompt. |
+| `--scope project\|user` | Where templates land. Default `project`. **Model aliases always land in user-global `~/.worca/settings.json` regardless of `--scope`.** |
+| `--non-interactive` | Don't prompt; honor the `--on-*-conflict` policies and `--resolutions` instead. |
+| `--on-template-conflict abort\|skip\|replace` | Non-interactive policy when a template id already exists in the target scope. Default `abort`. |
+| `--on-model-conflict abort\|skip\|overwrite\|rename` | Non-interactive policy when a model alias collides with one in user-global settings. Default `abort`. `rename` appends a zero-padded `-NN` suffix and rewrites the template's `config.agents.*.model` references. |
+| `--preview` | Print a JSON collision report to stdout and exit; no files are written. Used by the worca-ui dialog. |
+| `--resolutions <path>` | JSON file mapping each collision to an explicit action. Structured shape: `{"models": {"<alias>": {"action": "skip\|overwrite\|rename", "new_name": "<optional>"}}, "templates": {"<tid>": {"action": "skip\|replace"}}}`. A flat root-level object is treated as the `models` block for back-compat. |
 
-Collisions prompt interactively (`[r]eplace / [s]kip / [a]bort`); unrecognized input re-prompts. Imports are atomic with rollback (see [Rollback](#rollback-and-atomicity) below).
+In interactive mode, template collisions prompt `[r]eplace / [s]kip / [a]bort` and model alias collisions prompt `[s]kip / [o]verwrite / [r]ename / [a]bort`. Unrecognized input re-prompts. Imports are atomic with rollback (see [Rollback](#rollback-and-atomicity) below).
 
 ## What's in a bundle (the safety model)
 
@@ -296,7 +318,13 @@ Imports are atomic with full rollback. Before any mutation, every existing templ
 
 ### Schema forward compatibility
 
-Bundles carry `worca_bundle_version`. The importer accepts the current major (`1`, `"1"`, `"1.0"`) and any forward-compat minor (`"1.1"`, `"1.5"`, …) — minor mismatches log a warning but proceed; unknown additive fields are preserved. A different major version is rejected outright.
+Bundles carry `worca_bundle_version`. The importer accepts:
+
+- `1` (or string forms `"1"`, `"1.0"`) — original JSON bundle layout.
+- `2` (`"2"`, `"2.0"`) — zip bundle with `template.json` and `agents/*.md` overlays.
+- `3` (`"3"`, `"3.0"`) — zip bundle that also carries a top-level `models.json` for alias and pricing definitions.
+
+Forward-compat minor mismatches (`"1.1"`, `"2.3"`, `"3.1"`, …) log a warning but proceed; unknown additive fields are preserved. Major versions outside the supported set are rejected outright with a clear error so an older importer never silently drops content from a newer bundle.
 
 ## Where templates fit
 

--- a/docs-site/src/content/docs/configuration/pipeline-templates.md
+++ b/docs-site/src/content/docs/configuration/pipeline-templates.md
@@ -110,7 +110,11 @@ Once a default template is in play, project settings for `agents`, `stages`, `lo
 ## Exporting and importing
 
 - **Export** — click **Export** on any card (or inside the editor). The format is chosen automatically: `.zip` when the template has prompt overlay files (`agents/*.md`), `.json` for config-only templates. Secrets are redacted in either format, safe to share or commit. Export works on every tier, including built-ins.
-- **Import** — click **Import** in the list view to upload a `.json` or `.zip` bundle file. Zip bundles carry the template config and all overlay files; the post-import dialog lists the overlays that landed. If the imported id collides with an existing template in the target scope, the editor surfaces the same inline collision warning and prompts you to rename before saving.
+- **Import** — click **Import** in the list view to upload a `.json` or `.zip` bundle file. The UI runs a **preview pass** first and, if any collisions are detected, opens a dialog with two sections so you can decide what to do:
+  - **Template collisions** — for each template id that already exists in the target scope, pick **Replace** (overwrite) or **Skip** (keep the existing).
+  - **Model alias collisions** — for each model alias in the bundle that already exists in your user-global settings (`~/.worca/settings.json`), pick **Rename** (zero-padded `-NN` suffix; the imported template's `config.agents.*.model` references are rewritten transactionally), **Overwrite** (replace the existing definition), or **Skip** (keep the existing).
+
+  Click **Import** in the dialog footer to commit. The post-import view lists the templates that landed and any overlay files that came in.
 
 :::note[Gist sharing — JSON bundles only]
 The "Copy gist URL" action is available only on templates without prompt overlays. Templates with overlays must be shared as a downloaded `.zip` file attachment.

--- a/src/worca/cli/templates.py
+++ b/src/worca/cli/templates.py
@@ -311,6 +311,55 @@ def register_subcommand(sub):
         default=False,
         help="Skip collision prompts; auto-skip all collisions",
     )
+    import_parser.add_argument(
+        "--on-model-conflict",
+        dest="on_model_conflict",
+        choices=["abort", "skip", "overwrite", "rename"],
+        default="abort",
+        help=(
+            "Non-interactive policy when an incoming model alias collides with an "
+            "existing one in user-global settings. abort: refuse the import; "
+            "skip: drop the incoming alias and let the template reference the "
+            "existing one; overwrite: replace the existing definition; "
+            "rename: append a zero-padded -NN suffix and rewrite template refs."
+        ),
+    )
+    import_parser.add_argument(
+        "--on-template-conflict",
+        dest="on_template_conflict",
+        choices=["abort", "skip", "replace"],
+        default="abort",
+        help=(
+            "Non-interactive policy when an incoming template id already exists "
+            "in the target scope. abort: refuse the import; skip: keep the "
+            "existing template (drop the incoming one); replace: overwrite the "
+            "existing template with the incoming one."
+        ),
+    )
+    import_parser.add_argument(
+        "--resolutions",
+        dest="resolutions",
+        default=None,
+        help=(
+            "Path to a JSON file describing per-collision resolution actions. "
+            "Structured shape: {\"models\": {\"<alias>\": {\"action\": "
+            "\"skip|overwrite|rename\", \"new_name\": \"<optional>\"}}, "
+            "\"templates\": {\"<tid>\": {\"action\": \"skip|replace\"}}}. "
+            "A flat root-level mapping is treated as the models block for "
+            "backwards compatibility within this PR. Used by the worca-ui "
+            "import flow."
+        ),
+    )
+    import_parser.add_argument(
+        "--preview",
+        dest="preview",
+        action="store_true",
+        default=False,
+        help=(
+            "Print a JSON collision preview to stdout and exit without writing "
+            "anything. Used by the worca-ui import flow."
+        ),
+    )
 
     # validate
     validate_parser = templates_sub.add_parser(
@@ -755,12 +804,13 @@ def cmd_templates_export(args):
     for entry in template_entries:
         has_overlays = bool(entry.get("_overlays"))
 
-        # Build and redact a per-template manifest so redaction paths reference
-        # the single-template index (templates[0].*) consistently.
+        # Always carry models+pricing through the manifest so redaction sees
+        # any secret values. The zip layout (v3) ships them in models.json;
+        # the json layout keeps them at manifest top level.
         per_manifest = build_export_manifest(
             [entry],
-            models=models if not has_overlays else None,
-            pricing=pricing if not has_overlays else None,
+            models=models,
+            pricing=pricing,
             export_mode=export_mode,
         )
         redacted_manifest, redacted_paths = redact_bundle(per_manifest)
@@ -769,6 +819,8 @@ def cmd_templates_export(args):
                 print(f"info: redacted {rp}", file=sys.stderr)
 
         redacted_entry = redacted_manifest["templates"][0]
+        redacted_models = redacted_manifest.get("models")
+        redacted_pricing = redacted_manifest.get("pricing")
 
         if multi:
             ext = ".zip" if has_overlays else ".json"
@@ -777,7 +829,13 @@ def cmd_templates_export(args):
             out_path = dest
 
         if has_overlays:
-            _write_zip(redacted_entry, out_path, export_mode=export_mode)
+            _write_zip(
+                redacted_entry,
+                out_path,
+                export_mode=export_mode,
+                models=redacted_models,
+                pricing=redacted_pricing,
+            )
         else:
             Path(out_path).write_text(
                 json.dumps(redacted_manifest, indent=2), encoding="utf-8"
@@ -792,10 +850,45 @@ def cmd_templates_export(args):
 
 
 def cmd_templates_import(args):
-    """worca templates import --from <source> — import templates from a bundle."""
+    """worca templates import --from <source> — import templates from a bundle.
+
+    Model aliases (``worca.models``) and pricing (``worca.pricing.models``) in
+    the bundle always land in user-global settings (``~/.worca/settings.json``)
+    regardless of ``--scope``. Templates themselves still honor ``--scope``.
+    The split keeps repo-committed settings.json free of per-developer env /
+    secret scaffolding while letting the project template reference the alias.
+    """
     source = args.from_source
     scope = args.scope
     non_interactive = args.non_interactive
+    on_model_conflict = getattr(args, "on_model_conflict", "abort")
+    on_template_conflict = getattr(args, "on_template_conflict", "abort")
+    preview_only = getattr(args, "preview", False)
+    resolutions_path = getattr(args, "resolutions", None)
+
+    user_resolutions_raw: dict = {}
+    if resolutions_path:
+        try:
+            user_resolutions_raw = json.loads(Path(resolutions_path).read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"error: --resolutions: {e}", file=sys.stderr)
+            raise SystemExit(1)
+        if not isinstance(user_resolutions_raw, dict):
+            print("error: --resolutions JSON root must be an object", file=sys.stderr)
+            raise SystemExit(1)
+
+    # Two accepted shapes for --resolutions:
+    #   structured: {"models": {alias: {...}}, "templates": {tid: {...}}}
+    #   legacy:     {alias: {...}}  (treated as the models block)
+    if (
+        "models" in user_resolutions_raw
+        or "templates" in user_resolutions_raw
+    ):
+        model_resolutions = user_resolutions_raw.get("models") or {}
+        template_resolutions = user_resolutions_raw.get("templates") or {}
+    else:
+        model_resolutions = user_resolutions_raw
+        template_resolutions = {}
 
     try:
         manifest = fetch_bundle(source)
@@ -833,8 +926,26 @@ def cmd_templates_import(args):
         print("error: not in a git repository — cannot determine project template directory", file=sys.stderr)
         raise SystemExit(1)
 
-    to_import = {}
-    skipped_ids = []
+    # First pass: detect template-id collisions in the target scope so they can
+    # be surfaced by --preview alongside model collisions before any prompt.
+    template_collisions_meta: list[dict] = []
+    for tmpl in bundle_templates:
+        tid = tmpl["id"]
+        existing = resolver.get(tid)
+        has_collision = existing is not None and (
+            (scope == "project" and existing.tier == "project")
+            or (scope == "user" and existing.tier == "user")
+        )
+        if has_collision:
+            template_collisions_meta.append({
+                "id": tid,
+                "existing_tier": existing.tier,
+                "existing_name": existing.name,
+                "incoming_name": tmpl.get("name", tid),
+            })
+
+    to_import: dict = {}
+    skipped_ids: list[str] = []
     for tmpl in bundle_templates:
         tid = tmpl["id"]
         existing = resolver.get(tid)
@@ -849,12 +960,40 @@ def cmd_templates_import(args):
                 f"info: shadowing builtin template '{tid}' with {scope}-scope import",
                 file=sys.stderr,
             )
-        if has_collision:
-            if non_interactive:
-                skipped_ids.append(tid)
-                continue
-            # Re-prompt on unrecognized input — the operation isn't reversible,
-            # don't silently fall through to "skip".
+        if not has_collision:
+            to_import[tid] = tmpl
+            continue
+
+        # --preview is passive: never prompt, never abort, just record the
+        # template as skipped so the loop is consistent and the preview branch
+        # below returns the full collision metadata to the caller.
+        if preview_only:
+            skipped_ids.append(tid)
+            continue
+
+        # Collision-resolution precedence:
+        #   1. Per-template entry in user_resolutions_raw["templates"]
+        #   2. --on-template-conflict policy (in non-interactive mode)
+        #   3. Interactive prompt (skip/replace/abort)
+        spec = template_resolutions.get(tid) if isinstance(template_resolutions, dict) else None
+        action = None
+        if isinstance(spec, dict) and isinstance(spec.get("action"), str):
+            action = spec["action"]
+            if action not in ("skip", "replace"):
+                print(f"error: unknown template action {action!r} for {tid!r}", file=sys.stderr)
+                raise SystemExit(1)
+        elif non_interactive:
+            policy = on_template_conflict
+            if policy == "abort":
+                print(
+                    f"error: template '{tid}' already exists in {scope} scope "
+                    f"with --on-template-conflict=abort",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+            action = policy
+
+        if action is None:
             decided = False
             while not decided:
                 try:
@@ -863,7 +1002,6 @@ def cmd_templates_import(args):
                         f"[r]eplace / [s]kip / [a]bort? "
                     )
                 except EOFError:
-                    # No stdin available (CI, piped run) — treat as skip and stop.
                     skipped_ids.append(tid)
                     decided = True
                     break
@@ -872,31 +1010,41 @@ def cmd_templates_import(args):
                     print("aborted", file=sys.stderr)
                     raise SystemExit(1)
                 if choice.startswith("r"):
-                    to_import[tid] = tmpl
+                    action = "replace"
                     decided = True
                 elif choice.startswith("s"):
-                    skipped_ids.append(tid)
+                    action = "skip"
                     decided = True
                 else:
                     print(
                         f"  unrecognized choice {answer!r} — enter r, s, or a",
                         file=sys.stderr,
                     )
-        else:
+
+        if action == "replace":
             to_import[tid] = tmpl
+        else:
+            skipped_ids.append(tid)
 
     settings_patch: dict = {}
-    settings_path = _find_settings_path(scope)
+    template_settings_path = _find_settings_path(scope)
+    # Model aliases always land user-global so the project's committed
+    # settings.json stays free of per-developer env/secret scaffolds.
+    models_settings_path = _find_settings_path("user")
 
-    # Filter bundle's models/pricing to aliases actually referenced by templates
-    # that will land. Anything else is over-inclusion — it would silently
-    # inject entries the user didn't ask for and may overwrite their existing
-    # aliases. Mirror of the same filter on export.
+    # Filter bundle's models/pricing to aliases actually referenced by
+    # templates. For preview mode we consider the FULL bundle so the dialog
+    # can surface collisions even when the destination already has the
+    # template (which non-interactive skips). For commit mode we restrict to
+    # `to_import` so we don't carry aliases for skipped templates.
     if bundle_models or bundle_pricing:
-        imported_templates_list = list(to_import.values())
+        if preview_only:
+            referenced_source = list(bundle_templates)
+        else:
+            referenced_source = list(to_import.values())
         all_bundle_models = bundle_models or {}
         referenced = collect_referenced_model_aliases(
-            imported_templates_list, all_bundle_models
+            referenced_source, all_bundle_models
         )
         if bundle_models:
             bundle_models, _ = _filter_models_by_aliases(
@@ -925,13 +1073,31 @@ def cmd_templates_import(args):
             cleaned_models[model_key] = model_entry
         bundle_models = cleaned_models
 
-    # Detect per-alias collisions against the target's current settings and
-    # let the user decide (or default to skip in non-interactive mode). This
-    # mirrors the per-template collision UX rather than silently letting the
-    # bundle overwrite local model/pricing definitions via deep_merge.
-    bundle_models, bundle_pricing = _resolve_settings_alias_collisions(
-        bundle_models, bundle_pricing, settings_path, non_interactive
+    # --preview: print collisions JSON and exit without writing. Used by the
+    # worca-ui import flow to drive the collision dialog before commit.
+    if preview_only:
+        preview = _build_collision_preview(bundle_models, bundle_pricing, models_settings_path)
+        preview["template_ids"] = [t.get("id") for t in bundle_templates]
+        preview["template_collisions"] = template_collisions_meta
+        preview["models_scope"] = "user"
+        preview["template_scope"] = scope
+        preview["template_settings_path"] = template_settings_path
+        print(json.dumps(preview, indent=2))
+        return
+
+    bundle_models, bundle_pricing, rename_map = _resolve_settings_alias_collisions(
+        bundle_models,
+        bundle_pricing,
+        models_settings_path,
+        non_interactive,
+        on_conflict=on_model_conflict,
+        resolutions=model_resolutions,
     )
+
+    # Apply the rename map to templates BEFORE _atomic_import so the on-disk
+    # template never references a stale alias name. Transactional with the
+    # rename in the settings patch.
+    _rewrite_template_model_refs(to_import, rename_map)
 
     if bundle_models:
         settings_patch["models"] = bundle_models
@@ -946,11 +1112,23 @@ def cmd_templates_import(args):
             print("nothing to import")
         return
 
+    # Single atomic transaction: templates land in `target_dir` (per --scope),
+    # model aliases / pricing land in user-global settings.json. _atomic_import
+    # already handles cross-FS staging + rollback for both surfaces.
     try:
-        _atomic_import(to_import, settings_patch, target_dir, settings_path)
+        _atomic_import(to_import, settings_patch, target_dir, models_settings_path)
     except Exception as e:
         print(f"error: import failed: {e}", file=sys.stderr)
         raise SystemExit(1)
+
+    if to_import and settings_patch:
+        print(
+            f"info: templates landed in {scope} scope ({target_dir}); "
+            f"model aliases landed in user-global ({models_settings_path}). "
+            "Collaborators sharing the project must import this bundle on "
+            "their own machines to get the aliases.",
+            file=sys.stderr,
+        )
 
     # Surface any placeholder values that landed — the importer needs to fill
     # them in locally before the pipeline can use them.
@@ -1046,35 +1224,142 @@ def _filter_pricing_by_aliases(
     return result, dropped
 
 
+def _find_next_alias_name(base: str, taken: set[str], cap: int = 99) -> str | None:
+    """Probe ``base-01`` … ``base-{cap:02d}`` and return the first unused name.
+
+    Zero-padded so reimport ordering stays predictable. Returns ``None`` when
+    the cap is exhausted; caller treats that as a hard failure.
+    """
+    for n in range(1, cap + 1):
+        candidate = f"{base}-{n:02d}"
+        if candidate not in taken:
+            return candidate
+    return None
+
+
+def _rewrite_template_model_refs(
+    templates: dict, rename_map: dict[str, str]
+) -> None:
+    """Rewrite every ``config.agents.*.model`` reference in *templates* that
+    points at a renamed alias. Mutates in place; called transactionally with
+    the rename map AFTER collision resolution and BEFORE _atomic_import so the
+    on-disk template never references a stale alias.
+    """
+    if not rename_map:
+        return
+    for tmpl in templates.values():
+        config = tmpl.get("config")
+        if not isinstance(config, dict):
+            continue
+        agents = config.get("agents")
+        if not isinstance(agents, dict):
+            continue
+        for agent_cfg in agents.values():
+            if isinstance(agent_cfg, dict):
+                model = agent_cfg.get("model")
+                if isinstance(model, str) and model in rename_map:
+                    agent_cfg["model"] = rename_map[model]
+
+
+def _build_collision_preview(
+    bundle_models: dict | None,
+    bundle_pricing: dict | None,
+    settings_path: str | None,
+) -> dict:
+    """Return a JSON-serializable preview of incoming alias collisions.
+
+    Shape::
+        {
+          "collisions": [
+            {"alias": "glm-ds", "scope": "models",
+             "incoming": {...}, "existing": {...},
+             "suggested_rename": "glm-ds-01"},
+            ...
+          ],
+          "new_aliases": ["claude-private", ...],
+          "settings_path": "/Users/.../.worca/settings.json"
+        }
+
+    Used by the worca-ui preview endpoint so the dialog can render
+    per-alias resolution rows without re-running the import.
+    """
+    current_models, _ = _read_current_models_and_pricing(settings_path)
+    collisions: list[dict] = []
+    new_aliases: list[str] = []
+    taken = set(current_models.keys()) | set((bundle_models or {}).keys())
+    for alias, incoming in (bundle_models or {}).items():
+        if alias in current_models:
+            existing = current_models[alias]
+            if existing == incoming:
+                continue
+            suggested = _find_next_alias_name(alias, taken)
+            if suggested:
+                taken.add(suggested)
+            collisions.append({
+                "alias": alias,
+                "scope": "models",
+                "incoming": incoming,
+                "existing": existing,
+                "suggested_rename": suggested,
+            })
+        else:
+            new_aliases.append(alias)
+    return {
+        "collisions": collisions,
+        "new_aliases": sorted(new_aliases),
+        "settings_path": settings_path,
+    }
+
+
+def _read_current_models_and_pricing(settings_path: str | None) -> tuple[dict, dict]:
+    """Read the target settings.json and return its (models, pricing.models)."""
+    if not settings_path:
+        return {}, {}
+    sp = Path(settings_path)
+    if not sp.exists():
+        return {}, {}
+    try:
+        current_settings = json.loads(sp.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}, {}
+    if not isinstance(current_settings, dict):
+        return {}, {}
+    worca_cfg = current_settings.get("worca") or {}
+    if not isinstance(worca_cfg, dict):
+        return {}, {}
+    return (
+        worca_cfg.get("models") or {},
+        (worca_cfg.get("pricing") or {}).get("models") or {},
+    )
+
+
 def _resolve_settings_alias_collisions(
     bundle_models: dict | None,
     bundle_pricing: dict | None,
     settings_path: str | None,
     non_interactive: bool,
-) -> tuple[dict | None, dict | None]:
-    """For each alias the bundle would merge into `settings.worca.models` or
-    `settings.worca.pricing.models`, compare against the target's current
-    value. Surface collisions (different values for the same key) and either
-    skip them (non-interactive / EOF) or prompt for replace/skip/abort.
+    on_conflict: str = "abort",
+    resolutions: dict | None = None,
+) -> tuple[dict | None, dict | None, dict[str, str]]:
+    """Resolve per-alias collisions for incoming model and pricing entries.
 
-    No prompt is shown when collisions are absent. The reason this exists at
-    all is that the underlying `deep_merge` lets bundle values silently
-    overwrite local aliases — which is fine for additive merges but a real
-    footgun when the bundle ships e.g. `opus: claude-opus-4-6` over a local
-    `opus: claude-opus-4-7`.
+    Three resolution actions per colliding alias:
+      - ``skip``: drop the incoming entry; existing value retained.
+      - ``overwrite``: replace the existing value with the incoming one,
+        secrets included. Caller responsibility — the user explicitly chose it.
+      - ``rename``: assign a zero-padded ``-NN`` suffix and rewrite every
+        template ``config.agents.*.model`` reference to point at the new name.
+
+    Returns ``(bundle_models, bundle_pricing, rename_map)``. The caller MUST
+    apply ``rename_map`` to the templates BEFORE they are written via
+    ``_rewrite_template_model_refs``.
+
+    Resolution source-of-truth precedence:
+      1. ``resolutions`` dict (per-alias UI/CLI overrides) takes precedence.
+      2. ``on_conflict`` policy (CLI flag default) covers anything unresolved.
+      3. Interactive prompt only when no resolutions AND ``not non_interactive``.
     """
-    current_models: dict = {}
-    current_pricing_models: dict = {}
-    if settings_path:
-        sp = Path(settings_path)
-        if sp.exists():
-            try:
-                current_settings = json.loads(sp.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
-                current_settings = {}
-            worca_cfg = (current_settings.get("worca") or {}) if isinstance(current_settings, dict) else {}
-            current_models = worca_cfg.get("models") or {}
-            current_pricing_models = (worca_cfg.get("pricing") or {}).get("models") or {}
+    current_models, current_pricing_models = _read_current_models_and_pricing(settings_path)
 
     model_collisions = sorted(
         k for k, v in (bundle_models or {}).items()
@@ -1086,8 +1371,10 @@ def _resolve_settings_alias_collisions(
         if k in current_pricing_models and current_pricing_models[k] != v
     )
 
+    rename_map: dict[str, str] = {}
+
     if not model_collisions and not pricing_collisions:
-        return bundle_models, bundle_pricing
+        return bundle_models, bundle_pricing, rename_map
 
     summary_parts = []
     if model_collisions:
@@ -1095,48 +1382,125 @@ def _resolve_settings_alias_collisions(
     if pricing_collisions:
         summary_parts.append(f"pricing.models: {', '.join(pricing_collisions)}")
     print(
-        f"warning: bundle would overwrite existing values for {'; '.join(summary_parts)}",
+        f"warning: bundle collides with existing aliases — {'; '.join(summary_parts)}",
         file=sys.stderr,
     )
 
-    def _drop_collisions(bm, bp):
-        if bm is not None:
-            bm = {k: v for k, v in bm.items() if k not in model_collisions}
-            if not bm:
-                bm = None
-        if bp is not None and isinstance(bp.get("models"), dict):
-            new_pm = {k: v for k, v in bp["models"].items() if k not in pricing_collisions}
-            bp = {**bp, "models": new_pm}
-        return bm, bp
+    resolutions = resolutions or {}
+    taken = set(current_models.keys()) | set((bundle_models or {}).keys())
 
-    if non_interactive:
-        print(
-            "  non-interactive: kept target's existing values, skipped bundle's overwrites",
-            file=sys.stderr,
-        )
-        return _drop_collisions(bundle_models, bundle_pricing)
+    def _resolve_one(alias: str) -> tuple[str, str | None]:
+        """Return (action, new_name). action ∈ {skip, overwrite, rename}."""
+        spec = resolutions.get(alias)
+        if isinstance(spec, dict) and isinstance(spec.get("action"), str):
+            action = spec["action"]
+            new_name = spec.get("new_name")
+            if action == "rename":
+                if not isinstance(new_name, str) or not new_name:
+                    new_name = _find_next_alias_name(alias, taken)
+                if not new_name:
+                    raise SystemExit(
+                        f"error: rename for alias {alias!r} exhausted -01..-99 probe"
+                    )
+                if new_name in taken:
+                    raise SystemExit(
+                        f"error: rename target {new_name!r} for alias {alias!r} is already taken"
+                    )
+                taken.add(new_name)
+                return "rename", new_name
+            if action in ("skip", "overwrite"):
+                return action, None
+            raise SystemExit(f"error: unknown action {action!r} for alias {alias!r}")
 
-    while True:
-        try:
-            answer = input("[r]eplace all / [s]kip collided / [a]bort? ")
-        except EOFError:
+        if non_interactive:
+            policy = on_conflict
+            if policy == "abort":
+                print(
+                    f"error: model alias collision on {alias!r} with --on-model-conflict=abort",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+            if policy == "rename":
+                new_name = _find_next_alias_name(alias, taken)
+                if not new_name:
+                    raise SystemExit(
+                        f"error: rename for alias {alias!r} exhausted -01..-99 probe"
+                    )
+                taken.add(new_name)
+                return "rename", new_name
+            return policy, None
+
+        while True:
+            try:
+                answer = input(
+                    f"alias {alias!r} collides — [s]kip / [o]verwrite / [r]ename / [a]bort? "
+                )
+            except EOFError:
+                print(
+                    f"  no stdin: defaulting to {on_conflict!r} for alias {alias!r}",
+                    file=sys.stderr,
+                )
+                if on_conflict == "abort":
+                    raise SystemExit(1)
+                if on_conflict == "rename":
+                    new_name = _find_next_alias_name(alias, taken)
+                    if not new_name:
+                        raise SystemExit(1)
+                    taken.add(new_name)
+                    return "rename", new_name
+                return on_conflict, None
+            choice = answer.strip().lower()
+            if choice.startswith("a"):
+                print("aborted", file=sys.stderr)
+                raise SystemExit(1)
+            if choice.startswith("s"):
+                return "skip", None
+            if choice.startswith("o"):
+                return "overwrite", None
+            if choice.startswith("r"):
+                new_name = _find_next_alias_name(alias, taken)
+                if not new_name:
+                    print(
+                        f"  rename for {alias!r} exhausted -01..-99 probe",
+                        file=sys.stderr,
+                    )
+                    continue
+                taken.add(new_name)
+                return "rename", new_name
             print(
-                "  no stdin: kept target's existing values, skipped bundle's overwrites",
+                f"  unrecognized choice {answer!r} — enter s, o, r, or a",
                 file=sys.stderr,
             )
-            return _drop_collisions(bundle_models, bundle_pricing)
-        choice = answer.strip().lower()
-        if choice.startswith("a"):
-            print("aborted", file=sys.stderr)
-            raise SystemExit(1)
-        if choice.startswith("r"):
-            return bundle_models, bundle_pricing
-        if choice.startswith("s"):
-            return _drop_collisions(bundle_models, bundle_pricing)
-        print(
-            f"  unrecognized choice {answer!r} — enter r, s, or a",
-            file=sys.stderr,
-        )
+
+    all_collisions = sorted(set(model_collisions) | set(pricing_collisions))
+    decisions: dict[str, tuple[str, str | None]] = {}
+    for alias in all_collisions:
+        decisions[alias] = _resolve_one(alias)
+
+    new_models = dict(bundle_models or {})
+    new_pricing_models = dict(pricing_models_block)
+    for alias, (action, new_name) in decisions.items():
+        if action == "skip":
+            new_models.pop(alias, None)
+            new_pricing_models.pop(alias, None)
+        elif action == "overwrite":
+            pass  # entry stays under its original key, will overwrite on merge
+        elif action == "rename":
+            rename_map[alias] = new_name
+            if alias in new_models:
+                new_models[new_name] = new_models.pop(alias)
+            if alias in new_pricing_models:
+                new_pricing_models[new_name] = new_pricing_models.pop(alias)
+            print(
+                f"  renamed alias {alias!r} -> {new_name!r}",
+                file=sys.stderr,
+            )
+
+    out_models: dict | None = new_models if new_models else None
+    out_pricing = bundle_pricing
+    if out_pricing is not None:
+        out_pricing = {**out_pricing, "models": new_pricing_models}
+    return out_models, out_pricing, rename_map
 
 
 def _collect_placeholder_paths(obj, path: str, out: list[str]) -> None:
@@ -1152,6 +1516,25 @@ def _collect_placeholder_paths(obj, path: str, out: list[str]) -> None:
     if isinstance(obj, list):
         for i, item in enumerate(obj):
             _collect_placeholder_paths(item, f"{path}[{i}]", out)
+
+
+def _write_models_to_user_settings(path: str | None, settings_patch: dict) -> None:
+    """Deep-merge ``{worca: settings_patch}`` into the user-global settings.json
+    atomically. Creates ``~/.worca/`` if missing. No-op when ``path`` is None.
+    """
+    if not path or not settings_patch:
+        return
+    sp = Path(path)
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    if sp.exists():
+        try:
+            current = json.loads(sp.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            current = {}
+    else:
+        current = {}
+    patched = deep_merge(current, {"worca": settings_patch})
+    _atomic_write_json(str(sp), patched)
 
 
 def _atomic_write_json(path: str, data: dict) -> None:

--- a/src/worca/orchestrator/bundle.py
+++ b/src/worca/orchestrator/bundle.py
@@ -254,6 +254,11 @@ _MAX_ZIP_RATIO = 100                            # max expansion ratio (zip bomb 
 # Allowed overlay filenames: e.g. planner.md, plan.block.md, plan_reviewer.md
 _OVERLAY_NAME_RE = re.compile(r"^[a-z0-9._-]{1,64}\.(md|block\.md)$")
 
+# v3 zip layout adds a top-level `models.json` carrying both the models alias
+# map and the pricing map. Older v2 readers will reject it as unexpected_entry,
+# which is why this is a major bump and not additive.
+_MODELS_JSON_MEMBER = "models.json"
+
 
 class BundleError(ValueError):
     """Base class for bundle processing errors."""
@@ -345,6 +350,7 @@ def _parse_zip_bundle(raw_bytes: bytes, staging: Path) -> dict:
 
         seen: set[str] = set()
         template_info: zipfile.ZipInfo | None = None
+        models_info: zipfile.ZipInfo | None = None
         overlay_infos: dict[str, zipfile.ZipInfo] = {}
         total_uncompressed = 0
 
@@ -396,6 +402,8 @@ def _parse_zip_bundle(raw_bytes: bytes, staging: Path) -> dict:
 
             if name == "template.json":
                 template_info = info
+            elif name == _MODELS_JSON_MEMBER:
+                models_info = info
             else:
                 p = PurePosixPath(name)
                 parts = p.parts
@@ -445,32 +453,70 @@ def _parse_zip_bundle(raw_bytes: bytes, staging: Path) -> dict:
         # template.json stays clean.
         export_mode = tmpl_data.pop("export_mode", None)
 
+        bundle_models: dict | None = None
+        bundle_pricing: dict | None = None
+        bundle_version = 2
+        if models_info is not None:
+            with zf.open(models_info) as fh:
+                raw = fh.read(_MAX_ZIP_FILE_SIZE + 1)
+                if len(raw) > _MAX_ZIP_FILE_SIZE:
+                    raise BundleLayoutError(
+                        f"file exceeds 256 KiB: {_MODELS_JSON_MEMBER}",
+                        details={"member": _MODELS_JSON_MEMBER, "rule": "oversized_single"},
+                    )
+                try:
+                    models_data = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    raise BundleLayoutError(
+                        f"invalid JSON in {_MODELS_JSON_MEMBER}: {exc}",
+                        details={"member": _MODELS_JSON_MEMBER, "rule": "bad_json"},
+                    ) from exc
+            if isinstance(models_data, dict):
+                m = models_data.get("models")
+                p = models_data.get("pricing")
+                if isinstance(m, dict) and m:
+                    bundle_models = m
+                if isinstance(p, dict) and p:
+                    bundle_pricing = p
+            bundle_version = 3
+
         manifest: dict = {
-            "worca_bundle_version": 2,
+            "worca_bundle_version": bundle_version,
             "exported_at": datetime.now(timezone.utc).isoformat(),
             "templates": [tmpl_data],
         }
         if export_mode is not None:
             manifest["export_mode"] = export_mode
+        if bundle_models is not None:
+            manifest["models"] = bundle_models
+        if bundle_pricing is not None:
+            manifest["pricing"] = bundle_pricing
         return manifest
 
 
-def _write_zip(tmpl_entry: dict, dest: str, export_mode: str | None = None) -> None:
+def _write_zip(
+    tmpl_entry: dict,
+    dest: str,
+    export_mode: str | None = None,
+    models: dict | None = None,
+    pricing: dict | None = None,
+) -> None:
     """Write a single-template zip bundle to *dest*.
 
     *tmpl_entry* is a (redacted) template dict that may carry
     ``_overlays: {filename: content}``.  The zip layout is::
 
         template.json        — template data (without _overlays key)
+        models.json          — {"models": {...}, "pricing": {...}} (v3, optional)
         agents/<fname>       — one file per entry in _overlays
 
-    This mirrors the layout expected by ``_parse_zip_bundle`` so a zip
-    produced here can be round-tripped through ``fetch_bundle``.
+    ``models.json`` lifts back to the synthesized manifest's top-level
+    ``models`` / ``pricing`` keys via ``_parse_zip_bundle``. When either is
+    written the synthesized bundle version becomes v3.
 
     ``export_mode`` is a manifest-level concept, but the strict zip layout
     carries no manifest wrapper — so it rides inside ``template.json`` and is
-    lifted back to the synthesized manifest by ``_parse_zip_bundle`` (and
-    popped off the entry there, so it never lands in the on-disk template.json).
+    lifted back to the synthesized manifest by ``_parse_zip_bundle``.
     """
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
@@ -478,6 +524,13 @@ def _write_zip(tmpl_entry: dict, dest: str, export_mode: str | None = None) -> N
         if export_mode is not None:
             json_entry["export_mode"] = export_mode
         zf.writestr("template.json", json.dumps(json_entry, indent=2))
+        if models or pricing:
+            models_payload: dict = {}
+            if models:
+                models_payload["models"] = models
+            if pricing:
+                models_payload["pricing"] = pricing
+            zf.writestr(_MODELS_JSON_MEMBER, json.dumps(models_payload, indent=2))
         for fname, content in (tmpl_entry.get("_overlays") or {}).items():
             zf.writestr(f"agents/{fname}", content)
     Path(dest).write_bytes(buf.getvalue())
@@ -640,9 +693,9 @@ def _parse_bundle_version(v: object) -> tuple[int, int] | None:
 
 
 # Major versions this code understands.
-# v1 = JSON-only bundles; v2 = zip-sourced bundles with optional _overlays.
-SUPPORTED_BUNDLE_MAJOR = 2
-_SUPPORTED_BUNDLE_MAJORS = frozenset({1, 2})
+# v1 = JSON-only bundles; v2 = zip with template+overlays; v3 = v2 + models.json.
+SUPPORTED_BUNDLE_MAJOR = 3
+_SUPPORTED_BUNDLE_MAJORS = frozenset({1, 2, 3})
 
 
 def validate_bundle(manifest: dict) -> tuple[list[dict], list[str]]:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -406,8 +406,8 @@ class TestNonSecretPreservation:
 class TestValidateBundle:
 
     def test_rejects_unknown_major_version(self):
-        # v3 is still unsupported; v2 is now accepted (zip bundles).
-        manifest = _minimal_manifest(worca_bundle_version=3)
+        # v4 is still unsupported; v3 is now accepted (zip + models.json).
+        manifest = _minimal_manifest(worca_bundle_version=4)
         errors, _ = validate_bundle(manifest)
         assert len(errors) == 1
         assert errors[0]["field"] == "worca_bundle_version"
@@ -418,8 +418,14 @@ class TestValidateBundle:
         errors, _ = validate_bundle(manifest)
         assert not errors
 
-    def test_rejects_string_major_three(self):
-        manifest = _minimal_manifest(worca_bundle_version="3.0")
+    def test_accepts_version_three(self):
+        # v3 = zip with optional models.json carrying alias+pricing.
+        manifest = _minimal_manifest(worca_bundle_version=3)
+        errors, _ = validate_bundle(manifest)
+        assert not errors
+
+    def test_rejects_string_major_four(self):
+        manifest = _minimal_manifest(worca_bundle_version="4.0")
         errors, _ = validate_bundle(manifest)
         assert any(e["field"] == "worca_bundle_version" for e in errors)
 
@@ -958,3 +964,64 @@ class TestRedactBundleOverlays:
         redacted, paths = redact_bundle(manifest)
         assert redacted["templates"][0]["_overlays"]["planner.md"] == "# Normal prompt\nNo secrets here."
         assert paths == []
+
+
+# ---------------------------------------------------------------------------
+# v3 zip layout: models.json carries alias map + pricing
+# ---------------------------------------------------------------------------
+
+class TestBundleV3ModelsJson:
+    """Roundtrip a v3 zip carrying models.json through _write_zip → fetch_bundle."""
+
+    def test_write_zip_with_models_carries_models_json(self, tmp_path):
+        from worca.orchestrator.bundle import _write_zip
+        dest = tmp_path / "out.zip"
+        _write_zip(
+            {"id": "t", "name": "T", "description": "", "tags": [], "config": {}},
+            str(dest),
+            export_mode="standalone",
+            models={"glm-ds": {"id": "opus", "env": {"ANTHROPIC_BASE_URL": "https://example.com"}}},
+            pricing={"models": {"glm-ds": {"input_per_mtok": 1.5}}},
+        )
+        with zipfile.ZipFile(dest) as zf:
+            names = zf.namelist()
+            assert "template.json" in names
+            assert "models.json" in names
+            payload = json.loads(zf.read("models.json"))
+            assert payload["models"]["glm-ds"]["id"] == "opus"
+            assert payload["pricing"]["models"]["glm-ds"]["input_per_mtok"] == 1.5
+
+    def test_fetch_bundle_lifts_models_json_to_manifest(self, tmp_path):
+        from worca.orchestrator.bundle import _write_zip
+        dest = tmp_path / "out.zip"
+        _write_zip(
+            {"id": "t", "name": "T", "description": "", "tags": [], "config": {}},
+            str(dest),
+            export_mode="standalone",
+            models={"glm-ds": {"id": "opus"}},
+            pricing={"models": {"glm-ds": {"input_per_mtok": 1.5}}},
+        )
+        manifest = fetch_bundle(str(dest))
+        assert manifest["worca_bundle_version"] == 3
+        assert manifest["models"]["glm-ds"]["id"] == "opus"
+        assert manifest["pricing"]["models"]["glm-ds"]["input_per_mtok"] == 1.5
+        assert manifest["export_mode"] == "standalone"
+
+    def test_zip_without_models_json_synthesizes_v2(self, tmp_path):
+        from worca.orchestrator.bundle import _write_zip
+        dest = tmp_path / "out.zip"
+        _write_zip(
+            {"id": "t", "name": "T", "description": "", "tags": [], "config": {}},
+            str(dest),
+            export_mode="standalone",
+        )
+        manifest = fetch_bundle(str(dest))
+        assert manifest["worca_bundle_version"] == 2
+        assert "models" not in manifest
+        assert "pricing" not in manifest
+
+    def test_invalid_models_json_raises(self):
+        from worca.orchestrator.bundle import _manifest_from_zip
+        bad = _make_zip_bytes([("models.json", "not json {")])
+        with pytest.raises(BundleLayoutError, match="invalid JSON"):
+            _manifest_from_zip(bad)

--- a/tests/test_cli_templates.py
+++ b/tests/test_cli_templates.py
@@ -1287,7 +1287,10 @@ class TestTemplatesImport:
             "worca.cli.templates._find_settings_path",
             return_value=str(tmp_path / ".claude" / "settings.json"),
         ):
-            main(["templates", "import", "--from", str(bundle_file), "--non-interactive"])
+            main([
+                "templates", "import", "--from", str(bundle_file),
+                "--non-interactive", "--on-template-conflict", "skip",
+            ])
 
         out = capsys.readouterr()
         assert "skip" in out.out.lower() or "skipped" in out.err.lower() or "0 template" in out.out.lower()
@@ -1845,7 +1848,10 @@ class TestImportMixedCollision:
             "worca.cli.templates._find_settings_path",
             return_value=str(tmp_path / ".claude" / "settings.json"),
         ):
-            main(["templates", "import", "--from", str(bundle_file), "--non-interactive"])
+            main([
+                "templates", "import", "--from", str(bundle_file),
+                "--non-interactive", "--on-template-conflict", "skip",
+            ])
 
         # Colliding one: still original
         collides_data = json.loads((project_dir / "collides" / "template.json").read_text())
@@ -2279,27 +2285,28 @@ class TestImportAliasCollision:
         err = capsys.readouterr().err
         assert "would overwrite" not in err
 
-    def test_different_value_non_interactive_keeps_local(self, capsys, tmp_path):
+    def test_different_value_non_interactive_aborts_by_default(self, capsys, tmp_path):
         """Bundle's opus differs from local's — non-interactive defaults to
-        skip (preserve target), bundle value dropped."""
-        written = self._run(
-            tmp_path,
-            current_models={"opus": "claude-opus-4-7"},  # newer locally
-            bundle_models={"opus": "claude-opus-4-6"},   # older in bundle
-        )
-        assert written["worca"]["models"]["opus"] == "claude-opus-4-7"
-        err = capsys.readouterr().err
-        assert "would overwrite" in err
-        assert "kept target's existing values" in err
-
-    def test_different_value_interactive_replace(self, capsys, tmp_path):
+        abort (refuse to proceed). The _run helper swallows the SystemExit; we
+        assert the local value was preserved (no write happened)."""
         written = self._run(
             tmp_path,
             current_models={"opus": "claude-opus-4-7"},
             bundle_models={"opus": "claude-opus-4-6"},
-            interactive_input="r",
         )
-        # Replace: bundle wins.
+        assert written["worca"]["models"]["opus"] == "claude-opus-4-7"
+        err = capsys.readouterr().err
+        assert "collides with existing aliases" in err
+        assert "--on-model-conflict=abort" in err
+
+    def test_different_value_interactive_overwrite(self, capsys, tmp_path):
+        written = self._run(
+            tmp_path,
+            current_models={"opus": "claude-opus-4-7"},
+            bundle_models={"opus": "claude-opus-4-6"},
+            interactive_input="o",
+        )
+        # Overwrite: bundle wins.
         assert written["worca"]["models"]["opus"] == "claude-opus-4-6"
 
     def test_different_value_interactive_skip(self, capsys, tmp_path):
@@ -2782,3 +2789,306 @@ class TestValidateMergesProjectModels:
 
         monkeypatch.setenv("WORCA_HOME", str(tmp_path / "worca-home"))
         assert _resolve_project_models(str(tmp_path)) == {}
+
+
+# ---------------------------------------------------------------------------
+# Rename collision resolver: --on-model-conflict=rename + --resolutions
+# ---------------------------------------------------------------------------
+
+class TestImportAliasRename:
+    """Rename action assigns -01 suffix and rewrites template.config.agents.*.model
+    references atomically with the alias map write."""
+
+    def _run(self, tmp_path, *, current_models, bundle_models, on_conflict=None,
+             resolutions=None, interactive_input=None):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.json"
+        settings_path.write_text(json.dumps({"worca": {"models": current_models}}))
+
+        bundle = _make_bundle(
+            templates=[{
+                "id": "uses-alias",
+                "name": "Uses Alias",
+                "description": "",
+                "tags": [],
+                "config": {"agents": {"planner": {"model": "glm-ds"}}},
+            }],
+            models=bundle_models,
+        )
+        bundle_file = tmp_path / "bundle.json"
+        bundle_file.write_text(json.dumps(bundle))
+
+        patches = [
+            patch("worca.cli.templates._resolve_dirs",
+                  return_value=(builtin_dir, project_dir, user_dir)),
+            patch("worca.cli.templates._find_settings_path",
+                  return_value=str(settings_path)),
+        ]
+        args = ["templates", "import", "--from", str(bundle_file)]
+        if resolutions is not None:
+            rpath = tmp_path / "resolutions.json"
+            rpath.write_text(json.dumps(resolutions))
+            args.extend(["--resolutions", str(rpath)])
+        if on_conflict:
+            args.extend(["--on-model-conflict", on_conflict])
+        if interactive_input is None:
+            args.append("--non-interactive")
+        else:
+            patches.append(patch("builtins.input", return_value=interactive_input))
+
+        for p in patches:
+            p.__enter__()
+        try:
+            try:
+                main(args)
+            except SystemExit:
+                pass
+        finally:
+            for p in reversed(patches):
+                p.__exit__(None, None, None)
+
+        written = json.loads(settings_path.read_text())
+        landed_template = None
+        tpath = project_dir / "uses-alias" / "template.json"
+        if tpath.exists():
+            landed_template = json.loads(tpath.read_text())
+        return written, landed_template
+
+    def test_rename_policy_assigns_zero_padded_suffix(self, tmp_path):
+        written, landed = self._run(
+            tmp_path,
+            current_models={"glm-ds": {"id": "claude-opus-4-6"}},
+            bundle_models={"glm-ds": {"id": "claude-opus-4-7"}},
+            on_conflict="rename",
+        )
+        assert "glm-ds" in written["worca"]["models"]
+        assert "glm-ds-01" in written["worca"]["models"]
+        assert written["worca"]["models"]["glm-ds-01"] == {"id": "claude-opus-4-7"}
+        # Template ref rewritten transactionally
+        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds-01"
+
+    def test_rename_probes_next_available_suffix(self, tmp_path):
+        written, landed = self._run(
+            tmp_path,
+            current_models={
+                "glm-ds": {"id": "claude-opus-4-6"},
+                "glm-ds-01": {"id": "other"},
+            },
+            bundle_models={"glm-ds": {"id": "claude-opus-4-7"}},
+            on_conflict="rename",
+        )
+        assert "glm-ds-02" in written["worca"]["models"]
+        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds-02"
+
+    def test_resolutions_file_per_alias_overwrite(self, tmp_path):
+        written, landed = self._run(
+            tmp_path,
+            current_models={"glm-ds": {"id": "claude-opus-4-6"}},
+            bundle_models={"glm-ds": {"id": "claude-opus-4-7"}},
+            resolutions={"glm-ds": {"action": "overwrite"}},
+        )
+        assert written["worca"]["models"]["glm-ds"] == {"id": "claude-opus-4-7"}
+        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds"
+
+    def test_resolutions_file_per_alias_skip_keeps_local(self, tmp_path):
+        written, landed = self._run(
+            tmp_path,
+            current_models={"glm-ds": {"id": "claude-opus-4-6"}},
+            bundle_models={"glm-ds": {"id": "claude-opus-4-7"}},
+            resolutions={"glm-ds": {"action": "skip"}},
+        )
+        assert written["worca"]["models"]["glm-ds"] == {"id": "claude-opus-4-6"}
+        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds"
+
+    def test_resolutions_file_explicit_new_name(self, tmp_path):
+        written, landed = self._run(
+            tmp_path,
+            current_models={"glm-ds": {"id": "claude-opus-4-6"}},
+            bundle_models={"glm-ds": {"id": "claude-opus-4-7"}},
+            resolutions={"glm-ds": {"action": "rename", "new_name": "glm-ds-private"}},
+        )
+        assert "glm-ds-private" in written["worca"]["models"]
+        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds-private"
+
+    def test_skip_policy_drops_alias_and_leaves_template_pointing_at_existing(self, tmp_path):
+        written, landed = self._run(
+            tmp_path,
+            current_models={"glm-ds": {"id": "claude-opus-4-6"}},
+            bundle_models={"glm-ds": {"id": "claude-opus-4-7"}},
+            on_conflict="skip",
+        )
+        assert written["worca"]["models"]["glm-ds"] == {"id": "claude-opus-4-6"}
+        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds"
+
+
+class TestImportPreview:
+    """--preview prints JSON collisions and exits without writing."""
+
+    def test_preview_emits_collisions_and_exits_without_writing(self, tmp_path, capsys):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir()
+        settings_path = settings_dir / "settings.json"
+        settings_path.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"id": "claude-opus-4-6"}}}
+        }))
+
+        bundle = _make_bundle(
+            templates=[{
+                "id": "uses-alias",
+                "name": "Uses Alias",
+                "description": "",
+                "tags": [],
+                "config": {"agents": {"planner": {"model": "glm-ds"}}},
+            }],
+            models={"glm-ds": {"id": "claude-opus-4-7"}, "fresh": {"id": "claude-sonnet"}},
+        )
+        bundle["templates"][0]["config"]["agents"]["tester"] = {"model": "fresh"}
+        bundle_file = tmp_path / "bundle.json"
+        bundle_file.write_text(json.dumps(bundle))
+
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ), patch(
+            "worca.cli.templates._find_settings_path",
+            return_value=str(settings_path),
+        ):
+            main(["templates", "import", "--from", str(bundle_file), "--preview"])
+
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        aliases = {c["alias"] for c in payload["collisions"]}
+        assert "glm-ds" in aliases
+        assert "fresh" in payload["new_aliases"]
+        assert payload["models_scope"] == "user"
+        # Template was not written
+        assert not (project_dir / "uses-alias").exists()
+
+
+# ---------------------------------------------------------------------------
+# Template collisions: --on-template-conflict + structured --resolutions
+# ---------------------------------------------------------------------------
+
+class TestImportTemplateConflict:
+    """Per-template skip/replace/abort decisions via the new flags and via the
+    structured `--resolutions` payload."""
+
+    def _setup(self, tmp_path, existing_name="Original", incoming_name="FromBundle"):
+        builtin_dir = tmp_path / "builtin"
+        builtin_dir.mkdir()
+        project_dir = tmp_path / "project"
+        user_dir = tmp_path / "user"
+        _write_template(
+            project_dir / "tmpl",
+            _minimal("tmpl", tier="project", name=existing_name),
+        )
+        bundle = _make_bundle(templates=[{
+            "id": "tmpl",
+            "name": incoming_name,
+            "description": "d",
+            "tags": [],
+            "config": {},
+        }])
+        bundle_file = tmp_path / "bundle.json"
+        bundle_file.write_text(json.dumps(bundle))
+        return builtin_dir, project_dir, user_dir, bundle_file
+
+    def test_default_abort_refuses_template_collision(self, tmp_path, capsys):
+        builtin_dir, project_dir, user_dir, bundle_file = self._setup(tmp_path)
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ), patch(
+            "worca.cli.templates._find_settings_path",
+            return_value=str(tmp_path / ".claude" / "settings.json"),
+        ):
+            try:
+                main(["templates", "import", "--from", str(bundle_file), "--non-interactive"])
+            except SystemExit:
+                pass
+
+        landed = json.loads((project_dir / "tmpl" / "template.json").read_text())
+        assert landed["name"] == "Original"  # untouched
+        assert "on-template-conflict=abort" in capsys.readouterr().err
+
+    def test_replace_policy_overwrites_existing_template(self, tmp_path):
+        builtin_dir, project_dir, user_dir, bundle_file = self._setup(tmp_path)
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ), patch(
+            "worca.cli.templates._find_settings_path",
+            return_value=str(tmp_path / ".claude" / "settings.json"),
+        ):
+            main([
+                "templates", "import", "--from", str(bundle_file),
+                "--non-interactive", "--on-template-conflict", "replace",
+            ])
+
+        landed = json.loads((project_dir / "tmpl" / "template.json").read_text())
+        assert landed["name"] == "FromBundle"
+
+    def test_skip_policy_keeps_existing(self, tmp_path):
+        builtin_dir, project_dir, user_dir, bundle_file = self._setup(tmp_path)
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ), patch(
+            "worca.cli.templates._find_settings_path",
+            return_value=str(tmp_path / ".claude" / "settings.json"),
+        ):
+            main([
+                "templates", "import", "--from", str(bundle_file),
+                "--non-interactive", "--on-template-conflict", "skip",
+            ])
+
+        landed = json.loads((project_dir / "tmpl" / "template.json").read_text())
+        assert landed["name"] == "Original"
+
+    def test_structured_resolutions_per_template_replace(self, tmp_path):
+        builtin_dir, project_dir, user_dir, bundle_file = self._setup(tmp_path)
+        resolutions = tmp_path / "res.json"
+        resolutions.write_text(json.dumps({
+            "models": {},
+            "templates": {"tmpl": {"action": "replace"}},
+        }))
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ), patch(
+            "worca.cli.templates._find_settings_path",
+            return_value=str(tmp_path / ".claude" / "settings.json"),
+        ):
+            main([
+                "templates", "import", "--from", str(bundle_file),
+                "--non-interactive", "--resolutions", str(resolutions),
+            ])
+
+        landed = json.loads((project_dir / "tmpl" / "template.json").read_text())
+        assert landed["name"] == "FromBundle"
+
+    def test_preview_includes_template_collisions(self, tmp_path, capsys):
+        builtin_dir, project_dir, user_dir, bundle_file = self._setup(tmp_path)
+        with patch(
+            "worca.cli.templates._resolve_dirs",
+            return_value=(builtin_dir, project_dir, user_dir),
+        ), patch(
+            "worca.cli.templates._find_settings_path",
+            return_value=str(tmp_path / ".claude" / "settings.json"),
+        ):
+            main(["templates", "import", "--from", str(bundle_file), "--preview"])
+
+        payload = json.loads(capsys.readouterr().out)
+        assert any(c["id"] == "tmpl" for c in payload.get("template_collisions", []))
+        # Template is untouched even though preview ran
+        landed = json.loads((project_dir / "tmpl" / "template.json").read_text())
+        assert landed["name"] == "Original"

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -627,6 +627,38 @@ let _editorTemplatesFetching = false; // single in-flight templates fetch for in
 let _editorModule = null;
 let getEditorState = null;
 
+/**
+ * If the user is currently viewing one of the just-imported templates in the
+ * editor, the cached `editorState.template` is stale (the on-disk file changed
+ * but the editor only reloads on (tier,id) change). Force a fresh
+ * `loadTemplate` so the editor reflects the imported contents without needing
+ * a browser refresh.
+ *
+ * @param {Array<{id: string, tier: string}>} imported
+ */
+function _invalidateEditorCacheIfImported(imported) {
+  if (!Array.isArray(imported) || imported.length === 0) return;
+  if (!_editorModule || typeof getEditorState !== 'function') return;
+  let st;
+  try {
+    st = getEditorState();
+  } catch {
+    return;
+  }
+  if (!st?.templateId || !st?.tier) return;
+  const hit = imported.find(
+    (e) => e && e.id === st.templateId && e.tier === st.tier,
+  );
+  if (!hit) return;
+  const route = store.getState().currentRoute || {};
+  _editorModule
+    .loadTemplate(st.tier, st.templateId, route.projectId || null)
+    .then(() => rerender())
+    .catch(() => {
+      /* best-effort */
+    });
+}
+
 // ── Integrations state ──────────────────────────────────────────────────
 let integrationsStatus = null;
 let integrationsConfig = null;
@@ -2053,6 +2085,50 @@ function _dismissTemplateActionDialog() {
   rerender();
 }
 
+function _onCollisionActionChange(alias, action, suggested) {
+  if (!_templateActionDialog) return;
+  const prev = _templateActionDialog.resolutions?.[alias] || {};
+  const next = { action };
+  if (action === 'rename') {
+    next.new_name = prev.new_name || suggested || `${alias}-01`;
+  }
+  _templateActionDialog = {
+    ..._templateActionDialog,
+    resolutions: {
+      ...(_templateActionDialog.resolutions || {}),
+      [alias]: next,
+    },
+  };
+  rerender();
+}
+
+function _onCollisionRenameInput(alias, newName) {
+  if (!_templateActionDialog) return;
+  const prev = _templateActionDialog.resolutions?.[alias] || {
+    action: 'rename',
+  };
+  _templateActionDialog = {
+    ..._templateActionDialog,
+    resolutions: {
+      ...(_templateActionDialog.resolutions || {}),
+      [alias]: { ...prev, action: 'rename', new_name: newName },
+    },
+  };
+  rerender();
+}
+
+function _onTemplateCollisionChange(tid, action) {
+  if (!_templateActionDialog) return;
+  _templateActionDialog = {
+    ..._templateActionDialog,
+    templateResolutions: {
+      ...(_templateActionDialog.templateResolutions || {}),
+      [tid]: { action },
+    },
+  };
+  rerender();
+}
+
 const _TEMPLATE_ID_RE = /^[a-z0-9_-]{1,64}$/;
 
 /**
@@ -2383,6 +2459,119 @@ function _templateActionDialogTemplate(state) {
           `
           : ''
       }
+      ${
+        Array.isArray(dlg.templateCollisions) &&
+        dlg.templateCollisions.length > 0
+          ? html`
+            <div class="settings-field dialog-collisions">
+              <div class="dialog-collisions-header">
+                <sl-badge variant="warning">Template collisions</sl-badge>
+              </div>
+              <p class="settings-field-hint">
+                The bundle contains template ids that already exist in the
+                selected target storage. Pick whether to replace the existing
+                template or keep it.
+              </p>
+              <ul class="dialog-collision-list">
+                ${dlg.templateCollisions.map((t) => {
+                  const r = dlg.templateResolutions?.[t.id] || {
+                    action: 'replace',
+                  };
+                  return html`
+                    <li class="dialog-collision-row" data-rename="false">
+                      <div class="dialog-collision-alias">
+                        <code>${t.id}</code>
+                      </div>
+                      <sl-select
+                        size="small"
+                        hoist
+                        class="collision-action-select"
+                        data-template=${t.id}
+                        .value=${r.action}
+                        @sl-change=${(e) => _onTemplateCollisionChange(t.id, e.target.value)}
+                      >
+                        <sl-option value="skip">Skip (keep existing)</sl-option>
+                        <sl-option value="replace">Replace</sl-option>
+                      </sl-select>
+                    </li>
+                  `;
+                })}
+            </ul>
+            </div>
+          `
+          : ''
+      }
+      ${
+        Array.isArray(dlg.collisions) && dlg.collisions.length > 0
+          ? html`
+            <div class="settings-field dialog-collisions">
+              <div class="dialog-collisions-header">
+                <sl-badge variant="warning">Model alias collisions</sl-badge>
+              </div>
+              <p class="settings-field-hint">
+                The bundle includes model aliases that already exist in your
+                user-global settings (<code>~/.worca/settings.json</code>). Pick
+                a resolution per alias. Renames rewrite the template's
+                <code>config.agents.*.model</code> references so the imported
+                template keeps working.
+              </p>
+              <ul class="dialog-collision-list">
+                ${dlg.collisions.map((c) => {
+                  const r = dlg.resolutions?.[c.alias] || {
+                    action: 'rename',
+                    new_name: c.suggested_rename,
+                  };
+                  const isRename = r.action === 'rename';
+                  return html`
+                    <li class="dialog-collision-row" data-rename=${isRename ? 'true' : 'false'}>
+                      <div class="dialog-collision-alias">
+                        <code>${c.alias}</code>
+                      </div>
+                      <sl-select
+                        size="small"
+                        hoist
+                        class="collision-action-select"
+                        data-alias=${c.alias}
+                        .value=${r.action}
+                        @sl-change=${(e) => _onCollisionActionChange(c.alias, e.target.value, c.suggested_rename)}
+                      >
+                        <sl-option value="skip">Skip</sl-option>
+                        <sl-option value="overwrite">Overwrite</sl-option>
+                        <sl-option value="rename">Rename</sl-option>
+                      </sl-select>
+                      ${
+                        isRename
+                          ? html`
+                            <sl-input
+                              size="small"
+                              class="collision-rename-input"
+                              data-alias=${c.alias}
+                              placeholder="new alias name"
+                              .value=${r.new_name || c.suggested_rename || ''}
+                              @sl-input=${(e) => _onCollisionRenameInput(c.alias, e.target.value)}
+                            ></sl-input>
+                          `
+                          : ''
+                      }
+                    </li>
+                  `;
+                })}
+              </ul>
+              ${
+                dlg.newAliases && dlg.newAliases.length > 0
+                  ? html`
+                    <p class="settings-field-hint dialog-new-aliases-hint">
+                      ${dlg.newAliases.length} new alias${dlg.newAliases.length === 1 ? '' : 'es'}
+                      will land cleanly:
+                      ${dlg.newAliases.map((a) => html`<code>${a}</code> `)}
+                    </p>
+                  `
+                  : ''
+              }
+            </div>
+          `
+          : ''
+      }
       <div class="settings-field">
         <label class="settings-label" for="dlg-tier">Target storage</label>
         <sl-select
@@ -2629,58 +2818,93 @@ async function _confirmTemplateActionDialog() {
         return;
       }
 
-      if (dlg.parsed._kind === 'zip') {
-        // Binary POST: raw zip bytes + dst_tier as query param.
-        const importUrl = `${projectUrl('/templates/import')}?dst_tier=${encodeURIComponent(dlg.tier || 'project')}`;
-        const res = await fetch(importUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/zip' },
-          body: dlg.file,
-        });
-        const data = await res.json();
-        if (!res.ok || !data.ok) {
+      const tier = dlg.tier || 'project';
+      const isZip = dlg.parsed._kind === 'zip';
+
+      // Phase 1: preview surfaces alias collisions BEFORE any write. If
+      // collisions exist and the user hasn't resolved them yet, swap the
+      // dialog body to the collision resolver. On the next click (with
+      // resolutions in hand) we drop through to the commit POST.
+      if (!dlg.previewSeen) {
+        const previewUrl = `${projectUrl('/templates/import/preview')}?dst_tier=${encodeURIComponent(tier)}`;
+        const previewInit = isZip
+          ? {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/zip' },
+              body: dlg.file,
+            }
+          : {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ bundle: dlg.parsed }),
+            };
+        const previewRes = await fetch(previewUrl, previewInit);
+        const previewData = await previewRes.json();
+        if (!previewRes.ok || !previewData.ok) {
           _templateActionDialog = {
             ...dlg,
-            error: data.error || 'Failed to import',
+            error: previewData.error || 'Failed to preview import',
           };
           _templateActionBusy = false;
           rerender();
           return;
         }
-        // Fetch overlays for each imported template to show in the result view.
-        const overlaysByTemplate = {};
-        for (const { id, tier } of data.imported || []) {
-          try {
-            const oRes = await fetch(
-              projectUrl(`/templates/${tier}/${id}/overlays`),
-            );
-            const oData = await oRes.json();
-            if (oData.ok && oData.overlays) {
-              overlaysByTemplate[id] = Object.keys(oData.overlays);
-            }
-          } catch {
-            // best-effort; missing overlays don't fail the import
+        const collisions = previewData.collisions || [];
+        const templateCollisions = previewData.template_collisions || [];
+        if (collisions.length > 0 || templateCollisions.length > 0) {
+          const initialModels = {};
+          for (const c of collisions) {
+            initialModels[c.alias] = {
+              action: 'rename',
+              new_name: c.suggested_rename || `${c.alias}-01`,
+            };
           }
+          const initialTemplates = {};
+          for (const t of templateCollisions) {
+            initialTemplates[t.id] = { action: 'replace' };
+          }
+          _templateActionDialog = {
+            ...dlg,
+            previewSeen: true,
+            collisions,
+            templateCollisions,
+            newAliases: previewData.new_aliases || [],
+            modelsScope: previewData.models_scope || 'user',
+            resolutions: initialModels,
+            templateResolutions: initialTemplates,
+          };
+          _templateActionBusy = false;
+          rerender();
+          return;
         }
-        const templates = await fetchTemplates(route.projectId || null);
-        store.setState({
-          templates,
-          defaultTemplate: templates.defaultTemplate,
-        });
-        _templateActionDialog = {
-          ...dlg,
-          importResult: { imported: data.imported || [], overlaysByTemplate },
-        };
-        _templateActionBusy = false;
-        rerender();
-        return;
       }
 
-      const res = await fetch(projectUrl('/templates/import'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bundle: dlg.parsed, dst_tier: dlg.tier }),
-      });
+      const bodyResolutions = {
+        models: dlg.resolutions || {},
+        templates: dlg.templateResolutions || {},
+      };
+      let res;
+      if (isZip) {
+        const importUrl = `${projectUrl('/templates/import')}?dst_tier=${encodeURIComponent(tier)}`;
+        res = await fetch(importUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/zip',
+            'x-resolutions': JSON.stringify(bodyResolutions),
+          },
+          body: dlg.file,
+        });
+      } else {
+        res = await fetch(projectUrl('/templates/import'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            bundle: dlg.parsed,
+            dst_tier: tier,
+            resolutions: bodyResolutions,
+          }),
+        });
+      }
       const data = await res.json();
       if (!res.ok || !data.ok) {
         _templateActionDialog = {
@@ -2691,10 +2915,42 @@ async function _confirmTemplateActionDialog() {
         rerender();
         return;
       }
+
+      if (isZip) {
+        const overlaysByTemplate = {};
+        for (const { id, tier: t } of data.imported || []) {
+          try {
+            const oRes = await fetch(
+              projectUrl(`/templates/${t}/${id}/overlays`),
+            );
+            const oData = await oRes.json();
+            if (oData.ok && oData.overlays) {
+              overlaysByTemplate[id] = Object.keys(oData.overlays);
+            }
+          } catch {
+            /* best-effort */
+          }
+        }
+        const templates = await fetchTemplates(route.projectId || null);
+        store.setState({
+          templates,
+          defaultTemplate: templates.defaultTemplate,
+        });
+        _invalidateEditorCacheIfImported(data.imported || []);
+        _templateActionDialog = {
+          ...dlg,
+          importResult: { imported: data.imported || [], overlaysByTemplate },
+        };
+        _templateActionBusy = false;
+        rerender();
+        return;
+      }
+
       _templateActionDialog = null;
       _templateActionBusy = false;
       const templates = await fetchTemplates(route.projectId || null);
       store.setState({ templates, defaultTemplate: templates.defaultTemplate });
+      _invalidateEditorCacheIfImported(data.imported || []);
       return;
     }
 

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -8170,6 +8170,60 @@ sl-dialog.markdown-dialog::part(body) {
   color: var(--fg);
 }
 
+.template-action-dialog .dialog-collisions {
+  border-left: 3px solid var(--sl-color-warning-500, #f59e0b);
+  padding: 10px 12px;
+  background: var(--sl-color-warning-50, rgba(245, 158, 11, 0.05));
+  border-radius: 4px;
+  min-width: 0;
+}
+.template-action-dialog .dialog-collisions-header {
+  margin-bottom: 6px;
+}
+.template-action-dialog .dialog-collision-list {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.template-action-dialog .dialog-collision-row {
+  display: grid;
+  grid-template-columns: minmax(90px, 140px) minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.template-action-dialog .dialog-collision-alias {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.template-action-dialog .dialog-collision-alias code {
+  font-family: var(--sl-font-mono);
+  font-size: 13px;
+  color: var(--fg);
+}
+.template-action-dialog .collision-action-select,
+.template-action-dialog .collision-rename-input {
+  width: 100%;
+  min-width: 0;
+}
+.template-action-dialog .dialog-collision-row[data-rename="false"] .collision-action-select {
+  grid-column: 2 / span 2;
+}
+.template-action-dialog .dialog-new-aliases-hint {
+  margin-top: 8px;
+}
+.template-action-dialog .dialog-new-aliases-hint code {
+  font-family: var(--sl-font-mono);
+  font-size: 12px;
+  color: var(--fg);
+  margin-right: 4px;
+}
+
 .editor-content {
   flex: 1;
   overflow-y: auto;

--- a/worca-ui/app/views/pipelines-editor-models.test.js
+++ b/worca-ui/app/views/pipelines-editor-models.test.js
@@ -51,10 +51,13 @@ describe('pipelines-editor — project worca.models loading', () => {
     vi.restoreAllMocks();
   });
 
-  it('loads project worca.models into editorState.settings on loadTemplate', async () => {
+  it('loads effective worca.models into editorState.settings on loadTemplate', async () => {
     mockFetchByUrl({
-      // settings endpoint — checked before the template URL fragment below
-      '/settings': { worca: { models: { 'glm-ds': { id: 'opus' } } } },
+      // effective-settings endpoint layers user-global ~/.worca/settings.json
+      // over project settings.json so user-scope aliases land in the picker too
+      '/effective-settings': {
+        worca: { models: { 'glm-ds': { id: 'opus' } } },
+      },
       '/templates/project/feature-glm-ds': TEMPLATE_BODY,
     });
 
@@ -65,16 +68,16 @@ describe('pipelines-editor — project worca.models loading', () => {
     expect(st.settings.worca.models['glm-ds']).toEqual({ id: 'opus' });
   });
 
-  it('requests the project settings endpoint for the active project', async () => {
+  it('requests the effective-settings endpoint for the active project', async () => {
     mockFetchByUrl({
-      '/settings': { worca: { models: {} } },
+      '/effective-settings': { worca: { models: {} } },
       '/templates/project/feature-glm-ds': TEMPLATE_BODY,
     });
 
     await loadTemplate('project', 'feature-glm-ds', 'test-proj');
 
     const calledSettings = globalThis.fetch.mock.calls.some(([url]) =>
-      String(url).includes('/api/projects/test-proj/settings'),
+      String(url).includes('/api/projects/test-proj/effective-settings'),
     );
     expect(calledSettings).toBe(true);
   });

--- a/worca-ui/app/views/pipelines-editor.js
+++ b/worca-ui/app/views/pipelines-editor.js
@@ -636,9 +636,15 @@ export function slugifyId(name) {
  */
 async function _loadProjectSettings(projectId) {
   try {
+    // Read the EFFECTIVE settings stack (user-global → project base → project
+    // .local), not just the project's own file. Aliases registered in
+    // ~/.worca/settings.json must surface in the picker because that's what
+    // the Python runtime sees when it resolves `agents.*.model`. Without this
+    // layer the dropdown silently hides user-global aliases imported via
+    // template bundles.
     const url = projectId
-      ? `/api/projects/${projectId}/settings`
-      : '/api/settings';
+      ? `/api/projects/${projectId}/effective-settings`
+      : '/api/effective-settings';
     const res = await fetch(url);
     if (!res.ok) return;
     const data = await res.json();

--- a/worca-ui/server/paths.js
+++ b/worca-ui/server/paths.js
@@ -24,6 +24,17 @@ export function worcaHome() {
 }
 
 /**
+ * @returns {string} Absolute path to the user-global settings.json
+ * (`~/.worca/settings.json` by default, $WORCA_HOME-aware). The Python
+ * runtime reads this layer first and deep-merges project settings on top,
+ * so any UI surface that needs to mirror runtime resolution (e.g. model
+ * alias dropdowns) must layer this in.
+ */
+export function globalSettingsPath() {
+  return join(worcaHome(), 'settings.json');
+}
+
+/**
  * @param {string=} override Caller-supplied path that wins over $WORCA_HOME.
  * @returns {string} Absolute path to the fleet-runs directory.
  */

--- a/worca-ui/server/project-routes.js
+++ b/worca-ui/server/project-routes.js
@@ -29,7 +29,7 @@ import { getDefaultBranch } from './git-helpers.js';
 import { extractAndStripGlobalKeys } from './global-keys.js';
 import { LaunchLock } from './launch-lock.js';
 import { createModelEnvRouter } from './model-env-routes.js';
-import { preferencesPath } from './paths.js';
+import { globalSettingsPath, preferencesPath } from './paths.js';
 import { readPreferences } from './preferences.js';
 import { ProcessManager } from './process-manager.js';
 import { countRunningPipelinesAcrossProjects } from './process-registry.js';
@@ -45,6 +45,7 @@ import {
 import {
   deepMerge,
   localPathFor,
+  readEffectiveSettings,
   readLocalSettings,
   readMergedSettings,
 } from './settings-merge.js';
@@ -477,6 +478,28 @@ export function createProjectScopedRoutes({
     }
     try {
       const merged = readMergedSettings(settingsPath);
+      res.json({
+        worca: merged.worca || {},
+        permissions: merged.permissions || {},
+      });
+    } catch (err) {
+      res
+        .status(500)
+        .json({ error: { code: 'read_error', message: err.message } });
+    }
+  });
+
+  // GET /api/projects/:projectId/effective-settings
+  //
+  // Returns the fully-layered settings the Python runtime sees: user-global
+  // base → user-global .local → project base → project .local. Used by UI
+  // surfaces that must mirror runtime alias resolution (e.g. the per-agent
+  // model dropdown in the template editor — without this, aliases that live
+  // only in user-global ~/.worca/settings.json are invisible to projects).
+  router.get('/effective-settings', (req, res) => {
+    const { settingsPath } = req.project;
+    try {
+      const merged = readEffectiveSettings(settingsPath, globalSettingsPath());
       res.json({
         worca: merged.worca || {},
         permissions: merged.permissions || {},

--- a/worca-ui/server/settings-merge.js
+++ b/worca-ui/server/settings-merge.js
@@ -81,3 +81,48 @@ export function readLocalSettings(settingsPath) {
     return {};
   }
 }
+
+/**
+ * Read the full effective settings stack the way the Python runtime resolves
+ * it: user-global base → user-global .local → project base → project .local.
+ * Each layer deep-merges over the previous. Missing files are treated as
+ * empty objects. Used by UI surfaces (model alias dropdowns, etc.) that must
+ * mirror what `worca.utils.settings.resolve_model` sees at run time.
+ *
+ * `globalSettingsPath` is passed in so callers can substitute it during
+ * tests; production callers thread the result of `paths.globalSettingsPath()`.
+ */
+export function readEffectiveSettings(projectSettingsPath, globalSettingsPath) {
+  const layers = [];
+  if (globalSettingsPath) {
+    try {
+      layers.push(JSON.parse(readFileSync(globalSettingsPath, 'utf8')));
+    } catch {
+      /* missing or invalid — treat as empty */
+    }
+    const globalLocal = localPathFor(globalSettingsPath);
+    if (existsSync(globalLocal)) {
+      try {
+        layers.push(JSON.parse(readFileSync(globalLocal, 'utf8')));
+      } catch {
+        /* invalid — skip */
+      }
+    }
+  }
+  if (projectSettingsPath) {
+    try {
+      layers.push(JSON.parse(readFileSync(projectSettingsPath, 'utf8')));
+    } catch {
+      /* missing or invalid — treat as empty */
+    }
+    const projectLocal = localPathFor(projectSettingsPath);
+    if (existsSync(projectLocal)) {
+      try {
+        layers.push(JSON.parse(readFileSync(projectLocal, 'utf8')));
+      } catch {
+        /* invalid — skip */
+      }
+    }
+  }
+  return layers.reduce((acc, layer) => deepMerge(acc, layer), {});
+}

--- a/worca-ui/server/templates-routes.js
+++ b/worca-ui/server/templates-routes.js
@@ -378,6 +378,50 @@ function exportGist(projectRoot, id) {
   return match ? match[0] : null;
 }
 
+function _parseResolutionsHeader(req) {
+  const raw = req.headers['x-resolutions'];
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+function _writeResolutionsFile(dir, resolutions) {
+  if (!resolutions || Object.keys(resolutions).length === 0) return null;
+  const path = join(dir, 'resolutions.json');
+  writeFileSync(path, JSON.stringify(resolutions), 'utf8');
+  return path;
+}
+
+function _baseImportArgs(
+  bundlePath,
+  dstTier,
+  resolutionsPath,
+  onModelConflict,
+) {
+  const args = [
+    'import',
+    '--from',
+    bundlePath,
+    '--scope',
+    dstTier,
+    '--non-interactive',
+  ];
+  if (resolutionsPath) {
+    args.push('--resolutions', resolutionsPath);
+  }
+  if (onModelConflict) {
+    args.push('--on-model-conflict', onModelConflict);
+  }
+  return args;
+}
+
 function handleZipImport(req, res) {
   const dstTier = req.query.dst_tier;
   if (!isValidTier(dstTier)) {
@@ -389,18 +433,18 @@ function handleZipImport(req, res) {
   if (rejectBuiltinWrite(res, dstTier, 'import to')) return;
 
   const zipBuffer = req.body;
-  const tmpPath = join(
-    tmpdir(),
-    `worca-import-${Math.random().toString(36).slice(2)}.zip`,
-  );
+  const resolutions = _parseResolutionsHeader(req);
+  const onModelConflict = req.query.on_model_conflict || null;
+  const dir = mkdtempSync(join(tmpdir(), 'worca-import-'));
+  const tmpPath = join(dir, 'bundle.zip');
   try {
     writeFileSync(tmpPath, zipBuffer);
+    const resolutionsPath = _writeResolutionsFile(dir, resolutions);
     const stdout = runWorcaTemplates(
       req.project.projectRoot,
-      ['import', '--from', tmpPath, '--scope', dstTier, '--non-interactive'],
+      _baseImportArgs(tmpPath, dstTier, resolutionsPath, onModelConflict),
       { timeout: 60000 },
     );
-    // Best-effort summary: the CLI may print imported template ids to stdout
     const imported = [];
     for (const line of (stdout || '').split('\n')) {
       const m = line.match(/imported[:\s]+([a-z0-9_-]+)/i);
@@ -412,16 +456,76 @@ function handleZipImport(req, res) {
       .status(statusForCliCode(err.cliCode))
       .json({ ok: false, error: err.message, code: err.cliCode });
   } finally {
-    try {
-      rmSync(tmpPath, { force: true });
-    } catch {
-      /* ignore cleanup errors */
+    cleanupTemp(dir);
+  }
+}
+
+function handleImportPreview(req, res) {
+  const dstTier = req.query.dst_tier;
+  if (!isValidTier(dstTier)) {
+    return res.status(400).json({
+      ok: false,
+      error: `dst_tier must be one of: ${TIERS.join(', ')}`,
+    });
+  }
+  if (rejectBuiltinWrite(res, dstTier, 'import to')) return;
+
+  const ctype = req.headers['content-type'] || '';
+  const dir = mkdtempSync(join(tmpdir(), 'worca-import-preview-'));
+  try {
+    let bundlePath;
+    if (ctype.startsWith('application/zip')) {
+      bundlePath = join(dir, 'bundle.zip');
+      writeFileSync(bundlePath, req.body);
+    } else {
+      const { bundle } = req.body || {};
+      if (!bundle || typeof bundle !== 'object') {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'bundle must be a JSON object' });
+      }
+      bundlePath = join(dir, 'bundle.json');
+      writeFileSync(bundlePath, JSON.stringify(bundle), 'utf8');
     }
+    const stdout = runWorcaTemplates(
+      req.project.projectRoot,
+      [
+        'import',
+        '--from',
+        bundlePath,
+        '--scope',
+        dstTier,
+        '--non-interactive',
+        '--preview',
+      ],
+      { timeout: 30000 },
+    );
+    try {
+      const payload = JSON.parse(stdout);
+      res.json({ ok: true, ...payload });
+    } catch {
+      res.status(500).json({
+        ok: false,
+        error: 'CLI preview output was not valid JSON',
+        raw: stdout,
+      });
+    }
+  } catch (err) {
+    res
+      .status(statusForCliCode(err.cliCode))
+      .json({ ok: false, error: err.message, code: err.cliCode });
+  } finally {
+    cleanupTemp(dir);
   }
 }
 
 function handleJsonImport(req, res) {
-  const { bundle, dst_tier: dstTier } = req.body || {};
+  const {
+    bundle,
+    dst_tier: dstTier,
+    resolutions,
+    on_model_conflict: onModelConflict,
+  } = req.body || {};
   if (!bundle || typeof bundle !== 'object') {
     return res
       .status(400)
@@ -435,7 +539,10 @@ function handleJsonImport(req, res) {
   }
   if (rejectBuiltinWrite(res, dstTier, 'import to')) return;
   try {
-    const result = importBundle(req.project.projectRoot, bundle, dstTier);
+    const result = importBundle(req.project.projectRoot, bundle, dstTier, {
+      resolutions,
+      onModelConflict,
+    });
     res.json({ ok: true, ...result });
   } catch (err) {
     res
@@ -444,17 +551,19 @@ function handleJsonImport(req, res) {
   }
 }
 
-function importBundle(projectRoot, bundle, tier) {
+function importBundle(projectRoot, bundle, tier, opts = {}) {
   if (!bundle || !Array.isArray(bundle.templates)) {
     throw new Error('Bundle must contain a "templates" array');
   }
+  const { resolutions, onModelConflict } = opts;
   const dir = mkdtempSync(join(tmpdir(), 'worca-import-'));
   const bundlePath = join(dir, 'bundle.json');
   try {
     writeFileSync(bundlePath, JSON.stringify(bundle), 'utf8');
+    const resolutionsPath = _writeResolutionsFile(dir, resolutions);
     runWorcaTemplates(
       projectRoot,
-      ['import', '--from', bundlePath, '--scope', tier, '--non-interactive'],
+      _baseImportArgs(bundlePath, tier, resolutionsPath, onModelConflict),
       { timeout: 60000 },
     );
     const targetDir = dirForTier(projectRoot, tier);
@@ -591,6 +700,12 @@ export function createTemplatesRoutes() {
       }
       return handleJsonImport(req, res);
     },
+  );
+
+  router.post(
+    '/templates/import/preview',
+    expressRaw({ type: 'application/zip', limit: '1mb' }),
+    (req, res) => handleImportPreview(req, res),
   );
 
   /**


### PR DESCRIPTION
## Summary

- Standalone export now bundles `worca.models` aliases + pricing in a new `models.json` zip member (v3 layout). Fixes the silent drop where overlay-bearing templates produced bundles that didn't carry the custom model alias they referenced.
- Two-phase import: preview (`GET /templates/import/preview`) surfaces every collision before any write; commit honors per-row resolutions.
- Two collision dimensions resolved independently in the UI dialog:
  - **Template ids** → skip / replace (`--on-template-conflict`, default `abort`)
  - **Model aliases** → skip / overwrite / rename (`--on-model-conflict`, default `abort`). Rename uses zero-padded `-NN` suffix and transactionally rewrites every `config.agents.*.model` reference.
- Model aliases always land in user-global `~/.worca/settings.json` regardless of `--scope` — keeps committed `settings.json` free of per-developer env scaffolds and secret placeholders.
- New `/api/projects/:projectId/effective-settings` endpoint layers `userGlobal → userLocal → project → projectLocal` the way Python's `resolve_model` does, so the per-agent Model dropdown surfaces user-global aliases across every template.
- Editor cache is invalidated after import for any tid that was just imported — no more stale view requiring a manual refresh.
- Docs site updated (no screenshots): `docs-site/src/content/docs/advanced/authoring-templates.md` and `configuration/pipeline-templates.md` describe the v3 layout, the preview/commit flow, the per-row UX, and the new CLI flags.

## Test plan

- [x] Python tests green — `tests/test_bundle.py` (v3 roundtrip + validation) and `tests/test_cli_templates.py` (collision matrix, rename probing, structured resolutions, preview content)
- [x] Worca-ui vitest green (5016 tests including updated `pipelines-editor-models.test.js` for the new effective-settings endpoint)
- [x] Ruff + biome clean
- [x] Playwright e2e walkthrough: export from test-multi-01 → import into test-multi-02 → re-import triggers both template + model collision dialog → Apply rewrites template refs and lands the renamed alias
- [x] Editor picker on a second template in the same project now lists user-global aliases without a refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)