### PR TITLE
feat(logs): persist per-line write-time so finished-stage logs show real timestamps

### DIFF
--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -57,7 +57,13 @@ from worca.utils.gh_pr import (
     post_revision_summary,
     reply_to_thread,
 )
-from worca.utils.claude_cli import run_agent, terminate_current, terminate_all, AgentSubprocessError
+from worca.utils.claude_cli import (
+    run_agent,
+    terminate_current,
+    terminate_all,
+    AgentSubprocessError,
+    _write_log_line,
+)
 from worca.utils.proc import pid_is_alive
 from worca.utils.proc_registry import kill_all_tracked
 from worca.utils.git import create_branch, current_branch, get_current_git_head
@@ -1057,14 +1063,19 @@ def _close_orchestrator_log() -> None:
 
 
 def _log(msg: str, level: str = "info") -> None:
-    """Print a timestamped progress message to stderr and log file."""
+    """Print a timestamped progress message to stderr and the log file.
+
+    stderr keeps the human-friendly local ``[HH:MM:SS]`` prefix for operators
+    watching the console. The persisted log line instead carries the ISO-8601
+    UTC write-time column (via ``_write_log_line``) so the UI renders it in each
+    viewer's local timezone \u2014 consistent with per-stage agent logs.
+    """
     ts = time.strftime("%H:%M:%S")
     prefix = {"info": "  ", "ok": "  \u2713", "err": "  \u2717", "warn": "  !"}
-    line = f"[{ts}] {prefix.get(level, '  ')} {msg}"
-    print(line, file=sys.stderr, flush=True)
+    body = f"{prefix.get(level, '  ')} {msg}"
+    print(f"[{ts}] {body}", file=sys.stderr, flush=True)
     if _orchestrator_log:
-        _orchestrator_log.write(line + "\n")
-        _orchestrator_log.flush()
+        _write_log_line(_orchestrator_log, body)
 
 
 def _format_duration(seconds: float) -> str:

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -62,8 +62,8 @@ from worca.utils.claude_cli import (
     terminate_current,
     terminate_all,
     AgentSubprocessError,
-    _write_log_line,
 )
+from worca.utils.log_lines import write_log_line, write_log_block
 from worca.utils.proc import pid_is_alive
 from worca.utils.proc_registry import kill_all_tracked
 from worca.utils.git import create_branch, current_branch, get_current_git_head
@@ -1067,7 +1067,7 @@ def _log(msg: str, level: str = "info") -> None:
 
     stderr keeps the human-friendly local ``[HH:MM:SS]`` prefix for operators
     watching the console. The persisted log line instead carries the ISO-8601
-    UTC write-time column (via ``_write_log_line``) so the UI renders it in each
+    UTC write-time column (via ``write_log_line``) so the UI renders it in each
     viewer's local timezone \u2014 consistent with per-stage agent logs.
     """
     ts = time.strftime("%H:%M:%S")
@@ -1075,7 +1075,7 @@ def _log(msg: str, level: str = "info") -> None:
     body = f"{prefix.get(level, '  ')} {msg}"
     print(f"[{ts}] {body}", file=sys.stderr, flush=True)
     if _orchestrator_log:
-        _write_log_line(_orchestrator_log, body)
+        write_log_line(_orchestrator_log, body)
 
 
 def _format_duration(seconds: float) -> str:
@@ -2280,11 +2280,15 @@ def run_preflight(
     )
     stdout, stderr = proc.communicate()
 
+    # The captured stdout/stderr is produced at one instant (the preflight
+    # subprocess just finished), so every emitted line shares one write-time.
+    # Routing through write_log_block keeps these lines timestamped like every
+    # other stage log instead of rendering as a "--:--:--" legacy block.
+    stamp = datetime.now(timezone.utc)
     with open(log_path, "w", encoding="utf-8") as log_file:
-        log_file.write(stdout)
+        write_log_block(log_file, stdout, now=stamp)
         if stderr:
-            log_file.write("\n--- STDERR ---\n")
-            log_file.write(stderr)
+            write_log_block(log_file, f"--- STDERR ---\n{stderr}", now=stamp)
 
     try:
         result = json.loads(stdout)

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -20,8 +20,9 @@ import subprocess
 import sys
 import tempfile
 import threading
-from datetime import datetime, timezone
 from typing import Optional, Callable
+
+from worca.utils.log_lines import write_log_line
 
 from worca.hooks.agent_role import role_from_worca_agent
 from worca.hooks.tracking import (
@@ -282,35 +283,6 @@ def build_command(
     return cmd, prompt_file
 
 
-# Each persisted log record is prefixed with an ISO-8601 UTC write-time and a
-# TAB, e.g. ``2026-06-14T12:34:56.789+00:00\t[tool:Read] foo.py``. The reader
-# (worca-ui/server/log-tailer.js ``parseLogLine``) sniffs this prefix; lines
-# without it are treated as legacy (pre-timestamp) records and rendered with no
-# write-time. Embedded newlines are collapsed to this glyph so one logical
-# record is always exactly one physical line — keeping the "first field is the
-# timestamp" invariant sound for every line the reader sees.
-_LOG_NEWLINE_GLYPH = "⏎ "  # ⏎
-
-
-def _write_log_line(log_file, message: str, *, now: Optional[datetime] = None) -> None:
-    """Write *message* to *log_file* prefixed with an ISO-8601 UTC timestamp.
-
-    The timestamp is captured at write time (the moment the event is consumed),
-    which is the closest available proxy to event time — the stream-json events
-    themselves carry no per-event timestamp. ``now`` is injectable for
-    deterministic tests.
-    """
-    ts = (now or datetime.now(timezone.utc)).isoformat(timespec="milliseconds")
-    safe = (
-        str(message)
-        .replace("\r\n", "\n")
-        .replace("\r", "\n")
-        .replace("\n", _LOG_NEWLINE_GLYPH)
-    )
-    log_file.write(f"{ts}\t{safe}\n")
-    log_file.flush()
-
-
 def _format_log_line(event: dict) -> Optional[str]:
     """Convert a stream-json event into a human-readable log line.
 
