### PR TITLE
feat: per-tier model selection in templates via tier:alias ref syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,27 @@ Key gotchas:
 - **Secrets** belong in `settings.local.json` (gitignored, deep-merged over `settings.json`). The UI Secrets panel writes exclusively to this file. Never inline secrets in `settings.json`.
 - **Reserved keys** matching `WORCA_*`, `PATH`, or `CLAUDECODE` are silently stripped with a stderr warning. Denylist shared between Python (`src/worca/utils/env.py`) and JS (`worca-ui/server/reserved-env-keys.json`).
 - **Worktree materialization:** parent's `settings.local.json` secrets are materialized into the worktree's `settings.json` (gitignored). Same on-disk plaintext exposure model as `~/.aws/credentials`.
-- **`work_request.py` haiku coupling:** `extract_work_request` resolves its hardcoded `--model haiku` through `resolve_model()`, so customizing the `haiku` entry also retargets work-request title generation. Intentional.
+- **`work_request.py` haiku pin:** `extract_work_request` resolves `--model builtin:haiku` so title generation is deterministic regardless of user/project shadowing. This is a hard pin — user/project shadows of the `haiku` alias do **not** affect title generation.
 - **Cost source per alias:** if an alias's `env` block sets `ANTHROPIC_BASE_URL` (alt-endpoint routing), worca overrides Claude CLI's `total_cost_usd` using `worca.pricing.models.<alias>`. Otherwise Claude CLI's number is authoritative and the Pricing tab is informational/fallback. The trigger set lives in `_ALT_ENDPOINT_ENV_KEYS` in `src/worca/orchestrator/stages.py`.
+
+#### Tier-pinned refs
+
+Model refs in agent configs (`worca.agents.<name>.model`) and template configs support a `tier:alias` syntax that pins the alias to a specific settings tier:
+
+```
+tier:alias   →   user:sonnet   |   project:opus   |   builtin:haiku
+```
+
+- **Regex:** `^(user|project|builtin):([A-Za-z0-9_-]+)$`
+- **Bare alias** (no `tier:` prefix): resolved against the merged `worca.models` dict (project shadows user). The bare form is the default save behaviour — the UI writes bare aliases to `settings.json` by default (D1).
+- **`user:alias`**: hard-pinned to `~/.worca/settings.json`; ignores any project-level definition of that alias.
+- **`project:alias`**: hard-pinned to `.claude/settings.json`; ignores any user-level definition.
+- **`builtin:alias`**: resolves from the package's `_DEFAULT_MODEL_MAP` (`src/worca/utils/settings.py`), bypassing both user and project settings entirely. `work_request.py` uses `builtin:haiku` so title generation is always deterministic.
+- **Auto-pin on bundle import (D3):** `worca templates import` rewrites bare refs to `{scope}:alias` where `scope` matches the `--scope` argument (`user` or `project`). This prevents a template exported from one project from silently picking up a different project's same-named alias.
+- **`worca models add --tier`:** adds or updates an alias scoped to a specific tier (`user` or `project`); `builtin` is rejected (read-only). See Phase 7 in the models CLI.
+- **Preflight errors:** a pinned ref that names an alias not present in the target tier's stash raises a `PreflightError` before the run starts (Phase 5b).
+
+Full precedence reference: [`docs/configuration-precedence.md`](./docs/configuration-precedence.md).
 
 ### Effort Levels (`worca.effort`)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -927,6 +927,22 @@ UI-only release tracking the worca-cc 0.55.0 surface changes plus a docs-coverag
 - **Models editor polish.** New cost-source badge taxonomy (`explicit` / `Claude CLI` / no badge); `—` placeholder for unset pricing fields (so `0` stays meaningful for truly-free rates); a **Clear pricing** button that wipes all four fields; widened env-var key/value columns; a **Not configured** danger badge + red-outlined value cell when any env value is still `<YOUR-SECRET-HERE>`.
 - **Bundle import id/env split.** Imported `worca.models.<alias>` entries now land split across `settings.json` (id) and `settings.local.json` (env) so secret-bearing env always stays out of the committed file. Models cache refreshes automatically after import.
 
+### Unreleased — tier-pinned model refs
+
+Tier-pinned model refs (`user:alias`, `project:alias`, `builtin:alias`) are a new syntax for `worca.agents.<name>.model` and template model fields.
+
+- **New syntax.** A model ref may now be prefixed with a tier: `user:sonnet`, `project:opus`, `builtin:haiku`. This hard-pins resolution to that settings tier and bypasses the normal merged-dict lookup. Bare refs (no prefix) continue to work unchanged and remain the default save form.
+
+- **Bare-default save rule (D1).** No existing `settings.json` files are affected. The UI and `worca models add` write bare aliases by default unless `--tier` is passed. Tier-pinned refs are opt-in.
+
+- **Auto-pin on bundle import (D3).** `worca templates import --scope <tier>` now rewrites bare model refs in the imported bundle to `{scope}:alias`. This prevents the imported template from accidentally resolving against a same-named alias in the destination project. If you re-import a previously exported bundle, the resulting entries will carry tier pins that were not there before — this is intentional. To revert, replace the pinned ref with the bare alias in `settings.json`.
+
+- **`work_request.py` haiku pin — behaviour change (D5).** The internal title-generation call now uses `builtin:haiku` unconditionally. Previously it resolved `haiku` through the merged models dict, so a project that shadowed the `haiku` alias (e.g. for cost routing or an alt-endpoint) would see title generation use that custom model. That shadow is now bypassed. If you relied on this, configure the `extract_work_request` call explicitly or leave the `haiku` alias as-is for title generation.
+
+- **New `worca models add --tier` flag (D6).** `worca models add <alias> <model-id> [--tier user|project] [--env KEY=VAL]` places the alias directly in the chosen tier's settings file. `--tier builtin` is rejected. If `--tier` is omitted, the command infers `project` (git root found) or `user` (fallback). The `id` field goes to `settings.json`; `--env` pairs go to `settings.local.json`.
+
+No `worca init --upgrade` migration required — settings file shape is unchanged.
+
 ## Getting help
 
 - Issues: https://github.com/SinishaDjukic/worca-cc/issues

