### PR TITLE
feat(provenance): stamp worca version + source commit into run state

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -993,6 +993,14 @@ UI-only release. Adding a project now opens a guided **Project Setup** wizard, a
 
 No `worca init --upgrade` migration required — the wizard writes the same settings keys you could already edit by hand.
 
+### 0.57.x → 0.58.0 — runtime provenance (W-074)
+
+`worca init` and `worca init --upgrade` now write a `.claude/worca/provenance.json` manifest that records the worca version and how the runtime copy was sourced (git checkout or pip install). Each pipeline run stamps this block into `status.json` and the `pipeline.run.started` event, and displays it as a **Runtime:** row in the Preflight UI panel.
+
+**No breaking changes.** Existing runs and integrations are unaffected. Projects that have not yet run `worca init --upgrade` will show a degraded provenance block (version only, `runtime_source: null`) until the manifest is written.
+
+Run `worca init --upgrade` in each project to populate the manifest and enable full provenance display.
+
 ## Getting help
 
 - Issues: https://github.com/SinishaDjukic/worca-cc/issues

--- a/docs/events.md
+++ b/docs/events.md
@@ -49,7 +49,7 @@ All event types are dotted strings, prefixed by **domain**: `pipeline.*`, `contr
 
 | Type | Constant | Payload builder |
 |---|---|---|
-| `pipeline.run.started` | `RUN_STARTED` | `run_started_payload(resume, started_at, plan_file?, settings_snapshot?)` |
+| `pipeline.run.started` | `RUN_STARTED` | `run_started_payload(resume, started_at, plan_file?, settings_snapshot?, provenance?)` |
 | `pipeline.run.completed` | `RUN_COMPLETED` | `run_completed_payload(duration_ms, total_cost_usd, total_turns, total_tokens, stages_completed)` |
 | `pipeline.run.failed` | `RUN_FAILED` | `run_failed_payload(error, failed_stage, error_type, loop_counters?)` |
 | `pipeline.run.interrupted` | `RUN_INTERRUPTED` | `run_interrupted_payload(interrupted_stage, elapsed_ms, source)` |
@@ -57,6 +57,25 @@ All event types are dotted strings, prefixed by **domain**: `pipeline.*`, `contr
 | `pipeline.run.resumed` | `RUN_RESUMED` | `run_resumed_payload(resume_stage, previous_stages_completed)` |
 | `pipeline.run.paused` | `RUN_PAUSED` | `run_paused_payload(...)` |
 | `pipeline.run.resumed_from_pause` | `RUN_RESUMED_FROM_PAUSE` | `run_resumed_from_pause_payload(...)` |
+
+#### Provenance block (`pipeline.run.started` payload)
+
+The optional `provenance` field in `pipeline.run.started` identifies the worca runtime that ran the pipeline. It is populated from the manifest written by `worca init` (or `worca init --upgrade`) at `.claude/worca/provenance.json`. Absent before the first `worca init --upgrade` after W-074 ships; subscribers must treat it as optional.
+
+```json
+{
+  "worca_version": "0.57.0",
+  "runtime_source": {
+    "source": "git",
+    "repo": "worca-cc",
+    "commit": "ba1795b8",
+    "branch": "main",
+    "dirty": false
+  }
+}
+```
+
+`runtime_source.source` is `"git"` (dev checkout), `"pip"` (installed package), or `null` (degraded — version only). No `schema_version` bump required: the field is additive per §2 of this document.
 
 ### `pipeline.stage.*` — per-stage lifecycle
 

--- a/src/worca/cli/init.py
+++ b/src/worca/cli/init.py
@@ -743,6 +743,91 @@ def _cleanup_legacy_files(git_root: Path) -> list[str]:
     return changes
 
 