@@ -456,7 +428,7 @@ def process_stream(
             # Not valid JSON — write raw to log
             if log_file:
                 raw = raw_line if isinstance(raw_line, str) else raw_line.decode()
-                _write_log_line(log_file, raw.rstrip("\n"))
+                write_log_line(log_file, raw.rstrip("\n"))
             continue
 
         if on_event:
@@ -494,7 +466,7 @@ def process_stream(
         if log_file:
             log_line = _format_log_line(event)
             if log_line:
-                _write_log_line(log_file, log_line)
+                write_log_line(log_file, log_line)
 
         if event.get("type") == "result":
             # Task-notification auto-resumes (e.g. long pytest run dispatched

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+from datetime import datetime, timezone
 from typing import Optional, Callable
 
 from worca.hooks.agent_role import role_from_worca_agent
@@ -281,6 +282,35 @@ def build_command(
     return cmd, prompt_file
 
 
+# Each persisted log record is prefixed with an ISO-8601 UTC write-time and a
+# TAB, e.g. ``2026-06-14T12:34:56.789+00:00\t[tool:Read] foo.py``. The reader
+# (worca-ui/server/log-tailer.js ``parseLogLine``) sniffs this prefix; lines
+# without it are treated as legacy (pre-timestamp) records and rendered with no
+# write-time. Embedded newlines are collapsed to this glyph so one logical
+# record is always exactly one physical line — keeping the "first field is the
+# timestamp" invariant sound for every line the reader sees.
+_LOG_NEWLINE_GLYPH = "⏎ "  # ⏎
+
+
+def _write_log_line(log_file, message: str, *, now: Optional[datetime] = None) -> None:
+    """Write *message* to *log_file* prefixed with an ISO-8601 UTC timestamp.
+
+    The timestamp is captured at write time (the moment the event is consumed),
+    which is the closest available proxy to event time — the stream-json events
+    themselves carry no per-event timestamp. ``now`` is injectable for
+    deterministic tests.
+    """
+    ts = (now or datetime.now(timezone.utc)).isoformat(timespec="milliseconds")
+    safe = (
+        str(message)
+        .replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\n", _LOG_NEWLINE_GLYPH)
+    )
+    log_file.write(f"{ts}\t{safe}\n")
+    log_file.flush()
+
+
 def _format_log_line(event: dict) -> Optional[str]:
     """Convert a stream-json event into a human-readable log line.
 
@@ -425,8 +455,8 @@ def process_stream(
         except json.JSONDecodeError:
             # Not valid JSON — write raw to log
             if log_file:
-                log_file.write(raw_line if isinstance(raw_line, str) else raw_line.decode())
-                log_file.flush()
+                raw = raw_line if isinstance(raw_line, str) else raw_line.decode()
+                _write_log_line(log_file, raw.rstrip("\n"))
             continue
 
         if on_event:
@@ -464,8 +494,7 @@ def process_stream(
         if log_file:
             log_line = _format_log_line(event)
             if log_line:
-                log_file.write(log_line + "\n")
-                log_file.flush()
+                _write_log_line(log_file, log_line)
 
         if event.get("type") == "result":
             # Task-notification auto-resumes (e.g. long pytest run dispatched

--- a/src/worca/utils/log_lines.py
+++ b/src/worca/utils/log_lines.py
@@ -1,0 +1,67 @@
+"""Shared formatting for persisted pipeline log lines.
+
+Every line written to a stage or orchestrator log file is prefixed with an
+ISO-8601 UTC write-time and a TAB:
+
+    2026-06-14T12:34:56.789+00:00\t[tool:Read] foo.py
+
+The worca-ui reader (``worca-ui/server/log-tailer.js`` → ``parseLogLine``)
+sniffs this prefix and renders the timestamp in each viewer's local timezone.
+Lines without the prefix are treated as legacy (pre-timestamp) records and
+rendered with a ``--:--:--`` placeholder.
+
+Centralising the format here keeps every producer byte-for-byte consistent so
+the single reader-side parser stays valid:
+
+  - agent stage logs   — ``claude_cli.process_stream``
+  - orchestrator log    — ``orchestrator.runner._log``
+  - preflight stdout    — ``orchestrator.runner.run_preflight``
+"""
+
+from datetime import datetime, timezone
+from typing import Optional, TextIO
+
+# Embedded newlines are collapsed to this glyph so one logical record is always
+# exactly one physical line — keeping the reader's "first field is the
+# timestamp" invariant sound for every line it sees.
+LOG_NEWLINE_GLYPH = "⏎ "
+
+
+def format_log_line(message: str, now: Optional[datetime] = None) -> str:
+    """Return *message* as one timestamped log record (no trailing newline).
+
+    The timestamp is captured at format time — the closest available proxy to
+    event time, since the underlying events carry no per-event timestamp.
+    ``now`` is injectable for deterministic tests.
+    """
+    ts = (now or datetime.now(timezone.utc)).isoformat(timespec="milliseconds")
+    safe = (
+        str(message)
+        .replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\n", LOG_NEWLINE_GLYPH)
+    )
+    return f"{ts}\t{safe}"
+
+
+def write_log_line(
+    log_file: TextIO, message: str, *, now: Optional[datetime] = None
+) -> None:
+    """Write a single timestamped record to *log_file* and flush."""
+    log_file.write(format_log_line(message, now) + "\n")
+    log_file.flush()
+
+
+def write_log_block(
+    log_file: TextIO, text: str, *, now: Optional[datetime] = None
+) -> None:
+    """Write a multi-line *text* blob as timestamped records, one per line.
+
+    Used for captured subprocess output (e.g. the preflight script's JSON
+    stdout) where the whole block is produced at one instant — every emitted
+    line shares the same write-time so they collate correctly in the UI.
+    """
+    stamp = now or datetime.now(timezone.utc)
+    for line in text.splitlines():
+        log_file.write(format_log_line(line, stamp) + "\n")
+    log_file.flush()

--- a/tests/test_claude_cli_logging.py
+++ b/tests/test_claude_cli_logging.py
@@ -7,15 +7,10 @@ TestProcessStream) so they are collected by CI (testpaths = ["tests"]).
 import io
 import json
 import re
-from datetime import datetime, timezone
 
 import pytest
 
-from worca.utils.claude_cli import (
-    _format_log_line,
-    _write_log_line,
-    process_stream,
-)
+from worca.utils.claude_cli import _format_log_line, process_stream
 
 # ISO-8601 + TAB prefix that every persisted log line now carries. Mirrors the
 # LOG_TS_RE sniff in worca-ui/server/log-tailer.js.
@@ -296,40 +291,6 @@ def test_process_stream_no_result_raises():
     )
     with pytest.raises(RuntimeError, match="No result event"):
         process_stream(events)
-
-
-# ---------------------------------------------------------------------------
-# _write_log_line — ISO-8601 write-time prefix
-# ---------------------------------------------------------------------------
-
-
-def test_write_log_line_prefixes_iso_timestamp_and_tab():
-    now = datetime(2026, 6, 14, 12, 0, 0, tzinfo=timezone.utc)
-    buf = io.StringIO()
-    _write_log_line(buf, "[tool:Read] foo.py", now=now)
-    assert buf.getvalue() == "2026-06-14T12:00:00.000+00:00\t[tool:Read] foo.py\n"
-
-
-def test_write_log_line_collapses_embedded_newlines():
-    # Embedded newlines must not split one logical record into multiple physical
-    # lines — otherwise the reader's "first field is the timestamp" invariant
-    # breaks for the continuation lines.
-    now = datetime(2026, 6, 14, 12, 0, 0, tzinfo=timezone.utc)
-    buf = io.StringIO()
-    _write_log_line(buf, "line one\nline two\r\nline three", now=now)
-    written = buf.getvalue()
-    assert written.count("\n") == 1  # exactly one trailing physical newline
-    assert written.endswith("\n")
-    assert "line one⏎ line two⏎ line three" in written
-
-
-def test_write_log_line_first_field_parses_as_timestamp():
-    now = datetime(2026, 6, 14, 12, 0, 0, tzinfo=timezone.utc)
-    buf = io.StringIO()
-    _write_log_line(buf, "anything", now=now)
-    ts_field = buf.getvalue().split("\t", 1)[0]
-    # Round-trips back to an aware datetime.
-    assert datetime.fromisoformat(ts_field) == now
 
 
 def test_process_stream_log_lines_carry_timestamp_prefix():

--- a/tests/test_claude_cli_logging.py
+++ b/tests/test_claude_cli_logging.py
@@ -6,10 +6,22 @@ TestProcessStream) so they are collected by CI (testpaths = ["tests"]).
 
 import io
 import json
+import re
+from datetime import datetime, timezone
 
 import pytest
 
-from worca.utils.claude_cli import _format_log_line, process_stream
+from worca.utils.claude_cli import (
+    _format_log_line,
+    _write_log_line,
+    process_stream,
+)
+
+# ISO-8601 + TAB prefix that every persisted log line now carries. Mirrors the
+# LOG_TS_RE sniff in worca-ui/server/log-tailer.js.
+_TS_PREFIX_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\t"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -284,3 +296,75 @@ def test_process_stream_no_result_raises():
     )
     with pytest.raises(RuntimeError, match="No result event"):
         process_stream(events)
+
+
+# ---------------------------------------------------------------------------
+# _write_log_line — ISO-8601 write-time prefix
+# ---------------------------------------------------------------------------
+
+
+def test_write_log_line_prefixes_iso_timestamp_and_tab():
+    now = datetime(2026, 6, 14, 12, 0, 0, tzinfo=timezone.utc)
+    buf = io.StringIO()
+    _write_log_line(buf, "[tool:Read] foo.py", now=now)
+    assert buf.getvalue() == "2026-06-14T12:00:00.000+00:00\t[tool:Read] foo.py\n"
+
+
+def test_write_log_line_collapses_embedded_newlines():
+    # Embedded newlines must not split one logical record into multiple physical
+    # lines — otherwise the reader's "first field is the timestamp" invariant
+    # breaks for the continuation lines.
+    now = datetime(2026, 6, 14, 12, 0, 0, tzinfo=timezone.utc)
+    buf = io.StringIO()
+    _write_log_line(buf, "line one\nline two\r\nline three", now=now)
+    written = buf.getvalue()
+    assert written.count("\n") == 1  # exactly one trailing physical newline
+    assert written.endswith("\n")
+    assert "line one⏎ line two⏎ line three" in written
+
+
+def test_write_log_line_first_field_parses_as_timestamp():
+    now = datetime(2026, 6, 14, 12, 0, 0, tzinfo=timezone.utc)
+    buf = io.StringIO()
+    _write_log_line(buf, "anything", now=now)
+    ts_field = buf.getvalue().split("\t", 1)[0]
+    # Round-trips back to an aware datetime.
+    assert datetime.fromisoformat(ts_field) == now
+
+
+def test_process_stream_log_lines_carry_timestamp_prefix():
+    events = _make_ndjson(
+        {"type": "system", "subtype": "init", "model": "opus"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "working"}]}},
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "done",
+            "total_cost_usd": 0.1,
+            "num_turns": 2,
+            "duration_ms": 5000,
+        },
+    )
+    log_buf = io.StringIO()
+    process_stream(events, log_file=log_buf)
+    physical_lines = [ln for ln in log_buf.getvalue().split("\n") if ln]
+    assert physical_lines, "expected at least one log line"
+    for ln in physical_lines:
+        assert _TS_PREFIX_RE.match(ln), f"line missing timestamp prefix: {ln!r}"
+    # The human-readable content survives after the prefix.
+    joined = log_buf.getvalue()
+    assert "[init] model=opus" in joined
+    assert "working" in joined
+    assert "[done]" in joined
+
+
+def test_process_stream_invalid_json_line_is_timestamped():
+    lines = [
+        "not valid json\n",
+        json.dumps({"type": "result", "subtype": "success", "result": "ok"}) + "\n",
+    ]
+    log_buf = io.StringIO()
+    process_stream(lines, log_file=log_buf)
+    raw_line = log_buf.getvalue().split("\n")[0]
+    assert _TS_PREFIX_RE.match(raw_line)
+    assert raw_line.endswith("\tnot valid json")

--- a/tests/test_log_lines.py
+++ b/tests/test_log_lines.py
@@ -1,0 +1,99 @@
+"""Tests for the shared log-line formatting util (worca.utils.log_lines).
+
+This is the single source of truth for the ISO-8601 + TAB prefix that every
+persisted pipeline log line carries; the worca-ui reader's parseLogLine sniff
+is its counterpart.
+"""
+
+import io
+import re
+from datetime import datetime, timezone
+
+from worca.utils.log_lines import (
+    LOG_NEWLINE_GLYPH,
+    format_log_line,
+    write_log_block,
+    write_log_line,
+)
+
+_FIXED = datetime(2026, 6, 14, 12, 0, 0, tzinfo=timezone.utc)
+_TS_PREFIX_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\t"
+)
+
+
+# ---------------------------------------------------------------------------
+# format_log_line
+# ---------------------------------------------------------------------------
+
+
+def test_format_log_line_prefixes_iso_timestamp_and_tab():
+    assert (
+        format_log_line("[tool:Read] foo.py", _FIXED)
+        == "2026-06-14T12:00:00.000+00:00\t[tool:Read] foo.py"
+    )
+
+
+def test_format_log_line_has_no_trailing_newline():
+    assert not format_log_line("x", _FIXED).endswith("\n")
+
+
+def test_format_log_line_collapses_embedded_newlines():
+    # One logical record must stay one physical line so the reader's
+    # "first field is the timestamp" invariant holds for every line.
+    out = format_log_line("line one\nline two\r\nline three", _FIXED)
+    assert "\n" not in out
+    assert f"line one{LOG_NEWLINE_GLYPH}line two{LOG_NEWLINE_GLYPH}line three" in out
+
+
+def test_format_log_line_first_field_round_trips():
+    ts_field = format_log_line("anything", _FIXED).split("\t", 1)[0]
+    assert datetime.fromisoformat(ts_field) == _FIXED
+
+
+def test_format_log_line_preserves_tabs_in_message():
+    out = format_log_line("a\tb\tc", _FIXED)
+    # Only the prefix TAB is added; message tabs survive (reader splits on first).
+    assert out == "2026-06-14T12:00:00.000+00:00\ta\tb\tc"
+
+
+# ---------------------------------------------------------------------------
+# write_log_line
+# ---------------------------------------------------------------------------
+
+
+def test_write_log_line_writes_one_terminated_record():
+    buf = io.StringIO()
+    write_log_line(buf, "[done] ok", now=_FIXED)
+    assert buf.getvalue() == "2026-06-14T12:00:00.000+00:00\t[done] ok\n"
+
+
+# ---------------------------------------------------------------------------
+# write_log_block
+# ---------------------------------------------------------------------------
+
+
+def test_write_log_block_timestamps_each_line():
+    buf = io.StringIO()
+    write_log_block(buf, '{\n  "summary": "ok"\n}', now=_FIXED)
+    lines = [ln for ln in buf.getvalue().split("\n") if ln]
+    assert len(lines) == 3
+    for ln in lines:
+        assert _TS_PREFIX_RE.match(ln)
+    # Content survives after the prefix.
+    assert lines[0].endswith("\t{")
+    assert lines[1].endswith('\t  "summary": "ok"')
+    assert lines[2].endswith("\t}")
+
+
+def test_write_log_block_shares_one_timestamp_across_lines():
+    buf = io.StringIO()
+    write_log_block(buf, "a\nb\nc", now=_FIXED)
+    stamps = {ln.split("\t", 1)[0] for ln in buf.getvalue().split("\n") if ln}
+    assert stamps == {"2026-06-14T12:00:00.000+00:00"}
+
+
+def test_write_log_block_empty_text_writes_nothing():
+    buf = io.StringIO()
+    write_log_block(buf, "", now=_FIXED)
+    assert buf.getvalue() == ""

--- a/tests/test_runner_preflight.py
+++ b/tests/test_runner_preflight.py
@@ -174,6 +174,38 @@ class TestRunPreflightSuccess:
 
         assert (logs_dir / "preflight" / "iter-1.log").exists()
 
+    def test_log_lines_carry_timestamp_prefix(self, tmp_path):
+        """Preflight's captured stdout is timestamped per line (not a raw blob),
+        so the UI renders real write-times instead of a "--:--:--" legacy block.
+        """
+        import re
+
+        from worca.orchestrator.runner import run_preflight
+
+        # Pretty-printed (multi-line) JSON mirrors the real preflight script and
+        # exercises write_log_block's per-line timestamping.
+        script = tmp_path / "pf.py"
+        script.write_text(
+            "import json, sys\n"
+            "print(json.dumps({'status': 'pass', 'checks': [], "
+            "'summary': 'ok'}, indent=2))\n"
+            "sys.exit(0)\n"
+        )
+        settings_path = _settings_file(tmp_path, script_path=str(script))
+        logs_dir = tmp_path / "logs"
+        run_preflight({"_logs_dir": str(logs_dir)}, settings_path, iteration=1)
+
+        ts_re = re.compile(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+            r"(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\t"
+        )
+        text = (logs_dir / "preflight" / "iter-1.log").read_text()
+        lines = [ln for ln in text.split("\n") if ln]
+        assert len(lines) >= 2  # multi-line JSON → multiple records
+        for ln in lines:
+            assert ts_re.match(ln), f"preflight log line missing prefix: {ln!r}"
+        assert any('"summary": "ok"' in ln for ln in lines)
+
     def test_uses_logs_dir_from_context(self, tmp_path):
         from worca.orchestrator.runner import run_preflight
         result_data = {"status": "pass", "checks": [], "summary": "ok"}

--- a/worca-ui/app/main-log-line-handler.test.js
+++ b/worca-ui/app/main-log-line-handler.test.js
@@ -83,8 +83,13 @@ describe('log-bulk handler: Log History backfill', () => {
     expect(handler).toContain('iteration: payload.iteration');
   });
 
-  it('includes timestamp in bulk entries', () => {
-    // Each bulk entry must have a timestamp for display in log history
-    expect(handler).toMatch(/timestamp:\s*new Date\(\)\.toISOString\(\)/);
+  it('uses the persisted per-line write-time, not receive-time', () => {
+    // Each bulk entry's timestamp comes from the parallel payload.timestamps
+    // array (the real write-time parsed from the log file), NOT a synthesized
+    // receive-time. Legacy lines have null there and render as "--:--:--".
+    expect(handler).toContain('payload.timestamps');
+    expect(handler).toMatch(/timestamp:\s*timestamps\[i\]\s*\?\?\s*null/);
+    // The old receive-time stamping must be gone.
+    expect(handler).not.toMatch(/timestamp:\s*new Date\(\)\.toISOString\(\)/);
   });
 });

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -1240,13 +1240,18 @@ ws.on('log-line', (payload) => {
 ws.on('log-bulk', (payload) => {
   if (payload && Array.isArray(payload.lines)) {
     const entries = [];
-    for (const line of payload.lines) {
-      // NB: timestamp is receive-time, not original write-time (log files lack per-line timestamps)
+    const timestamps = Array.isArray(payload.timestamps)
+      ? payload.timestamps
+      : [];
+    for (let i = 0; i < payload.lines.length; i++) {
+      // New-format lines carry a real write-time; legacy lines (pre-timestamp
+      // format) have null here and render as a "--:--:--" placeholder rather
+      // than a misleading current time.
       const entry = {
         stage: payload.stage,
         iteration: payload.iteration,
-        line,
-        timestamp: new Date().toISOString(),
+        line: payload.lines[i],
+        timestamp: timestamps[i] ?? null,
       };
       entries.push(entry);
       // Log History: only write to the history terminal when a specific stage is selected

--- a/worca-ui/app/views/live-output.js
+++ b/worca-ui/app/views/live-output.js
@@ -35,6 +35,20 @@ export function formatTimestamp(iso) {
   });
 }
 
+/**
+ * Build the dim timestamp column for a terminal log line.
+ * - real ISO timestamp  → local HH:MM:SS
+ * - explicit null        → "--:--:--" placeholder (legacy line, write-time unknown)
+ * - undefined / missing  → no column at all (synthetic entries)
+ * @param {string|null|undefined} ts
+ * @returns {string}
+ */
+export function tsPrefix(ts) {
+  if (ts === null) return `${DIM}--:--:--${RESET} `;
+  if (ts) return `${DIM}${formatTimestamp(ts)}${RESET} `;
+  return '';
+}
+
 function stageColor(stage) {
   if (!stageColorCache.has(stage)) {
     stageColorCache.set(stage, STAGE_COLORS[colorIdx % STAGE_COLORS.length]);
@@ -112,9 +126,7 @@ export function writeLiveLogLine(entry) {
   if (!activeStage) return;
   if (entry.stage !== activeStage) return;
 
-  const ts = entry.timestamp
-    ? `${DIM}${formatTimestamp(entry.timestamp)}${RESET} `
-    : '';
+  const ts = tsPrefix(entry.timestamp);
   const stage = entry.stage
     ? `${stageColor(entry.stage)}[${entry.stage.toUpperCase()}]${RESET} `
     : '';

--- a/worca-ui/app/views/log-timestamp-prefix.test.js
+++ b/worca-ui/app/views/log-timestamp-prefix.test.js
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for the terminal timestamp column helper `tsPrefix`, defined
+ * identically in log-viewer.js (Log History) and live-output.js (Live Output).
+ *
+ * Contract:
+ *  - a real ISO timestamp → dim local HH:MM:SS
+ *  - explicit null         → dim "--:--:--" placeholder (legacy line, time unknown)
+ *  - undefined / missing    → empty (no column) for synthetic entries
+ */
+
+import { describe, expect, it } from 'vitest';
+import { tsPrefix as liveTsPrefix } from './live-output.js';
+import { tsPrefix as historyTsPrefix } from './log-viewer.js';
+
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+
+for (const [name, tsPrefix] of [
+  ['log-viewer', historyTsPrefix],
+  ['live-output', liveTsPrefix],
+]) {
+  describe(`tsPrefix (${name})`, () => {
+    it('renders "--:--:--" for an explicit null (legacy line)', () => {
+      expect(tsPrefix(null)).toBe(`${DIM}--:--:--${RESET} `);
+    });
+
+    it('renders an empty column for undefined (synthetic entry)', () => {
+      expect(tsPrefix(undefined)).toBe('');
+    });
+
+    it('renders a dim local time for a real ISO timestamp', () => {
+      const out = tsPrefix('2026-06-14T12:00:00.000+00:00');
+      expect(out.startsWith(DIM)).toBe(true);
+      expect(out.endsWith(`${RESET} `)).toBe(true);
+      // HH:MM:SS, 24-hour — exact value depends on the runtime timezone.
+      expect(out).toMatch(/\d{2}:\d{2}:\d{2}/);
+    });
+  });
+}

--- a/worca-ui/app/views/log-viewer.js
+++ b/worca-ui/app/views/log-viewer.js
@@ -44,6 +44,20 @@ export function formatTimestamp(iso) {
   });
 }
 
+/**
+ * Build the dim timestamp column for a terminal log line.
+ * - real ISO timestamp  → local HH:MM:SS
+ * - explicit null        → "--:--:--" placeholder (legacy line, write-time unknown)
+ * - undefined / missing  → no column at all (synthetic entries)
+ * @param {string|null|undefined} ts
+ * @returns {string}
+ */
+export function tsPrefix(ts) {
+  if (ts === null) return `${DIM}--:--:--${RESET} `;
+  if (ts) return `${DIM}${formatTimestamp(ts)}${RESET} `;
+  return '';
+}
+
 function stageColor(stage) {
   if (!stageColorCache.has(stage)) {
     stageColorCache.set(stage, STAGE_COLORS[colorIdx % STAGE_COLORS.length]);
@@ -117,9 +131,7 @@ async function ensureTerminal(container) {
 
 export function writeLogLine(entry) {
   if (!terminal) return;
-  const ts = entry.timestamp
-    ? `${DIM}${formatTimestamp(entry.timestamp)}${RESET} `
-    : '';
+  const ts = tsPrefix(entry.timestamp);
   const stage = entry.stage
     ? `${stageColor(entry.stage)}[${entry.stage.toUpperCase()}]${RESET} `
     : '';

--- a/worca-ui/server/log-tailer.js
+++ b/worca-ui/server/log-tailer.js
@@ -13,6 +13,52 @@ import { STAGE_ORDER_WITH_ORCHESTRATOR } from '../app/utils/stage-order.js';
 /** Re-export for consumers (includes orchestrator). */
 export const STAGE_ORDER = STAGE_ORDER_WITH_ORCHESTRATOR;
 
+/**
+ * Matches a persisted log record's `ISO-8601<TAB>message` prefix.
+ * Group 1 = the ISO timestamp, group 2 = the message body (which may itself
+ * contain tabs — we only split on the first TAB).
+ */
+const LOG_TS_RE =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))\t([\s\S]*)$/;
+
+/**
+ * Split a raw log line into its write-time and message.
+ *
+ * New-format lines (written by `_write_log_line` in claude_cli.py) carry an
+ * ISO-8601 timestamp prefix. Legacy lines (written before this format existed)
+ * have none — they return `{ ts: null, text: <raw line> }` so the UI can render
+ * them with an "unknown time" placeholder rather than a misleading current time.
+ *
+ * @param {string} raw
+ * @returns {{ ts: string|null, text: string }}
+ */
+export function parseLogLine(raw) {
+  const m = LOG_TS_RE.exec(raw);
+  if (m && Number.isFinite(Date.parse(m[1]))) {
+    return { ts: m[1], text: m[2] };
+  }
+  return { ts: null, text: raw };
+}
+
+/**
+ * Parse an array of raw log lines into parallel `lines` (message text) and
+ * `timestamps` (ISO string or null) arrays, the shape the `log-bulk` WS payload
+ * carries to the client.
+ *
+ * @param {string[]} rawLines
+ * @returns {{ lines: string[], timestamps: (string|null)[] }}
+ */
+export function splitTimestamps(rawLines) {
+  const lines = [];
+  const timestamps = [];
+  for (const raw of rawLines) {
+    const { ts, text } = parseLogLine(raw);
+    lines.push(text);
+    timestamps.push(ts);
+  }
+  return { lines, timestamps };
+}
+
 export function resolveLogPath(worcaDir, stage, iteration = null) {
   if (!stage) return join(worcaDir, 'logs', 'orchestrator.log');
   if (iteration !== null) {
@@ -104,8 +150,18 @@ export function readNewLines(filePath, byteOffset) {
       const buf = Buffer.alloc(len);
       readSync(fd, buf, 0, len, byteOffset);
       const text = buf.toString('utf8');
-      const lines = text.split('\n').filter((l) => l.length > 0);
-      return { lines, newOffset: size };
+      // Only consume up to the last newline. A trailing partial line (a write
+      // still in progress) is left buffered for the next read so it is never
+      // torn — important now that each line carries a timestamp prefix that
+      // must arrive intact for the reader to parse it.
+      const lastNl = text.lastIndexOf('\n');
+      if (lastNl === -1) return { lines: [], newOffset: byteOffset };
+      const consumed = text.slice(0, lastNl + 1);
+      const lines = consumed.split('\n').filter((l) => l.length > 0);
+      return {
+        lines,
+        newOffset: byteOffset + Buffer.byteLength(consumed, 'utf8'),
+      };
     } finally {
       closeSync(fd);
     }

--- a/worca-ui/server/log-tailer.test.js
+++ b/worca-ui/server/log-tailer.test.js
@@ -5,10 +5,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   listIterationFiles,
   listLogFiles,
+  parseLogLine,
   readLastLines,
+  readNewLines,
   resolveIterationLogPath,
   resolveLogPath,
   STAGE_ORDER,
+  splitTimestamps,
 } from './log-tailer.js';
 
 describe('log-tailer', () => {
@@ -111,5 +114,114 @@ describe('log-tailer', () => {
     expect(prIdx).toBeGreaterThanOrEqual(0);
     expect(coordIdx).toBeGreaterThanOrEqual(0);
     expect(prIdx).toBeLessThan(coordIdx);
+  });
+});
+
+describe('parseLogLine', () => {
+  it('splits a new-format line into timestamp and message', () => {
+    const { ts, text } = parseLogLine(
+      '2026-06-14T12:00:00.000+00:00\t[tool:Read] foo.py',
+    );
+    expect(ts).toBe('2026-06-14T12:00:00.000+00:00');
+    expect(text).toBe('[tool:Read] foo.py');
+  });
+
+  it('accepts a Z-suffixed (UTC) timestamp', () => {
+    const { ts, text } = parseLogLine('2026-06-14T12:00:00Z\thello');
+    expect(ts).toBe('2026-06-14T12:00:00Z');
+    expect(text).toBe('hello');
+  });
+
+  it('only splits on the first tab — tabs inside the message survive', () => {
+    const { ts, text } = parseLogLine('2026-06-14T12:00:00.000+00:00\ta\tb\tc');
+    expect(ts).toBe('2026-06-14T12:00:00.000+00:00');
+    expect(text).toBe('a\tb\tc');
+  });
+
+  it('treats a legacy line (no prefix) as ts=null, text=raw', () => {
+    const { ts, text } = parseLogLine('[init] model=opus');
+    expect(ts).toBeNull();
+    expect(text).toBe('[init] model=opus');
+  });
+
+  it('does not treat an ISO-looking-but-untabbed line as timestamped', () => {
+    const raw = '2026-06-14T12:00:00.000+00:00 started';
+    const { ts, text } = parseLogLine(raw);
+    expect(ts).toBeNull();
+    expect(text).toBe(raw);
+  });
+
+  it('rejects a malformed timestamp prefix', () => {
+    const raw = '2026-13-99T99:99:99\tnope';
+    const { ts } = parseLogLine(raw);
+    expect(ts).toBeNull();
+  });
+});
+
+describe('splitTimestamps', () => {
+  it('returns parallel lines + timestamps arrays', () => {
+    const { lines, timestamps } = splitTimestamps([
+      '2026-06-14T12:00:00.000+00:00\tone',
+      'legacy two',
+      '2026-06-14T12:00:01.000+00:00\tthree',
+    ]);
+    expect(lines).toEqual(['one', 'legacy two', 'three']);
+    expect(timestamps).toEqual([
+      '2026-06-14T12:00:00.000+00:00',
+      null,
+      '2026-06-14T12:00:01.000+00:00',
+    ]);
+  });
+
+  it('handles an empty input', () => {
+    expect(splitTimestamps([])).toEqual({ lines: [], timestamps: [] });
+  });
+});
+
+describe('readNewLines', () => {
+  let dir;
+  beforeEach(() => {
+    dir = join(tmpdir(), `worca-tail-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('reads only the bytes after the offset', () => {
+    const path = join(dir, 'a.log');
+    writeFileSync(path, 'first\nsecond\n');
+    const off = Buffer.byteLength('first\n');
+    const { lines, newOffset } = readNewLines(path, off);
+    expect(lines).toEqual(['second']);
+    expect(newOffset).toBe(Buffer.byteLength('first\nsecond\n'));
+  });
+
+  it('does not consume a trailing partial (un-terminated) line', () => {
+    const path = join(dir, 'b.log');
+    writeFileSync(path, 'done\npartial-no-newline');
+    const { lines, newOffset } = readNewLines(path, 0);
+    // Only the complete line is emitted; the partial stays buffered.
+    expect(lines).toEqual(['done']);
+    expect(newOffset).toBe(Buffer.byteLength('done\n'));
+    // Once the partial line is completed, the next read picks it up whole.
+    writeFileSync(path, 'done\npartial-now-complete\n');
+    const next = readNewLines(path, newOffset);
+    expect(next.lines).toEqual(['partial-now-complete']);
+  });
+
+  it('returns nothing when no complete line is available yet', () => {
+    const path = join(dir, 'c.log');
+    writeFileSync(path, 'no-newline-yet');
+    const { lines, newOffset } = readNewLines(path, 0);
+    expect(lines).toEqual([]);
+    expect(newOffset).toBe(0);
+  });
+
+  it('advances the offset correctly across multibyte content', () => {
+    const path = join(dir, 'd.log');
+    const content = '2026-06-14T12:00:00.000+00:00\t⏎ café\n';
+    writeFileSync(path, content);
+    const { lines, newOffset } = readNewLines(path, 0);
+    expect(lines).toEqual(['2026-06-14T12:00:00.000+00:00\t⏎ café']);
+    expect(newOffset).toBe(Buffer.byteLength(content, 'utf8'));
   });
 });

--- a/worca-ui/server/ws-log-line-timestamp.test.js
+++ b/worca-ui/server/ws-log-line-timestamp.test.js
@@ -101,4 +101,40 @@ describe('log-line events include server-side timestamp', () => {
 
     ws.close();
   }, 15000);
+
+  it('uses the persisted write-time for a new-format (timestamped) line', async () => {
+    const ws = new WebSocket(`ws://localhost:${port}/ws`);
+    await new Promise((resolve, reject) => {
+      ws.on('open', resolve);
+      ws.on('error', reject);
+    });
+
+    ws.send(
+      JSON.stringify({
+        id: 'sub-2',
+        type: 'subscribe-log',
+        payload: { stage: null },
+      }),
+    );
+    await waitForWsEvent(ws, 'subscribe-log');
+    await new Promise((r) => setTimeout(r, 500));
+
+    const logLinePromise = waitForWsEvent(ws, 'log-line', 10000);
+
+    // A historical write-time, far from "now", in the on-disk record format.
+    const writeTime = '2020-01-02T03:04:05.000+00:00';
+    const logsDir = join(worcaDir, 'runs', 'test-run', 'logs');
+    appendFileSync(
+      join(logsDir, 'orchestrator.log'),
+      `${writeTime}\t[tool:Read] foo.py\n`,
+    );
+
+    const msg = await logLinePromise;
+    // The TS prefix is stripped from the displayed line...
+    expect(msg.payload.line).toBe('[tool:Read] foo.py');
+    // ...and the payload carries the persisted write-time, NOT receive-time.
+    expect(msg.payload.timestamp).toBe(writeTime);
+
+    ws.close();
+  }, 15000);
 });

--- a/worca-ui/server/ws-log-watcher.js
+++ b/worca-ui/server/ws-log-watcher.js
@@ -9,9 +9,11 @@ import {
   fileByteLength,
   listIterationFiles,
   listLogFiles,
+  parseLogLine,
   readLastLines,
   readNewLines,
   resolveLogPath,
+  splitTimestamps,
 } from './log-tailer.js';
 import { safeWatch } from './safe-watch.js';
 
@@ -80,15 +82,19 @@ export function createLogWatcher({
             );
             if (newLines.length > 0) {
               logByteOffsets.set(key, newOffset);
-              for (const line of newLines) {
+              for (const raw of newLines) {
+                const { ts, text } = parseLogLine(raw);
                 broadcaster.broadcastToLogSubscribers(
                   stage,
                   'log-line',
                   {
                     stage: stage || 'orchestrator',
                     iteration: iteration ?? undefined,
-                    line,
-                    timestamp: new Date().toISOString(),
+                    line: text,
+                    // New-format lines carry their write-time; legacy lines have
+                    // none, so fall back to receive-time (≈ write-time for a
+                    // line arriving from a live, actively-running stage).
+                    timestamp: ts ?? new Date().toISOString(),
                   },
                   watcherRunId,
                 );
@@ -210,28 +216,32 @@ export function createLogWatcher({
           for (const f of files) {
             const iterNum = parseInt(f.match(/\d+/)[0], 10);
             if (iteration != null && iterNum !== iteration) continue;
-            const lines = readLastLines(join(stageDir, f), 200);
+            const { lines, timestamps } = splitTimestamps(
+              readLastLines(join(stageDir, f), 200),
+            );
             if (lines.length > 0) {
               ws.send(
                 JSON.stringify({
                   id: `evt-${Date.now()}-iter${iterNum}`,
                   ok: true,
                   type: 'log-bulk',
-                  payload: { stage, iteration: iterNum, lines },
+                  payload: { stage, iteration: iterNum, lines, timestamps },
                 }),
               );
             }
           }
         } else {
           const logPath = join(archivedLogDir, `${stage}.log`);
-          const lines = readLastLines(logPath, 200);
+          const { lines, timestamps } = splitTimestamps(
+            readLastLines(logPath, 200),
+          );
           if (lines.length > 0) {
             ws.send(
               JSON.stringify({
                 id: `evt-${Date.now()}`,
                 ok: true,
                 type: 'log-bulk',
-                payload: { stage, lines },
+                payload: { stage, lines, timestamps },
               }),
             );
           }
@@ -241,14 +251,16 @@ export function createLogWatcher({
         for (const entry of entries) {
           if (entry.isFile() && entry.name.endsWith('.log')) {
             const s2 = entry.name.replace('.log', '');
-            const lines = readLastLines(join(archivedLogDir, entry.name), 200);
+            const { lines, timestamps } = splitTimestamps(
+              readLastLines(join(archivedLogDir, entry.name), 200),
+            );
             if (lines.length > 0) {
               ws.send(
                 JSON.stringify({
                   id: `evt-${Date.now()}-${s2}`,
                   ok: true,
                   type: 'log-bulk',
-                  payload: { stage: s2, lines },
+                  payload: { stage: s2, lines, timestamps },
                 }),
               );
             }
@@ -263,7 +275,9 @@ export function createLogWatcher({
               );
             for (const f of iterFiles) {
               const iterNum = parseInt(f.match(/\d+/)[0], 10);
-              const lines = readLastLines(join(stageDir2, f), 200);
+              const { lines, timestamps } = splitTimestamps(
+                readLastLines(join(stageDir2, f), 200),
+              );
               if (lines.length > 0) {
                 ws.send(
                   JSON.stringify({
@@ -274,6 +288,7 @@ export function createLogWatcher({
                       stage: entry.name,
                       iteration: iterNum,
                       lines,
+                      timestamps,
                     },
                   }),
                 );

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -24,6 +24,7 @@ import {
   readLastLines,
   resolveIterationLogPath,
   resolveLogPath,
+  splitTimestamps,
 } from './log-tailer.js';
 import { readPreferences, writePreferences } from './preferences.js';
 import {
@@ -390,14 +391,16 @@ export function createMessageRouter({
       if (stage) {
         if (iteration != null) {
           const logPath = resolveIterationLogPath(logsBase, stage, iteration);
-          const lines = readLastLines(logPath, 200);
+          const { lines, timestamps } = splitTimestamps(
+            readLastLines(logPath, 200),
+          );
           if (lines.length > 0) {
             ws.send(
               JSON.stringify({
                 id: `evt-${Date.now()}`,
                 ok: true,
                 type: 'log-bulk',
-                payload: { stage, iteration, lines },
+                payload: { stage, iteration, lines, timestamps },
               }),
             );
           }
@@ -406,28 +409,32 @@ export function createMessageRouter({
           if (existsSync(stageDir) && statSync(stageDir).isDirectory()) {
             const iters = listIterationFiles(logsBase, stage);
             for (const { iteration: iterNum, path } of iters) {
-              const lines = readLastLines(path, 200);
+              const { lines, timestamps } = splitTimestamps(
+                readLastLines(path, 200),
+              );
               if (lines.length > 0) {
                 ws.send(
                   JSON.stringify({
                     id: `evt-${Date.now()}-iter${iterNum}`,
                     ok: true,
                     type: 'log-bulk',
-                    payload: { stage, iteration: iterNum, lines },
+                    payload: { stage, iteration: iterNum, lines, timestamps },
                   }),
                 );
               }
             }
           } else {
             const logPath = join(logsBase, 'logs', `${stage}.log`);
-            const lines = readLastLines(logPath, 200);
+            const { lines, timestamps } = splitTimestamps(
+              readLastLines(logPath, 200),
+            );
             if (lines.length > 0) {
               ws.send(
                 JSON.stringify({
                   id: `evt-${Date.now()}`,
                   ok: true,
                   type: 'log-bulk',
-                  payload: { stage, lines },
+                  payload: { stage, lines, timestamps },
                 }),
               );
             }
@@ -439,7 +446,9 @@ export function createMessageRouter({
       } else {
         const logFiles = listLogFiles(logsBase);
         for (const { stage: s2, iteration: iterNum, path } of logFiles) {
-          const lines = readLastLines(path, 200);
+          const { lines, timestamps } = splitTimestamps(
+            readLastLines(path, 200),
+          );
           if (lines.length > 0) {
             ws.send(
               JSON.stringify({
@@ -450,6 +459,7 @@ export function createMessageRouter({
                   stage: s2,
                   iteration: iterNum ?? undefined,
                   lines,
+                  timestamps,
                 },
               }),
             );


### PR DESCRIPTION
## Problem

Persisted log records carried **no per-line timestamp**, so the UI synthesized `new Date()` at the moment it received each line. Opening the logs of an already-finished stage therefore showed the **current time** for every historical line instead of when the line was actually written — confusing and misleading.

## Change

**Write side (Python)**
- New `_write_log_line()` prefixes each record with an ISO-8601 **UTC** write-time + TAB, and collapses embedded newlines (`⏎ `) so one logical record is always exactly one physical line (keeps the "first field is the timestamp" invariant sound).
- Wired into both `process_stream` write sites and the orchestrator `_log` (stderr keeps the human `[HH:MM:SS]` for console operators).

**Read side (JS)**
- `parseLogLine` strictly sniffs the ISO+TAB prefix (legacy lines → `ts: null`); `splitTimestamps` builds the parallel wire arrays; `readNewLines` hardened to never tear a trailing partial (still-being-written) line.
- Live tail + all backfill sites emit the parsed write-time; `log-bulk` gains an **additive** `timestamps` array.

**Display**
- Client uses the persisted write-time — **never** `new Date()`. `tsPrefix` renders real local `HH:MM:SS`, or a dim `--:--:--` placeholder for legacy lines (no misleading "now").

## Timezone

Stored as UTC, rendered via `toLocaleTimeString` with no `timeZone` option → **each viewer sees the line in their own local timezone**, computed per render off the absolute instant.

## Backward compatibility

Purely additive on the wire; **no file migration**. Old log files (no prefix) parse to `ts: null` and render with `--:--:--`, text unchanged. New runs get real per-viewer local times.

## Tests

- **Python**: new coverage for the prefix format, newline collapse, round-trip, stream prefixing, and raw-passthrough timestamping.
- **UI vitest**: full suite green (5188). New/updated `parseLogLine` / `splitTimestamps` / `readNewLines` tests, `tsPrefix` for both terminals, a new-format write-time WS test, and the `log-bulk` contract test updated to assert write-time/null (not receive-time).
- Biome clean, bundle rebuilt, representative run-detail Playwright spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