--- a/docs/configuration-precedence.md
+++ b/docs/configuration-precedence.md
@@ -79,6 +79,67 @@ Anything else you put in `~/.worca/settings.json` (e.g., `worca.agents.implement
 - **`worca.agents.coordinator.max_beads` has a three-level precedence:** per-run `--max-beads` CLI/API override (highest) → template `config.agents.coordinator.max_beads` → `0` (auto, lowest). Because `worca.agents` is template-owned, a project's raw `settings.json` value for `max_beads` is stripped when a template is in play — the template owns it outright. The key accepts integer `0`–`50`; `0` = auto (no cap), `1` = single-bead mandate, `>1` = advisory budget. Enforcement is soft (log on deviation, run proceeds as decomposed). The cap is suppressed when PR-revision mode is active (`has_review_comments`), where review-comment-to-bead rules take precedence.
 - **`worca.claude_md_mode` controls which CLAUDE.md files Claude Code loads, with four-level precedence:** per-run `--claude-md-mode` CLI flag (highest) → template `config.claude_md_mode` (if the template explicitly sets it) → project `worca.claude_md_mode` in `settings.json` → `"all"` (built-in default). Unlike most template-owned keys (`worca.agents`, `worca.stages`, etc.), `claude_md_mode` is **not** stripped when a template is active — the project value flows through as the base and is only overridden when a template explicitly sets it in its `config`. This means `worca.claude_md_mode: "project"` in `settings.json` works correctly for hermetic runs regardless of which built-in template is used. Custom templates may still pin a specific mode. Valid values: `none` (no CLAUDE.md loading, auto-memory disabled), `project` (project-root CLAUDE.md only), `project+local` (adds CLAUDE.local.md), `all` (standard behaviour, no overlay written). The resolved mode and its source are recorded in `status.json` and emitted as `pipeline.claude_md.mode_resolved` at run start.
 
+## Per-tier model refs
+
+Model refs in agent configs and templates support an optional `tier:alias` prefix that pins the resolution to a specific settings tier.
+
+### Grammar
+
+```
+model_ref  ::= bare_alias | tier_pinned
+bare_alias ::= [A-Za-z0-9_-]+
+tier_pinned ::= tier ":" bare_alias
+tier       ::= "user" | "project" | "builtin"
+```
+
+Full regex: `^(user|project|builtin):([A-Za-z0-9_-]+)$`
+
+### Bare vs pinned semantics
+
+| Form | Resolution | Typical use |
+|---|---|---|
+| `sonnet` (bare) | Merged `worca.models` dict — project wins on collision | Default save form; flexible override |
+| `project:sonnet` | `.claude/settings.json` only — ignores `~/.worca/settings.json` entry | Reproducible per-project routing |
+| `user:sonnet` | `~/.worca/settings.json` only — ignores project entry | Shared personal alt-endpoint creds |
+| `builtin:haiku` | `_DEFAULT_MODEL_MAP` in `src/worca/utils/settings.py` — bypasses all settings tiers | Deterministic CLI/pipeline internals |
+
+Bare aliases remain the **default save form** (D1). The UI writes bare aliases to `settings.json`; pinned forms are only created by explicit intent (CLI import, `worca models add --tier`, or manual edit).
+
+### Bundle round-trip
+
+When exporting a template via `worca templates export`:
+
+- `user:alias` and `project:alias` refs are **stripped** to the bare alias form. Tier pins are local-machine context; a bundle crossing to another project should resolve against that project's own models dict.
+- `builtin:alias` refs are **preserved** verbatim — built-ins are installation-scope and always resolvable.
+
+When importing via `worca templates import --scope <tier>` (D3):
+
+- Bare alias refs in the imported bundle are **auto-pinned** to `{scope}:alias`. This prevents the imported template from silently shadowing a differently-defined alias in the destination project.
+- `builtin:alias` refs pass through unchanged.
+
+### Preflight error semantics
+
+Before a run starts (Phase 5b), the preflight stage validates all tier-pinned refs:
+
+- `user:alias` — alias must exist in `~/.worca/settings.json` (`worca.models`). Missing → `PreflightError`.
+- `project:alias` — alias must exist in `.claude/settings.json` (`worca.models`). Missing → `PreflightError`.
+- `builtin:alias` — always resolvable from `_DEFAULT_MODEL_MAP`; no stash lookup needed.
+
+`PreflightError` halts the run before any agent starts and emits a structured error message naming the missing alias and its expected tier. The `WORCA_MODEL_AGENT` env var is checked first and wins over all refs if set (logs to stderr).
+
+### `worca models add --tier`
+
+The `worca models add` CLI command accepts a `--tier` flag (`user` or `project`) to explicitly place a new alias in a specific tier's settings file:
+
+```bash
+worca models add my-sonnet claude-sonnet-4-6 --tier project
+worca models add my-opus  claude-opus-4-8    --tier user --env ANTHROPIC_BASE_URL=https://…
+```
+
+- `--tier builtin` is **rejected** — built-in aliases are read-only (managed by `worca init --upgrade`).
+- If `--tier` is omitted, the command infers: `project` if a git root with `.claude/settings.json` is found, otherwise `user`.
+- The `id` field is written to the tier's `settings.json`; any `--env` pairs are written to the matching `settings.local.json` (kept gitignored). This mirrors the W-051 split between `id` (safe to commit) and `env` (may contain secrets).
+
 ## Managing templates in the UI
 
 The **Pipelines** section in the dashboard lets you browse, create, edit, duplicate, and delete templates without touching the CLI or editing JSON by hand. It also surfaces the dedup/shadowing relationships described above and marks the current default template. See the [Pipelines editor walkthrough](https://docs.worca.dev/configuration/pipelines-editor/) on the docs site.

--- a/src/worca/cli/main.py
+++ b/src/worca/cli/main.py
@@ -250,6 +250,10 @@ def create_parser() -> argparse.ArgumentParser:
     from worca.cli.crg_cmd import register_subcommand as register_crg
     register_crg(sub)
 
+    # models
+    from worca.cli.models_cmd import register_subcommand as register_models
+    register_models(sub)
+
     # pr (PR lifecycle)
     from worca.cli.pr import register_subcommand as register_pr
     register_pr(sub)
@@ -313,6 +317,9 @@ def main(argv=None):
     elif args.command == "pr":
         from worca.cli.pr import cmd_pr
         cmd_pr(args)
+    elif args.command == "models":
+        from worca.cli.models_cmd import cmd_models
+        cmd_models(args)
     else:
         print(f"error: unknown command {args.command!r}", file=sys.stderr)
         raise SystemExit(1)

--- a/src/worca/cli/models_cmd.py
+++ b/src/worca/cli/models_cmd.py
@@ -1,0 +1,161 @@
+"""CLI subcommand: worca models add <alias> <id> [--tier {user,project}] [--env K=V ...]"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _find_project_root() -> Path | None:
+    """Walk upward from cwd looking for a .git directory."""
+    cwd = Path(os.getcwd()).resolve()
+    for parent in [cwd, *cwd.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def _project_settings_path() -> Path | None:
+    root = _find_project_root()
+    if root is None:
+        return None
+    return root / ".claude" / "settings.json"
+
+
+def _global_settings_path() -> str:
+    from worca.utils.settings import _default_global_path
+    return _default_global_path()
+
+
+def _read_json(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _write_json(path: str, data: dict) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def _local_path_for(settings_path: str) -> str:
+    root, ext = os.path.splitext(settings_path)
+    return root + ".local" + ext
+
+
+def _is_reserved(key: str) -> bool:
+    from worca.utils.env import RESERVED_ENV_KEYS, RESERVED_PREFIXES
+    return key in RESERVED_ENV_KEYS or any(key.startswith(p) for p in RESERVED_PREFIXES)
+
+
+def register_subcommand(sub) -> None:
+    models_parser = sub.add_parser("models", help="Manage worca model aliases")
+    models_sub = models_parser.add_subparsers(dest="models_command")
+
+    add_parser = models_sub.add_parser("add", help="Add or update a model alias")
+    add_parser.add_argument("alias", help="Alias name (no colons)")
+    add_parser.add_argument("id", help="Model ID (e.g. claude-sonnet-4-6)")
+    add_parser.add_argument(
+        "--tier",
+        choices=["user", "project", "builtin"],
+        default=None,
+        help="Settings tier to write to (default: project if in a git repo, else user)",
+    )
+    add_parser.add_argument(
+        "--env",
+        action="append",
+        metavar="KEY=VAL",
+        default=None,
+        help="Environment variable for this model (repeatable); goes to settings.local.json",
+    )
+
+
+def cmd_models(args) -> None:
+    if not getattr(args, "models_command", None):
+        print("error: specify a subcommand, e.g. 'worca models add <alias> <id>'", file=sys.stderr)
+        raise SystemExit(1)
+
+    if args.models_command == "add":
+        _cmd_models_add(args)
+    else:
+        print(f"error: unknown models subcommand {args.models_command!r}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def _cmd_models_add(args) -> None:
+    alias = args.alias
+    model_id = args.id
+    tier = args.tier
+    env_pairs = args.env or []
+
+    # --- Reject builtin tier ---
+    if tier == "builtin":
+        print("error: built-in models are not user-writable", file=sys.stderr)
+        raise SystemExit(1)
+
+    # --- Reject colon in alias ---
+    if ":" in alias:
+        print(
+            f"error: alias name cannot contain colon: '{alias}'. "
+            "Use 'tier:alias' only in agent model references, not as a models key.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    # --- Parse --env pairs ---
+    env: dict[str, str] = {}
+    for pair in env_pairs:
+        if "=" not in pair:
+            print(f"error: --env value must be KEY=VAL, got {pair!r}", file=sys.stderr)
+            raise SystemExit(1)
+        k, v = pair.split("=", 1)
+        if _is_reserved(k):
+            print(
+                f"error: env key '{k}' is reserved and cannot be set via --env",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        env[k] = v
+
+    # --- Resolve tier ---
+    if tier is None:
+        tier = "project" if _find_project_root() is not None else "user"
+
+    # --- Resolve settings paths ---
+    if tier == "project":
+        project_path = _project_settings_path()
+        if project_path is None:
+            print(
+                "error: could not find a .git-rooted project directory; "
+                "use --tier user or run from a git repository",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        settings_path = str(project_path)
+    else:
+        settings_path = _global_settings_path()
+
+    # --- Write settings.json (id side) ---
+    base = _read_json(settings_path)
+    base.setdefault("worca", {}).setdefault("models", {})
+    base["worca"]["models"][alias] = {"id": model_id} if env else model_id
+    _write_json(settings_path, base)
+
+    # --- Write settings.local.json (env side) ---
+    local_path = _local_path_for(settings_path)
+    local = _read_json(local_path)
+    local.setdefault("worca", {}).setdefault("models", {})
+    if env:
+        local["worca"]["models"][alias] = {"env": env}
+        _write_json(local_path, local)
+    else:
+        # Remove any stale env entry if overwriting with no-env
+        if alias in local.get("worca", {}).get("models", {}):
+            del local["worca"]["models"][alias]
+            _write_json(local_path, local)
+
+    print(f"ok: wrote '{alias}' to {tier} settings ({settings_path})")

--- a/src/worca/cli/templates.py
+++ b/src/worca/cli/templates.py
@@ -32,6 +32,7 @@ from worca.orchestrator.bundle import (
     collect_referenced_model_aliases,
     fetch_bundle,
     redact_bundle,
+    strip_tier_prefixes,
     validate_bundle,
 )
 from worca.orchestrator.templates import (
@@ -40,7 +41,7 @@ from worca.orchestrator.templates import (
     materialize_config,
 )
 from worca.utils.env import filter_model_env
-from worca.utils.settings import deep_merge
+from worca.utils.settings import _parse_model_ref, deep_merge
 
 
 def _resolve_dirs(project_root: str | None = None):
@@ -974,6 +975,12 @@ def cmd_templates_export(args):
 
     any_overlays = any("_overlays" in e for e in template_entries)
 
+    # Pre-redaction pass: strip user:/project: prefixes from agent model refs so
+    # bundles ship bare refs (post-D2 wire format). builtin: and bare refs are
+    # preserved verbatim. Malformed refs are left as-is — the validator flagged
+    # them earlier; export is not the right place to silently rewrite them.
+    template_entries = strip_tier_prefixes(template_entries)
+
     dest = args.to
     if dest in ("gist", "gist:public"):
         if any_overlays:
@@ -1322,7 +1329,13 @@ def cmd_templates_import(args):
     # --preview: print collisions JSON and exit without writing. Used by the
     # worca-ui import flow to drive the collision dialog before commit.
     if preview_only:
-        preview = _build_collision_preview(bundle_models, bundle_pricing, models_settings_path)
+        preview = _build_collision_preview(
+            bundle_models,
+            bundle_pricing,
+            models_settings_path,
+            bundle_templates=list(bundle_templates),
+            landing_tier=scope,
+        )
         preview["template_ids"] = [t.get("id") for t in bundle_templates]
         preview["template_collisions"] = template_collisions_meta
         # Models, pricing, and templates all land in the same scope now
@@ -1343,9 +1356,20 @@ def cmd_templates_import(args):
     )
 
     # Apply the rename map to templates BEFORE _atomic_import so the on-disk
-    # template never references a stale alias name. Transactional with the
-    # rename in the settings patch.
-    _rewrite_template_model_refs(to_import, rename_map)
+    # template never references a stale alias name. Also auto-pins all bare
+    # refs to the landing tier. Transactional with the rename in the settings patch.
+    ref_rewrites = _rewrite_template_model_refs(to_import, rename_map, landing_tier=scope)
+    if ref_rewrites:
+        print(
+            f"info: rewrote {len(ref_rewrites)} template model ref(s) to pin to --scope {scope!r}:",
+            file=sys.stderr,
+        )
+        for tmpl_id, role, old_ref, new_ref, reason in ref_rewrites:
+            reason_label = reason.replace("_", " ")
+            print(
+                f"  - {tmpl_id}.{role}.model: {old_ref} → {new_ref} ({reason_label})",
+                file=sys.stderr,
+            )
 
     # Stamp bundle attribution on each imported model entry so the Models
     # page can surface a small "Imported from <X>" badge. Prefer the
@@ -1535,33 +1559,81 @@ def _find_next_alias_name(base: str, taken: set[str], cap: int = 99) -> str | No
 
 
 def _rewrite_template_model_refs(
-    templates: dict, rename_map: dict[str, str]
-) -> None:
-    """Rewrite every ``config.agents.*.model`` reference in *templates* that
-    points at a renamed alias. Mutates in place; called transactionally with
-    the rename map AFTER collision resolution and BEFORE _atomic_import so the
-    on-disk template never references a stale alias.
+    templates: dict, rename_map: dict[str, str], landing_tier: str = "project"
+) -> list[tuple]:
+    """Rewrite every ``config.agents.*.model`` reference in *templates*.
+
+    Mutates in place; called AFTER collision resolution and BEFORE
+    _atomic_import so the on-disk template never references a stale alias or
+    bare ref.
+
+    Rules per ref:
+    - builtin:alias  → pass through unchanged.
+    - user:/project: → wire-format violation (bundles must not carry tier
+      prefixes); emit stderr warning, strip the prefix, treat as bare.
+    - bare alias     → apply rename_map, then rewrite to
+                       ``{landing_tier}:{resolved_alias}``.
+
+    Returns a list of (template_id, role, old_ref, new_ref, reason) tuples
+    where reason ∈ {auto_pin, auto_pin_after_rename, wire_format_violation}.
     """
-    if not rename_map:
-        return
-    for tmpl in templates.values():
+    rewrites: list[tuple] = []
+    for tmpl_id, tmpl in templates.items():
         config = tmpl.get("config")
         if not isinstance(config, dict):
             continue
         agents = config.get("agents")
         if not isinstance(agents, dict):
             continue
-        for agent_cfg in agents.values():
-            if isinstance(agent_cfg, dict):
-                model = agent_cfg.get("model")
-                if isinstance(model, str) and model in rename_map:
-                    agent_cfg["model"] = rename_map[model]
+        for role, agent_cfg in agents.items():
+            if not isinstance(agent_cfg, dict):
+                continue
+            model = agent_cfg.get("model")
+            if not isinstance(model, str):
+                continue
+            old_ref = model
+            try:
+                tier, alias = _parse_model_ref(model)
+            except ValueError:
+                # Malformed ref — leave unchanged, no rewrite recorded.
+                continue
+
+            if tier == "builtin":
+                continue
+
+            reason: str
+            if tier in ("user", "project"):
+                # Wire-format violation: bundles must export bare aliases only.
+                print(
+                    f"warning: wire_format_violation: template '{tmpl_id}' agent "
+                    f"'{role}' model ref '{model}' carries a tier prefix — "
+                    f"stripping and re-pinning to --scope {landing_tier!r}",
+                    file=sys.stderr,
+                )
+                reason = "wire_format_violation"
+                # alias is already stripped of the prefix
+            else:
+                # Bare ref: apply rename map, then pin to landing tier.
+                new_alias = rename_map.get(alias, alias)
+                if new_alias != alias:
+                    reason = "auto_pin_after_rename"
+                    alias = new_alias
+                else:
+                    reason = "auto_pin"
+
+            new_ref = f"{landing_tier}:{alias}"
+            agent_cfg["model"] = new_ref
+            rewrites.append((tmpl_id, role, old_ref, new_ref, reason))
+    return rewrites
 
 
 def _build_collision_preview(
     bundle_models: dict | None,
     bundle_pricing: dict | None,
     settings_path: str | None,
+    *,
+    bundle_templates: list | None = None,
+    landing_tier: str = "project",
 ) -> dict:
     """Return a JSON-serializable preview of incoming alias collisions.
 
@@ -1574,6 +1646,11 @@ def _build_collision_preview(
             ...
           ],
           "new_aliases": ["claude-private", ...],
+          "ref_rewrites": [
+            {"template_id": "t1", "role": "planner",
+             "old": "glm-ds", "new": "project:glm-ds", "reason": "auto_pin"},
+            ...
+          ],
           "settings_path": "/Users/.../.worca/settings.json"
         }
 
@@ -1601,9 +1678,34 @@ def _build_collision_preview(
             })
         else:
             new_aliases.append(alias)
+
+    # Compute ref rewrites using an empty rename_map (no collision resolution
+    # yet in preview mode). The UI can derive the renamed-ref cascade by
+    # applying suggested_rename values from collisions to these entries.
+    ref_rewrites: list[dict] = []
+    if bundle_templates:
+        import copy
+        preview_templates = {
+            t["id"]: copy.deepcopy(t)
+            for t in bundle_templates
+            if isinstance(t, dict) and "id" in t
+        }
+        raw_rewrites = _rewrite_template_model_refs(
+            preview_templates, {}, landing_tier=landing_tier
+        )
+        for tmpl_id, role, old_ref, new_ref, reason in raw_rewrites:
+            ref_rewrites.append({
+                "template_id": tmpl_id,
+                "role": role,
+                "old": old_ref,
+                "new": new_ref,
+                "reason": reason,
+            })
+
     return {
         "collisions": collisions,
         "new_aliases": sorted(new_aliases),
+        "ref_rewrites": ref_rewrites,
         "settings_path": settings_path,
     }
 

--- a/src/worca/orchestrator/bundle.py
+++ b/src/worca/orchestrator/bundle.py
@@ -110,6 +110,16 @@ def collect_referenced_model_aliases(
     aliases that appear in `all_models`. Aliases not present in `all_models`
     are dropped silently (caller may surface them separately as typos).
 
+    Handles tier-qualified refs (post-D2 wire format):
+    - Bare alias `"glm-ds"` → looked up directly in all_models.
+    - `"user:glm-ds"` or `"project:glm-ds"` → alias portion `"glm-ds"` is
+      looked up (strip_tier_prefixes() has already rewritten these to bare
+      in the export path, but this function also handles them defensively).
+    - `"builtin:opus"` → EXCLUDED from the returned set. Builtin aliases
+      exist on every target machine via `_DEFAULT_MODEL_MAP`; shipping them
+      in `bundle_models` would create spurious entries the importer must
+      then reconcile or discard.
+
     Why no recursion through the `id` field: `resolve_model()` in
     `worca.utils.settings` is a single non-recursive lookup that returns
     `entry["id"]` verbatim as the string passed to `claude --model …`.
@@ -124,6 +134,8 @@ def collect_referenced_model_aliases(
     `worca.pricing.models`, and by import to apply the symmetric filter
     against the bundle's contents.
     """
+    from worca.utils.settings import _parse_model_ref
+
     referenced: set[str] = set()
 
     for tmpl in templates:
@@ -136,12 +148,55 @@ def collect_referenced_model_aliases(
         if not isinstance(agents, dict):
             continue
         for agent_cfg in agents.values():
-            if isinstance(agent_cfg, dict):
-                model = agent_cfg.get("model")
-                if isinstance(model, str) and model in all_models:
-                    referenced.add(model)
+            if not isinstance(agent_cfg, dict):
+                continue
+            model = agent_cfg.get("model")
+            if not isinstance(model, str):
+                continue
+            try:
+                tier, alias = _parse_model_ref(model)
+            except ValueError:
+                continue
+            # Builtin aliases exist on every target via _DEFAULT_MODEL_MAP;
+            # don't ship them in bundle_models.
+            if tier == "builtin":
+                continue
+            if alias in all_models:
+                referenced.add(alias)
 
     return referenced
+
+
+def strip_tier_prefixes(template_entries: list[dict]) -> list[dict]:
+    """Return a deep copy of template_entries with user:/project: stripped from model refs.
+
+    Post-D2 bundle wire format: bundles ship bare refs only so the importer
+    can auto-pin to the landing tier via --scope. builtin: refs are the
+    exception — they resolve deterministically on any target.
+
+    Stripping rules per agents.<role>.model value:
+    - 'user:X' or 'project:X' => 'X'   (strip prefix; bare alias in bundle)
+    - 'builtin:X'              => preserved verbatim
+    - bare 'X'                 => preserved verbatim
+    - malformed (e.g. 'bad::ref') => preserved as-is; export is not the rewrite site
+    """
+    entries = copy.deepcopy(template_entries)
+    for entry in entries:
+        config = entry.get("config")
+        if not isinstance(config, dict):
+            continue
+        agents = config.get("agents")
+        if not isinstance(agents, dict):
+            continue
+        for agent_cfg in agents.values():
+            if not isinstance(agent_cfg, dict):
+                continue
+            model = agent_cfg.get("model")
+            if not isinstance(model, str):
+                continue
+            if model.startswith("user:") or model.startswith("project:"):
+                agent_cfg["model"] = model.split(":", 1)[1]
+    return entries
 
 
 # Export modes. "standalone" = config materialised over built-in defaults and

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -33,6 +33,7 @@ from worca.orchestrator.file_access_aggregation import aggregate_iteration_file_
 from worca.orchestrator.stages import (
     Stage, get_stage_config, get_enabled_stages, STAGE_AGENT_MAP,
     is_learn_enabled, resolve_plan_review_mode,
+    PreflightError, validate_tier_pinned_agent_models,
 )
 from worca.orchestrator.work_request import WorkRequest
 from worca.state.status import (
@@ -53,7 +54,7 @@ from worca.utils.proc import pid_is_alive
 from worca.utils.proc_registry import kill_all_tracked
 from worca.utils.git import create_branch, current_branch, get_current_git_head
 from worca.utils.pr_url import parse_pr_url
-from worca.utils.settings import load_global_settings, load_settings
+from worca.utils.settings import load_global_settings, load_settings, load_settings_with_global_fallback
 from worca.scripts.crg_preflight import run_crg_preflight
 from worca.scripts.graphify_preflight import run_graphify_preflight
 from worca.utils.graphify import (
@@ -2876,6 +2877,16 @@ def run_pipeline(
             stage_idx = 0
         else:
             stage_idx = 0
+
+        # Validate tier-pinned agent model refs before entering the stage loop
+        # so errors surface at preflight rather than mid-stage.
+        _tier_settings = load_settings_with_global_fallback(settings_path)
+        _tier_errors = validate_tier_pinned_agent_models(_tier_settings)
+        if _tier_errors:
+            raise PreflightError(
+                "Tier-pinned agent model refs failed to resolve:\n"
+                + "\n".join(f"  {e}" for e in _tier_errors)
+            )
 
         # Track triggers for loop-back iterations
         _next_trigger = {}  # {stage_value: trigger_reason}

--- a/src/worca/orchestrator/stages.py
+++ b/src/worca/orchestrator/stages.py
@@ -1,7 +1,19 @@
 """Pipeline stage definitions and transition validation."""
+import os
+import sys
 from enum import Enum
 
-from worca.utils.settings import load_settings, resolve_model
+from worca.utils.settings import (
+    load_settings,
+    load_settings_with_global_fallback,
+    resolve_model,
+    _parse_model_ref,
+    resolve_tier_pinned,
+)
+
+
+class PreflightError(Exception):
+    """Raised when a tier-pinned model ref fails to resolve at preflight time."""
 
 
 class Stage(Enum):
@@ -99,7 +111,12 @@ def _resolve_model(shorthand, model_map):
     return resolve_model(shorthand, model_map)
 
 
-def get_stage_config(stage: Stage, settings_path: str = ".claude/settings.json") -> dict:
+def get_stage_config(
+    stage: Stage,
+    settings_path: str = ".claude/settings.json",
+    *,
+    global_path: str | None = None,
+) -> dict:
     """Read settings.json and return agent config for the given stage.
 
     Agent mapping priority:
@@ -107,10 +124,16 @@ def get_stage_config(stage: Stage, settings_path: str = ".claude/settings.json")
     2. STAGE_AGENT_MAP[stage] (hardcoded default)
 
     Model resolution:
-    1. worca.agents.<agent>.model (shorthand like "sonnet")
-    2. Resolved via worca.models mapping in settings, then _DEFAULT_MODEL_MAP
+    1. WORCA_MODEL_<AGENT> env var (highest priority, logs override to stderr)
+    2. worca.agents.<agent>.model — tier-pinned ('tier:alias') or bare alias
+    3. Resolved via worca.models / _DEFAULT_MODEL_MAP
+
+    Pass global_path to enable tier-pinned ('user:'/'project:') resolution via the
+    per-tier stash.  Without global_path, 'user:' and 'project:' pins raise
+    PreflightError.  'builtin:' pins always work (no stash needed).
     """
-    settings = _read_settings(settings_path)
+    settings = load_settings_with_global_fallback(settings_path, global_path=global_path)
+
     worca = settings.get("worca", {})
 
     # Determine agent: prefer stages config, fall back to hardcoded map
@@ -124,10 +147,39 @@ def get_stage_config(stage: Stage, settings_path: str = ".claude/settings.json")
     agent_config = worca.get("agents", {}).get(agent_name, {})
     model_map = worca.get("models", {})
     raw_model = agent_config.get("model", "sonnet")
-    model_id, model_env = _resolve_model(raw_model, model_map)
+
+    # WORCA_MODEL_<AGENT> env var wins over both bare and tier-pinned refs.
+    env_var_name = f"WORCA_MODEL_{agent_name.upper()}"
+    env_override = os.environ.get(env_var_name)
+    if env_override:
+        print(
+            f"[stages] model override: {env_var_name}={env_override!r} overrides {raw_model!r}",
+            file=sys.stderr,
+        )
+        raw_model = env_override
+
+    # Detect tier-pinned refs; malformed refs fall through to bare passthrough.
+    try:
+        tier, _alias = _parse_model_ref(raw_model)
+    except ValueError:
+        tier = None
+
+    if tier is not None:
+        # user:/project: require the per-tier stash populated by load_settings_with_global_fallback.
+        if tier in ("user", "project") and "_worca_tier_views" not in settings:
+            raise PreflightError(
+                f"tier-pinned ref {raw_model!r}: per-tier views unavailable; "
+                "load settings via load_settings_with_global_fallback"
+            )
+        model_id, model_env, error_msg = resolve_tier_pinned(raw_model, settings)
+        if error_msg:
+            raise PreflightError(error_msg)
+    else:
+        model_id, model_env = _resolve_model(raw_model, model_map)
+
     model_alias = raw_model if raw_model != model_id else None
     _reroutes_api = bool(_ALT_ENDPOINT_ENV_KEYS & set(model_env or {}))
-    cost_alias = raw_model if _reroutes_api else None
+    cost_alias = (_alias if tier else raw_model) if _reroutes_api else None
     return {
         "agent": agent_name,
         "model": model_id,
@@ -139,6 +191,32 @@ def get_stage_config(stage: Stage, settings_path: str = ".claude/settings.json")
         "max_beads": agent_config.get("max_beads", 0),
         "schema": STAGE_SCHEMA_MAP.get(stage, f"{stage.value}.json"),
     }
+
+
+def validate_tier_pinned_agent_models(settings: dict) -> list:
+    """Validate all tier-pinned agent model refs in settings.
+
+    Returns a list of error strings (empty if all pins resolve).
+    Bare refs are ignored — opaque pass-through is preserved.
+    """
+    agents_cfg = settings.get("worca", {}).get("agents", {})
+    errors = []
+    for role, agent_config in agents_cfg.items():
+        if not isinstance(agent_config, dict):
+            continue
+        ref = agent_config.get("model")
+        if ref is None:
+            continue
+        try:
+            tier, _alias = _parse_model_ref(ref)
+        except ValueError:
+            continue  # malformed — caught by template validator
+        if tier is None:
+            continue  # bare ref
+        _, _, error_msg = resolve_tier_pinned(ref, settings)
+        if error_msg:
+            errors.append(f"agents.{role}.model: {error_msg}")
+    return errors
 
 
 def get_enabled_stages(settings_path: str = ".claude/settings.json") -> list:

--- a/src/worca/orchestrator/templates.py
+++ b/src/worca/orchestrator/templates.py
@@ -289,6 +289,62 @@ def materialize_config(template_config: dict) -> dict:
 
 VALID_EFFORT_LEVELS = frozenset({"low", "medium", "high", "xhigh", "max"})
 
+_VALID_TIERS = frozenset({"builtin", "user", "project"})
+# Canonical grammar: ^(builtin:|user:|project:)?[a-zA-Z0-9_-]{1,64}$
+_TIER_ALIAS_RE = re.compile(r"^(builtin:|user:|project:)?[a-zA-Z0-9_-]{1,64}$")
+
+
+def _check_model_grammar(model: str, field: str, issues: list, models_config: dict, default_map: dict) -> None:
+    """Validate a model reference string and append issues as appropriate.
+
+    Accepts:
+      - bare alias (no colon) — warns if not in models_config or default_map
+      - tier:alias — errors if tier not in {builtin, user, project} or alias invalid
+    Rejects (severity=error):
+      - any string not matching the canonical grammar
+    """
+    if ":" in model:
+        # Must match tier:alias grammar exactly
+        if not _TIER_ALIAS_RE.match(model):
+            issues.append({
+                "field": field,
+                "severity": "error",
+                "message": (
+                    f"Malformed model reference '{model}'. "
+                    "Expected 'tier:alias' where tier ∈ {{builtin, user, project}} "
+                    "and alias matches [a-zA-Z0-9_-]{1,64}, "
+                    "or a bare alias without any colon."
+                ),
+            })
+            return
+        tier, alias = model.split(":", 1)
+        if tier not in _VALID_TIERS:
+            issues.append({
+                "field": field,
+                "severity": "error",
+                "message": (
+                    f"Malformed model reference '{model}': "
+                    f"tier '{tier}' is not valid. Must be one of: {sorted(_VALID_TIERS)}."
+                ),
+            })
+        # tier-pinned refs get a separate alias-not-in-named-tier check (future phase)
+        return
+
+    # Bare alias: warn if unknown
+    if (
+        model not in models_config
+        and model not in ("opa", "oha")
+        and model not in default_map
+    ):
+        issues.append({
+            "field": field,
+            "severity": "warning",
+            "message": (
+                f"Model alias '{model}' is not defined in worca.models "
+                "and not in default map (may be treated as a raw model ID)"
+            ),
+        })
+
 
 def validate_merged_config(merged: dict) -> list[dict]:
     """Run validation rules against an already-merged worca config.
@@ -337,21 +393,8 @@ def validate_merged_config(merged: dict) -> list[dict]:
             continue
 
         model = agent_data.get("model")
-        if (
-            model
-            and isinstance(model, str)
-            and model not in models_config
-            and model not in ("opa", "oha")
-            and model not in _DEFAULT_MODEL_MAP
-        ):
-            issues.append({
-                "field": f"agents.{agent_name}.model",
-                "severity": "warning",
-                "message": (
-                    f"Model alias '{model}' is not defined in worca.models "
-                    "and not in default map (may be treated as a raw model ID)"
-                ),
-            })
+        if model and isinstance(model, str):
+            _check_model_grammar(model, f"agents.{agent_name}.model", issues, models_config, _DEFAULT_MODEL_MAP)
 
         agent_effort = agent_data.get("effort")
         if agent_effort and agent_effort not in VALID_EFFORT_LEVELS:

--- a/src/worca/orchestrator/work_request.py
+++ b/src/worca/orchestrator/work_request.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from worca.utils.env import get_env, filter_model_env
 from worca.utils.gh_pr import current_repo_nwo, fetch_review_feedback
-from worca.utils.settings import load_settings, resolve_model
+from worca.utils.settings import load_settings, resolve_model, resolve_tier_pinned
 
 _DEFAULT_PLAN_PATH_TEMPLATE = "docs/plans/{timestamp}-{title_slug}.md"
 # Matches GitHub issue URLs: https://github.com/owner/repo/issues/42
@@ -71,8 +71,16 @@ def generate_smart_title(content: str, source_hint: str = "") -> str:
     prompt += f"\n\nContent:\n{truncated}"
 
     settings = load_settings(".claude/settings.json")
-    models_cfg = settings.get("worca", {}).get("models", {})
-    model_id, model_env = resolve_model("haiku", models_cfg)
+    model_id, model_env, err = resolve_tier_pinned("builtin:haiku", settings)
+    if err:
+        import sys
+        print(
+            f"warning: builtin:haiku pin failed ({err}); falling back to bare haiku",
+            file=sys.stderr,
+        )
+        model_id, model_env = resolve_model(
+            "haiku", settings.get("worca", {}).get("models", {})
+        )
     safe_env, _ = filter_model_env(model_env)
 
     try:

--- a/src/worca/utils/graphify.py
+++ b/src/worca/utils/graphify.py
@@ -215,12 +215,11 @@ def build_subprocess_env(
     given, sets ``GRAPHIFY_OUT`` so graphify reads/writes the per-commit cache
     snapshot instead of a ``graphify-out/`` dir in the repo.
     """
-    from worca.utils.settings import resolve_model
+    from worca.utils.settings import resolve_tier_pinned
 
     env = dict(base_env if base_env is not None else os.environ)
     if cfg.model_profile:
-        models_cfg = settings.get("worca", {}).get("models", {})
-        _, model_env = resolve_model(cfg.model_profile, models_cfg)
+        _, model_env, _ = resolve_tier_pinned(cfg.model_profile, settings)
         env.update(model_env)
     if graphify_out:
         env["GRAPHIFY_OUT"] = graphify_out

--- a/src/worca/utils/settings.py
+++ b/src/worca/utils/settings.py
@@ -115,13 +115,19 @@ _DEFAULT_MODEL_MAP = {
 }
 
 
-def normalize_model_entry(value):
+def normalize_model_entry(value, *, alias=None):
     """Canonicalize a worca.models entry to {id, env} form.
 
     - String value -> {"id": value, "env": {}}
     - Dict value -> must contain "id" (str); "env" defaults to {}; extra keys ignored.
     - Anything else -> raise ValueError.
+    - alias (optional): the alias key being normalized; rejected if it contains ':'.
     """
+    if alias is not None and ":" in alias:
+        raise ValueError(
+            f"alias name cannot contain colon: '{alias}'. "
+            "Use 'tier:alias' only in agent model references, not as a models key."
+        )
     if isinstance(value, str):
         return {"id": value, "env": {}}
     if isinstance(value, dict) and isinstance(value.get("id"), str):
@@ -172,6 +178,10 @@ def load_settings_with_global_fallback(
 
     Global values form the base; project values win on overlap.
     Missing or malformed global file is silently tolerated (warning on bad JSON).
+
+    After merging, attaches ``merged['_worca_tier_views']`` — a stash of per-tier
+    raw model maps (user, project, builtin) used by resolve_tier_pinned().
+    The stash is internal; the public API is resolve_tier_pinned().
     """
     if global_path is None:
         global_path = _default_global_path()
@@ -190,6 +200,12 @@ def load_settings_with_global_fallback(
 
     project = load_settings(settings_path)
     if not global_blob:
+        project.pop("_worca_tier_views", None)
+        project["_worca_tier_views"] = {
+            "user": {},
+            "project": project.get("worca", {}).get("models") or {},
+            "builtin": dict(_DEFAULT_MODEL_MAP),
+        }
         return project
 
     merged = deep_merge(global_blob, project)
@@ -199,4 +215,84 @@ def load_settings_with_global_fallback(
     # exactly one tier; mirrors how Pipeline Templates shadow across tiers.
     for path in _ATOMIC_LEAF_PATHS:
         _replace_atomic_subkeys(merged, project, path)
+
+    # Drop any pre-existing stash (regression guard for JSON round-tripping) and rebuild.
+    merged.pop("_worca_tier_views", None)
+    merged["_worca_tier_views"] = {
+        "user": global_blob.get("worca", {}).get("models") or {},
+        "project": project.get("worca", {}).get("models") or {},
+        "builtin": dict(_DEFAULT_MODEL_MAP),
+    }
     return merged
+
+
+_VALID_TIERS = frozenset({"user", "project", "builtin"})
+
+
+def _parse_model_ref(ref: str) -> tuple:
+    """Parse a model reference into (tier_or_None, alias).
+
+    Bare alias (no colon) -> (None, alias).
+    Qualified 'tier:alias' -> (tier, alias).
+    Malformed (unknown tier, empty alias, multiple colons) -> raises ValueError.
+    """
+    if ":" not in ref:
+        return (None, ref)
+    parts = ref.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"malformed model ref '{ref}': expected 'tier:alias' or bare alias")
+    tier, alias = parts
+    if tier not in _VALID_TIERS:
+        raise ValueError(
+            f"malformed model ref '{ref}': unknown tier '{tier}', must be one of {sorted(_VALID_TIERS)}"
+        )
+    if not alias:
+        raise ValueError(f"malformed model ref '{ref}': alias must not be empty")
+    return (tier, alias)
+
+
+def resolve_tier_pinned(ref, settings: dict) -> tuple:
+    """Resolve a (possibly tier-qualified) model ref from settings.
+
+    Returns (model_id, env_dict, error_msg).
+    - ref is None => (None, {}, None).
+    - Malformed ref => (None, {}, 'malformed model ref ...').
+    - Bare ref => delegates to resolve_model on settings['worca']['models'].
+    - Tier-qualified ref without _worca_tier_views stash => falls back to bare merged map.
+    - Tier-qualified with stash, alias absent => (None, {}, error message).
+    - Tier-qualified and present => (id, env) from that tier's entry verbatim.
+
+    The _worca_tier_views stash is internal; this function is the public API.
+    """
+    if ref is None:
+        return (None, {}, None)
+
+    try:
+        tier, alias = _parse_model_ref(ref)
+    except ValueError as exc:
+        return (None, {}, str(exc))
+
+    if tier is None:
+        models_cfg = settings.get("worca", {}).get("models") or {}
+        model_id, env = resolve_model(alias, models_cfg)
+        return (model_id, env, None)
+
+    # Tier-qualified path.
+    stash = settings.get("_worca_tier_views")
+    if stash is None:
+        if tier == "builtin":
+            # No stash but builtin tier pinned — resolve from _DEFAULT_MODEL_MAP,
+            # bypassing any user/project override in the merged models.
+            model_id, env = resolve_model(alias, _DEFAULT_MODEL_MAP)
+            return (model_id, env, None)
+        # Other tiers without stash — fall back to merged map for graceful degradation.
+        models_cfg = settings.get("worca", {}).get("models") or {}
+        model_id, env = resolve_model(alias, models_cfg)
+        return (model_id, env, None)
+
+    tier_map = stash.get(tier, {})
+    if alias not in tier_map:
+        return (None, {}, f"tier-pinned ref '{ref}': alias '{alias}' not defined in {tier} tier")
+
+    entry = normalize_model_entry(tier_map[alias])
+    return (entry["id"], entry["env"], None)

--- a/tests/integration/test_work_request_routing.py
+++ b/tests/integration/test_work_request_routing.py
@@ -1,8 +1,18 @@
-"""Integration test: work_request haiku resolver routing (decision #2)."""
+"""Integration test: work_request haiku resolver routing.
+
+Originally written for W-051 decision #2 (haiku alias resolved through the
+model resolver, so a user-tier shadow won the env+id of the call).
+
+#312 (D5) explicitly inverted that: title generation now hard-pins to
+`builtin:haiku` so internal pipeline mechanics no longer depend on user/project
+shadowing. This test now guards the new contract: user shadows of `haiku` MUST
+be ignored — id resolves to the package default and the shadow env is NOT
+inherited.
+"""
 from worca.orchestrator.work_request import generate_smart_title
 
 
-def test_generate_smart_title_uses_resolver_for_haiku(monkeypatch, tmp_path):
+def test_generate_smart_title_ignores_haiku_shadow(monkeypatch, tmp_path):
     settings = {"worca": {"models": {
         "haiku": {"id": "custom-haiku-id",
                   "env": {"ANTHROPIC_BASE_URL": "http://custom"}}}}}
@@ -26,5 +36,7 @@ def test_generate_smart_title_uses_resolver_for_haiku(monkeypatch, tmp_path):
     generate_smart_title("Some content to title")
 
     assert "--model" in captured["cmd"]
-    assert captured["cmd"][captured["cmd"].index("--model") + 1] == "custom-haiku-id"
-    assert captured["env"]["ANTHROPIC_BASE_URL"] == "http://custom"
+    # D5: builtin:haiku pin — user shadow's id is bypassed.
+    assert captured["cmd"][captured["cmd"].index("--model") + 1] == "claude-haiku-4-5-20251001"
+    # And the shadow's env must NOT leak into the call.
+    assert "ANTHROPIC_BASE_URL" not in captured["env"]

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -17,6 +17,7 @@ from worca.orchestrator.bundle import (
     collect_referenced_model_aliases,
     fetch_bundle,
     redact_bundle,
+    strip_tier_prefixes,
     validate_bundle,
 )
 
@@ -722,6 +723,155 @@ class TestCollectReferencedModelAliases:
             {"id": "ok4", "config": {"agents": {"planner": {"model": 123}}}},  # non-string model
         ]
         assert collect_referenced_model_aliases(templates, {"opus": "x"}) == set()
+
+    # --- Tier-qualified ref handling (Phase 4) ---
+
+    def test_user_qualified_ref_strips_to_alias(self):
+        """user:glm-ds => looks up 'glm-ds' in all_models, returns {"glm-ds"}."""
+        templates = [{"id": "t", "config": {"agents": {"planner": {"model": "user:glm-ds"}}}}]
+        models = {"glm-ds": {"id": "some-model-id", "env": {}}}
+        assert collect_referenced_model_aliases(templates, models) == {"glm-ds"}
+
+    def test_project_qualified_ref_strips_to_alias(self):
+        """project:glm-ds => looks up 'glm-ds' in all_models."""
+        templates = [{"id": "t", "config": {"agents": {"planner": {"model": "project:glm-ds"}}}}]
+        models = {"glm-ds": "some-model-id"}
+        assert collect_referenced_model_aliases(templates, models) == {"glm-ds"}
+
+    def test_builtin_qualified_ref_excluded(self):
+        """builtin:opus => excluded from returned set even if 'opus' is in all_models.
+
+        builtin aliases exist on every target and are not shipped in bundle_models.
+        """
+        templates = [{"id": "t", "config": {"agents": {"coordinator": {"model": "builtin:opus"}}}}]
+        models = {"opus": "claude-opus-4-7"}
+        assert collect_referenced_model_aliases(templates, models) == set()
+
+    def test_bare_and_project_same_alias_deduped(self):
+        """Both bare 'glm-ds' and 'project:glm-ds' strip to the same alias."""
+        templates = [{
+            "id": "t",
+            "config": {
+                "agents": {
+                    "planner": {"model": "glm-ds"},
+                    "implementer": {"model": "project:glm-ds"},
+                },
+            },
+        }]
+        models = {"glm-ds": "some-model-id"}
+        assert collect_referenced_model_aliases(templates, models) == {"glm-ds"}
+
+    def test_mixed_tiers_only_non_builtin_returned(self):
+        """user:, project:, builtin:, bare all handled correctly in one call."""
+        templates = [{
+            "id": "t",
+            "config": {
+                "agents": {
+                    "planner": {"model": "user:glm-ds"},
+                    "coordinator": {"model": "builtin:opus"},
+                    "implementer": {"model": "project:sonnet"},
+                    "tester": {"model": "haiku"},
+                },
+            },
+        }]
+        models = {"glm-ds": "gm-id", "sonnet": "s-id", "haiku": "h-id", "opus": "o-id"}
+        result = collect_referenced_model_aliases(templates, models)
+        assert result == {"glm-ds", "sonnet", "haiku"}
+        assert "opus" not in result
+
+    def test_tier_ref_unknown_alias_silently_dropped(self):
+        """user:no-such is not in all_models — silently dropped."""
+        templates = [{"id": "t", "config": {"agents": {"planner": {"model": "user:no-such"}}}}]
+        assert collect_referenced_model_aliases(templates, {"glm-ds": "x"}) == set()
+
+
+# ---------------------------------------------------------------------------
+# strip_tier_prefixes — pre-redaction pass for cmd_templates_export (Phase 4)
+# ---------------------------------------------------------------------------
+
+class TestStripTierPrefixes:
+    """strip_tier_prefixes() returns a new list with user:/project: stripped."""
+
+    def test_strips_user_prefix(self):
+        entries = [{"id": "t", "config": {"agents": {"planner": {"model": "user:glm-ds"}}}}]
+        result = strip_tier_prefixes(entries)
+        assert result[0]["config"]["agents"]["planner"]["model"] == "glm-ds"
+
+    def test_strips_project_prefix(self):
+        entries = [{"id": "t", "config": {"agents": {"planner": {"model": "project:glm-ds"}}}}]
+        result = strip_tier_prefixes(entries)
+        assert result[0]["config"]["agents"]["planner"]["model"] == "glm-ds"
+
+    def test_preserves_builtin_prefix(self):
+        entries = [{"id": "t", "config": {"agents": {"coordinator": {"model": "builtin:opus"}}}}]
+        result = strip_tier_prefixes(entries)
+        assert result[0]["config"]["agents"]["coordinator"]["model"] == "builtin:opus"
+
+    def test_preserves_bare_alias(self):
+        entries = [{"id": "t", "config": {"agents": {"planner": {"model": "glm-ds"}}}}]
+        result = strip_tier_prefixes(entries)
+        assert result[0]["config"]["agents"]["planner"]["model"] == "glm-ds"
+
+    def test_preserves_malformed_verbatim(self):
+        """Malformed refs are left as-is; export is not the rewrite site."""
+        entries = [{"id": "t", "config": {"agents": {"planner": {"model": "bad::ref"}}}}]
+        result = strip_tier_prefixes(entries)
+        assert result[0]["config"]["agents"]["planner"]["model"] == "bad::ref"
+
+    def test_does_not_mutate_original(self):
+        """strip_tier_prefixes returns a deep copy — original unchanged."""
+        import copy
+        entries = [{"id": "t", "config": {"agents": {"planner": {"model": "user:glm-ds"}}}}]
+        original = copy.deepcopy(entries)
+        strip_tier_prefixes(entries)
+        assert entries == original
+
+    def test_mixed_agents_all_tiers(self):
+        """All four cases in one template entry."""
+        entries = [{
+            "id": "t",
+            "config": {
+                "agents": {
+                    "planner": {"model": "user:glm-ds"},
+                    "coordinator": {"model": "builtin:opus"},
+                    "implementer": {"model": "project:sonnet"},
+                    "tester": {"model": "haiku"},
+                },
+            },
+        }]
+        result = strip_tier_prefixes(entries)
+        agents = result[0]["config"]["agents"]
+        assert agents["planner"]["model"] == "glm-ds"
+        assert agents["coordinator"]["model"] == "builtin:opus"
+        assert agents["implementer"]["model"] == "sonnet"
+        assert agents["tester"]["model"] == "haiku"
+
+    def test_user_prefix_ships_alias_in_bundle_models(self):
+        """End-to-end: after strip, collect_referenced_model_aliases picks up the bare alias."""
+        entries = [{"id": "t", "config": {"agents": {"planner": {"model": "user:glm-ds"}}}}]
+        stripped = strip_tier_prefixes(entries)
+        models = {"glm-ds": {"id": "some-model-id"}}
+        result = collect_referenced_model_aliases(stripped, models)
+        assert result == {"glm-ds"}
+
+    def test_builtin_not_shipped_in_bundle_models(self):
+        """builtin:opus remains in template after strip; collect excludes it from bundle."""
+        entries = [{"id": "t", "config": {"agents": {"coordinator": {"model": "builtin:opus"}}}}]
+        stripped = strip_tier_prefixes(entries)
+        assert stripped[0]["config"]["agents"]["coordinator"]["model"] == "builtin:opus"
+        models = {"opus": "claude-opus-4-7"}
+        result = collect_referenced_model_aliases(stripped, models)
+        assert result == set()
+
+    def test_tolerates_entries_without_config(self):
+        """Non-dict config or missing agents are skipped gracefully."""
+        entries = [
+            {"id": "a", "config": None},
+            {"id": "b"},
+            {"id": "c", "config": {"agents": "not-a-dict"}},
+        ]
+        result = strip_tier_prefixes(entries)
+        assert len(result) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1,0 +1,154 @@
+"""Tests for `worca models add` CLI subcommand (Phase 7)."""
+
+import json
+import os
+from unittest import mock
+
+import pytest
+
+from worca.cli.main import main
+
+
+def _run(*argv, expected_exit=0):
+    """Run worca CLI with given args; assert exit code matches expected_exit."""
+    if expected_exit == 0:
+        main(list(argv))
+        return
+    with pytest.raises(SystemExit) as exc_info:
+        main(list(argv))
+    assert exc_info.value.code == expected_exit, (
+        f"Expected exit {expected_exit}, got {exc_info.value.code}"
+    )
+
+
+def _read_json(path):
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestModelsAddUser:
+    def test_writes_user_settings(self, tmp_path):
+        global_path = str(tmp_path / "settings.json")
+        with mock.patch("worca.utils.settings._default_global_path", return_value=global_path):
+            _run("models", "add", "--tier", "user", "my-alias", "claude-sonnet-4-6")
+
+        data = _read_json(global_path)
+        assert data["worca"]["models"]["my-alias"] == "claude-sonnet-4-6"
+
+    def test_writes_user_settings_with_env(self, tmp_path):
+        global_path = str(tmp_path / "settings.json")
+        local_path = str(tmp_path / "settings.local.json")
+        with mock.patch("worca.utils.settings._default_global_path", return_value=global_path):
+            _run(
+                "models", "add", "--tier", "user",
+                "my-alias", "claude-sonnet-4-6",
+                "--env", "ANTHROPIC_BASE_URL=https://proxy.example",
+            )
+
+        data = _read_json(global_path)
+        assert data["worca"]["models"]["my-alias"] == {"id": "claude-sonnet-4-6"}
+
+        local = _read_json(local_path)
+        assert local["worca"]["models"]["my-alias"] == {"env": {"ANTHROPIC_BASE_URL": "https://proxy.example"}}
+
+
+class TestModelsAddProject:
+    def _make_project(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        return tmp_path
+
+    def test_writes_project_settings_with_env(self, tmp_path):
+        project = self._make_project(tmp_path)
+        settings_path = project / ".claude" / "settings.json"
+        local_path = project / ".claude" / "settings.local.json"
+
+        with mock.patch("os.getcwd", return_value=str(project)):
+            _run(
+                "models", "add", "--tier", "project",
+                "my-alias", "claude-sonnet-4-6",
+                "--env", "ANTHROPIC_BASE_URL=https://proxy.example",
+            )
+
+        data = _read_json(str(settings_path))
+        assert data["worca"]["models"]["my-alias"] == {"id": "claude-sonnet-4-6"}
+
+        local = _read_json(str(local_path))
+        assert local["worca"]["models"]["my-alias"] == {"env": {"ANTHROPIC_BASE_URL": "https://proxy.example"}}
+
+    def test_writes_project_settings_no_env(self, tmp_path):
+        project = self._make_project(tmp_path)
+        settings_path = project / ".claude" / "settings.json"
+
+        with mock.patch("os.getcwd", return_value=str(project)):
+            _run("models", "add", "--tier", "project", "bare-alias", "claude-opus-4-8")
+
+        data = _read_json(str(settings_path))
+        assert data["worca"]["models"]["bare-alias"] == "claude-opus-4-8"
+
+
+class TestModelsAddRejections:
+    def test_builtin_tier_rejected(self, capsys):
+        _run("models", "add", "--tier", "builtin", "foo", "bar", expected_exit=1)
+        out = capsys.readouterr()
+        assert "built-in models are not user-writable" in out.err
+
+    def test_colon_in_alias_rejected(self, capsys):
+        _run("models", "add", "--tier", "user", "foo:bar", "baz", expected_exit=1)
+        out = capsys.readouterr()
+        assert "alias name cannot contain" in out.err or "colon" in out.err
+
+    def test_reserved_env_key_rejected(self, capsys, tmp_path):
+        global_path = str(tmp_path / "settings.json")
+        with mock.patch("worca.utils.settings._default_global_path", return_value=global_path):
+            _run(
+                "models", "add", "--tier", "user",
+                "foo", "claude-sonnet-4-6",
+                "--env", "PATH=/usr/bin",
+                expected_exit=1,
+            )
+        out = capsys.readouterr()
+        assert "reserved" in out.err.lower() or "PATH" in out.err
+
+    def test_reserved_worca_prefix_rejected(self, capsys, tmp_path):
+        global_path = str(tmp_path / "settings.json")
+        with mock.patch("worca.utils.settings._default_global_path", return_value=global_path):
+            _run(
+                "models", "add", "--tier", "user",
+                "foo", "claude-sonnet-4-6",
+                "--env", "WORCA_CUSTOM=val",
+                expected_exit=1,
+            )
+        out = capsys.readouterr()
+        assert "reserved" in out.err.lower() or "WORCA_" in out.err
+
+
+class TestModelsAddTierInference:
+    """When --tier is omitted, infer project if cwd is a git project, else user."""
+
+    def test_infers_project_when_in_git_repo(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".claude").mkdir()
+        settings_path = tmp_path / ".claude" / "settings.json"
+
+        with mock.patch("os.getcwd", return_value=str(tmp_path)):
+            _run("models", "add", "inferred-alias", "claude-haiku-4-5-20251001")
+
+        data = _read_json(str(settings_path))
+        assert data["worca"]["models"]["inferred-alias"] == "claude-haiku-4-5-20251001"
+
+    def test_infers_user_when_not_in_git_repo(self, tmp_path):
+        plain_dir = tmp_path / "plain"
+        plain_dir.mkdir()
+        global_path = str(tmp_path / "settings.json")
+
+        with mock.patch("os.getcwd", return_value=str(plain_dir)), \
+             mock.patch("worca.utils.settings._default_global_path", return_value=global_path):
+            _run("models", "add", "inferred-alias", "claude-haiku-4-5-20251001")
+
+        data = _read_json(global_path)
+        assert data["worca"]["models"]["inferred-alias"] == "claude-haiku-4-5-20251001"

--- a/tests/test_cli_templates.py
+++ b/tests/test_cli_templates.py
@@ -1651,7 +1651,7 @@ class TestExportImportRoundtrip:
         assert landed["name"] == "Shared"
         # Imported config matches the redacted bundle — no webhooks leaked through.
         assert "webhooks" not in landed["config"]
-        assert landed["config"]["agents"]["planner"]["model"] == "opus"
+        assert landed["config"]["agents"]["planner"]["model"] == "project:opus"
 
 
 class TestImportRollbackOnSettingsFailure:
@@ -1834,7 +1834,7 @@ class TestImportCrossDeviceSafety:
         landed = json.loads(
             (project_dir / "imported-tmpl" / "template.json").read_text()
         )
-        assert landed["config"]["agents"]["planner"]["model"] == "opus"
+        assert landed["config"]["agents"]["planner"]["model"] == "project:opus"
         # Settings.json picked up the new model alias (imported entries
         # carry an `_imported_from` provenance stamp — compare by id).
         post = json.loads(settings_path.read_text())
@@ -2905,8 +2905,8 @@ class TestImportAliasRename:
         assert "glm-ds-01" in written["worca"]["models"]
         # Imported entry carries `_imported_from`; compare by id.
         assert _model_id(written["worca"]["models"]["glm-ds-01"]) == "claude-opus-4-7"
-        # Template ref rewritten transactionally
-        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds-01"
+        # Template ref rewritten transactionally and pinned to landing tier
+        assert landed["config"]["agents"]["planner"]["model"] == "project:glm-ds-01"
 
     def test_rename_probes_next_available_suffix(self, tmp_path):
         written, landed = self._run(
@@ -2919,7 +2919,7 @@ class TestImportAliasRename:
             on_conflict="rename",
         )
         assert "glm-ds-02" in written["worca"]["models"]
-        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds-02"
+        assert landed["config"]["agents"]["planner"]["model"] == "project:glm-ds-02"
 
     def test_resolutions_file_per_alias_overwrite(self, tmp_path):
         written, landed = self._run(
@@ -2930,7 +2930,7 @@ class TestImportAliasRename:
         )
         # Bundle-imported entry carries `_imported_from`; compare by id.
         assert _model_id(written["worca"]["models"]["glm-ds"]) == "claude-opus-4-7"
-        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds"
+        assert landed["config"]["agents"]["planner"]["model"] == "project:glm-ds"
 
     def test_resolutions_file_per_alias_skip_keeps_local(self, tmp_path):
         written, landed = self._run(
@@ -2940,7 +2940,7 @@ class TestImportAliasRename:
             resolutions={"glm-ds": {"action": "skip"}},
         )
         assert written["worca"]["models"]["glm-ds"] == {"id": "claude-opus-4-6"}
-        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds"
+        assert landed["config"]["agents"]["planner"]["model"] == "project:glm-ds"
 
     def test_resolutions_file_explicit_new_name(self, tmp_path):
         written, landed = self._run(
@@ -2950,7 +2950,7 @@ class TestImportAliasRename:
             resolutions={"glm-ds": {"action": "rename", "new_name": "glm-ds-private"}},
         )
         assert "glm-ds-private" in written["worca"]["models"]
-        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds-private"
+        assert landed["config"]["agents"]["planner"]["model"] == "project:glm-ds-private"
 
     def test_skip_policy_drops_alias_and_leaves_template_pointing_at_existing(self, tmp_path):
         written, landed = self._run(
@@ -2960,7 +2960,7 @@ class TestImportAliasRename:
             on_conflict="skip",
         )
         assert written["worca"]["models"]["glm-ds"] == {"id": "claude-opus-4-6"}
-        assert landed["config"]["agents"]["planner"]["model"] == "glm-ds"
+        assert landed["config"]["agents"]["planner"]["model"] == "project:glm-ds"
 
 
 class TestImportPreview:

--- a/tests/test_graphify_settings.py
+++ b/tests/test_graphify_settings.py
@@ -379,6 +379,59 @@ class TestBuildSubprocessEnv:
         assert "GRAPHIFY_OUT" not in env
 
 
+class TestBuildSubprocessEnvTierPinned:
+    """build_subprocess_env routes model_profile through resolve_tier_pinned."""
+
+    def test_user_tier_pin_resolves_env(self):
+        """model_profile='user:glm-ds' with user-tier entry resolves its id/env."""
+        cfg = effective_graphify_config(
+            {"worca": {"graphify": {"enabled": True, "model_profile": "user:glm-ds"}}},
+            {"worca": {"graphify": {"enabled": True}}},
+        )
+        settings = {
+            "worca": {"models": {}},
+            "_worca_tier_views": {
+                "user": {"glm-ds": {"id": "glm-4", "env": {"OPENAI_API_KEY": "sk-user"}}},
+                "project": {},
+                "builtin": {},
+            },
+        }
+        env = build_subprocess_env(cfg, settings, base_env={"BASE": "1"})
+        assert env["OPENAI_API_KEY"] == "sk-user"
+        assert env["BASE"] == "1"
+
+    def test_builtin_tier_pin_ignores_shadows(self):
+        """model_profile='builtin:opus' resolves from the builtin map regardless of shadows."""
+        cfg = effective_graphify_config(
+            {"worca": {"graphify": {"enabled": True, "model_profile": "builtin:opus"}}},
+            {"worca": {"graphify": {"enabled": True}}},
+        )
+        # user and project tiers shadow opus to something different
+        settings = {
+            "worca": {"models": {"opus": "shadowed-by-merged-models"}},
+            "_worca_tier_views": {
+                "user": {"opus": {"id": "user-opus-override", "env": {}}},
+                "project": {},
+                "builtin": {"opus": "claude-opus-4-7"},
+            },
+        }
+        env = build_subprocess_env(cfg, settings, base_env={})
+        # No env keys from the shadowed entries — builtin opus has no env dict
+        assert "OPENAI_API_KEY" not in env
+
+    def test_bare_profile_unchanged(self):
+        """Bare model_profile behaves identically to the pre-tier-pin path."""
+        cfg = effective_graphify_config(
+            {"worca": {"graphify": {"enabled": True, "model_profile": "gp"}}},
+            {"worca": {"graphify": {"enabled": True}}},
+        )
+        settings = {
+            "worca": {"models": {"gp": {"id": "x", "env": {"BARE_KEY": "bare-val"}}}}
+        }
+        env = build_subprocess_env(cfg, settings, base_env={})
+        assert env["BARE_KEY"] == "bare-val"
+
+
 class TestFreshnessResolution:
     """worca.graphify.freshness: default clean_only, project-overridable."""
 

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -1,7 +1,7 @@
-"""Tests for worca.utils.settings.resolve_model."""
+"""Tests for worca.utils.settings.resolve_model and resolve_tier_pinned."""
 import pytest
 
-from worca.utils.settings import resolve_model
+from worca.utils.settings import resolve_model, resolve_tier_pinned, _parse_model_ref
 
 
 class TestResolveModel:
@@ -37,3 +37,116 @@ class TestResolveModel:
     def test_resolve_settings_override_default(self):
         result = resolve_model("opus", {"opus": "claude-opus-4-99-custom"})
         assert result == ("claude-opus-4-99-custom", {})
+
+
+class TestParseModelRef:
+    def test_bare_alias(self):
+        assert _parse_model_ref("opus") == (None, "opus")
+
+    def test_user_qualified(self):
+        assert _parse_model_ref("user:opus") == ("user", "opus")
+
+    def test_project_qualified(self):
+        assert _parse_model_ref("project:mymodel") == ("project", "mymodel")
+
+    def test_builtin_qualified(self):
+        assert _parse_model_ref("builtin:sonnet") == ("builtin", "sonnet")
+
+    def test_malformed_empty_alias(self):
+        with pytest.raises(ValueError):
+            _parse_model_ref("user:")
+
+    def test_malformed_double_colon(self):
+        with pytest.raises(ValueError):
+            _parse_model_ref("user:foo:bar")
+
+    def test_malformed_unknown_tier(self):
+        with pytest.raises(ValueError):
+            _parse_model_ref("global:opus")
+
+
+class TestResolveTierPinned:
+    def _settings_with_stash(self, user_models=None, project_models=None, builtin_models=None):
+        from worca.utils.settings import _DEFAULT_MODEL_MAP
+        return {
+            "worca": {
+                "models": {**(user_models or {}), **(project_models or {})}
+            },
+            "_worca_tier_views": {
+                "user": user_models or {},
+                "project": project_models or {},
+                "builtin": {k: v for k, v in (builtin_models or _DEFAULT_MODEL_MAP).items()},
+            }
+        }
+
+    def test_ref_none_returns_triple_none(self):
+        assert resolve_tier_pinned(None, {}) == (None, {}, None)
+
+    def test_bare_matches_resolve_model(self):
+        settings = {"worca": {"models": {"mymodel": "claude-x-1"}}}
+        result = resolve_tier_pinned("mymodel", settings)
+        assert result == ("claude-x-1", {}, None)
+
+    def test_user_wins_over_project_shadow(self):
+        settings = self._settings_with_stash(
+            user_models={"fast": "claude-user-fast"},
+            project_models={"fast": "claude-project-fast"},
+        )
+        id_, env, err = resolve_tier_pinned("user:fast", settings)
+        assert id_ == "claude-user-fast"
+        assert env == {}
+        assert err is None
+
+    def test_project_wins_over_user_shadow(self):
+        settings = self._settings_with_stash(
+            user_models={"fast": "claude-user-fast"},
+            project_models={"fast": "claude-project-fast"},
+        )
+        id_, env, err = resolve_tier_pinned("project:fast", settings)
+        assert id_ == "claude-project-fast"
+        assert err is None
+
+    def test_builtin_tier_resolves(self):
+        settings = self._settings_with_stash()
+        id_, env, err = resolve_tier_pinned("builtin:opus", settings)
+        assert id_ == "claude-opus-4-7"
+        assert err is None
+
+    def test_user_alias_absent_returns_error(self):
+        settings = self._settings_with_stash(user_models={"other": "x"})
+        id_, env, err = resolve_tier_pinned("user:no-such", settings)
+        assert id_ is None
+        assert "no-such" in err
+        assert "user" in err
+
+    def test_malformed_ref_returns_error(self):
+        settings = self._settings_with_stash()
+        id_, env, err = resolve_tier_pinned("user:", settings)
+        assert id_ is None
+        assert err is not None
+        assert "malformed" in err.lower()
+
+    def test_pinned_without_stash_falls_back_to_merged(self):
+        settings = {"worca": {"models": {"mymodel": "claude-x-1"}}}
+        id_, env, err = resolve_tier_pinned("user:mymodel", settings)
+        assert id_ == "claude-x-1"
+        assert err is None
+
+    def test_builtin_pinned_without_stash_uses_default_model_map(self):
+        # When there is no _worca_tier_views stash (plain load_settings), builtin:
+        # refs must resolve from _DEFAULT_MODEL_MAP, not from the merged models —
+        # so user/project haiku shadowing cannot affect title-gen determinism.
+        settings = {"worca": {"models": {"haiku": "shadowed-custom-haiku"}}}
+        id_, env, err = resolve_tier_pinned("builtin:haiku", settings)
+        assert id_ == "claude-haiku-4-5-20251001"
+        assert env == {}
+        assert err is None
+
+    def test_pinned_with_object_entry(self):
+        settings = self._settings_with_stash(
+            project_models={"special": {"id": "claude-special", "env": {"TIMEOUT": "30"}}}
+        )
+        id_, env, err = resolve_tier_pinned("project:special", settings)
+        assert id_ == "claude-special"
+        assert env == {"TIMEOUT": "30"}
+        assert err is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,7 +4,9 @@
 import json
 import os
 
-from worca.utils.settings import deep_merge, load_settings
+import pytest
+
+from worca.utils.settings import deep_merge, load_settings, normalize_model_entry
 
 
 # ---------------------------------------------------------------------------
@@ -639,3 +641,24 @@ class TestEffortSettings:
         assert result["worca"]["effort"]["auto_cap"] == "high"
         assert result["worca"]["effort"]["auto_mode"] == "adaptive"
         assert result["worca"]["fleet"]["max_parallel"] == 5
+
+
+class TestNormalizeModelEntryColonRejection:
+    """Colon-in-alias guard on normalize_model_entry."""
+
+    def test_rejects_colon_in_alias(self):
+        with pytest.raises(ValueError, match="colon"):
+            normalize_model_entry("claude-opus-4-7", alias="user:opus")
+
+    def test_rejects_colon_dict_form(self):
+        with pytest.raises(ValueError, match="colon"):
+            normalize_model_entry({"id": "claude-opus-4-7"}, alias="project:x")
+
+    def test_valid_alias_no_colon_passes(self):
+        result = normalize_model_entry("claude-opus-4-7", alias="my-model")
+        assert result["id"] == "claude-opus-4-7"
+
+    def test_no_alias_arg_unchanged(self):
+        result = normalize_model_entry("claude-sonnet-4-6")
+        assert result == {"id": "claude-sonnet-4-6", "env": {}}
+

--- a/tests/test_settings_global_fallback.py
+++ b/tests/test_settings_global_fallback.py
@@ -47,7 +47,7 @@ class TestLoadSettingsWithGlobalFallback:
             global_path=str(tmp_path / "nonexistent" / "settings.json"),
         )
 
-        assert result == {"worca": {"stages": {"plan": {"enabled": True}}}}
+        assert result["worca"] == {"stages": {"plan": {"enabled": True}}}
 
     def test_malformed_global_json(self, tmp_path, capsys):
         """Malformed global JSON logs a warning and returns project settings."""
@@ -61,7 +61,7 @@ class TestLoadSettingsWithGlobalFallback:
             str(project_file), global_path=str(global_file)
         )
 
-        assert result == {"worca": {"key": "val"}}
+        assert result["worca"] == {"key": "val"}
         captured = capsys.readouterr()
         assert "invalid JSON" in captured.err
 
@@ -71,7 +71,7 @@ class TestLoadSettingsWithGlobalFallback:
             str(tmp_path / "no_project.json"),
             global_path=str(tmp_path / "no_global.json"),
         )
-        assert result == {}
+        assert result.get("worca") is None
 
     def test_global_only_no_project(self, tmp_path):
         """Only global file exists — its values appear in result."""
@@ -85,9 +85,7 @@ class TestLoadSettingsWithGlobalFallback:
             global_path=str(global_file),
         )
 
-        assert result == {
-            "worca": {"parallel": {"max_concurrent_pipelines": 7}}
-        }
+        assert result["worca"] == {"parallel": {"max_concurrent_pipelines": 7}}
 
     def test_deep_nested_merge(self, tmp_path):
         """Deep merge works across multiple nesting levels."""
@@ -116,6 +114,83 @@ class TestLoadSettingsWithGlobalFallback:
         assert result["worca"]["parallel"]["default_base_branch"] == "develop"
         assert result["worca"]["ui"]["worktree_disk_warning_bytes"] == 1000000
         assert result["worca"]["stages"]["plan"]["enabled"] is True
+
+    def test_tier_views_populated(self, tmp_path):
+        """_worca_tier_views stash has user, project, and builtin tiers."""
+        from worca.utils.settings import _DEFAULT_MODEL_MAP
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "worca": {"models": {"fast": "claude-user-fast"}}
+        }))
+        project_file = tmp_path / "project.json"
+        project_file.write_text(json.dumps({
+            "worca": {"models": {"fast": "claude-project-fast"}}
+        }))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        views = result["_worca_tier_views"]
+        assert views["user"] == {"fast": "claude-user-fast"}
+        assert views["project"] == {"fast": "claude-project-fast"}
+        assert "opus" in views["builtin"]
+        assert views["builtin"]["opus"] == _DEFAULT_MODEL_MAP["opus"]
+
+    def test_tier_views_builtin_always_present(self, tmp_path):
+        """builtin tier is always populated even when no models config exists."""
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({"worca": {}}))
+        project_file = tmp_path / "project.json"
+        project_file.write_text(json.dumps({"worca": {}}))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        views = result["_worca_tier_views"]
+        assert views["builtin"] != {}
+        assert "sonnet" in views["builtin"]
+
+    def test_tier_views_stash_regression_dropped(self, tmp_path):
+        """Pre-existing _worca_tier_views in input is dropped and rebuilt."""
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "_worca_tier_views": {"user": {"stale": "old"}, "project": {}, "builtin": {}},
+            "worca": {"models": {"mymodel": "fresh-id"}}
+        }))
+        project_file = tmp_path / "project.json"
+        project_file.write_text(json.dumps({"worca": {}}))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        # Rebuilt stash — should reflect fresh global models, not the stale stash
+        views = result["_worca_tier_views"]
+        assert views["user"] == {"mymodel": "fresh-id"}
+
+    def test_tier_views_worktree_case(self, tmp_path):
+        """Worktree-local project settings + separate user-global resolves correctly."""
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "worca": {"models": {"fast": "claude-user-fast", "slow": "claude-user-slow"}}
+        }))
+        project_file = tmp_path / "worktree" / "settings.json"
+        project_file.parent.mkdir()
+        project_file.write_text(json.dumps({
+            "worca": {"models": {"fast": "claude-worktree-fast"}}
+        }))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        views = result["_worca_tier_views"]
+        assert views["user"]["fast"] == "claude-user-fast"
+        assert views["user"]["slow"] == "claude-user-slow"
+        assert views["project"]["fast"] == "claude-worktree-fast"
+        assert "fast" not in views["project"] or views["project"]["fast"] == "claude-worktree-fast"
 
     def test_default_global_path(self, tmp_path, monkeypatch):
         """Without explicit global_path, uses $WORCA_HOME/settings.json."""

--- a/tests/test_settings_normalize.py
+++ b/tests/test_settings_normalize.py
@@ -38,3 +38,18 @@ class TestNormalizeModelEntry:
     def test_normalize_unknown_type_raises(self):
         with pytest.raises(ValueError, match="string ID"):
             normalize_model_entry(42)
+
+    def test_normalize_rejects_colon_in_alias_key(self):
+        """normalize_model_entry with alias= containing ':' must raise ValueError."""
+        with pytest.raises(ValueError, match="colon"):
+            normalize_model_entry("claude-opus-4-7", alias="user:opus")
+
+    def test_normalize_rejects_colon_dict_form_alias(self):
+        """Dict form also rejects ':' in alias key."""
+        with pytest.raises(ValueError, match="colon"):
+            normalize_model_entry({"id": "claude-opus-4-7"}, alias="project:opus")
+
+    def test_normalize_valid_alias_passes(self):
+        """Valid alias (no colon) with alias= kwarg is accepted."""
+        result = normalize_model_entry("claude-opus-4-7", alias="my-opus")
+        assert result == {"id": "claude-opus-4-7", "env": {}}

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,6 +1,8 @@
 """Tests for worca.orchestrator.stages module."""
 import json
 
+import pytest
+
 from worca.orchestrator.stages import (
     Stage,
     TRANSITIONS,
@@ -15,6 +17,8 @@ from worca.orchestrator.stages import (
     is_learn_enabled,
     resolve_plan_review_mode,
     validate_plan_review_settings,
+    PreflightError,
+    validate_tier_pinned_agent_models,
 )
 
 
@@ -1011,3 +1015,171 @@ class TestValidatePlanReviewSettings:
     def test_enforce_absent_no_error(self):
         settings = {"worca": {"governance": {}}}
         assert validate_plan_review_settings(settings) == []
+
+
+class TestGetStageConfigTierPinned:
+    """Tests for tier-pinned model ref resolution in get_stage_config (Phase 5b)."""
+
+    def _project_file(self, tmp_path, model_ref, extra_models=None):
+        data = {"worca": {"agents": {"planner": {"model": model_ref}}}}
+        if extra_models:
+            data["worca"]["models"] = extra_models
+        f = tmp_path / "settings.json"
+        f.write_text(json.dumps(data))
+        return str(f)
+
+    def _global_file(self, tmp_path, models=None, name="global.json"):
+        data = {"worca": {"models": models}} if models else {}
+        f = tmp_path / name
+        f.write_text(json.dumps(data))
+        return str(f)
+
+    # --- user: tier ---
+
+    def test_user_tier_resolves_when_alias_present(self, tmp_path):
+        project = self._project_file(tmp_path, "user:glm-ds")
+        global_ = self._global_file(tmp_path, {"glm-ds": "my-glm-ds-id"})
+        config = get_stage_config(Stage.PLAN, settings_path=project, global_path=global_)
+        assert config["model"] == "my-glm-ds-id"
+        assert config["agent"] == "planner"
+
+    def test_user_tier_raises_when_alias_absent(self, tmp_path):
+        project = self._project_file(tmp_path, "user:glm-ds")
+        global_ = self._global_file(tmp_path, {})  # no glm-ds in user tier
+        with pytest.raises(PreflightError) as exc_info:
+            get_stage_config(Stage.PLAN, settings_path=project, global_path=global_)
+        msg = str(exc_info.value)
+        assert "glm-ds" in msg
+        assert "user" in msg
+
+    def test_user_tier_without_matching_alias_raises_preflight_error(self, tmp_path):
+        """user: pin with no alias in user tier raises PreflightError (alias not found)."""
+        project = self._project_file(tmp_path, "user:glm-ds")
+        with pytest.raises(PreflightError) as exc_info:
+            get_stage_config(Stage.PLAN, settings_path=project)
+        assert "glm-ds" in str(exc_info.value)
+        assert "user" in str(exc_info.value)
+
+    # --- builtin: tier ---
+
+    def test_builtin_tier_resolves_to_default_map(self, tmp_path):
+        from worca.utils.settings import _DEFAULT_MODEL_MAP
+        project = self._project_file(tmp_path, "builtin:opus")
+        global_ = self._global_file(tmp_path, {"opus": "user-override-should-be-ignored"})
+        config = get_stage_config(Stage.PLAN, settings_path=project, global_path=global_)
+        assert config["model"] == _DEFAULT_MODEL_MAP["opus"]
+
+    def test_builtin_tier_works_without_global_path(self, tmp_path):
+        """builtin: tier doesn't need the stash — no global_path needed."""
+        from worca.utils.settings import _DEFAULT_MODEL_MAP
+        project = self._project_file(tmp_path, "builtin:opus")
+        config = get_stage_config(Stage.PLAN, settings_path=project)
+        assert config["model"] == _DEFAULT_MODEL_MAP["opus"]
+
+    # --- env-var override ---
+
+    def test_env_var_override_wins_over_tier_pinned(self, tmp_path, monkeypatch, capsys):
+        project = self._project_file(tmp_path, "user:glm-ds")
+        global_ = self._global_file(tmp_path, {"glm-ds": "my-glm-ds-id"})
+        monkeypatch.setenv("WORCA_MODEL_PLANNER", "claude-opus-4-7")
+        config = get_stage_config(Stage.PLAN, settings_path=project, global_path=global_)
+        assert config["model"] == "claude-opus-4-7"
+        captured = capsys.readouterr()
+        assert "WORCA_MODEL_PLANNER" in captured.err
+
+    # --- cost-source signal ---
+
+    def test_cost_alias_set_when_pinned_tier_has_alt_endpoint(self, tmp_path):
+        """user:glm-ds with ANTHROPIC_BASE_URL in user-tier entry sets cost_alias."""
+        project = self._project_file(tmp_path, "user:glm-ds")
+        global_ = self._global_file(tmp_path, {
+            "glm-ds": {"id": "my-model", "env": {"ANTHROPIC_BASE_URL": "https://x"}}
+        })
+        config = get_stage_config(Stage.PLAN, settings_path=project, global_path=global_)
+        assert config["cost_alias"] == "glm-ds"
+
+    def test_cost_alias_none_for_bare_ref_with_project_tier_no_endpoint(self, tmp_path):
+        """bare glm-ds resolves from project tier (no alt endpoint) → cost_alias None."""
+        project_path = tmp_path / "settings.json"
+        project_path.write_text(json.dumps({
+            "worca": {
+                "models": {"glm-ds": "my-model"},
+                "agents": {"planner": {"model": "glm-ds"}},
+            }
+        }))
+        global_path = tmp_path / "global.json"
+        global_path.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"id": "my-model", "env": {"ANTHROPIC_BASE_URL": "https://x"}}}}
+        }))
+        config = get_stage_config(Stage.PLAN, settings_path=str(project_path), global_path=str(global_path))
+        assert config["cost_alias"] is None
+
+
+class TestValidateTierPinnedAgentModels:
+    """Tests for validate_tier_pinned_agent_models() (Phase 5b)."""
+
+    def _settings_with_stash(self, user_models=None, project_models=None, agents=None):
+        from worca.utils.settings import _DEFAULT_MODEL_MAP
+        return {
+            "worca": {
+                "models": {**(user_models or {}), **(project_models or {})},
+                "agents": agents or {},
+            },
+            "_worca_tier_views": {
+                "user": user_models or {},
+                "project": project_models or {},
+                "builtin": dict(_DEFAULT_MODEL_MAP),
+            },
+        }
+
+    def test_empty_agents_returns_empty(self):
+        settings = self._settings_with_stash()
+        assert validate_tier_pinned_agent_models(settings) == []
+
+    def test_all_pins_resolve_returns_empty(self):
+        settings = self._settings_with_stash(
+            user_models={"glm-ds": "my-model"},
+            agents={"planner": {"model": "user:glm-ds"}},
+        )
+        assert validate_tier_pinned_agent_models(settings) == []
+
+    def test_missing_user_pin_returns_error(self):
+        settings = self._settings_with_stash(
+            user_models={},
+            agents={"planner": {"model": "user:glm-ds"}},
+        )
+        errors = validate_tier_pinned_agent_models(settings)
+        assert len(errors) == 1
+        assert "glm-ds" in errors[0]
+        assert "user" in errors[0]
+
+    def test_multiple_bad_pins_all_surface(self):
+        settings = self._settings_with_stash(
+            user_models={},
+            project_models={},
+            agents={
+                "implementer": {"model": "user:no-such"},
+                "reviewer": {"model": "project:no-such"},
+            },
+        )
+        errors = validate_tier_pinned_agent_models(settings)
+        assert len(errors) == 2
+
+    def test_bare_refs_ignored(self):
+        """Bare refs are opaque pass-through — not validated."""
+        settings = self._settings_with_stash(
+            agents={"planner": {"model": "nonexistent-bare"}},
+        )
+        assert validate_tier_pinned_agent_models(settings) == []
+
+    def test_mixed_bare_and_pinned(self):
+        settings = self._settings_with_stash(
+            user_models={},
+            agents={
+                "planner": {"model": "sonnet"},  # bare — ignored
+                "implementer": {"model": "user:missing"},  # pinned — error
+            },
+        )
+        errors = validate_tier_pinned_agent_models(settings)
+        assert len(errors) == 1
+        assert "missing" in errors[0]

--- a/tests/test_template_validate.py
+++ b/tests/test_template_validate.py
@@ -245,3 +245,84 @@ class TestTemplateResolverValidate:
         # No underscores or other separators
         for field in fields:
             assert "." in field or field in ["root"], f"Expected dot notation, got {field}"
+
+    # -- Phase 1: tier:alias grammar validation --
+
+    def test_validate_tier_alias_valid_bare(self, tmp_path):
+        """Bare alias (no tier prefix) in agents.<role>.model is accepted."""
+        resolver = _make_resolver(
+            tmp_path,
+            config={"agents": {"planner": {"model": "opus"}}},
+        )
+        base = {"models": {"opus": "claude-opus-4-7"}}
+        issues = resolver.validate("test-tmpl", base)
+        assert issues == []
+
+    def test_validate_tier_alias_valid_prefixed(self, tmp_path):
+        """tier:alias form with valid tier prefix and valid alias is accepted."""
+        resolver = _make_resolver(
+            tmp_path,
+            config={"agents": {"planner": {"model": "builtin:opus"}}},
+        )
+        issues = resolver.validate("test-tmpl", {})
+        # No error for tier:alias grammar itself
+        grammar_errors = [i for i in issues if "malformed" in i["message"].lower()]
+        assert grammar_errors == []
+
+    def test_validate_tier_alias_invalid_prefix(self, tmp_path):
+        """Unknown tier prefix is a grammar error (severity=error)."""
+        resolver = _make_resolver(
+            tmp_path,
+            config={"agents": {"planner": {"model": "BUILTIN:opus"}}},
+        )
+        issues = resolver.validate("test-tmpl", {})
+        errors = [i for i in issues if i["severity"] == "error" and "agents.planner.model" == i["field"]]
+        assert errors, f"Expected error for bad tier prefix, got: {issues}"
+        assert "malformed" in errors[0]["message"].lower()
+
+    def test_validate_tier_alias_empty_alias_part(self, tmp_path):
+        """':alias' with empty tier is a grammar error."""
+        resolver = _make_resolver(
+            tmp_path,
+            config={"agents": {"planner": {"model": ":opus"}}},
+        )
+        issues = resolver.validate("test-tmpl", {})
+        errors = [i for i in issues if i["severity"] == "error" and "agents.planner.model" == i["field"]]
+        assert errors, f"Expected error for ':opus', got: {issues}"
+        assert "malformed" in errors[0]["message"].lower()
+
+    def test_validate_tier_alias_double_colon(self, tmp_path):
+        """'user::opus' double-colon is a grammar error."""
+        resolver = _make_resolver(
+            tmp_path,
+            config={"agents": {"planner": {"model": "user::opus"}}},
+        )
+        issues = resolver.validate("test-tmpl", {})
+        errors = [i for i in issues if i["severity"] == "error" and "agents.planner.model" == i["field"]]
+        assert errors, f"Expected error for 'user::opus', got: {issues}"
+        assert "malformed" in errors[0]["message"].lower()
+
+    def test_validate_tier_alias_space_in_tier(self, tmp_path):
+        """'user :glm-ds' with space is a grammar error."""
+        resolver = _make_resolver(
+            tmp_path,
+            config={"agents": {"planner": {"model": "user :glm-ds"}}},
+        )
+        issues = resolver.validate("test-tmpl", {})
+        errors = [i for i in issues if i["severity"] == "error" and "agents.planner.model" == i["field"]]
+        assert errors, f"Expected error for 'user :glm-ds', got: {issues}"
+        assert "malformed" in errors[0]["message"].lower()
+
+    def test_validate_tier_alias_valid_tiers(self, tmp_path):
+        """All valid tiers (builtin, user, project) pass grammar check."""
+        for tier in ("builtin", "user", "project"):
+            resolver = _make_resolver(
+                tmp_path,
+                config={"agents": {"planner": {"model": f"{tier}:my-alias"}}},
+            )
+            issues = resolver.validate("test-tmpl", {})
+            grammar_errors = [
+                i for i in issues
+                if i["severity"] == "error" and "agents.planner.model" == i["field"] and "malformed" in i["message"].lower()
+            ]
+            assert grammar_errors == [], f"Unexpected grammar error for tier '{tier}': {grammar_errors}"

--- a/tests/test_templates_import_scope_models.py
+++ b/tests/test_templates_import_scope_models.py
@@ -18,6 +18,7 @@ import pytest
 
 from worca.cli.templates import (
     _derive_bundle_label,
+    _rewrite_template_model_refs,
     cmd_templates_import,
 )
 
@@ -237,3 +238,210 @@ class TestImportProvenanceStamping:
         assert "custom-alias" in pricing
         assert pricing["custom-alias"]["input_per_mtok"] == 1.5
         assert pricing["custom-alias"]["output_per_mtok"] == 7.5
+
+
+def _write_bundle_with_model_ref(
+    path: Path, *, model_ref: str, alias: str = "glm-ds", model_id: str = "claude-sonnet-4-6"
+) -> None:
+    """Write a minimal bundle whose planner.model is the given ref string."""
+    manifest = {
+        "worca_bundle_version": 1,
+        "templates": [
+            {
+                "id": "ref-tpl",
+                "name": "Ref Template",
+                "description": "",
+                "tags": [],
+                "params": {},
+                "config": {"agents": {"planner": {"model": model_ref}}},
+            }
+        ],
+        "models": {alias: {"id": model_id}},
+    }
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+
+class TestAutoPinModelRefs:
+    """Bare model refs are auto-pinned to --scope on import (D3)."""
+
+    def test_bare_ref_pinned_to_user_scope(self, project_dir, capsys):
+        project, worca_home = project_dir
+        bundle = project / "b.json"
+        _write_bundle_with_model_ref(bundle, model_ref="glm-ds")
+
+        cmd_templates_import(_make_import_args(source=str(bundle), scope="user"))
+
+        tpl_path = worca_home / "templates" / "ref-tpl" / "template.json"
+        assert tpl_path.exists()
+        tpl = json.loads(tpl_path.read_text())
+        assert tpl["config"]["agents"]["planner"]["model"] == "user:glm-ds"
+
+    def test_bare_ref_pinned_to_project_scope(self, project_dir, capsys):
+        project, worca_home = project_dir
+        bundle = project / "b.json"
+        _write_bundle_with_model_ref(bundle, model_ref="glm-ds")
+
+        cmd_templates_import(_make_import_args(source=str(bundle), scope="project"))
+
+        tpl_path = project / ".claude" / "templates" / "ref-tpl" / "template.json"
+        assert tpl_path.exists()
+        tpl = json.loads(tpl_path.read_text())
+        assert tpl["config"]["agents"]["planner"]["model"] == "project:glm-ds"
+
+    def test_builtin_ref_preserved_unchanged(self, project_dir, capsys):
+        """builtin:opus passes through without modification."""
+        project, worca_home = project_dir
+        bundle = project / "b.json"
+        # builtin refs have no alias in the models map — write without models.
+        manifest = {
+            "worca_bundle_version": 1,
+            "templates": [
+                {
+                    "id": "ref-tpl",
+                    "name": "Ref Template",
+                    "description": "",
+                    "tags": [],
+                    "params": {},
+                    "config": {"agents": {"planner": {"model": "builtin:opus"}}},
+                }
+            ],
+        }
+        bundle.write_text(json.dumps(manifest), encoding="utf-8")
+
+        cmd_templates_import(_make_import_args(source=str(bundle), scope="project"))
+
+        tpl_path = project / ".claude" / "templates" / "ref-tpl" / "template.json"
+        tpl = json.loads(tpl_path.read_text())
+        assert tpl["config"]["agents"]["planner"]["model"] == "builtin:opus"
+
+    def test_renamed_alias_ref_pinned(self, project_dir, capsys):
+        """When glm-ds collides and is renamed to glm-ds-01, the ref becomes project:glm-ds-01."""
+        project, worca_home = project_dir
+
+        # Pre-populate project settings with an existing glm-ds that differs.
+        existing_settings = {
+            "worca": {
+                "models": {
+                    "glm-ds": {"id": "claude-opus-4-7"},
+                }
+            }
+        }
+        settings_path = project / ".claude" / "settings.json"
+        settings_path.write_text(json.dumps(existing_settings), encoding="utf-8")
+
+        bundle = project / "b.json"
+        _write_bundle_with_model_ref(bundle, model_ref="glm-ds")
+
+        # Use resolutions to rename instead of aborting on collision.
+        resolutions = {"models": {"glm-ds": {"action": "rename"}}}
+        res_path = project / "res.json"
+        res_path.write_text(json.dumps(resolutions), encoding="utf-8")
+
+        args = _make_import_args(source=str(bundle), scope="project")
+        args.resolutions = str(res_path)
+        cmd_templates_import(args)
+
+        tpl_path = project / ".claude" / "templates" / "ref-tpl" / "template.json"
+        tpl = json.loads(tpl_path.read_text())
+        assert tpl["config"]["agents"]["planner"]["model"] == "project:glm-ds-01"
+
+    def test_wire_format_violation_warns_and_is_rewritten(self, project_dir, capsys):
+        """A ref like 'project:glm-ds' in the bundle is a violation — warn, treat as bare."""
+        project, worca_home = project_dir
+        bundle = project / "b.json"
+        _write_bundle_with_model_ref(bundle, model_ref="project:glm-ds")
+
+        cmd_templates_import(_make_import_args(source=str(bundle), scope="project"))
+
+        captured = capsys.readouterr()
+        assert "wire-format violation" in captured.err or "wire_format_violation" in captured.err
+
+        tpl_path = project / ".claude" / "templates" / "ref-tpl" / "template.json"
+        tpl = json.loads(tpl_path.read_text())
+        # After stripping the violation prefix, the bare alias is pinned to --scope.
+        assert tpl["config"]["agents"]["planner"]["model"] == "project:glm-ds"
+
+    def test_info_block_emitted_for_auto_pin(self, project_dir, capsys):
+        """An info block listing the rewrites is printed to stderr."""
+        project, worca_home = project_dir
+        bundle = project / "b.json"
+        _write_bundle_with_model_ref(bundle, model_ref="glm-ds")
+
+        cmd_templates_import(_make_import_args(source=str(bundle), scope="project"))
+
+        captured = capsys.readouterr()
+        assert "rewrote" in captured.err
+        assert "glm-ds" in captured.err
+        assert "project:glm-ds" in captured.err
+
+
+class TestBuildCollisionPreviewRefRewrites:
+    """_build_collision_preview surfaces ref_rewrites for the UI dialog."""
+
+    def test_ref_rewrites_included_in_preview(self, project_dir, capsys):
+        project, worca_home = project_dir
+        bundle = project / "b.json"
+        _write_bundle_with_model_ref(bundle, model_ref="glm-ds")
+
+        args = _make_import_args(source=str(bundle), scope="project")
+        args.preview = True
+        cmd_templates_import(args)
+
+        captured = capsys.readouterr()
+        preview = json.loads(captured.out)
+        assert "ref_rewrites" in preview
+        rewrites = preview["ref_rewrites"]
+        assert len(rewrites) == 1
+        rw = rewrites[0]
+        assert rw["template_id"] == "ref-tpl"
+        assert rw["role"] == "planner"
+        assert rw["old"] == "glm-ds"
+        assert rw["new"] == "project:glm-ds"
+        assert rw["reason"] == "auto_pin"
+
+
+class TestRewriteTemplateModelRefsUnit:
+    """Unit tests for _rewrite_template_model_refs extended behaviour."""
+
+    def _make_templates(self, *role_model_pairs, tid="t1"):
+        agents = {role: {"model": model} for role, model in role_model_pairs}
+        return {tid: {"config": {"agents": agents}}}
+
+    def test_bare_rewritten_to_landing_tier(self):
+        templates = self._make_templates(("planner", "my-model"))
+        rewrites = _rewrite_template_model_refs(templates, {}, landing_tier="user")
+        assert templates["t1"]["config"]["agents"]["planner"]["model"] == "user:my-model"
+        assert len(rewrites) == 1
+        assert rewrites[0][2] == "my-model"
+        assert rewrites[0][3] == "user:my-model"
+        assert rewrites[0][4] == "auto_pin"
+
+    def test_builtin_preserved(self):
+        templates = self._make_templates(("planner", "builtin:opus"))
+        rewrites = _rewrite_template_model_refs(templates, {}, landing_tier="project")
+        assert templates["t1"]["config"]["agents"]["planner"]["model"] == "builtin:opus"
+        assert rewrites == []
+
+    def test_rename_map_applied_before_pin(self):
+        templates = self._make_templates(("planner", "old-alias"))
+        rewrites = _rewrite_template_model_refs(
+            templates, {"old-alias": "new-alias"}, landing_tier="project"
+        )
+        assert templates["t1"]["config"]["agents"]["planner"]["model"] == "project:new-alias"
+        assert rewrites[0][4] == "auto_pin_after_rename"
+
+    def test_wire_format_violation_emits_warning(self, capsys):
+        templates = self._make_templates(("planner", "project:some-alias"))
+        rewrites = _rewrite_template_model_refs(templates, {}, landing_tier="user")
+        captured = capsys.readouterr()
+        assert "wire_format_violation" in captured.err or "wire-format violation" in captured.err
+        # After treating as bare, it's pinned to landing_tier.
+        assert templates["t1"]["config"]["agents"]["planner"]["model"] == "user:some-alias"
+        assert rewrites[0][4] == "wire_format_violation"
+
+    def test_user_tier_violation_treated_as_bare(self, capsys):
+        templates = self._make_templates(("planner", "user:my-alias"))
+        _rewrite_template_model_refs(templates, {}, landing_tier="project")
+        captured = capsys.readouterr()
+        assert "wire_format_violation" in captured.err or "wire-format violation" in captured.err
+        assert templates["t1"]["config"]["agents"]["planner"]["model"] == "project:my-alias"

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -493,3 +493,55 @@ def test_aggregate_token_usage_excludes_context_final_pct():
     ]
     result = aggregate_token_usage(usages)
     assert "context_final_pct" not in result or result.get("context_final_pct") is None
+
+
+# ---------------------------------------------------------------------------
+# pricing lookup — tier-prefix regression (W-058 review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_pricing_lookup_bare_alias_hits_table(tmp_path):
+    """Bare alias 'glm-ds' as _model_alias resolves pricing correctly."""
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({
+        "worca": {
+            "pricing": {
+                "models": {
+                    "glm-ds": {"input_per_mtok": 3.0, "output_per_mtok": 15.0}
+                }
+            }
+        }
+    }))
+    envelope = {
+        "_model_alias": "glm-ds",
+        "usage": {"input_tokens": 1_000_000, "output_tokens": 0},
+    }
+    result = extract_token_usage(envelope, settings_path=str(settings_file))
+    assert result["total_cost_usd"] == 3.0
+    assert result.get("cost_source") == "alias"
+
+
+def test_pricing_lookup_tier_prefixed_alias_misses_table(tmp_path):
+    """tier-prefixed alias 'user:glm-ds' does NOT hit the pricing table keyed by 'glm-ds'.
+
+    This test documents the pre-fix behavior: if cost_alias were passed as 'user:glm-ds',
+    the lookup would miss and cost would be $0.  After the stages.py fix the prefix is
+    stripped before the alias reaches extract_token_usage, so this path no longer occurs
+    in production.  The test is kept as a regression guard for the lookup contract.
+    """
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps({
+        "worca": {
+            "pricing": {
+                "models": {
+                    "glm-ds": {"input_per_mtok": 3.0, "output_per_mtok": 15.0}
+                }
+            }
+        }
+    }))
+    envelope = {
+        "_model_alias": "user:glm-ds",
+        "usage": {"input_tokens": 1_000_000, "output_tokens": 0},
+    }
+    result = extract_token_usage(envelope, settings_path=str(settings_file))
+    assert result["total_cost_usd"] == 0

--- a/tests/test_work_request.py
+++ b/tests/test_work_request.py
@@ -160,6 +160,8 @@ class TestGenerateSmartTitle:
     @patch("worca.orchestrator.work_request.subprocess.run")
     @patch("worca.orchestrator.work_request.load_settings")
     def test_resolves_haiku_through_model_resolver(self, mock_load, mock_run):
+        # Even with a custom haiku entry in models, generate_smart_title MUST use
+        # the builtin haiku (pinned via resolve_tier_pinned('builtin:haiku', ...)).
         mock_load.return_value = {
             "worca": {
                 "models": {
@@ -175,9 +177,7 @@ class TestGenerateSmartTitle:
         cmd = mock_run.call_args[0][0]
         assert "--model" in cmd
         idx = cmd.index("--model")
-        assert cmd[idx + 1] == "custom-haiku-id"
-        env = mock_run.call_args[1]["env"]
-        assert env["ANTHROPIC_BASE_URL"] == "http://custom"
+        assert cmd[idx + 1] == "claude-haiku-4-5-20251001"
 
     @patch("worca.orchestrator.work_request.subprocess.run")
     @patch("worca.orchestrator.work_request.load_settings")
@@ -189,6 +189,48 @@ class TestGenerateSmartTitle:
         assert "--model" in cmd
         idx = cmd.index("--model")
         assert cmd[idx + 1] == "claude-haiku-4-5-20251001"
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    @patch("worca.orchestrator.work_request.load_settings")
+    def test_builtin_haiku_used_regardless_of_project_override(self, mock_load, mock_run):
+        """D5: title gen is deterministic — builtin haiku wins even when project/user tier
+        shadows the haiku alias in worca.models."""
+        mock_load.return_value = {
+            "worca": {
+                "models": {
+                    "haiku": {
+                        "id": "project-shadowed-haiku",
+                        "env": {"ANTHROPIC_BASE_URL": "http://custom-proxy"},
+                    }
+                }
+            }
+        }
+        mock_run.return_value = MagicMock(returncode=0, stdout="Title\n")
+        generate_smart_title("some content")
+        cmd = mock_run.call_args[0][0]
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "claude-haiku-4-5-20251001"
+        # Explicitly verify the shadowed model was NOT used
+        assert cmd[idx + 1] != "project-shadowed-haiku"
+        env = mock_run.call_args[1]["env"]
+        assert "ANTHROPIC_BASE_URL" not in env
+
+    @patch("worca.orchestrator.work_request.subprocess.run")
+    @patch("worca.orchestrator.work_request.resolve_tier_pinned")
+    @patch("worca.orchestrator.work_request.load_settings")
+    def test_fallback_when_builtin_pin_fails(self, mock_load, mock_pin, mock_run):
+        """When resolve_tier_pinned returns an error, falls back to bare resolve_model."""
+        mock_load.return_value = {
+            "worca": {"models": {"haiku": "fallback-haiku-id"}}
+        }
+        mock_pin.return_value = (None, {}, "builtin:haiku pin failed")
+        mock_run.return_value = MagicMock(returncode=0, stdout="Title\n")
+        generate_smart_title("some content")
+        cmd = mock_run.call_args[0][0]
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "fallback-haiku-id"
 
 
 # --- normalize_plan_file ---

--- a/worca-ui/app/utils/icons.js
+++ b/worca-ui/app/utils/icons.js
@@ -39,6 +39,7 @@ import Lightbulb from 'lucide/dist/esm/icons/lightbulb';
 import List from 'lucide/dist/esm/icons/list';
 import Loader from 'lucide/dist/esm/icons/loader';
 import Lock from 'lucide/dist/esm/icons/lock';
+import LockOpen from 'lucide/dist/esm/icons/lock-open';
 import Moon from 'lucide/dist/esm/icons/moon';
 import PanelLeftClose from 'lucide/dist/esm/icons/panel-left-close';
 import PanelLeftOpen from 'lucide/dist/esm/icons/panel-left-open';
@@ -129,6 +130,7 @@ export {
   List,
   Loader,
   Lock,
+  LockOpen,
   Moon,
   PanelLeftClose,
   PanelLeftOpen,

--- a/worca-ui/app/views/pipelines-editor-models.test.js
+++ b/worca-ui/app/views/pipelines-editor-models.test.js
@@ -10,7 +10,12 @@
  * worca.models". This covers the data-loading half of that fix.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getEditorState, loadTemplate } from './pipelines-editor.js';
+import {
+  applyModelLockToggle,
+  formBufferToConfig,
+  getEditorState,
+  loadTemplate,
+} from './pipelines-editor.js';
 
 function mockFetchByUrl(map) {
   globalThis.fetch = vi.fn((url) => {
@@ -141,5 +146,175 @@ describe('pipelines-editor — project worca.models loading', () => {
     const st = getEditorState();
     // Default empty settings shape — dropdown will use built-in defaults.
     expect(st.settings.worca).toEqual({});
+  });
+});
+
+describe('pipelines-editor — per-tier model refs and lock toggle', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeTemplatBody = (model) => ({
+    ok: true,
+    template: {
+      id: 'feature-glm-ds',
+      name: 'Feature (GLM-DS)',
+      description: '',
+      tags: [],
+      params: {},
+      config: { agents: { planner: { model } } },
+    },
+  });
+
+  it('bare glm-ds with both user+project entries: PROJECT row selected, lock OFF, saves back glm-ds', async () => {
+    mockFetchByUrl({
+      '/effective-settings': {
+        worca: { models: { 'glm-ds': { id: 'opus' } } },
+      },
+      '/templates/project/feature-glm-ds': makeTemplatBody('glm-ds'),
+      '/projects/test-proj/models': {
+        ok: true,
+        models: [
+          { alias: 'glm-ds', tier: 'user' },
+          { alias: 'glm-ds', tier: 'project' },
+        ],
+      },
+    });
+
+    await loadTemplate('project', 'feature-glm-ds', 'test-proj');
+
+    const st = getEditorState();
+    // Bare ref → lock is OFF
+    expect(st.formBuffer.agents.planner._model_pin_locked).toBe(false);
+    // Project wins over user in tierMap (highest priority)
+    expect(st.modelTierMap['glm-ds']).toBe('project');
+    // Both rows are preserved (no priority collapse)
+    expect(st.modelTierRows.filter((r) => r.alias === 'glm-ds')).toHaveLength(
+      2,
+    );
+    // Serialises back to bare alias (lock is OFF)
+    const config = formBufferToConfig(st.formBuffer);
+    expect(config.agents.planner.model).toBe('glm-ds');
+  });
+
+  it('user:glm-ds present: USER row selected, lock ON, saves back user:glm-ds', async () => {
+    mockFetchByUrl({
+      '/effective-settings': {
+        worca: { models: { 'glm-ds': { id: 'opus' } } },
+      },
+      '/templates/project/feature-glm-ds': makeTemplatBody('user:glm-ds'),
+      '/projects/test-proj/models': {
+        ok: true,
+        models: [
+          { alias: 'glm-ds', tier: 'user' },
+          { alias: 'glm-ds', tier: 'project' },
+        ],
+      },
+    });
+
+    await loadTemplate('project', 'feature-glm-ds', 'test-proj');
+
+    const st = getEditorState();
+    // Pinned ref → lock is ON
+    expect(st.formBuffer.agents.planner._model_pin_locked).toBe(true);
+    expect(st.formBuffer.agents.planner.model).toBe('user:glm-ds');
+    // Serialises back preserving the tier prefix
+    const config = formBufferToConfig(st.formBuffer);
+    expect(config.agents.planner.model).toBe('user:glm-ds');
+  });
+
+  it('user:glm-ds absent from user tier: warning in validationIssues, value preserved', async () => {
+    mockFetchByUrl({
+      '/effective-settings': { worca: { models: {} } },
+      '/templates/project/feature-glm-ds': makeTemplatBody('user:glm-ds'),
+      '/projects/test-proj/models': {
+        ok: true,
+        // Only project tier — no user-tier glm-ds
+        models: [{ alias: 'glm-ds', tier: 'project' }],
+      },
+    });
+
+    await loadTemplate('project', 'feature-glm-ds', 'test-proj');
+
+    const st = getEditorState();
+    // Value preserved verbatim
+    expect(st.formBuffer.agents.planner.model).toBe('user:glm-ds');
+    // Warning surfaced
+    const warnings = st.validationIssues.filter(
+      (i) => i.severity === 'warning',
+    );
+    expect(warnings.some((w) => w.message.includes('user:glm-ds'))).toBe(true);
+  });
+
+  it('lock OFF→ON on a PROJECT row: agent.model becomes project:glm-ds', async () => {
+    mockFetchByUrl({
+      '/effective-settings': {
+        worca: { models: { 'glm-ds': { id: 'opus' } } },
+      },
+      '/templates/project/feature-glm-ds': makeTemplatBody('glm-ds'),
+      '/projects/test-proj/models': {
+        ok: true,
+        models: [{ alias: 'glm-ds', tier: 'project' }],
+      },
+    });
+
+    await loadTemplate('project', 'feature-glm-ds', 'test-proj');
+
+    const st = getEditorState();
+    expect(st.formBuffer.agents.planner._model_pin_locked).toBe(false);
+    expect(st.formBuffer.agents.planner.model).toBe('glm-ds');
+
+    applyModelLockToggle('planner');
+
+    expect(st.formBuffer.agents.planner._model_pin_locked).toBe(true);
+    expect(st.formBuffer.agents.planner.model).toBe('project:glm-ds');
+  });
+
+  it('lock ON→OFF: agent.model becomes bare glm-ds', async () => {
+    mockFetchByUrl({
+      '/effective-settings': { worca: { models: {} } },
+      '/templates/project/feature-glm-ds': makeTemplatBody('user:glm-ds'),
+      '/projects/test-proj/models': {
+        ok: true,
+        models: [{ alias: 'glm-ds', tier: 'user' }],
+      },
+    });
+
+    await loadTemplate('project', 'feature-glm-ds', 'test-proj');
+
+    const st = getEditorState();
+    expect(st.formBuffer.agents.planner._model_pin_locked).toBe(true);
+
+    applyModelLockToggle('planner');
+
+    expect(st.formBuffer.agents.planner._model_pin_locked).toBe(false);
+    expect(st.formBuffer.agents.planner.model).toBe('glm-ds');
+  });
+
+  it('regression: dropdown enumerates both user and project glm-ds rows (no priority collapse)', async () => {
+    mockFetchByUrl({
+      '/effective-settings': {
+        worca: { models: { 'glm-ds': { id: 'opus' } } },
+      },
+      '/templates/project/feature-glm-ds': makeTemplatBody('glm-ds'),
+      '/projects/test-proj/models': {
+        ok: true,
+        models: [
+          { alias: 'glm-ds', tier: 'user' },
+          { alias: 'glm-ds', tier: 'project' },
+          { alias: 'opus', tier: 'builtin' },
+        ],
+      },
+    });
+
+    await loadTemplate('project', 'feature-glm-ds', 'test-proj');
+
+    const st = getEditorState();
+    const glmDsRows = st.modelTierRows.filter((r) => r.alias === 'glm-ds');
+    expect(glmDsRows).toHaveLength(2);
+    expect(glmDsRows.map((r) => r.tier).sort()).toEqual(['project', 'user']);
   });
 });

--- a/worca-ui/app/views/pipelines-editor.js
+++ b/worca-ui/app/views/pipelines-editor.js
@@ -26,6 +26,8 @@ import {
   CircleCheck,
   FileText,
   iconSvg,
+  Lock,
+  LockOpen,
   RefreshCw,
   Save,
   Shield,
@@ -69,6 +71,11 @@ let editorState = {
   // (project-owned), so it lives here, not in the template config. Without it
   // the dropdown falls back to built-in defaults only and custom aliases vanish.
   settings: { worca: {} },
+  // Raw [{tier, alias, ...}] rows from /api/models — one entry per (tier, alias)
+  // pair. Unlike modelTierMap (which collapses to the highest-priority tier),
+  // this preserves both a user-tier and a project-tier row for the same alias
+  // so the lock-toggle dropdown can enumerate each row independently.
+  modelTierRows: [],
   loading: true,
   error: null,
   saving: false,
@@ -115,6 +122,7 @@ export function initEditorState() {
     template: null,
     builtinTemplate: null,
     settings: { worca: {} },
+    modelTierRows: [],
     loading: true,
     error: null,
     saving: false,
@@ -266,6 +274,11 @@ export function buildFormBuffer(templateConfig, settings) {
       model: agentConfig.model || 'sonnet',
       max_turns: agentConfig.max_turns || 30,
       effort: agentConfig.effort || null,
+      // UI-only lock flag: true when the saved model is a tier-pinned ref
+      // (e.g. 'user:glm-ds'). Stripped by formBufferToConfig — never persisted.
+      _model_pin_locked:
+        typeof agentConfig.model === 'string' &&
+        agentConfig.model.includes(':'),
     };
     if (name === 'coordinator') {
       agentEntry.max_beads = agentConfig.max_beads ?? 0;
@@ -642,6 +655,60 @@ export function slugifyId(name) {
 }
 
 /**
+ * Check each agent's model for tier-pinned refs (e.g. 'user:glm-ds') that
+ * no longer exist in the named tier. Returns warning-severity issue objects
+ * for any missing pins so the caller can push them to validationIssues.
+ */
+function _checkPinnedRefWarnings(formBuffer, tierRows) {
+  const rowKeySet = new Set(tierRows.map((r) => `${r.tier}::${r.alias}`));
+  const warnings = [];
+  for (const [agentName, agent] of Object.entries(formBuffer?.agents || {})) {
+    const model = agent.model;
+    if (typeof model !== 'string' || !model.includes(':')) continue;
+    const sep = model.indexOf(':');
+    const tier = model.slice(0, sep);
+    const alias = model.slice(sep + 1);
+    if (!rowKeySet.has(`${tier}::${alias}`)) {
+      warnings.push({
+        field: `agents.${agentName}.model`,
+        severity: 'warning',
+        message: `${model} no longer exists in ${tier} tier — pin will fail preflight`,
+      });
+    }
+  }
+  return warnings;
+}
+
+/**
+ * Toggle the tier-pin lock for an agent's model in the current form buffer.
+ *
+ * OFF→ON: rewrites the bare alias to '<tier>:<alias>' using the highest-priority
+ *         tier from modelTierMap.
+ * ON→OFF: strips the tier prefix back to the bare alias.
+ *
+ * Exported so tests can exercise the toggle logic directly without simulating
+ * a DOM click event.
+ */
+export function applyModelLockToggle(agentName) {
+  const agent = editorState.formBuffer?.agents?.[agentName];
+  if (!agent) return;
+  const tierMap = editorState.modelTierMap || {};
+  const currentModel = agent.model || 'sonnet';
+  const nowLocked = !agent._model_pin_locked;
+  if (nowLocked) {
+    if (!currentModel.includes(':')) {
+      const tier = tierMap[currentModel] || 'other';
+      agent.model = `${tier}:${currentModel}`;
+    }
+  } else {
+    if (currentModel.includes(':')) {
+      agent.model = currentModel.slice(currentModel.indexOf(':') + 1);
+    }
+  }
+  agent._model_pin_locked = nowLocked;
+}
+
+/**
  * Load a template from the server by (tier, id).
  *
  * The editor is now strict about tiers — every call must specify
@@ -687,18 +754,24 @@ async function _loadProjectSettings(projectId) {
       return;
     }
     const data = await res.json();
+    const rows = data.models || [];
+    // Store the raw rows so the per-agent dropdown can enumerate every
+    // (tier, alias) pair — e.g. both user:glm-ds and project:glm-ds —
+    // instead of collapsing to the highest-priority tier only.
+    editorState.modelTierRows = rows;
+    // Keep the derived tierMap (highest-priority tier per alias) for backward-
+    // compatible consumers: tier badge, tierTitle, link-out arrow when unlocked.
     const tierMap = {};
-    for (const m of data.models || []) {
-      // Project shadows User shadows Builtin — record the highest-priority
-      // tier per alias (mirrors how resolve_model() picks).
+    for (const m of rows) {
       const priority = { project: 3, user: 2, builtin: 1 };
       const current = tierMap[m.alias];
-      if (!current || priority[m.tier] > priority[current]) {
+      if (!current || (priority[m.tier] || 0) > (priority[current] || 0)) {
         tierMap[m.alias] = m.tier;
       }
     }
     editorState.modelTierMap = tierMap;
   } catch {
+    editorState.modelTierRows = [];
     editorState.modelTierMap = {};
   }
 }
@@ -767,6 +840,15 @@ export async function loadTemplate(tier, tid, projectId) {
         2,
       );
       editorState.validationIssues = [];
+      // Warn about tier-pinned refs that no longer exist in their named tier
+      // (e.g. 'user:glm-ds' when the user tier has no glm-ds entry). Keeps
+      // the value verbatim so the user can decide whether to fix or unlock.
+      editorState.validationIssues.push(
+        ..._checkPinnedRefWarnings(
+          editorState.formBuffer,
+          editorState.modelTierRows || [],
+        ),
+      );
 
       // Load built-in template for diff if this template shadows a built-in
       if (shadowsBuiltin(data.template || {}))
@@ -1726,58 +1808,68 @@ function _stagesSection(formBuffer, projectId, rerender) {
  */
 function _agentsTab(formBuffer, settings, projectId, rerender) {
   const agents = formBuffer?.agents || {};
-  // Base options come from the project's worca.models (+ built-in defaults).
-  // Union in any alias an agent currently references but that isn't in that
-  // list (a project alias that failed to load, or one later removed from
-  // worca.models) so the select never renders blank and the value round-trips.
-  const referencedModels = Object.values(agents)
-    .map((a) => a?.model)
-    .filter((m) => typeof m === 'string' && m.length > 0);
   const tierMap = editorState.modelTierMap || {};
-  // `getModelOptions(settings?.worca)` reads only the project's
-  // `worca.models` (so for a project that defined just `glm-ds`, that's
-  // the lone PROJECT option). The full per-tier inventory was already
-  // fetched into `modelTierMap` from /api/projects/:id/models — union
-  // its keys too so built-in and user-tier aliases populate the dropdown
-  // (PROJECT shadowing semantics still hold via `groupModelOptionsByTier`
-  // since `tierMap` records the highest-priority tier per alias).
-  const modelOptions = Array.from(
-    new Set([
-      ...getModelOptions(settings?.worca),
-      ...Object.keys(tierMap),
-      ...referencedModels,
-    ]),
-  );
+  const tierRows = editorState.modelTierRows || [];
+
+  // Build the full row list for the dropdown: start from the per-tier rows
+  // fetched from /api/models. Unlike the old flat modelOptions list (which
+  // collapsed user+project rows for the same alias to just one entry), this
+  // keeps both so the lock-toggle dropdown can enumerate each independently.
+  // Orphan rows are added for any model ref not already covered.
+  const rowKeySet = new Set(tierRows.map((r) => `${r.tier}::${r.alias}`));
+  const allModelRows = [...tierRows];
+  for (const alias of getModelOptions(settings?.worca)) {
+    const t = tierMap[alias] || 'other';
+    const key = `${t}::${alias}`;
+    if (!rowKeySet.has(key)) {
+      allModelRows.push({ tier: t, alias });
+      rowKeySet.add(key);
+    }
+  }
+  for (const ag of Object.values(agents)) {
+    const modelRef = ag?.model;
+    if (!modelRef) continue;
+    if (modelRef.includes(':')) {
+      const sep = modelRef.indexOf(':');
+      const tier = modelRef.slice(0, sep);
+      const alias = modelRef.slice(sep + 1);
+      const key = `${tier}::${alias}`;
+      if (!rowKeySet.has(key)) {
+        allModelRows.push({ tier: tier || 'other', alias });
+        rowKeySet.add(key);
+      }
+    } else {
+      const t = tierMap[modelRef] || 'other';
+      const key = `${t}::${modelRef}`;
+      if (!rowKeySet.has(key)) {
+        allModelRows.push({ tier: t, alias: modelRef });
+        rowKeySet.add(key);
+      }
+    }
+  }
+
   const effort = formBuffer?.effort || {};
   const autoMode = effort.auto_mode || 'adaptive';
   const autoCap = effort.auto_cap || 'xhigh';
   const state = editorState;
-  // Group the per-agent Model dropdown options by tier, mirroring the
-  // "Base template" picker on the New Pipeline / template-create dialog
-  // (small group label + sl-divider + indented options). Keeps the
-  // tier-aware UX consistent across surfaces — the previous "alias · P"
-  // single-letter suffix was implicit and easy to miss; group headers
-  // are explicit and let the user see the whole inventory grouped by
-  // where each alias lives.
-  //
-  // Order: PROJECT → USER → BUILT-IN — matches the resolution priority
-  // (Project shadows User shadows Built-in), so the first group is the
-  // tier the runtime actually picks from.
-  const groupModelOptionsByTier = (aliases) => {
+  // Group rows by tier: PROJECT → USER → BUILT-IN → OTHER.
+  // Each sl-option value is 'tier::alias' (double-colon) so user:glm-ds and
+  // project:glm-ds are separately selectable — the sl-change handler translates
+  // back to the saved model string based on the lock flag.
+  const groupModelOptionsByTier = (rows) => {
     const buckets = { project: [], user: [], builtin: [], other: [] };
-    for (const m of aliases) {
-      const t = tierMap[m] || 'other';
-      (buckets[t] || buckets.other).push(m);
+    for (const r of rows) {
+      const bucket = buckets[r.tier];
+      if (bucket) bucket.push(r);
+      else buckets.other.push(r);
     }
     for (const key of Object.keys(buckets)) {
-      buckets[key].sort((a, b) => a.localeCompare(b));
+      buckets[key].sort((a, b) => a.alias.localeCompare(b.alias));
     }
     return [
       { tier: 'project', label: 'PROJECT', items: buckets.project },
       { tier: 'user', label: 'USER', items: buckets.user },
       { tier: 'builtin', label: 'BUILT-IN', items: buckets.builtin },
-      // Aliases referenced by the template but missing from worca.models
-      // (orphans) — surfaced last so they don't silently disappear.
       {
         tier: 'other',
         label: 'OTHER (referenced but not in worca.models)',
@@ -1873,6 +1965,18 @@ function _agentsTab(formBuffer, settings, projectId, rerender) {
       <div class="settings-cards">
         ${AGENT_NAMES.map((name) => {
           const agent = agents[name] || {};
+          // Compute the dropdown's internal key ('tier::alias', double-colon).
+          // Bare 'glm-ds' maps to the highest-priority tier from tierMap;
+          // pinned 'user:glm-ds' maps directly to 'user::glm-ds'.
+          const modelRef = agent.model || 'sonnet';
+          const selectedInternalKey = (() => {
+            if (modelRef.includes(':')) {
+              const sep = modelRef.indexOf(':');
+              return `${modelRef.slice(0, sep)}::${modelRef.slice(sep + 1)}`;
+            }
+            return `${tierMap[modelRef] || 'other'}::${modelRef}`;
+          })();
+          const isLocked = agent._model_pin_locked || false;
           return html`
             <div class="settings-card">
               <div class="settings-card-header">
@@ -1884,12 +1988,20 @@ function _agentsTab(formBuffer, settings, projectId, rerender) {
                   <div class="agent-model-select-row">
                     <sl-select
                       id="agent-${name}-model"
-                      .value=${agent.model || 'sonnet'}
+                      .value=${selectedInternalKey}
                       size="small"
                       hoist
                       @sl-change=${(e) => {
-                        editorState.formBuffer.agents[name].model =
-                          e.target.value;
+                        const key = e.target.value;
+                        const sep = key.indexOf('::');
+                        if (sep === -1) return;
+                        const tier = key.slice(0, sep);
+                        const alias = key.slice(sep + 2);
+                        const locked =
+                          editorState.formBuffer.agents[name]._model_pin_locked;
+                        editorState.formBuffer.agents[name].model = locked
+                          ? `${tier}:${alias}`
+                          : alias;
                         rerender();
                       }}
                       @sl-blur=${() => {
@@ -1902,34 +2014,47 @@ function _agentsTab(formBuffer, settings, projectId, rerender) {
                       }}
                     >
                       ${(() => {
-                        // Render grouped tier sections — first PROJECT,
-                        // then USER, then BUILT-IN, matching the resolver
-                        // priority. Each group: small label + divider +
-                        // indented option rows (same pattern as the
-                        // template-create "Base template" picker).
-                        const groups = groupModelOptionsByTier(modelOptions);
+                        const groups = groupModelOptionsByTier(allModelRows);
                         return groups.flatMap((g, idx) => [
                           idx > 0 ? html`<sl-divider></sl-divider>` : '',
                           html`<small class="template-group-label">${g.label}</small>`,
                           ...g.items.map(
-                            (m) => html`<sl-option
+                            (row) => html`<sl-option
                               class="template-grouped"
-                              value="${m}"
-                              title=${tierTitle(m)}
-                            >${m}</sl-option>`,
+                              value="${row.tier}::${row.alias}"
+                              title=${tierTitle(row.alias)}
+                            >${row.alias}</sl-option>`,
                           ),
                         ]);
                       })()}
                     </sl-select>
+                    <button
+                      class="icon-btn model-lock-btn${isLocked ? ' model-lock-btn--locked' : ''}"
+                      data-testid="model-lock-toggle-${name}"
+                      title=${
+                        isLocked
+                          ? 'Pinned to tier — click to use bare alias'
+                          : 'Unlocked — click to pin to current tier'
+                      }
+                      aria-label=${isLocked ? 'Unpin model tier' : 'Pin model to tier'}
+                      @click=${() => {
+                        applyModelLockToggle(name);
+                        rerender();
+                      }}
+                    >${unsafeHTML(iconSvg(isLocked ? Lock : LockOpen, 14))}</button>
                     ${(() => {
-                      const alias = agent.model || 'sonnet';
-                      const t = tierMap[alias];
+                      // Link-out arrow: target the pinned tier when locked,
+                      // else the highest-priority tier from tierMap.
+                      let alias, t;
+                      if (modelRef.includes(':')) {
+                        const sep = modelRef.indexOf(':');
+                        alias = modelRef.slice(sep + 1);
+                        t = isLocked ? modelRef.slice(0, sep) : tierMap[alias];
+                      } else {
+                        alias = modelRef;
+                        t = tierMap[alias];
+                      }
                       if (!t) return '';
-                      // Use the full project-scoped Models URL so the
-                      // page lands in the right project context (matching
-                      // the route the user is editing this template in).
-                      // Falls back to the short form when projectId is
-                      // absent (single-project mode).
                       const href = projectId
                         ? `#/project/${projectId}/models/${encodeURIComponent(alias)}/edit/${t}`
                         : `#/models/${encodeURIComponent(alias)}/edit/${t}`;

--- a/worca-ui/e2e/pipelines-editor.spec.js
+++ b/worca-ui/e2e/pipelines-editor.spec.js
@@ -3,7 +3,7 @@
  * Run with: cd worca-ui && npx playwright test e2e/pipelines-editor.spec.js --workers=1
  */
 import { test, expect } from '@playwright/test';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { startServer } from './fixtures.js';
 
@@ -469,6 +469,109 @@ test('edit governance dispatch section', async ({ page }) => {
     const inputValue = await plannerInput.inputValue();
     expect(inputValue).toBe('Bis');
   } finally {
+    await ctx.close();
+  }
+});
+
+// ─── Smoke: user-tier pin lock toggle save and reload round-trip ────────────
+
+test('user-tier pinned model round-trips through save and reload', async ({ page }) => {
+  const ctx = await startServer();
+  // Redirect WORCA_HOME to an isolated directory so the user-tier model
+  // entry doesn't pollute the real ~/.worca/settings.json.
+  const origWorcaHome = process.env.WORCA_HOME;
+  process.env.WORCA_HOME = ctx.worcaDir;
+
+  try {
+    // Write a user-tier model into the isolated WORCA_HOME.
+    // globalSettingsPath() reads WORCA_HOME lazily, so this takes effect
+    // on the first /api/models request.
+    writeFileSync(
+      join(ctx.worcaDir, 'settings.json'),
+      JSON.stringify({ worca: { models: { 'my-model': 'claude-opus-4-7' } } }, null, 2),
+    );
+
+    // Create a project template that pins planner to the user-tier alias.
+    const templateDir = join(ctx.dir, '.claude', 'templates', 'tier-lock-test');
+    mkdirSync(templateDir, { recursive: true });
+    writeFileSync(
+      join(templateDir, 'template.json'),
+      JSON.stringify(
+        {
+          id: 'tier-lock-test',
+          name: 'Tier Lock Test',
+          description: '',
+          tags: [],
+          config: {
+            agents: { planner: { model: 'user:my-model', max_turns: 30 } },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    // Load in the editor
+    await page.goto(`${ctx.url}/#/templates/project/tier-lock-test/edit`, GOTO_OPTS);
+    await expect(page.locator('.pipelines-editor')).toBeAttached({ timeout: 30000 });
+
+    // Wait for template name to populate (signals loadTemplate completed)
+    await expect
+      .poll(
+        async () =>
+          page
+            .locator('.editor-name-input')
+            .evaluate((el) => el.value)
+            .catch(() => null),
+        { timeout: 5000 },
+      )
+      .toBe('Tier Lock Test');
+
+    // Lock toggle must be present for the planner agent (data-testid set in _agentsTab)
+    await expect(
+      page.locator('[data-testid="model-lock-toggle-planner"]'),
+    ).toBeAttached({ timeout: 5000 });
+
+    // Save — accept the first non-GET /templates response
+    const apiResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/templates') && res.request().method() !== 'GET',
+      { timeout: 10000 },
+    );
+    const saveButton = page.locator('.editor-footer sl-button', {
+      hasText: 'Save',
+    });
+    await expect(saveButton).toBeAttached();
+    await saveButton.click();
+    const response = await apiResponse;
+    expect(response.ok()).toBe(true);
+
+    // Verify the saved file preserved the tier-pinned ref
+    const saved = JSON.parse(readFileSync(join(templateDir, 'template.json'), 'utf8'));
+    expect(saved.config?.agents?.planner?.model).toBe('user:my-model');
+
+    // Reload and assert the lock toggle is still present (round-trip confirmed)
+    await page.reload(GOTO_OPTS);
+    await expect(page.locator('.pipelines-editor')).toBeAttached({ timeout: 30000 });
+    await expect
+      .poll(
+        async () =>
+          page
+            .locator('.editor-name-input')
+            .evaluate((el) => el.value)
+            .catch(() => null),
+        { timeout: 5000 },
+      )
+      .toBe('Tier Lock Test');
+    await expect(
+      page.locator('[data-testid="model-lock-toggle-planner"]'),
+    ).toBeAttached({ timeout: 5000 });
+  } finally {
+    if (origWorcaHome === undefined) {
+      delete process.env.WORCA_HOME;
+    } else {
+      process.env.WORCA_HOME = origWorcaHome;
+    }
     await ctx.close();
   }
 });

--- a/worca-ui/server/models-routes.js
+++ b/worca-ui/server/models-routes.js
@@ -195,6 +195,9 @@ function writeModelEntry(
   alias,
   { id, env, pricing },
 ) {
+  if (alias.includes(':')) {
+    throw new Error('alias name cannot contain colon');
+  }
   const settingsPath = tierSettingsPath(tier, projectSettingsPath);
   if (!settingsPath) {
     throw new Error(`tier "${tier}" has no writable settings path`);
@@ -401,6 +404,11 @@ export function createModelsRouter({ settingsPath: staticPath } = {}) {
     const body = req.body || {};
     const newAlias =
       typeof body.alias === 'string' && body.alias ? body.alias : urlAlias;
+    if (newAlias.includes(':')) {
+      return res
+        .status(400)
+        .json({ ok: false, error: 'alias name cannot contain colon' });
+    }
     if (!ALIAS_RE.test(newAlias)) {
       return res.status(400).json({
         ok: false,

--- a/worca-ui/server/models-routes.test.js
+++ b/worca-ui/server/models-routes.test.js
@@ -1,5 +1,4 @@
 import {
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -33,7 +32,6 @@ describe('/api/models — tier-aware CRUD', () => {
   let projectLocalPath;
   let worcaHome;
   let userSettingsPath;
-  let userLocalPath;
   let server;
   let base;
   let prevWorcaHome;
@@ -47,7 +45,6 @@ describe('/api/models — tier-aware CRUD', () => {
 
     worcaHome = mkdtempSync(join(tmpdir(), 'models-routes-home-'));
     userSettingsPath = join(worcaHome, 'settings.json');
-    userLocalPath = join(worcaHome, 'settings.local.json');
     prevWorcaHome = process.env.WORCA_HOME;
     process.env.WORCA_HOME = worcaHome;
 
@@ -226,6 +223,17 @@ describe('/api/models — tier-aware CRUD', () => {
         body: JSON.stringify({ alias: 'bad name!', id: 'claude-opus-4-7' }),
       });
       expect(res.status).toBe(400);
+    });
+
+    it('rejects alias containing colon', async () => {
+      const res = await fetch(`${base}/api/models/project/bad`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ alias: 'user:opus', id: 'claude-opus-4-7' }),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toMatch(/colon/i);
     });
 
     it('detects rename collisions in the same tier', async () => {


### PR DESCRIPTION
## Summary

Resurrects the implementation for #312 (per-tier model selection in templates via `tier:alias` ref syntax). The pipeline ran this on 2026-06-08 (~3h, $31, 23 iterations) but the guardian never committed — the changes sat staged in `.worktrees/pipeline-20260608-181924-857-fd3ed0a5` until manual recovery.

Adds an optional colon-prefixed ref form (`user:glm-ds`, `project:opus`, `builtin:haiku`) that pins a model ref to a specific settings tier, alongside the existing bare-alias form which keeps following shadow priority. Fully additive — no migration, no breaking change.

- **Resolver**: per-tier views stashed on merged settings; bare refs keep flowing through `resolve_model`.
- **UI editor**: drops the priority-collapse so all `(tier, alias)` pairs render; lock toggle opts into pinned save (bare by default per D1).
- **Bundle export** (D2): strips `user:`/`project:` prefixes, preserves `builtin:` verbatim, omits built-ins from the bundle's `worca.models` map.
- **Bundle import** (D3): auto-rewrites bare refs to `<scope>:alias` matching `--scope`; composes with collision rename; `--preview` JSON gains `ref_rewrites`.
- **Preflight**: tier-pinned refs that can't resolve are a hard error (no silent fallback).
- **`work_request.py`** (D5): title generation pinned to `builtin:haiku` — immune to user/project shadowing.
- **CLI** (D6): `worca models add --tier {user|project}`.
- **Schema**: alias regex tightened to reject `:` at write time.

33 files changed, +2360 / -142.

Closes #312.

## Test plan

- [ ] CI green (Python + UI lint, vitest, Playwright)
- [ ] Resolver: bare lookup, `user:`/`project:`/`builtin:` pin, missing-tier preflight error, env-override-wins
- [ ] Editor: load bare → bare save, load pinned → pinned save, lock toggle round-trip, missing-pin warning
- [ ] Bundle round-trip: `project:` strip, `user:` strip, `builtin:` preserve, built-in entries excluded
- [ ] Bundle import auto-pins to `--scope`, composes with collision rename, `builtin:` passes through
- [ ] `work_request.py` title gen runs `builtin:haiku` regardless of user `haiku` shadow
- [ ] `worca models add --tier user/project` writes correctly; `--tier builtin` rejected
- [ ] Manual spot-check the Pipeline Templates editor dropdown with same-name aliases in two tiers

## Notes

- Lint fixups (E402 + F841) applied during recovery; otherwise the commit is the pipeline's staged work verbatim.
- Pre-commit biome surfaced two warnings in `worca-ui/server/models-routes.test.js` (unused `existsSync` import, unused `userLocalPath` binding) — non-blocking, can clean up in a follow-up commit if the reviewer prefers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)