### PR TITLE
fix(ui): show all known model aliases in per-agent dropdown

### DIFF
--- a/worca-ui/app/views/pipelines-editor-models.test.js
+++ b/worca-ui/app/views/pipelines-editor-models.test.js
@@ -82,6 +82,44 @@ describe('pipelines-editor — project worca.models loading', () => {
     expect(calledSettings).toBe(true);
   });
 
+  it('populates modelTierMap with all tiers so the dropdown surfaces built-in/user aliases too', async () => {
+    // Repro of: editing a project template whose project only defines
+    // `glm-ds` showed just `glm-ds` (project) + whatever aliases the
+    // template already referenced. Built-in aliases (`opus`, `haiku`)
+    // were missing because the dropdown read only `worca.models`.
+    // Fix: union `Object.keys(editorState.modelTierMap)` into options.
+    // This test pins the tier-map populate path; the union itself is
+    // exercised live via the rendered editor.
+    mockFetchByUrl({
+      '/effective-settings': {
+        worca: { models: { 'glm-ds': { id: 'opus' } } },
+      },
+      '/templates/project/feature-glm-ds': TEMPLATE_BODY,
+      '/projects/test-proj/models': {
+        ok: true,
+        models: [
+          { alias: 'glm-ds', tier: 'project' },
+          { alias: 'opus', tier: 'builtin' },
+          { alias: 'sonnet', tier: 'builtin' },
+          { alias: 'haiku', tier: 'builtin' },
+        ],
+      },
+    });
+
+    await loadTemplate('project', 'feature-glm-ds', 'test-proj');
+
+    const st = getEditorState();
+    // All four aliases reachable for the dropdown union.
+    expect(Object.keys(st.modelTierMap).sort()).toEqual([
+      'glm-ds',
+      'haiku',
+      'opus',
+      'sonnet',
+    ]);
+    expect(st.modelTierMap['glm-ds']).toBe('project');
+    expect(st.modelTierMap.opus).toBe('builtin');
+  });
+
   it('falls back to empty settings when the settings fetch fails', async () => {
     globalThis.fetch = vi.fn((url) => {
       if (String(url).includes('/settings')) {

--- a/worca-ui/app/views/pipelines-editor.js
+++ b/worca-ui/app/views/pipelines-editor.js
@@ -1684,14 +1684,25 @@ function _agentsTab(formBuffer, settings, projectId, rerender) {
   const referencedModels = Object.values(agents)
     .map((a) => a?.model)
     .filter((m) => typeof m === 'string' && m.length > 0);
+  const tierMap = editorState.modelTierMap || {};
+  // `getModelOptions(settings?.worca)` reads only the project's
+  // `worca.models` (so for a project that defined just `glm-ds`, that's
+  // the lone PROJECT option). The full per-tier inventory was already
+  // fetched into `modelTierMap` from /api/projects/:id/models — union
+  // its keys too so built-in and user-tier aliases populate the dropdown
+  // (PROJECT shadowing semantics still hold via `groupModelOptionsByTier`
+  // since `tierMap` records the highest-priority tier per alias).
   const modelOptions = Array.from(
-    new Set([...getModelOptions(settings?.worca), ...referencedModels]),
+    new Set([
+      ...getModelOptions(settings?.worca),
+      ...Object.keys(tierMap),
+      ...referencedModels,
+    ]),
   );
   const effort = formBuffer?.effort || {};
   const autoMode = effort.auto_mode || 'adaptive';
   const autoCap = effort.auto_cap || 'xhigh';
   const state = editorState;
-  const tierMap = editorState.modelTierMap || {};
   // Group the per-agent Model dropdown options by tier, mirroring the
   // "Base template" picker on the New Pipeline / template-create dialog
   // (small group label + sl-divider + indented options). Keeps the


### PR DESCRIPTION
## Summary

- Per-agent **Model** dropdown in the Pipelines editor only listed aliases from the project's own `worca.models` + whatever the template currently referenced — built-in and user-tier aliases that the project didn't shadow (`opus`, `haiku`) silently disappeared.
- Cause: `_agentsTab` built `modelOptions` from `getModelOptions(settings?.worca)` + `referencedModels` only. The full per-tier inventory was already fetched into `editorState.modelTierMap` (used for tagging each option with its tier), but never folded back into the option set.
- Fix: union `Object.keys(tierMap)` into `modelOptions`. PROJECT-shadows-USER-shadows-BUILT-IN semantics still hold via `groupModelOptionsByTier`, which reads from `tierMap` (which records the highest-priority tier per alias).

Repro at `http://localhost:3400/#/project/test-multi-03/templates/project/feature-glm-ds/edit`: Planner dropdown shows just `glm-ds` (PROJECT) + `sonnet` (BUILT-IN, because the template still referenced it). After the fix: `glm-ds` + `opus` + `sonnet` + `haiku`.

## Test plan

- [x] `cd worca-ui && npx vitest run app/views/pipelines-editor` — 69/69 pass including new regression case
- [x] `cd worca-ui && npm run build && npm run lint`
- [ ] Manual: reload `/project/test-multi-03/templates/project/feature-glm-ds/edit`; confirm the Planner Model dropdown surfaces all built-ins (`opus`, `sonnet`, `haiku`) under the **BUILT-IN** group alongside `glm-ds` under **PROJECT**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
