### PR TITLE
feat(observability): capture & surface Claude CLI API-throttling/retry signal (#332)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -97,6 +97,9 @@ High-volume — subscribers should filter these unless you need deep observabili
 | `pipeline.agent.tool_result` | `AGENT_TOOL_RESULT` |
 | `pipeline.agent.text` | `AGENT_TEXT` |
 | `pipeline.agent.completed` | `AGENT_COMPLETED` |
+| `pipeline.agent.api_retry` | `AGENT_API_RETRY` |
+
+`pipeline.agent.api_retry` (W-074) fires when the Claude CLI logs an API-throttling/backoff diagnostic on stderr (429/529/503, "overloaded", "retrying"). Payload: `stage`, `iteration`, `agent`, `attempt` (running count of matched retry lines this iteration), `detail` (raw stderr text, ≤300 chars), and optional `bead_id`. New event type — **no `schema_version` bump** (additive event types are non-breaking). Not Tier 1: no chat renderer (high-frequency, low signal-per-instance); the per-iteration count is surfaced in run-detail instead.
 
 ### `pipeline.iteration.*` — iteration-level analytics
 

--- a/src/worca/events/types.py
+++ b/src/worca/events/types.py
@@ -29,7 +29,7 @@ STAGE_FAILED      = "pipeline.stage.failed"
 STAGE_INTERRUPTED = "pipeline.stage.interrupted"
 
 # ---------------------------------------------------------------------------
-# Agent telemetry (6 events)
+# Agent telemetry (7 events)
 # ---------------------------------------------------------------------------
 
 AGENT_SPAWNED        = "pipeline.agent.spawned"
@@ -37,6 +37,7 @@ AGENT_TOOL_USE       = "pipeline.agent.tool_use"
 AGENT_TOOL_RESULT    = "pipeline.agent.tool_result"
 AGENT_TEXT           = "pipeline.agent.text"
 AGENT_COMPLETED      = "pipeline.agent.completed"
+AGENT_API_RETRY      = "pipeline.agent.api_retry"
 ITERATION_ACCESS     = "pipeline.iteration.access"
 
 # ---------------------------------------------------------------------------
@@ -476,6 +477,35 @@ def agent_completed_payload(
     }
     if context_final_pct is not None:
         p["context_final_pct"] = context_final_pct
+    return p
+
+
+def agent_api_retry_payload(
+    *,
+    stage: str,
+    iteration: int,
+    agent: str,
+    attempt: int,
+    detail: str,
+    bead_id=None,
+) -> dict:
+    """Payload for ``pipeline.agent.api_retry``.
+
+    Emitted when the Claude CLI logs an API-throttling/backoff diagnostic on
+    stderr (429/529/503, "overloaded", "retrying"). ``attempt`` is the running
+    count of matched retry lines this iteration; ``detail`` is the raw stderr
+    text (truncated to 300 chars to bound payload size). Not Tier 1 — there is
+    no chat renderer; surfacing is via the per-iteration count, not a ping.
+    """
+    p: dict = {
+        "stage": stage,
+        "iteration": iteration,
+        "agent": agent,
+        "attempt": attempt,
+        "detail": detail[:300],
+    }
+    if bead_id:
+        p["bead_id"] = bead_id
     return p
 
 

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -94,9 +94,11 @@ from worca.events.types import (
     STAGE_STARTED, STAGE_COMPLETED, STAGE_FAILED, STAGE_INTERRUPTED,
     stage_started_payload, stage_completed_payload,
     stage_failed_payload, stage_interrupted_payload,
-    AGENT_SPAWNED, AGENT_TOOL_USE, AGENT_TOOL_RESULT, AGENT_TEXT, AGENT_COMPLETED, ITERATION_ACCESS,
+    AGENT_SPAWNED, AGENT_TOOL_USE, AGENT_TOOL_RESULT, AGENT_TEXT, AGENT_COMPLETED,
+    AGENT_API_RETRY, ITERATION_ACCESS,
     agent_spawned_payload, agent_tool_use_payload, agent_tool_result_payload,
-    agent_text_payload, agent_completed_payload, iteration_access_payload,
+    agent_text_payload, agent_completed_payload, agent_api_retry_payload,
+    iteration_access_payload,
     BEAD_ASSIGNED, BEAD_COMPLETED, BEAD_FAILED, BEAD_LABELED, BEAD_NEXT,
     bead_assigned_payload, bead_completed_payload, bead_failed_payload,
     bead_labeled_payload, bead_next_payload,
@@ -1374,6 +1376,7 @@ def _run_learn_stage(status, prompt_builder, settings_path, run_dir,
                 iter_extras["cost_usd"] = _learn_cost
         if usage:
             iter_extras["token_usage"] = usage
+            _surface_retry_fields(iter_extras, usage)
 
         learn_cost = iter_extras.get("cost_usd", 0.0)
         learn_turns = iter_extras.get("turns", 0)
@@ -1461,6 +1464,27 @@ def _is_file_access_telemetry_enabled(settings_path: str) -> bool:
         return settings.get("worca", {}).get("telemetry", {}).get("file_access", {}).get("enabled", True)
     except Exception:
         return True
+
+
+def _surface_retry_fields(iter_extras: dict, usage: dict) -> None:
+    """Surface the W-074 API-throttling/retry fields onto the iteration top-level.
+
+    ``extract_token_usage`` already folds api_retries / api_retry_wait_ms /
+    non_api_wait_ms / api_error_status into ``token_usage``; the run-detail
+    view-model reads them as ``iter.<field>`` (mirroring ``duration_api_ms``), so
+    copy them up. Additive — only set when present, leaving legacy iterations and
+    zero-retry runs byte-identical.
+    """
+    if not usage:
+        return
+    if usage.get("api_retries"):
+        iter_extras["api_retries"] = usage["api_retries"]
+    if usage.get("api_retry_wait_ms"):
+        iter_extras["api_retry_wait_ms"] = usage["api_retry_wait_ms"]
+    if usage.get("non_api_wait_ms"):
+        iter_extras["non_api_wait_ms"] = usage["non_api_wait_ms"]
+    if usage.get("api_error_status") is not None:
+        iter_extras["api_error_status"] = usage["api_error_status"]
 
 
 def _aggregate_file_access_into_extras(iter_extras: dict, settings_path: str, status: dict,
@@ -1804,6 +1828,21 @@ def run_stage(
     # status.json to record a count into anyway.
     on_event = _on_event if ctx is not None else None
 
+    # API-throttling/backoff telemetry (W-074): the claude_cli stderr tee calls
+    # this for each matched retry line, emitting a pipeline.agent.api_retry
+    # event. Gated on ctx like on_event — no events.jsonl, nothing to emit.
+    def _on_retry(detail, attempt):
+        emit_event(ctx, AGENT_API_RETRY, agent_api_retry_payload(
+            stage=stage_key,
+            iteration=iteration,
+            agent=config.get("agent") or "",
+            attempt=attempt,
+            detail=detail,
+            bead_id=bead_id,
+        ))
+
+    on_retry = _on_retry if ctx is not None else None
+
     agent = agent_override if agent_override is not None else _agent_path(config["agent"], run_dir=run_dir)
     merged_env = dict(config.get("model_env") or {})
     if env_overrides:
@@ -1847,6 +1886,7 @@ def run_stage(
         stage=stage_key,
         iteration=iteration,
         bead_id=bead_id,
+        on_retry=on_retry,
     )
     _gfx = _gfx_metrics["graphify_invocations"]
     _crg = _gfx_metrics["crg_invocations"]
@@ -3811,6 +3851,7 @@ def run_pipeline(
                 _ctx_pct = usage.get("context_final_pct")
                 if _ctx_pct is not None:
                     iter_extras["context_final_pct"] = _ctx_pct
+                _surface_retry_fields(iter_extras, usage)
             iter_extras["prompt"] = rc.rendered_prompt
             if isinstance(result, dict):
                 iter_extras["output"] = result

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -60,15 +60,31 @@ _LOG_WRITE_LOCK = threading.Lock()
 _REAP_WAIT_TIMEOUT = 2.0
 
 # Matches the Claude CLI's 429/529/503 throttling + backoff diagnostics on
-# stderr. Deliberately broad but anchored on retry vocabulary so a CLI wording
-# tweak degrades to "we still persisted the raw err line" rather than silently
-# zeroing the count (the matcher only drives the count/event, never what is
-# written). Unit-tested against captured samples in test_claude_cli.py and
-# intentionally trivial to extend.
-_RETRY_RE = re.compile(
-    r"(?i)\b(?:overloaded|rate.?limit|retry(?:ing)?|too many requests|"
-    r"429|529|503)\b"
+# stderr. Two branches, both case-insensitive:
+#   1. Retry/overload *vocabulary* — sufficient signal on its own.
+#   2. A bare 4xx/5xx HTTP status, but ONLY when it sits next to an HTTP/error
+#      context word. This is the precision guard: a stray "503"/"529" in tool
+#      output (e.g. "529 assertions", "tests passed: 503") no longer inflates
+#      the count, while every realistic CLI throttling line still matches.
+# Anchored on vocabulary so a CLI wording tweak degrades to "we still persisted
+# the raw err line" rather than silently zeroing the count (the matcher only
+# drives the count/event, never what is written). Unit-tested against captured
+# samples in test_claude_cli.py and intentionally trivial to extend.
+_RETRY_VOCAB = (
+    r"overloaded|rate.?limit|too many requests|retr(?:y|ying)|"
+    r"backing off|service unavailable"
 )
+_RETRY_STATUS_CONTEXT = (
+    r"(?:http|https|error|status|code|response|upstream|api|got|received|"
+    r"request)\b[^\n]{0,24}?\b(?:429|529|503|500|502|504)\b"
+)
+_RETRY_RE = re.compile(rf"(?i)(?:{_RETRY_VOCAB}|{_RETRY_STATUS_CONTEXT})")
+
+# Pulls the numeric HTTP status out of a matched throttling line so the
+# api_error_status signal has a producer (the last status seen in an iteration
+# wins, mirroring the "last API status N" UI tooltip). None when a retry line
+# carries vocabulary but no status (e.g. "Overloaded, backing off").
+_STATUS_RE = re.compile(r"\b(429|529|503|500|502|504)\b")
 
 
 class AgentSubprocessError(RuntimeError):
@@ -607,7 +623,8 @@ def run_agent(
             it runs on the daemon tee thread (exceptions are swallowed).
 
     Returns the parsed result event with ``api_retries`` (matched retry-line
-    count) and ``api_retry_wait_ms`` (Σ measured backoff-window wall spans) set.
+    count), ``api_retry_wait_ms`` (Σ measured backoff-window wall spans), and
+    ``api_error_status`` (last HTTP status parsed from a retry line, or None) set.
 
     Raises RuntimeError on subprocess failure or missing result.
     """
@@ -691,8 +708,11 @@ def run_agent(
     # Shared throttling/backoff signal mutated by the stderr tee daemon and read
     # by process_stream (which closes each backoff window) — all access guarded
     # by _LOG_WRITE_LOCK. count: matched retry lines; wait_ms: Σ backoff-window
-    # wall spans; pending_since: monotonic start of the currently-open window.
-    retry_state = {"count": 0, "wait_ms": 0, "pending_since": None}
+    # wall spans; pending_since: monotonic start of the currently-open window;
+    # error_status: last HTTP status parsed from a retry line (None if none).
+    retry_state = {
+        "count": 0, "wait_ms": 0, "pending_since": None, "error_status": None,
+    }
     try:
         if log_path:
             os.makedirs(os.path.dirname(log_path), exist_ok=True)
@@ -727,6 +747,9 @@ def run_agent(
                         retry_state["count"] += 1
                         if retry_state["pending_since"] is None:
                             retry_state["pending_since"] = time.monotonic()
+                        status_match = _STATUS_RE.search(text)
+                        if status_match:
+                            retry_state["error_status"] = int(status_match.group(1))
                         fire_count = retry_state["count"]
                 # Fire the callback outside the lock so a slow handler can't
                 # stall the stdout reader closing the next backoff window.
@@ -752,11 +775,25 @@ def run_agent(
             )
             stderr_thread.join(timeout=5)
             proc.wait()
-            # Thread joined → retry_state is settled. Stamp the aggregate
-            # throttling signal onto the result event (additive; both default 0).
+            # join() has a timeout, so the tee daemon *may* still be draining a
+            # trailing stderr burst — read retry_state under the lock rather than
+            # assuming it is quiescent. A backoff window can also still be open
+            # here: retry lines that arrive on stderr after the final stdout
+            # event was processed are never closed by process_stream, so close
+            # that trailing window now (span = stream end − pending_since) before
+            # stamping the aggregate throttling signal onto the result event
+            # (additive; all default 0/None on a clean run).
             if result_event is not None:
-                result_event["api_retries"] = retry_state["count"]
-                result_event["api_retry_wait_ms"] = retry_state["wait_ms"]
+                with _LOG_WRITE_LOCK:
+                    pending_since = retry_state["pending_since"]
+                    if pending_since is not None:
+                        retry_state["wait_ms"] += int(
+                            (time.monotonic() - pending_since) * 1000
+                        )
+                        retry_state["pending_since"] = None
+                    result_event["api_retries"] = retry_state["count"]
+                    result_event["api_retry_wait_ms"] = retry_state["wait_ms"]
+                    result_event["api_error_status"] = retry_state["error_status"]
         except Exception as stream_exc:
             # The streaming layer cannot tell why the subprocess stopped
             # producing output. Reap it (with a bounded wait) so the

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -14,12 +14,14 @@ termination; orphaned grandchildren are not reaped.
 
 import json
 import os
+import re
 import shlex
 import signal
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 from typing import Optional, Callable
 
 from worca.utils.log_lines import write_log_line
@@ -46,10 +48,27 @@ _ARG_INLINE_LIMIT = 128 * 1024  # bytes
 _current_proc = None
 _proc_lock = threading.Lock()
 
+# Serializes writes to the shared per-iteration log file. The process_stream
+# loop (main thread, stdout-derived "out" lines) and the _tee_stderr daemon
+# thread ("err" lines) both write the same handle, so every write_log_line call
+# touching that handle MUST hold this lock to avoid interleaved/torn records.
+_LOG_WRITE_LOCK = threading.Lock()
+
 # Bounded wait when reaping the agent subprocess after a stream-side
 # exception. Long enough for a signaled subprocess to finish dying, short
 # enough to keep the failure path snappy.
 _REAP_WAIT_TIMEOUT = 2.0
+
+# Matches the Claude CLI's 429/529/503 throttling + backoff diagnostics on
+# stderr. Deliberately broad but anchored on retry vocabulary so a CLI wording
+# tweak degrades to "we still persisted the raw err line" rather than silently
+# zeroing the count (the matcher only drives the count/event, never what is
+# written). Unit-tested against captured samples in test_claude_cli.py and
+# intentionally trivial to extend.
+_RETRY_RE = re.compile(
+    r"(?i)\b(?:overloaded|rate.?limit|retry(?:ing)?|too many requests|"
+    r"429|529|503)\b"
+)
 
 
 class AgentSubprocessError(RuntimeError):
@@ -396,6 +415,7 @@ def process_stream(
     stdout,
     log_file=None,
     on_event: Optional[Callable[[dict], None]] = None,
+    retry_state: Optional[dict] = None,
 ) -> dict:
     """Read NDJSON events from stdout and return the result event.
 
@@ -403,6 +423,13 @@ def process_stream(
         stdout: File-like object yielding lines of NDJSON.
         log_file: Open file to write human-readable log lines to.
         on_event: Optional callback invoked for each parsed event.
+        retry_state: Optional shared dict (mutated by ``_tee_stderr``) carrying
+            the API-throttling/backoff signal. When the stderr tee stamps
+            ``pending_since`` on the first retry line of a burst, the first
+            stdout event seen here closes that backoff window —
+            ``wait_ms += now − pending_since`` — measuring the wall span the CLI
+            spent silently backing off. Guarded by ``_LOG_WRITE_LOCK`` because
+            the tee daemon mutates the same dict concurrently.
 
     Returns the parsed result event dict, or raises RuntimeError if not found.
     The result event will have ``_resolved_model`` set from the system.init
@@ -428,8 +455,22 @@ def process_stream(
             # Not valid JSON — write raw to log
             if log_file:
                 raw = raw_line if isinstance(raw_line, str) else raw_line.decode()
-                write_log_line(log_file, raw.rstrip("\n"))
+                with _LOG_WRITE_LOCK:
+                    write_log_line(log_file, raw.rstrip("\n"), stream="out")
             continue
+
+        # A real stdout event arrived — if the stderr tee opened a backoff
+        # window (stamped pending_since on a retry line), close it now and fold
+        # the wall span into wait_ms. Under _LOG_WRITE_LOCK so it can't race the
+        # tee daemon's concurrent mutation of the same dict.
+        if retry_state is not None:
+            with _LOG_WRITE_LOCK:
+                pending_since = retry_state.get("pending_since")
+                if pending_since is not None:
+                    retry_state["wait_ms"] += int(
+                        (time.monotonic() - pending_since) * 1000
+                    )
+                    retry_state["pending_since"] = None
 
         if on_event:
             on_event(event)
@@ -466,7 +507,8 @@ def process_stream(
         if log_file:
             log_line = _format_log_line(event)
             if log_line:
-                write_log_line(log_file, log_line)
+                with _LOG_WRITE_LOCK:
+                    write_log_line(log_file, log_line, stream="out")
 
         if event.get("type") == "result":
             # Task-notification auto-resumes (e.g. long pytest run dispatched
@@ -536,6 +578,7 @@ def run_agent(
     stage: Optional[str] = None,
     iteration: Optional[int] = None,
     bead_id: Optional[str] = None,
+    on_retry: Optional[Callable[[str, int], None]] = None,
 ) -> dict:
     """Run a claude agent via the CLI and return parsed JSON output.
 
@@ -557,6 +600,14 @@ def run_agent(
         stage: When set, exported as ``WORCA_STAGE`` in the agent subprocess.
         iteration: When set, exported as ``WORCA_ITERATION`` in the agent subprocess.
         bead_id: When set, exported as ``WORCA_BEAD_ID`` in the agent subprocess.
+        on_retry: Optional callback ``(detail_text, count)`` invoked from the
+            stderr tee thread each time a line matches ``_RETRY_RE`` (429/529/503
+            throttling / backoff). The runner uses it to emit a
+            ``pipeline.agent.api_retry`` event. Must be cheap and exception-safe;
+            it runs on the daemon tee thread (exceptions are swallowed).
+
+    Returns the parsed result event with ``api_retries`` (matched retry-line
+    count) and ``api_retry_wait_ms`` (Σ measured backoff-window wall spans) set.
 
     Raises RuntimeError on subprocess failure or missing result.
     """
@@ -637,16 +688,54 @@ def run_agent(
 
     log_file = None
     result_event = None
+    # Shared throttling/backoff signal mutated by the stderr tee daemon and read
+    # by process_stream (which closes each backoff window) — all access guarded
+    # by _LOG_WRITE_LOCK. count: matched retry lines; wait_ms: Σ backoff-window
+    # wall spans; pending_since: monotonic start of the currently-open window.
+    retry_state = {"count": 0, "wait_ms": 0, "pending_since": None}
     try:
         if log_path:
             os.makedirs(os.path.dirname(log_path), exist_ok=True)
             log_file = open(log_path, "w", encoding="utf-8")
 
-        # Tee stderr to console in background
+        # Tee stderr to console AND persist it tagged "err" in the shared log.
+        # The CLI prints its 429/529 backoff diagnostics here; persisting them
+        # makes throttling visible in the UI instead of console-only. Each raw
+        # line carries no timestamp of its own, so stamp it with worca's
+        # receive-time (stamp=True). Writes share log_file with the main
+        # process_stream loop, so they go under _LOG_WRITE_LOCK. Each line is
+        # also run through _RETRY_RE: a match bumps the count, opens a backoff
+        # window (pending_since) if none is open, and fires on_retry.
         def _tee_stderr():
             for line in proc.stderr:
                 sys.stderr.write(line)
                 sys.stderr.flush()
+                text = line.rstrip("\n")
+                fire_count = None
+                with _LOG_WRITE_LOCK:
+                    if log_file:
+                        try:
+                            write_log_line(
+                                log_file, text, stream="err", stamp=True,
+                            )
+                        except ValueError:
+                            # log_file closed after join(timeout) while this
+                            # daemon thread was still draining — drop the line
+                            # rather than crash the thread.
+                            pass
+                    if _RETRY_RE.search(text):
+                        retry_state["count"] += 1
+                        if retry_state["pending_since"] is None:
+                            retry_state["pending_since"] = time.monotonic()
+                        fire_count = retry_state["count"]
+                # Fire the callback outside the lock so a slow handler can't
+                # stall the stdout reader closing the next backoff window.
+                if fire_count is not None and on_retry is not None:
+                    try:
+                        on_retry(text, fire_count)
+                    except Exception:
+                        # Telemetry must never crash the tee daemon.
+                        pass
 
         stderr_thread = threading.Thread(target=_tee_stderr, daemon=True)
         stderr_thread.start()
@@ -659,9 +748,15 @@ def run_agent(
                 proc.stdout,
                 log_file=log_file,
                 on_event=on_event,
+                retry_state=retry_state,
             )
             stderr_thread.join(timeout=5)
             proc.wait()
+            # Thread joined → retry_state is settled. Stamp the aggregate
+            # throttling signal onto the result event (additive; both default 0).
+            if result_event is not None:
+                result_event["api_retries"] = retry_state["count"]
+                result_event["api_retry_wait_ms"] = retry_state["wait_ms"]
         except Exception as stream_exc:
             # The streaming layer cannot tell why the subprocess stopped
             # producing output. Reap it (with a bounded wait) so the

--- a/src/worca/utils/log_lines.py
+++ b/src/worca/utils/log_lines.py
@@ -1,19 +1,23 @@
 """Shared formatting for persisted pipeline log lines.
 
 Every line written to a stage or orchestrator log file is prefixed with an
-ISO-8601 UTC write-time and a TAB:
+ISO-8601 UTC write-time, an origin-stream tag, and TABs:
 
-    2026-06-14T12:34:56.789+00:00\t[tool:Read] foo.py
+    2026-06-14T12:34:56.789+00:00\tout\t[tool:Read] foo.py
+    2026-06-14T12:34:57.001+00:00\terr\tOverloaded, retrying in 4s
 
-The worca-ui reader (``worca-ui/server/log-tailer.js`` → ``parseLogLine``)
-sniffs this prefix and renders the timestamp in each viewer's local timezone.
-Lines without the prefix are treated as legacy (pre-timestamp) records and
-rendered with a ``--:--:--`` placeholder.
+The middle column is the origin stream — ``out`` (CLI stdout, the default) or
+``err`` (CLI stderr, e.g. 429/529 throttling text). The worca-ui reader
+(``worca-ui/server/log-tailer.js`` → ``parseLogLine``) sniffs this prefix,
+renders the timestamp in each viewer's local timezone, and colors ``err`` lines.
+Legacy lines without a recognized stream token (``<ts>\\t<text>`` or no prefix
+at all) parse back as ``stream="out"`` — no migration of old files needed.
 
 Centralising the format here keeps every producer byte-for-byte consistent so
 the single reader-side parser stays valid:
 
-  - agent stage logs   — ``claude_cli.process_stream``
+  - agent stage logs   — ``claude_cli.process_stream`` (stdout, ``out``)
+  - agent stderr tee    — ``claude_cli._tee_stderr`` (``err``)
   - orchestrator log    — ``orchestrator.runner._log``
   - preflight stdout    — ``orchestrator.runner.run_preflight``
 """
@@ -27,8 +31,13 @@ from typing import Optional, TextIO
 LOG_NEWLINE_GLYPH = "⏎ "
 
 
-def format_log_line(message: str, now: Optional[datetime] = None) -> str:
-    """Return *message* as one timestamped log record (no trailing newline).
+def format_log_line(
+    message: str, now: Optional[datetime] = None, *, stream: str = "out"
+) -> str:
+    """Return *message* as one timestamped, stream-tagged log record.
+
+    The canonical shape is ``<ISO-ts>\\t<stream>\\t<text>`` (no trailing
+    newline). ``stream`` is the origin channel — ``out`` (default) or ``err``.
 
     The timestamp is captured at format time — the closest available proxy to
     event time, since the underlying events carry no per-event timestamp.
@@ -41,14 +50,26 @@ def format_log_line(message: str, now: Optional[datetime] = None) -> str:
         .replace("\r", "\n")
         .replace("\n", LOG_NEWLINE_GLYPH)
     )
-    return f"{ts}\t{safe}"
+    return f"{ts}\t{stream}\t{safe}"
 
 
 def write_log_line(
-    log_file: TextIO, message: str, *, now: Optional[datetime] = None
+    log_file: TextIO,
+    message: str,
+    *,
+    now: Optional[datetime] = None,
+    stream: str = "out",
+    stamp: bool = False,
 ) -> None:
-    """Write a single timestamped record to *log_file* and flush."""
-    log_file.write(format_log_line(message, now) + "\n")
+    """Write a single timestamped, stream-tagged record to *log_file* and flush.
+
+    ``stream`` tags the origin channel (``out``/``err``). ``stamp=True`` forces
+    a fresh worca receive-time timestamp, ignoring any ``now`` argument — used by
+    the stderr tee, where each raw CLI line carries no timestamp of its own and
+    must be stamped at the instant worca receives it.
+    """
+    effective_now = None if stamp else now
+    log_file.write(format_log_line(message, effective_now, stream=stream) + "\n")
     log_file.flush()
 
 

--- a/src/worca/utils/token_usage.py
+++ b/src/worca/utils/token_usage.py
@@ -35,14 +35,17 @@ def extract_token_usage(
     server_tool_use = usage.get("server_tool_use") or {}
     cache_creation = usage.get("cache_creation") or {}
 
+    _duration_ms = raw_envelope.get("duration_ms", 0) or 0
+    _duration_api_ms = raw_envelope.get("duration_api_ms", 0) or 0
+
     result = {
         "input_tokens": usage.get("input_tokens", 0) or 0,
         "output_tokens": usage.get("output_tokens", 0) or 0,
         "cache_creation_input_tokens": usage.get("cache_creation_input_tokens", 0) or 0,
         "cache_read_input_tokens": usage.get("cache_read_input_tokens", 0) or 0,
         "total_cost_usd": raw_envelope.get("total_cost_usd", 0) or 0,
-        "duration_ms": raw_envelope.get("duration_ms", 0) or 0,
-        "duration_api_ms": raw_envelope.get("duration_api_ms", 0) or 0,
+        "duration_ms": _duration_ms,
+        "duration_api_ms": _duration_api_ms,
         "num_turns": raw_envelope.get("num_turns", 0) or 0,
         "model": raw_envelope.get("_resolved_model") or raw_envelope.get("model", ""),
         "web_search_requests": server_tool_use.get("web_search_requests", 0) or 0,
@@ -51,6 +54,15 @@ def extract_token_usage(
         "cache_ephemeral_5m_tokens": cache_creation.get("ephemeral_5m_input_tokens", 0) or 0,
         "speed": usage.get("speed", "") or "",
         "context_final_pct": None,
+        # W-074 API-throttling/retry signal. api_retries / api_retry_wait_ms are
+        # the precise count and Σ backoff-window wall span (from claude_cli's
+        # stderr tee). non_api_wait_ms is the coarse wall-vs-api delta (folds in
+        # local tool execution too). api_error_status is the CLI's final API
+        # HTTP status (null on success). All additive — 0/null on legacy runs.
+        "api_retries": raw_envelope.get("api_retries", 0) or 0,
+        "api_retry_wait_ms": raw_envelope.get("api_retry_wait_ms", 0) or 0,
+        "non_api_wait_ms": max(0, _duration_ms - _duration_api_ms),
+        "api_error_status": raw_envelope.get("api_error_status"),
     }
 
     model_alias = raw_envelope.get("_model_alias")
@@ -103,6 +115,10 @@ def _empty_token_usage() -> dict:
         "cache_ephemeral_5m_tokens": 0,
         "speed": "",
         "context_final_pct": None,
+        "api_retries": 0,
+        "api_retry_wait_ms": 0,
+        "non_api_wait_ms": 0,
+        "api_error_status": None,
     }
 
 
@@ -119,6 +135,9 @@ _SUMMABLE_FIELDS = [
     "web_fetch_requests",
     "cache_ephemeral_1h_tokens",
     "cache_ephemeral_5m_tokens",
+    "api_retries",
+    "api_retry_wait_ms",
+    "non_api_wait_ms",
 ]
 
 

--- a/tests/integration/test_api_retry_signal.py
+++ b/tests/integration/test_api_retry_signal.py
@@ -58,8 +58,11 @@ def test_api_retry_signal_captured_end_to_end(pipeline_env):
     it, tu = retry_iters[0]
     assert tu["api_retries"] >= 1
     assert tu["api_retry_wait_ms"] >= 0
+    # The HTTP status parsed from "API Error 529: ..." flows through token_usage.
+    assert tu["api_error_status"] == 529
     # Surfaced onto the iteration top-level too (the UI view-model reads it there).
     assert it.get("api_retries", 0) >= 1
+    assert it.get("api_error_status") == 529
 
     # 3. A pipeline.agent.api_retry event is emitted.
     retry_events = [

--- a/tests/integration/test_api_retry_signal.py
+++ b/tests/integration/test_api_retry_signal.py
@@ -1,0 +1,72 @@
+"""Integration test: API-throttling/retry signal end-to-end (W-074).
+
+A mock-claude run whose agents print a synthetic "overloaded, retrying" line to
+stderr. Asserts the full spine captures it:
+  - the per-iteration log persists the stderr line tagged ``err``;
+  - status.json token_usage carries ``api_retries >= 1`` and
+    ``api_retry_wait_ms >= 0``;
+  - a ``pipeline.agent.api_retry`` event lands in events.jsonl.
+"""
+import pytest
+
+from tests.integration.helpers import read_run_dir
+
+pytestmark = pytest.mark.timeout(120)
+
+
+def _retry_scenario() -> dict:
+    """Every agent succeeds but first prints a 429/529 backoff line to stderr."""
+    retry = {
+        "action": "succeed",
+        "delay_s": 0.05,
+        "stderr_lines": ["API Error 529: overloaded, retrying in 4s"],
+    }
+    return {
+        "agents": {
+            "tester": {**retry, "structured_output": {"passed": True}},
+            "reviewer": {**retry, "structured_output": {"outcome": "approve", "issues": []}},
+        },
+        "default": retry,
+    }
+
+
+def test_api_retry_signal_captured_end_to_end(pipeline_env):
+    result = pipeline_env.run(_retry_scenario(), prompt="retry signal test",
+                              timeout=90)
+    assert result.returncode == 0, f"pipeline failed: {result.stderr[-500:]}"
+    assert result.status["pipeline_status"] == "completed"
+
+    # 1. The stderr line is persisted into a per-iteration log tagged "err".
+    run_dir = read_run_dir(pipeline_env.worca_dir)
+    logs_dir = run_dir / "logs"
+    err_logs = [
+        p for p in logs_dir.rglob("iter-*.log")
+        if any("\terr\t" in ln for ln in p.read_text(encoding="utf-8").splitlines())
+    ]
+    assert err_logs, "no iter log carried an \\terr\\t-tagged stderr line"
+    sample = err_logs[0].read_text(encoding="utf-8")
+    assert "overloaded" in sample
+
+    # 2. status.json token_usage carries api_retries >= 1 and api_retry_wait_ms >= 0.
+    retry_iters = []
+    for stage in result.status.get("stages", {}).values():
+        for it in stage.get("iterations", []):
+            tu = it.get("token_usage") or {}
+            if tu.get("api_retries", 0) >= 1:
+                retry_iters.append((it, tu))
+    assert retry_iters, "no iteration token_usage recorded api_retries >= 1"
+    it, tu = retry_iters[0]
+    assert tu["api_retries"] >= 1
+    assert tu["api_retry_wait_ms"] >= 0
+    # Surfaced onto the iteration top-level too (the UI view-model reads it there).
+    assert it.get("api_retries", 0) >= 1
+
+    # 3. A pipeline.agent.api_retry event is emitted.
+    retry_events = [
+        e for e in result.events
+        if e.get("event_type") == "pipeline.agent.api_retry"
+    ]
+    assert retry_events, "no pipeline.agent.api_retry event in events.jsonl"
+    payload = retry_events[0].get("payload", {})
+    assert payload.get("attempt", 0) >= 1
+    assert "detail" in payload

--- a/tests/mock_claude/mock_claude.py
+++ b/tests/mock_claude/mock_claude.py
@@ -158,6 +158,22 @@ def main():
 
     time.sleep(delay)
 
+    # Optional synthetic stderr (W-074): the real Claude CLI prints 429/529
+    # backoff diagnostics to stderr. A directive may set "stderr_lines" (a
+    # string or list of strings) to exercise worca's retry-signal capture
+    # (claude_cli._tee_stderr → _RETRY_RE → api_retries / api_retry_wait_ms and
+    # the pipeline.agent.api_retry event). Emitted before the result so the
+    # backoff window opens, then a brief sleep lets the next stdout event close
+    # it with a measurable (>= 0) span.
+    stderr_lines = directive.get("stderr_lines")
+    if stderr_lines is not None:
+        if isinstance(stderr_lines, str):
+            stderr_lines = [stderr_lines]
+        for _line in stderr_lines:
+            sys.stderr.write(str(_line).rstrip("\n") + "\n")
+            sys.stderr.flush()
+        time.sleep(0.05)
+
     if action == "succeed":
         run_cmd = directive.get("run_command")
         if run_cmd:

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -11,6 +11,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+import time
+
 from worca.utils.claude_cli import (
     AgentSubprocessError,
     _accumulate_usage,
@@ -18,6 +20,7 @@ from worca.utils.claude_cli import (
     _format_log_line,
     _resolve_tool_args,
     _resolve_tool_disallows,
+    _RETRY_RE,
     build_command,
     process_stream,
     run_agent,
@@ -1767,3 +1770,235 @@ def test_format_log_line_done_no_ctx_final_when_absent():
 
     assert line is not None
     assert "ctx_final" not in line
+
+
+# ---------------------------------------------------------------------------
+# stderr tee persistence (W-074 §1/§2)
+# ---------------------------------------------------------------------------
+
+
+def test_tee_stderr_persists_tagged_err_lines(tmp_path):
+    """stderr lines are persisted into the shared log tagged stream='err',
+    each with a worca receive-time ISO timestamp — not just echoed to console.
+    """
+    result_event = {
+        "type": "result",
+        "subtype": "success",
+        "result": "ok",
+        "total_cost_usd": 0.01,
+        "num_turns": 1,
+        "duration_ms": 1000,
+    }
+    mock_proc = MagicMock()
+    mock_proc.stdout = iter([json.dumps(result_event) + "\n"])
+    # The CLI prints throttling diagnostics to stderr (raw, no timestamp).
+    mock_proc.stderr = iter(
+        ["Overloaded (529), retrying in 4s\n", "Retry succeeded\n"]
+    )
+    mock_proc.returncode = 0
+    mock_proc.pid = 12345
+    mock_proc.wait.return_value = 0
+    log_path = str(tmp_path / "logs" / "iter-1.log")
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        run_agent(prompt="hi", agent="agent.md", log_path=log_path, settings={})
+
+    contents = open(log_path, encoding="utf-8").read()
+    err_lines = [ln for ln in contents.splitlines() if "\terr\t" in ln]
+    assert len(err_lines) == 2
+    # Each err line: <ISO-ts>\terr\t<text>
+    assert err_lines[0].endswith("\terr\tOverloaded (529), retrying in 4s")
+    assert err_lines[1].endswith("\terr\tRetry succeeded")
+    # The stderr text is genuinely stamped (col 0 is a parseable ISO ts).
+    from datetime import datetime as _dt
+
+    ts0 = err_lines[0].split("\t", 1)[0]
+    assert _dt.fromisoformat(ts0).tzinfo is not None
+    # stdout-derived lines are tagged "out" and share the same file.
+    assert "\tout\t" in contents
+
+
+def test_tee_stderr_still_echoes_to_console(tmp_path, capfd):
+    """The unchanged console echo to sys.stderr is preserved alongside the
+    new persistence — operators watching the console still see stderr live.
+    """
+    result_event = {
+        "type": "result",
+        "subtype": "success",
+        "result": "ok",
+        "total_cost_usd": 0.01,
+        "num_turns": 1,
+        "duration_ms": 1000,
+    }
+    mock_proc = MagicMock()
+    mock_proc.stdout = iter([json.dumps(result_event) + "\n"])
+    mock_proc.stderr = iter(["console-visible-stderr\n"])
+    mock_proc.returncode = 0
+    mock_proc.pid = 12345
+    mock_proc.wait.return_value = 0
+    log_path = str(tmp_path / "logs" / "iter-1.log")
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        run_agent(prompt="hi", agent="agent.md", log_path=log_path, settings={})
+    captured = capfd.readouterr()
+    assert "console-visible-stderr" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# API-throttling/retry signal (W-074 §2/§3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "API Error 529: overloaded, retrying in 4s",
+        "Overloaded, backing off",
+        "Rate limit exceeded (429)",
+        "rate-limit hit, retrying",
+        "ratelimit reached",
+        "HTTP 429 Too Many Requests",
+        "Got 529 from upstream",
+        "503 Service Unavailable",
+        "Retrying request (attempt 2)",
+        "retry scheduled",
+    ],
+)
+def test_retry_re_matches_samples(line):
+    """_RETRY_RE hits captured 429/529/503/overloaded/retrying lines."""
+    assert _RETRY_RE.search(line), f"expected match: {line!r}"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "[tool:Read] src/main.py",
+        "Wrote 42 lines to file",
+        "Compiling project assets",
+        "tests passed: 529 assertions",  # 529 embedded in a word-ish context: still digits, but...
+    ],
+)
+def test_retry_re_misses_benign(line):
+    """_RETRY_RE does not fire on benign progress lines without retry vocab.
+
+    Note "529 assertions" DOES contain a bare 529 token with word boundaries, so
+    it is intentionally treated as a (false-positive-tolerant) match by the broad
+    matcher — excluded here to keep the negative set honest.
+    """
+    if "529" in line or "429" in line or "503" in line:
+        pytest.skip("contains a bare HTTP-status token — broad matcher matches")
+    assert not _RETRY_RE.search(line), f"unexpected match: {line!r}"
+
+
+def _make_retry_mock_proc(stderr_lines, result_event=None, duration_ms=1000):
+    """Mock Popen yielding a result event on stdout and given stderr lines."""
+    result_event = result_event or {
+        "type": "result", "subtype": "success", "result": "ok",
+        "total_cost_usd": 0.01, "num_turns": 1, "duration_ms": duration_ms,
+    }
+    mock_proc = MagicMock()
+    mock_proc.stdout = iter([json.dumps(result_event) + "\n"])
+    mock_proc.stderr = iter(stderr_lines)
+    mock_proc.returncode = 0
+    mock_proc.pid = 12345
+    mock_proc.wait.return_value = 0
+    return mock_proc
+
+
+def test_tee_stderr_persists_and_counts(tmp_path):
+    """All stderr persisted tagged 'err'; only retry-vocab lines bump the count."""
+    mock_proc = _make_retry_mock_proc([
+        "overloaded, retrying in 4s\n",
+        "benign progress line\n",
+        "429 Too Many Requests\n",
+    ])
+    log_path = str(tmp_path / "logs" / "iter-1.log")
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", log_path=log_path, settings={})
+    contents = open(log_path, encoding="utf-8").read()
+    # All 3 stderr lines persisted (persist-all, not just matches).
+    assert len([ln for ln in contents.splitlines() if "\terr\t" in ln]) == 3
+    # Only the 2 retry-vocab lines counted.
+    assert result["api_retries"] == 2
+
+
+def test_run_agent_sets_api_retries():
+    """result_event['api_retries'] reflects the tee's matched-line count."""
+    mock_proc = _make_retry_mock_proc([
+        "Overloaded (529), retrying\n",
+        "rate limit, retrying\n",
+    ])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", settings={})
+    assert result["api_retries"] == 2
+
+
+def test_run_agent_sets_api_retries_zero_when_no_retries():
+    """A clean run reports api_retries=0 / api_retry_wait_ms=0 (legacy-identical)."""
+    mock_proc = _make_retry_mock_proc(["just some normal output\n"])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", settings={})
+    assert result["api_retries"] == 0
+    assert result["api_retry_wait_ms"] == 0
+
+
+def test_run_agent_sets_api_retry_wait_ms_key():
+    """run_agent always stamps api_retry_wait_ms (>= 0) onto the result."""
+    mock_proc = _make_retry_mock_proc(["overloaded, retrying\n"])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", settings={})
+    assert "api_retry_wait_ms" in result
+    assert result["api_retry_wait_ms"] >= 0
+
+
+def test_process_stream_closes_backoff_window():
+    """A stdout event closes an open backoff window: wait_ms += now − pending_since.
+
+    Deterministic unit of the §2 timing: the tee stamps pending_since; the next
+    stdout event seen by process_stream folds the wall span into wait_ms and
+    clears pending_since.
+    """
+    retry_state = {
+        "count": 1, "wait_ms": 0,
+        "pending_since": time.monotonic() - 0.05,  # window opened ~50ms ago
+    }
+    stdout = iter([json.dumps({"type": "result", "result": "ok", "duration_ms": 1}) + "\n"])
+    process_stream(stdout, retry_state=retry_state)
+    assert retry_state["pending_since"] is None
+    assert retry_state["wait_ms"] >= 40  # ~50ms, allow scheduler slack
+
+
+def test_process_stream_no_open_window_leaves_wait_ms_untouched():
+    """With no open backoff window, process_stream does not touch wait_ms."""
+    retry_state = {"count": 0, "wait_ms": 0, "pending_since": None}
+    stdout = iter([json.dumps({"type": "result", "result": "ok"}) + "\n"])
+    process_stream(stdout, retry_state=retry_state)
+    assert retry_state["wait_ms"] == 0
+    assert retry_state["pending_since"] is None
+
+
+def test_run_agent_invokes_on_retry_callback():
+    """on_retry(detail, count) fires once per matched stderr line, in order."""
+    calls = []
+    mock_proc = _make_retry_mock_proc([
+        "overloaded, retrying\n",
+        "benign\n",
+        "429 too many requests\n",
+    ])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        run_agent(
+            prompt="hi", agent="agent.md", settings={},
+            on_retry=lambda detail, count: calls.append((detail, count)),
+        )
+    assert len(calls) == 2
+    assert calls[0][1] == 1 and calls[1][1] == 2
+    assert "overloaded" in calls[0][0]
+
+
+def test_run_agent_on_retry_exception_does_not_crash():
+    """A throwing on_retry must not kill the tee daemon or the run."""
+    mock_proc = _make_retry_mock_proc(["overloaded, retrying\n"])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(
+            prompt="hi", agent="agent.md", settings={},
+            on_retry=lambda detail, count: (_ for _ in ()).throw(ValueError("boom")),
+        )
+    assert result["api_retries"] == 1

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -1850,16 +1850,22 @@ def test_tee_stderr_still_echoes_to_console(tmp_path, capfd):
 @pytest.mark.parametrize(
     "line",
     [
+        # Retry/overload vocabulary — sufficient on its own.
         "API Error 529: overloaded, retrying in 4s",
         "Overloaded, backing off",
         "Rate limit exceeded (429)",
         "rate-limit hit, retrying",
         "ratelimit reached",
         "HTTP 429 Too Many Requests",
-        "Got 529 from upstream",
         "503 Service Unavailable",
         "Retrying request (attempt 2)",
         "retry scheduled",
+        # Bare HTTP status next to an HTTP/error context word.
+        "Got 529 from upstream",
+        "HTTP 503",
+        "error 500 internal",
+        "received 502 from api",
+        "status code 429",
     ],
 )
 def test_retry_re_matches_samples(line):
@@ -1873,18 +1879,17 @@ def test_retry_re_matches_samples(line):
         "[tool:Read] src/main.py",
         "Wrote 42 lines to file",
         "Compiling project assets",
-        "tests passed: 529 assertions",  # 529 embedded in a word-ish context: still digits, but...
+        # Bare HTTP-status tokens with NO http/error context word: the
+        # precision guard keeps these from inflating the retry count.
+        "tests passed: 529 assertions",
+        "503 tests passed",
+        "ran 429 examples",
+        "line 500 of report.txt",
     ],
 )
 def test_retry_re_misses_benign(line):
-    """_RETRY_RE does not fire on benign progress lines without retry vocab.
-
-    Note "529 assertions" DOES contain a bare 529 token with word boundaries, so
-    it is intentionally treated as a (false-positive-tolerant) match by the broad
-    matcher — excluded here to keep the negative set honest.
-    """
-    if "529" in line or "429" in line or "503" in line:
-        pytest.skip("contains a bare HTTP-status token — broad matcher matches")
+    """_RETRY_RE does not fire on benign lines — including bare HTTP-status
+    tokens that lack any retry vocabulary or HTTP/error context word."""
     assert not _RETRY_RE.search(line), f"unexpected match: {line!r}"
 
 
@@ -2002,3 +2007,78 @@ def test_run_agent_on_retry_exception_does_not_crash():
             on_retry=lambda detail, count: (_ for _ in ()).throw(ValueError("boom")),
         )
     assert result["api_retries"] == 1
+
+
+def test_run_agent_sets_api_error_status_from_retry_line():
+    """The HTTP status parsed from a retry line is stamped as api_error_status."""
+    mock_proc = _make_retry_mock_proc(["API Error 529: overloaded, retrying\n"])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", settings={})
+    assert result["api_error_status"] == 529
+
+
+def test_run_agent_api_error_status_last_seen_wins():
+    """When multiple statuses appear, the last one parsed wins (mirrors the
+    'last API status N' UI tooltip)."""
+    mock_proc = _make_retry_mock_proc([
+        "HTTP 429 Too Many Requests, retrying\n",
+        "API Error 503: service unavailable, retrying\n",
+    ])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", settings={})
+    assert result["api_error_status"] == 503
+
+
+def test_run_agent_api_error_status_none_when_vocab_only():
+    """A vocabulary-only retry line (no numeric status) leaves api_error_status
+    None while still counting the retry."""
+    mock_proc = _make_retry_mock_proc(["Overloaded, backing off\n"])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", settings={})
+    assert result["api_retries"] == 1
+    assert result["api_error_status"] is None
+
+
+def test_run_agent_api_error_status_none_on_clean_run():
+    """A clean run reports api_error_status None (legacy-identical)."""
+    mock_proc = _make_retry_mock_proc(["just some normal output\n"])
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", settings={})
+    assert result["api_error_status"] is None
+
+
+def test_run_agent_closes_trailing_backoff_window():
+    """A retry line that arrives *after* the last stdout event is processed
+    still has its backoff window closed at stamp time, not lost.
+
+    process_stream closes a window only when it sees a stdout event; a retry
+    burst that lands on stderr once stdout has already EOF'd would otherwise
+    leave pending_since open forever. run_agent closes that trailing window
+    after joining the tee. The Event sequencing makes the ordering
+    deterministic: the retry line is read strictly after stdout is exhausted.
+    """
+    import threading as _t
+
+    stdout_done = _t.Event()
+
+    def _stdout():
+        yield json.dumps({"type": "result", "result": "ok", "duration_ms": 1}) + "\n"
+        stdout_done.set()  # signal: all stdout consumed before tee unblocks
+
+    def _stderr():
+        # Block until process_stream has fully drained stdout, so this retry
+        # line opens a window with no subsequent stdout event to close it.
+        stdout_done.wait(timeout=5)
+        yield "overloaded, retrying\n"
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = _stdout()
+    mock_proc.stderr = _stderr()
+    mock_proc.returncode = 0
+    mock_proc.pid = 12345
+    mock_proc.wait.return_value = 0
+    with patch("worca.utils.claude_cli.subprocess.Popen", return_value=mock_proc):
+        result = run_agent(prompt="hi", agent="agent.md", settings={})
+    # The trailing retry was counted and its window closed (no crash, wait >= 0).
+    assert result["api_retries"] == 1
+    assert result["api_retry_wait_ms"] >= 0

--- a/tests/test_event_types.py
+++ b/tests/test_event_types.py
@@ -44,12 +44,13 @@ PIPELINE_CONSTANTS = [
     ("STAGE_COMPLETED",   "pipeline.stage.completed"),
     ("STAGE_FAILED",      "pipeline.stage.failed"),
     ("STAGE_INTERRUPTED", "pipeline.stage.interrupted"),
-    # Agent telemetry (6)
+    # Agent telemetry (7)
     ("AGENT_SPAWNED",        "pipeline.agent.spawned"),
     ("AGENT_TOOL_USE",       "pipeline.agent.tool_use"),
     ("AGENT_TOOL_RESULT",    "pipeline.agent.tool_result"),
     ("AGENT_TEXT",           "pipeline.agent.text"),
     ("AGENT_COMPLETED",      "pipeline.agent.completed"),
+    ("AGENT_API_RETRY",      "pipeline.agent.api_retry"),
     ("ITERATION_ACCESS",     "pipeline.iteration.access"),
     # Bead lifecycle (6)
     ("BEAD_CREATED",      "pipeline.bead.created"),
@@ -142,20 +143,20 @@ def test_pipeline_constant_values_unique():
 
 
 def test_total_pipeline_constants():
-    """There must be exactly 59 pipeline.* outbound constants.
+    """There must be exactly 60 pipeline.* outbound constants.
 
     48 original + 2 dedicated learn events (pipeline.learn.completed/failed)
     + 1 dispatch_allowed hook event + 1 RUN_CANCELLED + 1 PLAN_EDITED
     + 2 template lifecycle events + 1 ITERATION_ACCESS + 1 GIT_PR_DEFERRED
-    + 1 CLAUDE_MD_MODE_RESOLVED = 59.
+    + 1 CLAUDE_MD_MODE_RESOLVED + 1 AGENT_API_RETRY (W-074) = 60.
     """
     import worca.events.types as T
     pipeline_vals = [
         v for k, v in vars(T).items()
         if k.isupper() and isinstance(v, str) and v.startswith("pipeline.")
     ]
-    assert len(pipeline_vals) == 59, (
-        f"Expected 59 pipeline.* constants, found {len(pipeline_vals)}"
+    assert len(pipeline_vals) == 60, (
+        f"Expected 60 pipeline.* constants, found {len(pipeline_vals)}"
     )
 
 
@@ -194,6 +195,7 @@ EXPECTED_BUILDERS = [
     "agent_tool_result_payload",
     "agent_text_payload",
     "agent_completed_payload",
+    "agent_api_retry_payload",
     "iteration_access_payload",
     # pipeline.bead.*
     "bead_created_payload",
@@ -488,6 +490,47 @@ def test_agent_completed_payload_required_fields():
     assert p["cost_usd"] == 0.25
     assert p["duration_ms"] == 45000
     assert p["exit_code"] == 0
+
+
+def test_agent_api_retry_payload_required_fields():
+    from worca.events.types import agent_api_retry_payload
+    p = agent_api_retry_payload(
+        stage="IMPLEMENT", iteration=2, agent="implementer",
+        attempt=3, detail="API Error 529: overloaded, retrying in 4s",
+    )
+    assert p["stage"] == "IMPLEMENT"
+    assert p["iteration"] == 2
+    assert p["agent"] == "implementer"
+    assert p["attempt"] == 3
+    assert p["detail"] == "API Error 529: overloaded, retrying in 4s"
+
+
+def test_agent_api_retry_payload_bead_id_omitted_by_default():
+    from worca.events.types import agent_api_retry_payload
+    p = agent_api_retry_payload(
+        stage="IMPLEMENT", iteration=1, agent="implementer",
+        attempt=1, detail="overloaded",
+    )
+    assert "bead_id" not in p
+
+
+def test_agent_api_retry_payload_bead_id_included_when_provided():
+    from worca.events.types import agent_api_retry_payload
+    p = agent_api_retry_payload(
+        stage="IMPLEMENT", iteration=1, agent="implementer",
+        attempt=1, detail="overloaded", bead_id="worca-cc-3rds",
+    )
+    assert p["bead_id"] == "worca-cc-3rds"
+
+
+def test_agent_api_retry_payload_detail_truncated():
+    from worca.events.types import agent_api_retry_payload
+    long_detail = "x" * 500
+    p = agent_api_retry_payload(
+        stage="IMPLEMENT", iteration=1, agent="implementer",
+        attempt=1, detail=long_detail,
+    )
+    assert len(p["detail"]) == 300
 
 
 def test_iteration_access_payload_required_fields():
@@ -1009,6 +1052,10 @@ def test_all_builders_return_dicts():
         "agent_completed_payload": dict(
             stage="PLAN", iteration=1, turns=1,
             cost_usd=0.0, duration_ms=1, exit_code=0,
+        ),
+        "agent_api_retry_payload": dict(
+            stage="IMPLEMENT", iteration=1, agent="implementer",
+            attempt=1, detail="overloaded, retrying",
         ),
         "iteration_access_payload": dict(
             run_id="r", stage="PLAN", agent="planner", iteration=1,

--- a/tests/test_log_lines.py
+++ b/tests/test_log_lines.py
@@ -27,10 +27,18 @@ _TS_PREFIX_RE = re.compile(
 # ---------------------------------------------------------------------------
 
 
-def test_format_log_line_prefixes_iso_timestamp_and_tab():
+def test_format_log_line_prefixes_iso_timestamp_stream_and_tab():
+    # Canonical shape is <ts>\t<stream>\t<text>; stream defaults to "out".
     assert (
         format_log_line("[tool:Read] foo.py", _FIXED)
-        == "2026-06-14T12:00:00.000+00:00\t[tool:Read] foo.py"
+        == "2026-06-14T12:00:00.000+00:00\tout\t[tool:Read] foo.py"
+    )
+
+
+def test_format_log_line_tags_explicit_stream():
+    assert (
+        format_log_line("Overloaded, retrying", _FIXED, stream="err")
+        == "2026-06-14T12:00:00.000+00:00\terr\tOverloaded, retrying"
     )
 
 
@@ -53,8 +61,9 @@ def test_format_log_line_first_field_round_trips():
 
 def test_format_log_line_preserves_tabs_in_message():
     out = format_log_line("a\tb\tc", _FIXED)
-    # Only the prefix TAB is added; message tabs survive (reader splits on first).
-    assert out == "2026-06-14T12:00:00.000+00:00\ta\tb\tc"
+    # Only the prefix (ts + stream) TABs are added; message tabs survive
+    # (the reader splits off the timestamp and stream token, then keeps the rest).
+    assert out == "2026-06-14T12:00:00.000+00:00\tout\ta\tb\tc"
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +74,38 @@ def test_format_log_line_preserves_tabs_in_message():
 def test_write_log_line_writes_one_terminated_record():
     buf = io.StringIO()
     write_log_line(buf, "[done] ok", now=_FIXED)
-    assert buf.getvalue() == "2026-06-14T12:00:00.000+00:00\t[done] ok\n"
+    assert buf.getvalue() == "2026-06-14T12:00:00.000+00:00\tout\t[done] ok\n"
+
+
+def test_write_log_line_tags_stream():
+    buf = io.StringIO()
+    write_log_line(buf, "boom", now=_FIXED, stream="err")
+    assert buf.getvalue() == "2026-06-14T12:00:00.000+00:00\terr\tboom\n"
+
+
+def test_write_log_line_defaults_to_out_stream():
+    buf = io.StringIO()
+    write_log_line(buf, "hello", now=_FIXED)
+    # Second column is the stream token; default is "out".
+    assert buf.getvalue().split("\t")[1] == "out"
+
+
+def test_write_log_line_stamp_true_ignores_injected_now():
+    # stamp=True forces a fresh receive-time stamp, so the deterministic `now`
+    # is deliberately ignored (the stderr tee stamps at receive time).
+    buf = io.StringIO()
+    write_log_line(buf, "stderr text", now=_FIXED, stream="err", stamp=True)
+    ts_field = buf.getvalue().split("\t", 1)[0]
+    assert ts_field != "2026-06-14T12:00:00.000+00:00"
+    # Still a valid ISO timestamp and still tagged err.
+    assert datetime.fromisoformat(ts_field).tzinfo is not None
+    assert buf.getvalue().split("\t")[1] == "err"
+
+
+def test_write_log_line_stamp_false_uses_injected_now():
+    buf = io.StringIO()
+    write_log_line(buf, "x", now=_FIXED, stamp=False)
+    assert buf.getvalue().split("\t", 1)[0] == "2026-06-14T12:00:00.000+00:00"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -183,6 +183,57 @@ def test_empty_token_usage_has_new_fields():
 
 
 # ---------------------------------------------------------------------------
+# extract_token_usage — API-throttling/retry fields (W-074 §3)
+# ---------------------------------------------------------------------------
+
+
+def test_token_usage_carries_retry_fields():
+    envelope = {
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+        "duration_ms": 5000,
+        "duration_api_ms": 1200,
+        "api_retries": 3,
+        "api_retry_wait_ms": 1042310,
+        "api_error_status": 529,
+    }
+    result = extract_token_usage(envelope)
+    assert result["api_retries"] == 3
+    assert result["api_retry_wait_ms"] == 1042310
+    # non_api_wait_ms = max(0, duration_ms - duration_api_ms)
+    assert result["non_api_wait_ms"] == 3800
+    assert result["api_error_status"] == 529
+
+
+def test_token_usage_retry_fields_default_on_legacy_envelope():
+    """Legacy envelopes (no retry fields) default to 0 / None — additive."""
+    envelope = {
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+        "duration_ms": 1000,
+        "duration_api_ms": 1000,
+    }
+    result = extract_token_usage(envelope)
+    assert result["api_retries"] == 0
+    assert result["api_retry_wait_ms"] == 0
+    assert result["non_api_wait_ms"] == 0
+    assert result["api_error_status"] is None
+
+
+def test_token_usage_non_api_wait_ms_never_negative():
+    """duration_api_ms > duration_ms (clock skew) clamps non_api_wait_ms to 0."""
+    envelope = {"duration_ms": 100, "duration_api_ms": 500}
+    result = extract_token_usage(envelope)
+    assert result["non_api_wait_ms"] == 0
+
+
+def test_empty_token_usage_has_retry_fields():
+    empty = _empty_token_usage()
+    assert empty["api_retries"] == 0
+    assert empty["api_retry_wait_ms"] == 0
+    assert empty["non_api_wait_ms"] == 0
+    assert empty["api_error_status"] is None
+
+
+# ---------------------------------------------------------------------------
 # _SUMMABLE_FIELDS — new summable fields (W-035 section 1b)
 # ---------------------------------------------------------------------------
 

--- a/worca-ui/app/main-log-line-handler.test.js
+++ b/worca-ui/app/main-log-line-handler.test.js
@@ -92,4 +92,17 @@ describe('log-bulk handler: Log History backfill', () => {
     // The old receive-time stamping must be gone.
     expect(handler).not.toMatch(/timestamp:\s*new Date\(\)\.toISOString\(\)/);
   });
+
+  it('carries the origin stream onto each bulk entry (W-074)', () => {
+    // The parallel payload.streams[] array tags each line out/err; entries
+    // must default to "out" for legacy/untagged backfill.
+    expect(handler).toContain('payload.streams');
+    expect(handler).toMatch(/stream:\s*streams\[i\]\s*\|\|\s*'out'/);
+  });
+
+  it('gates the Log History write on the stream filter (W-074)', () => {
+    // Backfill written to the history terminal must honor the active stream
+    // filter so a fresh subscribe matches a client-side replay.
+    expect(handler).toContain('logStreamMatches(entry)');
+  });
 });

--- a/worca-ui/app/main.js
+++ b/worca-ui/app/main.js
@@ -604,6 +604,14 @@ let worktreesDialogCheckbox = false; // resumable/grouped confirmation checkbox
 let logFilter = '*';
 let logSearch = '';
 let logIterationFilter = null; // null = all iterations, number = specific
+let logStreamFilter = 'all'; // 'all' | 'out' | 'err' — client-side view mode
+
+/** Does a log entry's origin stream pass the current stream filter? */
+function logStreamMatches(entry) {
+  return (
+    logStreamFilter === 'all' || (entry.stream || 'out') === logStreamFilter
+  );
+}
 
 // -- Prompt cache --
 const promptCache = {}; // { [runId]: { [stage]: { agentInstructions, userPrompt, agent } } }
@@ -916,6 +924,7 @@ function resetProjectState() {
   logFilter = '*';
   logSearch = '';
   logIterationFilter = null;
+  logStreamFilter = 'all';
   // Prompt cache
   for (const key of Object.keys(promptCache)) delete promptCache[key];
   promptCachePending.clear();
@@ -1243,19 +1252,23 @@ ws.on('log-bulk', (payload) => {
     const timestamps = Array.isArray(payload.timestamps)
       ? payload.timestamps
       : [];
+    const streams = Array.isArray(payload.streams) ? payload.streams : [];
     for (let i = 0; i < payload.lines.length; i++) {
       // New-format lines carry a real write-time; legacy lines (pre-timestamp
       // format) have null here and render as a "--:--:--" placeholder rather
-      // than a misleading current time.
+      // than a misleading current time. `stream` is the origin channel
+      // ("out"/"err"); legacy/untagged backfill defaults to "out".
       const entry = {
         stage: payload.stage,
         iteration: payload.iteration,
         line: payload.lines[i],
         timestamp: timestamps[i] ?? null,
+        stream: streams[i] || 'out',
       };
       entries.push(entry);
-      // Log History: only write to the history terminal when a specific stage is selected
-      if (logFilter !== '*') writeLogLine(entry);
+      // Log History: only write to the history terminal when a specific stage
+      // is selected, and only when the entry passes the stream filter.
+      if (logFilter !== '*' && logStreamMatches(entry)) writeLogLine(entry);
       writeLiveLogLine(entry);
     }
     // Single buffered append + one coalesced rerender for the whole backfill,
@@ -3395,6 +3408,22 @@ function handleIterationFilter(iteration) {
   rerender();
 }
 
+// Client-side stream filter: no refetch/resubscribe. Clear the history
+// terminal and replay the already-buffered lines, keeping only those whose
+// origin stream passes the filter. Mirrors the log-bulk write predicate so the
+// rendered output is identical to a fresh backfill under the same filter.
+async function handleStreamFilter(value) {
+  logStreamFilter = value || 'all';
+  if (logFilter !== '*') {
+    clearTerminal();
+    await mountTerminal(route.runId);
+    for (const entry of store.getState().logLines) {
+      if (logStreamMatches(entry)) writeLogLine(entry);
+    }
+  }
+  rerender();
+}
+
 function handleSearch(term) {
   logSearch = term;
   searchTerminal(term);
@@ -5230,9 +5259,11 @@ function mainContentView() {
           ${logViewerView(logState, {
             onStageFilter: handleStageFilter,
             onIterationFilter: handleIterationFilter,
+            onStreamFilter: handleStreamFilter,
             onSearch: handleSearch,
             onToggleAutoScroll: handleToggleAutoScroll,
             autoScroll,
+            streamFilter: logStreamFilter,
             stageIterations,
             runStages: run?.stages,
           })}

--- a/worca-ui/app/styles.css
+++ b/worca-ui/app/styles.css
@@ -1231,6 +1231,20 @@ h1, h2, h3, h4, h5, h6 {
   opacity: 0.4;
 }
 
+/* W-074: API Retry/Wait segment. A 45deg striped gradient (pattern, not solid)
+   so the meaning survives colorblindness and the a11y color-not-alone floor,
+   and stays visually distinct from the solid amber "Thinking" segment. The
+   error+caution stripe pair reads as "throttled / backing off". */
+.timing-bar-retry {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--status-error, #dc2626),
+    var(--status-error, #dc2626) 5px,
+    var(--status-blocked, #f59e0b) 5px,
+    var(--status-blocked, #f59e0b) 10px
+  );
+}
+
 .timing-bar-segment-text {
   font-size: 11px;
   font-weight: 600;
@@ -1300,6 +1314,20 @@ h1, h2, h3, h4, h5, h6 {
   align-items: center;
   gap: 4px;
   white-space: nowrap;
+}
+
+/* W-074: API-retry chip — amber "caution" per badge-color-language.md. The
+   ⟳ icon + count carry the meaning so color is never the sole signal. Applies
+   to both the per-iteration chip (.stage-info-item) and the collapsed
+   stage-header chip (.stage-meta-item). var(--status-blocked) is theme-aware,
+   so this reads correctly on both light and dark surfaces. */
+.iter-retry-warn,
+.iter-retry-warn .meta-value {
+  color: var(--status-blocked, #f59e0b);
+}
+
+.iter-retry-warn svg {
+  stroke: var(--status-blocked, #f59e0b);
 }
 
 .text-muted {
@@ -1680,6 +1708,16 @@ sl-details.log-history-panel::part(content) {
 
 .log-controls .terminal-copy-btn {
   margin-left: auto;
+}
+
+/* 3-way stdout/stderr/all stream filter — a segmented view-mode switch, not a
+   data dropdown. Stays its intrinsic width so it doesn't steal the search flex. */
+.log-controls .log-stream-filter {
+  flex: 0 0 auto;
+}
+
+.log-stream-filter sl-radio-button[value="err"]::part(button--checked) {
+  color: var(--status-blocked, #f59e0b);
 }
 
 .log-controls sl-input {

--- a/worca-ui/app/views/log-viewer-stream-filter.test.js
+++ b/worca-ui/app/views/log-viewer-stream-filter.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { logViewerView } from './log-viewer.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (typeof v === 'boolean') result += '';
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const BASE_STATE = {
+  logLines: [
+    { stage: 'implement', line: 'building', stream: 'out' },
+    { stage: 'implement', line: 'Overloaded, retrying', stream: 'err' },
+  ],
+  currentLogStage: 'implement',
+  currentLogIteration: null,
+};
+
+const BASE_OPTS = {
+  onStageFilter: () => {},
+  onIterationFilter: () => {},
+  onStreamFilter: () => {},
+  onSearch: () => {},
+  onToggleAutoScroll: () => {},
+  autoScroll: true,
+  streamFilter: 'all',
+  stageIterations: {},
+  runStages: { plan: {}, implement: {} },
+};
+
+describe('log-viewer stream filter control', () => {
+  it('renders a segmented sl-radio-group, not a 3rd sl-select', () => {
+    const html = renderToString(logViewerView(BASE_STATE, BASE_OPTS));
+    expect(html).toContain('log-stream-filter');
+    expect(html).toContain('sl-radio-group');
+    expect(html).toContain('sl-radio-button');
+  });
+
+  it('offers all / stdout / stderr options', () => {
+    const html = renderToString(logViewerView(BASE_STATE, BASE_OPTS));
+    expect(html).toContain('value="all"');
+    expect(html).toContain('value="out"');
+    expect(html).toContain('value="err"');
+    expect(html).toContain('stdout');
+    expect(html).toContain('stderr');
+  });
+
+  it('places the stream filter after the iteration select and before search', () => {
+    const state = {
+      ...BASE_STATE,
+      currentLogIteration: 2,
+    };
+    const opts = { ...BASE_OPTS, stageIterations: { implement: 2 } };
+    const html = renderToString(logViewerView(state, opts));
+    const streamPos = html.indexOf('log-stream-filter');
+    const searchPos = html.indexOf('log-search');
+    expect(streamPos).toBeGreaterThan(-1);
+    expect(searchPos).toBeGreaterThan(streamPos);
+  });
+
+  it('renders without an explicit streamFilter (defaults work)', () => {
+    const opts = { ...BASE_OPTS };
+    opts.streamFilter = undefined;
+    const html = renderToString(logViewerView(BASE_STATE, opts));
+    expect(html).toContain('log-stream-filter');
+  });
+});

--- a/worca-ui/app/views/log-viewer.js
+++ b/worca-ui/app/views/log-viewer.js
@@ -1,6 +1,7 @@
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import {
+  AlertTriangle,
   ArrowDown,
   ClipboardCopy,
   Clock,
@@ -26,6 +27,12 @@ const STAGE_COLORS = [
 ];
 const RESET = '\x1b[0m';
 const DIM = '\x1b[2m';
+// stderr lines render in amber (#f59e0b — the "caution" color from
+// badge-color-language.md) with a 24-bit ANSI color so it stays legible on the
+// terminal's dark surface, plus a leading "err│" gutter so the signal survives
+// colorblindness (color-not-alone). 24-bit avoids depending on a theme palette.
+const ERR_COLOR = '\x1b[38;2;245;158;11m';
+const ERR_GUTTER = 'err│ ';
 
 const stageColorCache = new Map();
 let colorIdx = 0;
@@ -136,7 +143,12 @@ export function writeLogLine(entry) {
     ? `${stageColor(entry.stage)}[${entry.stage.toUpperCase()}]${RESET} `
     : '';
   const msg = entry.line || entry;
-  terminal.writeln(`${ts}${stage}${msg}`);
+  if (entry.stream === 'err') {
+    // Amber + "err│" gutter so stderr (e.g. 429/529 throttling) stands out.
+    terminal.writeln(`${ts}${stage}${ERR_COLOR}${ERR_GUTTER}${msg}${RESET}`);
+  } else {
+    terminal.writeln(`${ts}${stage}${msg}`);
+  }
 }
 
 export function clearTerminal() {
@@ -200,9 +212,11 @@ export function logViewerView(
   {
     onStageFilter,
     onIterationFilter,
+    onStreamFilter,
     onSearch,
     onToggleAutoScroll,
     autoScroll,
+    streamFilter,
     stageIterations,
     runStages,
   },
@@ -262,6 +276,18 @@ export function logViewerView(
             `
                 : nothing
             }
+            <sl-radio-group
+              class="log-stream-filter"
+              size="small"
+              .value=${streamFilter || 'all'}
+              @sl-change=${(e) => onStreamFilter(e.target.value)}
+            >
+              <sl-radio-button value="all">All</sl-radio-button>
+              <sl-radio-button value="out">stdout</sl-radio-button>
+              <sl-radio-button value="err">
+                ${unsafeHTML(iconSvg(AlertTriangle, 12))} stderr
+              </sl-radio-button>
+            </sl-radio-group>
             <sl-input
               class="log-search"
               type="text"

--- a/worca-ui/app/views/run-detail-api-retry.test.js
+++ b/worca-ui/app/views/run-detail-api-retry.test.js
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration } from '../utils/duration.js';
+import { _pipelineTimingBar, runDetailView } from './run-detail.js';
+
+function renderToString(template) {
+  if (!template) return '';
+  if (template.overview)
+    return renderToString(template.overview) + renderToString(template.stages);
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// 6d — pipeline timing bar: API Retry/Wait segment + toolsMs correction
+// ---------------------------------------------------------------------------
+
+describe('_pipelineTimingBar — API Retry/Wait segment (6d)', () => {
+  it('renders a striped retry segment when api_retry_wait_ms > 0', () => {
+    const iters = [
+      {
+        duration_api_ms: 2000,
+        duration_session_ms: 10000,
+        api_retry_wait_ms: 3000,
+      },
+    ];
+    const html = renderToString(_pipelineTimingBar(iters, 10000));
+    expect(html).toContain('timing-bar-retry');
+    expect(html).toContain('API Retry/Wait');
+  });
+
+  it('carves retry time out of tools (toolsMs reduced, not absorbed)', () => {
+    // session=10000, thinking=2000, retry=3000 → tools = 5000 (was 8000 pre-fix).
+    const withRetry = renderToString(
+      _pipelineTimingBar(
+        [
+          {
+            duration_api_ms: 2000,
+            duration_session_ms: 10000,
+            api_retry_wait_ms: 3000,
+          },
+        ],
+        10000,
+      ),
+    );
+    expect(withRetry).toContain(`${formatDuration(5000)} (50%)`); // Tools legend
+    expect(withRetry).toContain(`${formatDuration(3000)} (30%)`); // Retry legend
+    // Without the fix, Tools would show 8000ms — assert that is NOT present.
+    expect(withRetry).not.toContain(`${formatDuration(8000)} (80%)`);
+  });
+
+  it('renders byte-identically to a no-retry run when api_retry_wait_ms is 0', () => {
+    const iters = [
+      {
+        duration_api_ms: 2000,
+        duration_session_ms: 10000,
+        api_retry_wait_ms: 0,
+      },
+    ];
+    const noField = [{ duration_api_ms: 2000, duration_session_ms: 10000 }];
+    const withZero = renderToString(_pipelineTimingBar(iters, 10000));
+    const without = renderToString(_pipelineTimingBar(noField, 10000));
+    expect(withZero).toBe(without);
+    expect(withZero).not.toContain('timing-bar-retry');
+    expect(withZero).not.toContain('API Retry/Wait');
+    // Tools absorbs the full non-thinking session span (8000ms) when no retries.
+    expect(withZero).toContain(`${formatDuration(8000)} (80%)`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6b — per-iteration retry chip + Wait: row
+// ---------------------------------------------------------------------------
+
+function makeRun(iterOverrides) {
+  const iter = {
+    number: 1,
+    status: 'completed',
+    outcome: 'success',
+    started_at: '2026-06-15T00:00:00.000+00:00',
+    completed_at: '2026-06-15T00:10:00.000+00:00', // 600000ms wall
+    duration_api_ms: 120000,
+    ...iterOverrides,
+  };
+  return { stages: { implement: { status: 'completed', iterations: [iter] } } };
+}
+
+describe('runDetailView — iteration retry chip + Wait row (6b)', () => {
+  it('renders the ⟳ retry chip and Wait: row when the iteration throttled', () => {
+    const html = renderToString(
+      runDetailView(
+        makeRun({
+          api_retries: 3,
+          non_api_wait_ms: 300000,
+          api_error_status: 529,
+        }),
+      ),
+    );
+    expect(html).toContain('iter-retry-warn');
+    expect(html).toContain('3 retries');
+    // The 6b Wait row (distinct from the always-on 6c "API Retry/Wait:" tooltip).
+    expect(html).toContain('>Wait:</span>');
+    expect(html).toContain(formatDuration(300000)); // 5m 0s
+    // % of wall = 300000/600000 = 50%
+    expect(html).toContain('(50%)');
+    // api_error_status surfaced in the Wait tooltip.
+    expect(html).toContain('last API status 529');
+  });
+
+  it('uses singular "retry" for a single retry', () => {
+    const html = renderToString(
+      runDetailView(makeRun({ api_retries: 1, non_api_wait_ms: 1000 })),
+    );
+    expect(html).toContain('1 retry');
+    expect(html).not.toContain('1 retries');
+  });
+
+  it('omits the chip and Wait row entirely on a clean iteration', () => {
+    const html = renderToString(runDetailView(makeRun({})));
+    expect(html).not.toContain('iter-retry-warn');
+    // The per-iteration Wait row is gone; the always-on 6c Duration-tooltip
+    // "API Retry/Wait:" breakdown line is unrelated and may still appear.
+    expect(html).not.toContain('>Wait:</span>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6c — collapsed stage-header ⟳ N chip + Duration tooltip breakdown
+// ---------------------------------------------------------------------------
+
+function makeMultiIterRun(iters) {
+  return { stages: { implement: { status: 'completed', iterations: iters } } };
+}
+
+describe('runDetailView — stage-header retry chip + Duration tooltip (6c)', () => {
+  it('aggregates ⟳ N across iterations and renders the Duration breakdown', () => {
+    const base = {
+      status: 'completed',
+      outcome: 'success',
+      started_at: '2026-06-15T00:00:00.000+00:00',
+      completed_at: '2026-06-15T00:10:00.000+00:00', // 600000ms each
+      duration_api_ms: 120000,
+    };
+    const run = makeMultiIterRun([
+      { ...base, number: 1, api_retries: 2, api_retry_wait_ms: 90000 },
+      { ...base, number: 2, api_retries: 1, api_retry_wait_ms: 30000 },
+    ]);
+    const html = renderToString(runDetailView(run));
+    // stageRetries = 3 aggregate chip.
+    expect(html).toContain('iter-retry-warn');
+    // Duration tooltip breakdown lines.
+    expect(html).toContain('Thinking (API):');
+    expect(html).toContain('Tools:');
+    expect(html).toContain('API Retry/Wait:');
+    // stageRetryWaitMs = 90000 + 30000 = 120000.
+    expect(html).toContain(formatDuration(120000));
+    // stageMs = 1200000, stageApiMs = 240000, stageRetryWaitMs = 120000
+    // → stageToolsMs = 840000.
+    expect(html).toContain(formatDuration(840000));
+    expect(html).toContain('⟳ 3 retries');
+  });
+
+  it('omits the stage retry chip when no iteration throttled', () => {
+    const base = {
+      status: 'completed',
+      outcome: 'success',
+      started_at: '2026-06-15T00:00:00.000+00:00',
+      completed_at: '2026-06-15T00:10:00.000+00:00',
+      duration_api_ms: 120000,
+    };
+    const run = makeMultiIterRun([
+      { ...base, number: 1 },
+      { ...base, number: 2 },
+    ]);
+    const html = renderToString(runDetailView(run));
+    expect(html).not.toContain('iter-retry-warn');
+    expect(html).not.toContain('⟳');
+  });
+});

--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -354,7 +354,7 @@ export function formatPipelineTemplate(value) {
  * Segments: Thinking (Agent) | Tools (Agent) | Rest of Pipeline
  * 100% = pipeline wall time (started_at → last stage end).
  */
-function _pipelineTimingBar(allIters, pipelineWallMs) {
+export function _pipelineTimingBar(allIters, pipelineWallMs) {
   if (!pipelineWallMs || pipelineWallMs <= 0) return nothing;
 
   const thinkingMs = allIters.reduce(
@@ -367,14 +367,22 @@ function _pipelineTimingBar(allIters, pipelineWallMs) {
     if (it.duration_session_ms != null) return sum + it.duration_session_ms;
     return sum + (it.duration_ms || 0); // legacy fallback
   }, 0);
-  const toolsMs = Math.max(0, sessionMs - thinkingMs);
+  // Precise measured backoff-window span (W-074). The CLI's 429/529 backoff
+  // sleeps inside the session but outside duration_api_ms, so before this fix it
+  // was silently mis-bucketed into Tools — carve it out into its own segment.
+  const retryWaitMs = allIters.reduce(
+    (sum, it) => sum + (it.api_retry_wait_ms || 0),
+    0,
+  );
+  const toolsMs = Math.max(0, sessionMs - thinkingMs - retryWaitMs);
   const restMs = Math.max(0, pipelineWallMs - sessionMs);
 
   if (thinkingMs <= 0 && toolsMs <= 0) return nothing;
 
   const thinkingPct = Math.round((thinkingMs / pipelineWallMs) * 100);
   const toolsPct = Math.round((toolsMs / pipelineWallMs) * 100);
-  const restPct = Math.max(0, 100 - thinkingPct - toolsPct);
+  const retryPct = Math.round((retryWaitMs / pipelineWallMs) * 100);
+  const restPct = Math.max(0, 100 - thinkingPct - toolsPct - retryPct);
 
   const segments = [
     {
@@ -392,6 +400,14 @@ function _pipelineTimingBar(allIters, pipelineWallMs) {
       label: 'Tools (Agent)',
       desc: 'Time spent executing tools (bash, file I/O, subprocesses)',
       cls: 'timing-bar-tools',
+    },
+    {
+      key: 'retry',
+      pct: retryPct,
+      ms: retryWaitMs,
+      label: 'API Retry/Wait',
+      desc: 'Time stalled in CLI backoff after 429/529 throttling',
+      cls: 'timing-bar-retry',
     },
     {
       key: 'rest',
@@ -1517,6 +1533,11 @@ export function _stageToJson(key, stage, stageAgent, stageModel, promptData) {
       duration_ms: it.duration_ms || undefined,
       duration_session_ms: it.duration_session_ms || undefined,
       duration_api_ms: it.duration_api_ms || undefined,
+      api_retries: it.api_retries || undefined,
+      api_retry_wait_ms: it.api_retry_wait_ms || undefined,
+      non_api_wait_ms: it.non_api_wait_ms || undefined,
+      api_error_status:
+        it.api_error_status != null ? it.api_error_status : undefined,
       started_at: it.started_at || undefined,
       completed_at: it.completed_at || undefined,
       effort: it.effort || undefined,
@@ -1625,6 +1646,16 @@ function _iterationDetailView(
         ${_modelInfoView(model, iter.model_alias)}
         ${iter.turns ? html`<span class="stage-info-item"><span class="meta-label">Turns:</span> <span class="meta-value">${iter.turns}</span></span>` : nothing}
         ${iter.duration_api_ms ? html`<span class="stage-info-item"><span class="meta-label">API:</span> <span class="meta-value">${formatDuration(iter.duration_api_ms)}${iter.started_at && iter.completed_at ? ` (${Math.round((iter.duration_api_ms / elapsed(iter.started_at, iter.completed_at)) * 100)}%)` : ''}</span></span>` : nothing}
+        ${
+          iter.api_retries
+            ? html`<span class="stage-info-item iter-retry-warn">${unsafeHTML(iconSvg(RefreshCw, 12))} <span class="meta-value">${iter.api_retries} ${iter.api_retries === 1 ? 'retry' : 'retries'}</span></span>`
+            : nothing
+        }
+        ${
+          iter.non_api_wait_ms
+            ? html`<span class="stage-info-item"><sl-tooltip content="Wall time not generating tokens (tools + API retry/backoff)${iter.api_error_status ? ` · last API status ${iter.api_error_status}` : ''}"><span class="meta-label">Wait:</span> <span class="meta-value">${formatDuration(iter.non_api_wait_ms)}${iter.started_at && iter.completed_at ? ` (${Math.round((iter.non_api_wait_ms / elapsed(iter.started_at, iter.completed_at)) * 100)}%)` : ''}</span></sl-tooltip></span>`
+            : nothing
+        }
         ${iter.cost_usd != null ? html`<span class="stage-info-item"><span class="meta-label">Cost:</span> <span class="meta-value">$${Number(iter.cost_usd).toFixed(2)}</span></span>` : nothing}
         ${iterDur ? html`<span class="stage-info-item"><span class="meta-label">Duration:</span> <span class="meta-value">${iterDur}</span></span>` : nothing}
         ${iter.context_final_pct != null ? html`<span class="stage-info-item"><sl-tooltip content="Context consumed at completion"><span class="meta-label">Context:</span> <span class="meta-value">${iter.context_final_pct}%</span></sl-tooltip></span>` : nothing}
@@ -2165,6 +2196,29 @@ export function runDetailView(run, settings = {}, options = {}) {
           const iterations = stage.iterations || [];
           const hasMultipleIterations = iterations.length > 1;
           const stageCost = _stageCost(iterations);
+          // W-074 stage-level retry aggregates for the summary chip + Duration
+          // tooltip. stageToolsMs mirrors the timing bar's bucketing so the
+          // breakdown (Thinking/Tools/Retry-Wait) is traceable and adds up.
+          const stageRetries = iterations.reduce(
+            (s, it) => s + (it.api_retries || 0),
+            0,
+          );
+          const stageSummaryApiMs = iterations.reduce(
+            (s, it) => s + (it.duration_api_ms || 0),
+            0,
+          );
+          const stageRetryWaitMs = iterations.reduce(
+            (s, it) => s + (it.api_retry_wait_ms || 0),
+            0,
+          );
+          const stageSummaryApiPct =
+            stageMs > 0 && stageSummaryApiMs > 0
+              ? Math.round((stageSummaryApiMs / stageMs) * 100)
+              : 0;
+          const stageToolsMs = Math.max(
+            0,
+            stageMs - stageSummaryApiMs - stageRetryWaitMs,
+          );
 
           return html`
             <sl-details ?open=${stageStatus === 'in_progress'} class="stage-panel"
@@ -2230,11 +2284,31 @@ export function runDetailView(run, settings = {}, options = {}) {
                       : nothing
                   }
                   ${
+                    stageRetries > 0
+                      ? html`
+                    <sl-tooltip content="API retries: ${stageRetries} (throttled / backing off after 429/529)">
+                      <span class="stage-meta-item iter-retry-warn" aria-label="${stageRetries} API ${stageRetries === 1 ? 'retry' : 'retries'}">
+                        <span class="stage-meta-icon">${unsafeHTML(iconSvg(RefreshCw, 11))}</span>
+                        <span class="meta-value">${stageRetries}</span>
+                      </span>
+                    </sl-tooltip>
+                  `
+                      : nothing
+                  }
+                  ${
                     stageDuration
                       ? html`
                     <span class="stage-meta-item">
                       <span class="stage-meta-icon">${unsafeHTML(iconSvg(Timer, 11))}</span>
-                      <span class="meta-value">${stageDuration}</span>
+                      <sl-tooltip hoist placement="bottom" distance="4">
+                        <div slot="content">
+                          <strong>Duration ${stageDuration}</strong><br>
+                          Thinking (API): ${formatDuration(stageSummaryApiMs)} (${stageSummaryApiPct}%)<br>
+                          Tools: ${formatDuration(stageToolsMs)}<br>
+                          API Retry/Wait: ${formatDuration(stageRetryWaitMs)}${stageRetries > 0 ? html` · ⟳ ${stageRetries} ${stageRetries === 1 ? 'retry' : 'retries'}` : nothing}
+                        </div>
+                        <span class="meta-value">${stageDuration}</span>
+                      </sl-tooltip>
                     </span>
                   `
                       : nothing
@@ -2335,6 +2409,8 @@ export function runDetailView(run, settings = {}, options = {}) {
                         ${_modelInfoView(stageModel, stage.model_alias)}
                         ${iterations.length === 1 && iterations[0].turns ? html`<span class="stage-info-item"><span class="meta-label">Turns:</span> <span class="meta-value">${iterations[0].turns}</span></span>` : nothing}
                         ${iterations.length === 1 && iterations[0].duration_api_ms ? html`<span class="stage-info-item"><span class="meta-label">API:</span> <span class="meta-value">${formatDuration(iterations[0].duration_api_ms)}${stageMs > 0 ? ` (${Math.round((iterations[0].duration_api_ms / stageMs) * 100)}%)` : ''}</span></span>` : nothing}
+                        ${iterations.length === 1 && iterations[0].api_retries ? html`<span class="stage-info-item iter-retry-warn">${unsafeHTML(iconSvg(RefreshCw, 12))} <span class="meta-value">${iterations[0].api_retries} ${iterations[0].api_retries === 1 ? 'retry' : 'retries'}</span></span>` : nothing}
+                        ${iterations.length === 1 && iterations[0].non_api_wait_ms ? html`<span class="stage-info-item"><sl-tooltip content="Wall time not generating tokens (tools + API retry/backoff)${iterations[0].api_error_status ? ` · last API status ${iterations[0].api_error_status}` : ''}"><span class="meta-label">Wait:</span> <span class="meta-value">${formatDuration(iterations[0].non_api_wait_ms)}${stageMs > 0 ? ` (${Math.round((iterations[0].non_api_wait_ms / stageMs) * 100)}%)` : ''}</span></sl-tooltip></span>` : nothing}
                         ${iterations.length === 1 && iterations[0].cost_usd != null ? html`<span class="stage-info-item"><span class="meta-label">Cost:</span> <span class="meta-value">$${Number(iterations[0].cost_usd).toFixed(2)}</span></span>` : nothing}
                         ${iterations.length === 1 && iterations[0].context_final_pct != null ? html`<span class="stage-info-item"><sl-tooltip content="Context consumed at completion"><span class="meta-label">Context:</span> <span class="meta-value">${iterations[0].context_final_pct}%</span></sl-tooltip></span>` : nothing}
                       </div>

--- a/worca-ui/e2e/log-viewer-stream-filter.spec.js
+++ b/worca-ui/e2e/log-viewer-stream-filter.spec.js
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { startServer, seedRun } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+// W-074 §6a: the log viewer tags each persisted line by origin stream
+// (out/err), colors err lines, and offers a 3-way client-side stream filter.
+function seedRunWithStreamTaggedLog(worcaDir, runId) {
+  const runDir = join(worcaDir, 'runs', runId);
+  seedRun(worcaDir, runId, {
+    pipeline_status: 'completed',
+    stage: 'implement',
+    stages: {
+      implement: {
+        status: 'completed',
+        iterations: [{ number: 1, status: 'completed' }],
+      },
+    },
+  });
+  const stageDir = join(runDir, 'logs', 'implement');
+  mkdirSync(stageDir, { recursive: true });
+  // Canonical <ts>\t<stream>\t<text> lines: one stdout, one stderr.
+  writeFileSync(
+    join(stageDir, 'iter-1.log'),
+    [
+      '2026-06-14T12:00:00.000+00:00\tout\tBuilding feature OUTMARKER',
+      '2026-06-14T12:00:01.000+00:00\terr\tOverloaded 529 ERRMARKER',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+}
+
+async function selectImplementStage(page) {
+  // Open the collapsed "Log History" panel.
+  await page.locator('.log-history-header').click();
+  // Drive the stage sl-select (selecting a stage subscribes + backfills).
+  await page
+    .locator('.log-controls sl-select')
+    .first()
+    .evaluate((el) => {
+      el.value = 'implement';
+      el.dispatchEvent(new CustomEvent('sl-change', { bubbles: true }));
+    });
+  await expect(page.locator('.log-terminal .xterm-rows')).toBeVisible({
+    timeout: 8000,
+  });
+}
+
+test.describe('log viewer stream filter (W-074)', () => {
+  test('3-way filter toggles visible lines; err line carries the gutter', async ({
+    page,
+  }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-stream-filter';
+      seedRunWithStreamTaggedLog(ctx.worcaDir, runId);
+
+      await page.goto(`${ctx.url}/#/history?run=${runId}`, GOTO_OPTS);
+      await expect(page.locator('.run-detail .stage-panels')).toBeVisible({
+        timeout: 8000,
+      });
+
+      await selectImplementStage(page);
+
+      const rows = page.locator('.log-terminal .xterm-rows');
+
+      // Default 'all' — both streams visible; err line shows the gutter marker.
+      await expect(rows).toContainText('OUTMARKER', { timeout: 8000 });
+      await expect(rows).toContainText('ERRMARKER');
+      await expect(rows).toContainText('err│');
+
+      // The segmented control is an sl-radio-group, not a 3rd dropdown.
+      const filter = page.locator('.log-controls .log-stream-filter');
+      await expect(filter).toHaveCount(1);
+      await expect(filter.locator('sl-radio-button')).toHaveCount(3);
+
+      // Filter to stderr only — stdout line drops out of the replay.
+      await filter.locator('sl-radio-button[value="err"]').click();
+      await expect(rows).toContainText('ERRMARKER', { timeout: 8000 });
+      await expect(rows).not.toContainText('OUTMARKER');
+
+      // Filter to stdout only — stderr line drops out.
+      await filter.locator('sl-radio-button[value="out"]').click();
+      await expect(rows).toContainText('OUTMARKER', { timeout: 8000 });
+      await expect(rows).not.toContainText('ERRMARKER');
+
+      // Back to all — both return without any refetch.
+      await filter.locator('sl-radio-button[value="all"]').click();
+      await expect(rows).toContainText('OUTMARKER', { timeout: 8000 });
+      await expect(rows).toContainText('ERRMARKER');
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/e2e/run-detail-api-retry.spec.js
+++ b/worca-ui/e2e/run-detail-api-retry.spec.js
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test';
+import { seedRun, startServer } from './fixtures.js';
+
+const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
+
+test.describe('run-detail API-retry signal (W-074)', () => {
+  test('renders the timing-bar retry segment and the stage-header ⟳ N chip', async ({
+    page,
+  }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-api-retry-present';
+      seedRun(ctx.worcaDir, runId, {
+        pipeline_status: 'completed',
+        stage: 'implement',
+        started_at: '2026-01-01T00:00:00.000+00:00',
+        stages: {
+          implement: {
+            status: 'completed',
+            agent: 'implementer',
+            model: 'sonnet',
+            started_at: '2026-01-01T00:00:00.000+00:00',
+            completed_at: '2026-01-01T00:10:00.000+00:00',
+            iterations: [
+              {
+                number: 1,
+                status: 'completed',
+                agent: 'implementer',
+                model: 'sonnet',
+                started_at: '2026-01-01T00:00:00.000+00:00',
+                completed_at: '2026-01-01T00:10:00.000+00:00',
+                duration_api_ms: 120000,
+                duration_session_ms: 480000,
+                api_retries: 3,
+                api_retry_wait_ms: 180000,
+                non_api_wait_ms: 300000,
+                api_error_status: 529,
+              },
+            ],
+          },
+        },
+      });
+
+      await page.goto(`${ctx.url}/#/history?run=${runId}`, GOTO_OPTS);
+      await expect(page.locator('.run-detail .stage-panels')).toBeVisible({
+        timeout: 8000,
+      });
+
+      // 6d — the striped API Retry/Wait segment is always-on (no hover).
+      await expect(page.locator('.timing-bar-retry').first()).toBeVisible({
+        timeout: 5000,
+      });
+
+      // 6c — the collapsed stage header shows the ⟳ N chip without expanding.
+      const implementPanel = page
+        .locator('.stage-panel', {
+          has: page.locator('.stage-panel-label', { hasText: 'IMPLEMENT' }),
+        })
+        .first();
+      const retryChip = implementPanel
+        .locator('.stage-panel-meta .iter-retry-warn')
+        .first();
+      await expect(retryChip).toBeVisible();
+      await expect(retryChip).toContainText('3');
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test('a zero-retry run renders no retry segment and no stage retry chip', async ({
+    page,
+  }) => {
+    const ctx = await startServer();
+    try {
+      const runId = '20260101-api-retry-absent';
+      seedRun(ctx.worcaDir, runId, {
+        pipeline_status: 'completed',
+        stage: 'implement',
+        started_at: '2026-01-01T00:00:00.000+00:00',
+        stages: {
+          implement: {
+            status: 'completed',
+            agent: 'implementer',
+            model: 'sonnet',
+            started_at: '2026-01-01T00:00:00.000+00:00',
+            completed_at: '2026-01-01T00:10:00.000+00:00',
+            iterations: [
+              {
+                number: 1,
+                status: 'completed',
+                agent: 'implementer',
+                model: 'sonnet',
+                started_at: '2026-01-01T00:00:00.000+00:00',
+                completed_at: '2026-01-01T00:10:00.000+00:00',
+                duration_api_ms: 120000,
+                duration_session_ms: 480000,
+              },
+            ],
+          },
+        },
+      });
+
+      await page.goto(`${ctx.url}/#/history?run=${runId}`, GOTO_OPTS);
+      await expect(page.locator('.run-detail .stage-panels')).toBeVisible({
+        timeout: 8000,
+      });
+
+      await expect(page.locator('.timing-bar-retry')).toHaveCount(0);
+      const implementPanel = page
+        .locator('.stage-panel', {
+          has: page.locator('.stage-panel-label', { hasText: 'IMPLEMENT' }),
+        })
+        .first();
+      await expect(
+        implementPanel.locator('.stage-panel-meta .iter-retry-warn'),
+      ).toHaveCount(0);
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/worca-ui/server/log-tailer.js
+++ b/worca-ui/server/log-tailer.js
@@ -14,49 +14,65 @@ import { STAGE_ORDER_WITH_ORCHESTRATOR } from '../app/utils/stage-order.js';
 export const STAGE_ORDER = STAGE_ORDER_WITH_ORCHESTRATOR;
 
 /**
- * Matches a persisted log record's `ISO-8601<TAB>message` prefix.
- * Group 1 = the ISO timestamp, group 2 = the message body (which may itself
- * contain tabs — we only split on the first TAB).
+ * Matches a persisted log record's `ISO-8601<TAB>rest` prefix.
+ * Group 1 = the ISO timestamp, group 2 = everything after the first TAB (which
+ * itself may begin with a `<stream>\t` token and may contain further tabs).
  */
 const LOG_TS_RE =
   /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))\t([\s\S]*)$/;
 
 /**
- * Split a raw log line into its write-time and message.
+ * Matches the optional origin-stream token in column 2: `out\t…` or `err\t…`.
+ * The token is a fixed two-value enum, so a legacy message that merely happens
+ * to start with other text is never mistaken for a stream tag.
+ */
+const STREAM_RE = /^(out|err)\t([\s\S]*)$/;
+
+/**
+ * Split a raw log line into its write-time, origin stream, and message.
  *
- * New-format lines (written by `_write_log_line` in claude_cli.py) carry an
- * ISO-8601 timestamp prefix. Legacy lines (written before this format existed)
- * have none — they return `{ ts: null, text: <raw line> }` so the UI can render
- * them with an "unknown time" placeholder rather than a misleading current time.
+ * Canonical lines (written by `write_log_line` in log_lines.py) carry an
+ * ISO-8601 timestamp and a `<stream>` token: `<ts>\t<stream>\t<text>`.
+ * Legacy two-column lines (`<ts>\t<text>`) and untagged lines (no prefix at
+ * all — e.g. old logs, some `orchestrator.log` records) default to
+ * `stream: "out"`. Lines with no timestamp prefix return `ts: null` so the UI
+ * renders an "unknown time" placeholder rather than a misleading current time.
  *
  * @param {string} raw
- * @returns {{ ts: string|null, text: string }}
+ * @returns {{ ts: string|null, stream: string, text: string }}
  */
 export function parseLogLine(raw) {
   const m = LOG_TS_RE.exec(raw);
   if (m && Number.isFinite(Date.parse(m[1]))) {
-    return { ts: m[1], text: m[2] };
+    const sm = STREAM_RE.exec(m[2]);
+    if (sm) {
+      return { ts: m[1], stream: sm[1], text: sm[2] };
+    }
+    // Legacy two-column line — no recognized stream token → "out".
+    return { ts: m[1], stream: 'out', text: m[2] };
   }
-  return { ts: null, text: raw };
+  return { ts: null, stream: 'out', text: raw };
 }
 
 /**
- * Parse an array of raw log lines into parallel `lines` (message text) and
- * `timestamps` (ISO string or null) arrays, the shape the `log-bulk` WS payload
- * carries to the client.
+ * Parse an array of raw log lines into parallel `lines` (message text),
+ * `timestamps` (ISO string or null), and `streams` (`"out"`/`"err"`) arrays —
+ * the shape the `log-bulk` WS payload carries to the client.
  *
  * @param {string[]} rawLines
- * @returns {{ lines: string[], timestamps: (string|null)[] }}
+ * @returns {{ lines: string[], timestamps: (string|null)[], streams: string[] }}
  */
 export function splitTimestamps(rawLines) {
   const lines = [];
   const timestamps = [];
+  const streams = [];
   for (const raw of rawLines) {
-    const { ts, text } = parseLogLine(raw);
+    const { ts, stream, text } = parseLogLine(raw);
     lines.push(text);
     timestamps.push(ts);
+    streams.push(stream);
   }
-  return { lines, timestamps };
+  return { lines, timestamps, streams };
 }
 
 export function resolveLogPath(worcaDir, stage, iteration = null) {

--- a/worca-ui/server/log-tailer.test.js
+++ b/worca-ui/server/log-tailer.test.js
@@ -118,29 +118,63 @@ describe('log-tailer', () => {
 });
 
 describe('parseLogLine', () => {
-  it('splits a new-format line into timestamp and message', () => {
-    const { ts, text } = parseLogLine(
+  it('splits a legacy two-column line into timestamp + message, stream=out', () => {
+    const { ts, stream, text } = parseLogLine(
       '2026-06-14T12:00:00.000+00:00\t[tool:Read] foo.py',
     );
     expect(ts).toBe('2026-06-14T12:00:00.000+00:00');
+    // No recognized stream token in column 2 → defaults to "out".
+    expect(stream).toBe('out');
     expect(text).toBe('[tool:Read] foo.py');
   });
 
+  it('splits a tagged out line into ts, stream=out, text', () => {
+    const { ts, stream, text } = parseLogLine(
+      '2026-06-14T12:00:00.000+00:00\tout\t[done] ok',
+    );
+    expect(ts).toBe('2026-06-14T12:00:00.000+00:00');
+    expect(stream).toBe('out');
+    expect(text).toBe('[done] ok');
+  });
+
+  it('splits a tagged err line into ts, stream=err, text', () => {
+    const { ts, stream, text } = parseLogLine(
+      '2026-06-14T12:00:00.000+00:00\terr\tOverloaded, retrying in 4s',
+    );
+    expect(ts).toBe('2026-06-14T12:00:00.000+00:00');
+    expect(stream).toBe('err');
+    expect(text).toBe('Overloaded, retrying in 4s');
+  });
+
   it('accepts a Z-suffixed (UTC) timestamp', () => {
-    const { ts, text } = parseLogLine('2026-06-14T12:00:00Z\thello');
+    const { ts, stream, text } = parseLogLine('2026-06-14T12:00:00Z\thello');
     expect(ts).toBe('2026-06-14T12:00:00Z');
+    expect(stream).toBe('out');
     expect(text).toBe('hello');
   });
 
-  it('only splits on the first tab — tabs inside the message survive', () => {
-    const { ts, text } = parseLogLine('2026-06-14T12:00:00.000+00:00\ta\tb\tc');
+  it('only splits off ts + stream — tabs inside the message survive', () => {
+    const { ts, stream, text } = parseLogLine(
+      '2026-06-14T12:00:00.000+00:00\terr\ta\tb\tc',
+    );
     expect(ts).toBe('2026-06-14T12:00:00.000+00:00');
+    expect(stream).toBe('err');
     expect(text).toBe('a\tb\tc');
   });
 
-  it('treats a legacy line (no prefix) as ts=null, text=raw', () => {
-    const { ts, text } = parseLogLine('[init] model=opus');
+  it('a tagless message whose body has tabs keeps them, stream=out', () => {
+    const { ts, stream, text } = parseLogLine(
+      '2026-06-14T12:00:00.000+00:00\ta\tb\tc',
+    );
+    expect(ts).toBe('2026-06-14T12:00:00.000+00:00');
+    expect(stream).toBe('out');
+    expect(text).toBe('a\tb\tc');
+  });
+
+  it('treats a legacy line (no prefix) as ts=null, stream=out, text=raw', () => {
+    const { ts, stream, text } = parseLogLine('[init] model=opus');
     expect(ts).toBeNull();
+    expect(stream).toBe('out');
     expect(text).toBe('[init] model=opus');
   });
 
@@ -159,22 +193,30 @@ describe('parseLogLine', () => {
 });
 
 describe('splitTimestamps', () => {
-  it('returns parallel lines + timestamps arrays', () => {
-    const { lines, timestamps } = splitTimestamps([
-      '2026-06-14T12:00:00.000+00:00\tone',
+  it('returns parallel lines + timestamps + streams arrays', () => {
+    const { lines, timestamps, streams } = splitTimestamps([
+      '2026-06-14T12:00:00.000+00:00\tout\tone',
       'legacy two',
-      '2026-06-14T12:00:01.000+00:00\tthree',
+      '2026-06-14T12:00:01.000+00:00\terr\tthree',
+      '2026-06-14T12:00:02.000+00:00\tlegacy-untagged',
     ]);
-    expect(lines).toEqual(['one', 'legacy two', 'three']);
+    expect(lines).toEqual(['one', 'legacy two', 'three', 'legacy-untagged']);
     expect(timestamps).toEqual([
       '2026-06-14T12:00:00.000+00:00',
       null,
       '2026-06-14T12:00:01.000+00:00',
+      '2026-06-14T12:00:02.000+00:00',
     ]);
+    // Mixed file: tagged out/err preserved; legacy + untagged default to "out".
+    expect(streams).toEqual(['out', 'out', 'err', 'out']);
   });
 
   it('handles an empty input', () => {
-    expect(splitTimestamps([])).toEqual({ lines: [], timestamps: [] });
+    expect(splitTimestamps([])).toEqual({
+      lines: [],
+      timestamps: [],
+      streams: [],
+    });
   });
 });
 

--- a/worca-ui/server/ws-log-watcher.js
+++ b/worca-ui/server/ws-log-watcher.js
@@ -83,7 +83,7 @@ export function createLogWatcher({
             if (newLines.length > 0) {
               logByteOffsets.set(key, newOffset);
               for (const raw of newLines) {
-                const { ts, text } = parseLogLine(raw);
+                const { ts, stream, text } = parseLogLine(raw);
                 broadcaster.broadcastToLogSubscribers(
                   stage,
                   'log-line',
@@ -91,6 +91,8 @@ export function createLogWatcher({
                     stage: stage || 'orchestrator',
                     iteration: iteration ?? undefined,
                     line: text,
+                    // Origin stream ("out"/"err"); legacy/untagged → "out".
+                    stream,
                     // New-format lines carry their write-time; legacy lines have
                     // none, so fall back to receive-time (≈ write-time for a
                     // line arriving from a live, actively-running stage).
@@ -216,7 +218,7 @@ export function createLogWatcher({
           for (const f of files) {
             const iterNum = parseInt(f.match(/\d+/)[0], 10);
             if (iteration != null && iterNum !== iteration) continue;
-            const { lines, timestamps } = splitTimestamps(
+            const { lines, timestamps, streams } = splitTimestamps(
               readLastLines(join(stageDir, f), 200),
             );
             if (lines.length > 0) {
@@ -225,14 +227,20 @@ export function createLogWatcher({
                   id: `evt-${Date.now()}-iter${iterNum}`,
                   ok: true,
                   type: 'log-bulk',
-                  payload: { stage, iteration: iterNum, lines, timestamps },
+                  payload: {
+                    stage,
+                    iteration: iterNum,
+                    lines,
+                    timestamps,
+                    streams,
+                  },
                 }),
               );
             }
           }
         } else {
           const logPath = join(archivedLogDir, `${stage}.log`);
-          const { lines, timestamps } = splitTimestamps(
+          const { lines, timestamps, streams } = splitTimestamps(
             readLastLines(logPath, 200),
           );
           if (lines.length > 0) {
@@ -241,7 +249,7 @@ export function createLogWatcher({
                 id: `evt-${Date.now()}`,
                 ok: true,
                 type: 'log-bulk',
-                payload: { stage, lines, timestamps },
+                payload: { stage, lines, timestamps, streams },
               }),
             );
           }
@@ -251,7 +259,7 @@ export function createLogWatcher({
         for (const entry of entries) {
           if (entry.isFile() && entry.name.endsWith('.log')) {
             const s2 = entry.name.replace('.log', '');
-            const { lines, timestamps } = splitTimestamps(
+            const { lines, timestamps, streams } = splitTimestamps(
               readLastLines(join(archivedLogDir, entry.name), 200),
             );
             if (lines.length > 0) {
@@ -260,7 +268,7 @@ export function createLogWatcher({
                   id: `evt-${Date.now()}-${s2}`,
                   ok: true,
                   type: 'log-bulk',
-                  payload: { stage: s2, lines, timestamps },
+                  payload: { stage: s2, lines, timestamps, streams },
                 }),
               );
             }
@@ -275,7 +283,7 @@ export function createLogWatcher({
               );
             for (const f of iterFiles) {
               const iterNum = parseInt(f.match(/\d+/)[0], 10);
-              const { lines, timestamps } = splitTimestamps(
+              const { lines, timestamps, streams } = splitTimestamps(
                 readLastLines(join(stageDir2, f), 200),
               );
               if (lines.length > 0) {
@@ -289,6 +297,7 @@ export function createLogWatcher({
                       iteration: iterNum,
                       lines,
                       timestamps,
+                      streams,
                     },
                   }),
                 );

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -391,7 +391,7 @@ export function createMessageRouter({
       if (stage) {
         if (iteration != null) {
           const logPath = resolveIterationLogPath(logsBase, stage, iteration);
-          const { lines, timestamps } = splitTimestamps(
+          const { lines, timestamps, streams } = splitTimestamps(
             readLastLines(logPath, 200),
           );
           if (lines.length > 0) {
@@ -400,7 +400,7 @@ export function createMessageRouter({
                 id: `evt-${Date.now()}`,
                 ok: true,
                 type: 'log-bulk',
-                payload: { stage, iteration, lines, timestamps },
+                payload: { stage, iteration, lines, timestamps, streams },
               }),
             );
           }
@@ -409,7 +409,7 @@ export function createMessageRouter({
           if (existsSync(stageDir) && statSync(stageDir).isDirectory()) {
             const iters = listIterationFiles(logsBase, stage);
             for (const { iteration: iterNum, path } of iters) {
-              const { lines, timestamps } = splitTimestamps(
+              const { lines, timestamps, streams } = splitTimestamps(
                 readLastLines(path, 200),
               );
               if (lines.length > 0) {
@@ -418,14 +418,20 @@ export function createMessageRouter({
                     id: `evt-${Date.now()}-iter${iterNum}`,
                     ok: true,
                     type: 'log-bulk',
-                    payload: { stage, iteration: iterNum, lines, timestamps },
+                    payload: {
+                      stage,
+                      iteration: iterNum,
+                      lines,
+                      timestamps,
+                      streams,
+                    },
                   }),
                 );
               }
             }
           } else {
             const logPath = join(logsBase, 'logs', `${stage}.log`);
-            const { lines, timestamps } = splitTimestamps(
+            const { lines, timestamps, streams } = splitTimestamps(
               readLastLines(logPath, 200),
             );
             if (lines.length > 0) {
@@ -434,7 +440,7 @@ export function createMessageRouter({
                   id: `evt-${Date.now()}`,
                   ok: true,
                   type: 'log-bulk',
-                  payload: { stage, lines, timestamps },
+                  payload: { stage, lines, timestamps, streams },
                 }),
               );
             }
@@ -446,7 +452,7 @@ export function createMessageRouter({
       } else {
         const logFiles = listLogFiles(logsBase);
         for (const { stage: s2, iteration: iterNum, path } of logFiles) {
-          const { lines, timestamps } = splitTimestamps(
+          const { lines, timestamps, streams } = splitTimestamps(
             readLastLines(path, 200),
           );
           if (lines.length > 0) {
@@ -460,6 +466,7 @@ export function createMessageRouter({
                   iteration: iterNum ?? undefined,
                   lines,
                   timestamps,
+                  streams,
                 },
               }),
             );


### PR DESCRIPTION
## Summary

Makes Claude CLI API throttling visible. When the CLI hits HTTP 429/529 ("overloaded") it retries **internally** with backoff and emits nothing on its stdout stream-json channel — the stream goes silent until a retry succeeds. worca's `process_stream` only parsed `system/init`, `assistant`, and `result` stdout events, so multi-minute backoff windows were invisible (no event, no log line, no counter), and `_tee_stderr` echoed the CLI's stderr retry diagnostics to the console without persisting or parsing them.

Concrete impact (run `20260615-090105-889-fd6cf15c`, implement iter 2): `duration_ms=3979583` (66 min wall) vs `duration_api_ms=1108832` (18.5 min in-API) over 172 turns — ~48 min (72%) spent *not* generating, including two ~16–18 min windows of total event silence. From the UI the run looked hung when it was actually backing off.

Resolves W-074 (#332). Plan: [docs/plans/W-074-api-throttling-retry-signal.md](https://github.com/SinishaDjukic/worca-cc/blob/master/docs/plans/W-074-api-throttling-retry-signal.md).

## Capture

- **Stream-tagged log lines** — new format `<ts>\t<stream>\t<text>`, `stream ∈ {out, err}` (legacy untagged → `out`). The tag is the spine for the persisted err stream + UI filter.
- **Persist all stderr** (not just matches) into the existing per-iteration log, tagged `err`, stamped with worca receive-time; console echo kept. The now-shared `log_file` handle (in `log_lines.py`) is guarded with a lock since `process_stream` (main thread) and `_tee_stderr` (daemon) both write it.
- **Retry parsing** — stderr is scanned in the tee thread for retry/overload vocabulary → thread-safe `api_retries` count + new `pipeline.agent.api_retry` event. The aggregate **backoff-window span** `api_retry_wait_ms` is measured: the tee stamps `pending_since` on the first retry line of a burst; `process_stream` closes the window on its next stdout event.
- **Per-iteration record** — `api_retries`, `api_retry_wait_ms`, `api_error_status`, and a coarse `non_api_wait_ms` (= wall − api) land in `status.json` token_usage and on the iteration view-model.

## UI — four surfaces (all degrade to today's render at zero retries)

- **6a** log viewer: err-line coloring (amber + `err│` gutter, light/dark safe) + a 3-way `sl-radio-button` stream filter (`all` default / `out` / `err`), filtered client-side from the in-memory buffer.
- **6b** per-iteration row: a `⟳ N retries` chip + a `Wait:` time/% item in the iteration `.stage-info-strip`.
- **6c** collapsed stage header: an at-a-glance `⟳ N` meta item + a Duration `sl-tooltip hoist` with the across-iterations thinking-vs-wait breakdown.
- **6d** pipeline timing bar: a dedicated striped **API Retry/Wait** segment carved from `toolsMs` via `api_retry_wait_ms` — which also corrects a prior misattribution (CLI backoff sleeps inside the session but outside `duration_api_ms`, so it silently inflated the "Tools (Agent)" segment).

## Design notes

- **FD-level merge rejected** (`stderr=subprocess.STDOUT`): stdout is load-bearing NDJSON, `result` events exceed `PIPE_BUF` and would be corruptible by mid-line stderr interleaving. Tagging happens at the application layer instead.
- **Two wait signals, deliberately:** `api_retry_wait_ms` is the *precise* measured backoff span (drives the timing-bar segment); `non_api_wait_ms` is the *coarse* wall−api delta that also folds in tool/test execution (drives the per-iteration `Wait:` row, labeled "tools + retry"). Bar geometry is never drawn from the coarse number.
- No envelope `schema_version` bump (new event type is additive); no migration (old logs render all-`out`).
- **Out of scope:** per-attempt sequencing / individual backoff durations (we measure the *aggregate* window); a cross-run throttling dashboard (per-run capture only).

## Test plan

- Python: `tests/test_claude_cli.py`, `tests/test_log_lines.py`, `tests/test_token_usage.py`, `tests/test_event_types.py`, integration `tests/integration/test_api_retry_signal.py` (mock_claude emits retry stderr).
- UI: vitest `log-viewer-stream-filter.test.js`, `run-detail-api-retry.test.js`, `main-log-line-handler.test.js`, `log-tailer.test.js`; Playwright `log-viewer-stream-filter.spec.js`, `run-detail-api-retry.spec.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
