### PR TITLE
feat(ui): edit claude_md_mode in template editor

### DIFF
--- a/worca-ui/app/views/new-run.js
+++ b/worca-ui/app/views/new-run.js
@@ -152,23 +152,28 @@ export function resolveEffectiveClaudeMdMode() {
 }
 
 /**
- * lit-html ref callback for the Max Beads <sl-select>.
+ * lit-html ref callback for an <sl-select> whose "Template Default: <X>"
+ * option carries a dynamic value.
  *
  * Shoelace's sl-select derives `displayLabel` from `selectedOption.getTextLabel()`
  * inside selectionChanged(), which only fires on value/multiple changes — NOT
  * when the selected option's textContent changes underneath. Our first option
- * ("Template Default: <X>") embeds a dynamic value that shifts on template
- * switch, so attach a MutationObserver to force a re-derive whenever any
- * descendant sl-option's text content changes.
+ * embeds a dynamic value that shifts on template switch, so attach a
+ * MutationObserver to force a re-derive whenever any descendant sl-option's
+ * text content changes.
  *
  * lit-html refs fire only on mount/unmount, not per render, so setting up the
  * observer here is a once-per-instance cost. The trailing microtask refresh
  * covers the initial mount, after which the observer drives subsequent updates.
+ *
+ * Reused for any sl-select with a dynamic first-option label (Max Beads,
+ * CLAUDE.md mode). The per-element guard is keyed on the DOM node so each
+ * instance gets its own observer.
  */
 function _refreshSlSelectDisplay(el) {
   if (!el) return;
-  if (el.__maxBeadsObserverAttached) return;
-  el.__maxBeadsObserverAttached = true;
+  if (el.__dynamicLabelObserverAttached) return;
+  el.__dynamicLabelObserverAttached = true;
   const refresh = () => {
     if (typeof el.selectionChanged === 'function') {
       el.selectionChanged();
@@ -956,7 +961,7 @@ export function newRunView(_state, { rerender }) {
 
             <div class="settings-field">
               <label class="settings-label">CLAUDE.md Mode</label>
-              <sl-select id="new-run-claude-md-mode" value=${claudeMdMode === null ? '' : claudeMdMode} @sl-change=${handleClaudeMdModeChange}>
+              <sl-select id="new-run-claude-md-mode" ${ref(_refreshSlSelectDisplay)} value=${claudeMdMode === null ? '' : claudeMdMode} @sl-change=${handleClaudeMdModeChange}>
                 ${(() => {
                   const effective = resolveEffectiveClaudeMdMode();
                   return html`<sl-option value="">Template Default: ${effective}</sl-option>`;
@@ -968,10 +973,15 @@ export function newRunView(_state, { rerender }) {
               </sl-select>
               ${(() => {
                 const mode = claudeMdMode;
-                if (mode === 'project' || mode === 'project+local') {
-                  return html`<span class="settings-field-hint">CLAUDE.md loading mode. <sl-tag size="small" variant="neutral">best-effort</sl-tag> — project-scoped CLAUDE.md discovery may not find all files in complex repo layouts.</span>`;
+                const effective = resolveEffectiveClaudeMdMode();
+                const bestEffortTag = html`<sl-tag size="small" variant="neutral">best-effort</sl-tag>`;
+                if (mode === null) {
+                  return html`<span class="settings-field-hint">Using Template Default (${effective}). Picking an Explicit option overrides this.</span>`;
                 }
-                return html`<span class="settings-field-hint">Controls which CLAUDE.md files agents load. "all" = default Claude Code behavior.</span>`;
+                if (mode === 'project' || mode === 'project+local') {
+                  return html`<span class="settings-field-hint">Explicit: ${mode} — overrides the template default. ${bestEffortTag} — project-scoped CLAUDE.md discovery may not find all files in complex repo layouts.</span>`;
+                }
+                return html`<span class="settings-field-hint">Explicit: ${mode} — overrides the template default.</span>`;
               })()}
             </div>
 

--- a/worca-ui/app/views/pipelines-editor-roundtrip.test.js
+++ b/worca-ui/app/views/pipelines-editor-roundtrip.test.js
@@ -457,3 +457,44 @@ describe('buildFormBuffer / formBufferToConfig — coordinator max_beads', () =>
     expect(out.agents.coordinator).not.toHaveProperty('max_beads');
   });
 });
+
+// --- claude_md_mode: cross-template but template may pin it ---
+
+describe('buildFormBuffer / formBufferToConfig — claude_md_mode', () => {
+  it('seeds form.claude_md_mode from config when template pins it', () => {
+    const config = { claude_md_mode: 'project' };
+    const form = buildFormBuffer(config, { worca: {} });
+    expect(form.claude_md_mode).toBe('project');
+  });
+
+  it('seeds empty string when config does not set claude_md_mode', () => {
+    const form = buildFormBuffer({}, { worca: {} });
+    expect(form.claude_md_mode).toBe('');
+  });
+
+  it('round-trips an explicit mode without loss', () => {
+    for (const mode of ['all', 'project', 'project+local', 'none']) {
+      const form = buildFormBuffer({ claude_md_mode: mode }, { worca: {} });
+      const out = formBufferToConfig(form);
+      expect(out.claude_md_mode).toBe(mode);
+    }
+  });
+
+  it('omits claude_md_mode from output when form buffer is empty string', () => {
+    const form = buildFormBuffer({}, { worca: {} });
+    const out = formBufferToConfig(form);
+    expect(out).not.toHaveProperty('claude_md_mode');
+  });
+
+  it('clearing a previously-set mode (form="") removes the key on save', () => {
+    const form = buildFormBuffer({ claude_md_mode: 'none' }, { worca: {} });
+    form.claude_md_mode = ''; // user picked "Not set"
+    const out = formBufferToConfig(form);
+    expect(out).not.toHaveProperty('claude_md_mode');
+  });
+
+  it('ignores non-string config.claude_md_mode (defensive)', () => {
+    const form = buildFormBuffer({ claude_md_mode: 42 }, { worca: {} });
+    expect(form.claude_md_mode).toBe('');
+  });
+});

--- a/worca-ui/app/views/pipelines-editor.js
+++ b/worca-ui/app/views/pipelines-editor.js
@@ -309,6 +309,13 @@ export function buildFormBuffer(templateConfig, settings) {
     ...(config.milestones || {}),
   };
 
+  // CLAUDE.md load mode — cross-template (NOT in TEMPLATE_OWNED_KEYS)
+  // but templates may still override it via deep-merge. Empty string
+  // = "not set" sentinel; the editor will omit the key on save so
+  // the project-level setting (or runtime default) applies.
+  form.claude_md_mode =
+    typeof config.claude_md_mode === 'string' ? config.claude_md_mode : '';
+
   return form;
 }
 
@@ -526,6 +533,16 @@ export function formBufferToConfig(formBuffer) {
   // legacy project-Settings value that might still be on disk.
   if (formBuffer.milestones) {
     config.milestones = { ...formBuffer.milestones };
+  }
+
+  // CLAUDE.md load mode — omit when "not set" so the project-level
+  // worca.claude_md_mode (or runtime default 'all') applies. Only
+  // persist when the user explicitly chose a mode.
+  if (
+    typeof formBuffer.claude_md_mode === 'string' &&
+    formBuffer.claude_md_mode !== ''
+  ) {
+    config.claude_md_mode = formBuffer.claude_md_mode;
   }
 
   return config;
@@ -1494,6 +1511,7 @@ export function pipelinesEditorView(state, options) {
             <div class="editor-pipeline-tab">
               ${_stagesSection(formBuffer, projectId, rerender)}
               ${_milestonesSection(formBuffer, projectId, rerender)}
+              ${_claudeMdModeSection(formBuffer, projectId, rerender)}
               ${_loopsSection(formBuffer, projectId, rerender)}
               ${_circuitBreakerSection(formBuffer, projectId, rerender)}
             </div>
@@ -2085,6 +2103,72 @@ function _milestonesSection(formBuffer, projectId, rerender) {
             default to avoid hanging unattended runs.</span
           >
         </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * CLAUDE.md load mode — top-level cross-template setting. Templates
+ * may still pin a mode via deep-merge override; "not set" means the
+ * project-level worca.claude_md_mode (or runtime default 'all') wins.
+ */
+function _claudeMdModeSection(formBuffer, projectId, rerender) {
+  const state = editorState;
+  const mode = formBuffer?.claude_md_mode ?? '';
+  const isProjectScoped = mode === 'project' || mode === 'project+local';
+  return html`
+    <div class="settings-tab-content">
+      <h3 class="settings-section-title">CLAUDE.md load mode</h3>
+      <p class="settings-section-desc">
+        Pins which CLAUDE.md files Claude Code loads for every agent
+        in this template. Leave unset to inherit the project-level
+        setting (or the runtime default <code>all</code>). Templates
+        explicitly set this when they need a hermetic run (e.g. CI)
+        or to disable auto-memory writes.
+      </p>
+      <div class="settings-field">
+        <label class="settings-label" for="claude-md-mode-select"
+          >Mode</label
+        >
+        <sl-select
+          id="claude-md-mode-select"
+          .value=${mode}
+          size="small"
+          hoist
+          @sl-change=${(e) => {
+            editorState.formBuffer.claude_md_mode = e.target.value || '';
+            rerender();
+          }}
+          @sl-blur=${() => {
+            validateConfigDebounced(
+              projectId,
+              editorState.formBuffer,
+              state.viewMode,
+              rerender,
+            );
+          }}
+        >
+          <sl-option value="">Not set (inherit project)</sl-option>
+          <sl-option value="all">all — default Claude Code behavior</sl-option>
+          <sl-option value="project">project — project root only</sl-option>
+          <sl-option value="project+local"
+            >project+local — project + CLAUDE.local.md</sl-option
+          >
+          <sl-option value="none">none — disable CLAUDE.md loading</sl-option>
+        </sl-select>
+        <span class="settings-field-hint">
+          ${
+            isProjectScoped
+              ? html`Project-scoped modes are
+                  <sl-tag size="small" variant="neutral">best-effort</sl-tag>
+                  — discovery may not exclude every ancestor CLAUDE.md in
+                  complex repo layouts.`
+              : mode === 'none'
+                ? html`Also disables Claude Code auto-memory writes.`
+                : 'Empty = use project setting; explicit = template overrides project.'
+          }
+        </span>
       </div>
     </div>
   `;


### PR DESCRIPTION
## Summary

Follow-up to #314. That PR added per-run / CLI / template-config support for `claude_md_mode` but the **template editor UI** had no field for it — you had to hand-edit JSON. This PR adds the editor field and fixes two small UX issues on the new-run dropdown.

## What changed

- **Template editor** (`pipelines-editor.js`) — New "CLAUDE.md load mode" section in the Pipeline tab, between Approval Gates and Loops. `sl-select` with Not set (inherit project) / all / project / project+local / none. Round-trip:
  - `buildFormBuffer` seeds `form.claude_md_mode` from `config.claude_md_mode` (empty string = "Not set").
  - `formBufferToConfig` omits the key when "Not set" so the project-level `worca.claude_md_mode` (or runtime default `all`) wins; writes the value when set so the template overrides via deep-merge.
  - Best-effort tag on `project` / `project+local`; auto-memory-write caveat on `none`. Mirrors the language already used on the new-run dropdown.
- **New-run hint parity** (`new-run.js`) — The new-run CLAUDE.md Mode dropdown's hint now mirrors Max Beads:
  - Passthrough: _"Using Template Default (X). Picking an Explicit option overrides this."_
  - Explicit: _"Explicit: <mode> — overrides the template default."_ (with best-effort tag retained on project / project+local).
- **Shoelace label-refresh fix** (`new-run.js`) — The collapsed sl-select label was stale after switching templates: the option text `Template Default: <X>` was mutating but the cached `displayLabel` wasn't being re-derived. Reused the existing `_refreshSlSelectDisplay` MutationObserver helper (previously bespoke to Max Beads). Renamed the per-element guard flag from `__maxBeadsObserverAttached` to `__dynamicLabelObserverAttached` now that the helper is genuinely shared.

## Why this design

`claude_md_mode` is intentionally **NOT** in `TEMPLATE_OWNED_KEYS` (PR #314 design note) — it's a cross-template project setting that flows through like `worca.models`. A template can still pin it via deep-merge override. The editor surfaces that override path without changing the precedence chain: **CLI > template > project > `all`** is unchanged.

## Test plan

- [x] `pipelines-editor-roundtrip.test.js` — 6 new tests: seed from config, default to empty, round-trip all 4 modes, omit when empty, clearing removes the key, defensive non-string ignore. **Full UI vitest suite: 5034/5034 passing locally.**
- [x] `npm run build` succeeds; bundle reflects new code.
- [ ] Manual: open a template, set CLAUDE.md mode = project+local, save, start a new run on that template — the launcher dropdown's first option reads `Template Default: project+local` (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)