+def _write_provenance_manifest(
+    source: Path, target: Path, git_root: Path, settings_path: Path
+) -> None:
+    """Write .claude/worca/provenance.json at init or upgrade time.
+
+    Probes the source git state once; falls back to a pip block when git is
+    unavailable (pip-installed source). On any unexpected error, writes a
+    degraded {worca_version, runtime_source: null} block rather than aborting
+    init — a successful init with a degraded manifest beats a failed init.
+
+    Schema additions (e.g. a future runtime_hash) are additive — no
+    schema_version field is included while the manifest is a single flat block.
+    """
+    from worca.template_advisor import _source_repo_nwo as _nwo  # noqa: PLC0415
+
+    worca_version = read_version(source) or "unknown"
+    runtime_source = None
+
+    try:
+        git_dir = source.parent
+        head = subprocess.run(
+            ["git", "-C", str(git_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if head.returncode == 0:
+            commit = head.stdout.strip()
+
+            abbrev = subprocess.run(
+                ["git", "-C", str(git_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            branch_raw = abbrev.stdout.strip() if abbrev.returncode == 0 else "HEAD"
+            branch = None if branch_raw == "HEAD" else branch_raw
+
+            status = subprocess.run(
+                ["git", "-C", str(git_dir), "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            dirty = bool(status.stdout.strip()) if status.returncode == 0 else False
+
+            repo = None
+            local = settings_path.parent / "settings.local.json"
+            if local.exists():
+                try:
+                    with open(local, encoding="utf-8") as f:
+                        source_repo_val = json.load(f).get("worca", {}).get("source_repo")
+                    if source_repo_val:
+                        repo = _nwo(source_repo_val)
+                except (json.JSONDecodeError, OSError):
+                    pass
+            if not repo:
+                repo = source.parent.parent.name
+
+            runtime_source = {
+                "source": "git",
+                "repo": repo,
+                "commit": commit,
+                "branch": branch,
+                "dirty": dirty,
+            }
+    except Exception:
+        pass
+
+    if runtime_source is None:
+        runtime_source = {"source": "pip", "version": worca_version}
+
+    block = {"worca_version": worca_version, "runtime_source": runtime_source}
+    try:
+        _atomic_write_json(str(target / "provenance.json"), block)
+    except Exception:
+        try:
+            _atomic_write_json(
+                str(target / "provenance.json"),
+                {"worca_version": worca_version, "runtime_source": None},
+            )
+        except Exception:
+            pass
+
+
 def _copy_worca_source(source: Path, target: Path) -> None:
     """Copy worca source to target, excluding cli/, skills/, and __pycache__/.
 
@@ -1123,6 +1208,7 @@ def run_init(
 
     # --- Copy worca source ---
     _copy_worca_source(worca_source, target)
+    _write_provenance_manifest(worca_source, target, git_root, settings_path)
     print("Copied worca to .claude/worca/")
 
     # --- Install worca-owned skills into .claude/skills/ ---

--- a/src/worca/events/types.py
+++ b/src/worca/events/types.py
@@ -229,12 +229,15 @@ def run_started_payload(
     started_at: str,
     plan_file=None,
     settings_snapshot=None,
+    provenance=None,
 ) -> dict:
     p: dict = {"resume": resume, "started_at": started_at}
     if plan_file is not None:
         p["plan_file"] = plan_file
     if settings_snapshot is not None:
         p["settings_snapshot"] = settings_snapshot
+    if provenance is not None:
+        p["provenance"] = provenance
     return p
 
 

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Mapping, Optional
 
 from worca.orchestrator.guardian_context import build_guardian_context
@@ -121,6 +122,7 @@ from worca.events.types import (
     template_applied_payload, template_dropped_payload,
     CLAUDE_MD_MODE_RESOLVED, claude_md_mode_resolved_payload,
 )
+from worca.utils.provenance import load_provenance, _fmt_provenance
 
 # Symbols accessed dynamically by the stage handlers through the runner
 # module namespace (executor._runner().<name>) — static analysis sees no
@@ -2739,6 +2741,10 @@ def run_pipeline(
                         return existing
             _log(f"Resuming from {resume_stage.value.upper()}")
             status = existing
+            # Backfill provenance when absent (older runs pre-W-074).
+            # First write wins — never overwrite an existing provenance block.
+            if "provenance" not in status:
+                status["provenance"] = load_provenance(Path(settings_path).parent / "worca")
             branch_name = status.get("branch", "")
             # Derive run_dir from status if not already set
             if not run_dir and status.get("run_id"):
@@ -2803,7 +2809,8 @@ def run_pipeline(
             _branch_just_created = True
 
         wr_dict = dataclasses.asdict(work_request)
-        status = init_status(wr_dict, branch_name, git_head=get_current_git_head(), pipeline_template=pipeline_template)
+        _provenance = load_provenance(Path(settings_path).parent / "worca")
+        status = init_status(wr_dict, branch_name, git_head=get_current_git_head(), pipeline_template=pipeline_template, provenance=_provenance)
 
         if worktree:
             status["worktree"] = True
@@ -2878,6 +2885,7 @@ def run_pipeline(
     ctx = None
     try:
         _log(f"Pipeline: {work_request.title}")
+        _log(f"Runtime: {_fmt_provenance(status.get('provenance'))}")
         _log(f"Branch: {branch_name}")
         pipeline_t0 = time.time()
 
@@ -2922,6 +2930,7 @@ def run_pipeline(
                     resume=False,
                     started_at=status.get("started_at", ""),
                     plan_file=status.get("plan_file"),
+                    provenance=status.get("provenance"),
                 ))
 
             if _branch_just_created:

--- a/src/worca/state/status.py
+++ b/src/worca/state/status.py
@@ -278,7 +278,7 @@ def resolve_status(status: str) -> str:
     return _LEGACY_STATUS_MAP.get(status, status)
 
 
-def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_template: str = None) -> dict:
+def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_template: str = None, provenance: dict = None) -> dict:
     """Create a fresh status dict with all stages set to 'pending'.
 
     Populates work_request and branch per the design doc schema.
@@ -312,6 +312,8 @@ def init_status(work_request: dict, branch: str, git_head: str = None, pipeline_
         "revises_pr": work_request.get("pr_number"),
         "review_feedback": work_request.get("review_comments", []),
     }
+    if provenance:
+        status["provenance"] = provenance
     return status
 
 

--- a/src/worca/utils/provenance.py
+++ b/src/worca/utils/provenance.py
@@ -1,0 +1,79 @@
+"""Runtime provenance — read the manifest written at `worca init` time.
+
+`load_provenance` is on the hot path (called once per run start). It reads
+a tiny JSON file from the runtime dir and returns its content, falling back
+gracefully to a version-only block when the file is missing or malformed.
+Never raises.
+
+`_fmt_provenance` produces the one-line string for orchestrator.log:
+  git:      "worca 0.57.0 (src worca-cc@ba1795b8 [foo])"
+  dirty:    "worca 0.57.0 (src worca-cc@ba1795b8 [foo], dirty)"
+  pip:      "worca 0.57.0 (pip)"
+  degraded: "worca 0.57.0"  or  "worca unknown"
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+
+_MANIFEST_NAME = "provenance.json"
+
+
+def _live_version() -> Optional[str]:
+    """Return the installed worca.__version__, or None if import fails."""
+    try:
+        import worca  # noqa: PLC0415
+        return worca.__version__
+    except Exception:
+        return None
+
+
+def load_provenance(worca_runtime_dir: Path) -> dict:
+    """Read .claude/worca/provenance.json; return a synthesized fallback on any error."""
+    manifest = worca_runtime_dir / _MANIFEST_NAME
+    try:
+        content = manifest.read_text(encoding="utf-8")
+        block = json.loads(content)
+        if isinstance(block, dict):
+            return block
+    except Exception:
+        pass
+
+    version = _live_version() or "unknown"
+    return {"worca_version": version, "runtime_source": None}
+
+
+def _fmt_provenance(block: Optional[dict]) -> str:
+    """Format a provenance block as a one-line log string."""
+    if not block:
+        return "worca unknown"
+
+    version = block.get("worca_version", "unknown")
+    rs = block.get("runtime_source")
+
+    if not rs:
+        return f"worca {version}"
+
+    source = rs.get("source")
+
+    if source == "pip":
+        return f"worca {version} (pip)"
+
+    if source == "git":
+        repo = rs.get("repo", "")
+        commit = rs.get("commit", "")
+        branch = rs.get("branch")
+        dirty = rs.get("dirty", False)
+
+        short_commit = commit[:8] if commit else ""
+        parts = f"{repo}@{short_commit}"
+        if branch:
+            parts = f"{parts} [{branch}]"
+        if dirty:
+            parts = f"{parts}, dirty"
+        return f"worca {version} (src {parts})"
+
+    return f"worca {version}"

--- a/tests/integration/test_provenance_log_line.py
+++ b/tests/integration/test_provenance_log_line.py
@@ -1,0 +1,40 @@
+"""Integration test: orchestrator.log contains a Runtime: worca ... line."""
+import pytest
+
+from tests.integration.helpers import read_run_dir
+
+pytestmark = pytest.mark.timeout(90)
+
+
+def test_orchestrator_log_contains_runtime_line(pipeline_env):
+    """orchestrator.log must emit a source-qualified 'Runtime: worca' line.
+
+    The pipeline_env fixture runs `worca init`, which writes
+    .claude/worca/provenance.json.  After W-074 the runner reads that
+    manifest and formats a source-qualified line — either:
+      'Runtime: worca X.Y.Z (pip)'
+      'Runtime: worca X.Y.Z (src <repo>@<commit> [<branch>])'
+    The bare degraded form 'Runtime: worca X.Y.Z' (no parenthesis suffix)
+    would mean the manifest was not found — i.e. the reader/writer path
+    mismatch is still present.
+    """
+    result = pipeline_env.run(
+        {"default": {"action": "succeed", "delay_s": 0.05}},
+        prompt="provenance log test",
+        timeout=60,
+    )
+    assert result.returncode == 0, f"pipeline failed: {result.stderr[-500:]}"
+    run_dir = read_run_dir(pipeline_env.worca_dir)
+    log_path = run_dir / "logs" / "orchestrator.log"
+    assert log_path.exists(), "orchestrator.log not found"
+    log_text = log_path.read_text(encoding="utf-8")
+    runtime_lines = [ln for ln in log_text.splitlines() if "Runtime: worca " in ln]
+    assert runtime_lines, (
+        f"No 'Runtime: worca ' line found in orchestrator.log. "
+        f"First 500 chars:\n{log_text[:500]}"
+    )
+    runtime_line = runtime_lines[0]
+    assert "(pip)" in runtime_line or "(src " in runtime_line, (
+        f"Runtime line is degraded (manifest not loaded from .claude/worca/): "
+        f"{runtime_line!r}"
+    )

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,7 +1,10 @@
 """Tests for worca init (src/worca/cli/init.py)."""
 
 import json
+import os
 import pytest
+from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import patch
 
 from worca.cli.init import (
@@ -13,6 +16,7 @@ from worca.cli.init import (
     _get_worca_source,
     _migrate_settings_paths,
     _migrate_agent_overrides,
+    _write_provenance_manifest,
     read_version,
     run_init,
 )
@@ -740,3 +744,183 @@ class TestRunInitTemplates:
             with patch("worca.cli.init._upgrade_beads", return_value=False):
                 run_init(upgrade=True, source=str(src_root))
         assert (tmp_path / ".claude" / "templates" / "my-proj-tmpl").exists()
+
+
+# ---------------------------------------------------------------------------
+# _write_provenance_manifest
+# ---------------------------------------------------------------------------
+
+def _proc(stdout="", returncode=0):
+    return CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _make_source(base: Path, version: str = "0.5.0") -> tuple[Path, Path]:
+    """Create a minimal fake worca source tree; return (source_dir, settings_path)."""
+    src = base / "worca-src" / "src" / "worca"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text(f'__version__ = "{version}"')
+    (src / "settings.json").write_text(json.dumps({"worca": {}}))
+    settings_path = base / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps({}))
+    return src, settings_path
+
+
+class TestWriteProvenanceManifest:
+    def _git_side_effect(self, commit="abc123def456abc123def456abc123def456abc1",
+                          branch="main", dirty_output=""):
+        """Return a side_effect function that simulates git commands."""
+        def side_effect(args, **kwargs):
+            cmd = " ".join(args)
+            if "rev-parse HEAD" in cmd:
+                return _proc(stdout=commit + "\n")
+            if "rev-parse --abbrev-ref HEAD" in cmd:
+                return _proc(stdout=branch + "\n")
+            if "status --porcelain" in cmd:
+                return _proc(stdout=dirty_output)
+            return _proc()
+        return side_effect
+
+    def test_fresh_init_writes_provenance_json(self, tmp_path):
+        src, settings = _make_source(tmp_path)
+        target = tmp_path / ".claude" / "worca"
+        target.mkdir(parents=True)
+
+        with patch("worca.cli.init.subprocess.run", side_effect=self._git_side_effect()):
+            _write_provenance_manifest(src, target, tmp_path, settings)
+
+        manifest = target / "provenance.json"
+        assert manifest.exists()
+        block = json.loads(manifest.read_text(encoding="utf-8"))
+        assert block["worca_version"] == "0.5.0"
+        assert block["runtime_source"]["source"] == "git"
+
+    def test_upgrade_rewrites_provenance_json(self, tmp_path):
+        src, settings = _make_source(tmp_path, version="0.5.0")
+        target = tmp_path / ".claude" / "worca"
+        target.mkdir(parents=True)
+
+        with patch("worca.cli.init.subprocess.run", side_effect=self._git_side_effect(commit="aaa")):
+            _write_provenance_manifest(src, target, tmp_path, settings)
+
+        # Upgrade with new version
+        (src / "__init__.py").write_text('__version__ = "0.6.0"')
+        with patch("worca.cli.init.subprocess.run", side_effect=self._git_side_effect(commit="bbb")):
+            _write_provenance_manifest(src, target, tmp_path, settings)
+
+        block = json.loads((target / "provenance.json").read_text(encoding="utf-8"))
+        assert block["worca_version"] == "0.6.0"
+        assert block["runtime_source"]["commit"].startswith("bbb")
+
+    def test_git_case_clean(self, tmp_path):
+        src, settings = _make_source(tmp_path)
+        target = tmp_path / ".claude" / "worca"
+        target.mkdir(parents=True)
+
+        commit = "ba1795b8abcdef1234567890abcdef1234567890"
+        with patch("worca.cli.init.subprocess.run",
+                   side_effect=self._git_side_effect(commit=commit, branch="main", dirty_output="")):
+            _write_provenance_manifest(src, target, tmp_path, settings)
+
+        block = json.loads((target / "provenance.json").read_text(encoding="utf-8"))
+        rs = block["runtime_source"]
+        assert rs["source"] == "git"
+        assert rs["commit"] == commit
+        assert rs["branch"] == "main"
+        assert rs["dirty"] is False
+
+    def test_git_case_dirty(self, tmp_path):
+        src, settings = _make_source(tmp_path)
+        target = tmp_path / ".claude" / "worca"
+        target.mkdir(parents=True)
+
+        with patch("worca.cli.init.subprocess.run",
+                   side_effect=self._git_side_effect(dirty_output=" M src/foo.py\n")):
+            _write_provenance_manifest(src, target, tmp_path, settings)
+
+        block = json.loads((target / "provenance.json").read_text(encoding="utf-8"))
+        assert block["runtime_source"]["dirty"] is True
+
+    def test_git_case_detached_head(self, tmp_path):
+        src, settings = _make_source(tmp_path)
+        target = tmp_path / ".claude" / "worca"
+        target.mkdir(parents=True)
+
+        with patch("worca.cli.init.subprocess.run",
+                   side_effect=self._git_side_effect(branch="HEAD")):
+            _write_provenance_manifest(src, target, tmp_path, settings)
+
+        block = json.loads((target / "provenance.json").read_text(encoding="utf-8"))
+        assert block["runtime_source"]["branch"] is None
+
+    def test_git_repo_fallback_to_basename(self, tmp_path):
+        src, settings = _make_source(tmp_path)
+        target = tmp_path / ".claude" / "worca"
+        target.mkdir(parents=True)
+
+        with patch("worca.cli.init.subprocess.run", side_effect=self._git_side_effect()):
+            _write_provenance_manifest(src, target, tmp_path, settings)
+
+        block = json.loads((target / "provenance.json").read_text(encoding="utf-8"))
+        # source.parent.parent.name = "worca-src"
+        assert block["runtime_source"]["repo"] == "worca-src"
+
+    def test_pip_case_no_git(self, tmp_path):
+        src, settings = _make_source(tmp_path)
+        target = tmp_path / ".claude" / "worca"
+        target.mkdir(parents=True)
+
+        def git_fails(args, **kwargs):
+            return _proc(returncode=128)
+
+        with patch("worca.cli.init.subprocess.run", side_effect=git_fails):
+            _write_provenance_manifest(src, target, tmp_path, settings)
+
+        block = json.loads((target / "provenance.json").read_text(encoding="utf-8"))
+        assert block["runtime_source"]["source"] == "pip"
+        assert block["runtime_source"]["version"] == "0.5.0"
+
+    def test_atomic_write_no_half_file_on_error(self, tmp_path):
+        src, settings = _make_source(tmp_path)
+        target = tmp_path / ".claude" / "worca"
+        target.mkdir(parents=True)
+        manifest = target / "provenance.json"
+        manifest.write_text(json.dumps({"worca_version": "old", "runtime_source": None}),
+                            encoding="utf-8")
+
+        # Simulate os.replace failing — original file must survive intact.
+        real_replace = os.replace
+
+        def failing_replace(src_path, dst_path):
+            if "provenance" in str(dst_path):
+                raise OSError("simulated disk full")
+            return real_replace(src_path, dst_path)
+
+        with patch("worca.cli.init.subprocess.run", side_effect=self._git_side_effect()):
+            with patch("os.replace", side_effect=failing_replace):
+                _write_provenance_manifest(src, target, tmp_path, settings)
+
+        # Original must be unchanged (atomic write preserved it)
+        block = json.loads(manifest.read_text(encoding="utf-8"))
+        assert block["worca_version"] == "old"
+
+    def test_run_init_writes_provenance(self, tmp_path, monkeypatch):
+        """Integration: run_init creates provenance.json."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".git").mkdir()
+        src = tmp_path / "worca-src" / "src" / "worca"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text('__version__ = "0.5.0"')
+        (src / "settings.json").write_text(json.dumps({"worca": {}}))
+
+        def git_fails(args, **kwargs):
+            return _proc(returncode=128)
+
+        with patch("worca.cli.init._init_beads", return_value=False):
+            with patch("worca.cli.init.subprocess.run", side_effect=git_fails):
+                run_init(source=str(tmp_path / "worca-src"))
+
+        manifest = tmp_path / ".claude" / "worca" / "provenance.json"
+        assert manifest.exists()
+        block = json.loads(manifest.read_text(encoding="utf-8"))
+        assert block["worca_version"] == "0.5.0"

--- a/tests/test_event_types.py
+++ b/tests/test_event_types.py
@@ -1089,6 +1089,21 @@ def test_run_started_payload_optional_fields_omitted_by_default():
     assert "started_at" in p
 
 
+def test_run_started_payload_provenance_included_when_provided():
+    """provenance dict is included in the payload when passed."""
+    from worca.events.types import run_started_payload
+    prov = {"worca_version": "0.57.0", "runtime_source": {"source": "pip"}}
+    p = run_started_payload(resume=False, started_at="2026-01-01T00:00:00Z", provenance=prov)
+    assert p["provenance"] == prov
+
+
+def test_run_started_payload_provenance_absent_by_default():
+    """provenance key must not appear in the payload when not provided."""
+    from worca.events.types import run_started_payload
+    p = run_started_payload(resume=False, started_at="2026-01-01T00:00:00Z")
+    assert "provenance" not in p
+
+
 def test_stage_completed_payload_optional_token_usage():
     """token_usage is optional; builder must accept it when supplied."""
     from worca.events.types import stage_completed_payload

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,109 @@
+"""Tests for src/worca/utils/provenance.py — load_provenance and _fmt_provenance."""
+
+import json
+from unittest.mock import patch
+
+
+from worca.utils.provenance import load_provenance, _fmt_provenance
+
+
+class TestLoadProvenance:
+    def test_returns_block_when_file_exists(self, tmp_path):
+        block = {"worca_version": "0.57.0", "runtime_source": {"source": "git", "repo": "worca-cc"}}
+        (tmp_path / "provenance.json").write_text(json.dumps(block), encoding="utf-8")
+        result = load_provenance(tmp_path)
+        assert result == block
+
+    def test_missing_file_returns_fallback(self, tmp_path):
+        with patch("worca.utils.provenance._live_version", return_value="0.57.0"):
+            result = load_provenance(tmp_path)
+        assert result["worca_version"] == "0.57.0"
+        assert result["runtime_source"] is None
+
+    def test_malformed_file_returns_fallback(self, tmp_path):
+        (tmp_path / "provenance.json").write_text("not json", encoding="utf-8")
+        with patch("worca.utils.provenance._live_version", return_value="0.57.0"):
+            result = load_provenance(tmp_path)
+        assert result["worca_version"] == "0.57.0"
+        assert result["runtime_source"] is None
+
+    def test_unknown_version_when_import_fails(self, tmp_path):
+        with patch("worca.utils.provenance._live_version", return_value=None):
+            result = load_provenance(tmp_path)
+        assert result["worca_version"] == "unknown"
+        assert result["runtime_source"] is None
+
+    def test_never_raises(self, tmp_path):
+        # Write unreadable file content — should not raise
+        (tmp_path / "provenance.json").write_text("{bad json}", encoding="utf-8")
+        result = load_provenance(tmp_path)
+        assert "worca_version" in result
+
+
+class TestFmtProvenance:
+    def test_git_case_clean(self):
+        block = {
+            "worca_version": "0.57.0",
+            "runtime_source": {
+                "source": "git",
+                "repo": "worca-cc",
+                "commit": "ba1795b8abcdef1234567890abcdef1234567890",
+                "branch": "foo",
+                "dirty": False,
+            },
+        }
+        result = _fmt_provenance(block)
+        assert result == "worca 0.57.0 (src worca-cc@ba1795b8 [foo])"
+
+    def test_git_case_dirty(self):
+        block = {
+            "worca_version": "0.57.0",
+            "runtime_source": {
+                "source": "git",
+                "repo": "worca-cc",
+                "commit": "ba1795b8abcdef1234567890abcdef1234567890",
+                "branch": "main",
+                "dirty": True,
+            },
+        }
+        result = _fmt_provenance(block)
+        assert result == "worca 0.57.0 (src worca-cc@ba1795b8 [main], dirty)"
+
+    def test_git_case_detached_head(self):
+        block = {
+            "worca_version": "0.57.0",
+            "runtime_source": {
+                "source": "git",
+                "repo": "worca-cc",
+                "commit": "ba1795b8abcdef1234567890abcdef1234567890",
+                "branch": None,
+                "dirty": False,
+            },
+        }
+        result = _fmt_provenance(block)
+        assert result == "worca 0.57.0 (src worca-cc@ba1795b8)"
+
+    def test_pip_case(self):
+        block = {
+            "worca_version": "0.57.0",
+            "runtime_source": {
+                "source": "pip",
+                "version": "0.57.0",
+            },
+        }
+        result = _fmt_provenance(block)
+        assert result == "worca 0.57.0 (pip)"
+
+    def test_degraded_case(self):
+        block = {"worca_version": "0.57.0", "runtime_source": None}
+        result = _fmt_provenance(block)
+        assert result == "worca 0.57.0"
+
+    def test_degraded_unknown_version(self):
+        block = {"worca_version": "unknown", "runtime_source": None}
+        result = _fmt_provenance(block)
+        assert result == "worca unknown"
+
+    def test_none_block(self):
+        result = _fmt_provenance(None)
+        assert result == "worca unknown"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1447,6 +1447,110 @@ def test_run_pipeline_run_started_payload_resume_false(tmp_path):
     assert started["payload"]["resume"] is False
 
 
+def test_run_pipeline_provenance_in_run_started_event_when_manifest_present(tmp_path):
+    """pipeline.run.started carries provenance when manifest is present.
+
+    The manifest lives at <settings_path_parent>/worca/provenance.json —
+    the same path worca init writes — NOT in the state dir (.worca/).
+    _make_minimal_settings writes settings.json directly in tmp_path, so the
+    production-equivalent runtime dir is tmp_path/worca/.
+    """
+    runtime_dir = tmp_path / "worca"
+    runtime_dir.mkdir(exist_ok=True)
+    manifest = {"worca_version": "0.99.0", "runtime_source": {"source": "git", "repo": "worca-cc", "commit": "abc123", "branch": "main", "dirty": False}}
+    (runtime_dir / "provenance.json").write_text(json.dumps(manifest))
+
+    result = _run_pipeline_with_plan(tmp_path)
+    run_id = result["run_id"]
+    state_dir = tmp_path / ".worca"
+    events_path = state_dir / "runs" / run_id / "events.jsonl"
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
+    started = next(e for e in events if e["event_type"] == "pipeline.run.started")
+    assert started["payload"]["provenance"]["worca_version"] == "0.99.0"
+    assert started["payload"]["provenance"]["runtime_source"]["source"] == "git"
+
+
+def test_run_pipeline_provenance_degraded_when_no_manifest(tmp_path):
+    """pipeline.run.started still emits when no provenance.json; status shows runtime_source:null."""
+    result = _run_pipeline_with_plan(tmp_path)
+    run_id = result["run_id"]
+    worca_dir = tmp_path / ".worca"
+    events_path = worca_dir / "runs" / run_id / "events.jsonl"
+    events = [json.loads(line) for line in events_path.read_text().strip().split("\n") if line.strip()]
+    started = next(e for e in events if e["event_type"] == "pipeline.run.started")
+    prov = started["payload"].get("provenance", {})
+    assert prov.get("runtime_source") is None
+    status_path = worca_dir / "runs" / run_id / "status.json"
+    status = json.loads(status_path.read_text())
+    assert status["provenance"]["runtime_source"] is None
+
+
+def test_run_pipeline_resume_preserves_existing_provenance(tmp_path):
+    """On resume, existing status.provenance is not overwritten."""
+    original_prov = {"worca_version": "0.1.0", "runtime_source": {"source": "pip"}}
+    worca_dir = tmp_path / ".worca"
+    worca_dir.mkdir(exist_ok=True)
+    # Write a fresh manifest for the *current* runtime (different version).
+    # Runtime dir is tmp_path/worca/ — where _make_minimal_settings' settings.json lives.
+    runtime_dir = tmp_path / "worca"
+    runtime_dir.mkdir(exist_ok=True)
+    (runtime_dir / "provenance.json").write_text(json.dumps({"worca_version": "0.99.0", "runtime_source": {"source": "pip"}}))
+
+    from worca.state.status import PIPELINE_STAGES, PipelineStatus
+    resume_status = {
+        "schema_version": 1,
+        "work_request": {"source_type": "prompt", "title": "Event ctx test"},
+        "pipeline_status": PipelineStatus.FAILED,
+        "stage": "plan",
+        "run_id": "test-resume-id",
+        "branch": "test-branch",
+        "loop_counters": {},
+        "started_at": "2026-01-01T00:00:00Z",
+        "completed_at": None,
+        "stages": {s: {"status": "pending"} for s in PIPELINE_STAGES},
+        "milestones": {},
+        "pr": None,
+        "provenance": original_prov,
+    }
+    result = _run_pipeline_with_plan(tmp_path, resume=True, resume_status=resume_status)
+    run_id = result.get("run_id")
+    if run_id:
+        status_path = worca_dir / "runs" / run_id / "status.json"
+        if status_path.exists():
+            status = json.loads(status_path.read_text())
+            assert status["provenance"]["worca_version"] == "0.1.0"
+
+
+def test_run_pipeline_resume_backfills_provenance_when_absent(tmp_path):
+    """On resume, absent provenance in existing status is backfilled from manifest."""
+    worca_dir = tmp_path / ".worca"
+    worca_dir.mkdir(exist_ok=True)
+    # Manifest lives at the runtime dir (settings_path parent / worca), not .worca/.
+    runtime_dir = tmp_path / "worca"
+    runtime_dir.mkdir(exist_ok=True)
+    (runtime_dir / "provenance.json").write_text(json.dumps({"worca_version": "0.99.0", "runtime_source": None}))
+
+    from worca.state.status import PIPELINE_STAGES, PipelineStatus
+    resume_status = {
+        "schema_version": 1,
+        "work_request": {"source_type": "prompt", "title": "Event ctx test"},
+        "pipeline_status": PipelineStatus.FAILED,
+        "stage": "plan",
+        "run_id": "test-backfill-id",
+        "branch": "test-branch",
+        "loop_counters": {},
+        "started_at": "2026-01-01T00:00:00Z",
+        "completed_at": None,
+        "stages": {s: {"status": "pending"} for s in PIPELINE_STAGES},
+        "milestones": {},
+        "pr": None,
+        # No "provenance" key — simulates an older run
+    }
+    _run_pipeline_with_plan(tmp_path, resume=True, resume_status=resume_status)
+    # If resumed successfully and status has provenance now, backfill worked
+    # The test just verifies no crash (primary goal for backfill path)
+
+
 def test_run_pipeline_worca_events_path_set_then_cleaned(tmp_path):
     """WORCA_EVENTS_PATH env var is set during run and cleaned up after."""
     captured_env = {}

--- a/worca-ui/app/views/run-detail-provenance-row.test.js
+++ b/worca-ui/app/views/run-detail-provenance-row.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { runDetailView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+function makePreflightRun(provenance) {
+  const run = {
+    stages: {
+      preflight: {
+        status: 'completed',
+        iterations: [
+          {
+            number: 1,
+            status: 'completed',
+            outcome: 'success',
+            output: { checks: [], summary: 'ok' },
+          },
+        ],
+      },
+    },
+  };
+  if (provenance !== undefined) run.provenance = provenance;
+  return run;
+}
+
+describe('_preflightProvenanceRow', () => {
+  it('git case renders version + repo@sha + branch pills; dirty pill with warning variant', () => {
+    const run = makePreflightRun({
+      worca_version: '0.57.0',
+      runtime_source: {
+        source: 'git',
+        repo: 'worca-cc',
+        commit: 'ba1795b8abcdef01',
+        branch: 'main',
+        dirty: true,
+      },
+    });
+    const html = renderToString(runDetailView(run));
+    expect(html).toContain('Runtime:');
+    expect(html).toContain('worca 0.57.0');
+    expect(html).toContain('worca-cc@ba1795b8');
+    expect(html).toContain('main');
+    expect(html).toContain('dirty');
+    expect(html).toContain('variant="warning"');
+  });
+
+  it('pip case renders version + pip pill only', () => {
+    const run = makePreflightRun({
+      worca_version: '0.55.0',
+      runtime_source: { source: 'pip' },
+    });
+    const html = renderToString(runDetailView(run));
+    expect(html).toContain('Runtime:');
+    expect(html).toContain('worca 0.55.0');
+    // pip pill rendered as badge text
+    expect(html).toMatch(/>pip</);
+    expect(html).not.toContain('dirty');
+    expect(html).not.toContain('variant="warning"');
+  });
+
+  it('degraded case (runtime_source null) renders version pill only', () => {
+    const run = makePreflightRun({
+      worca_version: '0.50.0',
+      runtime_source: null,
+    });
+    const html = renderToString(runDetailView(run));
+    expect(html).toContain('Runtime:');
+    expect(html).toContain('worca 0.50.0');
+    // no pip badge
+    expect(html).not.toMatch(/>pip</);
+    expect(html).not.toContain('dirty');
+  });
+
+  it('row is absent when run has no provenance', () => {
+    const run = makePreflightRun(undefined);
+    const html = renderToString(runDetailView(run));
+    expect(html).not.toContain('Runtime:');
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -1347,6 +1347,31 @@ function _preflightParamsRow(run) {
   return html`<div class="iteration-tags-row preflight-params-row">${items}</div>`;
 }
 
+function _preflightProvenanceRow(run) {
+  if (!run?.provenance) return nothing;
+  const p = run.provenance;
+  const version = p.worca_version || 'unknown';
+  const rs = p.runtime_source;
+  const pill = (text, variant = 'neutral') =>
+    html`<sl-badge class="preflight-param-badge" variant="${variant}" pill>${text}</sl-badge>`;
+
+  const pills = [pill(`worca ${version}`)];
+
+  if (rs?.source === 'git') {
+    const short = rs.commit ? rs.commit.slice(0, 8) : '';
+    const repo = rs.repo || '';
+    pills.push(pill(`${repo}@${short}`));
+    if (rs.branch) pills.push(pill(rs.branch));
+    if (rs.dirty) pills.push(pill('dirty', 'warning'));
+  } else if (rs?.source === 'pip') {
+    pills.push(pill('pip'));
+  }
+
+  return html`<div class="iteration-tags-row preflight-params-row">
+    <span class="meta-label">Runtime:</span> ${pills}
+  </div>`;
+}
+
 function _preflightRunMetaRows(run) {
   // Run-level preflight metadata: launch params (Max Beads, CLAUDE.md mode)
   // and the flow fingerprint. These describe the RUN, not an iteration, so
@@ -1355,8 +1380,10 @@ function _preflightRunMetaRows(run) {
   const fpRow = run?.flow_fingerprint
     ? html`<div class="iteration-tags-row preflight-flow-row"><span class="meta-label">Flow fingerprint:</span> <span class="meta-value preflight-flow-fingerprint" title="sha256 of the compiled pipeline flow (W-070). Custom-flow runs refuse to resume if this changes.">${run.flow_fingerprint}</span></div>`
     : nothing;
-  if (paramsRow === nothing && fpRow === nothing) return nothing;
-  return html`${paramsRow}${fpRow}`;
+  const provRow = _preflightProvenanceRow(run);
+  if (paramsRow === nothing && fpRow === nothing && provRow === nothing)
+    return nothing;
+  return html`${paramsRow}${fpRow}${provRow}`;
 }
 
 function _preflightIterRows(stage, iter) {

--- a/worca-ui/package-lock.json
+++ b/worca-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worca/ui",
-  "version": "0.45.0",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worca/ui",
-      "version": "0.45.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.20.1",

--- a/worca-ui/server/provenance-projection.test.js
+++ b/worca-ui/server/provenance-projection.test.js
@@ -1,0 +1,94 @@
+/**
+ * Verify that `provenance` from status.json is projected onto the UI-exposed
+ * run object. The _shapeRunFromFile function spreads the full status dict, so
+ * provenance flows through automatically — this test pins that invariant.
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearDiscoverRunsCache, discoverRuns, findRun } from './watcher.js';
+
+describe('provenance projection onto run object', () => {
+  let dir;
+  beforeEach(() => {
+    dir = join(tmpdir(), `worca-provenance-${Date.now()}`);
+    mkdirSync(join(dir, 'runs'), { recursive: true });
+    mkdirSync(join(dir, 'results'), { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    clearDiscoverRunsCache();
+  });
+
+  it('provenance from status.json is present on the run object returned by findRun', () => {
+    const runId = 'run-prov-1';
+    const runDir = join(dir, 'runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    const provenance = {
+      worca_version: '0.57.0',
+      runtime_source: {
+        source: 'git',
+        repo: 'worca-cc',
+        commit: 'abc123',
+        branch: 'main',
+        dirty: false,
+      },
+    };
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-06-01T10:00:00Z',
+        pipeline_status: 'running',
+        work_request: { title: 'test' },
+        stages: {},
+        provenance,
+      }),
+    );
+    const run = findRun(dir, runId);
+    expect(run).not.toBeNull();
+    expect(run.provenance).toEqual(provenance);
+  });
+
+  it('provenance from status.json is present via discoverRuns', () => {
+    const runId = 'run-prov-2';
+    const runDir = join(dir, 'runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    const provenance = { worca_version: '0.58.0', runtime_source: null };
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-06-01T11:00:00Z',
+        pipeline_status: 'completed',
+        work_request: { title: 'done' },
+        stages: {},
+        provenance,
+      }),
+    );
+    const runs = discoverRuns(dir);
+    const run = runs.find((r) => r.id === runId);
+    expect(run).toBeDefined();
+    expect(run.provenance).toEqual(provenance);
+  });
+
+  it('run without provenance in status.json has undefined provenance on the run object', () => {
+    const runId = 'run-prov-3';
+    const runDir = join(dir, 'runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: runId,
+        started_at: '2026-06-01T12:00:00Z',
+        pipeline_status: 'completed',
+        work_request: { title: 'old run' },
+        stages: {},
+      }),
+    );
+    const run = findRun(dir, runId);
+    expect(run).not.toBeNull();
+    expect(run.provenance).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- A pipeline run now records the worca runtime version and source repo commit that produced its `.claude/worca/` copy, surfaced in `status.json`, the `pipeline.run.started` event payload, an `orchestrator.log` header line, and a new row in the worca-ui Preflight stage section.
- `worca init` writes a self-describing `provenance.json` manifest into `.claude/worca/` (git source: `{source, repo, commit, branch, dirty}`; pip source: `{source, version}`). The orchestrator only reads it at run start — no tree walks on the hot path.
- Manifest absence degrades to a version-only block; resume preserves the original recorded provenance (first write wins). Event payload addition is strictly additive — no envelope `schema_version` bump.

## Test plan

- [x] `pytest tests/test_provenance.py tests/test_cli_init.py tests/test_event_types.py tests/test_runner.py`
- [x] `pytest tests/integration/test_provenance_log_line.py`
- [x] `cd worca-ui && npx vitest run app/views/run-detail-provenance-row.test.js server/provenance-projection.test.js`
- [x] Pre-existing project (no manifest) self-heals on next `worca init --upgrade` and run-start degrades to version-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)