### PR TITLE
refactor(advisor): match templates by name + description only

### DIFF
--- a/src/worca/agents/core/template-advisor.md
+++ b/src/worca/agents/core/template-advisor.md
@@ -9,40 +9,37 @@ You do not analyze the codebase. You do not write code. You do not propose plans
 ## Context
 
 You receive:
-- The **work content** (title + description + optional review comments, all already normalized for you).
-- The **template catalog** — every template available to the project (built-in, project-local, user-global), each with `id`, `name`, `description`, `tags`, and `tier`.
 
-A `tier` value of `project` or `user` means a template the operator authored or imported — these should be preferred over built-ins when their description is a clear match for the work, since the operator customized them deliberately.
+- The **work content** — title, description, source type, optional review comments, and whether a `## Plan` link is already present. All normalised for you.
+- The **template catalog** — every template available to the project (built-in, project-local, user-global), each with `id`, `name`, `description`, and `tier`.
 
-## Signal-matching guidance
+## How to choose
 
-Use these signals from the work content to narrow the candidates. The mapping below describes the **built-in** templates; for project/user templates, fall back to matching the user's intent against the template's `name`, `description`, and `tags`.
+Match the work against each template's **name and description**. The description is the operator's (or the project author's) statement of when this template fits — read it as a "use when…" rule. Built-in templates are treated identically to project/user templates: no extra heuristics, no hidden keyword rules. If a template's description does not name a signal you care about, that signal does not apply to it.
 
-| Signal in the work content | Built-in template that typically fits |
-|---|---|
-| Bug language ("fix", "broken", "regression"), GitHub `bug` label, scoped to a single defect, no `## Plan` link | `bugfix` |
-| Investigation, audit, "how does X work", "analyze", read-only with no implementation | `investigate` |
-| "Add tests", "improve coverage", test-only scope, no production behavior change | `test-only` |
-| Refactor, "no behavior change", "behavioral preservation", restructuring with same outputs | `refactor` |
-| Trivial / single-line / typo / one-file-only fix | `quick-fix` |
-| `W-NNN:` title prefix, `## Plan` link present, full feature spec | `feature` |
-| Substantial feature, multi-file, but no plan link yet | `feature-fast` or `feature-minor` |
-| GitHub PR with review comments (revision mode) | The template the project uses for revisions (often `feature-minor` or `bugfix`) |
+Two structural signals on the work are worth weighing explicitly because they aren't always obvious in the prose:
 
-These are heuristics, not rules. The actual project may ship custom templates that supersede any of the above — always check the catalog first.
+- **`has_plan_link`** — when true, the work already carries a pre-drafted plan. Match against templates whose description mentions requiring or skipping a plan.
+- **`has_review_comments`** — when true, this is PR-revision work driven by review feedback. Match against templates whose description mentions PR revisions or constrained-scope work.
+
+## Tier preference
+
+When a project-tier or user-tier template plausibly matches the work, **prefer it over any built-in match**, even when a built-in description is a tighter fit. The operator authored those templates deliberately for this project; the catalog ships built-ins as a fallback.
+
+"Plausibly matches" means the template's description names work the operator could reasonably want this template to handle. A vague description ("My template", "TODO") is not a plausible match for anything — fall back to the best-fitting built-in.
 
 ## Confidence
 
-- **Confident match.** Recommend a single template. Populate `template_id` and `rationale`. Leave `alternatives` empty.
-- **Genuinely ambiguous** (two templates fit comparably and you cannot tell which the operator wants without more context). Recommend the more conservative of the two as `template_id`, and put the runner-up in `alternatives` with a one-line rationale.
-- **No reasonable match** (e.g. catalog is empty or work is unparseable). Recommend the first item in the catalog as a fallback, set `confidence` to `low`, and explain in the `rationale` that the operator should pick manually.
+- **Confident match** — one template clearly fits. Set `confidence: high`, populate `template_id` and `rationale`, leave `alternatives` empty.
+- **Genuinely ambiguous** — two templates fit comparably. Recommend the more conservative as `template_id`, put the runner-up in `alternatives` with a one-line rationale.
+- **No reasonable match** — catalog is empty or work is unparseable. Recommend the first catalog item as a fallback, set `confidence: low`, and explain in the rationale that the operator should pick manually.
 
 Never invent a template id — `template_id` and every `alternatives[].template_id` MUST come from the catalog provided in the user prompt.
 
 ## Rationale style
 
 - One sentence, plain language, naming the signal you matched on.
-- Reference the work, not the schema. "Bug language and no plan link" beats "Matches the bugfix template heuristic in row 1".
+- Reference the work and the template's description, not internal rules. "The description targets bug fixes without a pre-drafted plan" beats "Matches the bugfix heuristic".
 - For runners-up, the rationale should be a one-clause "or … if … is what you want" — not a full explanation.
 
 ## Output

--- a/src/worca/template_advisor.py
+++ b/src/worca/template_advisor.py
@@ -142,17 +142,18 @@ def _load_user_prompt(project_root: Path, context: dict) -> str:
 
 
 def _render_catalog(templates: list[TemplateSummary]) -> str:
-    """Render the template catalog as a compact Markdown list for the LLM."""
+    """Render the template catalog as a compact Markdown list for the LLM.
+
+    Includes id, tier, name, and description only — tags are intentionally
+    omitted (the advisor matches on name + description; tags would just be
+    a second axis the model has to weigh against the same signal).
+    """
     if not templates:
         return "(no templates available)"
     lines = []
     for t in templates:
-        tags = ", ".join(t.tags) if t.tags else ""
-        tag_suffix = f" — tags: {tags}" if tags else ""
         desc = (t.description or "").strip().replace("\n", " ")
-        lines.append(
-            f"- **{t.id}** ({t.tier}): {t.name}{tag_suffix}\n  {desc}"
-        )
+        lines.append(f"- **{t.id}** ({t.tier}): {t.name}\n  {desc}")
     return "\n".join(lines)
 
 

--- a/src/worca/templates/bugfix/template.json
+++ b/src/worca/templates/bugfix/template.json
@@ -1,7 +1,7 @@
 {
   "id": "bugfix",
   "name": "Bugfix",
-  "description": "Fast bug fix pipeline. Opus planner investigates root cause, coordinator creates focused tasks, implementer fixes.",
+  "description": "Fast pipeline for fixing a single defect — bug language (\"fix\", \"broken\", \"regression\"), no pre-drafted plan. Root-cause investigation followed by a targeted fix.",
   "builtin": true,
   "created_at": "2026-03-10T00:00:00Z",
   "tags": [

--- a/src/worca/templates/feature-fast/template.json
+++ b/src/worca/templates/feature-fast/template.json
@@ -1,7 +1,7 @@
 {
   "id": "feature-fast",
   "name": "Feature Development (Fast)",
-  "description": "Full pipeline with plan review in review-and-edit mode and learn stage enabled. Higher retry limits for complex features. The plan reviewer can directly edit the plan, shortcutting the review-revise loop.",
+  "description": "Full pipeline for substantial features without a pre-drafted plan. Plan is drafted and reviewed in-line — review can edit directly, shortcutting the review-revise loop. Learn stage on, higher retry limits.",
   "builtin": true,
   "created_at": "2026-05-29T00:00:00Z",
   "tags": [

--- a/src/worca/templates/feature-minor/template.json
+++ b/src/worca/templates/feature-minor/template.json
@@ -1,7 +1,7 @@
 {
   "id": "feature-minor",
   "name": "Minor Feature",
-  "description": "Lean feature pipeline for well-scoped work a planner can handle confidently. Full implement/test/review/PR; no plan-review stage, no learn stage, no plan-approval gate \u2014 runs autonomously. Supplying a plan skips the PLAN stage.",
+  "description": "Lean autonomous pipeline for well-scoped features. Full implement/test/review/PR but no plan review, no learn, no approval gates. Good fit for PR-revision work where scope is already constrained by review comments.",
   "builtin": true,
   "created_at": "2026-05-27T00:00:00Z",
   "tags": [

--- a/src/worca/templates/feature/template.json
+++ b/src/worca/templates/feature/template.json
@@ -1,7 +1,7 @@
 {
   "id": "feature",
   "name": "Feature Development",
-  "description": "Full pipeline with plan review and learn stages enabled. Higher retry limits for complex features. All approval gates active.",
+  "description": "Full pipeline for substantial features with a pre-drafted plan link (typically `W-NNN:`-prefixed issues). Plan review + learn stages on, higher retry limits, all approval gates active.",
   "builtin": true,
   "created_at": "2026-03-10T00:00:00Z",
   "tags": [

--- a/src/worca/templates/investigate/template.json
+++ b/src/worca/templates/investigate/template.json
@@ -1,7 +1,7 @@
 {
   "id": "investigate",
   "name": "Investigation",
-  "description": "Analysis mode. Opus planner explores codebase and produces a detailed report. The guardian publishes the plan to docs/plans/ and opens a PR. No implementation changes.",
+  "description": "Read-only investigation mode — \"how does X work\", \"audit Y\", \"analyze Z\". Produces a detailed analysis report, publishes it to `docs/plans/`, and opens a PR. No code changes.",
   "builtin": true,
   "created_at": "2026-03-10T00:00:00Z",
   "tags": [

--- a/src/worca/templates/quick-fix/template.json
+++ b/src/worca/templates/quick-fix/template.json
@@ -1,7 +1,7 @@
 {
   "id": "quick-fix",
   "name": "Quick Fix",
-  "description": "Minimal pipeline for trivial changes. Opus plans, sonnet implements. No test, review, or PR \u2014 changes left on branch for manual commit.",
+  "description": "Minimal pipeline for trivial changes \u2014 one-line edits, typo fixes, single-file tweaks. Plan and implement only; no test, review, or PR. Changes left on branch for manual commit.",
   "builtin": true,
   "created_at": "2026-03-10T00:00:00Z",
   "tags": [

--- a/src/worca/templates/refactor/template.json
+++ b/src/worca/templates/refactor/template.json
@@ -1,7 +1,7 @@
 {
   "id": "refactor",
   "name": "Refactor",
-  "description": "Full pipeline with all agents on Opus. Reviewer enforces behavioral preservation. PR opened for human review before merge; learn stage captures invariants surfaced during the refactor.",
+  "description": "Full pipeline for refactor work — \"restructure without changing behavior\", \"behavioral preservation\", \"no functional change\". Review enforces behavioral preservation; learn stage captures invariants. PR opened for human review.",
   "builtin": true,
   "created_at": "2026-03-10T00:00:00Z",
   "tags": [

--- a/src/worca/templates/test-only/template.json
+++ b/src/worca/templates/test-only/template.json
@@ -1,7 +1,7 @@
 {
   "id": "test-only",
-  "name": "Test Coverage",
-  "description": "Add test coverage without changing production code. Opus planner analyzes gaps, coordinator creates per-module test tasks, implementer writes tests only.",
+  "name": "Add Test Coverage",
+  "description": "Adds new test code to increase coverage of existing production code — \"add tests\", \"improve coverage\", \"cover the X module\". The output is new test files; the existing test suite is not the deliverable.",
   "builtin": true,
   "created_at": "2026-03-10T00:00:00Z",
   "tags": [

--- a/tests/test_template_advisor.py
+++ b/tests/test_template_advisor.py
@@ -109,7 +109,6 @@ class TestRenderCatalog:
         assert "(builtin)" in rendered
         assert "Bugfix" in rendered
         assert "Fix a thing" in rendered
-        assert "fast" in rendered
 
     def test_empty_catalog(self):
         assert _render_catalog([]) == "(no templates available)"


### PR DESCRIPTION
## Summary

- Drop the advisor's built-in-only heuristic table and the per-template keyword bridges; built-in, project, and user templates are now matched identically through `name` + `description` only.
- Drop tags from the catalog rendering (descriptions already carry the signal; tags were a second axis to weigh against the same content).
- Strengthen the tier-preference rule: a project/user template wins over any built-in whenever it plausibly matches the work. A vague description ("My template", "TODO") still falls back to the best-fit built-in.
- Rewrite all eight built-in descriptions: outcome-fronted, no model names, structural signals (plan link, PR revisions, bug language, refactor preservation, trivial scope) baked in.
- `test-only`: rename `Test Coverage` → `Add Test Coverage` and reword the description so it can't be misread as "run the existing test suite". The id stays `test-only` (changing it would break `worca.default_template` pins and `--template` flags — separate decision).
- `feature-minor` owns PR-revision work explicitly; `bugfix` drops its PR-revision claim and competes on bug-language alone.

## Test plan

- [ ] CI: ruff, pytest, vitest, Playwright across linux 3.10/3.12, macOS, windows
- [ ] Manual: open the worca-ui launcher, click **Suggest** on a bug-language prompt → expect `bugfix`
- [ ] Manual: open the worca-ui launcher, click **Suggest** on a "how does X work" prompt → expect `investigate`
- [ ] Manual: open the worca-ui launcher with a GitHub PR URL that carries review comments → expect `feature-minor` (or the project's revision template if customized)
- [ ] Manual: add a project-tier template with `name: "Custom Bug Pipeline"`, `description: "For internal hot-fix flow"`, then **Suggest** on a bug prompt → expect the project template (tier preference)

## Notes

Single test assertion removed: `tests/test_template_advisor.py::TestRenderCatalog` no longer asserts `"fast" in rendered` since tags are dropped from the catalog render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)