### PR TITLE
fix(settings): read user-tier settings.local.json in model resolution

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -997,6 +997,14 @@ No `worca init --upgrade` migration required — the wizard writes the same sett
 
 `worca init` and `worca init --upgrade` now write a `.claude/worca/provenance.json` manifest that records the worca version and how the runtime copy was sourced (git checkout or pip install). Each pipeline run stamps this block into `status.json` and the `pipeline.run.started` event, and displays it as a **Runtime:** row in the Preflight UI panel.
 
+### 0.57.x → 0.58.0 — user-tier `settings.local.json` now read by model resolution (bug fix)
+
+The user-global tier now deep-merges `~/.worca/settings.local.json` everywhere, matching how the project tier and the public `load_global_settings` API already behaved. Previously `load_settings_with_global_fallback` read `~/.worca/settings.json` with a raw `json.load` that skipped the `.local` sibling, so user-tier model `env` blocks (alt-endpoint base URLs, auth tokens) stored there were silently dropped from both the merged config and the `user:` tier-pin views.
+
+**Symptom this fixes.** `worca templates import --scope user` of an alt-endpoint alias writes the `env` (secrets) to `~/.worca/settings.local.json` and auto-pins the template's refs to `user:<alias>` — but the resolver never saw that env, so every agent ran against the default Anthropic endpoint instead of the routed one (the `[init] model=` line showed the builtin model, not the alias target).
+
+**Action required only if** you have a user-tier model alias whose `env` (routing/secrets) lives outside `~/.worca/settings.local.json` — e.g. the `id` in `~/.worca/settings.json` but the `env` only in a *project's* `settings.local.json`. For `user:<alias>` refs to route correctly, the `env` block must live in `~/.worca/settings.local.json`. Move it there (or re-run `worca templates import --scope user`, which now writes it to the right place). No `worca init --upgrade` migration is needed — this is a resolver fix; the on-disk file shape is unchanged.
+
 **No breaking changes.** Existing runs and integrations are unaffected. Projects that have not yet run `worca init --upgrade` will show a degraded provenance block (version only, `runtime_source: null`) until the manifest is written.
 
 Run `worca init --upgrade` in each project to populate the manifest and enable full provenance display.

