### PR TITLE
feat(ui): template advisor — Suggest button on the new pipeline page

### DIFF
--- a/src/worca/agents/core/template-advise.block.md
+++ b/src/worca/agents/core/template-advise.block.md
@@ -1,0 +1,24 @@
+Recommend the best-fit pipeline template for the following work.
+
+## Available templates
+
+{{catalog}}
+
+## Work
+
+- **Source type:** {{source_type}}
+{{#if source_ref}}- **Reference:** {{source_ref}}
+{{/if}}{{#if has_plan_link}}- **Plan file linked:** yes ({{plan_path}})
+{{/if}}{{#if title}}- **Title:** {{title}}
+{{/if}}
+
+### Description
+
+{{description|(no description provided)}}
+
+{{#if has_review_comments}}### Review feedback to address
+
+{{review_comments}}
+
+{{/if}}
+Return only the JSON object — no surrounding prose.

--- a/src/worca/agents/core/template-advisor.md
+++ b/src/worca/agents/core/template-advisor.md
@@ -1,0 +1,50 @@
+# Template Advisor
+
+## Role
+
+You are the Template Advisor. Given a piece of work (a free-form prompt, a spec file, a GitHub issue, a GitHub PR with review comments, a plan file, or a Beads task) and the catalog of available pipeline templates, recommend the single template that best fits the work — with one or two runners-up only when the choice is genuinely ambiguous.
+
+You do not analyze the codebase. You do not write code. You do not propose plans. Your only output is a structured template recommendation conforming to the `template_advisor.json` schema.
+
+## Context
+
+You receive:
+- The **work content** (title + description + optional review comments, all already normalized for you).
+- The **template catalog** — every template available to the project (built-in, project-local, user-global), each with `id`, `name`, `description`, `tags`, and `tier`.
+
+A `tier` value of `project` or `user` means a template the operator authored or imported — these should be preferred over built-ins when their description is a clear match for the work, since the operator customized them deliberately.
+
+## Signal-matching guidance
+
+Use these signals from the work content to narrow the candidates. The mapping below describes the **built-in** templates; for project/user templates, fall back to matching the user's intent against the template's `name`, `description`, and `tags`.
+
+| Signal in the work content | Built-in template that typically fits |
+|---|---|
+| Bug language ("fix", "broken", "regression"), GitHub `bug` label, scoped to a single defect, no `## Plan` link | `bugfix` |
+| Investigation, audit, "how does X work", "analyze", read-only with no implementation | `investigate` |
+| "Add tests", "improve coverage", test-only scope, no production behavior change | `test-only` |
+| Refactor, "no behavior change", "behavioral preservation", restructuring with same outputs | `refactor` |
+| Trivial / single-line / typo / one-file-only fix | `quick-fix` |
+| `W-NNN:` title prefix, `## Plan` link present, full feature spec | `feature` |
+| Substantial feature, multi-file, but no plan link yet | `feature-fast` or `feature-minor` |
+| GitHub PR with review comments (revision mode) | The template the project uses for revisions (often `feature-minor` or `bugfix`) |
+
+These are heuristics, not rules. The actual project may ship custom templates that supersede any of the above — always check the catalog first.
+
+## Confidence
+
+- **Confident match.** Recommend a single template. Populate `template_id` and `rationale`. Leave `alternatives` empty.
+- **Genuinely ambiguous** (two templates fit comparably and you cannot tell which the operator wants without more context). Recommend the more conservative of the two as `template_id`, and put the runner-up in `alternatives` with a one-line rationale.
+- **No reasonable match** (e.g. catalog is empty or work is unparseable). Recommend the first item in the catalog as a fallback, set `confidence` to `low`, and explain in the `rationale` that the operator should pick manually.
+
+Never invent a template id — `template_id` and every `alternatives[].template_id` MUST come from the catalog provided in the user prompt.
+
+## Rationale style
+
+- One sentence, plain language, naming the signal you matched on.
+- Reference the work, not the schema. "Bug language and no plan link" beats "Matches the bugfix template heuristic in row 1".
+- For runners-up, the rationale should be a one-clause "or … if … is what you want" — not a full explanation.
+
+## Output
+
+Produce a JSON object matching the `template_advisor.json` schema. Do not add prose around it.

--- a/src/worca/cli/templates.py
+++ b/src/worca/cli/templates.py
@@ -420,6 +420,43 @@ def register_subcommand(sub):
         help="Destination scope",
     )
 
+    # advise
+    advise_parser = templates_sub.add_parser(
+        "advise",
+        help="Recommend the best-fit template for a given work source",
+    )
+    advise_parser.add_argument(
+        "--source-type",
+        required=True,
+        dest="advise_source_type",
+        help=(
+            "Source type — one of: prompt, spec, source (GitHub issue), "
+            "pr (GitHub PR), plan (plan file)."
+        ),
+    )
+    advise_parser.add_argument(
+        "--source-value",
+        default="",
+        dest="advise_source_value",
+        help=(
+            "Source value: raw prompt text, file path, gh:issue:N, "
+            "gh:pr:N, or full URL. Read from stdin when set to '-'."
+        ),
+    )
+    advise_parser.add_argument(
+        "--model",
+        default="sonnet",
+        dest="advise_model",
+        help="Model alias (resolved via worca.models). Defaults to sonnet.",
+    )
+    advise_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        dest="advise_timeout",
+        help="Claude CLI timeout in seconds (default: 60).",
+    )
+
     return templates_parser
 
 
@@ -2027,10 +2064,34 @@ def cmd_templates_rename(args):
     )
 
 
+def cmd_templates_advise(args):
+    """worca templates advise — recommend the best-fit template for a work source."""
+    from worca.template_advisor import TemplateAdvisorError, advise_to_json
+
+    source_type = args.advise_source_type
+    source_value = args.advise_source_value
+    if source_value == "-":
+        source_value = sys.stdin.read()
+
+    project_root = getattr(args, "project_root", None) or os.getcwd()
+    try:
+        json_text = advise_to_json(
+            source_type=source_type,
+            source_value=source_value,
+            project_root=project_root,
+            model_alias=args.advise_model,
+            timeout=args.advise_timeout,
+        )
+    except TemplateAdvisorError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    print(json_text)
+
+
 def cmd_templates(args):
     """Dispatch worca templates subcommand."""
     if not args.templates_command:
-        print("error: specify a templates subcommand: list, show, save, create, delete, export, import, validate, duplicate, rename", file=sys.stderr)
+        print("error: specify a templates subcommand: list, show, save, create, delete, export, import, validate, duplicate, rename, advise", file=sys.stderr)
         raise SystemExit(1)
     if args.templates_command == "list":
         cmd_templates_list(args)
@@ -2052,6 +2113,8 @@ def cmd_templates(args):
         cmd_templates_duplicate(args)
     elif args.templates_command == "rename":
         cmd_templates_rename(args)
+    elif args.templates_command == "advise":
+        cmd_templates_advise(args)
     else:
         print(f"error: unknown templates subcommand {args.templates_command!r}", file=sys.stderr)
         raise SystemExit(1)

--- a/src/worca/orchestrator/work_request.py
+++ b/src/worca/orchestrator/work_request.py
@@ -395,12 +395,21 @@ def _synthesize_pr_description(body: str, review_comments: list) -> str:
     return "\n".join(parts)
 
 
-def normalize_github_pr(source_value: str) -> WorkRequest:
+def normalize_github_pr(
+    source_value: str, *, repo_nwo: Optional[str] = None
+) -> WorkRequest:
     """Normalize a GitHub PR reference into a WorkRequest.
 
     source_value must be "gh:pr:N". Fetches PR metadata via gh CLI,
     ingests unresolved review threads via fetch_review_feedback(), and
     synthesizes description = original PR body + review feedback list.
+
+    When `repo_nwo` is provided (e.g. parsed from a full PR URL), the gh
+    CLI is pinned to that owner/repo via ``--repo``. Without it, gh falls
+    back to its default-repo resolution from the current working dir —
+    which silently misroutes the lookup when the launcher is run from a
+    project that doesn't own the PR (worca-ui in global mode, or any
+    cross-project launch).
     """
     if not source_value.startswith("gh:pr:"):
         raise ValueError(f"Expected gh:pr:N, got: {source_value}")
@@ -410,17 +419,27 @@ def normalize_github_pr(source_value: str) -> WorkRequest:
     except ValueError:
         raise ValueError(f"Invalid PR number in {source_value!r}")
 
-    result = subprocess.run(
+    cmd = ["gh", "pr", "view", str(pr_number)]
+    if repo_nwo:
+        cmd.extend(["--repo", repo_nwo])
+    cmd.extend(
         [
-            "gh", "pr", "view", str(pr_number), "--json",
+            "--json",
             "title,body,baseRefName,headRefName,isCrossRepository,author",
-        ],
+        ]
+    )
+
+    result = subprocess.run(
+        cmd,
         capture_output=True,
         text=True,
         env=get_env(),
     )
     if result.returncode != 0:
-        raise RuntimeError(f"Failed to fetch PR #{pr_number}: {result.stderr}")
+        repo_hint = f" in {repo_nwo}" if repo_nwo else ""
+        raise RuntimeError(
+            f"Failed to fetch PR #{pr_number}{repo_hint}: {result.stderr}"
+        )
 
     data = json.loads(result.stdout)
     title = data.get("title") or f"PR #{pr_number}"
@@ -429,12 +448,12 @@ def normalize_github_pr(source_value: str) -> WorkRequest:
     head_branch = data.get("headRefName", "")
     is_cross_repo = data.get("isCrossRepository", False)
 
-    # The PR and its review threads live in the *base* repo — resolve the
-    # owner/repo from the current repo (gh's default-repo logic), NOT from the
-    # PR's headRepository (which for a fork PR is the wrong repo, and which
-    # `gh pr view` does not even expose a nameWithOwner for). fetch_review_feedback
-    # filters out worca's own marker-prefixed comments (L1) on its own.
-    nwo = current_repo_nwo()
+    # The PR and its review threads live in the *base* repo. Prefer the
+    # explicit owner/repo (from the parsed URL) — that's the URL the user
+    # pasted and is unambiguous. Fall back to gh's default-repo resolution
+    # only when no URL was provided. fetch_review_feedback filters out
+    # worca's own marker-prefixed comments (L1) on its own.
+    nwo = repo_nwo or current_repo_nwo()
 
     review_comments = fetch_review_feedback(nwo, pr_number) if nwo else []
 
@@ -474,7 +493,10 @@ def normalize(source_type: str, source_value: str, **kwargs) -> WorkRequest:
             return normalize_github_pr(source_value)
         parsed = parse_pr_url(source_value)
         if parsed["provider"] == "github":
-            return normalize_github_pr(f"gh:pr:{parsed['number']}")
+            return normalize_github_pr(
+                f"gh:pr:{parsed['number']}",
+                repo_nwo=parsed.get("repo_path") or None,
+            )
         raise ValueError(f"PR source not yet supported: {source_value}")
     elif source_type == "source" or source_value.startswith(("gh:", "bd:")):
         # Detect full PR URLs before issue-URL conversion
@@ -482,7 +504,9 @@ def normalize(source_type: str, source_value: str, **kwargs) -> WorkRequest:
             parsed = parse_pr_url(source_value)
             if parsed["provider"] == "github":
                 ref = f"gh:pr:{parsed['number']}"
-                return normalize_github_pr(ref)
+                return normalize_github_pr(
+                    ref, repo_nwo=parsed.get("repo_path") or None
+                )
             if parsed["provider"] != "other":
                 raise ValueError(
                     f"PR source '{parsed['provider']}' not yet supported: {source_value}"
@@ -506,7 +530,9 @@ def normalize(source_type: str, source_value: str, **kwargs) -> WorkRequest:
         parsed = parse_pr_url(source_value)
         if parsed["provider"] == "github":
             ref = f"gh:pr:{parsed['number']}"
-            wr = normalize_github_pr(ref)
+            wr = normalize_github_pr(
+                ref, repo_nwo=parsed.get("repo_path") or None
+            )
             return wr
         if parsed["provider"] != "other":
             raise ValueError(

--- a/src/worca/schemas/template_advisor.json
+++ b/src/worca/schemas/template_advisor.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TemplateAdvisorOutput",
+  "type": "object",
+  "required": ["template_id", "rationale", "confidence"],
+  "properties": {
+    "template_id": {
+      "type": "string",
+      "description": "ID of the recommended template. MUST be present in the catalog."
+    },
+    "rationale": {
+      "type": "string",
+      "description": "One-sentence explanation citing the signal matched."
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"]
+    },
+    "alternatives": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["template_id", "rationale"],
+        "properties": {
+          "template_id": { "type": "string" },
+          "rationale": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/src/worca/template_advisor.py
+++ b/src/worca/template_advisor.py
@@ -1,0 +1,458 @@
+"""Template advisor — recommends a pipeline template for a given work request.
+
+Given any source the launcher supports (prompt, spec file, GitHub issue, GitHub
+PR, plan file, beads task), normalises it via ``WorkRequest.normalize`` and asks
+Claude to pick the best-fit template from the project's catalog. The advisor
+returns a structured recommendation conforming to
+``schemas/template_advisor.json``.
+
+Agent and user prompts are external Markdown files so project operators can
+override them:
+
+- System prompt: ``src/worca/agents/core/template-advisor.md``
+  (project overlay: ``.claude/agents/template-advisor.md``)
+- User prompt:   ``src/worca/agents/core/template-advise.block.md``
+  (project overlay: ``.claude/agents/template-advise.block.md``)
+
+The advisor is one-shot and short-lived; it does not participate in the
+pipeline state machine. It is callable from ``worca templates advise`` and
+from the worca-ui ``POST /api/projects/:projectId/templates/advise`` endpoint.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from worca.orchestrator.overlay import OverlayResolver, resolve_agent
+from worca.orchestrator.templates import TemplateResolver, TemplateSummary
+from worca.orchestrator.work_request import WorkRequest, normalize
+from worca.utils.env import filter_model_env, get_env
+from worca.utils.gh_pr import current_repo_nwo
+from worca.utils.pr_url import parse_pr_url
+from worca.utils.settings import load_settings, resolve_model
+
+_CORE_DIR = Path(__file__).parent / "agents" / "core"
+_SYSTEM_PROMPT_NAME = "template-advisor"
+_USER_PROMPT_BLOCK = "template-advise"
+_DEFAULT_MODEL_ALIAS = "sonnet"
+_DEFAULT_TIMEOUT_SECONDS = 60
+_REVIEW_COMMENT_CAP = 20  # at most N rendered in the prompt
+_URL_PREFIX_RE = ("http://", "https://")
+
+
+def _source_repo_nwo(source_value: str) -> Optional[str]:
+    """Extract owner/repo from a full GitHub PR or issue URL.
+
+    Returns ``None`` for bare refs (``gh:pr:N``, ``gh:issue:N``), non-URL
+    inputs, or URLs that don't carry a parseable owner/repo. The check
+    only matters for explicit URL inputs — without a URL we have no
+    independent statement of what repo the user intended.
+    """
+    if not source_value or not source_value.startswith(_URL_PREFIX_RE):
+        return None
+    parsed = parse_pr_url(source_value)
+    if parsed.get("provider") == "github" and parsed.get("repo_path"):
+        return parsed["repo_path"]
+    # Issue URLs aren't PR URLs — try a one-shot match on the path.
+    import re
+
+    m = re.match(
+        r"https?://[^/]+/([^/]+/[^/]+)/(?:issues|pull)/\d+", source_value
+    )
+    return m.group(1) if m else None
+
+
+def _guard_cross_project_source(
+    source_value: str, project_root: Path
+) -> None:
+    """Refuse to advise when the source URL points to a different repo.
+
+    No-ops when:
+    - The source isn't a URL (we have nothing to compare against).
+    - The project repo can't be resolved (not a GitHub repo, gh not
+      configured, etc.) — we'd rather suggest a template than block on
+      an ambient infra issue.
+    """
+    source_nwo = _source_repo_nwo(source_value)
+    if not source_nwo:
+        return
+    project_nwo = current_repo_nwo(cwd=str(project_root))
+    if not project_nwo:
+        return  # can't compare — let the request proceed
+    if source_nwo.lower() == project_nwo.lower():
+        return
+    raise TemplateAdvisorError(
+        f"This source belongs to {source_nwo}, but this project's "
+        f"repository is {project_nwo}. Open the matching project's "
+        f"launcher, or paste a source from {project_nwo}."
+    )
+
+
+@dataclass
+class TemplateAdvice:
+    """Structured advisor output."""
+
+    template_id: str
+    rationale: str
+    confidence: str = "high"  # "high" | "medium" | "low"
+    alternatives: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "template_id": self.template_id,
+            "rationale": self.rationale,
+            "confidence": self.confidence,
+            "alternatives": list(self.alternatives),
+        }
+
+
+class TemplateAdvisorError(Exception):
+    """Raised when the advisor cannot produce a valid recommendation."""
+
+
+def _load_system_prompt(project_root: Path) -> str:
+    """Load the advisor system prompt with project-overlay support."""
+    core_path = _CORE_DIR / f"{_SYSTEM_PROMPT_NAME}.md"
+    if not core_path.exists():
+        raise TemplateAdvisorError(
+            f"advisor system prompt missing: {core_path}"
+        )
+    rendered = core_path.read_text(encoding="utf-8")
+    resolver = OverlayResolver(
+        overrides_dir=str(project_root / ".claude" / "agents")
+    )
+    return resolver.resolve(_SYSTEM_PROMPT_NAME, rendered)
+
+
+def _load_user_prompt(project_root: Path, context: dict) -> str:
+    """Load and render the advisor user-prompt block."""
+    resolver = OverlayResolver(
+        overrides_dir=str(project_root / ".claude" / "agents")
+    )
+    block = resolver.resolve_block(_USER_PROMPT_BLOCK, str(_CORE_DIR))
+    if block is None:
+        raise TemplateAdvisorError(
+            f"advisor user-prompt block missing: {_USER_PROMPT_BLOCK}.block.md"
+        )
+    return resolve_agent(block, context, resolver, str(_CORE_DIR))
+
+
+def _render_catalog(templates: list[TemplateSummary]) -> str:
+    """Render the template catalog as a compact Markdown list for the LLM."""
+    if not templates:
+        return "(no templates available)"
+    lines = []
+    for t in templates:
+        tags = ", ".join(t.tags) if t.tags else ""
+        tag_suffix = f" — tags: {tags}" if tags else ""
+        desc = (t.description or "").strip().replace("\n", " ")
+        lines.append(
+            f"- **{t.id}** ({t.tier}): {t.name}{tag_suffix}\n  {desc}"
+        )
+    return "\n".join(lines)
+
+
+def _render_review_comments(comments: list[dict]) -> str:
+    """Render review comments compactly for the user prompt."""
+    if not comments:
+        return ""
+    rendered = []
+    for c in comments[:_REVIEW_COMMENT_CAP]:
+        path = c.get("path", "")
+        line = c.get("line")
+        author = c.get("author", "")
+        body = (c.get("body") or "").strip().splitlines()
+        body_first = body[0] if body else ""
+        loc = f"{path}:{line}" if path and line is not None else (path or "PR-level")
+        rendered.append(f"- [{loc}] @{author}: {body_first}")
+    remaining = max(0, len(comments) - _REVIEW_COMMENT_CAP)
+    if remaining:
+        rendered.append(f"- … and {remaining} more comment(s) omitted.")
+    return "\n".join(rendered)
+
+
+def _build_user_context(work: WorkRequest) -> dict:
+    """Build the substitution context for the user-prompt block."""
+    description = (work.description or "").strip()
+    return {
+        "source_type": work.source_type,
+        "source_ref": work.source_ref or "",
+        "title": work.title or "",
+        "description": description,
+        "has_plan_link": bool(work.plan_path),
+        "plan_path": work.plan_path or "",
+        "review_comments": _render_review_comments(work.review_comments or []),
+        "has_review_comments": bool(work.review_comments),
+    }
+
+
+def _truncate_for_llm(text: str, max_chars: int = 12_000) -> str:
+    """Soft cap on description size to keep the prompt small and fast."""
+    if not text or len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "\n\n…[truncated]"
+
+
+def _list_templates(project_root: Path) -> list[TemplateSummary]:
+    """Enumerate templates the project can pick from.
+
+    Mirrors the CLI's resolution: when ``.claude/worca/templates`` exists
+    (post ``worca init``), use it; otherwise fall back to the installed
+    package's bundled templates so the advisor still works in fresh repos.
+    """
+    builtin_runtime = project_root / ".claude" / "worca" / "templates"
+    builtin_pkg = Path(__file__).parent / "templates"
+    builtin_dir = builtin_runtime if builtin_runtime.is_dir() else builtin_pkg
+    project_dir = project_root / ".claude" / "templates"
+    user_dir = Path.home() / ".worca" / "templates"
+    return TemplateResolver(builtin_dir, project_dir, user_dir).list()
+
+
+def _extract_json_object(text: str) -> Optional[dict]:
+    """Pull the outermost JSON object out of a model response.
+
+    The advisor prompt instructs the model to emit raw JSON, but some
+    responses still slip a fenced block or a leading sentence in. Extract
+    the substring between the first ``{`` and the matching outermost ``}``
+    and parse it. Returns ``None`` when no valid object is found.
+    """
+    if not text:
+        return None
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if esc:
+            esc = False
+            continue
+        if ch == "\\":
+            esc = True
+            continue
+        if ch == '"':
+            in_str = not in_str
+            continue
+        if in_str:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                snippet = text[start : i + 1]
+                try:
+                    parsed = json.loads(snippet)
+                except json.JSONDecodeError:
+                    return None
+                return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def _call_claude(
+    *,
+    system_prompt: str,
+    user_prompt: str,
+    model_id: str,
+    model_env: dict,
+    timeout: int,
+) -> str:
+    """Invoke the Claude CLI one-shot and return its stdout text."""
+    safe_env, _ = filter_model_env(model_env)
+    args = [
+        "claude",
+        "-p",
+        user_prompt,
+        "--model",
+        model_id,
+        "--append-system-prompt",
+        system_prompt,
+        "--output-format",
+        "text",
+    ]
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=get_env(**safe_env),
+    )
+    if result.returncode != 0:
+        raise TemplateAdvisorError(
+            f"claude CLI exited {result.returncode}: "
+            f"{result.stderr.strip() or '(no stderr)'}"
+        )
+    return result.stdout or ""
+
+
+def _coerce_advice(
+    payload: dict, catalog_ids: set[str]
+) -> TemplateAdvice:
+    """Validate the LLM payload and coerce it into a TemplateAdvice."""
+    template_id = (payload.get("template_id") or "").strip()
+    if not template_id:
+        raise TemplateAdvisorError("model response missing template_id")
+    if template_id not in catalog_ids:
+        raise TemplateAdvisorError(
+            f"model recommended unknown template '{template_id}'"
+        )
+    rationale = (payload.get("rationale") or "").strip()
+    if not rationale:
+        rationale = "Best fit based on the work content."
+    confidence = (payload.get("confidence") or "high").strip().lower()
+    if confidence not in {"high", "medium", "low"}:
+        confidence = "high"
+    alternatives_raw = payload.get("alternatives") or []
+    alternatives: list[dict] = []
+    if isinstance(alternatives_raw, list):
+        for alt in alternatives_raw:
+            if not isinstance(alt, dict):
+                continue
+            alt_id = (alt.get("template_id") or "").strip()
+            alt_rationale = (alt.get("rationale") or "").strip()
+            if alt_id and alt_id in catalog_ids and alt_id != template_id:
+                alternatives.append(
+                    {
+                        "template_id": alt_id,
+                        "rationale": alt_rationale
+                        or "Plausible alternative.",
+                    }
+                )
+    return TemplateAdvice(
+        template_id=template_id,
+        rationale=rationale,
+        confidence=confidence,
+        alternatives=alternatives,
+    )
+
+
+def advise(
+    *,
+    source_type: str,
+    source_value: str = "",
+    project_root: str | os.PathLike[str] | None = None,
+    settings_path: str | os.PathLike[str] | None = None,
+    model_alias: str = _DEFAULT_MODEL_ALIAS,
+    timeout: int = _DEFAULT_TIMEOUT_SECONDS,
+    plan_path_template: Optional[str] = None,
+    work_request: Optional[WorkRequest] = None,
+) -> TemplateAdvice:
+    """Return a template recommendation for the given source.
+
+    Args:
+        source_type: One of the launcher source types — ``prompt``,
+            ``spec``, ``source`` (GitHub issue auto-detect),
+            ``pr`` (GitHub PR), ``plan`` (plan file), or a backend
+            type (``github_issue``, ``github_pr``, ``spec_file``,
+            ``plan_file``, ``beads``) when calling with a pre-built
+            ``work_request``.
+        source_value: The raw value the operator entered (prompt text,
+            file path, ``gh:issue:N``, URL, etc.). Ignored when
+            ``work_request`` is supplied.
+        project_root: Project root used for template discovery and
+            overlay resolution. Defaults to the current working
+            directory.
+        settings_path: Override the settings path (mainly for tests).
+        model_alias: Model alias (resolved through ``worca.models``)
+            to drive the advisor. Defaults to ``sonnet``.
+        timeout: Claude CLI timeout in seconds.
+        plan_path_template: Optional ``worca.plan_path_template`` for
+            GitHub issue plan-link detection.
+        work_request: Pre-built work request. When provided,
+            ``source_type``/``source_value`` are ignored and the call
+            skips normalisation (useful for tests).
+
+    Raises:
+        TemplateAdvisorError: When normalisation fails, no templates
+            are available, the model errors out, or the response can
+            not be coerced into a valid recommendation.
+    """
+    root = Path(project_root or os.getcwd()).resolve()
+
+    work = work_request
+    if work is None:
+        # Refuse cross-project URL sources BEFORE shelling out to gh /
+        # claude — otherwise the user pays the round-trip + LLM cost for a
+        # recommendation that wouldn't apply to this project's launch
+        # anyway. Bare refs (gh:pr:N) skip this since we have no second
+        # source of truth for the intended repo.
+        _guard_cross_project_source(source_value, root)
+        try:
+            work = normalize(
+                source_type,
+                source_value,
+                plan_path_template=plan_path_template,
+            )
+        except (ValueError, RuntimeError, OSError) as exc:
+            # The inner exception is already specific
+            # ("Failed to fetch PR #313 in foo/bar: …", "[Errno 2] No such
+            # file or directory: …", "Unknown source reference format: …").
+            # Surface it verbatim — the extra "could not normalise work
+            # source:" wrapper just adds noise without information.
+            raise TemplateAdvisorError(str(exc)) from exc
+
+    work.description = _truncate_for_llm(work.description)
+
+    templates = _list_templates(root)
+    if not templates:
+        raise TemplateAdvisorError(
+            "no templates available — run `worca init` or define one first"
+        )
+    catalog_ids = {t.id for t in templates}
+
+    settings = load_settings(
+        str(settings_path) if settings_path else str(
+            root / ".claude" / "settings.json"
+        )
+    )
+    models_cfg = settings.get("worca", {}).get("models", {})
+    model_id, model_env = resolve_model(model_alias, models_cfg)
+
+    catalog_md = _render_catalog(templates)
+    user_ctx = _build_user_context(work)
+    user_ctx["catalog"] = catalog_md
+
+    system_prompt = _load_system_prompt(root)
+    user_prompt = _load_user_prompt(root, user_ctx)
+
+    raw = _call_claude(
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        model_id=model_id,
+        model_env=model_env,
+        timeout=timeout,
+    )
+    payload = _extract_json_object(raw)
+    if payload is None:
+        # one retry with an explicit corrective instruction
+        retry_user = (
+            user_prompt
+            + "\n\nReturn ONLY a JSON object matching the schema. "
+            "No prose, no Markdown fence."
+        )
+        raw = _call_claude(
+            system_prompt=system_prompt,
+            user_prompt=retry_user,
+            model_id=model_id,
+            model_env=model_env,
+            timeout=timeout,
+        )
+        payload = _extract_json_object(raw)
+    if payload is None:
+        raise TemplateAdvisorError(
+            "model did not return a parseable JSON object"
+        )
+
+    return _coerce_advice(payload, catalog_ids)
+
+
+def advise_to_json(**kwargs: Any) -> str:
+    """Convenience wrapper used by the CLI: return JSON text for stdout."""
+    advice = advise(**kwargs)
+    return json.dumps(advice.to_dict(), indent=2)

--- a/tests/test_template_advisor.py
+++ b/tests/test_template_advisor.py
@@ -1,0 +1,550 @@
+"""Tests for worca.template_advisor — the UI/CLI "Suggest template" feature."""
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from worca.orchestrator.work_request import WorkRequest
+from worca.template_advisor import (
+    TemplateAdvisorError,
+    _build_user_context,
+    _coerce_advice,
+    _extract_json_object,
+    _render_catalog,
+    _render_review_comments,
+    advise,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _seed_project(root: Path, *, template_ids=("bugfix", "feature")) -> None:
+    """Create a minimal project layout with built-in templates for resolver."""
+    (root / ".claude").mkdir(parents=True, exist_ok=True)
+    (root / ".claude" / "settings.json").write_text(
+        json.dumps({"worca": {"models": {}}}), encoding="utf-8"
+    )
+    templates_dir = root / ".claude" / "worca" / "templates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    descriptions = {
+        "bugfix": "Fast bug fix pipeline. Investigates root cause, focused fix.",
+        "feature": "Full feature pipeline with plan review and learn stages.",
+        "investigate": "Analysis-only pipeline. No implementation changes.",
+        "quick-fix": "Minimal pipeline for trivial single-line fixes.",
+    }
+    for tid in template_ids:
+        d = templates_dir / tid
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "template.json").write_text(
+            json.dumps(
+                {
+                    "id": tid,
+                    "name": tid.replace("-", " ").title(),
+                    "description": descriptions.get(tid, f"{tid} template"),
+                    "builtin": True,
+                    "created_at": "2026-03-10T00:00:00Z",
+                    "tags": [],
+                    "config": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+def _claude_returns(payload: dict) -> MagicMock:
+    """Build a MagicMock subprocess.run return that emits the JSON payload."""
+    return MagicMock(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+# ---------------------------------------------------------------------------
+# Pure-function helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJsonObject:
+    def test_raw_json(self):
+        assert _extract_json_object('{"a": 1}') == {"a": 1}
+
+    def test_json_inside_prose(self):
+        text = 'Here you go:\n{"template_id": "bugfix"}\nThat\'s my pick.'
+        assert _extract_json_object(text) == {"template_id": "bugfix"}
+
+    def test_json_inside_fence(self):
+        text = '```json\n{"template_id": "bugfix"}\n```'
+        assert _extract_json_object(text) == {"template_id": "bugfix"}
+
+    def test_braces_inside_strings_do_not_close_early(self):
+        text = '{"rationale": "uses { and } characters", "x": 1}'
+        out = _extract_json_object(text)
+        assert out == {"rationale": "uses { and } characters", "x": 1}
+
+    def test_returns_none_when_no_object(self):
+        assert _extract_json_object("no json here") is None
+
+    def test_returns_none_for_array_root(self):
+        assert _extract_json_object("[1, 2, 3]") is None
+
+
+class TestRenderCatalog:
+    def test_includes_id_tier_name_and_description(self):
+        from worca.orchestrator.templates import TemplateSummary
+
+        templates = [
+            TemplateSummary(
+                id="bugfix",
+                name="Bugfix",
+                description="Fix a thing",
+                builtin=True,
+                tags=("fast",),
+                created_at="2026-03-10T00:00:00Z",
+                tier="builtin",
+            ),
+        ]
+        rendered = _render_catalog(templates)
+        assert "**bugfix**" in rendered
+        assert "(builtin)" in rendered
+        assert "Bugfix" in rendered
+        assert "Fix a thing" in rendered
+        assert "fast" in rendered
+
+    def test_empty_catalog(self):
+        assert _render_catalog([]) == "(no templates available)"
+
+
+class TestRenderReviewComments:
+    def test_empty(self):
+        assert _render_review_comments([]) == ""
+
+    def test_formats_path_and_author(self):
+        out = _render_review_comments(
+            [{"path": "a.py", "line": 12, "author": "u", "body": "nit"}]
+        )
+        assert "a.py:12" in out
+        assert "@u" in out
+        assert "nit" in out
+
+    def test_caps_long_lists(self):
+        comments = [
+            {"path": f"f{i}.py", "line": 1, "author": "u", "body": "x"}
+            for i in range(25)
+        ]
+        out = _render_review_comments(comments)
+        # 20 rendered + 1 trailing "omitted" line
+        assert out.count("\n") == 20
+        assert "5 more" in out
+
+
+class TestBuildUserContext:
+    def test_prompt_source(self):
+        work = WorkRequest(source_type="prompt", title="Add X", description="Add X")
+        ctx = _build_user_context(work)
+        assert ctx["source_type"] == "prompt"
+        assert ctx["has_plan_link"] is False
+        assert ctx["has_review_comments"] is False
+
+    def test_github_issue_with_plan_link(self):
+        work = WorkRequest(
+            source_type="github_issue",
+            title="W-099: Foo",
+            description="Body",
+            source_ref="gh:99",
+            plan_path="docs/plans/W-099-foo.md",
+        )
+        ctx = _build_user_context(work)
+        assert ctx["has_plan_link"] is True
+        assert ctx["plan_path"] == "docs/plans/W-099-foo.md"
+
+    def test_github_pr_with_review_comments(self):
+        work = WorkRequest(
+            source_type="github_pr",
+            title="PR title",
+            description="body",
+            review_comments=[
+                {"path": "x.py", "line": 1, "author": "u", "body": "fix this"}
+            ],
+        )
+        ctx = _build_user_context(work)
+        assert ctx["has_review_comments"] is True
+        assert "@u" in ctx["review_comments"]
+
+
+# ---------------------------------------------------------------------------
+# Coerce / validation
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceAdvice:
+    def test_minimal_valid_payload(self):
+        advice = _coerce_advice(
+            {"template_id": "bugfix", "rationale": "fits"},
+            {"bugfix", "feature"},
+        )
+        assert advice.template_id == "bugfix"
+        assert advice.confidence == "high"
+        assert advice.alternatives == []
+
+    def test_unknown_template_id_raises(self):
+        with pytest.raises(TemplateAdvisorError):
+            _coerce_advice(
+                {"template_id": "nope", "rationale": "x"}, {"bugfix"}
+            )
+
+    def test_missing_template_id_raises(self):
+        with pytest.raises(TemplateAdvisorError):
+            _coerce_advice({"rationale": "x"}, {"bugfix"})
+
+    def test_drops_unknown_alternatives(self):
+        advice = _coerce_advice(
+            {
+                "template_id": "bugfix",
+                "rationale": "fits",
+                "alternatives": [
+                    {"template_id": "feature", "rationale": "or feature"},
+                    {"template_id": "ghost", "rationale": "ignore"},
+                    {"template_id": "bugfix", "rationale": "dup"},
+                ],
+            },
+            {"bugfix", "feature"},
+        )
+        assert len(advice.alternatives) == 1
+        assert advice.alternatives[0]["template_id"] == "feature"
+
+    def test_normalises_bad_confidence(self):
+        advice = _coerce_advice(
+            {"template_id": "bugfix", "rationale": "x", "confidence": "MEGA"},
+            {"bugfix"},
+        )
+        assert advice.confidence == "high"
+
+    def test_accepts_low_confidence(self):
+        advice = _coerce_advice(
+            {"template_id": "bugfix", "rationale": "x", "confidence": "low"},
+            {"bugfix"},
+        )
+        assert advice.confidence == "low"
+
+
+# ---------------------------------------------------------------------------
+# advise() — end-to-end with mocked subprocess
+# ---------------------------------------------------------------------------
+
+
+class TestAdviseEndToEnd:
+    def test_prompt_source_happy_path(self, tmp_path):
+        _seed_project(tmp_path)
+        with patch("worca.template_advisor.subprocess.run") as mock_run:
+            mock_run.return_value = _claude_returns(
+                {
+                    "template_id": "bugfix",
+                    "rationale": "bug language and small scope",
+                    "confidence": "high",
+                }
+            )
+            advice = advise(
+                source_type="prompt",
+                source_value="Fix the regression in the login flow",
+                project_root=tmp_path,
+            )
+        assert advice.template_id == "bugfix"
+        assert advice.rationale.startswith("bug language")
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "claude"
+        assert "--model" in cmd
+
+    def test_spec_source_normalises_via_work_request(self, tmp_path):
+        _seed_project(tmp_path)
+        spec = tmp_path / "spec.md"
+        spec.write_text("# Refactor X\n\nBody body body", encoding="utf-8")
+        with patch("worca.template_advisor.subprocess.run") as mock_run:
+            mock_run.return_value = _claude_returns(
+                {"template_id": "feature", "rationale": "spec-driven"}
+            )
+            # smart-title also goes through subprocess.run via work_request;
+            # so the first call is the title generator, the second is advise.
+            # We accept either, just check the call count is at least 1.
+            advice = advise(
+                source_type="spec",
+                source_value=str(spec),
+                project_root=tmp_path,
+            )
+        assert advice.template_id == "feature"
+
+    def test_retries_once_when_response_is_not_json(self, tmp_path):
+        _seed_project(tmp_path)
+        with patch("worca.template_advisor.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="No JSON here at all", stderr=""),
+                _claude_returns({"template_id": "bugfix", "rationale": "retry"}),
+            ]
+            advice = advise(
+                source_type="prompt",
+                source_value="Fix bug",
+                project_root=tmp_path,
+                work_request=WorkRequest(
+                    source_type="prompt",
+                    title="Fix bug",
+                    description="Fix bug",
+                ),
+            )
+        assert advice.template_id == "bugfix"
+        assert mock_run.call_count == 2
+
+    def test_raises_when_no_templates_available(self, tmp_path):
+        # No templates directory at all.
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "settings.json").write_text(
+            "{}", encoding="utf-8"
+        )
+        # Make the fallback (package builtin) also empty by pointing project_root
+        # to tmp_path; the resolver scans `<root>/.claude/worca/templates`. With
+        # nothing there it falls through to the package builtin which DOES exist
+        # for the worca repo — so just assert the advise() flow handles the
+        # package fallback by mocking the resolver.
+        with patch("worca.template_advisor._list_templates", return_value=[]):
+            with pytest.raises(TemplateAdvisorError, match="no templates"):
+                advise(
+                    source_type="prompt",
+                    source_value="anything",
+                    project_root=tmp_path,
+                    work_request=WorkRequest(
+                        source_type="prompt", title="x", description="x"
+                    ),
+                )
+
+    def test_raises_when_claude_exits_nonzero(self, tmp_path):
+        _seed_project(tmp_path)
+        with patch("worca.template_advisor.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="boom"
+            )
+            with pytest.raises(TemplateAdvisorError, match="claude CLI"):
+                advise(
+                    source_type="prompt",
+                    source_value="x",
+                    project_root=tmp_path,
+                    work_request=WorkRequest(
+                        source_type="prompt", title="x", description="x"
+                    ),
+                )
+
+    def test_raises_when_template_id_unknown(self, tmp_path):
+        _seed_project(tmp_path)
+        with patch("worca.template_advisor.subprocess.run") as mock_run:
+            mock_run.return_value = _claude_returns(
+                {"template_id": "ghost-template", "rationale": "made up"}
+            )
+            with pytest.raises(TemplateAdvisorError, match="unknown template"):
+                advise(
+                    source_type="prompt",
+                    source_value="x",
+                    project_root=tmp_path,
+                    work_request=WorkRequest(
+                        source_type="prompt", title="x", description="x"
+                    ),
+                )
+
+    def test_normalisation_failure_surfaces_inner_message(self, tmp_path):
+        _seed_project(tmp_path)
+        with pytest.raises(
+            TemplateAdvisorError, match="Unknown source reference format"
+        ):
+            advise(
+                source_type="source",  # auto-detect
+                source_value="not-a-real-ref",
+                project_root=tmp_path,
+            )
+
+
+class TestCrossProjectGuard:
+    """Refuse to advise when a URL source points to a different repo."""
+
+    def test_refuses_when_pr_url_belongs_to_different_repo(self, tmp_path):
+        _seed_project(tmp_path)
+        with patch(
+            "worca.template_advisor.current_repo_nwo",
+            return_value="owner-a/repo-a",
+        ):
+            with patch("worca.template_advisor.subprocess.run") as mock_run:
+                with pytest.raises(
+                    TemplateAdvisorError,
+                    match=r"owner-b/repo-b.*owner-a/repo-a",
+                ):
+                    advise(
+                        source_type="pr",
+                        source_value="https://github.com/owner-b/repo-b/pull/313",
+                        project_root=tmp_path,
+                    )
+                # MUST short-circuit before any subprocess call (gh, claude).
+                mock_run.assert_not_called()
+
+    def test_refuses_when_issue_url_belongs_to_different_repo(self, tmp_path):
+        _seed_project(tmp_path)
+        with patch(
+            "worca.template_advisor.current_repo_nwo",
+            return_value="owner-a/repo-a",
+        ):
+            with patch("worca.template_advisor.subprocess.run") as mock_run:
+                with pytest.raises(
+                    TemplateAdvisorError,
+                    match=r"owner-b/repo-b.*owner-a/repo-a",
+                ):
+                    advise(
+                        source_type="source",
+                        source_value="https://github.com/owner-b/repo-b/issues/42",
+                        project_root=tmp_path,
+                    )
+                mock_run.assert_not_called()
+
+    def test_allows_when_pr_url_matches_project_repo(self, tmp_path):
+        _seed_project(tmp_path)
+        with patch(
+            "worca.template_advisor.current_repo_nwo",
+            return_value="owner-a/repo-a",
+        ):
+            with patch("worca.template_advisor.subprocess.run") as mock_run:
+                mock_run.return_value = _claude_returns(
+                    {
+                        "template_id": "bugfix",
+                        "rationale": "matched",
+                        "confidence": "high",
+                    }
+                )
+                # Pre-built work_request short-circuits normalize, so we
+                # only exercise the guard's URL parse here. The guard
+                # accepts because the URL nwo matches project nwo
+                # (case-insensitive).
+                from worca.orchestrator.work_request import WorkRequest
+
+                advise(
+                    source_type="pr",
+                    source_value="https://github.com/Owner-A/Repo-A/pull/99",
+                    project_root=tmp_path,
+                    work_request=WorkRequest(
+                        source_type="github_pr",
+                        title="x",
+                        description="x",
+                    ),
+                )
+                assert mock_run.called
+
+    def test_allows_when_project_nwo_cannot_be_resolved(self, tmp_path):
+        _seed_project(tmp_path)
+        # Project repo unresolvable (gh not configured, non-GitHub remote).
+        # Don't block — let normalize/gh produce a more specific error.
+        from worca.orchestrator.work_request import WorkRequest
+
+        with patch(
+            "worca.template_advisor.current_repo_nwo",
+            return_value="",
+        ):
+            with patch("worca.template_advisor.subprocess.run") as mock_run:
+                mock_run.return_value = _claude_returns(
+                    {
+                        "template_id": "bugfix",
+                        "rationale": "no repo to compare",
+                        "confidence": "low",
+                    }
+                )
+                advise(
+                    source_type="pr",
+                    source_value="https://github.com/owner-b/repo-b/pull/1",
+                    project_root=tmp_path,
+                    work_request=WorkRequest(
+                        source_type="github_pr",
+                        title="x",
+                        description="x",
+                    ),
+                )
+                assert mock_run.called
+
+    def test_skips_guard_for_bare_gh_pr_ref(self, tmp_path):
+        """`gh:pr:N` has no URL nwo — guard must not block."""
+        _seed_project(tmp_path)
+        from worca.orchestrator.work_request import WorkRequest
+
+        with patch(
+            "worca.template_advisor.current_repo_nwo",
+            return_value="owner-a/repo-a",
+        ):
+            with patch("worca.template_advisor.subprocess.run") as mock_run:
+                mock_run.return_value = _claude_returns(
+                    {
+                        "template_id": "bugfix",
+                        "rationale": "x",
+                        "confidence": "high",
+                    }
+                )
+                advise(
+                    source_type="pr",
+                    source_value="gh:pr:55",
+                    project_root=tmp_path,
+                    work_request=WorkRequest(
+                        source_type="github_pr",
+                        title="x",
+                        description="x",
+                    ),
+                )
+                assert mock_run.called
+
+    def test_skips_guard_for_prompt_source(self, tmp_path):
+        _seed_project(tmp_path)
+        from worca.orchestrator.work_request import WorkRequest
+
+        with patch(
+            "worca.template_advisor.current_repo_nwo",
+            return_value="owner-a/repo-a",
+        ):
+            with patch("worca.template_advisor.subprocess.run") as mock_run:
+                mock_run.return_value = _claude_returns(
+                    {
+                        "template_id": "bugfix",
+                        "rationale": "x",
+                        "confidence": "high",
+                    }
+                )
+                advise(
+                    source_type="prompt",
+                    source_value="fix the bug",
+                    project_root=tmp_path,
+                    work_request=WorkRequest(
+                        source_type="prompt",
+                        title="x",
+                        description="x",
+                    ),
+                )
+                assert mock_run.called
+
+    def test_passes_review_comments_into_user_prompt(self, tmp_path):
+        _seed_project(tmp_path)
+        wr = WorkRequest(
+            source_type="github_pr",
+            title="PR title",
+            description="body",
+            review_comments=[
+                {
+                    "path": "a.py",
+                    "line": 1,
+                    "author": "alice",
+                    "body": "address this",
+                }
+            ],
+        )
+        with patch("worca.template_advisor.subprocess.run") as mock_run:
+            mock_run.return_value = _claude_returns(
+                {"template_id": "bugfix", "rationale": "PR review"}
+            )
+            advise(
+                source_type="pr",
+                source_value="gh:pr:99",
+                project_root=tmp_path,
+                work_request=wr,
+            )
+        # The user prompt is positional arg [0][2] — claude -p <prompt>
+        user_prompt = mock_run.call_args[0][0][2]
+        assert "address this" in user_prompt
+        assert "alice" in user_prompt

--- a/tests/test_work_request.py
+++ b/tests/test_work_request.py
@@ -1320,6 +1320,73 @@ class TestNormalizeGithubPrDispatch:
         wr = normalize("source", "https://github.com/owner/repo/pull/33")
         assert wr.source_ref == "gh:pr:33"
 
+    # --- repo_nwo propagation from a parsed URL ---
+    # When a full GitHub PR URL is passed (regardless of dispatch path),
+    # the owner/repo must reach `gh pr view --repo …` so the lookup hits
+    # the right repo rather than gh's current-dir default. Without this,
+    # launching against worca-cc/pull/313 from a different project would
+    # silently try to find PR #313 in that other project's repo.
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback", return_value=[])
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_full_url_passes_repo_flag_to_gh_view(
+        self, mock_subprocess, mock_fetch
+    ):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(_DISPATCH_PR_RESPONSE)
+        mock_subprocess.run.return_value = mock_result
+        normalize("source", "https://github.com/some-owner/some-repo/pull/313")
+        cmd = mock_subprocess.run.call_args[0][0]
+        assert "--repo" in cmd
+        idx = cmd.index("--repo")
+        assert cmd[idx + 1] == "some-owner/some-repo"
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback", return_value=[])
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_full_url_uses_url_repo_for_review_feedback(
+        self, mock_subprocess, mock_fetch
+    ):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(_DISPATCH_PR_RESPONSE)
+        mock_subprocess.run.return_value = mock_result
+        normalize(
+            "pr", "https://github.com/some-owner/some-repo/pull/313"
+        )
+        # Reviews must come from the URL's repo, not current_repo_nwo()
+        mock_fetch.assert_called_once_with("some-owner/some-repo", 313)
+
+    @patch("worca.orchestrator.work_request.fetch_review_feedback", return_value=[])
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_bare_gh_pr_scheme_still_falls_back_to_current_repo(
+        self, mock_subprocess, mock_fetch
+    ):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(_DISPATCH_PR_RESPONSE)
+        mock_subprocess.run.return_value = mock_result
+        normalize("source", "gh:pr:55")
+        cmd = mock_subprocess.run.call_args[0][0]
+        # No --repo flag — gh resolves the current-dir default repo.
+        assert "--repo" not in cmd
+        # Reviews come from current_repo_nwo() = "owner/repo" (fixture).
+        mock_fetch.assert_called_once_with("owner/repo", 55)
+
+    @patch("worca.orchestrator.work_request.subprocess")
+    def test_pr_fetch_error_message_includes_repo_hint(
+        self, mock_subprocess
+    ):
+        from worca.orchestrator.work_request import normalize_github_pr
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "Could not resolve to a PullRequest"
+        mock_subprocess.run.return_value = mock_result
+        with pytest.raises(RuntimeError, match=r"in some-owner/some-repo"):
+            normalize_github_pr("gh:pr:313", repo_nwo="some-owner/some-repo")
+
 
 # --- graph report static-injection surface removed (W-053 query pivot) ---
 

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -3647,6 +3647,86 @@ sl-option.template-grouped:focus::part(suffix) {
   line-height: 1.5;
 }
 
+/* Pipeline-template header row: label on the left, Suggest button on the right. */
+.template-select-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.template-select-header .settings-label {
+  margin-bottom: 0;
+}
+
+.btn-suggest-template::part(base) {
+  font-size: 12px;
+}
+
+/* Center the Sparkles SVG with the label. Without this, the SVG inherits
+ * baseline alignment from inline-flow and sits ~2px below the cap line. */
+.btn-suggest-template::part(prefix) {
+  display: inline-flex;
+  align-items: center;
+}
+
+.btn-suggest-template svg {
+  display: block;
+}
+
+/* Advisor dialog */
+.advisor-dialog::part(panel) {
+  max-width: 560px;
+}
+
+.advisor-dialog-body {
+  font-size: 14px;
+  color: inherit;
+  line-height: 1.55;
+}
+
+.advisor-loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+}
+
+.advisor-error {
+  color: var(--sl-color-danger-600, #c41e3a);
+}
+
+.advisor-headline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.advisor-template-name {
+  font-size: 16px;
+}
+
+.advisor-rationale {
+  margin: 6px 0 12px;
+}
+
+.advisor-alternatives ul {
+  list-style: disc;
+  padding-left: 20px;
+  margin: 4px 0 0;
+}
+
+.advisor-alternatives li {
+  margin-bottom: 6px;
+}
+
+.advisor-alternatives .btn-advisor-pick-alt {
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
 /* Plan file autocomplete */
 .plan-autocomplete {
   position: relative;

--- a/worca-ui/app/utils/icons.js
+++ b/worca-ui/app/utils/icons.js
@@ -54,6 +54,7 @@ import Search from 'lucide/dist/esm/icons/search';
 import Settings from 'lucide/dist/esm/icons/settings';
 import Shield from 'lucide/dist/esm/icons/shield';
 import SlidersHorizontal from 'lucide/dist/esm/icons/sliders-horizontal';
+import Sparkles from 'lucide/dist/esm/icons/sparkles';
 import Square from 'lucide/dist/esm/icons/square';
 import Star from 'lucide/dist/esm/icons/star';
 import Sun from 'lucide/dist/esm/icons/sun';
@@ -143,6 +144,7 @@ export {
   Settings,
   Shield,
   SlidersHorizontal,
+  Sparkles,
   Square,
   Star,
   Sun,

--- a/worca-ui/app/views/new-run-advisor.test.js
+++ b/worca-ui/app/views/new-run-advisor.test.js
@@ -1,0 +1,418 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock lit-html since it requires DOM APIs that aren't present here.
+vi.mock('lit-html', () => ({
+  html: () => null,
+  nothing: null,
+}));
+vi.mock('lit-html/directives/unsafe-html.js', () => ({
+  unsafeHTML: () => null,
+}));
+vi.mock('lit-html/directives/ref.js', () => ({
+  ref: () => null,
+}));
+vi.mock('../utils/icons.js', () => ({
+  iconSvg: () => '',
+  FileText: 'FileText',
+  Sparkles: 'Sparkles',
+  Circle: 'Circle',
+  CircleAlert: 'CircleAlert',
+  CircleCheck: 'CircleCheck',
+  CircleSlash: 'CircleSlash',
+  Loader: 'Loader',
+  Pause: 'Pause',
+}));
+
+function createDocStub() {
+  const elements = {};
+  return {
+    getElementById: vi.fn((id) => elements[id] || null),
+    _set(id, value) {
+      elements[id] = { value, id };
+    },
+    _clear() {
+      for (const k of Object.keys(elements)) delete elements[k];
+    },
+  };
+}
+
+describe('Template advisor — Suggest button flow', () => {
+  let origFetch;
+  let mod;
+  let docStub;
+
+  beforeEach(async () => {
+    origFetch = globalThis.fetch;
+    docStub = createDocStub();
+    globalThis.document = docStub;
+    vi.resetModules();
+    vi.doMock('lit-html', () => ({ html: () => null, nothing: null }));
+    vi.doMock('lit-html/directives/ref.js', () => ({ ref: () => null }));
+    vi.doMock('lit-html/directives/unsafe-html.js', () => ({
+      unsafeHTML: () => null,
+    }));
+    vi.doMock('../utils/icons.js', () => ({
+      iconSvg: () => '',
+      FileText: 'FileText',
+      Sparkles: 'Sparkles',
+      Circle: 'Circle',
+      CircleAlert: 'CircleAlert',
+      CircleCheck: 'CircleCheck',
+      CircleSlash: 'CircleSlash',
+      Loader: 'Loader',
+      Pause: 'Pause',
+    }));
+    mod = await import('./new-run.js');
+    mod.resetNewRunState({
+      templates: [
+        {
+          id: 'bugfix',
+          name: 'Bugfix',
+          tier: 'builtin',
+          description: 'Fast bug fix',
+          config: {},
+        },
+        {
+          id: 'feature',
+          name: 'Feature',
+          tier: 'builtin',
+          description: 'Full feature pipeline',
+          config: {},
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    docStub._clear();
+  });
+
+  describe('readAdvisorInputs', () => {
+    it('reads the prompt textarea when sourceType is none', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', '  fix the bug  ');
+      const out = mod.readAdvisorInputs();
+      expect(out).toEqual({ sourceType: 'none', sourceValue: 'fix the bug' });
+    });
+
+    it('reads the source-value input when sourceType is github-issue', async () => {
+      mod.resetNewRunState({ sourceType: 'source' });
+      docStub._set('new-run-source-value', 'gh:issue:42');
+      const out = mod.readAdvisorInputs();
+      expect(out).toEqual({ sourceType: 'source', sourceValue: 'gh:issue:42' });
+    });
+
+    it('reads the source-value input when sourceType is pr', async () => {
+      mod.resetNewRunState({ sourceType: 'pr' });
+      docStub._set('new-run-source-value', 'gh:pr:99');
+      const out = mod.readAdvisorInputs();
+      expect(out.sourceValue).toBe('gh:pr:99');
+    });
+
+    it('reads the source-value input when sourceType is spec', async () => {
+      mod.resetNewRunState({ sourceType: 'spec' });
+      docStub._set('new-run-source-value', 'docs/spec.md');
+      const out = mod.readAdvisorInputs();
+      expect(out.sourceValue).toBe('docs/spec.md');
+    });
+  });
+
+  describe('requestTemplateAdvice', () => {
+    it('shows error state when prompt is empty', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      // no prompt set
+      await mod.requestTemplateAdvice({ projectId: 'p1' });
+      expect(mod.advisorStatus).toBe('error');
+      expect(mod.advisorDialogOpen).toBe(true);
+      expect(mod.advisorError).toMatch(/prompt/i);
+    });
+
+    it('shows error state when source value is empty', async () => {
+      mod.resetNewRunState({ sourceType: 'source' });
+      // no source value set
+      await mod.requestTemplateAdvice({ projectId: 'p1' });
+      expect(mod.advisorStatus).toBe('error');
+      expect(mod.advisorError).toMatch(/github issue/i);
+    });
+
+    it('posts to the project-scoped endpoint on success', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', 'Fix the bug');
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          advice: {
+            template_id: 'bugfix',
+            rationale: 'bug language',
+            confidence: 'high',
+            alternatives: [],
+          },
+        }),
+      });
+      await mod.requestTemplateAdvice({ projectId: 'p1' });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      const [url, init] = globalThis.fetch.mock.calls[0];
+      expect(url).toBe('/api/projects/p1/templates/advise');
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(init.body);
+      expect(body.sourceType).toBe('none');
+      expect(body.sourceValue).toBe('Fix the bug');
+      expect(mod.advisorStatus).toBe('ready');
+      expect(mod.advisorAdvice.template_id).toBe('bugfix');
+      expect(mod.advisorDialogOpen).toBe(true);
+    });
+
+    it('posts to the global endpoint when no projectId is provided', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', 'Fix the bug');
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          advice: {
+            template_id: 'bugfix',
+            rationale: 'x',
+            confidence: 'high',
+            alternatives: [],
+          },
+        }),
+      });
+      await mod.requestTemplateAdvice({});
+      expect(globalThis.fetch.mock.calls[0][0]).toBe('/api/templates/advise');
+    });
+
+    it('surfaces server errors in advisorError', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', 'Fix the bug');
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ ok: false, error: 'claude exited 1' }),
+      });
+      await mod.requestTemplateAdvice({ projectId: 'p1' });
+      expect(mod.advisorStatus).toBe('error');
+      expect(mod.advisorError).toMatch(/claude exited 1/);
+    });
+
+    it('handles fetch rejecting outright', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', 'x');
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+      await mod.requestTemplateAdvice({ projectId: 'p1' });
+      expect(mod.advisorStatus).toBe('error');
+      expect(mod.advisorError).toMatch(/network down/);
+    });
+
+    it('paints the loading frame before awaiting the network call', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', 'Fix the bug');
+      let resolveFetch;
+      globalThis.fetch = vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      const rerender = vi.fn();
+      const pending = mod.requestTemplateAdvice({
+        projectId: 'p1',
+        rerender,
+      });
+      // Loading state and dialog visibility must be set synchronously, and
+      // rerender must have been called before any await unblocks.
+      expect(mod.advisorStatus).toBe('loading');
+      expect(mod.advisorDialogOpen).toBe(true);
+      expect(rerender).toHaveBeenCalled();
+      const callsBeforeResolve = rerender.mock.calls.length;
+      // Resolve the fetch so the awaiting code runs and stamps the result.
+      resolveFetch({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          advice: {
+            template_id: 'bugfix',
+            rationale: 'x',
+            confidence: 'high',
+            alternatives: [],
+          },
+        }),
+      });
+      await pending;
+      expect(mod.advisorStatus).toBe('ready');
+      expect(rerender.mock.calls.length).toBeGreaterThan(callsBeforeResolve);
+    });
+
+    it('passes an AbortSignal so dismissAdvisor can cancel the call', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', 'Fix the bug');
+      let capturedInit;
+      globalThis.fetch = vi.fn().mockImplementation((_url, init) => {
+        capturedInit = init;
+        return new Promise(() => {});
+      });
+      mod.requestTemplateAdvice({ projectId: 'p1', rerender: () => {} });
+      expect(capturedInit?.signal).toBeDefined();
+      expect(capturedInit.signal.aborted).toBe(false);
+      mod.dismissAdvisor();
+      expect(capturedInit.signal.aborted).toBe(true);
+    });
+
+    it('ignores a late response after dismissAdvisor was called', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', 'Fix the bug');
+      let resolveFetch;
+      globalThis.fetch = vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      const pending = mod.requestTemplateAdvice({
+        projectId: 'p1',
+        rerender: () => {},
+      });
+      mod.dismissAdvisor();
+      expect(mod.advisorStatus).toBe('idle');
+      // A late response arrives — it must NOT flip state back to 'ready'.
+      resolveFetch({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          advice: {
+            template_id: 'bugfix',
+            rationale: 'late',
+            confidence: 'high',
+            alternatives: [],
+          },
+        }),
+      });
+      await pending;
+      expect(mod.advisorStatus).toBe('idle');
+      expect(mod.advisorAdvice).toBeNull();
+      expect(mod.advisorDialogOpen).toBe(false);
+    });
+
+    it('a fresh Suggest click supersedes the previous in-flight call', async () => {
+      mod.resetNewRunState({ sourceType: 'none' });
+      docStub._set('new-run-prompt', 'Fix the bug');
+      let firstResolve;
+      let secondResolve;
+      const responses = [
+        new Promise((resolve) => {
+          firstResolve = resolve;
+        }),
+        new Promise((resolve) => {
+          secondResolve = resolve;
+        }),
+      ];
+      let call = 0;
+      globalThis.fetch = vi.fn().mockImplementation(() => responses[call++]);
+      const first = mod.requestTemplateAdvice({
+        projectId: 'p1',
+        rerender: () => {},
+      });
+      const second = mod.requestTemplateAdvice({
+        projectId: 'p1',
+        rerender: () => {},
+      });
+      // Resolve the SECOND call first with feature, then the stale first call.
+      secondResolve({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          advice: {
+            template_id: 'feature',
+            rationale: 'second wins',
+            confidence: 'high',
+            alternatives: [],
+          },
+        }),
+      });
+      await second;
+      expect(mod.advisorAdvice.template_id).toBe('feature');
+      // Now the stale first call resolves — it MUST be discarded.
+      firstResolve({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          advice: {
+            template_id: 'bugfix',
+            rationale: 'first (stale)',
+            confidence: 'high',
+            alternatives: [],
+          },
+        }),
+      });
+      await first;
+      expect(mod.advisorAdvice.template_id).toBe('feature');
+    });
+  });
+
+  describe('applyAdvisorRecommendation', () => {
+    it('sets selectedTemplate when the id is in the catalog', async () => {
+      mod.resetNewRunState({
+        templates: [
+          { id: 'bugfix', name: 'Bugfix', tier: 'builtin', config: {} },
+        ],
+        advisorDialogOpen: true,
+      });
+      const applied = mod.applyAdvisorRecommendation('bugfix');
+      expect(applied).toBe(true);
+      expect(mod.selectedTemplate).toBe('bugfix');
+      expect(mod.advisorDialogOpen).toBe(false);
+    });
+
+    it('refuses to apply an unknown template id', async () => {
+      mod.resetNewRunState({
+        templates: [
+          { id: 'bugfix', name: 'Bugfix', tier: 'builtin', config: {} },
+        ],
+        advisorDialogOpen: true,
+        selectedTemplate: 'default',
+      });
+      const applied = mod.applyAdvisorRecommendation('ghost');
+      expect(applied).toBe(false);
+      expect(mod.selectedTemplate).toBe('default');
+      expect(mod.advisorDialogOpen).toBe(true);
+    });
+  });
+
+  describe('dismissAdvisor', () => {
+    it('closes the dialog and clears errors', async () => {
+      mod.resetNewRunState({
+        advisorDialogOpen: true,
+        advisorStatus: 'error',
+        advisorError: 'boom',
+      });
+      mod.dismissAdvisor();
+      expect(mod.advisorDialogOpen).toBe(false);
+      expect(mod.advisorStatus).toBe('idle');
+      expect(mod.advisorError).toBe('');
+    });
+
+    it('keeps ready state on close so reopen shows the last result', async () => {
+      mod.resetNewRunState({
+        advisorDialogOpen: true,
+        advisorStatus: 'ready',
+        advisorAdvice: {
+          template_id: 'bugfix',
+          rationale: 'x',
+          confidence: 'high',
+          alternatives: [],
+        },
+      });
+      mod.dismissAdvisor();
+      expect(mod.advisorDialogOpen).toBe(false);
+      expect(mod.advisorStatus).toBe('ready');
+      expect(mod.advisorAdvice).not.toBeNull();
+    });
+  });
+});

--- a/worca-ui/app/views/new-run-claude-md-mode.test.js
+++ b/worca-ui/app/views/new-run-claude-md-mode.test.js
@@ -21,6 +21,7 @@ function createDocStub() {
 const ICON_MOCKS = {
   iconSvg: () => '',
   FileText: 'FileText',
+  Sparkles: 'Sparkles',
   Circle: 'Circle',
   CircleAlert: 'CircleAlert',
   CircleCheck: 'CircleCheck',

--- a/worca-ui/app/views/new-run-header-integration.test.js
+++ b/worca-ui/app/views/new-run-header-integration.test.js
@@ -24,6 +24,7 @@ vi.mock('lit-html/directives/unsafe-html.js', () => ({
 vi.mock('../utils/icons.js', () => ({
   iconSvg: () => '',
   FileText: 'FileText',
+  Sparkles: 'Sparkles',
   Circle: 'Circle',
   CircleAlert: 'CircleAlert',
   CircleCheck: 'CircleCheck',
@@ -44,6 +45,7 @@ describe('header Start button contract — getNewRunSubmitState + getEffectivePr
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -149,6 +151,7 @@ describe('header Start button — disabled state derivation', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',

--- a/worca-ui/app/views/new-run-max-beads.test.js
+++ b/worca-ui/app/views/new-run-max-beads.test.js
@@ -32,6 +32,7 @@ describe('new-run — maxBeads passthrough sentinel', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -110,6 +111,7 @@ describe('new-run — project-level maxBeads caching', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -264,6 +266,7 @@ describe('new-run — resolveEffectiveMaxBeads helper', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -373,6 +376,7 @@ describe('new-run — maxBeads seeding from template', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -517,6 +521,7 @@ describe('new-run — maxBeads in submit body', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',

--- a/worca-ui/app/views/new-run-project.test.js
+++ b/worca-ui/app/views/new-run-project.test.js
@@ -20,6 +20,7 @@ vi.mock('lit-html/directives/unsafe-html.js', () => ({
 vi.mock('../utils/icons.js', () => ({
   iconSvg: () => '<svg></svg>',
   FileText: 'FileText',
+  Sparkles: 'Sparkles',
   Circle: 'Circle',
   CircleAlert: 'CircleAlert',
   CircleCheck: 'CircleCheck',
@@ -61,6 +62,7 @@ describe('new-run project picker', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '<svg></svg>',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -195,6 +197,7 @@ describe('new-run project picker — state and interactions', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '<svg></svg>',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -376,6 +379,7 @@ describe('new-run source type dropdown', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '<svg></svg>',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',

--- a/worca-ui/app/views/new-run-submit.test.js
+++ b/worca-ui/app/views/new-run-submit.test.js
@@ -14,6 +14,7 @@ vi.mock('lit-html/directives/ref.js', () => ({
 vi.mock('../utils/icons.js', () => ({
   iconSvg: () => '',
   FileText: 'FileText',
+  Sparkles: 'Sparkles',
   Circle: 'Circle',
   CircleAlert: 'CircleAlert',
   CircleCheck: 'CircleCheck',
@@ -56,6 +57,7 @@ describe('submitNewRun — new format validation and payload', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -257,6 +259,7 @@ describe('submitNewRun — 409 max_concurrent_exceeded handling', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -371,6 +374,7 @@ describe('submitNewRun — project validation and routing', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -561,6 +565,7 @@ describe('getNewRunSubmitState — noProject flag', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',

--- a/worca-ui/app/views/new-run-template.test.js
+++ b/worca-ui/app/views/new-run-template.test.js
@@ -15,6 +15,7 @@ vi.mock('lit-html/directives/ref.js', () => ({
 vi.mock('../utils/icons.js', () => ({
   iconSvg: () => '',
   FileText: 'FileText',
+  Sparkles: 'Sparkles',
   Circle: 'Circle',
   CircleAlert: 'CircleAlert',
   CircleCheck: 'CircleCheck',
@@ -55,6 +56,7 @@ describe('new-run — template module state and submit', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -158,6 +160,7 @@ describe('new-run — fetchTemplates via newRunView', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -257,6 +260,7 @@ describe('new-run — defaultOptionLabel reflects worca.default_template', () =>
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',
@@ -316,6 +320,7 @@ describe('new-run — preselect default template when worca.default_template is 
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',

--- a/worca-ui/app/views/new-run-tier-order.test.js
+++ b/worca-ui/app/views/new-run-tier-order.test.js
@@ -17,6 +17,7 @@ vi.mock('lit-html/directives/unsafe-html.js', () => ({
 vi.mock('../utils/icons.js', () => ({
   iconSvg: () => '<svg></svg>',
   FileText: 'FileText',
+  Sparkles: 'Sparkles',
   Circle: 'Circle',
   CircleAlert: 'CircleAlert',
   CircleCheck: 'CircleCheck',
@@ -58,6 +59,7 @@ describe('new-run — template tier order', () => {
     vi.doMock('../utils/icons.js', () => ({
       iconSvg: () => '<svg></svg>',
       FileText: 'FileText',
+      Sparkles: 'Sparkles',
       Circle: 'Circle',
       CircleAlert: 'CircleAlert',
       CircleCheck: 'CircleCheck',

--- a/worca-ui/app/views/new-run.js
+++ b/worca-ui/app/views/new-run.js
@@ -2,7 +2,7 @@ import { html, nothing } from 'lit-html';
 import { ref } from 'lit-html/directives/ref.js';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { helpFor } from '../utils/help-links.js';
-import { FileText, iconSvg } from '../utils/icons.js';
+import { FileText, iconSvg, Sparkles } from '../utils/icons.js';
 import { statusDotClass } from '../utils/status-badge.js';
 import { getDefaults } from './settings.js';
 import { projectStatus } from './sidebar.js';
@@ -28,6 +28,12 @@ export let maxBeads = null; // null = passthrough (use template/project default)
 export let projectLevelMaxBeads = null; // cached from /settings endpoint
 export let claudeMdMode = null; // null = passthrough, string = explicit mode
 export let projectLevelClaudeMdMode = null; // cached from /settings endpoint
+
+// Template advisor — "Suggest" button state
+export let advisorStatus = 'idle'; // 'idle' | 'loading' | 'ready' | 'error'
+export let advisorAdvice = null; // { template_id, rationale, confidence, alternatives }
+export let advisorError = '';
+export let advisorDialogOpen = false;
 
 // Dismissable worktree info banner — persisted via localStorage
 export let bannerDismissed = (() => {
@@ -120,6 +126,157 @@ export function resetNewRunState(overrides = {}) {
     'projectLevelClaudeMdMode' in overrides
       ? overrides.projectLevelClaudeMdMode
       : null;
+  advisorStatus = overrides.advisorStatus ?? 'idle';
+  advisorAdvice = overrides.advisorAdvice ?? null;
+  advisorError = overrides.advisorError ?? '';
+  advisorDialogOpen = overrides.advisorDialogOpen ?? false;
+}
+
+/**
+ * Read the current launcher source value from the form inputs.
+ * Returns { sourceType, sourceValue } trimmed. For sourceType === 'none',
+ * sourceValue is the prompt textarea content.
+ */
+export function readAdvisorInputs() {
+  const promptEl = document.getElementById('new-run-prompt');
+  const sourceValueEl = document.getElementById('new-run-source-value');
+  if (sourceType === 'none') {
+    return {
+      sourceType: 'none',
+      sourceValue: (promptEl?.value || '').trim(),
+    };
+  }
+  return {
+    sourceType,
+    sourceValue: (sourceValueEl?.value || '').trim(),
+  };
+}
+
+// AbortController for the in-flight advisor request, plus a token so a
+// late-arriving response from a cancelled run can't clobber fresh state.
+let _advisorAbort = null;
+let _advisorRequestToken = 0;
+
+/**
+ * Request a template suggestion from the server. Opens the dialog
+ * immediately in 'loading' state (so the spinner appears synchronously),
+ * then resolves once the result has been stored. Pass `rerender` so the
+ * loading frame paints before the await — otherwise the dialog stays
+ * invisible until the network call returns.
+ */
+export async function requestTemplateAdvice({ projectId, rerender } = {}) {
+  const { sourceType: st, sourceValue } = readAdvisorInputs();
+  if (!sourceValue) {
+    advisorStatus = 'error';
+    advisorError =
+      st === 'none'
+        ? 'Type a prompt first.'
+        : `Enter a ${sourceLabel(st).toLowerCase()} first.`;
+    advisorDialogOpen = true;
+    advisorAdvice = null;
+    if (rerender) rerender();
+    return;
+  }
+
+  // Cancel any prior in-flight call so its late response doesn't overwrite
+  // this run's state. The new token is the source of truth — only stamp
+  // results that carry the active token.
+  if (_advisorAbort) {
+    try {
+      _advisorAbort.abort();
+    } catch {
+      /* ignore */
+    }
+  }
+  const controller =
+    typeof AbortController === 'function' ? new AbortController() : null;
+  _advisorAbort = controller;
+  _advisorRequestToken += 1;
+  const myToken = _advisorRequestToken;
+
+  advisorStatus = 'loading';
+  advisorError = '';
+  advisorAdvice = null;
+  advisorDialogOpen = true;
+  // Paint the loading frame BEFORE awaiting the network call so the user
+  // immediately sees the dialog + spinner + Analyzing… copy.
+  if (rerender) rerender();
+
+  const url = projectId
+    ? `/api/projects/${projectId}/templates/advise`
+    : '/api/templates/advise';
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sourceType: st, sourceValue }),
+      signal: controller?.signal,
+    });
+    const data = await res.json().catch(() => ({}));
+    if (myToken !== _advisorRequestToken) return; // superseded — drop the result
+    if (!res.ok || !data?.ok || !data?.advice) {
+      throw new Error(data?.error || `Advisor failed (HTTP ${res.status}).`);
+    }
+    advisorStatus = 'ready';
+    advisorAdvice = data.advice;
+  } catch (err) {
+    if (myToken !== _advisorRequestToken) return; // user moved on; ignore
+    if (err?.name === 'AbortError') {
+      // Cancelled by the user via Cancel / re-trigger — leave dialog state
+      // to whatever dismissAdvisor() or the next call set.
+      return;
+    }
+    advisorStatus = 'error';
+    advisorError = err?.message || 'Advisor failed.';
+  } finally {
+    if (_advisorAbort === controller) _advisorAbort = null;
+    if (rerender && myToken === _advisorRequestToken) rerender();
+  }
+}
+
+/**
+ * Apply the advisor's recommendation by selecting it in the template
+ * dropdown. Closes the dialog. Returns true when applied, false when the
+ * advised template id is no longer in the catalog (resetting state).
+ */
+export function applyAdvisorRecommendation(templateId) {
+  if (!templateId) return false;
+  const known = (templates || []).some((t) => t.id === templateId);
+  if (!known) return false;
+  selectedTemplate = templateId;
+  advisorDialogOpen = false;
+  return true;
+}
+
+export function dismissAdvisor() {
+  // If a request is in flight, abort it so its late response doesn't
+  // re-populate the dialog after the user already closed it. The Python
+  // subprocess may keep running on the server (no way to interrupt the
+  // claude CLI mid-call) — only the UI flow is cancelled.
+  if (_advisorAbort) {
+    try {
+      _advisorAbort.abort();
+    } catch {
+      /* ignore */
+    }
+    _advisorAbort = null;
+  }
+  // Bump the request token so any in-flight handler whose AbortError
+  // failed to surface (mocked fetch in tests, race against fetch internals)
+  // sees its token go stale and discards its result.
+  _advisorRequestToken += 1;
+  if (advisorStatus === 'loading') {
+    advisorStatus = 'idle';
+    advisorError = '';
+    advisorAdvice = null;
+  } else if (advisorStatus === 'error') {
+    // Clear transient errors so re-opening doesn't show the stale message.
+    advisorStatus = 'idle';
+    advisorError = '';
+  }
+  // Otherwise keep advisorAdvice/advisorStatus around so a re-open shows
+  // the last completed result.
+  advisorDialogOpen = false;
 }
 
 /**
@@ -817,7 +974,28 @@ export function newRunView(_state, { rerender }) {
           <div class="new-run-section">
             <h3 class="new-run-section-title">Pipeline</h3>
             <div class="settings-field">
-              <label class="settings-label">Pipeline Template</label>
+              <div class="template-select-header">
+                <label class="settings-label">Pipeline Template</label>
+                <sl-button
+                  class="btn-suggest-template"
+                  size="small"
+                  variant="default"
+                  ?loading=${advisorStatus === 'loading'}
+                  @click=${() => {
+                    // Don't await here — requestTemplateAdvice paints the
+                    // loading frame synchronously via the rerender it
+                    // receives, then rerenders again when the result lands.
+                    requestTemplateAdvice({
+                      projectId: effectiveId,
+                      rerender,
+                    });
+                  }}
+                  title="Recommend the best-fit template based on your prompt or source"
+                >
+                  <span slot="prefix">${unsafeHTML(iconSvg(Sparkles, 14))}</span>
+                  Suggest
+                </sl-button>
+              </div>
               <sl-select value=${selectedTemplate} @sl-change=${handleTemplateChange}>
                 <sl-option value="default">${defaultOptionLabel()}</sl-option>
                 ${
@@ -1000,6 +1178,128 @@ export function newRunView(_state, { rerender }) {
           </div>
         </div>
       </div>
+
+      ${advisorDialogView(rerender)}
     </div>
+  `;
+}
+
+/**
+ * Render the "Suggested template" dialog. Always present in the DOM so
+ * `?open` can drive it; renders nothing visible when closed.
+ */
+function advisorDialogView(rerender) {
+  const recommendedName = (() => {
+    if (!advisorAdvice?.template_id) return '';
+    const t = (templates || []).find((x) => x.id === advisorAdvice.template_id);
+    return t ? t.name || t.id : advisorAdvice.template_id;
+  })();
+  return html`
+    <sl-dialog
+      class="advisor-dialog"
+      label="Template Suggestion"
+      ?open=${advisorDialogOpen}
+      @sl-after-hide=${() => {
+        dismissAdvisor();
+        rerender();
+      }}
+    >
+      ${(() => {
+        if (advisorStatus === 'loading') {
+          return html`
+            <div class="advisor-dialog-body advisor-loading">
+              <sl-spinner></sl-spinner>
+              <span>Analyzing…</span>
+            </div>
+          `;
+        }
+        if (advisorStatus === 'error') {
+          return html`
+            <div class="advisor-dialog-body advisor-error">
+              <p>${advisorError || 'Advisor failed.'}</p>
+            </div>
+          `;
+        }
+        if (advisorStatus === 'ready' && advisorAdvice) {
+          const confTag = (() => {
+            const c = advisorAdvice.confidence || 'high';
+            const variant =
+              c === 'low' ? 'warning' : c === 'medium' ? 'neutral' : 'success';
+            return html`<sl-tag size="small" variant=${variant}>${c} confidence</sl-tag>`;
+          })();
+          return html`
+            <div class="advisor-dialog-body">
+              <div class="advisor-headline">
+                <strong class="advisor-template-name">${recommendedName}</strong>
+                ${confTag}
+              </div>
+              <p class="advisor-rationale">${advisorAdvice.rationale}</p>
+              ${
+                (advisorAdvice.alternatives || []).length > 0
+                  ? html`
+                    <sl-details summary="Other options" class="advisor-alternatives">
+                      <ul>
+                        ${(advisorAdvice.alternatives || []).map(
+                          (alt) => html`
+                            <li>
+                              <strong>${(() => {
+                                const t = (templates || []).find(
+                                  (x) => x.id === alt.template_id,
+                                );
+                                return t ? t.name || t.id : alt.template_id;
+                              })()}</strong>
+                              — ${alt.rationale || ''}
+                              <sl-button
+                                size="small"
+                                variant="default"
+                                class="btn-advisor-pick-alt"
+                                @click=${() => {
+                                  if (
+                                    applyAdvisorRecommendation(alt.template_id)
+                                  ) {
+                                    rerender();
+                                  }
+                                }}
+                              >Use instead</sl-button>
+                            </li>
+                          `,
+                        )}
+                      </ul>
+                    </sl-details>
+                  `
+                  : nothing
+              }
+            </div>
+          `;
+        }
+        return nothing;
+      })()}
+      <div slot="footer">
+        <sl-button
+          class="btn-advisor-cancel"
+          @click=${() => {
+            dismissAdvisor();
+            rerender();
+          }}
+        >${advisorStatus === 'error' ? 'Close' : 'Cancel'}</sl-button>
+        ${
+          advisorStatus === 'error'
+            ? nothing
+            : html`
+              <sl-button
+                variant="primary"
+                class="btn-advisor-accept"
+                ?disabled=${advisorStatus !== 'ready' || !advisorAdvice}
+                @click=${() => {
+                  if (advisorStatus !== 'ready' || !advisorAdvice) return;
+                  if (applyAdvisorRecommendation(advisorAdvice.template_id)) {
+                    rerender();
+                  }
+                }}
+              >Use this template</sl-button>
+            `
+        }
+      </div>
+    </sl-dialog>
   `;
 }

--- a/worca-ui/server/templates-routes.advise.test.js
+++ b/worca-ui/server/templates-routes.advise.test.js
@@ -1,0 +1,311 @@
+/**
+ * Tests: POST /templates/advise — Suggest Template button endpoint.
+ *
+ * Mutations delegate to `worca templates advise`; we mock execFileSync and
+ * assert on CLI args + HTTP shape.
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecSync = vi.fn();
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    execFileSync: (...args) => mockExecSync(...args),
+  };
+});
+
+const { createTemplatesRoutes } = await import('./templates-routes.js');
+
+function createTestApp(projectRoot) {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api/projects/:projectId',
+    (req, _res, next) => {
+      req.project = {
+        name: req.params.projectId,
+        path: projectRoot,
+        settingsPath: join(projectRoot, '.claude', 'settings.json'),
+        worcaDir: join(projectRoot, '.worca'),
+        projectRoot,
+      };
+      next();
+    },
+    createTemplatesRoutes(),
+  );
+  return app;
+}
+
+async function request(app, method, path, body) {
+  const { createServer } = await import('node:http');
+  const server = createServer(app);
+  return new Promise((resolve, reject) => {
+    server.listen(0, '127.0.0.1', async () => {
+      const { port } = server.address();
+      try {
+        const options = {
+          method,
+          headers: { 'Content-Type': 'application/json' },
+        };
+        if (body) options.body = JSON.stringify(body);
+        const res = await fetch(`http://127.0.0.1:${port}${path}`, options);
+        const text = await res.text();
+        let json;
+        try {
+          json = JSON.parse(text);
+        } catch {
+          json = { raw: text };
+        }
+        resolve({ status: res.status, body: json });
+      } catch (err) {
+        reject(err);
+      } finally {
+        server.close();
+      }
+    });
+  });
+}
+
+function cliOk(stdout) {
+  return stdout;
+}
+
+function cliError(stderr) {
+  const err = new Error('Command failed');
+  err.status = 1;
+  err.stderr = Buffer.from(stderr);
+  err.stdout = Buffer.from('');
+  return err;
+}
+
+describe('POST /templates/advise', () => {
+  let projectRoot;
+
+  beforeEach(() => {
+    projectRoot = join(
+      tmpdir(),
+      `worca-advise-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(projectRoot, { recursive: true });
+    mockExecSync.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('returns the advisor payload on success', async () => {
+    mockExecSync.mockReturnValueOnce(
+      cliOk(
+        JSON.stringify({
+          template_id: 'bugfix',
+          rationale: 'bug language and tight scope',
+          confidence: 'high',
+          alternatives: [],
+        }),
+      ),
+    );
+    const app = createTestApp(projectRoot);
+    const res = await request(
+      app,
+      'POST',
+      '/api/projects/p1/templates/advise',
+      {
+        sourceType: 'none',
+        sourceValue: 'Fix the broken login flow',
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.advice.template_id).toBe('bugfix');
+    expect(res.body.advice.confidence).toBe('high');
+  });
+
+  it('maps launcher "none" → backend "prompt" on the CLI', async () => {
+    mockExecSync.mockReturnValueOnce(
+      cliOk(
+        JSON.stringify({
+          template_id: 'bugfix',
+          rationale: 'x',
+          confidence: 'high',
+        }),
+      ),
+    );
+    const app = createTestApp(projectRoot);
+    await request(app, 'POST', '/api/projects/p1/templates/advise', {
+      sourceType: 'none',
+      sourceValue: 'do a thing',
+    });
+    const args = mockExecSync.mock.calls[0][1];
+    expect(args).toContain('advise');
+    const idx = args.indexOf('--source-type');
+    expect(args[idx + 1]).toBe('prompt');
+  });
+
+  it('streams the prompt text via stdin to avoid argv blow-up', async () => {
+    mockExecSync.mockReturnValueOnce(
+      cliOk(
+        JSON.stringify({
+          template_id: 'bugfix',
+          rationale: 'x',
+          confidence: 'high',
+        }),
+      ),
+    );
+    const longPrompt = 'a'.repeat(20000);
+    const app = createTestApp(projectRoot);
+    await request(app, 'POST', '/api/projects/p1/templates/advise', {
+      sourceType: 'none',
+      sourceValue: longPrompt,
+    });
+    const args = mockExecSync.mock.calls[0][1];
+    const idx = args.indexOf('--source-value');
+    expect(args[idx + 1]).toBe('-');
+    const opts = mockExecSync.mock.calls[0][2];
+    expect(opts.input).toBe(longPrompt);
+  });
+
+  it('accepts each launcher source type', async () => {
+    const app = createTestApp(projectRoot);
+    for (const sourceType of ['spec', 'source', 'pr']) {
+      mockExecSync.mockReturnValueOnce(
+        cliOk(
+          JSON.stringify({
+            template_id: 'bugfix',
+            rationale: 'x',
+            confidence: 'high',
+          }),
+        ),
+      );
+      const res = await request(
+        app,
+        'POST',
+        '/api/projects/p1/templates/advise',
+        { sourceType, sourceValue: 'some-value' },
+      );
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('rejects missing sourceType', async () => {
+    const app = createTestApp(projectRoot);
+    const res = await request(
+      app,
+      'POST',
+      '/api/projects/p1/templates/advise',
+      {
+        sourceValue: 'x',
+      },
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/sourceType/);
+  });
+
+  it('rejects unknown sourceType', async () => {
+    const app = createTestApp(projectRoot);
+    const res = await request(
+      app,
+      'POST',
+      '/api/projects/p1/templates/advise',
+      {
+        sourceType: 'bogus',
+        sourceValue: 'x',
+      },
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/must be one of/);
+  });
+
+  it('rejects empty prompt', async () => {
+    const app = createTestApp(projectRoot);
+    const res = await request(
+      app,
+      'POST',
+      '/api/projects/p1/templates/advise',
+      {
+        sourceType: 'none',
+        sourceValue: '   ',
+      },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty source value for non-prompt sources', async () => {
+    const app = createTestApp(projectRoot);
+    const res = await request(
+      app,
+      'POST',
+      '/api/projects/p1/templates/advise',
+      {
+        sourceType: 'source',
+        sourceValue: '',
+      },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('passes the model alias through to the CLI', async () => {
+    mockExecSync.mockReturnValueOnce(
+      cliOk(
+        JSON.stringify({
+          template_id: 'bugfix',
+          rationale: 'x',
+          confidence: 'high',
+        }),
+      ),
+    );
+    const app = createTestApp(projectRoot);
+    await request(app, 'POST', '/api/projects/p1/templates/advise', {
+      sourceType: 'none',
+      sourceValue: 'x',
+      model: 'opus',
+    });
+    const args = mockExecSync.mock.calls[0][1];
+    const idx = args.indexOf('--model');
+    expect(args[idx + 1]).toBe('opus');
+  });
+
+  it('defaults to sonnet when no model is provided', async () => {
+    mockExecSync.mockReturnValueOnce(
+      cliOk(
+        JSON.stringify({
+          template_id: 'bugfix',
+          rationale: 'x',
+          confidence: 'high',
+        }),
+      ),
+    );
+    const app = createTestApp(projectRoot);
+    await request(app, 'POST', '/api/projects/p1/templates/advise', {
+      sourceType: 'none',
+      sourceValue: 'x',
+    });
+    const args = mockExecSync.mock.calls[0][1];
+    const idx = args.indexOf('--model');
+    expect(args[idx + 1]).toBe('sonnet');
+  });
+
+  it('surfaces CLI errors as 500 with the error text', async () => {
+    mockExecSync.mockImplementationOnce(() => {
+      throw cliError('claude CLI exited 1: boom');
+    });
+    const app = createTestApp(projectRoot);
+    const res = await request(
+      app,
+      'POST',
+      '/api/projects/p1/templates/advise',
+      {
+        sourceType: 'none',
+        sourceValue: 'x',
+      },
+    );
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/boom/);
+  });
+});

--- a/worca-ui/server/templates-routes.js
+++ b/worca-ui/server/templates-routes.js
@@ -747,6 +747,76 @@ export function createTemplatesRoutes() {
   );
 
   /**
+   * POST /api/projects/:projectId/templates/advise
+   * Body: { sourceType, sourceValue?, model? }
+   *
+   * Asks the Python advisor to pick the best-fit pipeline template for
+   * the given source. `sourceType` mirrors the launcher's options
+   * ("none" | "spec" | "source" | "pr", or "prompt"/"plan" when called
+   * directly). The route forwards "none" to the Python advisor as
+   * "prompt" so the prompt textarea path works unchanged.
+   *
+   * Returns { ok: true, advice: { template_id, rationale, confidence,
+   * alternatives: [...] } } on success.
+   */
+  router.post('/templates/advise', (req, res) => {
+    const body = req.body || {};
+    const rawSourceType = String(body.sourceType || '').trim();
+    if (!rawSourceType) {
+      return res
+        .status(400)
+        .json({ ok: false, error: 'sourceType is required' });
+    }
+    // Launcher uses "none" for the prompt textarea path. Map it to the
+    // backend's `prompt` source so the same wire shape covers both.
+    const sourceType = rawSourceType === 'none' ? 'prompt' : rawSourceType;
+    const ALLOWED = new Set(['prompt', 'spec', 'source', 'pr', 'plan']);
+    if (!ALLOWED.has(sourceType)) {
+      return res.status(400).json({
+        ok: false,
+        error: `sourceType must be one of: ${Array.from(ALLOWED).join(', ')}`,
+      });
+    }
+    const sourceValue = String(body.sourceValue || '');
+    if (sourceType !== 'prompt' && !sourceValue.trim()) {
+      return res.status(400).json({
+        ok: false,
+        error: 'sourceValue is required for non-prompt sources',
+      });
+    }
+    if (sourceType === 'prompt' && !sourceValue.trim()) {
+      return res
+        .status(400)
+        .json({ ok: false, error: 'sourceValue (prompt text) is required' });
+    }
+    const model =
+      body.model && typeof body.model === 'string' ? body.model : 'sonnet';
+    const { projectRoot } = req.project;
+    try {
+      const stdout = runWorcaTemplates(
+        projectRoot,
+        [
+          'advise',
+          '--source-type',
+          sourceType,
+          '--source-value',
+          '-',
+          '--model',
+          model,
+        ],
+        { stdin: sourceValue, timeout: 90000 },
+      );
+      const advice = JSON.parse(stdout || '{}');
+      res.json({ ok: true, advice });
+    } catch (err) {
+      const status = statusForCliCode(err.cliCode);
+      res
+        .status(status === 500 ? 500 : status)
+        .json({ ok: false, error: err.message || 'advise failed' });
+    }
+  });
+
+  /**
    * POST /api/projects/:projectId/templates/validate
    * Body: { config }
    *


### PR DESCRIPTION
## Summary

Adds a **Suggest** button next to the pipeline template dropdown on the new-pipeline launcher. Analyses the work source (prompt, spec file, GitHub issue, GitHub PR with review comments, plan file) via an LLM agent and recommends the best-fit template from the project's catalog (built-in + project + user).

### Backend

- `src/worca/template_advisor.py` + agent prompt files (`src/worca/agents/core/template-advisor.md` + `template-advise.block.md`) — external `.md` so project overlays apply via the standard `OverlayResolver`, matching every other pipeline agent.
- `src/worca/cli/templates.py`: new `worca templates advise` subcommand. Prompt streamed via stdin to avoid argv blow-up.
- `POST /api/projects/:id/templates/advise` (and the global variant) in `worca-ui/server/templates-routes.js` — shells out to the CLI.

### UI

- `new-run.js`: Sparkles button next to the template dropdown. `sl-dialog` paints an **Analyzing…** spinner synchronously (rerender passed into `requestTemplateAdvice` so the loading frame lands before the await).
- AbortController + request token: cancel in-flight calls on dismiss; supersede stale responses on re-click.
- "Use this template" stays visible-but-disabled during loading; hidden entirely on error (just a Close button).

### Companion fixes

- `normalize_github_pr` now honours `owner/repo` from a parsed URL via `gh pr view --repo …`, fixing cross-project PR lookups for the advisor **and** any pipeline launch that pastes a full PR URL.
- Advisor short-circuits **before** running `gh` / `claude` when a URL source's `owner/repo` doesn't match the project's — surfaces _"This source belongs to X, but this project's repository is Y"_ in the dialog.

## Test plan

- [x] Python unit tests pass — `pytest tests/ --ignore=tests/integration` → 6431 passed.
- [x] worca-ui vitest pass — `cd worca-ui && npx vitest run` → 5081 passed.
- [x] Biome lint clean.
- [x] `worca templates advise --help` resolves to the new subcommand.
- [x] Synced and smoke-tested against an external project (`test-multi-01`) via `worca init --upgrade`.
- [ ] Manual UI: click Suggest with each source type (prompt / spec / GitHub issue / GitHub PR) and confirm dialog flow, cancel-mid-loading, cross-project rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)