--- a/src/worca/utils/settings.py
+++ b/src/worca/utils/settings.py
@@ -186,9 +186,18 @@ def load_settings_with_global_fallback(
     if global_path is None:
         global_path = _default_global_path()
 
+    # Probe the committed global file first so a malformed-JSON warning is still
+    # emitted for it; then read through load_global_settings so the sibling
+    # ~/.worca/settings.local.json is deep-merged in. The .local merge mirrors
+    # how the project tier (load_settings) and the public load_global_settings
+    # API already treat .local. Without it, user-tier model `env` blocks were
+    # unreachable: `worca templates import --scope user` of an alt-endpoint alias
+    # writes the env (secrets) to ~/.worca/settings.local.json, but a raw
+    # json.load of ~/.worca/settings.json never saw it — so both the merged
+    # config below and the `user` tier-view stash silently dropped the env.
     try:
         with open(global_path, encoding="utf-8") as f:
-            global_blob = json.load(f)
+            json.load(f)
     except FileNotFoundError:
         global_blob = {}
     except json.JSONDecodeError:
@@ -197,6 +206,8 @@ def load_settings_with_global_fallback(
             file=sys.stderr,
         )
         global_blob = {}
+    else:
+        global_blob = load_global_settings(global_path=global_path)
 
     project = load_settings(settings_path)
     if not global_blob:

--- a/tests/test_settings_global_fallback.py
+++ b/tests/test_settings_global_fallback.py
@@ -192,6 +192,110 @@ class TestLoadSettingsWithGlobalFallback:
         assert views["project"]["fast"] == "claude-worktree-fast"
         assert "fast" not in views["project"] or views["project"]["fast"] == "claude-worktree-fast"
 
+    def test_user_local_env_merges_into_merged_config(self, tmp_path):
+        """User-global settings.local.json env deep-merges into the merged config.
+
+        Regression for the user-tier parity bug: the global tier was read with a
+        raw json.load that skipped ~/.worca/settings.local.json, so model env
+        blocks (alt-endpoint secrets) written there by `templates import
+        --scope user` were silently dropped.
+        """
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"id": "opus"}}}
+        }))
+        # Sibling .local carries the env block (secrets), id stays in base.
+        global_local = tmp_path / "global.local.json"
+        global_local.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"env": {"ANTHROPIC_BASE_URL": "https://alt.example"}}}}
+        }))
+
+        project_file = tmp_path / "project.json"
+        project_file.write_text(json.dumps({"worca": {}}))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        merged = result["worca"]["models"]["glm-ds"]
+        assert merged["id"] == "opus"
+        assert merged["env"]["ANTHROPIC_BASE_URL"] == "https://alt.example"
+
+    def test_user_local_env_in_tier_view_stash(self, tmp_path):
+        """The `user` tier-view stash includes env merged from the .local sibling."""
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"id": "opus"}}}
+        }))
+        global_local = tmp_path / "global.local.json"
+        global_local.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"env": {"ANTHROPIC_AUTH_TOKEN": "tok"}}}}
+        }))
+        project_file = tmp_path / "project.json"
+        project_file.write_text(json.dumps({"worca": {}}))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        user_view = result["_worca_tier_views"]["user"]["glm-ds"]
+        assert user_view["id"] == "opus"
+        assert user_view["env"]["ANTHROPIC_AUTH_TOKEN"] == "tok"
+
+    def test_user_tier_pinned_ref_resolves_local_env(self, tmp_path):
+        """resolve_tier_pinned('user:alias') returns env from the .local sibling.
+
+        End-to-end: this is what makes a user-tier template pinned to
+        `user:glm-ds` actually route through the alt endpoint.
+        """
+        from worca.utils.settings import resolve_tier_pinned
+
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"id": "opus"}}}
+        }))
+        global_local = tmp_path / "global.local.json"
+        global_local.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"env": {"ANTHROPIC_BASE_URL": "https://alt.example"}}}}
+        }))
+        project_file = tmp_path / "project.json"
+        project_file.write_text(json.dumps({"worca": {}}))
+
+        settings = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        model_id, env, err = resolve_tier_pinned("user:glm-ds", settings)
+        assert err is None
+        assert model_id == "opus"
+        assert env == {"ANTHROPIC_BASE_URL": "https://alt.example"}
+
+    def test_project_tier_still_shadows_user_with_local_env(self, tmp_path):
+        """Atomic cross-tier replace still holds: a project-tier entry shadows the
+        user entry wholesale even when the user entry now carries .local env."""
+        global_file = tmp_path / "global.json"
+        global_file.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"id": "opus"}}}
+        }))
+        global_local = tmp_path / "global.local.json"
+        global_local.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": {"env": {"ANTHROPIC_BASE_URL": "https://user.example"}}}}
+        }))
+        project_file = tmp_path / "project.json"
+        project_file.write_text(json.dumps({
+            "worca": {"models": {"glm-ds": "sonnet"}}
+        }))
+
+        result = load_settings_with_global_fallback(
+            str(project_file), global_path=str(global_file)
+        )
+
+        # Project tier wins wholesale — no leakage of the user-tier env.
+        assert result["worca"]["models"]["glm-ds"] == "sonnet"
+        # But the user tier-view still carries its own merged entry intact.
+        user_view = result["_worca_tier_views"]["user"]["glm-ds"]
+        assert user_view["env"]["ANTHROPIC_BASE_URL"] == "https://user.example"
+
     def test_default_global_path(self, tmp_path, monkeypatch):
         """Without explicit global_path, uses $WORCA_HOME/settings.json."""
         fake_home = tmp_path / "home"

--- a/tests/test_templates_import_scope_models.py
+++ b/tests/test_templates_import_scope_models.py
@@ -375,6 +375,54 @@ class TestAutoPinModelRefs:
         assert "project:glm-ds" in captured.err
 
 
+class TestUserScopeImportRoundTrip:
+    """`import --scope user` of an alt-endpoint alias resolves end-to-end.
+
+    Regression for the user-tier parity bug: import writes the model `env`
+    (secrets) to ~/.worca/settings.local.json and auto-pins the template ref to
+    `user:<alias>`, but the resolver used to read ~/.worca/settings.json raw,
+    silently dropping the env — so the pinned ref ran against the wrong endpoint.
+    """
+
+    def test_user_import_env_lands_in_local_and_resolves(self, project_dir, capsys):
+        from worca.utils.settings import (
+            load_settings_with_global_fallback,
+            resolve_tier_pinned,
+        )
+
+        project, worca_home = project_dir
+        bundle = project / "bundle.json"
+        _write_bundle(bundle)  # custom-alias carries env={ANTHROPIC_BASE_URL: ...}
+
+        cmd_templates_import(_make_import_args(source=str(bundle), scope="user"))
+
+        # id stays in the committed user settings.json; env (secret) in .local.
+        user_settings = worca_home / "settings.json"
+        user_local = worca_home / "settings.local.json"
+        assert user_local.exists(), "import --scope user must write env to settings.local.json"
+        local_data = json.loads(user_local.read_text())
+        assert (
+            local_data["worca"]["models"]["custom-alias"]["env"]["ANTHROPIC_BASE_URL"]
+            == "https://example.com/"
+        )
+
+        # The auto-pinned template ref is user:custom-alias.
+        tpl = json.loads(
+            (worca_home / "templates" / "imported-tpl" / "template.json").read_text()
+        )
+        assert tpl["config"]["agents"]["planner"]["model"] == "user:custom-alias"
+
+        # End-to-end: the resolver now sees the .local env for the user tier.
+        settings = load_settings_with_global_fallback(
+            str(project / ".claude" / "settings.json"),
+            global_path=str(user_settings),
+        )
+        model_id, env, err = resolve_tier_pinned("user:custom-alias", settings)
+        assert err is None
+        assert model_id == "claude-opus-4-7"
+        assert env.get("ANTHROPIC_BASE_URL") == "https://example.com/"
+
+
 class TestBuildCollisionPreviewRefRewrites:
     """_build_collision_preview surfaces ref_rewrites for the UI dialog."""
 


### PR DESCRIPTION
## Problem

A user-tier pipeline template pinned to a `user:<alias>` model ref silently ran against the **default Anthropic endpoint** instead of the alias's alt endpoint. Observed as `[COORDINATE] [init] model=claude-opus-4-8` in a pipeline whose template referenced an alt-endpoint `glm-ds` alias.

Root cause: `load_settings_with_global_fallback` read `~/.worca/settings.json` with a **raw `json.load`** that skipped the `~/.worca/settings.local.json` sibling. So user-tier model `env` blocks (alt-endpoint base URLs, auth tokens) were dropped from **both** the merged config and the `user:` tier-pin views.

This is an internal inconsistency: the project tier (`load_settings`), the public `load_global_settings` API, and the **import path itself** (`worca templates import --scope user` writes model `env` to `~/.worca/settings.local.json` and auto-pins refs to `user:<alias>`) all already assume the user tier reads `.local`. Only the resolver disagreed — so user-scope import of any alt-endpoint alias was silently broken end-to-end.

## Fix

Read the user-global tier through `load_global_settings` (which already deep-merges `.local`), mirroring the project tier. The committed-file malformed-JSON warning is preserved via an explicit probe read so existing behavior/tests are unchanged. On-disk file shape is unchanged — this is a read-side fix only.

## Tests

- user-tier `.local` env merges into the merged config **and** the `user` tier-view stash
- `resolve_tier_pinned('user:alias')` returns env sourced from `.local`
- project tier still shadows the user tier wholesale (atomic cross-tier replace intact)
- **end-to-end round-trip:** `import --scope user` of an alt-endpoint alias → env lands in `~/.worca/settings.local.json` → `user:<alias>` resolves with the env

412 settings/model/template/stage tests pass; ruff clean.

## Migration

Resolver fix, no `worca init --upgrade` needed. Action required only if you have a user-tier alias whose `env` lives outside `~/.worca/settings.local.json` — move it there (or re-import `--scope user`). Documented in MIGRATION.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
