### PR TITLE
W-075: worca-bench — config evaluation harness + dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,15 @@ Linux, macOS, and Windows are all supported targets. worca-ui, the governance ho
 
 Key Windows degradations (all guarded): liveness probes route through `worca.utils.proc.pid_is_alive()` (never `os.kill(pid, 0)`, which would `TerminateProcess`); `SIGTERM` is a hard kill (no graceful handler); process-group reaping falls back to best-effort single-child `terminate()`; `start_new_session` detach is ignored. Full matrix and details: [`docs/platform-support.md`](./docs/platform-support.md).
 
+## Config Evaluation (worca-bench)
+
+`worca-bench/` is a standalone harness (W-075) for measuring whether one pipeline config (per-agent model/effort, template, worca version) beats another on **SWE-bench Verified** and **Commit0**. It is **version-agnostic — it never imports worca**: it provisions an isolated venv per ref, `pip install`s the requested branch/tag/commit/version, and shells out to that venv's `run_pipeline`. The dashboard half mirrors the worca-ui stack (lit-html + Shoelace + esbuild + Express) and reads results from a `--target-dir`.
+
+- **Free, deterministic e2e:** the runner has a mock mode that points the spawned pipeline at the repo's `tests/mock_claude/mock_claude.py` via `WORCA_CLAUDE_BIN` + `MOCK_CLAUDE_SCENARIO`. `tests/test_e2e_mock.py` drives a full pipeline this way (self-skips if the worca-cc repo isn't found); grading uses `grade.mode: stub`. This is also a user dry-run before paying for real grading.
+- **Grading is source-only on a pristine tree** — the diff excludes `.claude/`/`.worca/`/`MASTER_PLAN.md`/test paths; the harness supplies the tests. Commit0 stashes gold tests during the run with a leakage guard.
+- **tier:name** (`builtin:`/`project:`/`user:`) is a worca-bench concept (worca's `--template` takes a bare id) — it's parsed and project/user templates are seeded before launch.
+- Run: `worca-bench run --profile <name> --target-dir <dir>` (Python engine); `node worca-bench/bin/worca-bench-ui.js --target-dir <dir>` (dashboard, port 3500). Tests: `cd worca-bench && pytest tests/` + `npx vitest run`. Full design: [`docs/plans/W-075-worca-bench.md`](./docs/plans/W-075-worca-bench.md) and `worca-bench/README.md`.
+
 ## Migrating
 
 User-facing upgrade and cleanup steps live in [`MIGRATION.md`](./MIGRATION.md).

--- a/src/worca/agents/core/reviewer.md
+++ b/src/worca/agents/core/reviewer.md
@@ -10,7 +10,7 @@ You receive the test results and proof status from the Tester. You have read-onl
 
 ## Process
 
-1. Verify proof status = verified (return `reject` immediately if failed)
+1. Verify proof status = verified (return `reject` immediately if failed). Then inspect the tester's `failures[]` and proof artifacts directly: a non-empty `failures[]`, or any failing/regressed test visible in the proof, is a hard `reject` — even if `passed` is `true`. The pipeline must never ship with a red or regressed test; do not approve around an over-optimistic tester.
 2. Review all changes against the base branch:
    {{#if review_base}}
    - Run `git diff {{review_base}}..HEAD` to see all changed files since pipeline start

--- a/src/worca/agents/core/tester.md
+++ b/src/worca/agents/core/tester.md
@@ -13,10 +13,20 @@ You run after all Implementer tasks are complete. You verify that the full syste
 1. Check CLAUDE.md for the project's test command and use it. If not specified, infer the command from project configuration files.
 2. Check coverage if configured
 3. Run any integration tests
-4. Collect proof artifacts (test output, coverage reports)
-5. Set proof status: verified or failed
+4. Run the regression gate (below) — the full test suite, run complete and to completion.
+5. Collect proof artifacts (test output, coverage reports)
+6. Set proof status: verified or failed
 
 The work request and implementation summary arrive as a user message.
+
+## Regression gate
+
+Run the project's full test suite to completion. Two requirements that hold in any language or framework:
+
+- **Run the whole suite, not a subset.** Don't narrow the run to a single test, a single case, or only the tests you added — the point is to surface tests your change may have broken elsewhere. If the full suite is too large or can't run cleanly in this environment, fall back to running the complete set of tests for every touched module/file.
+- **Let it run to completion — don't stop at the first failure.** You need the full list of failures, not just the first. If the runner defaults to fail-fast (aborting on the first failure), disable that for this run.
+
+Report `passed: false` with every failing test in `failures[]` if any test fails that was **not already failing before this change** (ignore pre-existing or environmental failures unrelated to the change — but the target behavior's test and any test your change newly breaks are always failures you own).
 
 ## Output
 
@@ -49,6 +59,8 @@ Only populate `guide_conflicts` when a real conflict exists. Do not emit conflic
 - Report failures with file, test name, and error so the implementer can fix them
 - Proof artifacts must be saved to a reviewable location
 - Coverage below project threshold = failed
+- **`passed: true` requires a clean final run of the whole suite — every test green, zero regressions.** A subset run, or a run that aborted early on the first failure, is not proof.
+- **Never report `passed: true` to move the pipeline forward.** If the acceptance behavior or any test your change breaks is still failing after your run — including when you've hit the iteration limit — report `passed: false` with the failing tests. A truthful red result is correct and expected; the orchestrator and Reviewer rely on this flag to gate the PR.
 
 {{block:graphify-orientation}}
 

--- a/worca-bench/.gitignore
+++ b/worca-bench/.gitignore
@@ -1,0 +1,14 @@
+# Node (dashboard)
+node_modules/
+app/main.bundle.js
+app/main.bundle.js.map
+
+# Python
+__pycache__/
+*.egg-info/
+.pytest_cache/
+.venv/
+
+# Default runner output / caches (the --target-dir)
+worca-bench-out/
+out/

--- a/worca-bench/.gitignore
+++ b/worca-bench/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 worca-bench-out/
 out/
 worca-bench.wb-*.json
+
+# sb-cli default report output (grader artifact)
+sb-cli-reports/

--- a/worca-bench/.gitignore
+++ b/worca-bench/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 # Default runner output / caches (the --target-dir)
 worca-bench-out/
 out/
+worca-bench.wb-*.json

--- a/worca-bench/README.md
+++ b/worca-bench/README.md
@@ -1,0 +1,83 @@
+# worca-bench
+
+Config-evaluation harness for worca pipelines (**W-075**). Measures whether one
+pipeline configuration (per-agent model/effort, template, worca version) beats another
+on real coding benchmarks — **SWE-bench Verified** and **Commit0** — joining the
+benchmark's correctness oracle with worca's native cost/token/iteration telemetry.
+
+It is a **version-agnostic orchestrator**: it never imports worca. For each experiment
+it provisions an isolated venv, `pip install`s the requested worca ref, and shells out
+to that venv's pipeline — so you can compare any branch/tag/commit/version in one run.
+
+## Layout
+
+```
+worca_bench/            # headless Python engine (the runner)
+  cli.py                # worca-bench run | list | stats
+  runner.py             # per-rep lifecycle + sweep + canary
+  venvs.py              # worca ref provisioning (req 1)
+  worca_install.py      # worca init + 3-layer settings seed (req 5 portability)
+  templates.py          # tier:name resolution (req 2)
+  launcher.py           # spawn run_pipeline (real or mock Claude)
+  harvest.py            # source-only diff + telemetry parse
+  normalize.py          # results.jsonl rows (req 4)
+  stats.py              # aggregate by profile
+  plugins/{swebench,commit0}.py
+app/  server/  bin/     # worca-ui-style dashboard (lit-html + Shoelace + Express)
+profiles/               # example experiment definitions (req 5)
+```
+
+## Quick start
+
+```bash
+pip install -e worca-bench            # or: pip install -e ".[dev]" from worca-bench/
+
+# Smoke a profile for free with the mock Claude (no API spend, deterministic):
+#   set mock: true in the profile, grade.mode: stub
+worca-bench run --profile swebench-feature-opus --target-dir ./out --dry-run
+worca-bench run --profile swebench-feature-opus --target-dir ./out --max-instances 1
+
+worca-bench list                       # available profiles
+worca-bench stats --target-dir ./out   # aggregate results.jsonl
+
+# Dashboard (worca-ui stack):
+cd worca-bench && npm install && npm run build
+node bin/worca-bench-ui.js --target-dir ../out      # http://127.0.0.1:3500
+```
+
+## How a rep runs (per instance × rep)
+
+1. **Resolve worca env** — venv per ref, cached (`local` uses the current env for tests/dev).
+2. **Materialize** the base tree (clone @ base_commit; Commit0 skeleton).
+3. **Install worca** — `worca init` + minimal settings overlay (model aliases; secrets to
+   `settings.local.json`); the template carries the experiment.
+4. **Launch** the pipeline hermetically (`--claude-md-mode none --skip-preflight`, `pr.defer`).
+5. **Harvest** a source-only diff (excludes `.claude/`, `.worca/`, `MASTER_PLAN.md`, gold tests)
+   + telemetry from `status.json`.
+6. **Grade** — `stub` (plumbing), `sb-cli`/`modal`/`local-docker` (SWE-bench), `local-docker` (Commit0).
+7. **Normalize** → append one row to `<target-dir>/results.jsonl`; archive artifacts.
+
+A **canary** runs each template once before the sweep and skips configs a worca version
+rejects (fail-fast). The **Commit0 leakage guard** fails any rep whose diff touches a
+gold-test path.
+
+## `--target-dir` contract (CLI writes, dashboard reads)
+
+```
+<target-dir>/
+  cache/{repos,venvs,commit0}/      results.jsonl        # dashboard source of truth
+  runs/<profile>/<instance>/repN/   predictions/<profile>.jsonl
+```
+
+## Testing
+
+```bash
+cd worca-bench && python -m pytest tests/ -q          # unit + mock-Claude e2e
+cd worca-bench && python -m pytest -m "not live_worca" # unit only (no worca spawn)
+cd worca-bench && npx vitest run && npx playwright test --workers=1
+```
+
+The e2e (`tests/test_e2e_mock.py`) spawns a **real** worca pipeline driven by the repo's
+mock Claude — free and deterministic. It self-skips if the worca-cc source repo isn't found.
+
+See `docs/plans/W-075-worca-bench.md` for the full design.

--- a/worca-bench/README.md
+++ b/worca-bench/README.md
@@ -61,6 +61,24 @@ A **canary** runs each template once before the sweep and skips configs a worca 
 rejects (fail-fast). The **Commit0 leakage guard** fails any rep whose diff touches a
 gold-test path.
 
+## Grader credentials (sb-cli / Modal)
+
+The cloud (`sb-cli` → `SWEBENCH_API_KEY`) and Modal (`modal` → `MODAL_TOKEN_ID` +
+`MODAL_TOKEN_SECRET`) graders need credentials. They are never stored in the repo. Three
+ways to supply them, in precedence order:
+
+- **CLI flags** — `worca-bench run|regrade … --swebench-api-key … --modal-token-id … --modal-token-secret …` (override the environment).
+- **Environment** — export the vars before launching; `collect_secret_env()` picks them up.
+- **Dashboard (browser)** — Settings → *Grader credentials* stores them in this browser's
+  `localStorage` only. On Run/Regrade the browser forwards them in the request body; the
+  server merges them into the runner subprocess's **environment** (never argv, never disk).
+
+The grade backend is pluggable: `SwebenchPlugin.GRADERS` maps `grade.mode` → a
+`_grade_<x>(prediction, target_dir, grade, secret_env)` method. The dashboard's per-row
+**Re-grade** action opens a dialog to pick the backend (local Docker / SWE-bench cloud /
+Modal); the last choice is remembered. Modal fails fast with an actionable message when its
+tokens are absent.
+
 ## `--target-dir` contract (CLI writes, dashboard reads)
 
 ```

--- a/worca-bench/app/index.html
+++ b/worca-bench/app/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>worca-bench</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap">
+  <link rel="stylesheet" href="/vendor/shoelace-light.css">
+  <link rel="stylesheet" href="/vendor/shoelace-dark.css">
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/main.bundle.js"></script>
+</body>
+</html>

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -15,7 +15,8 @@ import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
-import '@shoelace-style/shoelace/dist/components/switch/switch.js';
+import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
+import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
 
 import { outcomeIcon, profileOutcome } from './utils/badge.js';
 import { confirmDialogTemplate, showConfirm } from './utils/confirm-dialog.js';

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -436,12 +436,22 @@ function renderView(view) {
         selected,
         onToggleSelect: toggleSelect,
       });
-    case 'detail':
+    case 'detail': {
+      // Disable Run while this profile already has a live run action — the
+      // anti-double-click guard (the dock shows the in-flight one).
+      const runningRun = state.actions.some(
+        (a) =>
+          a.type === 'run' &&
+          a.status === 'running' &&
+          a.profile === view.data?.aggregate?.name,
+      );
       return profileDetailView(view.data, {
         onRun: (name, opts) => runProfile(name, opts),
         onRegrade: (name, instanceId) => regradeInstance(name, instanceId),
         onNotes: (name) => openNotes(name),
+        runDisabled: runningRun,
       });
+    }
     case 'compare':
       return compareView(view.data);
     case 'leaderboard':

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -149,13 +149,16 @@ function toastView() {
   </div>`;
 }
 
-// Profile names checked for comparison on the dashboard (persists across renders).
+// Profiles checked for comparison (keyed `name@src` so same-named profiles from
+// different result dirs are tracked separately). Persists across renders.
 const selected = new Set();
-function toggleSelect(name) {
-  if (selected.has(name)) {
-    selected.delete(name);
+const profileKey = (agg) => `${agg.name}@${agg.src}`;
+function toggleSelect(agg) {
+  const key = profileKey(agg);
+  if (selected.has(key)) {
+    selected.delete(key);
   } else {
-    selected.add(name);
+    selected.add(key);
   }
   rerender();
 }
@@ -249,8 +252,8 @@ function buildHeader(path, view) {
     action = html`<button
       class="action-btn"
       @click=${() => {
-        const names = profiles.map((p) => p.name).join(',');
-        navigate(`#/compare?profiles=${encodeURIComponent(names)}`);
+        const refs = profiles.map((p) => `${p.name}@${p.src}`).join(',');
+        navigate(`#/compare?profiles=${encodeURIComponent(refs)}`);
       }}
     >Compare all</button>`;
   }
@@ -320,8 +323,10 @@ function renderView(view) {
   switch (view.kind) {
     case 'dashboard':
       return dashboardView(view.data, {
-        onOpen: (name) =>
-          navigate(`#/profile?name=${encodeURIComponent(name)}`),
+        onOpen: (agg) =>
+          navigate(
+            `#/profile?name=${encodeURIComponent(agg.name)}&src=${encodeURIComponent(agg.src)}`,
+          ),
         onRun: (name) => runProfile(name),
         selected,
         onToggleSelect: toggleSelect,
@@ -360,7 +365,9 @@ async function loadView(path, params) {
   }
   if (path === '/profile') {
     const name = params.get('name');
-    const data = await getJSON(`/api/profiles/${encodeURIComponent(name)}`);
+    const src = params.get('src');
+    const q = src ? `?src=${encodeURIComponent(src)}` : '';
+    const data = await getJSON(`/api/profiles/${encodeURIComponent(name)}${q}`);
     return { kind: 'detail', data };
   }
   if (path === '/compare') {

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -17,6 +17,7 @@ import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
 import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
+import '@shoelace-style/shoelace/dist/components/radio/radio.js';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 
 import { outcomeIcon, profileOutcome } from './utils/badge.js';
@@ -25,6 +26,11 @@ import {
   folderPickerTemplate,
   openFolderPicker,
 } from './utils/folder-picker.js';
+import {
+  regradeDialogTemplate,
+  showRegradeDialog,
+} from './utils/regrade-dialog.js';
+import { clearSecret, launchSecrets, saveSecrets } from './utils/secrets.js';
 import { compareView } from './views/compare.js';
 import { leaderboardView } from './views/leaderboard.js';
 import { profileDetailView } from './views/profile-detail.js';
@@ -294,6 +300,7 @@ function shell(activeKey, header, body) {
       ${toastView()}
       ${confirmDialogTemplate()}
       ${folderPickerTemplate()}
+      ${regradeDialogTemplate()}
     </div>
   `;
 }
@@ -351,6 +358,8 @@ function renderView(view) {
         onSetCache: setCache,
         onBrowseAdd: browseAdd,
         onBrowseCache: browseCache,
+        onSaveSecrets: saveGraderSecrets,
+        onClearSecret: clearGraderSecret,
       });
     default:
       return errorView('Unknown view');
@@ -460,6 +469,10 @@ async function runProfile(name, opts = {}) {
     if (opts.canary === false) body.canary = false;
     if (opts.graphify) body.graphify = opts.graphify;
     if (opts.codeReviewGraph) body.codeReviewGraph = opts.codeReviewGraph;
+    // Forward browser-held grader credentials so the run can grade (sb-cli /
+    // Modal). Omitted when none are stored.
+    const secrets = launchSecrets();
+    if (secrets) body.secrets = secrets;
     const res = await fetch('/api/run', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -490,24 +503,33 @@ async function runProfile(name, opts = {}) {
   }
 }
 
-async function regradeInstance(name, instanceId) {
+// Regrade flows through a dialog so the operator picks the backend (local Docker
+// / SWE-bench cloud / Modal); the choice is remembered for next time.
+function regradeInstance(name, instanceId) {
+  showRegradeDialog(
+    { instanceId, onConfirm: (mode) => doRegrade(name, instanceId, mode) },
+    rerender,
+  );
+}
+
+async function doRegrade(name, instanceId, mode) {
   try {
+    const body = { profile: name, instance: instanceId, mode };
+    // Cloud (sb-cli) / Modal graders need credentials — forward from the browser.
+    const secrets = launchSecrets();
+    if (secrets) body.secrets = secrets;
     const res = await fetch('/api/regrade', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        profile: name,
-        instance: instanceId,
-        mode: 'sb-cli',
-      }),
+      body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
     if (res.ok && data.ok) {
       showToast(
         'success',
-        `Re-grading ${instanceId} via sb-cli — pid ${data.pid}`,
+        `Re-grading ${instanceId} via ${mode} — pid ${data.pid}`,
       );
-      // Results land after the hosted eval completes; nudge a few refreshes.
+      // Results land after the eval completes; nudge a refresh.
       setTimeout(refreshCurrent, 2000);
     } else {
       showToast('danger', `Regrade failed: ${data.error || res.statusText}`);
@@ -564,6 +586,18 @@ function confirmRemoveDir(dir) {
 
 const browseAdd = () => openFolderPicker({ onPick: addDir }, rerender);
 const browseCache = () => openFolderPicker({ onPick: setCache }, rerender);
+
+// Grader credentials live only in the browser; persist + re-render so the
+// "Set"/"Not set" status updates. No server round-trip.
+function saveGraderSecrets(patch) {
+  saveSecrets(patch);
+  showToast('success', 'Saved grader credentials (this browser only)');
+  rerender();
+}
+function clearGraderSecret(name) {
+  clearSecret(name);
+  rerender();
+}
 
 // Destructive: stop a profile's active runs (kills the runner trees).
 function stopRuns(name) {

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -26,6 +26,7 @@ import {
   folderPickerTemplate,
   openFolderPicker,
 } from './utils/folder-picker.js';
+import { notesDialogTemplate, showNotesDialog } from './utils/notes-dialog.js';
 import {
   regradeDialogTemplate,
   showRegradeDialog,
@@ -333,6 +334,7 @@ function shell(activeKey, header, body) {
       ${confirmDialogTemplate()}
       ${folderPickerTemplate()}
       ${regradeDialogTemplate()}
+      ${notesDialogTemplate()}
     </div>
   `;
 }
@@ -375,6 +377,7 @@ function renderView(view) {
       return profileDetailView(view.data, {
         onRun: (name, opts) => runProfile(name, opts),
         onRegrade: (name, instanceId) => regradeInstance(name, instanceId),
+        onNotes: (name) => openNotes(name),
       });
     case 'compare':
       return compareView(view.data);
@@ -524,6 +527,8 @@ async function runProfile(name, opts = {}) {
     if (opts.canary === false) body.canary = false;
     if (opts.graphify) body.graphify = opts.graphify;
     if (opts.codeReviewGraph) body.codeReviewGraph = opts.codeReviewGraph;
+    if (typeof opts.preflight === 'boolean') body.preflight = opts.preflight;
+    if (opts.claudeMdMode) body.claudeMdMode = opts.claudeMdMode;
     // Forward browser-held grader credentials so the run can grade (sb-cli /
     // Modal). Omitted when none are stored.
     const secrets = launchSecrets();
@@ -580,6 +585,41 @@ function regradeAll(name) {
     },
     rerender,
   );
+}
+
+// Per-profile human notes: fetch current notes, open the editor, PUT on save.
+async function openNotes(name) {
+  let notes = '';
+  try {
+    const res = await fetch(`/api/profiles/${encodeURIComponent(name)}/notes`);
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.ok) notes = data.notes || '';
+  } catch {
+    // Open the editor empty; saving will surface any write error.
+  }
+  showNotesDialog(
+    { profile: name, notes, onSave: (text) => saveNotes(name, text) },
+    rerender,
+  );
+}
+
+async function saveNotes(name, text) {
+  try {
+    const res = await fetch(`/api/profiles/${encodeURIComponent(name)}/notes`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes: text }),
+    });
+    const data = await res.json().catch(() => ({}));
+    showToast(
+      res.ok && data.ok ? 'success' : 'danger',
+      res.ok && data.ok
+        ? 'Notes saved'
+        : `Save failed: ${data.error || res.statusText}`,
+    );
+  } catch (err) {
+    showToast('danger', `Save failed: ${err.message}`);
+  }
 }
 
 // Stop an in-flight regrade sweep (kills the runner tree). Confirmed because it

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -301,6 +301,7 @@ function renderView(view) {
       return settingsView(view.data, {
         onAddDir: addDir,
         onRemoveDir: removeDir,
+        onSetCache: setCache,
       });
     default:
       return errorView('Unknown view');
@@ -459,6 +460,34 @@ async function mutateSettingsDir(method, dir) {
 
 const addDir = (dir) => mutateSettingsDir('POST', dir);
 const removeDir = (dir) => mutateSettingsDir('DELETE', dir);
+
+async function setCache(dir) {
+  try {
+    const res = await fetch('/api/settings/cache-dir', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dir }),
+    });
+    const data = await res.json();
+    if (!res.ok || !data.ok) {
+      state.view = {
+        kind: 'settings',
+        data: {
+          ...(state.view?.data || {}),
+          error: data.error || 'request failed',
+        },
+      };
+    } else {
+      state.view = { kind: 'settings', data };
+    }
+  } catch (err) {
+    state.view = {
+      kind: 'settings',
+      data: { ...(state.view?.data || {}), error: err.message },
+    };
+  }
+  rerender();
+}
 
 window.addEventListener('hashchange', route);
 route();

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -453,6 +453,7 @@ async function runProfile(name, opts = {}) {
     if (Number.isInteger(opts.reps)) body.reps = opts.reps;
     if (Number.isInteger(opts.maxInstances))
       body.maxInstances = opts.maxInstances;
+    if (Number.isInteger(opts.maxParallel)) body.maxParallel = opts.maxParallel;
     if (opts.graphify) body.graphify = opts.graphify;
     if (opts.codeReviewGraph) body.codeReviewGraph = opts.codeReviewGraph;
     const res = await fetch('/api/run', {
@@ -465,7 +466,10 @@ async function runProfile(name, opts = {}) {
       const extra = [
         Number.isInteger(opts.reps) ? `${opts.reps} reps` : null,
         Number.isInteger(opts.maxInstances)
-          ? `${opts.maxInstances} instances`
+          ? `${opts.maxInstances} tests`
+          : null,
+        Number.isInteger(opts.maxParallel)
+          ? `${opts.maxParallel}× parallel`
           : null,
       ].filter(Boolean);
       const suffix = extra.length ? ` (${extra.join(', ')})` : '';

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -15,8 +15,9 @@ import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
+import '@shoelace-style/shoelace/dist/components/switch/switch.js';
 
-import { outcomeIcon, profileOutcome, variantFor } from './utils/badge.js';
+import { outcomeIcon, profileOutcome } from './utils/badge.js';
 import { confirmDialogTemplate, showConfirm } from './utils/confirm-dialog.js';
 import {
   folderPickerTemplate,
@@ -180,16 +181,23 @@ function buildHeader(path, view) {
 
   if (path === '/profile') {
     const agg = view?.kind === 'detail' ? view.data?.aggregate : null;
+    const active = (view?.kind === 'detail' && view.data?.active) || [];
+    const isActive = active.length > 0;
     const outcome = agg ? profileOutcome(agg) : null;
     return {
       showBack: true,
       onBack: backToDashboard,
       title: agg
-        ? html`<span class="content-header-status">${unsafeHTML(outcomeIcon(outcome, 18))}</span>${agg.name}`
+        ? html`<span class="content-header-status">${
+            isActive
+              ? html`<span class="running-dot"></span>`
+              : unsafeHTML(outcomeIcon(outcome, 18))
+          }</span>${agg.name}`
         : 'Profile',
-      badge: outcome
-        ? html`<sl-badge variant="${variantFor(outcome)}" pill>${outcome}</sl-badge>`
-        : null,
+      // No single outcome badge: a multi-rep profile has reps in mixed states
+      // (running / graded / skipped). State lives in the live block, the
+      // resolved-rate stat, and the per-rep table instead.
+      badge: null,
       action: agg
         ? html`<button class="action-btn action-btn--primary" @click=${() => runProfile(agg.name)}>Run profile</button>`
         : null,
@@ -433,6 +441,8 @@ async function runProfile(name, opts = {}) {
     if (Number.isInteger(opts.reps)) body.reps = opts.reps;
     if (Number.isInteger(opts.maxInstances))
       body.maxInstances = opts.maxInstances;
+    if (opts.graphify) body.graphify = opts.graphify;
+    if (opts.codeReviewGraph) body.codeReviewGraph = opts.codeReviewGraph;
     const res = await fetch('/api/run', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -1,0 +1,185 @@
+// app/main.js — worca-bench dashboard entry point.
+//
+// Hash-router dispatch (#/, #/profile?name=X, #/compare, #/leaderboard),
+// data fetch, and lit-html render. Mirrors worca-ui's functional-template
+// approach: views are pure functions of data; main.js owns fetch + routing.
+
+import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
+import { html, render } from 'lit-html';
+
+import '@shoelace-style/shoelace/dist/components/badge/badge.js';
+import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+
+import { compareView } from './views/compare.js';
+import { leaderboardView } from './views/leaderboard.js';
+import { profileDetailView } from './views/profile-detail.js';
+import { dashboardView } from './views/profile-list.js';
+
+// Shoelace ships its icon assets relative to a base path; point it at the
+// bundled copy location (we don't use sl-icon, but the lib still resolves it).
+setBasePath('/vendor');
+
+const root = document.getElementById('app');
+
+// ─── Routing ────────────────────────────────────────────────────────────
+
+/** Parse `#/path?query` into { path, params }. */
+function parseHash(hash) {
+  const raw = (hash || '').replace(/^#/, '') || '/';
+  const [path, queryStr] = raw.split('?');
+  const params = new URLSearchParams(queryStr || '');
+  return { path: path || '/', params };
+}
+
+function navigate(hash) {
+  if (location.hash === hash) {
+    rerender();
+  } else {
+    location.hash = hash;
+  }
+}
+
+// ─── Fetch helpers ──────────────────────────────────────────────────────
+
+async function getJSON(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+  return res.json();
+}
+
+// ─── App state ──────────────────────────────────────────────────────────
+
+const state = {
+  loading: false,
+  error: null,
+  view: null, // { kind, data }
+};
+
+function loadingView() {
+  return html`<section class="page loading-state"><sl-spinner></sl-spinner> <span>Loading…</span></section>`;
+}
+
+function errorView(message) {
+  return html`<section class="page"><p class="error-state">Error: ${message}</p></section>`;
+}
+
+function headerView(activePath) {
+  const link = (hash, label, key) => html`<a
+    class="nav-link ${activePath === key ? 'nav-link--active' : ''}"
+    href=${hash}
+  >${label}</a>`;
+  return html`
+    <header class="app-header">
+      <div class="app-brand"><span class="app-logo">⬡</span> worca-bench</div>
+      <nav class="app-nav">
+        ${link('#/', 'Dashboard', '/')}
+        ${link('#/compare', 'Compare', '/compare')}
+        ${link('#/leaderboard', 'Leaderboard', '/leaderboard')}
+      </nav>
+    </header>
+  `;
+}
+
+function shell(activePath, body) {
+  return html`${headerView(activePath)}<main class="app-main">${body}</main>`;
+}
+
+// ─── Render ─────────────────────────────────────────────────────────────
+
+function rerender() {
+  const { path } = parseHash(location.hash);
+  let body;
+  if (state.loading) {
+    body = loadingView();
+  } else if (state.error) {
+    body = errorView(state.error);
+  } else if (state.view) {
+    body = renderView(state.view);
+  } else {
+    body = loadingView();
+  }
+  render(shell(path, body), root);
+}
+
+function renderView(view) {
+  switch (view.kind) {
+    case 'dashboard':
+      return dashboardView(view.data, {
+        onOpen: (name) =>
+          navigate(`#/profile?name=${encodeURIComponent(name)}`),
+        onRun: (name) => runProfile(name),
+        onCompare: () => {
+          const names = view.data.map((p) => p.name).join(',');
+          navigate(`#/compare?profiles=${encodeURIComponent(names)}`);
+        },
+      });
+    case 'detail':
+      return profileDetailView(view.data, {
+        onBack: () => navigate('#/'),
+        onRun: (name) => runProfile(name),
+      });
+    case 'compare':
+      return compareView(view.data, { onBack: () => navigate('#/') });
+    case 'leaderboard':
+      return leaderboardView(view.data, {
+        onBack: () => navigate('#/'),
+        onSelectBenchmark: (b) =>
+          navigate(`#/leaderboard?benchmark=${encodeURIComponent(b)}`),
+      });
+    default:
+      return errorView('Unknown view');
+  }
+}
+
+// ─── Route handlers ─────────────────────────────────────────────────────
+
+async function route() {
+  const { path, params } = parseHash(location.hash);
+  state.loading = true;
+  state.error = null;
+  rerender();
+  try {
+    if (path === '/' || path === '') {
+      const { profiles } = await getJSON('/api/profiles');
+      state.view = { kind: 'dashboard', data: profiles };
+    } else if (path === '/profile') {
+      const name = params.get('name');
+      const data = await getJSON(`/api/profiles/${encodeURIComponent(name)}`);
+      state.view = { kind: 'detail', data };
+    } else if (path === '/compare') {
+      const profiles = params.get('profiles') || '';
+      const { compare } = await getJSON(
+        `/api/compare?profiles=${encodeURIComponent(profiles)}`,
+      );
+      state.view = { kind: 'compare', data: compare };
+    } else if (path === '/leaderboard') {
+      const benchmark = params.get('benchmark') || 'swe-bench-verified';
+      const data = await getJSON(
+        `/api/leaderboard?benchmark=${encodeURIComponent(benchmark)}`,
+      );
+      state.view = { kind: 'leaderboard', data };
+    } else {
+      state.error = `No such route: ${path}`;
+    }
+  } catch (err) {
+    state.error = err.message;
+  } finally {
+    state.loading = false;
+    rerender();
+  }
+}
+
+async function runProfile(name) {
+  try {
+    await fetch('/api/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profile: name }),
+    });
+  } catch {
+    // Fire-and-forget; surface nothing beyond console for now.
+  }
+}
+
+window.addEventListener('hashchange', route);
+route();

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -529,6 +529,7 @@ async function runProfile(name, opts = {}) {
     if (opts.codeReviewGraph) body.codeReviewGraph = opts.codeReviewGraph;
     if (typeof opts.preflight === 'boolean') body.preflight = opts.preflight;
     if (opts.claudeMdMode) body.claudeMdMode = opts.claudeMdMode;
+    if (opts.gradeMode) body.gradeMode = opts.gradeMode;
     // Forward browser-held grader credentials so the run can grade (sb-cli /
     // Modal). Omitted when none are stored.
     const secrets = launchSecrets();

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -1,25 +1,37 @@
 // app/main.js — worca-bench dashboard entry point.
 //
 // Hash-router dispatch (#/, #/profile?name=X, #/compare, #/leaderboard),
-// data fetch, and lit-html render. Mirrors worca-ui's functional-template
-// approach: views are pure functions of data; main.js owns fetch + routing.
+// data fetch, and lit-html render. Mirrors worca-ui's app shell: a left
+// `.sidebar` for section nav + a `.main-content` area whose every view is
+// rendered under a shared `.content-header` (title, optional back button,
+// optional per-page actions). Views are pure functions of data; main.js
+// owns fetch, routing, and the header/shell composition.
 
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
 import { html, render } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
 
+import { outcomeIcon, profileOutcome, variantFor } from './utils/badge.js';
 import { compareView } from './views/compare.js';
 import { leaderboardView } from './views/leaderboard.js';
 import { profileDetailView } from './views/profile-detail.js';
 import { dashboardView } from './views/profile-list.js';
+import { settingsView } from './views/settings.js';
+import { sidebarView } from './views/sidebar.js';
 
 // Shoelace ships its icon assets relative to a base path; point it at the
 // bundled copy location (we don't use sl-icon, but the lib still resolves it).
 setBasePath('/vendor');
 
 const root = document.getElementById('app');
+
+// Lucide ArrowLeft — the content-header back button (parity with worca-ui's
+// `iconSvg(ArrowLeft)`). Inlined to keep worca-bench dependency-light.
+const BACK_ARROW =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>';
 
 // ─── Routing ────────────────────────────────────────────────────────────
 
@@ -37,6 +49,26 @@ function navigate(hash) {
   } else {
     location.hash = hash;
   }
+}
+
+/** Sidebar nav callback: section key → hash route. */
+function onNavigate(key) {
+  if (key === 'compare') navigate('#/compare');
+  else if (key === 'leaderboard') navigate('#/leaderboard');
+  else if (key === 'settings') navigate('#/settings');
+  else navigate('#/');
+}
+
+/**
+ * Which sidebar item is highlighted for a given route path. Profile detail
+ * is reached from the dashboard, so it highlights Dashboard (parity with
+ * worca-ui, where detail views light up their parent section).
+ */
+function activeKeyForPath(path) {
+  if (path === '/compare') return 'compare';
+  if (path === '/leaderboard') return 'leaderboard';
+  if (path === '/settings') return 'settings';
+  return 'dashboard';
 }
 
 // ─── Fetch helpers ──────────────────────────────────────────────────────
@@ -63,31 +95,107 @@ function errorView(message) {
   return html`<section class="page"><p class="error-state">Error: ${message}</p></section>`;
 }
 
-function headerView(activePath) {
-  const link = (hash, label, key) => html`<a
-    class="nav-link ${activePath === key ? 'nav-link--active' : ''}"
-    href=${hash}
-  >${label}</a>`;
-  return html`
-    <header class="app-header">
-      <div class="app-brand"><span class="app-logo">⬡</span> worca-bench</div>
-      <nav class="app-nav">
-        ${link('#/', 'Dashboard', '/')}
-        ${link('#/compare', 'Compare', '/compare')}
-        ${link('#/leaderboard', 'Leaderboard', '/leaderboard')}
-      </nav>
-    </header>
-  `;
+// ─── Content header ─────────────────────────────────────────────────────
+
+/**
+ * Build the content-header spec for a route. Data-dependent bits (the
+ * profile name/badge/Run button, the dashboard "Compare all" action) read
+ * from `view` and are omitted while a fetch is in flight.
+ *
+ * @returns {{ showBack:boolean, onBack?:Function, title:any, badge?:any, action?:any }}
+ */
+function buildHeader(path, view) {
+  const backToDashboard = () => navigate('#/');
+
+  if (path === '/profile') {
+    const agg = view?.kind === 'detail' ? view.data?.aggregate : null;
+    const outcome = agg ? profileOutcome(agg) : null;
+    return {
+      showBack: true,
+      onBack: backToDashboard,
+      title: agg
+        ? html`<span class="content-header-status">${unsafeHTML(outcomeIcon(outcome, 18))}</span>${agg.name}`
+        : 'Profile',
+      badge: outcome
+        ? html`<sl-badge variant="${variantFor(outcome)}" pill>${outcome}</sl-badge>`
+        : null,
+      action: agg
+        ? html`<button class="action-btn action-btn--primary" @click=${() => runProfile(agg.name)}>Run profile</button>`
+        : null,
+    };
+  }
+
+  if (path === '/compare') {
+    return {
+      showBack: true,
+      onBack: backToDashboard,
+      title: 'Compare Profiles',
+    };
+  }
+
+  if (path === '/leaderboard') {
+    return { showBack: true, onBack: backToDashboard, title: 'Leaderboard' };
+  }
+
+  if (path === '/settings') {
+    return { showBack: true, onBack: backToDashboard, title: 'Settings' };
+  }
+
+  // Dashboard (home) — no back button.
+  const profiles = view?.kind === 'dashboard' ? view.data : null;
+  const canCompare = Array.isArray(profiles) && profiles.length > 1;
+  return {
+    showBack: false,
+    title: 'Benchmark Profiles',
+    action: canCompare
+      ? html`<button
+          class="action-btn"
+          @click=${() => {
+            const names = profiles.map((p) => p.name).join(',');
+            navigate(`#/compare?profiles=${encodeURIComponent(names)}`);
+          }}
+        >Compare all</button>`
+      : null,
+  };
 }
 
-function shell(activePath, body) {
-  return html`${headerView(activePath)}<main class="app-main">${body}</main>`;
+function contentHeaderView({ showBack, onBack, title, badge, action }) {
+  return html`
+    <div class="content-header">
+      ${
+        showBack
+          ? html`<button
+              class="content-header-back"
+              aria-label="Back to dashboard"
+              @click=${onBack}
+            >${unsafeHTML(BACK_ARROW)}</button>`
+          : ''
+      }
+      <h1 class="content-header-title">${title}</h1>
+      ${badge || ''}
+      ${action ? html`<div class="content-header-actions">${action}</div>` : ''}
+    </div>
+  `;
 }
 
 // ─── Render ─────────────────────────────────────────────────────────────
 
+function shell(activeKey, header, body) {
+  return html`
+    <div class="app-shell">
+      ${sidebarView(activeKey, { onNavigate })}
+      <main class="main-content">
+        ${header}
+        ${body}
+      </main>
+    </div>
+  `;
+}
+
 function rerender() {
   const { path } = parseHash(location.hash);
+  const activeKey = activeKeyForPath(path);
+
   let body;
   if (state.loading) {
     body = loadingView();
@@ -98,7 +206,12 @@ function rerender() {
   } else {
     body = loadingView();
   }
-  render(shell(path, body), root);
+
+  // Suppress data-dependent header bits while loading so a stale view's
+  // title/actions don't flash during a fetch.
+  const headerView = state.loading ? null : state.view;
+  const header = contentHeaderView(buildHeader(path, headerView));
+  render(shell(activeKey, header, body), root);
 }
 
 function renderView(view) {
@@ -108,23 +221,20 @@ function renderView(view) {
         onOpen: (name) =>
           navigate(`#/profile?name=${encodeURIComponent(name)}`),
         onRun: (name) => runProfile(name),
-        onCompare: () => {
-          const names = view.data.map((p) => p.name).join(',');
-          navigate(`#/compare?profiles=${encodeURIComponent(names)}`);
-        },
       });
     case 'detail':
-      return profileDetailView(view.data, {
-        onBack: () => navigate('#/'),
-        onRun: (name) => runProfile(name),
-      });
+      return profileDetailView(view.data);
     case 'compare':
-      return compareView(view.data, { onBack: () => navigate('#/') });
+      return compareView(view.data);
     case 'leaderboard':
       return leaderboardView(view.data, {
-        onBack: () => navigate('#/'),
         onSelectBenchmark: (b) =>
           navigate(`#/leaderboard?benchmark=${encodeURIComponent(b)}`),
+      });
+    case 'settings':
+      return settingsView(view.data, {
+        onAddDir: addDir,
+        onRemoveDir: removeDir,
       });
     default:
       return errorView('Unknown view');
@@ -158,6 +268,9 @@ async function route() {
         `/api/leaderboard?benchmark=${encodeURIComponent(benchmark)}`,
       );
       state.view = { kind: 'leaderboard', data };
+    } else if (path === '/settings') {
+      const data = await getJSON('/api/settings');
+      state.view = { kind: 'settings', data };
     } else {
       state.error = `No such route: ${path}`;
     }
@@ -180,6 +293,37 @@ async function runProfile(name) {
     // Fire-and-forget; surface nothing beyond console for now.
   }
 }
+
+async function mutateSettingsDir(method, dir) {
+  try {
+    const res = await fetch('/api/settings/dirs', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dir }),
+    });
+    const data = await res.json();
+    if (!res.ok || !data.ok) {
+      state.view = {
+        kind: 'settings',
+        data: {
+          ...(state.view?.data || {}),
+          error: data.error || 'request failed',
+        },
+      };
+    } else {
+      state.view = { kind: 'settings', data };
+    }
+  } catch (err) {
+    state.view = {
+      kind: 'settings',
+      data: { ...(state.view?.data || {}), error: err.message },
+    };
+  }
+  rerender();
+}
+
+const addDir = (dir) => mutateSettingsDir('POST', dir);
+const removeDir = (dir) => mutateSettingsDir('DELETE', dir);
 
 window.addEventListener('hashchange', route);
 route();

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -87,6 +87,17 @@ const state = {
   view: null, // { kind, data }
 };
 
+// Profile names checked for comparison on the dashboard (persists across renders).
+const selected = new Set();
+function toggleSelect(name) {
+  if (selected.has(name)) {
+    selected.delete(name);
+  } else {
+    selected.add(name);
+  }
+  rerender();
+}
+
 function loadingView() {
   return html`<section class="page loading-state"><sl-spinner></sl-spinner> <span>Loading…</span></section>`;
 }
@@ -144,19 +155,35 @@ function buildHeader(path, view) {
   // Dashboard (home) — no back button.
   const profiles = view?.kind === 'dashboard' ? view.data : null;
   const canCompare = Array.isArray(profiles) && profiles.length > 1;
-  return {
-    showBack: false,
-    title: 'Benchmark Profiles',
-    action: canCompare
-      ? html`<button
-          class="action-btn"
-          @click=${() => {
-            const names = profiles.map((p) => p.name).join(',');
-            navigate(`#/compare?profiles=${encodeURIComponent(names)}`);
-          }}
-        >Compare all</button>`
-      : null,
-  };
+
+  let action = null;
+  if (selected.size > 0) {
+    const names = [...selected].join(',');
+    action = html`
+      <button
+        class="action-btn"
+        @click=${() => {
+          selected.clear();
+          rerender();
+        }}
+      >Clear</button>
+      <button
+        class="action-btn action-btn--primary"
+        @click=${() =>
+          navigate(`#/compare?profiles=${encodeURIComponent(names)}`)}
+      >Compare selected (${selected.size})</button>
+    `;
+  } else if (canCompare) {
+    action = html`<button
+      class="action-btn"
+      @click=${() => {
+        const names = profiles.map((p) => p.name).join(',');
+        navigate(`#/compare?profiles=${encodeURIComponent(names)}`);
+      }}
+    >Compare all</button>`;
+  }
+
+  return { showBack: false, title: 'Benchmark Profiles', action };
 }
 
 function contentHeaderView({ showBack, onBack, title, badge, action }) {
@@ -221,6 +248,8 @@ function renderView(view) {
         onOpen: (name) =>
           navigate(`#/profile?name=${encodeURIComponent(name)}`),
         onRun: (name) => runProfile(name),
+        selected,
+        onToggleSelect: toggleSelect,
       });
     case 'detail':
       return profileDetailView(view.data);

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -13,8 +13,15 @@ import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 
 import '@shoelace-style/shoelace/dist/components/badge/badge.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
+import '@shoelace-style/shoelace/dist/components/button/button.js';
 
 import { outcomeIcon, profileOutcome, variantFor } from './utils/badge.js';
+import { confirmDialogTemplate, showConfirm } from './utils/confirm-dialog.js';
+import {
+  folderPickerTemplate,
+  openFolderPicker,
+} from './utils/folder-picker.js';
 import { compareView } from './views/compare.js';
 import { leaderboardView } from './views/leaderboard.js';
 import { profileDetailView } from './views/profile-detail.js';
@@ -86,7 +93,25 @@ const state = {
   error: null,
   view: null, // { kind, data }
   toast: null, // { variant: 'success'|'danger', message }
+  connection: 'connecting', // 'connected' | 'connecting' | 'disconnected'
 };
+
+// Backend connection indicator (sidebar footer). worca-bench has no WS, so we
+// poll /api/health; the dot reflects reachability.
+function setConnection(next) {
+  if (state.connection !== next) {
+    state.connection = next;
+    rerender();
+  }
+}
+async function heartbeat() {
+  try {
+    const r = await fetch('/api/health');
+    setConnection(r.ok ? 'connected' : 'disconnected');
+  } catch {
+    setConnection('disconnected');
+  }
+}
 
 // Transient launch feedback. Auto-dismisses; a new toast replaces the old.
 let toastTimer = null;
@@ -244,12 +269,14 @@ function contentHeaderView({ showBack, onBack, title, badge, action }) {
 function shell(activeKey, header, body) {
   return html`
     <div class="app-shell">
-      ${sidebarView(activeKey, { onNavigate })}
+      ${sidebarView(activeKey, { onNavigate, connection: state.connection })}
       <main class="main-content">
         ${header}
         ${body}
       </main>
       ${toastView()}
+      ${confirmDialogTemplate()}
+      ${folderPickerTemplate()}
     </div>
   `;
 }
@@ -300,8 +327,10 @@ function renderView(view) {
     case 'settings':
       return settingsView(view.data, {
         onAddDir: addDir,
-        onRemoveDir: removeDir,
+        onRemoveDir: confirmRemoveDir,
         onSetCache: setCache,
+        onBrowseAdd: browseAdd,
+        onBrowseCache: browseCache,
       });
     default:
       return errorView('Unknown view');
@@ -461,6 +490,23 @@ async function mutateSettingsDir(method, dir) {
 const addDir = (dir) => mutateSettingsDir('POST', dir);
 const removeDir = (dir) => mutateSettingsDir('DELETE', dir);
 
+// Destructive: removing a result dir requires explicit confirmation.
+function confirmRemoveDir(dir) {
+  showConfirm(
+    {
+      label: 'Remove directory',
+      message: `Stop reading results from “${dir}”? This only removes it from the dashboard config — the files on disk are left untouched.`,
+      confirmLabel: 'Remove',
+      confirmVariant: 'danger',
+      onConfirm: () => removeDir(dir),
+    },
+    rerender,
+  );
+}
+
+const browseAdd = () => openFolderPicker({ onPick: addDir }, rerender);
+const browseCache = () => openFolderPicker({ onPick: setCache }, rerender);
+
 async function setCache(dir) {
   try {
     const res = await fetch('/api/settings/cache-dir', {
@@ -492,3 +538,7 @@ async function setCache(dir) {
 window.addEventListener('hashchange', route);
 route();
 startPolling();
+heartbeat();
+setInterval(() => {
+  if (!document.hidden) heartbeat();
+}, 5000);

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -85,7 +85,42 @@ const state = {
   loading: false,
   error: null,
   view: null, // { kind, data }
+  toast: null, // { variant: 'success'|'danger', message }
 };
+
+// Transient launch feedback. Auto-dismisses; a new toast replaces the old.
+let toastTimer = null;
+function showToast(variant, message) {
+  state.toast = { variant, message };
+  rerender();
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    state.toast = null;
+    toastTimer = null;
+    rerender();
+  }, 6000);
+}
+
+function toastView() {
+  if (!state.toast) return '';
+  const { variant, message } = state.toast;
+  return html`<div
+    class="launch-toast launch-toast--${variant}"
+    role="status"
+    aria-live="polite"
+  >
+    <span class="launch-toast-msg">${message}</span>
+    <button
+      class="launch-toast-close"
+      aria-label="Dismiss"
+      @click=${() => {
+        state.toast = null;
+        if (toastTimer) clearTimeout(toastTimer);
+        rerender();
+      }}
+    >×</button>
+  </div>`;
+}
 
 // Profile names checked for comparison on the dashboard (persists across renders).
 const selected = new Set();
@@ -214,6 +249,7 @@ function shell(activeKey, header, body) {
         ${header}
         ${body}
       </main>
+      ${toastView()}
     </div>
   `;
 }
@@ -312,13 +348,19 @@ async function route() {
 
 async function runProfile(name) {
   try {
-    await fetch('/api/run', {
+    const res = await fetch('/api/run', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ profile: name }),
     });
-  } catch {
-    // Fire-and-forget; surface nothing beyond console for now.
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.ok) {
+      showToast('success', `Launched ${name} — pid ${data.pid}`);
+    } else {
+      showToast('danger', `Launch failed: ${data.error || res.statusText}`);
+    }
+  } catch (err) {
+    showToast('danger', `Launch failed: ${err.message}`);
   }
 }
 

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -454,6 +454,8 @@ async function runProfile(name, opts = {}) {
     if (Number.isInteger(opts.maxInstances))
       body.maxInstances = opts.maxInstances;
     if (Number.isInteger(opts.maxParallel)) body.maxParallel = opts.maxParallel;
+    // Canary is on by default — only send the flag when explicitly disabled.
+    if (opts.canary === false) body.canary = false;
     if (opts.graphify) body.graphify = opts.graphify;
     if (opts.codeReviewGraph) body.codeReviewGraph = opts.codeReviewGraph;
     const res = await fetch('/api/run', {
@@ -471,6 +473,7 @@ async function runProfile(name, opts = {}) {
         Number.isInteger(opts.maxParallel)
           ? `${opts.maxParallel}× parallel`
           : null,
+        opts.canary === false ? 'no canary' : null,
       ].filter(Boolean);
       const suffix = extra.length ? ` (${extra.join(', ')})` : '';
       showToast('success', `Launched ${name}${suffix} — pid ${data.pid}`);

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -112,6 +112,11 @@ const state = {
   actionsDismissed: new Set(
     JSON.parse(localStorage.getItem('wb.activity.dismissed') || '[]'),
   ),
+  // Dashboard visibility filter: 'active' (non-archived, default) | 'all' |
+  // 'archived'. The pill choice is a UI nicety persisted per-browser; the
+  // archived state itself is server-side (see /api/profiles/archive).
+  dashFilter: localStorage.getItem('wb.dash.filter') || 'active',
+  dashSearch: '',
 };
 
 // Backend connection indicator (sidebar footer). worca-bench has no WS, so we
@@ -177,6 +182,44 @@ function toggleSelect(agg) {
     selected.add(key);
   }
   rerender();
+}
+
+function setDashFilter(key) {
+  state.dashFilter = key;
+  localStorage.setItem('wb.dash.filter', key);
+  rerender();
+}
+function setDashSearch(q) {
+  state.dashSearch = q;
+  rerender();
+}
+
+// Archive / un-archive the checked profiles (server-persisted). After it lands,
+// clear the selection and refresh so the cards move between filter tabs.
+async function archiveSelected(archived) {
+  const keys = [...selected];
+  if (keys.length === 0) return;
+  try {
+    const res = await fetch('/api/profiles/archive', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ keys, archived }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.ok) {
+      const verb = archived ? 'Archived' : 'Unarchived';
+      showToast(
+        'success',
+        `${verb} ${keys.length} profile${keys.length === 1 ? '' : 's'}`,
+      );
+      selected.clear();
+      refreshCurrent();
+    } else {
+      showToast('danger', `Archive failed: ${data.error || res.statusText}`);
+    }
+  } catch (err) {
+    showToast('danger', `Archive failed: ${err.message}`);
+  }
 }
 
 function loadingView() {
@@ -282,7 +325,14 @@ function buildHeader(path, view) {
   let action = null;
   if (selected.size > 0) {
     const names = [...selected].join(',');
+    // On the Archived tab the selected cards are already archived, so the
+    // action restores them; everywhere else it archives.
+    const unarchiving = state.dashFilter === 'archived';
     action = html`
+      <button
+        class="action-btn"
+        @click=${() => archiveSelected(!unarchiving)}
+      >${unarchiving ? 'Unarchive' : 'Archive'} (${selected.size})</button>
       <button
         class="action-btn"
         @click=${() => {
@@ -435,6 +485,10 @@ function renderView(view) {
         onRun: (name) => runProfile(name),
         selected,
         onToggleSelect: toggleSelect,
+        filter: state.dashFilter,
+        search: state.dashSearch,
+        onFilter: setDashFilter,
+        onSearch: setDashSearch,
       });
     case 'detail': {
       // Disable Run while this profile already has a live run action — the

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -136,20 +136,19 @@ function buildHeader(path, view) {
     };
   }
 
+  // Compare / Leaderboard / Settings are top-level sidebar sections (peers of
+  // the dashboard), so they carry no back button — only true drill-downs (the
+  // profile detail above) do. Navigation back to the dashboard is the sidebar.
   if (path === '/compare') {
-    return {
-      showBack: true,
-      onBack: backToDashboard,
-      title: 'Compare Profiles',
-    };
+    return { showBack: false, title: 'Compare Profiles' };
   }
 
   if (path === '/leaderboard') {
-    return { showBack: true, onBack: backToDashboard, title: 'Leaderboard' };
+    return { showBack: false, title: 'Leaderboard' };
   }
 
   if (path === '/settings') {
-    return { showBack: true, onBack: backToDashboard, title: 'Settings' };
+    return { showBack: false, title: 'Settings' };
   }
 
   // Dashboard (home) — no back button.

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -17,6 +17,7 @@ import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
 import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
+import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 
 import { outcomeIcon, profileOutcome } from './utils/badge.js';
 import { confirmDialogTemplate, showConfirm } from './utils/confirm-dialog.js';
@@ -334,6 +335,7 @@ function renderView(view) {
     case 'detail':
       return profileDetailView(view.data, {
         onRun: (name, opts) => runProfile(name, opts),
+        onRegrade: (name, instanceId) => regradeInstance(name, instanceId),
       });
     case 'compare':
       return compareView(view.data);
@@ -485,6 +487,33 @@ async function runProfile(name, opts = {}) {
     }
   } catch (err) {
     showToast('danger', `Launch failed: ${err.message}`);
+  }
+}
+
+async function regradeInstance(name, instanceId) {
+  try {
+    const res = await fetch('/api/regrade', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profile: name,
+        instance: instanceId,
+        mode: 'sb-cli',
+      }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.ok) {
+      showToast(
+        'success',
+        `Re-grading ${instanceId} via sb-cli — pid ${data.pid}`,
+      );
+      // Results land after the hosted eval completes; nudge a few refreshes.
+      setTimeout(refreshCurrent, 2000);
+    } else {
+      showToast('danger', `Regrade failed: ${data.error || res.statusText}`);
+    }
+  } catch (err) {
+    showToast('danger', `Regrade failed: ${err.message}`);
   }
 }
 

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -287,7 +287,9 @@ function renderView(view) {
         onToggleSelect: toggleSelect,
       });
     case 'detail':
-      return profileDetailView(view.data);
+      return profileDetailView(view.data, {
+        onRun: (name, opts) => runProfile(name, opts),
+      });
     case 'compare':
       return compareView(view.data);
     case 'leaderboard':
@@ -307,37 +309,47 @@ function renderView(view) {
 
 // ─── Route handlers ─────────────────────────────────────────────────────
 
+/** Fetch the view object for a route. Pure data — no state mutation. */
+async function loadView(path, params) {
+  if (path === '/' || path === '') {
+    const { profiles } = await getJSON('/api/profiles');
+    return { kind: 'dashboard', data: profiles };
+  }
+  if (path === '/profile') {
+    const name = params.get('name');
+    const data = await getJSON(`/api/profiles/${encodeURIComponent(name)}`);
+    return { kind: 'detail', data };
+  }
+  if (path === '/compare') {
+    const profiles = params.get('profiles') || '';
+    const { compare } = await getJSON(
+      `/api/compare?profiles=${encodeURIComponent(profiles)}`,
+    );
+    return { kind: 'compare', data: compare };
+  }
+  if (path === '/leaderboard') {
+    const benchmark = params.get('benchmark') || 'swe-bench-verified';
+    const data = await getJSON(
+      `/api/leaderboard?benchmark=${encodeURIComponent(benchmark)}`,
+    );
+    return { kind: 'leaderboard', data };
+  }
+  if (path === '/settings') {
+    const data = await getJSON('/api/settings');
+    return { kind: 'settings', data };
+  }
+  return null;
+}
+
 async function route() {
   const { path, params } = parseHash(location.hash);
   state.loading = true;
   state.error = null;
   rerender();
   try {
-    if (path === '/' || path === '') {
-      const { profiles } = await getJSON('/api/profiles');
-      state.view = { kind: 'dashboard', data: profiles };
-    } else if (path === '/profile') {
-      const name = params.get('name');
-      const data = await getJSON(`/api/profiles/${encodeURIComponent(name)}`);
-      state.view = { kind: 'detail', data };
-    } else if (path === '/compare') {
-      const profiles = params.get('profiles') || '';
-      const { compare } = await getJSON(
-        `/api/compare?profiles=${encodeURIComponent(profiles)}`,
-      );
-      state.view = { kind: 'compare', data: compare };
-    } else if (path === '/leaderboard') {
-      const benchmark = params.get('benchmark') || 'swe-bench-verified';
-      const data = await getJSON(
-        `/api/leaderboard?benchmark=${encodeURIComponent(benchmark)}`,
-      );
-      state.view = { kind: 'leaderboard', data };
-    } else if (path === '/settings') {
-      const data = await getJSON('/api/settings');
-      state.view = { kind: 'settings', data };
-    } else {
-      state.error = `No such route: ${path}`;
-    }
+    const view = await loadView(path, params);
+    if (view) state.view = view;
+    else state.error = `No such route: ${path}`;
   } catch (err) {
     state.error = err.message;
   } finally {
@@ -346,16 +358,69 @@ async function route() {
   }
 }
 
-async function runProfile(name) {
+// ─── Background auto-refresh ─────────────────────────────────────────────
+//
+// A live dashboard: the current route's data is re-fetched on an interval and
+// re-rendered only when it actually changed (so a run launched here surfaces
+// its results without a manual reload). No spinner — this is silent. Settings
+// is excluded so a poll never clobbers the add-dir form/error state. The
+// interval is overridable via `?poll=<ms>` (used by e2e to speed the tick up).
+
+const POLL_MS = (() => {
+  const raw = Number.parseInt(
+    new URLSearchParams(location.search).get('poll') || '',
+    10,
+  );
+  return Number.isInteger(raw) && raw >= 250 ? raw : 5000;
+})();
+let pollTimer = null;
+
+async function refreshCurrent() {
+  if (state.loading) return;
+  const { path, params } = parseHash(location.hash);
+  if (path === '/settings') return;
   try {
+    const next = await loadView(path, params);
+    if (next && JSON.stringify(next) !== JSON.stringify(state.view)) {
+      state.view = next;
+      rerender();
+    }
+  } catch {
+    // Silent — the next tick retries.
+  }
+}
+
+function startPolling() {
+  if (pollTimer) return;
+  pollTimer = setInterval(() => {
+    if (!document.hidden) refreshCurrent();
+  }, POLL_MS);
+}
+
+async function runProfile(name, opts = {}) {
+  try {
+    const body = { profile: name };
+    if (Number.isInteger(opts.reps)) body.reps = opts.reps;
+    if (Number.isInteger(opts.maxInstances))
+      body.maxInstances = opts.maxInstances;
     const res = await fetch('/api/run', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ profile: name }),
+      body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
     if (res.ok && data.ok) {
-      showToast('success', `Launched ${name} — pid ${data.pid}`);
+      const extra = [
+        Number.isInteger(opts.reps) ? `${opts.reps} reps` : null,
+        Number.isInteger(opts.maxInstances)
+          ? `${opts.maxInstances} instances`
+          : null,
+      ].filter(Boolean);
+      const suffix = extra.length ? ` (${extra.join(', ')})` : '';
+      showToast('success', `Launched ${name}${suffix} — pid ${data.pid}`);
+      // Nudge a refresh so the run's first results surface without waiting a
+      // full poll tick (results land in seconds under mock).
+      setTimeout(refreshCurrent, 1500);
     } else {
       showToast('danger', `Launch failed: ${data.error || res.statusText}`);
     }
@@ -397,3 +462,4 @@ const removeDir = (dir) => mutateSettingsDir('DELETE', dir);
 
 window.addEventListener('hashchange', route);
 route();
+startPolling();

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -180,6 +180,40 @@ function errorView(message) {
 
 // ─── Content header ─────────────────────────────────────────────────────
 
+/** Top-right actions for the profile header (mutually exclusive states). */
+function _profileActions(agg, isActive, view) {
+  if (isActive) {
+    return html`<button
+      class="action-btn action-btn--danger"
+      @click=${() => stopRuns(agg.name)}
+    >Stop Runs</button>`;
+  }
+  const rg = view?.data?.regrade;
+  if (rg?.active) {
+    return html`<button
+        class="action-btn"
+        disabled
+        title="Regrade in progress"
+      >Regrading ${rg.done ?? 0}/${rg.total ?? 0}…</button
+      ><button
+        class="action-btn action-btn--danger"
+        @click=${() => stopRegradeSweep(agg.name)}
+      >Stop Regrade</button>`;
+  }
+  const hasReps = (view?.data?.reps || []).length > 0;
+  return html`<button
+      class="action-btn"
+      @click=${() => clearResults(agg.name)}
+    >Clear Results</button>${
+      hasReps
+        ? html`<button
+            class="action-btn"
+            @click=${() => regradeAll(agg.name)}
+          >Regrade All</button>`
+        : ''
+    }`;
+}
+
 /**
  * Build the content-header spec for a route. Data-dependent bits (the
  * profile name/badge/Run button, the dashboard "Compare all" action) read
@@ -209,13 +243,11 @@ function buildHeader(path, view) {
       // (running / graded / skipped). State lives in the live block, the
       // resolved-rate stat, and the per-rep table instead.
       badge: null,
-      // Run lives in Run options. Top-right is Stop Runs (when active) or
-      // Clear Results (when idle) — never both.
-      action: !agg
-        ? null
-        : isActive
-          ? html`<button class="action-btn action-btn--danger" @click=${() => stopRuns(agg.name)}>Stop Runs</button>`
-          : html`<button class="action-btn" @click=${() => clearResults(agg.name)}>Clear Results</button>`,
+      // Run lives in Run options. Top-right: Stop Runs while a pipeline run is
+      // active; a "Regrading X/N…" + Stop Regrade pair while a sweep runs;
+      // otherwise Clear Results with Regrade All to its right (only when there
+      // are reps to re-grade).
+      action: !agg ? null : _profileActions(agg, isActive, view),
     };
   }
 
@@ -402,6 +434,24 @@ async function loadView(path, params) {
   return null;
 }
 
+// Detect a regrade sweep finishing (active → not active for the same profile)
+// across fetches and raise a one-shot completion toast with the verdict counts.
+let _prevRegrade = { profile: null, active: false };
+function _noteRegradeCompletion(view) {
+  if (view?.kind !== 'detail') return;
+  const name = view.data?.aggregate?.name || null;
+  const rg = view.data?.regrade;
+  const active = !!rg?.active;
+  if (_prevRegrade.active && _prevRegrade.profile === name && !active) {
+    const c = rg?.counts || {};
+    showToast(
+      'success',
+      `Regrade complete for ${name}: ${c.resolved ?? 0} resolved · ${c.graded ?? 0} graded · ${c.error ?? 0} error`,
+    );
+  }
+  _prevRegrade = { profile: name, active };
+}
+
 async function route() {
   const { path, params } = parseHash(location.hash);
   state.loading = true;
@@ -409,8 +459,12 @@ async function route() {
   rerender();
   try {
     const view = await loadView(path, params);
-    if (view) state.view = view;
-    else state.error = `No such route: ${path}`;
+    if (view) {
+      state.view = view;
+      _noteRegradeCompletion(view);
+    } else {
+      state.error = `No such route: ${path}`;
+    }
   } catch (err) {
     state.error = err.message;
   } finally {
@@ -442,6 +496,7 @@ async function refreshCurrent() {
   if (path === '/settings') return;
   try {
     const next = await loadView(path, params);
+    if (next) _noteRegradeCompletion(next);
     if (next && JSON.stringify(next) !== JSON.stringify(state.view)) {
       state.view = next;
       rerender();
@@ -507,14 +562,61 @@ async function runProfile(name, opts = {}) {
 // / SWE-bench cloud / Modal); the choice is remembered for next time.
 function regradeInstance(name, instanceId) {
   showRegradeDialog(
-    { instanceId, onConfirm: (mode) => doRegrade(name, instanceId, mode) },
+    {
+      title: `Re-grade ${instanceId}`,
+      onConfirm: (mode) => doRegrade(name, { instance: instanceId, mode }),
+    },
     rerender,
   );
 }
 
-async function doRegrade(name, instanceId, mode) {
+// Whole-profile regrade (header "Regrade All"): same backend dialog, then a
+// single sequential sweep over every saved diff for the profile.
+function regradeAll(name) {
+  showRegradeDialog(
+    {
+      title: `Re-grade all of ${name}`,
+      onConfirm: (mode) => doRegrade(name, { mode, sequential: true }),
+    },
+    rerender,
+  );
+}
+
+// Stop an in-flight regrade sweep (kills the runner tree). Confirmed because it
+// abandons in-progress (paid) Modal/Docker evals.
+function stopRegradeSweep(name) {
+  showConfirm(
+    {
+      label: 'Stop regrade',
+      message: `Stop the in-flight regrade sweep for “${name}”? The instance currently grading is abandoned; rows already graded are kept.`,
+      confirmLabel: 'Stop regrade',
+      confirmVariant: 'danger',
+      onConfirm: async () => {
+        try {
+          const res = await fetch(
+            `/api/profiles/${encodeURIComponent(name)}/regrade/stop`,
+            { method: 'POST' },
+          );
+          const data = await res.json();
+          showToast(
+            data.ok ? 'success' : 'danger',
+            data.ok ? 'Regrade stopped' : `Stop failed: ${data.error}`,
+          );
+          setTimeout(refreshCurrent, 1200);
+        } catch (err) {
+          showToast('danger', `Stop failed: ${err.message}`);
+        }
+      },
+    },
+    rerender,
+  );
+}
+
+async function doRegrade(name, { instance, mode, sequential } = {}) {
   try {
-    const body = { profile: name, instance: instanceId, mode };
+    const body = { profile: name, mode };
+    if (instance) body.instance = instance;
+    if (sequential) body.sequential = true;
     // Cloud (sb-cli) / Modal graders need credentials — forward from the browser.
     const secrets = launchSecrets();
     if (secrets) body.secrets = secrets;
@@ -525,10 +627,8 @@ async function doRegrade(name, instanceId, mode) {
     });
     const data = await res.json().catch(() => ({}));
     if (res.ok && data.ok) {
-      showToast(
-        'success',
-        `Re-grading ${instanceId} via ${mode} — pid ${data.pid}`,
-      );
+      const what = instance ? instance : `all of ${name}`;
+      showToast('success', `Re-grading ${what} via ${mode} — pid ${data.pid}`);
       // Results land after the eval completes; nudge a refresh.
       setTimeout(refreshCurrent, 2000);
     } else {

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -199,9 +199,13 @@ function buildHeader(path, view) {
       // (running / graded / skipped). State lives in the live block, the
       // resolved-rate stat, and the per-rep table instead.
       badge: null,
-      action: agg
-        ? html`<button class="action-btn action-btn--primary" @click=${() => runProfile(agg.name)}>Run profile</button>`
-        : null,
+      // Run lives in Run options. Top-right is Stop Runs (when active) or
+      // Clear Results (when idle) — never both.
+      action: !agg
+        ? null
+        : isActive
+          ? html`<button class="action-btn action-btn--danger" @click=${() => stopRuns(agg.name)}>Stop Runs</button>`
+          : html`<button class="action-btn" @click=${() => clearResults(agg.name)}>Clear Results</button>`,
     };
   }
 
@@ -517,6 +521,67 @@ function confirmRemoveDir(dir) {
 
 const browseAdd = () => openFolderPicker({ onPick: addDir }, rerender);
 const browseCache = () => openFolderPicker({ onPick: setCache }, rerender);
+
+// Destructive: stop a profile's active runs (kills the runner trees).
+function stopRuns(name) {
+  showConfirm(
+    {
+      label: 'Stop runs',
+      message: `Stop all active runs for “${name}”? Running reps are killed immediately.`,
+      confirmLabel: 'Stop runs',
+      confirmVariant: 'danger',
+      onConfirm: async () => {
+        try {
+          const res = await fetch(
+            `/api/profiles/${encodeURIComponent(name)}/stop`,
+            { method: 'POST' },
+          );
+          const data = await res.json();
+          showToast(
+            data.ok ? 'success' : 'danger',
+            data.ok
+              ? `Stopped ${data.stopped} run${data.stopped === 1 ? '' : 's'}`
+              : `Stop failed: ${data.error}`,
+          );
+          setTimeout(refreshCurrent, 1200);
+        } catch (err) {
+          showToast('danger', `Stop failed: ${err.message}`);
+        }
+      },
+    },
+    rerender,
+  );
+}
+
+// Destructive: clear a profile's recorded results + artifacts.
+function clearResults(name) {
+  showConfirm(
+    {
+      label: 'Clear results',
+      message: `Delete all recorded results for “${name}” (rows + run artifacts)? This cannot be undone.`,
+      confirmLabel: 'Clear results',
+      confirmVariant: 'danger',
+      onConfirm: async () => {
+        try {
+          const res = await fetch(
+            `/api/profiles/${encodeURIComponent(name)}/clear`,
+            { method: 'POST' },
+          );
+          const data = await res.json();
+          if (data.ok) {
+            showToast('success', `Cleared ${data.removed} result rows`);
+            navigate('#/');
+          } else {
+            showToast('danger', `Clear failed: ${data.error}`);
+          }
+        } catch (err) {
+          showToast('danger', `Clear failed: ${err.message}`);
+        }
+      },
+    },
+    rerender,
+  );
+}
 
 async function setCache(dir) {
   try {

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -636,12 +636,38 @@ async function refreshCurrent() {
   }
 }
 
+// Live elapsed time, sweep ETA, and dock duration are derived from `Date.now()`
+// at render time (see `_elapsedSince` / `_etaForSweep` in profile-detail.js and
+// `_fmtDur` in activity-dock.js). When a run/grading is in flight but its server
+// payload is byte-identical between polls, the diff-guarded refreshes above skip
+// the re-render — and those clocks visibly freeze until a manual reload. This
+// returns true when such a wall-clock value is on screen so the poll can force a
+// tick. Pure in (view, actions) so it stays trivially correct.
+function _hasLiveClock(view, actions) {
+  const d = view?.data;
+  const viewLive = Array.isArray(d)
+    ? d.some((p) => p?.active || p?.regrade) // dashboard: per-profile aggregates
+    : !!(d?.active?.length || d?.regrade?.active); // detail: live runs / sweep
+  const dockLive = Array.isArray(actions)
+    ? actions.some((a) => a?.status === 'running')
+    : false;
+  return viewLive || dockLive;
+}
+
 function startPolling() {
   if (pollTimer) return;
   pollTimer = setInterval(() => {
-    if (!document.hidden) {
-      refreshCurrent();
-      refreshActions(); // keep the Activity dock live on every page
+    if (document.hidden) return;
+    refreshCurrent();
+    refreshActions(); // keep the Activity dock live on every page
+    // Advance the wall-clock-derived values even when the server payload hasn't
+    // changed. Settings is excluded (matching refreshCurrent) so a forced
+    // re-render never clobbers the add-dir form mid-edit.
+    if (
+      parseHash(location.hash).path !== '/settings' &&
+      _hasLiveClock(state.view, state.actions)
+    ) {
+      rerender();
     }
   }, POLL_MS);
 }

--- a/worca-bench/app/main.js
+++ b/worca-bench/app/main.js
@@ -32,6 +32,7 @@ import {
   showRegradeDialog,
 } from './utils/regrade-dialog.js';
 import { clearSecret, launchSecrets, saveSecrets } from './utils/secrets.js';
+import { activityDock } from './views/activity-dock.js';
 import { compareView } from './views/compare.js';
 import { leaderboardView } from './views/leaderboard.js';
 import { profileDetailView } from './views/profile-detail.js';
@@ -104,6 +105,13 @@ const state = {
   view: null, // { kind, data }
   toast: null, // { variant: 'success'|'danger', message }
   connection: 'connecting', // 'connected' | 'connecting' | 'disconnected'
+  // Activity dock: the actions ledger (Run/Regrade launches), refreshed from
+  // /api/actions so it's visible on every page and survives a reload.
+  actions: [],
+  actionsCollapsed: localStorage.getItem('wb.activity.collapsed') !== 'false', // default collapsed
+  actionsDismissed: new Set(
+    JSON.parse(localStorage.getItem('wb.activity.dismissed') || '[]'),
+  ),
 };
 
 // Backend connection indicator (sidebar footer). worca-bench has no WS, so we
@@ -330,6 +338,14 @@ function shell(activeKey, header, body) {
         ${header}
         ${body}
       </main>
+      ${activityDock(state.actions, {
+        collapsed: state.actionsCollapsed,
+        dismissed: state.actionsDismissed,
+        onToggle: toggleActivity,
+        onStop: stopAction,
+        onView: viewAction,
+        onDismiss: dismissAction,
+      })}
       ${toastView()}
       ${confirmDialogTemplate()}
       ${folderPickerTemplate()}
@@ -337,6 +353,53 @@ function shell(activeKey, header, body) {
       ${notesDialogTemplate()}
     </div>
   `;
+}
+
+// ─── Activity dock: refresh + controls ──────────────────────────────────────
+
+async function refreshActions() {
+  try {
+    const data = await getJSON('/api/actions');
+    const next = data.actions || [];
+    if (JSON.stringify(next) !== JSON.stringify(state.actions)) {
+      state.actions = next;
+      rerender();
+    }
+  } catch {
+    // Silent — the next poll tick retries.
+  }
+}
+
+function toggleActivity() {
+  state.actionsCollapsed = !state.actionsCollapsed;
+  localStorage.setItem('wb.activity.collapsed', String(state.actionsCollapsed));
+  rerender();
+}
+
+async function stopAction(a) {
+  try {
+    await fetch(`/api/actions/${encodeURIComponent(a.id)}/stop`, {
+      method: 'POST',
+    });
+    showToast('success', `Stopping ${a.type} ${a.profile}…`);
+    setTimeout(refreshActions, 800);
+  } catch (err) {
+    showToast('danger', `Stop failed: ${err.message}`);
+  }
+}
+
+function viewAction(a) {
+  const src = a.src ? `&src=${encodeURIComponent(a.src)}` : '';
+  navigate(`#/profile?name=${encodeURIComponent(a.profile)}${src}`);
+}
+
+function dismissAction(a) {
+  state.actionsDismissed.add(a.id);
+  localStorage.setItem(
+    'wb.activity.dismissed',
+    JSON.stringify([...state.actionsDismissed]),
+  );
+  rerender();
 }
 
 function rerender() {
@@ -512,7 +575,10 @@ async function refreshCurrent() {
 function startPolling() {
   if (pollTimer) return;
   pollTimer = setInterval(() => {
-    if (!document.hidden) refreshCurrent();
+    if (!document.hidden) {
+      refreshCurrent();
+      refreshActions(); // keep the Activity dock live on every page
+    }
   }, POLL_MS);
 }
 
@@ -553,8 +619,9 @@ async function runProfile(name, opts = {}) {
       ].filter(Boolean);
       const suffix = extra.length ? ` (${extra.join(', ')})` : '';
       showToast('success', `Launched ${name}${suffix} — pid ${data.pid}`);
-      // Nudge a refresh so the run's first results surface without waiting a
-      // full poll tick (results land in seconds under mock).
+      // Surface the new action in the dock immediately (server recorded it on
+      // launch), and nudge a results refresh for the run's first rows.
+      refreshActions();
       setTimeout(refreshCurrent, 1500);
     } else {
       showToast('danger', `Launch failed: ${data.error || res.statusText}`);
@@ -670,7 +737,8 @@ async function doRegrade(name, { instance, mode, sequential } = {}) {
     if (res.ok && data.ok) {
       const what = instance ? instance : `all of ${name}`;
       showToast('success', `Re-grading ${what} via ${mode} — pid ${data.pid}`);
-      // Results land after the eval completes; nudge a refresh.
+      // Surface the regrade action in the dock now; results land after the eval.
+      refreshActions();
       setTimeout(refreshCurrent, 2000);
     } else {
       showToast('danger', `Regrade failed: ${data.error || res.statusText}`);
@@ -833,6 +901,7 @@ window.addEventListener('hashchange', route);
 route();
 startPolling();
 heartbeat();
+refreshActions(); // populate the Activity dock on first paint (survives reload)
 setInterval(() => {
   if (!document.hidden) heartbeat();
 }, 5000);

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -460,6 +460,9 @@ code {
   flex-wrap: wrap;
   gap: 8px;
   padding-left: 26px;
+  /* Pin to the card's bottom-right so Run stays in one place regardless of how
+     much meta/stage content sits above it (grid stretches cards to equal height). */
+  margin-top: auto;
 }
 
 .run-card-actions:empty {

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -990,6 +990,39 @@ code {
 .reps-row--grading {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
+
+/* Run-options native select (CLAUDE.md mode) — match the number inputs. */
+.run-opt-select {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--fg);
+  font-size: 13px;
+}
+.run-opt-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* Notes dialog textarea. */
+.notes-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--fg);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 13px;
+  line-height: 1.5;
+  resize: vertical;
+}
+.notes-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
 .live-run {
   border: 1px solid var(--accent);
   border-radius: var(--radius);

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -626,3 +626,43 @@ code {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px var(--accent) inset;
 }
+
+/* ─── Launch toast (run feedback) ──────────────────────────────────────── */
+.launch-toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  max-width: 420px;
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border-left: 4px solid var(--border);
+  background: var(--surface);
+  color: var(--fg);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  font-size: 13px;
+}
+.launch-toast--success {
+  border-left-color: var(--status-completed);
+}
+.launch-toast--danger {
+  border-left-color: var(--status-failed);
+}
+.launch-toast-msg {
+  flex: 1;
+}
+.launch-toast-close {
+  border: none;
+  background: none;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.launch-toast-close:hover {
+  color: var(--fg);
+}

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -165,6 +165,68 @@ code {
   opacity: 1;
 }
 
+/* Footer pinned to the bottom: connection indicator (left) + Settings gear (right). */
+.sidebar-footer {
+  margin-top: auto;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.sidebar-settings-btn {
+  border: 1px solid var(--border);
+}
+.sidebar-settings-btn:hover {
+  color: var(--fg);
+}
+.sidebar-settings-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+}
+
+.connection-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.conn-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--muted);
+}
+
+.connection-indicator.connected .conn-dot {
+  background: var(--status-completed);
+}
+
+.connection-indicator.disconnected .conn-dot {
+  background: var(--status-failed);
+}
+
+.connection-indicator.connecting .conn-dot {
+  background: #f59e0b;
+  animation: conn-blink 1.2s ease-in-out infinite;
+}
+
+@keyframes conn-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
 /* ─── Main content + content header ────────────────────────────────────── */
 
 .main-content {
@@ -544,89 +606,198 @@ code {
   text-decoration: underline;
 }
 
-/* ─── Settings page ─────────────────────────────────────────────────────── */
+/* ─── Settings page (card-based) ───────────────────────────────────────── */
 .settings-view {
-  max-width: 760px;
+  max-width: 820px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
-.settings-note {
-  color: var(--muted);
+
+.settings-alert {
+  padding: 10px 14px;
+  border-radius: var(--radius);
+  border-left: 4px solid var(--status-failed);
+  background: var(--bg-secondary);
+  color: var(--fg);
   font-size: 13px;
-  line-height: 1.5;
-  margin-bottom: 18px;
 }
-.settings-block {
-  margin-bottom: 24px;
+
+.settings-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  overflow: hidden;
 }
-.settings-h {
-  font-size: 13px;
+
+.settings-card-head {
+  padding: 16px 18px 12px;
+}
+.settings-card-title {
+  margin: 0 0 4px;
+  font-size: 15px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  color: var(--fg);
+}
+.settings-card-desc {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.5;
   color: var(--muted);
-  margin: 0 0 10px;
 }
-.settings-dirs {
-  width: 100%;
-  border-collapse: collapse;
+.settings-card-desc code {
+  font-size: 11.5px;
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--bg-tertiary);
 }
-.settings-dir td {
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border-subtle, #2a2a2a);
-  font-size: 13px;
-  vertical-align: middle;
+
+.settings-list {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--border-subtle);
 }
-.settings-dir-path {
+.settings-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.settings-row:last-child {
+  border-bottom: none;
+}
+.settings-row-icon {
+  display: inline-flex;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.settings-row-path {
+  flex: 1;
+  min-width: 0;
   font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12.5px;
+  color: var(--fg);
   word-break: break-all;
 }
-.settings-dir-tag {
+.settings-empty {
+  padding: 14px 18px;
+  font-size: 13px;
   color: var(--muted);
-  font-size: 12px;
-  white-space: nowrap;
 }
-.settings-dir--primary .settings-dir-path {
-  color: var(--text-secondary, var(--muted));
-}
-.settings-remove {
+
+/* Plain icon button (Lucide SVG) — used for row removal. */
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
   background: transparent;
-  border: 1px solid var(--status-error, #ef4444);
-  color: var(--status-error, #ef4444);
-  border-radius: var(--radius, 6px);
-  padding: 3px 10px;
-  font-size: 12px;
+  color: var(--muted);
   cursor: pointer;
+  flex-shrink: 0;
 }
-.settings-remove:hover {
-  background: var(--status-error, #ef4444);
-  color: #fff;
+.icon-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--fg);
 }
-.settings-add {
+.icon-btn--danger:hover {
+  color: var(--status-failed);
+}
+
+.settings-inline-form {
   display: flex;
   gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
 }
-.settings-add-input {
+.settings-input {
   flex: 1;
-  padding: 7px 10px;
-  border: 1px solid var(--border-subtle, #2a2a2a);
-  border-radius: var(--radius, 6px);
-  background: var(--surface, #1a1a1a);
-  color: var(--text-primary, #e5e5e5);
+  min-width: 0;
+  padding: 8px 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--fg);
   font-size: 13px;
   font-family: var(--mono, ui-monospace, monospace);
 }
-.settings-add-btn {
-  background: var(--accent, #3b82f6);
-  color: #fff;
+.settings-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.settings-row-hint {
+  font-size: 11.5px;
+  color: var(--muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.settings-browse-btn {
+  flex-shrink: 0;
+}
+
+/* ─── Folder picker dialog ─────────────────────────────────────────────── */
+.folder-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.folder-picker-path {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px;
+  color: var(--muted);
+  word-break: break-all;
+  padding: 6px 8px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius);
+}
+.folder-picker-list {
+  display: flex;
+  flex-direction: column;
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+}
+.folder-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
   border: none;
-  border-radius: var(--radius, 6px);
-  padding: 7px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--fg);
   font-size: 13px;
   cursor: pointer;
 }
-.settings-error {
-  color: var(--status-error, #ef4444);
+.folder-picker-item:last-child {
+  border-bottom: none;
+}
+.folder-picker-item:hover {
+  background: var(--bg-tertiary);
+}
+.folder-picker-icon {
+  display: inline-flex;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.folder-picker-up {
+  color: var(--muted);
+  font-weight: 600;
+}
+.folder-picker-empty {
+  padding: 12px;
   font-size: 13px;
-  margin-top: 8px;
+  color: var(--muted);
+  text-align: center;
 }
 
 /* ─── Profile selection (Compare) ──────────────────────────────────────── */

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -1168,6 +1168,16 @@ code {
   border-color: var(--status-failed);
   color: var(--status-failed);
 }
+/* Bead progress (completed/dispatched) + loop-back count inside a stage chip. */
+.stage-chip-beads,
+.stage-chip-iters {
+  margin-left: 5px;
+  padding-left: 5px;
+  border-left: 1px solid currentColor;
+  opacity: 0.85;
+  font-variant-numeric: tabular-nums;
+  font-size: 10.5px;
+}
 /* Spacer that sets the post-pipeline "Grade" chip apart from the worca stages. */
 .stage-chip-sep {
   align-self: stretch;

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -938,6 +938,58 @@ code {
   gap: 10px;
   margin-bottom: 16px;
 }
+
+/* ─── Regrade sweep progress ───────────────────────────────────────────── */
+.regrade-progress {
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  padding: 12px 14px;
+  margin-bottom: 16px;
+}
+.regrade-progress-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  color: var(--accent);
+}
+.regrade-progress-label {
+  font-weight: 600;
+  font-size: 13px;
+}
+.regrade-progress-current {
+  font-size: 12px;
+  font-family: var(--mono, ui-monospace, monospace);
+  color: var(--fg);
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--surface);
+}
+.regrade-progress-eta {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--muted);
+}
+.regrade-progress-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--surface);
+  overflow: hidden;
+}
+.regrade-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.4s ease;
+}
+.regrade-progress-counts {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.reps-row--grading {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
 .live-run {
   border: 1px solid var(--accent);
   border-radius: var(--radius);

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -1225,3 +1225,176 @@ code {
   color: #4338ca;
   border-color: rgba(99, 102, 241, 0.3);
 }
+
+/* ─── Activity dock (persistent Run/Regrade ledger) ─────────────────────────
+   Fixed to the bottom of the content area (right of the sidebar); a slim bar
+   that expands into a table. Visible on every page, reflects the server ledger. */
+.activity-dock {
+  position: fixed;
+  left: var(--sidebar-width);
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.08);
+  font-size: 13px;
+}
+.activity-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--bg-secondary);
+  border: none;
+  cursor: pointer;
+  color: var(--fg);
+  font: inherit;
+}
+.activity-bar-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+}
+.activity-caret {
+  color: var(--muted);
+}
+.activity-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.act-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+}
+.act-chip--running {
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.12);
+}
+.act-chip--failed {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.12);
+}
+.act-chip--done {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.12);
+}
+.act-chip--stopped {
+  color: var(--muted);
+  background: rgba(148, 163, 184, 0.15);
+}
+.act-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2563eb;
+  animation: act-pulse 1.4s ease-in-out infinite;
+}
+@keyframes act-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+.activity-panel {
+  max-height: 38vh;
+  overflow: auto;
+  border-top: 1px solid var(--border-subtle);
+}
+.activity-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.activity-table th {
+  position: sticky;
+  top: 0;
+  text-align: left;
+  padding: 6px 12px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+  background: var(--surface);
+}
+.activity-table td {
+  padding: 6px 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+.activity-row--running {
+  background: rgba(37, 99, 235, 0.05);
+}
+.act-type {
+  font-weight: 600;
+}
+.act-profile {
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.act-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+}
+.act-status--running {
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.12);
+}
+.act-status--done {
+  color: #16a34a;
+  background: rgba(22, 163, 74, 0.12);
+}
+.act-status--failed {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.12);
+}
+.act-status--stopped {
+  color: var(--muted);
+  background: rgba(148, 163, 184, 0.15);
+}
+.act-progress,
+.act-time,
+.act-dur {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.act-actions {
+  display: flex;
+  gap: 6px;
+}
+.act-btn {
+  padding: 3px 9px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 12px;
+}
+.act-btn:hover {
+  background: var(--bg-tertiary);
+}
+.act-btn--stop {
+  color: #dc2626;
+  border-color: rgba(220, 38, 38, 0.4);
+}
+.act-btn--dismiss {
+  color: var(--muted);
+}
+/* Reserve room so page content never hides behind the collapsed dock bar. */
+.main-content {
+  padding-bottom: 46px;
+}

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -1136,22 +1136,26 @@ code {
 
 /* ─── Run options (per-run reps / instance override) ───────────────────── */
 .run-options {
-  display: flex;
-  align-items: flex-end;
-  flex-wrap: wrap;
-  gap: 16px;
   padding: 12px 14px;
   margin-bottom: 16px;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius);
   background: var(--bg-secondary);
 }
+/* Card header — matches .config-meta-title for visual parity. */
 .run-options-title {
-  align-self: center;
-  margin-right: 4px;
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   color: var(--muted);
+  margin-bottom: 10px;
+}
+.run-options-row {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 16px;
 }
 .run-opt {
   display: flex;

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -256,30 +256,45 @@ code {
 .action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   padding: 6px 14px;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
   color: var(--fg);
-  font-weight: 500;
   font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
   transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .action-btn:hover {
-  background: var(--bg-tertiary);
+  background: var(--border);
+}
+
+.action-btn--danger {
+  border-color: var(--status-failed);
+  color: var(--status-failed);
+}
+
+.action-btn--danger:hover {
+  background: var(--status-failed);
+  color: #ffffff;
 }
 
 .action-btn--primary {
-  background: var(--accent);
   border-color: var(--accent);
-  color: #fff;
+  color: var(--accent);
 }
 
 .action-btn--primary:hover {
-  filter: brightness(1.05);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.action-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 /* ─── Profile grid ─────────────────────────────────────────────────────── */

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -613,3 +613,16 @@ code {
   font-size: 13px;
   margin-top: 8px;
 }
+
+/* ─── Profile selection (Compare) ──────────────────────────────────────── */
+.run-card-select {
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+  flex-shrink: 0;
+  accent-color: var(--accent);
+}
+.run-card--selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent) inset;
+}

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -747,6 +747,64 @@ code {
   flex-shrink: 0;
 }
 
+/* ─── Grader credentials (browser-only secrets) ────────────────────────── */
+.settings-secrets-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+}
+.settings-secret-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.settings-secret-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.settings-secret-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.settings-secret-input {
+  flex: 1;
+  min-width: 0;
+}
+.settings-secret-hint {
+  margin: 0;
+  font-size: 11.5px;
+  color: var(--muted);
+}
+.settings-secrets-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ─── Regrade backend dialog ───────────────────────────────────────────── */
+.regrade-dialog-intro {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.regrade-mode-label {
+  display: block;
+  font-weight: 600;
+}
+.regrade-mode-hint {
+  display: block;
+  font-size: 11.5px;
+  color: var(--muted);
+  line-height: 1.35;
+}
+
 /* ─── Folder picker dialog ─────────────────────────────────────────────── */
 .folder-picker {
   display: flex;

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -240,9 +240,15 @@ code {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding-bottom: 20px;
-  margin-bottom: 18px;
   border-bottom: 1px solid var(--border-subtle);
+  /* Sticky (mirrors worca-ui): bleed out to absorb .main-content's 24px/32px
+     padding so the header pins flush to the top and spans the full width. */
+  position: sticky;
+  top: -24px;
+  z-index: 10;
+  background: var(--bg);
+  margin: -24px -32px 18px;
+  padding: 24px 32px 20px;
 }
 
 .content-header-back {
@@ -1019,4 +1025,12 @@ code {
   background: var(--surface);
   color: var(--fg);
   font-size: 13px;
+}
+.run-opt-toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--fg);
+  padding-bottom: 4px;
 }

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -887,14 +887,29 @@ code {
   margin-bottom: 10px;
   color: var(--accent);
 }
+.live-run--failed {
+  border-color: var(--status-failed);
+}
+.live-run--failed .live-run-head {
+  color: var(--status-failed);
+}
 .live-run-label {
   font-weight: 600;
   font-size: 13px;
 }
-.live-run-status {
+.live-run-stage {
   font-size: 12px;
+  font-family: var(--mono, ui-monospace, monospace);
+  color: var(--fg);
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+}
+.live-run-meta {
+  margin-left: auto;
+  font-size: 11.5px;
   color: var(--muted);
-  text-transform: capitalize;
+  font-variant: tabular-nums;
 }
 .stage-chips {
   display: flex;

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -23,7 +23,17 @@
   --status-unknown: #94a3b8;
 
   --radius-lg: 12px;
+  --radius: 8px;
   --transition-fast: 0.15s ease;
+  --sidebar-width: 240px;
+
+  /* Aliases consumed by the app-shell rules copied from worca-ui/app/styles.css
+   * so its class names resolve against worca-bench's palette. */
+  --text-primary: var(--fg);
+  --text-secondary: var(--muted);
+  --text-muted: var(--muted);
+  --bg-hover: var(--bg-tertiary);
+  --status-error: var(--status-failed);
 
   --sl-color-success-600: var(--status-completed);
   --sl-color-warning-600: var(--status-paused);
@@ -62,83 +72,160 @@ code {
   font-size: 0.9em;
 }
 
-/* ─── Header / nav ─────────────────────────────────────────────────────── */
+/* ─── App shell (sidebar | content) — copied from worca-ui/app/styles.css ── */
 
-.app-header {
+.app-shell {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 24px;
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-secondary);
+  flex-direction: row;
+  height: 100vh;
+  overflow: hidden;
 }
 
-.app-brand {
-  font-weight: 700;
-  font-size: 16px;
+/* ─── Sidebar ──────────────────────────────────────────────────────────── */
+
+.sidebar {
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-subtle);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.sidebar-logo {
+  padding: 16px 12px 12px 16px;
+  border-bottom: 1px solid var(--border-subtle);
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.app-logo {
-  color: var(--accent);
-}
-
-.app-nav {
-  display: flex;
-  gap: 4px;
-}
-
-.nav-link {
-  padding: 6px 14px;
-  border-radius: 8px;
-  color: var(--muted);
-  text-decoration: none;
-  font-weight: 500;
-  transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.nav-link:hover {
-  background: var(--bg-tertiary);
+.logo-text {
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   color: var(--fg);
 }
 
-.nav-link--active {
-  background: var(--bg-tertiary);
-  color: var(--accent);
+.sidebar-section {
+  padding: 8px 0;
 }
 
-.app-main {
-  padding: 24px;
-  max-width: 1100px;
-  margin: 0 auto;
+.sidebar-section-header {
+  padding: 8px 16px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
 }
 
-/* ─── Page scaffolding ─────────────────────────────────────────────────── */
-
-.page-head {
+.sidebar-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 18px;
-  gap: 12px;
+  padding: 8px 12px;
+  cursor: pointer;
+  color: var(--fg);
+  border-radius: var(--radius);
+  margin: 2px 8px;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  font-size: 13px;
+  font-weight: 500;
 }
 
-.page-head-title {
+.sidebar-item-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sidebar-item-left svg {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.sidebar-item:hover {
+  background: var(--border);
+}
+
+.sidebar-item:hover .sidebar-item-left svg {
+  opacity: 1;
+}
+
+.sidebar-item.active {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.sidebar-item.active .sidebar-item-left svg {
+  opacity: 1;
+}
+
+/* ─── Main content + content header ────────────────────────────────────── */
+
+.main-content {
+  flex: 1;
+  overflow: auto;
+  padding: 24px 32px;
+  background: var(--bg);
+}
+
+.content-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-bottom: 20px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.content-header-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  flex-shrink: 0;
+}
+
+.content-header-back:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
+.content-header-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.content-header-status {
+  display: inline-flex;
+  align-items: center;
+}
+
+.content-header-actions {
+  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 10px;
-}
-
-.page-head h1 {
-  font-size: 20px;
-  margin: 0;
-}
-
-.page-head-actions {
-  display: flex;
-  gap: 8px;
 }
 
 .loading-state,
@@ -431,4 +518,98 @@ code {
 .leaderboard-source {
   color: var(--muted);
   font-size: 12px;
+}
+
+.leaderboard-source--link {
+  color: var(--accent, #3b82f6);
+  text-decoration: none;
+}
+
+.leaderboard-source--link:hover {
+  text-decoration: underline;
+}
+
+/* ─── Settings page ─────────────────────────────────────────────────────── */
+.settings-view {
+  max-width: 760px;
+}
+.settings-note {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-bottom: 18px;
+}
+.settings-block {
+  margin-bottom: 24px;
+}
+.settings-h {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin: 0 0 10px;
+}
+.settings-dirs {
+  width: 100%;
+  border-collapse: collapse;
+}
+.settings-dir td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-subtle, #2a2a2a);
+  font-size: 13px;
+  vertical-align: middle;
+}
+.settings-dir-path {
+  font-family: var(--mono, ui-monospace, monospace);
+  word-break: break-all;
+}
+.settings-dir-tag {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+.settings-dir--primary .settings-dir-path {
+  color: var(--text-secondary, var(--muted));
+}
+.settings-remove {
+  background: transparent;
+  border: 1px solid var(--status-error, #ef4444);
+  color: var(--status-error, #ef4444);
+  border-radius: var(--radius, 6px);
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.settings-remove:hover {
+  background: var(--status-error, #ef4444);
+  color: #fff;
+}
+.settings-add {
+  display: flex;
+  gap: 8px;
+}
+.settings-add-input {
+  flex: 1;
+  padding: 7px 10px;
+  border: 1px solid var(--border-subtle, #2a2a2a);
+  border-radius: var(--radius, 6px);
+  background: var(--surface, #1a1a1a);
+  color: var(--text-primary, #e5e5e5);
+  font-size: 13px;
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.settings-add-btn {
+  background: var(--accent, #3b82f6);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius, 6px);
+  padding: 7px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.settings-error {
+  color: var(--status-error, #ef4444);
+  font-size: 13px;
+  margin-top: 8px;
 }

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -853,6 +853,46 @@ code {
   color: var(--fg);
 }
 
+/* ─── Configuration metadata (profile detail) ──────────────────────────── */
+.config-meta {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  padding: 12px 14px;
+  margin-bottom: 16px;
+}
+.config-meta-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.config-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px 18px;
+}
+.config-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.config-meta-label {
+  font-size: 11px;
+  color: var(--muted);
+}
+.config-meta-value {
+  font-size: 13px;
+  color: var(--fg);
+  font-family: var(--mono, ui-monospace, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ─── Run options (per-run reps / instance override) ───────────────────── */
 .run-options {
   display: flex;

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -1026,11 +1026,41 @@ code {
   color: var(--fg);
   font-size: 13px;
 }
-.run-opt-toggle {
-  flex-direction: row;
+.run-opt-engine {
+  gap: 4px;
+}
+.run-opt-label {
+  font-size: 12px;
+  color: var(--muted);
+}
+.run-opt-engine sl-radio-group::part(button-group) {
+  display: flex;
+}
+
+/* Engine value badges (reps table): graphify cyan, crg indigo, OFF gray —
+   matching worca-ui's access-engine-badge colors. */
+.engine-badge {
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: var(--fg);
-  padding-bottom: 4px;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+.engine-badge--off {
+  background: var(--bg-tertiary);
+  color: var(--muted);
+  border-color: var(--border);
+}
+.engine-badge--graphify {
+  background: rgba(8, 145, 178, 0.12);
+  color: #0e7490;
+  border-color: rgba(8, 145, 178, 0.3);
+}
+.engine-badge--crg {
+  background: rgba(99, 102, 241, 0.12);
+  color: #4338ca;
+  border-color: rgba(99, 102, 241, 0.3);
 }

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -1,0 +1,434 @@
+/* worca-bench dashboard styles.
+ * Card rules (.run-card and its sub-elements) are copied from
+ * worca-ui/app/styles.css so the benchmark cards share worca-ui's look.
+ * Status-color CSS variables mirror worca-ui/docs/badge-color-language.md. */
+
+:root {
+  --fg: #1e293b;
+  --bg: #ffffff;
+  --bg-secondary: #f8fafc;
+  --bg-tertiary: #f1f5f9;
+  --surface: var(--bg);
+  --border: #e2e8f0;
+  --border-subtle: rgba(226, 232, 240, 0.6);
+  --muted: #94a3b8;
+  --accent: #3b82f6;
+
+  --status-pending: #94a3b8;
+  --status-running: #3b82f6;
+  --status-paused: #f59e0b;
+  --status-completed: #22c55e;
+  --status-failed: #ef4444;
+  --status-skipped: #94a3b8;
+  --status-unknown: #94a3b8;
+
+  --radius-lg: 12px;
+  --transition-fast: 0.15s ease;
+
+  --sl-color-success-600: var(--status-completed);
+  --sl-color-warning-600: var(--status-paused);
+  --sl-color-danger-600: var(--status-failed);
+  --sl-color-primary-600: var(--status-running);
+  --sl-color-neutral-600: var(--status-pending);
+  --sl-border-radius-large: var(--radius-lg);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #e2e8f0;
+    --bg: #0f172a;
+    --bg-secondary: #1e293b;
+    --bg-tertiary: #1a2332;
+    --border: #334155;
+    --border-subtle: rgba(51, 65, 85, 0.6);
+    --muted: #64748b;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+  font-size: 14px;
+}
+
+code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9em;
+}
+
+/* ─── Header / nav ─────────────────────────────────────────────────────── */
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+}
+
+.app-brand {
+  font-weight: 700;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-logo {
+  color: var(--accent);
+}
+
+.app-nav {
+  display: flex;
+  gap: 4px;
+}
+
+.nav-link {
+  padding: 6px 14px;
+  border-radius: 8px;
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 500;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.nav-link:hover {
+  background: var(--bg-tertiary);
+  color: var(--fg);
+}
+
+.nav-link--active {
+  background: var(--bg-tertiary);
+  color: var(--accent);
+}
+
+.app-main {
+  padding: 24px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+/* ─── Page scaffolding ─────────────────────────────────────────────────── */
+
+.page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+  gap: 12px;
+}
+
+.page-head-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.page-head h1 {
+  font-size: 20px;
+  margin: 0;
+}
+
+.page-head-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.loading-state,
+.empty-state,
+.error-state {
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.empty-state {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.empty-state-hint {
+  font-size: 12px;
+}
+
+.error-state {
+  color: var(--status-failed);
+}
+
+/* ─── Action buttons (plain, mirrors worca-ui action-btn) ──────────────── */
+
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--fg);
+  font-weight: 500;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.action-btn:hover {
+  background: var(--bg-tertiary);
+}
+
+.action-btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.action-btn--primary:hover {
+  filter: brightness(1.05);
+}
+
+/* ─── Profile grid ─────────────────────────────────────────────────────── */
+
+.profile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 14px;
+}
+
+/* ─── Card base (copied from worca-ui/app/styles.css) ──────────────────── */
+
+.run-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 18px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  background: var(--surface);
+  transition: background var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
+}
+
+.run-card:hover {
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}
+
+.run-card-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.run-card-status {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.run-card-title {
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.run-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  padding-left: 26px;
+  font-size: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.meta-label {
+  font-weight: 500;
+  color: var(--fg);
+  opacity: 0.7;
+}
+
+.meta-value {
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.run-card-stages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding-left: 26px;
+}
+
+.run-card-stage-badge {
+  font-size: 10px;
+}
+
+.run-card-stage-badge::part(base) {
+  font-size: 10px;
+  padding: 2px 8px;
+  letter-spacing: 0.03em;
+}
+
+.run-card-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-left: 26px;
+}
+
+.run-card-actions:empty {
+  display: none;
+}
+
+/* Status-colored left border accent (subset used by the bench domain). */
+.run-card.status-running { border-left: 3px solid var(--status-running); }
+.run-card.status-paused { border-left: 3px solid var(--status-paused); }
+.run-card.status-completed { border-left: 3px solid var(--status-completed); }
+.run-card.status-failed { border-left: 3px solid var(--status-failed); }
+.run-card.status-pending { border-left: 3px solid var(--status-pending); }
+.run-card.status-skipped { border-left: 3px solid var(--status-pending); }
+.run-card.status-unknown { border-left: 3px solid var(--status-unknown); }
+
+.icon-spin {
+  animation: icon-spin 1.5s linear infinite;
+}
+
+@keyframes icon-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ─── Stat tiles (profile detail) ──────────────────────────────────────── */
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.stat {
+  padding: 12px 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.stat-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.stat-value {
+  font-size: 18px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Tables ───────────────────────────────────────────────────────────── */
+
+.reps-table,
+.compare-table,
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.reps-table th,
+.compare-table th,
+.leaderboard-table th {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 2px solid var(--border);
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.reps-table td,
+.compare-table td,
+.leaderboard-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-variant-numeric: tabular-nums;
+}
+
+.reps-instance {
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-metric {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.compare-col-name {
+  font-weight: 600;
+  color: var(--fg);
+}
+
+/* ─── Leaderboard ──────────────────────────────────────────────────────── */
+
+.leaderboard-tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.leaderboard-tab {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.leaderboard-tab--active {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.leaderboard-note {
+  color: var(--muted);
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+.leaderboard-row--local {
+  background: var(--bg-tertiary);
+  font-weight: 600;
+}
+
+.leaderboard-source {
+  color: var(--muted);
+  font-size: 12px;
+}

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -1188,6 +1188,12 @@ code {
   font-size: 12px;
   color: var(--muted);
 }
+/* Tooltip-bearing inline label (e.g. Timeout) — dotted underline + help cursor
+   signal that hovering reveals the value semantics. */
+.run-opt-label-inline {
+  cursor: help;
+  border-bottom: 1px dotted var(--muted);
+}
 .run-opt-engine sl-radio-group::part(button-group) {
   display: flex;
 }

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -884,6 +884,69 @@ code {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px var(--accent) inset;
 }
+/* Archived cards: visible (in the All/Archived tabs) but visually de-emphasised. */
+.run-card--archived {
+  opacity: 0.62;
+}
+.run-card--archived:hover {
+  opacity: 1;
+}
+
+/* ─── Dashboard filter bar (pills + search) ────────────────────────────── */
+.profile-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.filter-pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.filter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-secondary);
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+.filter-pill:hover {
+  background: var(--border);
+  color: var(--fg);
+}
+.filter-pill--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+}
+.filter-pill-count {
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  opacity: 0.75;
+}
+.filter-search {
+  width: 100%;
+  max-width: 480px;
+  padding: 9px 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  color: var(--fg);
+  font-size: 14px;
+}
+.filter-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
 
 /* ─── Launch toast (run feedback) ──────────────────────────────────────── */
 .launch-toast {

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -681,3 +681,39 @@ code {
 .launch-toast-close:hover {
   color: var(--fg);
 }
+
+/* ─── Run options (per-run reps / instance override) ───────────────────── */
+.run-options {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+}
+.run-options-title {
+  align-self: center;
+  margin-right: 4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.run-opt {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.run-opt input {
+  width: 96px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--fg);
+  font-size: 13px;
+}

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -554,6 +554,14 @@ code {
   white-space: nowrap;
 }
 
+/* Fine-grained suite count (e.g. 38/38) beside the numeric score. */
+.reps-testcount {
+  margin-left: 0.4em;
+  font-size: 0.82em;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
 .compare-metric {
   font-weight: 600;
   color: var(--muted);

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -1120,13 +1120,11 @@ code {
   font-weight: 600;
   font-size: 13px;
 }
-.live-run-stage {
-  font-size: 12px;
-  font-family: var(--mono, ui-monospace, monospace);
+.live-run-instance {
+  font-size: 14px;
+  font-weight: 700;
   color: var(--fg);
-  padding: 1px 7px;
-  border-radius: 999px;
-  background: var(--bg-tertiary);
+  letter-spacing: -0.01em;
 }
 .live-run-meta {
   margin-left: auto;

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -1159,13 +1159,21 @@ code {
   color: var(--status-completed);
 }
 .stage-chip--active {
-  border-color: var(--accent);
+  /* in-progress = worca-ui "primary" blue (same hue as --accent). */
+  border-color: var(--status-running);
   color: #fff;
-  background: var(--accent);
+  background: var(--status-running);
 }
 .stage-chip--failed {
   border-color: var(--status-failed);
   color: var(--status-failed);
+}
+/* Spacer that sets the post-pipeline "Grade" chip apart from the worca stages. */
+.stage-chip-sep {
+  align-self: stretch;
+  width: 1px;
+  margin: 2px 6px;
+  background: var(--border);
 }
 
 /* ─── Configuration metadata (profile detail) ──────────────────────────── */

--- a/worca-bench/app/styles.css
+++ b/worca-bench/app/styles.css
@@ -853,6 +853,83 @@ code {
   color: var(--fg);
 }
 
+/* ─── Live run progress (stage chips + running dot) ────────────────────── */
+.running-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  margin-right: 5px;
+  vertical-align: middle;
+  animation: conn-blink 1.2s ease-in-out infinite;
+}
+.run-card-running {
+  font-variant: tabular-nums;
+}
+
+.live-runs {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.live-run {
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  padding: 12px 14px;
+}
+.live-run-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  color: var(--accent);
+}
+.live-run-label {
+  font-weight: 600;
+  font-size: 13px;
+}
+.live-run-status {
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: capitalize;
+}
+.stage-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.stage-chip {
+  font-size: 11.5px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--muted);
+}
+.stage-chip--pending {
+  opacity: 0.65;
+}
+.stage-chip--skipped {
+  opacity: 0.45;
+  text-decoration: line-through;
+}
+.stage-chip--done {
+  border-color: var(--status-completed);
+  color: var(--status-completed);
+}
+.stage-chip--active {
+  border-color: var(--accent);
+  color: #fff;
+  background: var(--accent);
+}
+.stage-chip--failed {
+  border-color: var(--status-failed);
+  color: var(--status-failed);
+}
+
 /* ─── Configuration metadata (profile detail) ──────────────────────────── */
 .config-meta {
   border: 1px solid var(--border-subtle);

--- a/worca-bench/app/utils/badge.js
+++ b/worca-bench/app/utils/badge.js
@@ -1,0 +1,130 @@
+// app/utils/badge.js
+//
+// Per-domain badge + status mapping for the benchmark dashboard. Mirrors the
+// worca-ui `status-badge.js` contract: a single source of truth for status →
+// CSS class (card left border) and status → Shoelace badge variant. NEVER
+// inline `variant="success"` in a view — route through OUTCOME_VARIANT here.
+//
+// Badge color language (see worca-ui/docs/badge-color-language.md):
+//   resolved / high-score  -> success (green)
+//   partial                -> warning (orange)
+//   unresolved / failed / error -> danger (red)
+//   pending / skipped      -> neutral (grey)
+//   running                -> primary (blue)
+
+/** Canonical benchmark outcomes used across the dashboard. */
+export const OUTCOME_VARIANT = Object.freeze({
+  resolved: 'success',
+  partial: 'warning',
+  unresolved: 'danger',
+  error: 'danger',
+  pending: 'neutral',
+  skipped: 'neutral',
+  running: 'primary',
+  unknown: 'neutral',
+});
+
+const OUTCOME_CLASS = Object.freeze({
+  resolved: 'status-completed',
+  partial: 'status-paused',
+  unresolved: 'status-failed',
+  error: 'status-failed',
+  pending: 'status-pending',
+  skipped: 'status-skipped',
+  running: 'status-running',
+  unknown: 'status-unknown',
+});
+
+const HIGH_SCORE = 0.999;
+
+/**
+ * Classify a single benchmark rep row into a canonical outcome string.
+ *
+ * @param {object} row
+ * @returns {keyof typeof OUTCOME_VARIANT}
+ */
+export function outcomeOf(row) {
+  if (!row) return 'unknown';
+  const status = row.status;
+  if (status === 'error') return 'error';
+  if (status === 'skipped') return 'skipped';
+  if (row.pipeline_status === 'running' || status === 'running') {
+    return 'running';
+  }
+  if (status === 'ran') return 'pending'; // ran but not yet graded
+  if (status === 'graded') {
+    if (row.resolved === true) return 'resolved';
+    if (typeof row.score === 'number') {
+      if (row.score >= HIGH_SCORE) return 'resolved';
+      if (row.score > 0) return 'partial';
+    }
+    return 'unresolved';
+  }
+  return 'unknown';
+}
+
+/**
+ * Classify an aggregated profile (from results-store) into an overall outcome,
+ * driven by its resolved_rate and grading progress.
+ *
+ * @param {object} agg  aggregate summary from aggregateProfile
+ * @returns {keyof typeof OUTCOME_VARIANT}
+ */
+export function profileOutcome(agg) {
+  if (!agg?.reps) return 'pending';
+  if (agg.graded === 0) return 'pending';
+  const rate = agg.resolved_rate ?? 0;
+  if (rate >= HIGH_SCORE) return 'resolved';
+  if (rate > 0) return 'partial';
+  return 'unresolved';
+}
+
+/**
+ * Shoelace badge variant for an outcome string.
+ * @param {string} outcome
+ * @returns {string}
+ */
+export function variantFor(outcome) {
+  return OUTCOME_VARIANT[outcome] || 'neutral';
+}
+
+/**
+ * CSS modifier class (status-colored left border) for an outcome string.
+ * @param {string} outcome
+ * @returns {string}
+ */
+export function outcomeClass(outcome) {
+  return OUTCOME_CLASS[outcome] || 'status-unknown';
+}
+
+// Inline SVG status icons (Lucide-derived paths) rendered as the card status
+// pip via unsafeHTML — keeps worca-bench dependency-light (no lucide package)
+// while matching worca-ui's `statusIcon()` affordance.
+const ICON_PATHS = Object.freeze({
+  resolved: '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>',
+  partial:
+    '<circle cx="12" cy="12" r="10"/><path d="M12 8v4"/><path d="M12 16h.01"/>',
+  unresolved:
+    '<circle cx="12" cy="12" r="10"/><path d="M12 8v4"/><path d="M12 16h.01"/>',
+  error:
+    '<circle cx="12" cy="12" r="10"/><path d="M12 8v4"/><path d="M12 16h.01"/>',
+  pending: '<circle cx="12" cy="12" r="10"/>',
+  skipped: '<circle cx="12" cy="12" r="10"/><path d="m4.9 4.9 14.2 14.2"/>',
+  running:
+    '<path d="M12 2v4"/><path d="m16.2 7.8 2.9-2.9"/><path d="M18 12h4"/><path d="m16.2 16.2 2.9 2.9"/><path d="M12 18v4"/><path d="m4.9 19.1 2.9-2.9"/><path d="M2 12h4"/><path d="m4.9 4.9 2.9 2.9"/>',
+  unknown: '<circle cx="12" cy="12" r="10"/><path d="M12 17h.01"/>',
+});
+
+/**
+ * Render an outcome's status icon as an SVG string for use with unsafeHTML.
+ * The `running` icon spins via the `.icon-spin` class.
+ *
+ * @param {string} outcome
+ * @param {number} [size=16]
+ * @returns {string}
+ */
+export function outcomeIcon(outcome, size = 16) {
+  const path = ICON_PATHS[outcome] || ICON_PATHS.unknown;
+  const cls = outcome === 'running' ? 'icon-spin' : '';
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="${cls}">${path}</svg>`;
+}

--- a/worca-bench/app/utils/badge.js
+++ b/worca-bench/app/utils/badge.js
@@ -46,12 +46,12 @@ const HIGH_SCORE = 0.999;
 export function outcomeOf(row) {
   if (!row) return 'unknown';
   const status = row.status;
+  // A results.jsonl row is always a COMPLETED rep (in-flight reps surface via
+  // /api/active, not as rows). So a terminal grade verdict wins outright — even
+  // if the row carries a stale `pipeline_status: 'running'` from the agent run's
+  // telemetry (regrade updates the verdict, not the original pipeline_status).
   if (status === 'error') return 'error';
   if (status === 'skipped') return 'skipped';
-  if (row.pipeline_status === 'running' || status === 'running') {
-    return 'running';
-  }
-  if (status === 'ran') return 'pending'; // ran but not yet graded
   if (status === 'graded') {
     if (row.resolved === true) return 'resolved';
     if (typeof row.score === 'number') {
@@ -59,6 +59,12 @@ export function outcomeOf(row) {
       if (row.score > 0) return 'partial';
     }
     return 'unresolved';
+  }
+  if (status === 'ran') return 'pending'; // ran but not yet graded
+  // Only a non-terminal row falls through to "running" (defensive — a persisted
+  // row normally shouldn't be here).
+  if (row.pipeline_status === 'running' || status === 'running') {
+    return 'running';
   }
   return 'unknown';
 }

--- a/worca-bench/app/utils/badge.test.js
+++ b/worca-bench/app/utils/badge.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { OUTCOME_VARIANT, outcomeOf, variantFor } from './badge.js';
+
+describe('outcomeOf', () => {
+  it('maps a graded+resolved row to resolved', () => {
+    expect(outcomeOf({ status: 'graded', resolved: true })).toBe('resolved');
+  });
+
+  it('maps a graded+unresolved row to unresolved', () => {
+    expect(outcomeOf({ status: 'graded', resolved: false, score: 0 })).toBe(
+      'unresolved',
+    );
+  });
+
+  it('maps a partial score to partial', () => {
+    expect(outcomeOf({ status: 'graded', resolved: false, score: 0.5 })).toBe(
+      'partial',
+    );
+  });
+
+  it('maps error / skipped straight through', () => {
+    expect(outcomeOf({ status: 'error' })).toBe('error');
+    expect(outcomeOf({ status: 'skipped' })).toBe('skipped');
+  });
+
+  // Regression: a completed grade must win over a stale pipeline_status from the
+  // original agent run's telemetry (regrade updates the verdict, not that field).
+  // Previously this rendered as "running" forever after a regrade.
+  it('ignores a stale pipeline_status:running on a graded row', () => {
+    expect(
+      outcomeOf({
+        status: 'graded',
+        resolved: false,
+        score: 0,
+        pipeline_status: 'running',
+        grade_mode: 'modal',
+      }),
+    ).toBe('unresolved');
+    expect(
+      outcomeOf({
+        status: 'graded',
+        resolved: true,
+        pipeline_status: 'running',
+      }),
+    ).toBe('resolved');
+  });
+
+  it('still surfaces a genuinely non-terminal row as running', () => {
+    expect(outcomeOf({ status: 'running' })).toBe('running');
+    expect(outcomeOf({ pipeline_status: 'running' })).toBe('running');
+  });
+
+  it('every outcome has a known badge variant', () => {
+    for (const o of [
+      'resolved',
+      'unresolved',
+      'partial',
+      'error',
+      'skipped',
+      'running',
+      'unknown',
+    ]) {
+      expect(OUTCOME_VARIANT[o]).toBeTruthy();
+    }
+    expect(variantFor('resolved')).toBe('success');
+  });
+});

--- a/worca-bench/app/utils/confirm-dialog.js
+++ b/worca-bench/app/utils/confirm-dialog.js
@@ -1,0 +1,109 @@
+// app/utils/confirm-dialog.js — reusable confirmation dialog.
+//
+// Ported from worca-ui (app/utils/confirm-dialog.js). A single global <sl-dialog>
+// lives in the app shell; showConfirm() stores the pending request, triggers a
+// rerender, then opens the dialog. Destructive actions (e.g. removing a result
+// dir) route through this so they always require explicit confirmation.
+
+import { html, nothing } from 'lit-html';
+
+let _pending = null;
+
+/**
+ * Open the global confirmation dialog.
+ *
+ * @param {object} opts
+ * @param {string} opts.label              dialog title
+ * @param {string|object} opts.message     body text or a lit template
+ * @param {string} opts.confirmLabel       confirm button text
+ * @param {'danger'|'primary'|'warning'|'default'} [opts.confirmVariant='danger']
+ * @param {string} [opts.cancelLabel='Cancel']
+ * @param {boolean} [opts.singleButton=false]  info-style (no cancel)
+ * @param {() => void} [opts.onConfirm]
+ * @param {() => void} [opts.onCancel]
+ * @param {() => void} rerender
+ */
+export function showConfirm(
+  {
+    label,
+    message,
+    confirmLabel,
+    confirmVariant = 'danger',
+    cancelLabel,
+    singleButton = false,
+    onConfirm,
+    onCancel,
+  },
+  rerender,
+) {
+  _pending = {
+    label,
+    message,
+    confirmLabel,
+    confirmVariant,
+    cancelLabel,
+    singleButton,
+    onConfirm,
+    onCancel,
+  };
+  rerender();
+  requestAnimationFrame(() => {
+    document.getElementById('global-confirm-dialog')?.show();
+  });
+}
+
+function dismiss(callback) {
+  document.getElementById('global-confirm-dialog')?.hide();
+  const cb = callback;
+  _pending = null;
+  cb?.();
+}
+
+/** The dialog template — render once in the app shell. Renders nothing when idle. */
+export function confirmDialogTemplate() {
+  if (!_pending) return nothing;
+  const {
+    label,
+    message,
+    confirmLabel,
+    confirmVariant,
+    cancelLabel,
+    singleButton,
+    onConfirm,
+    onCancel,
+  } = _pending;
+  return html`
+    <sl-dialog
+      id="global-confirm-dialog"
+      label=${label}
+      @sl-after-hide=${() => dismiss(onCancel)}
+    >
+      ${typeof message === 'string' ? html`<p>${message}</p>` : message}
+      <div
+        slot="footer"
+        style="display:flex; justify-content:flex-end; gap:0.5rem; width:100%"
+      >
+        ${
+          singleButton
+            ? nothing
+            : html`<sl-button
+                variant="default"
+                @click=${() => dismiss(onCancel)}
+                >${cancelLabel || 'Cancel'}</sl-button
+              >`
+        }
+        <sl-button
+          variant=${confirmVariant}
+          ?autofocus=${singleButton}
+          @click=${() => dismiss(onConfirm)}
+          >${confirmLabel}</sl-button
+        >
+      </div>
+    </sl-dialog>
+  `;
+}
+
+/** Test seam: current pending request (or null). */
+export function _pendingConfirm() {
+  return _pending;
+}

--- a/worca-bench/app/utils/folder-picker.js
+++ b/worca-bench/app/utils/folder-picker.js
@@ -1,0 +1,136 @@
+// app/utils/folder-picker.js — server-side directory browser dialog.
+//
+// A browser can't hand the server an absolute path (the File System Access API
+// only yields a name), so this picker drives a backend dir listing (/api/fs/list):
+// navigate into subfolders, go up, and "Select this folder" returns the absolute
+// path via onPick. A single global <sl-dialog> lives in the app shell.
+
+import { html, nothing } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+
+const FOLDER =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>';
+const UP =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>';
+
+let _state = null; // { path, parent, dirs, loading, error, onPick }
+let _rerender = () => {};
+
+export function openFolderPicker({ onPick }, rerender) {
+  _rerender = rerender;
+  _state = {
+    path: null,
+    parent: null,
+    dirs: [],
+    loading: true,
+    error: null,
+    onPick,
+  };
+  rerender();
+  requestAnimationFrame(() => {
+    document.getElementById('folder-picker-dialog')?.show();
+  });
+  loadDir(null);
+}
+
+async function loadDir(path) {
+  _state = { ..._state, loading: true, error: null };
+  _rerender();
+  try {
+    const url = path
+      ? `/api/fs/list?path=${encodeURIComponent(path)}`
+      : '/api/fs/list';
+    const res = await fetch(url);
+    const data = await res.json();
+    if (!res.ok || !data.ok) throw new Error(data.error || 'listing failed');
+    _state = {
+      ..._state,
+      path: data.path,
+      parent: data.parent,
+      dirs: data.dirs,
+      loading: false,
+    };
+  } catch (err) {
+    _state = { ..._state, loading: false, error: err.message };
+  }
+  _rerender();
+}
+
+function close() {
+  document.getElementById('folder-picker-dialog')?.hide();
+  _state = null;
+}
+
+/** Render once in the app shell. Renders nothing when idle. */
+export function folderPickerTemplate() {
+  if (!_state) return nothing;
+  const s = _state;
+  return html`
+    <sl-dialog
+      id="folder-picker-dialog"
+      label="Select a folder"
+      class="folder-picker-dialog"
+      @sl-after-hide=${() => {
+        _state = null;
+      }}
+    >
+      <div class="folder-picker">
+        <div class="folder-picker-path" title=${s.path || ''}>
+          ${s.path || '…'}
+        </div>
+        ${
+          s.error
+            ? html`<div class="settings-alert" role="alert">${s.error}</div>`
+            : nothing
+        }
+        <div class="folder-picker-list">
+          ${
+            s.parent
+              ? html`<button
+                  class="folder-picker-item folder-picker-up"
+                  @click=${() => loadDir(s.parent)}
+                >
+                  <span class="folder-picker-icon">${unsafeHTML(UP)}</span> ..
+                </button>`
+              : nothing
+          }
+          ${
+            s.loading
+              ? html`<div class="folder-picker-empty">Loading…</div>`
+              : s.dirs.map(
+                  (d) => html`<button
+                    class="folder-picker-item"
+                    @click=${() => loadDir(d.path)}
+                  >
+                    <span class="folder-picker-icon">${unsafeHTML(FOLDER)}</span>
+                    ${d.name}
+                  </button>`,
+                )
+          }
+          ${
+            !s.loading && s.dirs.length === 0 && !s.error
+              ? html`<div class="folder-picker-empty">No subfolders.</div>`
+              : nothing
+          }
+        </div>
+      </div>
+      <div
+        slot="footer"
+        style="display:flex; justify-content:space-between; gap:0.5rem; width:100%"
+      >
+        <sl-button variant="default" @click=${close}>Cancel</sl-button>
+        <sl-button
+          variant="primary"
+          ?disabled=${!s.path}
+          @click=${() => {
+            const picked = s.path;
+            const cb = s.onPick;
+            close();
+            if (picked) cb?.(picked);
+          }}
+          >Select this folder</sl-button
+        >
+      </div>
+    </sl-dialog>
+  `;
+}

--- a/worca-bench/app/utils/format.js
+++ b/worca-bench/app/utils/format.js
@@ -1,0 +1,76 @@
+// app/utils/format.js — display formatters for benchmark stats.
+
+/**
+ * Format a USD cost. Sub-cent values get 4 decimals so tiny runs stay legible;
+ * everything else gets 2. Null/zero returns null so callers can hide the row.
+ *
+ * @param {number|null|undefined} usd
+ * @returns {string|null}
+ */
+export function formatCost(usd) {
+  if (usd === null || usd === undefined || Number.isNaN(usd)) return null;
+  if (usd === 0) return '$0.00';
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+/**
+ * Format a wall-clock duration given in seconds as "1h 2m 3s" / "2m 3s" / "3s".
+ *
+ * @param {number|null|undefined} seconds
+ * @returns {string}
+ */
+export function formatDuration(seconds) {
+  if (seconds === null || seconds === undefined || Number.isNaN(seconds)) {
+    return 'N/A';
+  }
+  const total = Math.floor(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+/**
+ * Format a 0..1 fraction as a whole-number percentage, e.g. 0.6667 -> "67%".
+ *
+ * @param {number|null|undefined} fraction
+ * @returns {string}
+ */
+export function pct(fraction) {
+  if (fraction === null || fraction === undefined || Number.isNaN(fraction)) {
+    return 'N/A';
+  }
+  return `${Math.round(fraction * 100)}%`;
+}
+
+/**
+ * Format an ISO timestamp as "YYYY.MM.DD HH:MM" (local). N/A when absent.
+ *
+ * @param {string|null|undefined} iso
+ * @returns {string}
+ */
+export function formatTimestamp(iso) {
+  if (!iso) return 'N/A';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'N/A';
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}.${pad(d.getMonth() + 1)}.${pad(d.getDate())} ${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Round a number to at most `digits` decimals, returning a string. N/A for
+ * null/undefined so callers can hide the row.
+ *
+ * @param {number|null|undefined} n
+ * @param {number} [digits=2]
+ * @returns {string}
+ */
+export function num(n, digits = 2) {
+  if (n === null || n === undefined || Number.isNaN(n)) return 'N/A';
+  return Number(n.toFixed(digits)).toString();
+}

--- a/worca-bench/app/utils/notes-dialog.js
+++ b/worca-bench/app/utils/notes-dialog.js
@@ -1,0 +1,77 @@
+// app/utils/notes-dialog.js — editable per-profile human notes.
+//
+// A single global <sl-dialog> in the app shell with a textarea. showNotesDialog()
+// is given the notes already loaded from the server (GET in main.js); on Save the
+// textarea value is read at click time (lit-html is stateless) and handed to
+// onSave, which PUTs it back. Notes persist server-side alongside the profile's
+// results, so they survive reloads and aren't browser-local.
+
+import { html, nothing } from 'lit-html';
+
+let _pending = null;
+
+/**
+ * Open the notes dialog.
+ * @param {object} opts
+ * @param {string} opts.profile             profile name (dialog title)
+ * @param {string} opts.notes               current notes text (already fetched)
+ * @param {(text: string) => void} opts.onSave
+ * @param {() => void} rerender
+ */
+export function showNotesDialog({ profile, notes, onSave }, rerender) {
+  _pending = { profile, notes: notes || '', onSave };
+  rerender();
+  requestAnimationFrame(() => {
+    document.getElementById('notes-dialog')?.show();
+  });
+}
+
+function dismiss(save) {
+  const pending = _pending;
+  let text = pending?.notes ?? '';
+  if (save) {
+    text = document.getElementById('notes-textarea')?.value ?? text;
+  }
+  document.getElementById('notes-dialog')?.hide();
+  _pending = null;
+  if (save && pending?.onSave) pending.onSave(text);
+}
+
+/** The dialog template — render once in the app shell. Renders nothing when idle. */
+export function notesDialogTemplate() {
+  if (!_pending) return nothing;
+  const { profile, notes } = _pending;
+  return html`
+    <sl-dialog
+      id="notes-dialog"
+      label="Notes — ${profile}"
+      @sl-after-hide=${() => {
+        if (_pending) _pending = null;
+      }}
+    >
+      <textarea
+        id="notes-textarea"
+        class="notes-textarea"
+        rows="16"
+        placeholder="Human notes for this profile / run — context, intent, observations…"
+        .value=${notes}
+      ></textarea>
+      <div
+        slot="footer"
+        style="display:flex; justify-content:flex-end; gap:0.5rem; width:100%"
+      >
+        <sl-button variant="default" @click=${() => dismiss(false)}>
+          Close
+        </sl-button>
+        <sl-button variant="primary" @click=${() => dismiss(true)}>
+          Save
+        </sl-button>
+      </div>
+    </sl-dialog>
+  `;
+}
+
+/** Test seam: current pending request (or null). */
+export function _pendingNotes() {
+  return _pending;
+}

--- a/worca-bench/app/utils/regrade-dialog.js
+++ b/worca-bench/app/utils/regrade-dialog.js
@@ -58,12 +58,12 @@ let _pending = null;
  * Open the regrade-backend dialog.
  *
  * @param {object} opts
- * @param {string} opts.instanceId            instance being regraded (for the title)
+ * @param {string} opts.title                 dialog title (e.g. one instance, or "all of <profile>")
  * @param {(mode: string) => void} opts.onConfirm  called with the chosen backend
  * @param {() => void} rerender
  */
-export function showRegradeDialog({ instanceId, onConfirm }, rerender) {
-  _pending = { instanceId, onConfirm, mode: loadRegradeMode() };
+export function showRegradeDialog({ title, onConfirm }, rerender) {
+  _pending = { title, onConfirm, mode: loadRegradeMode() };
   rerender();
   requestAnimationFrame(() => {
     document.getElementById('regrade-dialog')?.show();
@@ -89,11 +89,11 @@ function dismiss(confirmed) {
 /** The dialog template — render once in the app shell. Renders nothing when idle. */
 export function regradeDialogTemplate() {
   if (!_pending) return nothing;
-  const { instanceId, mode } = _pending;
+  const { title, mode } = _pending;
   return html`
     <sl-dialog
       id="regrade-dialog"
-      label="Re-grade ${instanceId}"
+      label=${title}
       @sl-after-hide=${() => {
         // Closing via the X / backdrop counts as cancel (clear pending once).
         if (_pending) {
@@ -102,8 +102,8 @@ export function regradeDialogTemplate() {
       }}
     >
       <p class="regrade-dialog-intro">
-        Re-grade this instance from its saved diff — no pipeline re-run. Pick the
-        grading backend:
+        Re-grade from the saved diff(s) — no pipeline re-run. Pick the grading
+        backend:
       </p>
       <sl-radio-group id="regrade-mode-group" value=${mode}>
         ${REGRADE_MODES.map(

--- a/worca-bench/app/utils/regrade-dialog.js
+++ b/worca-bench/app/utils/regrade-dialog.js
@@ -1,0 +1,134 @@
+// app/utils/regrade-dialog.js — pick the grading backend for a regrade.
+//
+// Mirrors confirm-dialog.js: a single global <sl-dialog> lives in the app shell;
+// showRegradeDialog() stores the pending request, rerenders, then opens it. The
+// dialog offers the three real grade backends (local Docker / SWE-bench cloud /
+// Modal) and remembers the last pick in localStorage so future regrades default
+// to it. The chosen mode is read from the DOM at confirm time (lit-html is
+// stateless) and handed to onConfirm(mode).
+
+import { html, nothing } from 'lit-html';
+
+const MODE_KEY = 'worca-bench:regrade-mode';
+const DEFAULT_MODE = 'sb-cli';
+
+export const REGRADE_MODES = [
+  {
+    value: 'local-docker',
+    label: 'Local (Docker)',
+    hint: 'Run the SWE-bench harness in local Docker. Free, but Verified images are x86 — unreliable on Apple Silicon.',
+  },
+  {
+    value: 'sb-cli',
+    label: 'SWE-bench Cloud (sb-cli)',
+    hint: 'Hosted official grader. Needs a SWE-bench API key (Settings).',
+  },
+  {
+    value: 'modal',
+    label: 'Modal (serverless x86)',
+    hint: 'Run the harness on Modal’s x86 workers. Needs Modal tokens (Settings).',
+  },
+];
+
+const _VALUES = new Set(REGRADE_MODES.map((m) => m.value));
+
+/** Last-used grade backend (defaults to sb-cli), guarded against bad storage. */
+export function loadRegradeMode() {
+  try {
+    const v = localStorage.getItem(MODE_KEY);
+    return v && _VALUES.has(v) ? v : DEFAULT_MODE;
+  } catch {
+    return DEFAULT_MODE;
+  }
+}
+
+/** Persist the chosen backend as the new default (best-effort). */
+export function saveRegradeMode(mode) {
+  if (!_VALUES.has(mode)) return;
+  try {
+    localStorage.setItem(MODE_KEY, mode);
+  } catch {
+    // localStorage unavailable — the choice just won't persist.
+  }
+}
+
+let _pending = null;
+
+/**
+ * Open the regrade-backend dialog.
+ *
+ * @param {object} opts
+ * @param {string} opts.instanceId            instance being regraded (for the title)
+ * @param {(mode: string) => void} opts.onConfirm  called with the chosen backend
+ * @param {() => void} rerender
+ */
+export function showRegradeDialog({ instanceId, onConfirm }, rerender) {
+  _pending = { instanceId, onConfirm, mode: loadRegradeMode() };
+  rerender();
+  requestAnimationFrame(() => {
+    document.getElementById('regrade-dialog')?.show();
+  });
+}
+
+function dismiss(confirmed) {
+  const dlg = document.getElementById('regrade-dialog');
+  const pending = _pending;
+  let mode = pending?.mode || DEFAULT_MODE;
+  if (confirmed) {
+    const picked = document.getElementById('regrade-mode-group')?.value;
+    if (picked && _VALUES.has(picked)) mode = picked;
+  }
+  dlg?.hide();
+  _pending = null;
+  if (confirmed && pending?.onConfirm) {
+    saveRegradeMode(mode);
+    pending.onConfirm(mode);
+  }
+}
+
+/** The dialog template — render once in the app shell. Renders nothing when idle. */
+export function regradeDialogTemplate() {
+  if (!_pending) return nothing;
+  const { instanceId, mode } = _pending;
+  return html`
+    <sl-dialog
+      id="regrade-dialog"
+      label="Re-grade ${instanceId}"
+      @sl-after-hide=${() => {
+        // Closing via the X / backdrop counts as cancel (clear pending once).
+        if (_pending) {
+          _pending = null;
+        }
+      }}
+    >
+      <p class="regrade-dialog-intro">
+        Re-grade this instance from its saved diff — no pipeline re-run. Pick the
+        grading backend:
+      </p>
+      <sl-radio-group id="regrade-mode-group" value=${mode}>
+        ${REGRADE_MODES.map(
+          (m) => html`<sl-radio value=${m.value}>
+            <span class="regrade-mode-label">${m.label}</span>
+            <span class="regrade-mode-hint">${m.hint}</span>
+          </sl-radio>`,
+        )}
+      </sl-radio-group>
+      <div
+        slot="footer"
+        style="display:flex; justify-content:flex-end; gap:0.5rem; width:100%"
+      >
+        <sl-button variant="default" @click=${() => dismiss(false)}>
+          Cancel
+        </sl-button>
+        <sl-button variant="primary" @click=${() => dismiss(true)}>
+          Re-grade
+        </sl-button>
+      </div>
+    </sl-dialog>
+  `;
+}
+
+/** Test seam: current pending request (or null). */
+export function _pendingRegrade() {
+  return _pending;
+}

--- a/worca-bench/app/utils/regrade-dialog.test.js
+++ b/worca-bench/app/utils/regrade-dialog.test.js
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  loadRegradeMode,
+  REGRADE_MODES,
+  saveRegradeMode,
+} from './regrade-dialog.js';
+
+describe('regrade mode persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to sb-cli when nothing is stored', () => {
+    expect(loadRegradeMode()).toBe('sb-cli');
+  });
+
+  it('round-trips a valid backend choice', () => {
+    saveRegradeMode('modal');
+    expect(loadRegradeMode()).toBe('modal');
+  });
+
+  it('rejects an unknown backend (save no-op, load falls back)', () => {
+    saveRegradeMode('bogus');
+    expect(loadRegradeMode()).toBe('sb-cli');
+    localStorage.setItem('worca-bench:regrade-mode', 'also-bogus');
+    expect(loadRegradeMode()).toBe('sb-cli');
+  });
+
+  it('offers exactly the three real grade backends', () => {
+    expect(REGRADE_MODES.map((m) => m.value)).toEqual([
+      'local-docker',
+      'sb-cli',
+      'modal',
+    ]);
+  });
+});

--- a/worca-bench/app/utils/run-prefs.js
+++ b/worca-bench/app/utils/run-prefs.js
@@ -1,0 +1,40 @@
+// app/utils/run-prefs.js
+//
+// Per-profile persistence of the "Run options" launcher controls (reps, max
+// tests, max parallel, canary, engine modes) in the browser's localStorage, so
+// a page reload restores what the user last set instead of snapping back to the
+// profile defaults. Values are stored in their raw control form (strings for
+// the number inputs, radio values like 'on'/'off'/'structural') keyed by
+// profile name. All access is guarded — localStorage may be unavailable
+// (private mode, quota) and persistence is best-effort, never fatal.
+
+const KEY = 'worca-bench:run-options';
+
+function _all() {
+  try {
+    const raw = localStorage.getItem(KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Saved run-option controls for a profile, or `{}` when none/unavailable. */
+export function loadRunPrefs(profile) {
+  if (!profile) return {};
+  const v = _all()[profile];
+  return v && typeof v === 'object' ? v : {};
+}
+
+/** Persist the raw control values for a profile (best-effort). */
+export function saveRunPrefs(profile, prefs) {
+  if (!profile) return;
+  try {
+    const all = _all();
+    all[profile] = prefs;
+    localStorage.setItem(KEY, JSON.stringify(all));
+  } catch {
+    // localStorage unavailable or over quota — settings just won't persist.
+  }
+}

--- a/worca-bench/app/utils/run-prefs.test.js
+++ b/worca-bench/app/utils/run-prefs.test.js
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { loadRunPrefs, saveRunPrefs } from './run-prefs.js';
+
+describe('run-prefs', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns {} when nothing is stored for the profile', () => {
+    expect(loadRunPrefs('demo')).toEqual({});
+  });
+
+  it('round-trips saved controls for a profile', () => {
+    const prefs = {
+      reps: '3',
+      maxInstances: '5',
+      maxParallel: '8',
+      canary: 'off',
+      graphify: 'full',
+      codeReviewGraph: 'structural',
+    };
+    saveRunPrefs('demo', prefs);
+    expect(loadRunPrefs('demo')).toEqual(prefs);
+  });
+
+  it('keeps profiles isolated from each other', () => {
+    saveRunPrefs('a', { reps: '1' });
+    saveRunPrefs('b', { reps: '9' });
+    expect(loadRunPrefs('a')).toEqual({ reps: '1' });
+    expect(loadRunPrefs('b')).toEqual({ reps: '9' });
+  });
+
+  it('overwrites prior values for the same profile', () => {
+    saveRunPrefs('demo', { reps: '1', canary: 'on' });
+    saveRunPrefs('demo', { reps: '2', canary: 'off' });
+    expect(loadRunPrefs('demo')).toEqual({ reps: '2', canary: 'off' });
+  });
+
+  it('returns {} for a corrupt store instead of throwing', () => {
+    localStorage.setItem('worca-bench:run-options', '{not json');
+    expect(loadRunPrefs('demo')).toEqual({});
+  });
+
+  it('ignores empty/missing profile names', () => {
+    expect(loadRunPrefs('')).toEqual({});
+    expect(() => saveRunPrefs('', { reps: '1' })).not.toThrow();
+  });
+});

--- a/worca-bench/app/utils/secrets.js
+++ b/worca-bench/app/utils/secrets.js
@@ -1,0 +1,102 @@
+// app/utils/secrets.js
+//
+// Browser-only store for grader credentials (SWE-bench API key + Modal tokens).
+// These never touch the repo or the server's disk: they live solely in this
+// browser's localStorage and are forwarded in the POST body on launch/regrade,
+// where the server merges them into the runner subprocess's environment. All
+// access is guarded — localStorage may be unavailable (private mode, quota).
+
+const KEY = 'worca-bench:secrets';
+
+// Allowlist of credential env-var names the dashboard knows how to forward.
+// Kept in lockstep with GRADER_SECRET_KEYS in server/process-manager.js and
+// SECRET_ENV_KEYS in worca_bench/worca_install.py.
+export const SECRET_FIELDS = [
+  {
+    key: 'SWEBENCH_API_KEY',
+    label: 'SWE-bench API key',
+    hint: 'Hosted sb-cli grader (cloud). Get one with `sb-cli gen-api-key <email>`.',
+  },
+  {
+    key: 'MODAL_TOKEN_ID',
+    label: 'Modal token ID',
+    hint: 'Modal serverless x86 grader — token id.',
+  },
+  {
+    key: 'MODAL_TOKEN_SECRET',
+    label: 'Modal token secret',
+    hint: 'Modal serverless x86 grader — token secret.',
+  },
+];
+
+const KEYS = SECRET_FIELDS.map((f) => f.key);
+
+function _all() {
+  try {
+    const raw = localStorage.getItem(KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function _write(obj) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(obj));
+  } catch {
+    // localStorage unavailable or over quota — secrets just won't persist.
+  }
+}
+
+/** All stored secrets as `{ENV_NAME: value}`, allowlisted + non-empty only. */
+export function loadSecrets() {
+  const all = _all();
+  const out = {};
+  for (const k of KEYS) {
+    if (typeof all[k] === 'string' && all[k]) out[k] = all[k];
+  }
+  return out;
+}
+
+/**
+ * Per-field "is it set?" map for status display — never returns the value
+ * itself, so the UI can show "Set"/"Not set" without echoing a secret.
+ */
+export function secretStatus() {
+  const set = loadSecrets();
+  return Object.fromEntries(KEYS.map((k) => [k, Boolean(set[k])]));
+}
+
+/**
+ * Merge a `{ENV_NAME: value}` patch. A field whose value is `''`/null is
+ * cleared; absent fields are left untouched. Unknown keys are ignored.
+ */
+export function saveSecrets(patch) {
+  if (!patch || typeof patch !== 'object') return;
+  const all = _all();
+  for (const k of KEYS) {
+    if (!(k in patch)) continue;
+    const v = patch[k];
+    if (typeof v === 'string' && v.trim()) {
+      all[k] = v.trim();
+    } else {
+      delete all[k];
+    }
+  }
+  _write(all);
+}
+
+/** Remove a single stored secret. */
+export function clearSecret(name) {
+  if (!KEYS.includes(name)) return;
+  const all = _all();
+  delete all[name];
+  _write(all);
+}
+
+/** Secrets to attach to a launch/regrade POST body, or undefined when none. */
+export function launchSecrets() {
+  const s = loadSecrets();
+  return Object.keys(s).length ? s : undefined;
+}

--- a/worca-bench/app/utils/secrets.test.js
+++ b/worca-bench/app/utils/secrets.test.js
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearSecret,
+  launchSecrets,
+  loadSecrets,
+  SECRET_FIELDS,
+  saveSecrets,
+  secretStatus,
+} from './secrets.js';
+
+describe('secrets store', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('starts empty', () => {
+    expect(loadSecrets()).toEqual({});
+    expect(launchSecrets()).toBeUndefined();
+    expect(secretStatus()).toEqual({
+      SWEBENCH_API_KEY: false,
+      MODAL_TOKEN_ID: false,
+      MODAL_TOKEN_SECRET: false,
+    });
+  });
+
+  it('saves + round-trips allowlisted secrets (trimmed)', () => {
+    saveSecrets({ SWEBENCH_API_KEY: '  swb  ', MODAL_TOKEN_ID: 'mid' });
+    expect(loadSecrets()).toEqual({
+      SWEBENCH_API_KEY: 'swb',
+      MODAL_TOKEN_ID: 'mid',
+    });
+    expect(launchSecrets()).toEqual({
+      SWEBENCH_API_KEY: 'swb',
+      MODAL_TOKEN_ID: 'mid',
+    });
+    expect(secretStatus().SWEBENCH_API_KEY).toBe(true);
+    expect(secretStatus().MODAL_TOKEN_SECRET).toBe(false);
+  });
+
+  it('ignores unknown keys', () => {
+    saveSecrets({ EVIL: 'x', SWEBENCH_API_KEY: 'ok' });
+    expect(loadSecrets()).toEqual({ SWEBENCH_API_KEY: 'ok' });
+  });
+
+  it('a blank value in a patch clears that field; absent fields untouched', () => {
+    saveSecrets({ SWEBENCH_API_KEY: 'a', MODAL_TOKEN_ID: 'b' });
+    saveSecrets({ SWEBENCH_API_KEY: '   ' }); // clear one, leave the other
+    expect(loadSecrets()).toEqual({ MODAL_TOKEN_ID: 'b' });
+  });
+
+  it('clearSecret removes a single field', () => {
+    saveSecrets({ SWEBENCH_API_KEY: 'a', MODAL_TOKEN_ID: 'b' });
+    clearSecret('SWEBENCH_API_KEY');
+    expect(loadSecrets()).toEqual({ MODAL_TOKEN_ID: 'b' });
+    clearSecret('NOT_A_KEY'); // no-op, no throw
+    expect(loadSecrets()).toEqual({ MODAL_TOKEN_ID: 'b' });
+  });
+
+  it('survives a corrupt store', () => {
+    localStorage.setItem('worca-bench:secrets', '{not json');
+    expect(loadSecrets()).toEqual({});
+    expect(() => saveSecrets({ SWEBENCH_API_KEY: 'x' })).not.toThrow();
+  });
+
+  it('exposes the three grader fields in lockstep with the server allowlist', () => {
+    expect(SECRET_FIELDS.map((f) => f.key)).toEqual([
+      'SWEBENCH_API_KEY',
+      'MODAL_TOKEN_ID',
+      'MODAL_TOKEN_SECRET',
+    ]);
+  });
+});

--- a/worca-bench/app/utils/stages.js
+++ b/worca-bench/app/utils/stages.js
@@ -1,0 +1,43 @@
+/**
+ * Canonical worca pipeline stage order + human labels.
+ *
+ * worca-bench is a separate npm package and cannot import from worca-ui, so this
+ * MIRRORS worca-ui/app/utils/stage-order.js (which itself mirrors stages.py
+ * STAGE_ORDER on the Python side). Keep all three in sync. The live stage row on
+ * the profile page sorts the status.json stages by this order and labels them
+ * with the same human names worca-ui uses, so the two dashboards read identically.
+ */
+export const STAGE_ORDER = [
+  'preflight',
+  'plan',
+  'plan_review',
+  'coordinate',
+  'implement',
+  'test',
+  'review',
+  'pr',
+  'learn',
+];
+
+const _ORDER = new Map(STAGE_ORDER.map((s, i) => [s, i]));
+
+/** Sort stage objects by canonical order (by `.name`); unknown stages last. */
+export function sortStagesByOrder(stages) {
+  return [...(stages || [])].sort(
+    (a, b) =>
+      (_ORDER.has(a.name) ? _ORDER.get(a.name) : 999) -
+      (_ORDER.has(b.name) ? _ORDER.get(b.name) : 999),
+  );
+}
+
+// "pr" → "PR" (acronym); "plan_review" → "Plan Review"; etc. Matches worca-ui's
+// toDisplayLabel in timeline-layout.js.
+const _ACRONYMS = new Set(['pr', 'crg']);
+export function stageLabel(key) {
+  if (!key) return '';
+  if (_ACRONYMS.has(key)) return key.toUpperCase();
+  return key
+    .split('_')
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : ''))
+    .join(' ');
+}

--- a/worca-bench/app/utils/stages.test.js
+++ b/worca-bench/app/utils/stages.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { STAGE_ORDER, sortStagesByOrder, stageLabel } from './stages.js';
+
+describe('stage order', () => {
+  it('mirrors the canonical worca pipeline order', () => {
+    expect(STAGE_ORDER).toEqual([
+      'preflight',
+      'plan',
+      'plan_review',
+      'coordinate',
+      'implement',
+      'test',
+      'review',
+      'pr',
+      'learn',
+    ]);
+  });
+
+  it('sorts scrambled stages into canonical order', () => {
+    const scrambled = [
+      { name: 'pr' },
+      { name: 'plan_review' },
+      { name: 'preflight' },
+      { name: 'plan' },
+    ];
+    expect(sortStagesByOrder(scrambled).map((s) => s.name)).toEqual([
+      'preflight',
+      'plan',
+      'plan_review',
+      'pr',
+    ]);
+  });
+
+  it('puts unknown stages at the end, preserving known order', () => {
+    const stages = [
+      { name: 'mystery' },
+      { name: 'plan' },
+      { name: 'preflight' },
+    ];
+    expect(sortStagesByOrder(stages).map((s) => s.name)).toEqual([
+      'preflight',
+      'plan',
+      'mystery',
+    ]);
+  });
+
+  it('tolerates null/undefined', () => {
+    expect(sortStagesByOrder(null)).toEqual([]);
+    expect(sortStagesByOrder(undefined)).toEqual([]);
+  });
+});
+
+describe('stageLabel', () => {
+  it('title-cases snake_case keys', () => {
+    expect(stageLabel('plan_review')).toBe('Plan Review');
+    expect(stageLabel('coordinate')).toBe('Coordinate');
+    expect(stageLabel('preflight')).toBe('Preflight');
+  });
+
+  it('upper-cases known acronyms', () => {
+    expect(stageLabel('pr')).toBe('PR');
+    expect(stageLabel('crg')).toBe('CRG');
+  });
+
+  it('returns empty string for a falsy key', () => {
+    expect(stageLabel('')).toBe('');
+    expect(stageLabel(undefined)).toBe('');
+  });
+});

--- a/worca-bench/app/vendor/shoelace-dark.css
+++ b/worca-bench/app/vendor/shoelace-dark.css
@@ -1,0 +1,483 @@
+:host,
+.sl-theme-dark {
+  color-scheme: dark;
+
+  --sl-color-gray-50: hsl(240 5.1% 15%);
+  --sl-color-gray-100: hsl(240 5.7% 18.2%);
+  --sl-color-gray-200: hsl(240 4.6% 22%);
+  --sl-color-gray-300: hsl(240 5% 27.6%);
+  --sl-color-gray-400: hsl(240 5% 35.5%);
+  --sl-color-gray-500: hsl(240 3.7% 44%);
+  --sl-color-gray-600: hsl(240 5.3% 58%);
+  --sl-color-gray-700: hsl(240 5.6% 73%);
+  --sl-color-gray-800: hsl(240 7.3% 84%);
+  --sl-color-gray-900: hsl(240 9.1% 91.8%);
+  --sl-color-gray-950: hsl(0 0% 95%);
+
+  --sl-color-red-50: hsl(0 56% 23.9%);
+  --sl-color-red-100: hsl(0.6 60% 33.9%);
+  --sl-color-red-200: hsl(0.9 67.2% 37.1%);
+  --sl-color-red-300: hsl(1.1 71.3% 43.7%);
+  --sl-color-red-400: hsl(1 76% 52.5%);
+  --sl-color-red-500: hsl(0.7 89.6% 57.2%);
+  --sl-color-red-600: hsl(0 98.6% 67.9%);
+  --sl-color-red-700: hsl(0 100% 72.3%);
+  --sl-color-red-800: hsl(0 100% 85.6%);
+  --sl-color-red-900: hsl(0 100% 90.3%);
+  --sl-color-red-950: hsl(0 100% 95.9%);
+
+  --sl-color-orange-50: hsl(15 64.2% 23.3%);
+  --sl-color-orange-100: hsl(15.1 70.9% 31.1%);
+  --sl-color-orange-200: hsl(15.3 75.7% 35.5%);
+  --sl-color-orange-300: hsl(17.1 83.5% 42.7%);
+  --sl-color-orange-400: hsl(20.1 88% 50.8%);
+  --sl-color-orange-500: hsl(24.3 100% 50.5%);
+  --sl-color-orange-600: hsl(27.2 100% 57.7%);
+  --sl-color-orange-700: hsl(31.3 100% 68.7%);
+  --sl-color-orange-800: hsl(33.8 100% 79.3%);
+  --sl-color-orange-900: hsl(38.9 100% 87.7%);
+  --sl-color-orange-950: hsl(46.2 100% 95%);
+
+  --sl-color-amber-50: hsl(21.9 66.3% 21.1%);
+  --sl-color-amber-100: hsl(21.5 73.6% 29.7%);
+  --sl-color-amber-200: hsl(22.3 77.6% 33.3%);
+  --sl-color-amber-300: hsl(25.4 84.2% 39.6%);
+  --sl-color-amber-400: hsl(31.4 87.4% 46.7%);
+  --sl-color-amber-500: hsl(37 96.6% 48.3%);
+  --sl-color-amber-600: hsl(43.3 100% 53.4%);
+  --sl-color-amber-700: hsl(46.5 100% 61.1%);
+  --sl-color-amber-800: hsl(49.3 100% 73%);
+  --sl-color-amber-900: hsl(51.8 100% 85%);
+  --sl-color-amber-950: hsl(60 100% 94.6%);
+
+  --sl-color-yellow-50: hsl(32.5 60% 18.2%);
+  --sl-color-yellow-100: hsl(28.1 68.6% 29%);
+  --sl-color-yellow-200: hsl(31.3 75.8% 30.8%);
+  --sl-color-yellow-300: hsl(34.7 84.4% 35.3%);
+  --sl-color-yellow-400: hsl(40.1 87.3% 43.3%);
+  --sl-color-yellow-500: hsl(44.7 88% 46%);
+  --sl-color-yellow-600: hsl(47.7 100% 50.9%);
+  --sl-color-yellow-700: hsl(51.3 100% 59.9%);
+  --sl-color-yellow-800: hsl(54.6 100% 73%);
+  --sl-color-yellow-900: hsl(58.9 100% 84.2%);
+  --sl-color-yellow-950: hsl(60 100% 94%);
+
+  --sl-color-lime-50: hsl(86.5 54.4% 18%);
+  --sl-color-lime-100: hsl(87.6 56.8% 23.3%);
+  --sl-color-lime-200: hsl(85.8 63.2% 24.5%);
+  --sl-color-lime-300: hsl(86.1 72% 29.4%);
+  --sl-color-lime-400: hsl(85.5 76.8% 37.3%);
+  --sl-color-lime-500: hsl(84.3 74.2% 42.1%);
+  --sl-color-lime-600: hsl(82.8 81.5% 52.6%);
+  --sl-color-lime-700: hsl(82 89.9% 64%);
+  --sl-color-lime-800: hsl(80.9 97.9% 76.6%);
+  --sl-color-lime-900: hsl(77.9 100% 85.8%);
+  --sl-color-lime-950: hsl(69.5 100% 93.8%);
+
+  --sl-color-green-50: hsl(144.3 53.6% 16%);
+  --sl-color-green-100: hsl(143.2 55.4% 23.5%);
+  --sl-color-green-200: hsl(141.5 58.2% 26.3%);
+  --sl-color-green-300: hsl(140.8 64.2% 31.8%);
+  --sl-color-green-400: hsl(140.3 68% 39.2%);
+  --sl-color-green-500: hsl(141.1 64.9% 43%);
+  --sl-color-green-600: hsl(141.6 72.4% 55.2%);
+  --sl-color-green-700: hsl(141.7 82.7% 70.1%);
+  --sl-color-green-800: hsl(141 90.9% 82.1%);
+  --sl-color-green-900: hsl(142 100% 89.1%);
+  --sl-color-green-950: hsl(144 100% 95.5%);
+
+  --sl-color-emerald-50: hsl(164.3 75% 13.5%);
+  --sl-color-emerald-100: hsl(163.5 72.6% 20.1%);
+  --sl-color-emerald-200: hsl(162.1 73.7% 22.4%);
+  --sl-color-emerald-300: hsl(161.3 77.3% 27.6%);
+  --sl-color-emerald-400: hsl(159.6 77.1% 34.3%);
+  --sl-color-emerald-500: hsl(159.1 73.5% 37.9%);
+  --sl-color-emerald-600: hsl(157.8 66.8% 48.9%);
+  --sl-color-emerald-700: hsl(156.2 76.1% 63.8%);
+  --sl-color-emerald-800: hsl(152.4 84.4% 77.4%);
+  --sl-color-emerald-900: hsl(149.3 100% 87%);
+  --sl-color-emerald-950: hsl(158.6 100% 94.8%);
+
+  --sl-color-teal-50: hsl(176.5 51.5% 15.4%);
+  --sl-color-teal-100: hsl(175.9 54.7% 22.3%);
+  --sl-color-teal-200: hsl(175.9 60.7% 23.9%);
+  --sl-color-teal-300: hsl(174.5 67.3% 28.8%);
+  --sl-color-teal-400: hsl(174.4 71.9% 34.9%);
+  --sl-color-teal-500: hsl(173.1 71% 38.3%);
+  --sl-color-teal-600: hsl(172.3 68.2% 48.1%);
+  --sl-color-teal-700: hsl(170.5 81.3% 61.5%);
+  --sl-color-teal-800: hsl(168.4 92.1% 75.2%);
+  --sl-color-teal-900: hsl(168.3 100% 86%);
+  --sl-color-teal-950: hsl(180 100% 95.5%);
+
+  --sl-color-cyan-50: hsl(197.1 53.8% 20.3%);
+  --sl-color-cyan-100: hsl(196.8 57.3% 27.2%);
+  --sl-color-cyan-200: hsl(195.3 62.7% 29.4%);
+  --sl-color-cyan-300: hsl(193.5 71.3% 34.1%);
+  --sl-color-cyan-400: hsl(192.5 76.8% 40.6%);
+  --sl-color-cyan-500: hsl(189.4 78.6% 42.6%);
+  --sl-color-cyan-600: hsl(188.2 89.1% 51.7%);
+  --sl-color-cyan-700: hsl(187 98.6% 66.2%);
+  --sl-color-cyan-800: hsl(184.9 100% 78.3%);
+  --sl-color-cyan-900: hsl(180 100% 86.6%);
+  --sl-color-cyan-950: hsl(180 100% 94.8%);
+
+  --sl-color-sky-50: hsl(203 63.8% 20.9%);
+  --sl-color-sky-100: hsl(203.4 70.4% 28%);
+  --sl-color-sky-200: hsl(202.7 75.8% 30.8%);
+  --sl-color-sky-300: hsl(203.1 80.4% 36.1%);
+  --sl-color-sky-400: hsl(202.1 80.5% 44.3%);
+  --sl-color-sky-500: hsl(199.7 85.9% 47.7%);
+  --sl-color-sky-600: hsl(198.7 97.9% 57.2%);
+  --sl-color-sky-700: hsl(198.7 100% 70.5%);
+  --sl-color-sky-800: hsl(198.8 100% 82.5%);
+  --sl-color-sky-900: hsl(198.5 100% 89.9%);
+  --sl-color-sky-950: hsl(186 100% 95.5%);
+
+  --sl-color-blue-50: hsl(227.1 49.5% 22.7%);
+  --sl-color-blue-100: hsl(225.8 58.9% 36.8%);
+  --sl-color-blue-200: hsl(227.7 64.4% 42.9%);
+  --sl-color-blue-300: hsl(226.1 72.7% 51.2%);
+  --sl-color-blue-400: hsl(222.6 86.5% 56.3%);
+  --sl-color-blue-500: hsl(217.8 95.8% 57.4%);
+  --sl-color-blue-600: hsl(213.3 100% 65%);
+  --sl-color-blue-700: hsl(210.9 100% 74.8%);
+  --sl-color-blue-800: hsl(211.5 100% 83.4%);
+  --sl-color-blue-900: hsl(211 100% 88.9%);
+  --sl-color-blue-950: hsl(201.8 100% 95.3%);
+
+  --sl-color-indigo-50: hsl(243.5 40.8% 27%);
+  --sl-color-indigo-100: hsl(242.9 45.7% 37.6%);
+  --sl-color-indigo-200: hsl(244.7 52.7% 43.1%);
+  --sl-color-indigo-300: hsl(245.3 60.5% 52.4%);
+  --sl-color-indigo-400: hsl(244.1 79.2% 60.4%);
+  --sl-color-indigo-500: hsl(239.6 88.7% 63.8%);
+  --sl-color-indigo-600: hsl(234.5 96.7% 70.9%);
+  --sl-color-indigo-700: hsl(229.4 100% 78.3%);
+  --sl-color-indigo-800: hsl(227.1 100% 85%);
+  --sl-color-indigo-900: hsl(223.8 100% 89.9%);
+  --sl-color-indigo-950: hsl(220 100% 95.1%);
+
+  --sl-color-violet-50: hsl(265.1 57.3% 25.4%);
+  --sl-color-violet-100: hsl(263.5 63.8% 39.4%);
+  --sl-color-violet-200: hsl(263.4 66.2% 44.1%);
+  --sl-color-violet-300: hsl(263.7 72.8% 52.4%);
+  --sl-color-violet-400: hsl(262.5 87.3% 59.8%);
+  --sl-color-violet-500: hsl(258.3 95.1% 63.2%);
+  --sl-color-violet-600: hsl(255.1 100% 67.2%);
+  --sl-color-violet-700: hsl(253 100% 81.5%);
+  --sl-color-violet-800: hsl(251.7 100% 87.9%);
+  --sl-color-violet-900: hsl(254.1 100% 91.7%);
+  --sl-color-violet-950: hsl(257.1 100% 96.1%);
+
+  --sl-color-purple-50: hsl(276 54.3% 20.5%);
+  --sl-color-purple-100: hsl(273.6 61.8% 35.4%);
+  --sl-color-purple-200: hsl(272.9 64% 41.4%);
+  --sl-color-purple-300: hsl(271.9 68.1% 49.2%);
+  --sl-color-purple-400: hsl(271.5 85.1% 57.8%);
+  --sl-color-purple-500: hsl(270.7 96.4% 62.1%);
+  --sl-color-purple-600: hsl(270.5 100% 71.9%);
+  --sl-color-purple-700: hsl(270.9 100% 81.3%);
+  --sl-color-purple-800: hsl(272.4 100% 87.7%);
+  --sl-color-purple-900: hsl(276.7 100% 91.5%);
+  --sl-color-purple-950: hsl(300 100% 96.5%);
+
+  --sl-color-fuchsia-50: hsl(297.1 51.2% 18.6%);
+  --sl-color-fuchsia-100: hsl(296.7 59.5% 31.5%);
+  --sl-color-fuchsia-200: hsl(295.4 65.4% 35.1%);
+  --sl-color-fuchsia-300: hsl(294.6 67.4% 42.2%);
+  --sl-color-fuchsia-400: hsl(293.3 68.7% 51.2%);
+  --sl-color-fuchsia-500: hsl(292.1 88.4% 57.7%);
+  --sl-color-fuchsia-600: hsl(292 98.5% 59.5%);
+  --sl-color-fuchsia-700: hsl(292.4 100% 79.5%);
+  --sl-color-fuchsia-800: hsl(292.9 100% 86.8%);
+  --sl-color-fuchsia-900: hsl(300 100% 91.5%);
+  --sl-color-fuchsia-950: hsl(300 100% 96.3%);
+
+  --sl-color-pink-50: hsl(336.2 59.6% 20%);
+  --sl-color-pink-100: hsl(336.8 63.9% 34%);
+  --sl-color-pink-200: hsl(336.8 68.7% 37.6%);
+  --sl-color-pink-300: hsl(336.1 71.8% 44.5%);
+  --sl-color-pink-400: hsl(333.9 74.9% 53.1%);
+  --sl-color-pink-500: hsl(330.7 86.3% 57.7%);
+  --sl-color-pink-600: hsl(328.6 91.5% 67.2%);
+  --sl-color-pink-700: hsl(327.4 97.6% 78.7%);
+  --sl-color-pink-800: hsl(325.1 100% 86.6%);
+  --sl-color-pink-900: hsl(322.1 100% 91.3%);
+  --sl-color-pink-950: hsl(315 100% 95.9%);
+
+  --sl-color-rose-50: hsl(342.3 62.9% 21.5%);
+  --sl-color-rose-100: hsl(342.8 68.9% 34.2%);
+  --sl-color-rose-200: hsl(344.8 72.6% 37.3%);
+  --sl-color-rose-300: hsl(346.9 75.8% 43.7%);
+  --sl-color-rose-400: hsl(348.2 80.1% 52.7%);
+  --sl-color-rose-500: hsl(350.4 94.8% 57.5%);
+  --sl-color-rose-600: hsl(351.2 100% 58.1%);
+  --sl-color-rose-700: hsl(352.3 100% 78.1%);
+  --sl-color-rose-800: hsl(352 100% 86.2%);
+  --sl-color-rose-900: hsl(354.5 100% 90.7%);
+  --sl-color-rose-950: hsl(353.3 100% 95.7%);
+
+  --sl-color-primary-50: var(--sl-color-sky-50);
+  --sl-color-primary-100: var(--sl-color-sky-100);
+  --sl-color-primary-200: var(--sl-color-sky-200);
+  --sl-color-primary-300: var(--sl-color-sky-300);
+  --sl-color-primary-400: var(--sl-color-sky-400);
+  --sl-color-primary-500: var(--sl-color-sky-500);
+  --sl-color-primary-600: var(--sl-color-sky-600);
+  --sl-color-primary-700: var(--sl-color-sky-700);
+  --sl-color-primary-800: var(--sl-color-sky-800);
+  --sl-color-primary-900: var(--sl-color-sky-900);
+  --sl-color-primary-950: var(--sl-color-sky-950);
+
+  --sl-color-success-50: var(--sl-color-green-50);
+  --sl-color-success-100: var(--sl-color-green-100);
+  --sl-color-success-200: var(--sl-color-green-200);
+  --sl-color-success-300: var(--sl-color-green-300);
+  --sl-color-success-400: var(--sl-color-green-400);
+  --sl-color-success-500: var(--sl-color-green-500);
+  --sl-color-success-600: var(--sl-color-green-600);
+  --sl-color-success-700: var(--sl-color-green-700);
+  --sl-color-success-800: var(--sl-color-green-800);
+  --sl-color-success-900: var(--sl-color-green-900);
+  --sl-color-success-950: var(--sl-color-green-950);
+
+  --sl-color-warning-50: var(--sl-color-amber-50);
+  --sl-color-warning-100: var(--sl-color-amber-100);
+  --sl-color-warning-200: var(--sl-color-amber-200);
+  --sl-color-warning-300: var(--sl-color-amber-300);
+  --sl-color-warning-400: var(--sl-color-amber-400);
+  --sl-color-warning-500: var(--sl-color-amber-500);
+  --sl-color-warning-600: var(--sl-color-amber-600);
+  --sl-color-warning-700: var(--sl-color-amber-700);
+  --sl-color-warning-800: var(--sl-color-amber-800);
+  --sl-color-warning-900: var(--sl-color-amber-900);
+  --sl-color-warning-950: var(--sl-color-amber-950);
+
+  --sl-color-danger-50: var(--sl-color-red-50);
+  --sl-color-danger-100: var(--sl-color-red-100);
+  --sl-color-danger-200: var(--sl-color-red-200);
+  --sl-color-danger-300: var(--sl-color-red-300);
+  --sl-color-danger-400: var(--sl-color-red-400);
+  --sl-color-danger-500: var(--sl-color-red-500);
+  --sl-color-danger-600: var(--sl-color-red-600);
+  --sl-color-danger-700: var(--sl-color-red-700);
+  --sl-color-danger-800: var(--sl-color-red-800);
+  --sl-color-danger-900: var(--sl-color-red-900);
+  --sl-color-danger-950: var(--sl-color-red-950);
+
+  --sl-color-neutral-50: var(--sl-color-gray-50);
+  --sl-color-neutral-100: var(--sl-color-gray-100);
+  --sl-color-neutral-200: var(--sl-color-gray-200);
+  --sl-color-neutral-300: var(--sl-color-gray-300);
+  --sl-color-neutral-400: var(--sl-color-gray-400);
+  --sl-color-neutral-500: var(--sl-color-gray-500);
+  --sl-color-neutral-600: var(--sl-color-gray-600);
+  --sl-color-neutral-700: var(--sl-color-gray-700);
+  --sl-color-neutral-800: var(--sl-color-gray-800);
+  --sl-color-neutral-900: var(--sl-color-gray-900);
+  --sl-color-neutral-950: var(--sl-color-gray-950);
+
+  --sl-color-neutral-0: hsl(240, 5.9%, 11%);
+  --sl-color-neutral-1000: hsl(0, 0%, 100%);
+
+  --sl-border-radius-small: 0.1875rem;
+  --sl-border-radius-medium: 0.25rem;
+  --sl-border-radius-large: 0.5rem;
+  --sl-border-radius-x-large: 1rem;
+
+  --sl-border-radius-circle: 50%;
+  --sl-border-radius-pill: 9999px;
+
+  --sl-shadow-x-small: 0 1px 2px rgb(0 0 0 / 18%);
+  --sl-shadow-small: 0 1px 2px rgb(0 0 0 / 24%);
+  --sl-shadow-medium: 0 2px 4px rgb(0 0 0 / 24%);
+  --sl-shadow-large: 0 2px 8px rgb(0 0 0 / 24%);
+  --sl-shadow-x-large: 0 4px 16px rgb(0 0 0 / 24%);
+
+  --sl-spacing-3x-small: 0.125rem;
+  --sl-spacing-2x-small: 0.25rem;
+  --sl-spacing-x-small: 0.5rem;
+  --sl-spacing-small: 0.75rem;
+  --sl-spacing-medium: 1rem;
+  --sl-spacing-large: 1.25rem;
+  --sl-spacing-x-large: 1.75rem;
+  --sl-spacing-2x-large: 2.25rem;
+  --sl-spacing-3x-large: 3rem;
+  --sl-spacing-4x-large: 4.5rem;
+
+  --sl-transition-x-slow: 1000ms;
+  --sl-transition-slow: 500ms;
+  --sl-transition-medium: 250ms;
+  --sl-transition-fast: 150ms;
+  --sl-transition-x-fast: 50ms;
+
+  --sl-font-mono: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  --sl-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
+  --sl-font-serif: Georgia, "Times New Roman", serif;
+
+  --sl-font-size-2x-small: 0.625rem;
+  --sl-font-size-x-small: 0.75rem;
+  --sl-font-size-small: 0.875rem;
+  --sl-font-size-medium: 1rem;
+  --sl-font-size-large: 1.25rem;
+  --sl-font-size-x-large: 1.5rem;
+  --sl-font-size-2x-large: 2.25rem;
+  --sl-font-size-3x-large: 3rem;
+  --sl-font-size-4x-large: 4.5rem;
+
+  --sl-font-weight-light: 300;
+  --sl-font-weight-normal: 400;
+  --sl-font-weight-semibold: 500;
+  --sl-font-weight-bold: 700;
+
+  --sl-letter-spacing-denser: -0.03em;
+  --sl-letter-spacing-dense: -0.015em;
+  --sl-letter-spacing-normal: normal;
+  --sl-letter-spacing-loose: 0.075em;
+  --sl-letter-spacing-looser: 0.15em;
+
+  --sl-line-height-denser: 1;
+  --sl-line-height-dense: 1.4;
+  --sl-line-height-normal: 1.8;
+  --sl-line-height-loose: 2.2;
+  --sl-line-height-looser: 2.6;
+
+  --sl-focus-ring-color: var(--sl-color-primary-700);
+  --sl-focus-ring-style: solid;
+  --sl-focus-ring-width: 3px;
+  --sl-focus-ring: var(--sl-focus-ring-style) var(--sl-focus-ring-width)
+    var(--sl-focus-ring-color);
+  --sl-focus-ring-offset: 1px;
+
+  --sl-button-font-size-small: var(--sl-font-size-x-small);
+  --sl-button-font-size-medium: var(--sl-font-size-small);
+  --sl-button-font-size-large: var(--sl-font-size-medium);
+
+  --sl-input-height-small: 1.875rem;
+  --sl-input-height-medium: 2.5rem;
+  --sl-input-height-large: 3.125rem;
+
+  --sl-input-background-color: var(--sl-color-neutral-0);
+  --sl-input-background-color-hover: var(--sl-input-background-color);
+  --sl-input-background-color-focus: var(--sl-input-background-color);
+  --sl-input-background-color-disabled: var(--sl-color-neutral-100);
+  --sl-input-border-color: var(--sl-color-neutral-400);
+  --sl-input-border-color-hover: var(--sl-color-neutral-500);
+  --sl-input-border-color-focus: var(--sl-color-primary-600);
+  --sl-input-border-color-disabled: var(--sl-color-neutral-400);
+  --sl-input-border-width: 1px;
+  --sl-input-required-content: "*";
+  --sl-input-required-content-offset: -2px;
+  --sl-input-required-content-color: var(--sl-input-label-color);
+
+  --sl-input-border-radius-small: var(--sl-border-radius-medium);
+  --sl-input-border-radius-medium: var(--sl-border-radius-medium);
+  --sl-input-border-radius-large: var(--sl-border-radius-medium);
+
+  --sl-input-font-family: var(--sl-font-sans);
+  --sl-input-font-weight: var(--sl-font-weight-normal);
+  --sl-input-font-size-small: var(--sl-font-size-small);
+  --sl-input-font-size-medium: var(--sl-font-size-medium);
+  --sl-input-font-size-large: var(--sl-font-size-large);
+  --sl-input-letter-spacing: var(--sl-letter-spacing-normal);
+
+  --sl-input-color: var(--sl-color-neutral-700);
+  --sl-input-color-hover: var(--sl-color-neutral-700);
+  --sl-input-color-focus: var(--sl-color-neutral-700);
+  --sl-input-color-disabled: var(--sl-color-neutral-900);
+  --sl-input-icon-color: var(--sl-color-neutral-500);
+  --sl-input-icon-color-hover: var(--sl-color-neutral-600);
+  --sl-input-icon-color-focus: var(--sl-color-neutral-600);
+  --sl-input-placeholder-color: var(--sl-color-neutral-500);
+  --sl-input-placeholder-color-disabled: var(--sl-color-neutral-600);
+  --sl-input-spacing-small: var(--sl-spacing-small);
+  --sl-input-spacing-medium: var(--sl-spacing-medium);
+  --sl-input-spacing-large: var(--sl-spacing-large);
+
+  --sl-input-focus-ring-color: hsl(198.6 88.7% 48.4% / 40%);
+  --sl-input-focus-ring-offset: 0;
+
+  --sl-input-filled-background-color: var(--sl-color-neutral-100);
+  --sl-input-filled-background-color-hover: var(--sl-color-neutral-100);
+  --sl-input-filled-background-color-focus: var(--sl-color-neutral-100);
+  --sl-input-filled-background-color-disabled: var(--sl-color-neutral-100);
+  --sl-input-filled-color: var(--sl-color-neutral-800);
+  --sl-input-filled-color-hover: var(--sl-color-neutral-800);
+  --sl-input-filled-color-focus: var(--sl-color-neutral-700);
+  --sl-input-filled-color-disabled: var(--sl-color-neutral-800);
+
+  --sl-input-label-font-size-small: var(--sl-font-size-small);
+  --sl-input-label-font-size-medium: var(--sl-font-size-medium);
+  --sl-input-label-font-size-large: var(--sl-font-size-large);
+  --sl-input-label-color: inherit;
+
+  --sl-input-help-text-font-size-small: var(--sl-font-size-x-small);
+  --sl-input-help-text-font-size-medium: var(--sl-font-size-small);
+  --sl-input-help-text-font-size-large: var(--sl-font-size-medium);
+  --sl-input-help-text-color: var(--sl-color-neutral-600);
+
+  --sl-toggle-size-small: 0.875rem;
+  --sl-toggle-size-medium: 1.125rem;
+  --sl-toggle-size-large: 1.375rem;
+
+  --sl-overlay-background-color: hsl(0 0% 0% / 43%);
+
+  --sl-panel-background-color: var(--sl-color-neutral-50);
+  --sl-panel-border-color: var(--sl-color-neutral-200);
+  --sl-panel-border-width: 1px;
+
+  --sl-tooltip-border-radius: var(--sl-border-radius-medium);
+  --sl-tooltip-background-color: var(--sl-color-neutral-800);
+  --sl-tooltip-color: var(--sl-color-neutral-0);
+  --sl-tooltip-font-family: var(--sl-font-sans);
+  --sl-tooltip-font-weight: var(--sl-font-weight-normal);
+  --sl-tooltip-font-size: var(--sl-font-size-small);
+  --sl-tooltip-line-height: var(--sl-line-height-dense);
+  --sl-tooltip-padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);
+  --sl-tooltip-arrow-size: 6px;
+
+  --sl-z-index-drawer: 700;
+  --sl-z-index-dialog: 800;
+  --sl-z-index-dropdown: 900;
+  --sl-z-index-toast: 950;
+  --sl-z-index-tooltip: 1000;
+}
+
+@supports (scrollbar-gutter: stable) {
+  .sl-scroll-lock {
+    scrollbar-gutter: var(--sl-scroll-lock-gutter) !important;
+  }
+
+  .sl-scroll-lock body {
+    overflow: hidden !important;
+  }
+}
+
+@supports not (scrollbar-gutter: stable) {
+  .sl-scroll-lock body {
+    padding-right: var(--sl-scroll-lock-size) !important;
+    overflow: hidden !important;
+  }
+}
+
+.sl-toast-stack {
+  position: fixed;
+  top: 0;
+  inset-inline-end: 0;
+  z-index: var(--sl-z-index-toast);
+  width: 28rem;
+  max-width: 100%;
+  max-height: 100%;
+  overflow: auto;
+}
+
+.sl-toast-stack sl-alert {
+  margin: var(--sl-spacing-medium);
+}
+
+.sl-toast-stack sl-alert::part(base) {
+  box-shadow: var(--sl-shadow-large);
+}

--- a/worca-bench/app/vendor/shoelace-light.css
+++ b/worca-bench/app/vendor/shoelace-light.css
@@ -1,0 +1,484 @@
+:root,
+:host,
+.sl-theme-light {
+  color-scheme: light;
+
+  --sl-color-gray-50: hsl(0 0% 97.5%);
+  --sl-color-gray-100: hsl(240 4.8% 95.9%);
+  --sl-color-gray-200: hsl(240 5.9% 90%);
+  --sl-color-gray-300: hsl(240 4.9% 83.9%);
+  --sl-color-gray-400: hsl(240 5% 64.9%);
+  --sl-color-gray-500: hsl(240 3.8% 46.1%);
+  --sl-color-gray-600: hsl(240 5.2% 33.9%);
+  --sl-color-gray-700: hsl(240 5.3% 26.1%);
+  --sl-color-gray-800: hsl(240 3.7% 15.9%);
+  --sl-color-gray-900: hsl(240 5.9% 10%);
+  --sl-color-gray-950: hsl(240 7.3% 8%);
+
+  --sl-color-red-50: hsl(0 85.7% 97.3%);
+  --sl-color-red-100: hsl(0 93.3% 94.1%);
+  --sl-color-red-200: hsl(0 96.3% 89.4%);
+  --sl-color-red-300: hsl(0 93.5% 81.8%);
+  --sl-color-red-400: hsl(0 90.6% 70.8%);
+  --sl-color-red-500: hsl(0 84.2% 60.2%);
+  --sl-color-red-600: hsl(0 72.2% 50.6%);
+  --sl-color-red-700: hsl(0 73.7% 41.8%);
+  --sl-color-red-800: hsl(0 70% 35.3%);
+  --sl-color-red-900: hsl(0 62.8% 30.6%);
+  --sl-color-red-950: hsl(0 60% 19.6%);
+
+  --sl-color-orange-50: hsl(33.3 100% 96.5%);
+  --sl-color-orange-100: hsl(34.3 100% 91.8%);
+  --sl-color-orange-200: hsl(32.1 97.7% 83.1%);
+  --sl-color-orange-300: hsl(30.7 97.2% 72.4%);
+  --sl-color-orange-400: hsl(27 96% 61%);
+  --sl-color-orange-500: hsl(24.6 95% 53.1%);
+  --sl-color-orange-600: hsl(20.5 90.2% 48.2%);
+  --sl-color-orange-700: hsl(17.5 88.3% 40.4%);
+  --sl-color-orange-800: hsl(15 79.1% 33.7%);
+  --sl-color-orange-900: hsl(15.3 74.6% 27.8%);
+  --sl-color-orange-950: hsl(15.2 69.1% 19%);
+
+  --sl-color-amber-50: hsl(48 100% 96.1%);
+  --sl-color-amber-100: hsl(48 96.5% 88.8%);
+  --sl-color-amber-200: hsl(48 96.6% 76.7%);
+  --sl-color-amber-300: hsl(45.9 96.7% 64.5%);
+  --sl-color-amber-400: hsl(43.3 96.4% 56.3%);
+  --sl-color-amber-500: hsl(37.7 92.1% 50.2%);
+  --sl-color-amber-600: hsl(32.1 94.6% 43.7%);
+  --sl-color-amber-700: hsl(26 90.5% 37.1%);
+  --sl-color-amber-800: hsl(22.7 82.5% 31.4%);
+  --sl-color-amber-900: hsl(21.7 77.8% 26.5%);
+  --sl-color-amber-950: hsl(22.9 74.1% 16.7%);
+
+  --sl-color-yellow-50: hsl(54.5 91.7% 95.3%);
+  --sl-color-yellow-100: hsl(54.9 96.7% 88%);
+  --sl-color-yellow-200: hsl(52.8 98.3% 76.9%);
+  --sl-color-yellow-300: hsl(50.4 97.8% 63.5%);
+  --sl-color-yellow-400: hsl(47.9 95.8% 53.1%);
+  --sl-color-yellow-500: hsl(45.4 93.4% 47.5%);
+  --sl-color-yellow-600: hsl(40.6 96.1% 40.4%);
+  --sl-color-yellow-700: hsl(35.5 91.7% 32.9%);
+  --sl-color-yellow-800: hsl(31.8 81% 28.8%);
+  --sl-color-yellow-900: hsl(28.4 72.5% 25.7%);
+  --sl-color-yellow-950: hsl(33.1 69% 13.9%);
+
+  --sl-color-lime-50: hsl(78.3 92% 95.1%);
+  --sl-color-lime-100: hsl(79.6 89.1% 89.2%);
+  --sl-color-lime-200: hsl(80.9 88.5% 79.6%);
+  --sl-color-lime-300: hsl(82 84.5% 67.1%);
+  --sl-color-lime-400: hsl(82.7 78% 55.5%);
+  --sl-color-lime-500: hsl(83.7 80.5% 44.3%);
+  --sl-color-lime-600: hsl(84.8 85.2% 34.5%);
+  --sl-color-lime-700: hsl(85.9 78.4% 27.3%);
+  --sl-color-lime-800: hsl(86.3 69% 22.7%);
+  --sl-color-lime-900: hsl(87.6 61.2% 20.2%);
+  --sl-color-lime-950: hsl(86.5 60.6% 13.9%);
+
+  --sl-color-green-50: hsl(138.5 76.5% 96.7%);
+  --sl-color-green-100: hsl(140.6 84.2% 92.5%);
+  --sl-color-green-200: hsl(141 78.9% 85.1%);
+  --sl-color-green-300: hsl(141.7 76.6% 73.1%);
+  --sl-color-green-400: hsl(141.9 69.2% 58%);
+  --sl-color-green-500: hsl(142.1 70.6% 45.3%);
+  --sl-color-green-600: hsl(142.1 76.2% 36.3%);
+  --sl-color-green-700: hsl(142.4 71.8% 29.2%);
+  --sl-color-green-800: hsl(142.8 64.2% 24.1%);
+  --sl-color-green-900: hsl(143.8 61.2% 20.2%);
+  --sl-color-green-950: hsl(144.3 60.7% 12%);
+
+  --sl-color-emerald-50: hsl(151.8 81% 95.9%);
+  --sl-color-emerald-100: hsl(149.3 80.4% 90%);
+  --sl-color-emerald-200: hsl(152.4 76% 80.4%);
+  --sl-color-emerald-300: hsl(156.2 71.6% 66.9%);
+  --sl-color-emerald-400: hsl(158.1 64.4% 51.6%);
+  --sl-color-emerald-500: hsl(160.1 84.1% 39.4%);
+  --sl-color-emerald-600: hsl(161.4 93.5% 30.4%);
+  --sl-color-emerald-700: hsl(162.9 93.5% 24.3%);
+  --sl-color-emerald-800: hsl(163.1 88.1% 19.8%);
+  --sl-color-emerald-900: hsl(164.2 85.7% 16.5%);
+  --sl-color-emerald-950: hsl(164.3 87.5% 9.4%);
+
+  --sl-color-teal-50: hsl(166.2 76.5% 96.7%);
+  --sl-color-teal-100: hsl(167.2 85.5% 89.2%);
+  --sl-color-teal-200: hsl(168.4 83.8% 78.2%);
+  --sl-color-teal-300: hsl(170.6 76.9% 64.3%);
+  --sl-color-teal-400: hsl(172.5 66% 50.4%);
+  --sl-color-teal-500: hsl(173.4 80.4% 40%);
+  --sl-color-teal-600: hsl(174.7 83.9% 31.6%);
+  --sl-color-teal-700: hsl(175.3 77.4% 26.1%);
+  --sl-color-teal-800: hsl(176.1 69.4% 21.8%);
+  --sl-color-teal-900: hsl(175.9 60.8% 19%);
+  --sl-color-teal-950: hsl(176.5 58.6% 11.4%);
+
+  --sl-color-cyan-50: hsl(183.2 100% 96.3%);
+  --sl-color-cyan-100: hsl(185.1 95.9% 90.4%);
+  --sl-color-cyan-200: hsl(186.2 93.5% 81.8%);
+  --sl-color-cyan-300: hsl(187 92.4% 69%);
+  --sl-color-cyan-400: hsl(187.9 85.7% 53.3%);
+  --sl-color-cyan-500: hsl(188.7 94.5% 42.7%);
+  --sl-color-cyan-600: hsl(191.6 91.4% 36.5%);
+  --sl-color-cyan-700: hsl(192.9 82.3% 31%);
+  --sl-color-cyan-800: hsl(194.4 69.6% 27.1%);
+  --sl-color-cyan-900: hsl(196.4 63.6% 23.7%);
+  --sl-color-cyan-950: hsl(196.8 61% 16.1%);
+
+  --sl-color-sky-50: hsl(204 100% 97.1%);
+  --sl-color-sky-100: hsl(204 93.8% 93.7%);
+  --sl-color-sky-200: hsl(200.6 94.4% 86.1%);
+  --sl-color-sky-300: hsl(199.4 95.5% 73.9%);
+  --sl-color-sky-400: hsl(198.4 93.2% 59.6%);
+  --sl-color-sky-500: hsl(198.6 88.7% 48.4%);
+  --sl-color-sky-600: hsl(200.4 98% 39.4%);
+  --sl-color-sky-700: hsl(201.3 96.3% 32.2%);
+  --sl-color-sky-800: hsl(201 90% 27.5%);
+  --sl-color-sky-900: hsl(202 80.3% 23.9%);
+  --sl-color-sky-950: hsl(202.3 73.8% 16.5%);
+
+  --sl-color-blue-50: hsl(213.8 100% 96.9%);
+  --sl-color-blue-100: hsl(214.3 94.6% 92.7%);
+  --sl-color-blue-200: hsl(213.3 96.9% 87.3%);
+  --sl-color-blue-300: hsl(211.7 96.4% 78.4%);
+  --sl-color-blue-400: hsl(213.1 93.9% 67.8%);
+  --sl-color-blue-500: hsl(217.2 91.2% 59.8%);
+  --sl-color-blue-600: hsl(221.2 83.2% 53.3%);
+  --sl-color-blue-700: hsl(224.3 76.3% 48%);
+  --sl-color-blue-800: hsl(225.9 70.7% 40.2%);
+  --sl-color-blue-900: hsl(224.4 64.3% 32.9%);
+  --sl-color-blue-950: hsl(226.2 55.3% 18.4%);
+
+  --sl-color-indigo-50: hsl(225.9 100% 96.7%);
+  --sl-color-indigo-100: hsl(226.5 100% 93.9%);
+  --sl-color-indigo-200: hsl(228 96.5% 88.8%);
+  --sl-color-indigo-300: hsl(229.7 93.5% 81.8%);
+  --sl-color-indigo-400: hsl(234.5 89.5% 73.9%);
+  --sl-color-indigo-500: hsl(238.7 83.5% 66.7%);
+  --sl-color-indigo-600: hsl(243.4 75.4% 58.6%);
+  --sl-color-indigo-700: hsl(244.5 57.9% 50.6%);
+  --sl-color-indigo-800: hsl(243.7 54.5% 41.4%);
+  --sl-color-indigo-900: hsl(242.2 47.4% 34.3%);
+  --sl-color-indigo-950: hsl(243.5 43.6% 22.9%);
+
+  --sl-color-violet-50: hsl(250 100% 97.6%);
+  --sl-color-violet-100: hsl(251.4 91.3% 95.5%);
+  --sl-color-violet-200: hsl(250.5 95.2% 91.8%);
+  --sl-color-violet-300: hsl(252.5 94.7% 85.1%);
+  --sl-color-violet-400: hsl(255.1 91.7% 76.3%);
+  --sl-color-violet-500: hsl(258.3 89.5% 66.3%);
+  --sl-color-violet-600: hsl(262.1 83.3% 57.8%);
+  --sl-color-violet-700: hsl(263.4 70% 50.4%);
+  --sl-color-violet-800: hsl(263.4 69.3% 42.2%);
+  --sl-color-violet-900: hsl(263.5 67.4% 34.9%);
+  --sl-color-violet-950: hsl(265.1 61.5% 21.4%);
+
+  --sl-color-purple-50: hsl(270 100% 98%);
+  --sl-color-purple-100: hsl(268.7 100% 95.5%);
+  --sl-color-purple-200: hsl(268.6 100% 91.8%);
+  --sl-color-purple-300: hsl(269.2 97.4% 85.1%);
+  --sl-color-purple-400: hsl(270 95.2% 75.3%);
+  --sl-color-purple-500: hsl(270.7 91% 65.1%);
+  --sl-color-purple-600: hsl(271.5 81.3% 55.9%);
+  --sl-color-purple-700: hsl(272.1 71.7% 47.1%);
+  --sl-color-purple-800: hsl(272.9 67.2% 39.4%);
+  --sl-color-purple-900: hsl(273.6 65.6% 32%);
+  --sl-color-purple-950: hsl(276 59.5% 16.5%);
+
+  --sl-color-fuchsia-50: hsl(289.1 100% 97.8%);
+  --sl-color-fuchsia-100: hsl(287 100% 95.5%);
+  --sl-color-fuchsia-200: hsl(288.3 95.8% 90.6%);
+  --sl-color-fuchsia-300: hsl(291.1 93.1% 82.9%);
+  --sl-color-fuchsia-400: hsl(292 91.4% 72.5%);
+  --sl-color-fuchsia-500: hsl(292.2 84.1% 60.6%);
+  --sl-color-fuchsia-600: hsl(293.4 69.5% 48.8%);
+  --sl-color-fuchsia-700: hsl(294.7 72.4% 39.8%);
+  --sl-color-fuchsia-800: hsl(295.4 70.2% 32.9%);
+  --sl-color-fuchsia-900: hsl(296.7 63.6% 28%);
+  --sl-color-fuchsia-950: hsl(297.1 56.8% 14.5%);
+
+  --sl-color-pink-50: hsl(327.3 73.3% 97.1%);
+  --sl-color-pink-100: hsl(325.7 77.8% 94.7%);
+  --sl-color-pink-200: hsl(325.9 84.6% 89.8%);
+  --sl-color-pink-300: hsl(327.4 87.1% 81.8%);
+  --sl-color-pink-400: hsl(328.6 85.5% 70.2%);
+  --sl-color-pink-500: hsl(330.4 81.2% 60.4%);
+  --sl-color-pink-600: hsl(333.3 71.4% 50.6%);
+  --sl-color-pink-700: hsl(335.1 77.6% 42%);
+  --sl-color-pink-800: hsl(335.8 74.4% 35.3%);
+  --sl-color-pink-900: hsl(335.9 69% 30.4%);
+  --sl-color-pink-950: hsl(336.2 65.4% 15.9%);
+
+  --sl-color-rose-50: hsl(355.7 100% 97.3%);
+  --sl-color-rose-100: hsl(355.6 100% 94.7%);
+  --sl-color-rose-200: hsl(352.7 96.1% 90%);
+  --sl-color-rose-300: hsl(352.6 95.7% 81.8%);
+  --sl-color-rose-400: hsl(351.3 94.5% 71.4%);
+  --sl-color-rose-500: hsl(349.7 89.2% 60.2%);
+  --sl-color-rose-600: hsl(346.8 77.2% 49.8%);
+  --sl-color-rose-700: hsl(345.3 82.7% 40.8%);
+  --sl-color-rose-800: hsl(343.4 79.7% 34.7%);
+  --sl-color-rose-900: hsl(341.5 75.5% 30.4%);
+  --sl-color-rose-950: hsl(341.3 70.1% 17.1%);
+
+  --sl-color-primary-50: var(--sl-color-sky-50);
+  --sl-color-primary-100: var(--sl-color-sky-100);
+  --sl-color-primary-200: var(--sl-color-sky-200);
+  --sl-color-primary-300: var(--sl-color-sky-300);
+  --sl-color-primary-400: var(--sl-color-sky-400);
+  --sl-color-primary-500: var(--sl-color-sky-500);
+  --sl-color-primary-600: var(--sl-color-sky-600);
+  --sl-color-primary-700: var(--sl-color-sky-700);
+  --sl-color-primary-800: var(--sl-color-sky-800);
+  --sl-color-primary-900: var(--sl-color-sky-900);
+  --sl-color-primary-950: var(--sl-color-sky-950);
+
+  --sl-color-success-50: var(--sl-color-green-50);
+  --sl-color-success-100: var(--sl-color-green-100);
+  --sl-color-success-200: var(--sl-color-green-200);
+  --sl-color-success-300: var(--sl-color-green-300);
+  --sl-color-success-400: var(--sl-color-green-400);
+  --sl-color-success-500: var(--sl-color-green-500);
+  --sl-color-success-600: var(--sl-color-green-600);
+  --sl-color-success-700: var(--sl-color-green-700);
+  --sl-color-success-800: var(--sl-color-green-800);
+  --sl-color-success-900: var(--sl-color-green-900);
+  --sl-color-success-950: var(--sl-color-green-950);
+
+  --sl-color-warning-50: var(--sl-color-amber-50);
+  --sl-color-warning-100: var(--sl-color-amber-100);
+  --sl-color-warning-200: var(--sl-color-amber-200);
+  --sl-color-warning-300: var(--sl-color-amber-300);
+  --sl-color-warning-400: var(--sl-color-amber-400);
+  --sl-color-warning-500: var(--sl-color-amber-500);
+  --sl-color-warning-600: var(--sl-color-amber-600);
+  --sl-color-warning-700: var(--sl-color-amber-700);
+  --sl-color-warning-800: var(--sl-color-amber-800);
+  --sl-color-warning-900: var(--sl-color-amber-900);
+  --sl-color-warning-950: var(--sl-color-amber-950);
+
+  --sl-color-danger-50: var(--sl-color-red-50);
+  --sl-color-danger-100: var(--sl-color-red-100);
+  --sl-color-danger-200: var(--sl-color-red-200);
+  --sl-color-danger-300: var(--sl-color-red-300);
+  --sl-color-danger-400: var(--sl-color-red-400);
+  --sl-color-danger-500: var(--sl-color-red-500);
+  --sl-color-danger-600: var(--sl-color-red-600);
+  --sl-color-danger-700: var(--sl-color-red-700);
+  --sl-color-danger-800: var(--sl-color-red-800);
+  --sl-color-danger-900: var(--sl-color-red-900);
+  --sl-color-danger-950: var(--sl-color-red-950);
+
+  --sl-color-neutral-50: var(--sl-color-gray-50);
+  --sl-color-neutral-100: var(--sl-color-gray-100);
+  --sl-color-neutral-200: var(--sl-color-gray-200);
+  --sl-color-neutral-300: var(--sl-color-gray-300);
+  --sl-color-neutral-400: var(--sl-color-gray-400);
+  --sl-color-neutral-500: var(--sl-color-gray-500);
+  --sl-color-neutral-600: var(--sl-color-gray-600);
+  --sl-color-neutral-700: var(--sl-color-gray-700);
+  --sl-color-neutral-800: var(--sl-color-gray-800);
+  --sl-color-neutral-900: var(--sl-color-gray-900);
+  --sl-color-neutral-950: var(--sl-color-gray-950);
+
+  --sl-color-neutral-0: hsl(0, 0%, 100%);
+  --sl-color-neutral-1000: hsl(0, 0%, 0%);
+
+  --sl-border-radius-small: 0.1875rem;
+  --sl-border-radius-medium: 0.25rem;
+  --sl-border-radius-large: 0.5rem;
+  --sl-border-radius-x-large: 1rem;
+
+  --sl-border-radius-circle: 50%;
+  --sl-border-radius-pill: 9999px;
+
+  --sl-shadow-x-small: 0 1px 2px hsl(240 3.8% 46.1% / 6%);
+  --sl-shadow-small: 0 1px 2px hsl(240 3.8% 46.1% / 12%);
+  --sl-shadow-medium: 0 2px 4px hsl(240 3.8% 46.1% / 12%);
+  --sl-shadow-large: 0 2px 8px hsl(240 3.8% 46.1% / 12%);
+  --sl-shadow-x-large: 0 4px 16px hsl(240 3.8% 46.1% / 12%);
+
+  --sl-spacing-3x-small: 0.125rem;
+  --sl-spacing-2x-small: 0.25rem;
+  --sl-spacing-x-small: 0.5rem;
+  --sl-spacing-small: 0.75rem;
+  --sl-spacing-medium: 1rem;
+  --sl-spacing-large: 1.25rem;
+  --sl-spacing-x-large: 1.75rem;
+  --sl-spacing-2x-large: 2.25rem;
+  --sl-spacing-3x-large: 3rem;
+  --sl-spacing-4x-large: 4.5rem;
+
+  --sl-transition-x-slow: 1000ms;
+  --sl-transition-slow: 500ms;
+  --sl-transition-medium: 250ms;
+  --sl-transition-fast: 150ms;
+  --sl-transition-x-fast: 50ms;
+
+  --sl-font-mono: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  --sl-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
+  --sl-font-serif: Georgia, "Times New Roman", serif;
+
+  --sl-font-size-2x-small: 0.625rem;
+  --sl-font-size-x-small: 0.75rem;
+  --sl-font-size-small: 0.875rem;
+  --sl-font-size-medium: 1rem;
+  --sl-font-size-large: 1.25rem;
+  --sl-font-size-x-large: 1.5rem;
+  --sl-font-size-2x-large: 2.25rem;
+  --sl-font-size-3x-large: 3rem;
+  --sl-font-size-4x-large: 4.5rem;
+
+  --sl-font-weight-light: 300;
+  --sl-font-weight-normal: 400;
+  --sl-font-weight-semibold: 500;
+  --sl-font-weight-bold: 700;
+
+  --sl-letter-spacing-denser: -0.03em;
+  --sl-letter-spacing-dense: -0.015em;
+  --sl-letter-spacing-normal: normal;
+  --sl-letter-spacing-loose: 0.075em;
+  --sl-letter-spacing-looser: 0.15em;
+
+  --sl-line-height-denser: 1;
+  --sl-line-height-dense: 1.4;
+  --sl-line-height-normal: 1.8;
+  --sl-line-height-loose: 2.2;
+  --sl-line-height-looser: 2.6;
+
+  --sl-focus-ring-color: var(--sl-color-primary-600);
+  --sl-focus-ring-style: solid;
+  --sl-focus-ring-width: 3px;
+  --sl-focus-ring: var(--sl-focus-ring-style) var(--sl-focus-ring-width)
+    var(--sl-focus-ring-color);
+  --sl-focus-ring-offset: 1px;
+
+  --sl-button-font-size-small: var(--sl-font-size-x-small);
+  --sl-button-font-size-medium: var(--sl-font-size-small);
+  --sl-button-font-size-large: var(--sl-font-size-medium);
+
+  --sl-input-height-small: 1.875rem;
+  --sl-input-height-medium: 2.5rem;
+  --sl-input-height-large: 3.125rem;
+
+  --sl-input-background-color: var(--sl-color-neutral-0);
+  --sl-input-background-color-hover: var(--sl-input-background-color);
+  --sl-input-background-color-focus: var(--sl-input-background-color);
+  --sl-input-background-color-disabled: var(--sl-color-neutral-100);
+  --sl-input-border-color: var(--sl-color-neutral-300);
+  --sl-input-border-color-hover: var(--sl-color-neutral-400);
+  --sl-input-border-color-focus: var(--sl-color-primary-500);
+  --sl-input-border-color-disabled: var(--sl-color-neutral-300);
+  --sl-input-border-width: 1px;
+  --sl-input-required-content: "*";
+  --sl-input-required-content-offset: -2px;
+  --sl-input-required-content-color: var(--sl-input-label-color);
+
+  --sl-input-border-radius-small: var(--sl-border-radius-medium);
+  --sl-input-border-radius-medium: var(--sl-border-radius-medium);
+  --sl-input-border-radius-large: var(--sl-border-radius-medium);
+
+  --sl-input-font-family: var(--sl-font-sans);
+  --sl-input-font-weight: var(--sl-font-weight-normal);
+  --sl-input-font-size-small: var(--sl-font-size-small);
+  --sl-input-font-size-medium: var(--sl-font-size-medium);
+  --sl-input-font-size-large: var(--sl-font-size-large);
+  --sl-input-letter-spacing: var(--sl-letter-spacing-normal);
+
+  --sl-input-color: var(--sl-color-neutral-700);
+  --sl-input-color-hover: var(--sl-color-neutral-700);
+  --sl-input-color-focus: var(--sl-color-neutral-700);
+  --sl-input-color-disabled: var(--sl-color-neutral-900);
+  --sl-input-icon-color: var(--sl-color-neutral-500);
+  --sl-input-icon-color-hover: var(--sl-color-neutral-600);
+  --sl-input-icon-color-focus: var(--sl-color-neutral-600);
+  --sl-input-placeholder-color: var(--sl-color-neutral-500);
+  --sl-input-placeholder-color-disabled: var(--sl-color-neutral-600);
+  --sl-input-spacing-small: var(--sl-spacing-small);
+  --sl-input-spacing-medium: var(--sl-spacing-medium);
+  --sl-input-spacing-large: var(--sl-spacing-large);
+
+  --sl-input-focus-ring-color: hsl(198.6 88.7% 48.4% / 40%);
+  --sl-input-focus-ring-offset: 0;
+
+  --sl-input-filled-background-color: var(--sl-color-neutral-100);
+  --sl-input-filled-background-color-hover: var(--sl-color-neutral-100);
+  --sl-input-filled-background-color-focus: var(--sl-color-neutral-100);
+  --sl-input-filled-background-color-disabled: var(--sl-color-neutral-100);
+  --sl-input-filled-color: var(--sl-color-neutral-800);
+  --sl-input-filled-color-hover: var(--sl-color-neutral-800);
+  --sl-input-filled-color-focus: var(--sl-color-neutral-700);
+  --sl-input-filled-color-disabled: var(--sl-color-neutral-800);
+
+  --sl-input-label-font-size-small: var(--sl-font-size-small);
+  --sl-input-label-font-size-medium: var(--sl-font-size-medium);
+  --sl-input-label-font-size-large: var(--sl-font-size-large);
+  --sl-input-label-color: inherit;
+
+  --sl-input-help-text-font-size-small: var(--sl-font-size-x-small);
+  --sl-input-help-text-font-size-medium: var(--sl-font-size-small);
+  --sl-input-help-text-font-size-large: var(--sl-font-size-medium);
+  --sl-input-help-text-color: var(--sl-color-neutral-500);
+
+  --sl-toggle-size-small: 0.875rem;
+  --sl-toggle-size-medium: 1.125rem;
+  --sl-toggle-size-large: 1.375rem;
+
+  --sl-overlay-background-color: hsl(240 3.8% 46.1% / 33%);
+
+  --sl-panel-background-color: var(--sl-color-neutral-0);
+  --sl-panel-border-color: var(--sl-color-neutral-200);
+  --sl-panel-border-width: 1px;
+
+  --sl-tooltip-border-radius: var(--sl-border-radius-medium);
+  --sl-tooltip-background-color: var(--sl-color-neutral-800);
+  --sl-tooltip-color: var(--sl-color-neutral-0);
+  --sl-tooltip-font-family: var(--sl-font-sans);
+  --sl-tooltip-font-weight: var(--sl-font-weight-normal);
+  --sl-tooltip-font-size: var(--sl-font-size-small);
+  --sl-tooltip-line-height: var(--sl-line-height-dense);
+  --sl-tooltip-padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);
+  --sl-tooltip-arrow-size: 6px;
+
+  --sl-z-index-drawer: 700;
+  --sl-z-index-dialog: 800;
+  --sl-z-index-dropdown: 900;
+  --sl-z-index-toast: 950;
+  --sl-z-index-tooltip: 1000;
+}
+
+@supports (scrollbar-gutter: stable) {
+  .sl-scroll-lock {
+    scrollbar-gutter: var(--sl-scroll-lock-gutter) !important;
+  }
+
+  .sl-scroll-lock body {
+    overflow: hidden !important;
+  }
+}
+
+@supports not (scrollbar-gutter: stable) {
+  .sl-scroll-lock body {
+    padding-right: var(--sl-scroll-lock-size) !important;
+    overflow: hidden !important;
+  }
+}
+
+.sl-toast-stack {
+  position: fixed;
+  top: 0;
+  inset-inline-end: 0;
+  z-index: var(--sl-z-index-toast);
+  width: 28rem;
+  max-width: 100%;
+  max-height: 100%;
+  overflow: auto;
+}
+
+.sl-toast-stack sl-alert {
+  margin: var(--sl-spacing-medium);
+}
+
+.sl-toast-stack sl-alert::part(base) {
+  box-shadow: var(--sl-shadow-large);
+}

--- a/worca-bench/app/views/activity-dock.js
+++ b/worca-bench/app/views/activity-dock.js
@@ -20,7 +20,12 @@ function _fmtClock(iso) {
   if (!iso) return '—';
   const t = Date.parse(iso);
   if (Number.isNaN(t)) return '—';
-  return new Date(t).toISOString().slice(11, 16); // HH:MM (UTC)
+  // Local browser time (HH:MM), honoring the user's locale 12h/24h preference —
+  // the timestamps in `started_at` are UTC ISO strings.
+  return new Date(t).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
 function _fmtDur(start, end) {

--- a/worca-bench/app/views/activity-dock.js
+++ b/worca-bench/app/views/activity-dock.js
@@ -1,0 +1,184 @@
+import { html, nothing } from 'lit-html';
+
+// Persistent bottom "Activity" dock: a slim always-visible bar that expands into
+// a table of Run/Regrade actions with lifecycle, progress, and per-row controls.
+// Pure/stateless (lit-html) — state (actions, collapsed) is owned by main.js and
+// refreshed from the server's actions ledger, so it survives a page reload.
+
+const TYPE_LABEL = { run: 'Run', regrade: 'Regrade' };
+
+// Status → badge class (badge color language: blue=active, green=done,
+// red=failed, gray=stopped).
+const STATUS_CLASS = {
+  running: 'act-status--running',
+  completed: 'act-status--done',
+  failed: 'act-status--failed',
+  stopped: 'act-status--stopped',
+};
+
+function _fmtClock(iso) {
+  if (!iso) return '—';
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '—';
+  return new Date(t).toISOString().slice(11, 16); // HH:MM (UTC)
+}
+
+function _fmtDur(start, end) {
+  const a = Date.parse(start || '');
+  const b = end ? Date.parse(end) : Date.now();
+  if (Number.isNaN(a) || Number.isNaN(b) || b < a) return '—';
+  let s = Math.floor((b - a) / 1000);
+  const h = Math.floor(s / 3600);
+  s -= h * 3600;
+  const m = Math.floor(s / 60);
+  s -= m * 60;
+  const pad = (n) => String(n).padStart(2, '0');
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}
+
+function _progressText(a) {
+  const p = a.progress;
+  if (!p) return a.status === 'running' ? 'starting…' : '';
+  if (p.unit === 'instances') {
+    const total = p.total != null ? `/${p.total}` : '';
+    const err = p.errors ? ` · ${p.errors} err` : '';
+    return `${p.done}${total} inst${err}`;
+  }
+  if (p.unit === 'regraded') {
+    const total = p.total != null ? `/${p.total}` : '';
+    const err = p.errors ? ` · ${p.errors} err` : '';
+    return `${p.done ?? 0}${total} regraded${err}`;
+  }
+  return '';
+}
+
+function _row(a, { onStop, onView, onDismiss }) {
+  const running = a.status === 'running';
+  const statusClass = STATUS_CLASS[a.status] || 'act-status--stopped';
+  return html`
+    <tr class="activity-row activity-row--${a.status}">
+      <td class="act-type">${TYPE_LABEL[a.type] || a.type}</td>
+      <td class="act-profile" title=${a.profile}>${a.profile}</td>
+      <td>
+        <span class="act-status ${statusClass}"
+          >${running ? html`<span class="act-dot"></span>` : nothing}${a.status}</span
+        >
+      </td>
+      <td class="act-progress">${_progressText(a)}</td>
+      <td class="act-time">${_fmtClock(a.started_at)}</td>
+      <td class="act-dur">${_fmtDur(a.started_at, a.ended_at)}</td>
+      <td class="act-actions">
+        ${
+          running
+            ? html`<button
+                class="act-btn act-btn--stop"
+                title="Stop this action"
+                @click=${() => onStop?.(a)}
+              >Stop</button>`
+            : nothing
+        }
+        <button
+          class="act-btn act-btn--view"
+          title="Open this profile"
+          @click=${() => onView?.(a)}
+        >View</button>
+        ${
+          running
+            ? nothing
+            : html`<button
+                class="act-btn act-btn--dismiss"
+                title="Dismiss from the list"
+                @click=${() => onDismiss?.(a)}
+              >✕</button>`
+        }
+      </td>
+    </tr>
+  `;
+}
+
+/**
+ * @param {Array} actions  ledger actions (newest-first), each enriched w/ progress
+ * @param {{collapsed?: boolean, onToggle?: fn, onStop?: fn, onView?: fn,
+ *          onDismiss?: fn, dismissed?: Set<string>}} opts
+ */
+export function activityDock(actions = [], opts = {}) {
+  const {
+    collapsed = true,
+    onToggle,
+    onStop,
+    onView,
+    onDismiss,
+    dismissed,
+  } = opts;
+  const visible = dismissed
+    ? actions.filter((a) => !dismissed.has(a.id))
+    : actions;
+  if (visible.length === 0) return nothing; // no dock when there's nothing to show
+
+  const running = visible.filter((a) => a.status === 'running').length;
+  const failed = visible.filter((a) => a.status === 'failed').length;
+  const done = visible.filter((a) => a.status === 'completed').length;
+  const stopped = visible.filter((a) => a.status === 'stopped').length;
+
+  return html`
+    <div class="activity-dock ${collapsed ? 'is-collapsed' : 'is-expanded'}">
+      <button
+        class="activity-bar"
+        @click=${() => onToggle?.()}
+        aria-expanded=${collapsed ? 'false' : 'true'}
+      >
+        <span class="activity-bar-title">
+          <span class="activity-caret">${collapsed ? '▴' : '▾'}</span> Activity
+        </span>
+        <span class="activity-summary">
+          ${
+            running
+              ? html`<span class="act-chip act-chip--running"
+                ><span class="act-dot"></span>${running} running</span
+              >`
+              : nothing
+          }
+          ${
+            failed
+              ? html`<span class="act-chip act-chip--failed">✗ ${failed} failed</span>`
+              : nothing
+          }
+          ${
+            stopped
+              ? html`<span class="act-chip act-chip--stopped">■ ${stopped} stopped</span>`
+              : nothing
+          }
+          ${
+            done
+              ? html`<span class="act-chip act-chip--done">✓ ${done} done</span>`
+              : nothing
+          }
+        </span>
+      </button>
+      ${
+        collapsed
+          ? nothing
+          : html`
+              <div class="activity-panel">
+                <table class="activity-table">
+                  <thead>
+                    <tr>
+                      <th>Type</th>
+                      <th>Profile</th>
+                      <th>Status</th>
+                      <th>Progress</th>
+                      <th>Started</th>
+                      <th>Duration</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${visible.map((a) => _row(a, { onStop, onView, onDismiss }))}
+                  </tbody>
+                </table>
+              </div>
+            `
+      }
+    </div>
+  `;
+}

--- a/worca-bench/app/views/activity-dock.test.js
+++ b/worca-bench/app/views/activity-dock.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { activityDock } from './activity-dock.js';
+
+// renderToString helper shared with the other worca-bench view tests.
+function renderToString(template) {
+  if (template == null) return '';
+  if (typeof template === 'symbol') return ''; // lit `nothing`
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const RUN = {
+  id: 'run-demo-1-1',
+  type: 'run',
+  profile: 'demo',
+  status: 'running',
+  started_at: '2026-06-18T10:00:00Z',
+  progress: { unit: 'instances', done: 3, total: 9, errors: 1 },
+};
+const DONE = {
+  id: 'regrade-demo-2-2',
+  type: 'regrade',
+  profile: 'demo',
+  status: 'completed',
+  started_at: '2026-06-18T09:00:00Z',
+  ended_at: '2026-06-18T09:05:00Z',
+  progress: { unit: 'regraded', done: 20, total: 20, errors: 0 },
+};
+
+describe('activityDock', () => {
+  it('renders nothing when there are no actions', () => {
+    expect(renderToString(activityDock([]))).toBe('');
+  });
+
+  it('shows a summary bar with running/done counts', () => {
+    const out = renderToString(activityDock([RUN, DONE], { collapsed: true }));
+    expect(out).toContain('activity-dock');
+    expect(out).toContain('is-collapsed');
+    expect(out).toContain('Activity');
+    expect(out).toContain('1 running');
+    expect(out).toContain('1 done');
+    // collapsed => no table
+    expect(out).not.toContain('activity-table');
+  });
+
+  it('renders the table with rows when expanded', () => {
+    const out = renderToString(activityDock([RUN, DONE], { collapsed: false }));
+    expect(out).toContain('is-expanded');
+    expect(out).toContain('activity-table');
+    expect(out).toContain('Run');
+    expect(out).toContain('Regrade');
+    expect(out).toContain('demo');
+    expect(out).toContain('3/9 inst'); // run progress
+    expect(out).toContain('1 err');
+    expect(out).toContain('20/20 regraded'); // regrade progress
+  });
+
+  it('offers a Stop button only for running actions', () => {
+    const running = renderToString(activityDock([RUN], { collapsed: false }));
+    expect(running).toContain('act-btn--stop');
+    expect(running).not.toContain('act-btn--dismiss'); // running has no dismiss
+    const done = renderToString(activityDock([DONE], { collapsed: false }));
+    expect(done).not.toContain('act-btn--stop');
+    expect(done).toContain('act-btn--dismiss'); // terminal can be dismissed
+  });
+
+  it('hides dismissed actions (and the dock when all are dismissed)', () => {
+    const dismissed = new Set([DONE.id]);
+    const out = renderToString(
+      activityDock([DONE], { collapsed: false, dismissed }),
+    );
+    expect(out).toBe('');
+    // a still-visible action keeps the dock
+    const mixed = renderToString(
+      activityDock([RUN, DONE], { collapsed: false, dismissed }),
+    );
+    expect(mixed).toContain('activity-table');
+    expect(mixed).toContain('3/9 inst'); // the surviving RUN row is present
+  });
+
+  it('marks a running action with the active status class + dot', () => {
+    const out = renderToString(activityDock([RUN], { collapsed: false }));
+    expect(out).toContain('act-status--running');
+    expect(out).toContain('act-dot');
+  });
+});

--- a/worca-bench/app/views/compare.js
+++ b/worca-bench/app/views/compare.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html, nothing } from 'lit-html';
 import { profileOutcome, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
 
@@ -19,10 +19,21 @@ export function compareView(rows) {
           <thead>
             <tr>
               <th>Metric</th>
-              ${rows.map(
-                (r) =>
-                  html`<th><span class="compare-col-name">${r.name}</span></th>`,
-              )}
+              ${(() => {
+                const counts = new Map();
+                for (const r of rows)
+                  counts.set(r.name, (counts.get(r.name) || 0) + 1);
+                return rows.map(
+                  (r) => html`<th>
+                    <span class="compare-col-name">${r.name}</span>
+                    ${
+                      counts.get(r.name) > 1 && r.source_label
+                        ? html`<span class="compare-col-src">${r.source_label}</span>`
+                        : nothing
+                    }
+                  </th>`,
+                );
+              })()}
             </tr>
           </thead>
           <tbody>

--- a/worca-bench/app/views/compare.js
+++ b/worca-bench/app/views/compare.js
@@ -19,13 +19,20 @@ export function compareView(rows) {
           <thead>
             <tr>
               <th>Metric</th>
-              ${rows.map((r) => {
-                const o = profileOutcome(r);
-                return html`<th><span class="compare-col-name">${r.name}</span> <sl-badge variant="${variantFor(o)}" pill>${o}</sl-badge></th>`;
-              })}
+              ${rows.map(
+                (r) =>
+                  html`<th><span class="compare-col-name">${r.name}</span></th>`,
+              )}
             </tr>
           </thead>
           <tbody>
+            <tr>
+              <td class="compare-metric">Status</td>
+              ${rows.map((r) => {
+                const o = profileOutcome(r);
+                return html`<td><sl-badge variant="${variantFor(o)}" pill>${o}</sl-badge></td>`;
+              })}
+            </tr>
             <tr>
               <td class="compare-metric">Reps (n)</td>
               ${rows.map((r) => html`<td>${r.n ?? r.reps ?? 0}</td>`)}

--- a/worca-bench/app/views/compare.js
+++ b/worca-bench/app/views/compare.js
@@ -1,21 +1,16 @@
-import { html, nothing } from 'lit-html';
+import { html } from 'lit-html';
 import { profileOutcome, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
 
 /**
- * Config-vs-config comparison table. Each requested profile is a column.
+ * Config-vs-config comparison table body. Each requested profile is a column.
+ * The page title and back button live in main.js's shared content header.
  *
  * @param {object[]} rows  aggregate summaries from /api/compare
- * @param {object} [handlers]
- * @param {() => void} [handlers.onBack]
  */
-export function compareView(rows, { onBack } = {}) {
+export function compareView(rows) {
   return html`
     <section class="page">
-      <div class="page-head">
-        <h1>Compare Profiles</h1>
-        ${onBack ? html`<button class="action-btn" @click=${onBack}>Back</button>` : nothing}
-      </div>
       ${
         !rows || rows.length === 0
           ? html`<p class="empty-state">No profiles selected to compare.</p>`

--- a/worca-bench/app/views/compare.js
+++ b/worca-bench/app/views/compare.js
@@ -42,15 +42,19 @@ export function compareView(rows) {
               ${rows.map((r) => html`<td>${pct(r.resolved_rate)}</td>`)}
             </tr>
             <tr>
-              <td class="compare-metric">Mean cost</td>
+              <td class="compare-metric">Avg score</td>
+              ${rows.map((r) => html`<td>${typeof r.mean_score === 'number' ? num(r.mean_score, 2) : 'N/A'}</td>`)}
+            </tr>
+            <tr>
+              <td class="compare-metric">Avg cost</td>
               ${rows.map((r) => html`<td>${formatCost(r.mean_cost_usd) || 'N/A'}</td>`)}
             </tr>
             <tr>
-              <td class="compare-metric">Mean wall time</td>
+              <td class="compare-metric">Avg duration</td>
               ${rows.map((r) => html`<td>${formatDuration(r.mean_wall_s)}</td>`)}
             </tr>
             <tr>
-              <td class="compare-metric">Mean iterations</td>
+              <td class="compare-metric">Avg iterations</td>
               ${rows.map((r) => html`<td>${num(r.mean_iterations, 2)}</td>`)}
             </tr>
           </tbody>

--- a/worca-bench/app/views/compare.js
+++ b/worca-bench/app/views/compare.js
@@ -1,0 +1,60 @@
+import { html, nothing } from 'lit-html';
+import { profileOutcome, variantFor } from '../utils/badge.js';
+import { formatCost, formatDuration, num, pct } from '../utils/format.js';
+
+/**
+ * Config-vs-config comparison table. Each requested profile is a column.
+ *
+ * @param {object[]} rows  aggregate summaries from /api/compare
+ * @param {object} [handlers]
+ * @param {() => void} [handlers.onBack]
+ */
+export function compareView(rows, { onBack } = {}) {
+  return html`
+    <section class="page">
+      <div class="page-head">
+        <h1>Compare Profiles</h1>
+        ${onBack ? html`<button class="action-btn" @click=${onBack}>Back</button>` : nothing}
+      </div>
+      ${
+        !rows || rows.length === 0
+          ? html`<p class="empty-state">No profiles selected to compare.</p>`
+          : html`
+        <table class="compare-table">
+          <thead>
+            <tr>
+              <th>Metric</th>
+              ${rows.map((r) => {
+                const o = profileOutcome(r);
+                return html`<th><span class="compare-col-name">${r.name}</span> <sl-badge variant="${variantFor(o)}" pill>${o}</sl-badge></th>`;
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="compare-metric">Reps (n)</td>
+              ${rows.map((r) => html`<td>${r.n ?? r.reps ?? 0}</td>`)}
+            </tr>
+            <tr>
+              <td class="compare-metric">Resolved rate</td>
+              ${rows.map((r) => html`<td>${pct(r.resolved_rate)}</td>`)}
+            </tr>
+            <tr>
+              <td class="compare-metric">Mean cost</td>
+              ${rows.map((r) => html`<td>${formatCost(r.mean_cost_usd) || 'N/A'}</td>`)}
+            </tr>
+            <tr>
+              <td class="compare-metric">Mean wall time</td>
+              ${rows.map((r) => html`<td>${formatDuration(r.mean_wall_s)}</td>`)}
+            </tr>
+            <tr>
+              <td class="compare-metric">Mean iterations</td>
+              ${rows.map((r) => html`<td>${num(r.mean_iterations, 2)}</td>`)}
+            </tr>
+          </tbody>
+        </table>
+      `
+      }
+    </section>
+  `;
+}

--- a/worca-bench/app/views/leaderboard.js
+++ b/worca-bench/app/views/leaderboard.js
@@ -43,7 +43,7 @@ export function leaderboardView(data, { onSelectBenchmark } = {}) {
           : html`
         <table class="leaderboard-table">
           <thead>
-            <tr><th>#</th><th>Agent</th><th>Resolved rate</th><th>Source</th></tr>
+            <tr><th>#</th><th>Agent</th><th>Resolved rate</th><th>Date</th><th>Source</th></tr>
           </thead>
           <tbody>
             ${rows.map(
@@ -52,6 +52,7 @@ export function leaderboardView(data, { onSelectBenchmark } = {}) {
                 <td>${i + 1}</td>
                 <td>${r.agent}</td>
                 <td>${r.resolved_rate === null || r.resolved_rate === undefined ? '—' : pct(r.resolved_rate)}</td>
+                <td class="leaderboard-date">${r.date || '—'}</td>
                 <td>
                   ${
                     r.url

--- a/worca-bench/app/views/leaderboard.js
+++ b/worca-bench/app/views/leaderboard.js
@@ -1,0 +1,69 @@
+import { html, nothing } from 'lit-html';
+import { pct } from '../utils/format.js';
+
+/**
+ * Public cross-agent leaderboard view. Rows come from the server's static
+ * fixture today (a later phase fetches live standings). The local entry
+ * (resolved_rate null) renders as a "this run" placeholder row.
+ *
+ * @param {object} data  { benchmark, rows, benchmarks }
+ * @param {object} [handlers]
+ * @param {() => void} [handlers.onBack]
+ * @param {(benchmark: string) => void} [handlers.onSelectBenchmark]
+ */
+export function leaderboardView(data, { onBack, onSelectBenchmark } = {}) {
+  const rows = data?.rows || [];
+  const benchmarks = data?.benchmarks || [];
+  const current = data?.benchmark || '';
+
+  return html`
+    <section class="page">
+      <div class="page-head">
+        <h1>Leaderboard</h1>
+        ${onBack ? html`<button class="action-btn" @click=${onBack}>Back</button>` : nothing}
+      </div>
+
+      ${
+        benchmarks.length > 1 && onSelectBenchmark
+          ? html`<div class="leaderboard-tabs">
+        ${benchmarks.map(
+          (b) => html`<button
+            class="leaderboard-tab ${b === current ? 'leaderboard-tab--active' : ''}"
+            @click=${() => onSelectBenchmark(b)}
+          >${b}</button>`,
+        )}
+      </div>`
+          : nothing
+      }
+
+      <p class="leaderboard-note">
+        Cross-agent standings for <strong>${current}</strong>. Public rows are a
+        static snapshot — a later phase fetches swebench.com / commit-0 live.
+      </p>
+
+      ${
+        rows.length === 0
+          ? html`<p class="empty-state">No leaderboard data for this benchmark.</p>`
+          : html`
+        <table class="leaderboard-table">
+          <thead>
+            <tr><th>#</th><th>Agent</th><th>Resolved rate</th><th>Source</th></tr>
+          </thead>
+          <tbody>
+            ${rows.map(
+              (r, i) => html`
+              <tr class=${r.source === 'local' ? 'leaderboard-row--local' : ''}>
+                <td>${i + 1}</td>
+                <td>${r.agent}</td>
+                <td>${r.resolved_rate === null || r.resolved_rate === undefined ? '—' : pct(r.resolved_rate)}</td>
+                <td><span class="leaderboard-source">${r.source}</span></td>
+              </tr>
+            `,
+            )}
+          </tbody>
+        </table>
+      `
+      }
+    </section>
+  `;
+}

--- a/worca-bench/app/views/leaderboard.js
+++ b/worca-bench/app/views/leaderboard.js
@@ -2,27 +2,22 @@ import { html, nothing } from 'lit-html';
 import { pct } from '../utils/format.js';
 
 /**
- * Public cross-agent leaderboard view. Rows come from the server's static
- * fixture today (a later phase fetches live standings). The local entry
- * (resolved_rate null) renders as a "this run" placeholder row.
+ * Public cross-agent leaderboard view body. Rows come from the server's
+ * static fixture today (a later phase fetches live standings). The local
+ * entry (resolved_rate null) renders as a "this run" placeholder row. The
+ * page title and back button live in main.js's shared content header.
  *
  * @param {object} data  { benchmark, rows, benchmarks }
  * @param {object} [handlers]
- * @param {() => void} [handlers.onBack]
  * @param {(benchmark: string) => void} [handlers.onSelectBenchmark]
  */
-export function leaderboardView(data, { onBack, onSelectBenchmark } = {}) {
+export function leaderboardView(data, { onSelectBenchmark } = {}) {
   const rows = data?.rows || [];
   const benchmarks = data?.benchmarks || [];
   const current = data?.benchmark || '';
 
   return html`
     <section class="page">
-      <div class="page-head">
-        <h1>Leaderboard</h1>
-        ${onBack ? html`<button class="action-btn" @click=${onBack}>Back</button>` : nothing}
-      </div>
-
       ${
         benchmarks.length > 1 && onSelectBenchmark
           ? html`<div class="leaderboard-tabs">
@@ -37,8 +32,9 @@ export function leaderboardView(data, { onBack, onSelectBenchmark } = {}) {
       }
 
       <p class="leaderboard-note">
-        Cross-agent standings for <strong>${current}</strong>. Public rows are a
-        static snapshot — a later phase fetches swebench.com / commit-0 live.
+        Cross-agent standings for <strong>${current}</strong>. Public rows are fetched
+        live (cached) from swebench.com / commit-0.github.io; falls back to a snapshot
+        when offline.
       </p>
 
       ${
@@ -56,7 +52,19 @@ export function leaderboardView(data, { onBack, onSelectBenchmark } = {}) {
                 <td>${i + 1}</td>
                 <td>${r.agent}</td>
                 <td>${r.resolved_rate === null || r.resolved_rate === undefined ? '—' : pct(r.resolved_rate)}</td>
-                <td><span class="leaderboard-source">${r.source}</span></td>
+                <td>
+                  ${
+                    r.url
+                      ? html`<a
+                          class="leaderboard-source leaderboard-source--link"
+                          href=${r.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          >${r.source}</a
+                        >`
+                      : html`<span class="leaderboard-source">${r.source}</span>`
+                  }
+                </td>
               </tr>
             `,
             )}

--- a/worca-bench/app/views/profile-card.js
+++ b/worca-bench/app/views/profile-card.js
@@ -1,0 +1,104 @@
+import { html, nothing } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import {
+  outcomeClass,
+  outcomeIcon,
+  profileOutcome,
+  variantFor,
+} from '../utils/badge.js';
+import {
+  formatCost,
+  formatDuration,
+  formatTimestamp,
+  num,
+  pct,
+} from '../utils/format.js';
+
+/**
+ * One card per benchmark profile. Follows the worca-ui 4-section card layout:
+ * top (status pip + name + outcome badge) -> meta (benchmark/ref/template) ->
+ * stages (resolved-rate + cost/time/iteration badges) -> actions (View / Run).
+ *
+ * @param {object} agg  aggregate summary from the /api/profiles endpoint
+ * @param {object} [handlers]
+ * @param {(name: string) => void} [handlers.onOpen]
+ * @param {(name: string) => void} [handlers.onRun]
+ */
+export function profileCardView(agg, { onOpen, onRun } = {}) {
+  const outcome = profileOutcome(agg);
+  const variant = variantFor(outcome);
+  const cost = formatCost(agg.mean_cost_usd);
+
+  return html`
+    <div class="run-card ${outcomeClass(outcome)}" @click=${onOpen ? () => onOpen(agg.name) : null}>
+      <div class="run-card-top">
+        <span class="run-card-status">${unsafeHTML(outcomeIcon(outcome, 16))}</span>
+        <span class="run-card-title">${agg.name}</span>
+        <sl-badge variant="${variant}" pill class="status-badge-${outcome}">${outcome}</sl-badge>
+      </div>
+
+      <div class="run-card-meta">
+        ${
+          agg.benchmark
+            ? html`<span class="run-card-meta-item"><span class="meta-label">Benchmark:</span> <span class="meta-value">${agg.benchmark}</span></span>`
+            : nothing
+        }
+        ${
+          agg.worca_ref
+            ? html`<span class="run-card-meta-item"><span class="meta-label">worca:</span> <span class="meta-value">${agg.worca_ref}</span></span>`
+            : nothing
+        }
+        ${
+          agg.template
+            ? html`<span class="run-card-meta-item"><span class="meta-label">Template:</span> <span class="meta-value">${agg.template}</span></span>`
+            : nothing
+        }
+      </div>
+
+      <div class="run-card-meta">
+        <span class="run-card-meta-item"><span class="meta-label">Reps:</span> <span class="meta-value">${agg.reps}</span></span>
+        <span class="run-card-meta-item"><span class="meta-label">Last run:</span> <span class="meta-value">${formatTimestamp(agg.last_run)}</span></span>
+      </div>
+
+      <div class="run-card-stages">
+        <sl-badge variant="${variant}" pill class="run-card-stage-badge">Resolved ${pct(agg.resolved_rate)}</sl-badge>
+        ${
+          cost
+            ? html`<sl-badge variant="neutral" pill class="run-card-stage-badge">${cost} avg</sl-badge>`
+            : nothing
+        }
+        ${
+          agg.mean_wall_s !== null && agg.mean_wall_s !== undefined
+            ? html`<sl-badge variant="neutral" pill class="run-card-stage-badge">${formatDuration(agg.mean_wall_s)} avg</sl-badge>`
+            : nothing
+        }
+        ${
+          agg.mean_iterations !== null && agg.mean_iterations !== undefined
+            ? html`<sl-badge variant="neutral" pill class="run-card-stage-badge">${num(agg.mean_iterations, 1)} iters</sl-badge>`
+            : nothing
+        }
+      </div>
+
+      <div class="run-card-actions">
+        ${
+          onOpen
+            ? html`<button class="action-btn" @click=${(e) => {
+                e.stopPropagation();
+                onOpen(agg.name);
+              }}>View</button>`
+            : nothing
+        }
+        ${
+          onRun
+            ? html`<button class="action-btn action-btn--primary" @click=${(
+                e,
+              ) => {
+                e.stopPropagation();
+                onRun(agg.name);
+              }}>Run</button>`
+            : nothing
+        }
+      </div>
+    </div>
+  `;
+}

--- a/worca-bench/app/views/profile-card.js
+++ b/worca-bench/app/views/profile-card.js
@@ -82,11 +82,6 @@ export function profileCardView(
             : nothing
         }
         ${
-          agg.worca_ref
-            ? html`<span class="run-card-meta-item"><span class="meta-label">worca:</span> <span class="meta-value">${agg.worca_ref}</span></span>`
-            : nothing
-        }
-        ${
           agg.template
             ? html`<span class="run-card-meta-item"><span class="meta-label">Template:</span> <span class="meta-value">${agg.template}</span></span>`
             : nothing
@@ -99,6 +94,7 @@ export function profileCardView(
       </div>
 
       <div class="run-card-meta">
+        <span class="run-card-meta-item"><span class="meta-label">Tests:</span> <span class="meta-value">${agg.instance_count ?? 'all'}</span></span>
         <span class="run-card-meta-item"><span class="meta-label">Runs:</span> <span class="meta-value">${agg.reps}</span></span>
         <span class="run-card-meta-item"><span class="meta-label">Last run:</span> <span class="meta-value">${formatTimestamp(agg.last_run)}</span></span>
       </div>
@@ -123,14 +119,6 @@ export function profileCardView(
       </div>
 
       <div class="run-card-actions">
-        ${
-          onOpen
-            ? html`<button class="action-btn" @click=${(e) => {
-                e.stopPropagation();
-                onOpen(agg);
-              }}>View</button>`
-            : nothing
-        }
         ${
           onRun
             ? html`<button class="action-btn action-btn--primary" @click=${(

--- a/worca-bench/app/views/profile-card.js
+++ b/worca-bench/app/views/profile-card.js
@@ -58,7 +58,13 @@ export function profileCardView(
         }
         <span class="run-card-status">${unsafeHTML(outcomeIcon(outcome, 16))}</span>
         <span class="run-card-title">${agg.name}</span>
-        <sl-badge variant="${variant}" pill class="status-badge-${outcome}">${outcome}</sl-badge>
+        ${
+          agg.active
+            ? html`<sl-badge variant="primary" pill class="run-card-running"
+                ><span class="running-dot"></span>${agg.active_kind === 'canary' ? 'canary' : 'running'}${agg.stage ? ` · ${agg.stage}` : ''}</sl-badge
+              >`
+            : html`<sl-badge variant="${variant}" pill class="status-badge-${outcome}">${outcome}</sl-badge>`
+        }
       </div>
 
       <div class="run-card-meta">

--- a/worca-bench/app/views/profile-card.js
+++ b/worca-bench/app/views/profile-card.js
@@ -45,7 +45,7 @@ export function profileCardView(
 
   return html`
     <div
-      class="run-card ${outcomeClass(outcome)} ${isSelected ? 'run-card--selected' : ''}"
+      class="run-card ${outcomeClass(outcome)} ${isSelected ? 'run-card--selected' : ''} ${agg.archived ? 'run-card--archived' : ''}"
       @click=${onOpen ? () => onOpen(agg) : null}
     >
       <div class="run-card-top">
@@ -99,7 +99,7 @@ export function profileCardView(
       </div>
 
       <div class="run-card-meta">
-        <span class="run-card-meta-item"><span class="meta-label">Reps:</span> <span class="meta-value">${agg.reps}</span></span>
+        <span class="run-card-meta-item"><span class="meta-label">Runs:</span> <span class="meta-value">${agg.reps}</span></span>
         <span class="run-card-meta-item"><span class="meta-label">Last run:</span> <span class="meta-value">${formatTimestamp(agg.last_run)}</span></span>
       </div>
 

--- a/worca-bench/app/views/profile-card.js
+++ b/worca-bench/app/views/profile-card.js
@@ -35,17 +35,18 @@ function _activeLabel(agg) {
 
 export function profileCardView(
   agg,
-  { onOpen, onRun, selected, onToggleSelect } = {},
+  { onOpen, onRun, selected, onToggleSelect, showSource } = {},
 ) {
   const outcome = profileOutcome(agg);
   const variant = variantFor(outcome);
   const cost = formatCost(agg.mean_cost_usd);
-  const isSelected = selected?.has(agg.name) ?? false;
+  const selKey = `${agg.name}@${agg.src}`;
+  const isSelected = selected?.has(selKey) ?? false;
 
   return html`
     <div
       class="run-card ${outcomeClass(outcome)} ${isSelected ? 'run-card--selected' : ''}"
-      @click=${onOpen ? () => onOpen(agg.name) : null}
+      @click=${onOpen ? () => onOpen(agg) : null}
     >
       <div class="run-card-top">
         ${
@@ -58,7 +59,7 @@ export function profileCardView(
                 @click=${(e) => e.stopPropagation()}
                 @change=${(e) => {
                   e.stopPropagation();
-                  onToggleSelect(agg.name);
+                  onToggleSelect(agg);
                 }}
               />`
             : nothing
@@ -88,6 +89,11 @@ export function profileCardView(
         ${
           agg.template
             ? html`<span class="run-card-meta-item"><span class="meta-label">Template:</span> <span class="meta-value">${agg.template}</span></span>`
+            : nothing
+        }
+        ${
+          showSource && agg.source_label
+            ? html`<span class="run-card-meta-item"><span class="meta-label">Source:</span> <span class="meta-value">${agg.source_label}</span></span>`
             : nothing
         }
       </div>
@@ -121,7 +127,7 @@ export function profileCardView(
           onOpen
             ? html`<button class="action-btn" @click=${(e) => {
                 e.stopPropagation();
-                onOpen(agg.name);
+                onOpen(agg);
               }}>View</button>`
             : nothing
         }

--- a/worca-bench/app/views/profile-card.js
+++ b/worca-bench/app/views/profile-card.js
@@ -23,15 +23,39 @@ import {
  * @param {object} [handlers]
  * @param {(name: string) => void} [handlers.onOpen]
  * @param {(name: string) => void} [handlers.onRun]
+ * @param {Set<string>} [handlers.selected]  names currently selected to compare
+ * @param {(name: string) => void} [handlers.onToggleSelect]
  */
-export function profileCardView(agg, { onOpen, onRun } = {}) {
+export function profileCardView(
+  agg,
+  { onOpen, onRun, selected, onToggleSelect } = {},
+) {
   const outcome = profileOutcome(agg);
   const variant = variantFor(outcome);
   const cost = formatCost(agg.mean_cost_usd);
+  const isSelected = selected?.has(agg.name) ?? false;
 
   return html`
-    <div class="run-card ${outcomeClass(outcome)}" @click=${onOpen ? () => onOpen(agg.name) : null}>
+    <div
+      class="run-card ${outcomeClass(outcome)} ${isSelected ? 'run-card--selected' : ''}"
+      @click=${onOpen ? () => onOpen(agg.name) : null}
+    >
       <div class="run-card-top">
+        ${
+          onToggleSelect
+            ? html`<input
+                class="run-card-select"
+                type="checkbox"
+                aria-label=${`Select ${agg.name} to compare`}
+                .checked=${isSelected}
+                @click=${(e) => e.stopPropagation()}
+                @change=${(e) => {
+                  e.stopPropagation();
+                  onToggleSelect(agg.name);
+                }}
+              />`
+            : nothing
+        }
         <span class="run-card-status">${unsafeHTML(outcomeIcon(outcome, 16))}</span>
         <span class="run-card-title">${agg.name}</span>
         <sl-badge variant="${variant}" pill class="status-badge-${outcome}">${outcome}</sl-badge>

--- a/worca-bench/app/views/profile-card.js
+++ b/worca-bench/app/views/profile-card.js
@@ -26,6 +26,13 @@ import {
  * @param {Set<string>} [handlers.selected]  names currently selected to compare
  * @param {(name: string) => void} [handlers.onToggleSelect]
  */
+/** Compact active-state label for the card badge. */
+function _activeLabel(agg) {
+  if (agg.active_kind === 'canary') return 'canary';
+  if (agg.phase === 'grading') return 'grading';
+  return agg.stage ? `running · ${agg.stage}` : 'running';
+}
+
 export function profileCardView(
   agg,
   { onOpen, onRun, selected, onToggleSelect } = {},
@@ -61,7 +68,7 @@ export function profileCardView(
         ${
           agg.active
             ? html`<sl-badge variant="primary" pill class="run-card-running"
-                ><span class="running-dot"></span>${agg.active_kind === 'canary' ? 'canary' : 'running'}${agg.stage ? ` · ${agg.stage}` : ''}</sl-badge
+                ><span class="running-dot"></span>${_activeLabel(agg)}</sl-badge
               >`
             : html`<sl-badge variant="${variant}" pill class="status-badge-${outcome}">${outcome}</sl-badge>`
         }

--- a/worca-bench/app/views/profile-card.test.js
+++ b/worca-bench/app/views/profile-card.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { profileCardView } from './profile-card.js';
+
+// Mirrors the worca-ui renderToString helper: walks the lit-html template
+// tree, inlining strings/numbers/arrays/nested templates. unsafeHTML directives
+// and functions are skipped (the static prefix is still captured).
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+function agg(overrides = {}) {
+  return {
+    name: 'smoke-feature-opus',
+    benchmark: 'swe-bench-verified',
+    worca_ref: 'local',
+    template: 'builtin:feature',
+    reps: 4,
+    graded: 4,
+    resolved: 4,
+    resolved_rate: 1.0,
+    mean_cost_usd: 0.42,
+    mean_wall_s: 612,
+    mean_iterations: 2,
+    last_run: '2026-06-16T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('profileCardView', () => {
+  it('applies the resolved status class when fully resolved', () => {
+    const out = renderToString(profileCardView(agg()));
+    expect(out).toContain('run-card');
+    expect(out).toContain('status-completed');
+  });
+
+  it('uses the success badge variant for a fully-resolved profile', () => {
+    const out = renderToString(profileCardView(agg()));
+    expect(out).toContain('variant="success"');
+  });
+
+  it('uses the danger variant when nothing resolved', () => {
+    const out = renderToString(
+      profileCardView(agg({ resolved: 0, resolved_rate: 0 })),
+    );
+    expect(out).toContain('variant="danger"');
+    expect(out).toContain('status-failed');
+  });
+
+  it('uses the warning variant for a partial resolve rate', () => {
+    const out = renderToString(
+      profileCardView(agg({ resolved: 2, resolved_rate: 0.5 })),
+    );
+    expect(out).toContain('variant="warning"');
+    expect(out).toContain('status-paused');
+  });
+
+  it('uses the neutral pending variant when no reps are graded', () => {
+    const out = renderToString(
+      profileCardView(agg({ graded: 0, resolved: 0, resolved_rate: 0 })),
+    );
+    expect(out).toContain('status-pending');
+  });
+
+  it('does NOT hardcode an inline variant="success" ladder in source', async () => {
+    // The card must route every badge variant through the central variant map
+    // (utils/badge.js), never inline a per-status literal ladder in the view.
+    const fs = await import('node:fs');
+    const url = await import('node:url');
+    const src = fs.readFileSync(
+      url.fileURLToPath(new URL('./profile-card.js', import.meta.url)),
+      'utf8',
+    );
+    expect(src).not.toMatch(/variant="success"/);
+    expect(src).not.toMatch(/variant="danger"/);
+    expect(src).toContain('variantFor(');
+  });
+
+  it('renders the profile name and benchmark', () => {
+    const out = renderToString(profileCardView(agg()));
+    expect(out).toContain('smoke-feature-opus');
+    expect(out).toContain('swe-bench-verified');
+  });
+});

--- a/worca-bench/app/views/profile-card.test.js
+++ b/worca-bench/app/views/profile-card.test.js
@@ -114,4 +114,22 @@ describe('profileCardView', () => {
     );
     expect(out).toContain('run-card--selected');
   });
+
+  it('shows a running badge with the current stage when active', () => {
+    const out = renderToString(
+      profileCardView(agg({ active: true, stage: 'coordinate' })),
+    );
+    expect(out).toContain('run-card-running');
+    expect(out).toContain('running');
+    expect(out).toContain('coordinate');
+  });
+
+  it('labels an active canary run as canary', () => {
+    const out = renderToString(
+      profileCardView(
+        agg({ active: true, active_kind: 'canary', stage: 'plan' }),
+      ),
+    );
+    expect(out).toContain('canary');
+  });
 });

--- a/worca-bench/app/views/profile-card.test.js
+++ b/worca-bench/app/views/profile-card.test.js
@@ -124,6 +124,16 @@ describe('profileCardView', () => {
     expect(out).toContain('coordinate');
   });
 
+  it('labels the grading phase distinctly', () => {
+    const out = renderToString(
+      profileCardView(
+        agg({ active: true, phase: 'grading', stage: 'implement' }),
+      ),
+    );
+    expect(out).toContain('grading');
+    expect(out).not.toContain('running · implement');
+  });
+
   it('labels an active canary run as canary', () => {
     const out = renderToString(
       profileCardView(

--- a/worca-bench/app/views/profile-card.test.js
+++ b/worca-bench/app/views/profile-card.test.js
@@ -161,6 +161,27 @@ describe('profileCardView', () => {
     expect(out).toContain('7');
   });
 
+  it('shows the configured test count (instance_count), "all" when unset', () => {
+    expect(renderToString(profileCardView(agg({ instance_count: 9 })))).toMatch(
+      /Tests:<\/span>\s*<span class="meta-value">9/,
+    );
+    expect(
+      renderToString(profileCardView(agg({ instance_count: null }))),
+    ).toMatch(/Tests:<\/span>\s*<span class="meta-value">all/);
+  });
+
+  it('drops the worca ref line from the card', () => {
+    expect(renderToString(profileCardView(agg()))).not.toContain('worca:');
+  });
+
+  it('has a Run action but no View button (card click opens the detail)', () => {
+    const out = renderToString(
+      profileCardView(agg(), { onOpen: () => {}, onRun: () => {} }),
+    );
+    expect(out).toContain('>Run</button>');
+    expect(out).not.toContain('>View</button>');
+  });
+
   it('marks an archived profile with run-card--archived', () => {
     expect(renderToString(profileCardView(agg()))).not.toContain(
       'run-card--archived',

--- a/worca-bench/app/views/profile-card.test.js
+++ b/worca-bench/app/views/profile-card.test.js
@@ -25,6 +25,7 @@ function renderToString(template) {
 function agg(overrides = {}) {
   return {
     name: 'smoke-feature-opus',
+    src: 'srchash1',
     benchmark: 'swe-bench-verified',
     worca_ref: 'local',
     template: 'builtin:feature',
@@ -105,14 +106,25 @@ describe('profileCardView', () => {
     expect(out).toContain('run-card-select');
   });
 
-  it('marks the card selected when its name is in the selected set', () => {
+  it('marks the card selected when its name@src key is in the selected set', () => {
     const out = renderToString(
       profileCardView(agg(), {
-        selected: new Set(['smoke-feature-opus']),
+        selected: new Set(['smoke-feature-opus@srchash1']),
         onToggleSelect: () => {},
       }),
     );
     expect(out).toContain('run-card--selected');
+  });
+
+  it('shows the source label only when a name is duplicated (showSource)', () => {
+    expect(renderToString(profileCardView(agg()))).not.toContain('Source:');
+    const out = renderToString(profileCardView(agg(), { showSource: true }));
+    expect(out).not.toContain('Source:'); // no source_label on the fixture
+    const out2 = renderToString(
+      profileCardView(agg({ source_label: 'results-b' }), { showSource: true }),
+    );
+    expect(out2).toContain('Source:');
+    expect(out2).toContain('results-b');
   });
 
   it('shows a running badge with the current stage when active', () => {

--- a/worca-bench/app/views/profile-card.test.js
+++ b/worca-bench/app/views/profile-card.test.js
@@ -154,4 +154,18 @@ describe('profileCardView', () => {
     );
     expect(out).toContain('canary');
   });
+
+  it('shows the run count under a "Runs:" label', () => {
+    const out = renderToString(profileCardView(agg({ reps: 7 })));
+    expect(out).toContain('Runs:');
+    expect(out).toContain('7');
+  });
+
+  it('marks an archived profile with run-card--archived', () => {
+    expect(renderToString(profileCardView(agg()))).not.toContain(
+      'run-card--archived',
+    );
+    const out = renderToString(profileCardView(agg({ archived: true })));
+    expect(out).toContain('run-card--archived');
+  });
 });

--- a/worca-bench/app/views/profile-card.test.js
+++ b/worca-bench/app/views/profile-card.test.js
@@ -94,4 +94,24 @@ describe('profileCardView', () => {
     expect(out).toContain('smoke-feature-opus');
     expect(out).toContain('swe-bench-verified');
   });
+
+  it('renders a compare checkbox only when selection is enabled', () => {
+    expect(renderToString(profileCardView(agg()))).not.toContain(
+      'run-card-select',
+    );
+    const out = renderToString(
+      profileCardView(agg(), { onToggleSelect: () => {} }),
+    );
+    expect(out).toContain('run-card-select');
+  });
+
+  it('marks the card selected when its name is in the selected set', () => {
+    const out = renderToString(
+      profileCardView(agg(), {
+        selected: new Set(['smoke-feature-opus']),
+        onToggleSelect: () => {},
+      }),
+    );
+    expect(out).toContain('run-card--selected');
+  });
 });

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -228,6 +228,7 @@ export function profileDetailView(data, { onRun } = {}) {
         ${_statRow('Benchmark', agg.benchmark || 'N/A')}
         ${_statRow('Reps', String(agg.reps))}
         ${_statRow('Resolved rate', pct(agg.resolved_rate))}
+        ${_statRow('Avg score', typeof agg.mean_score === 'number' ? num(agg.mean_score, 2) : 'N/A')}
         ${_statRow('Avg cost', formatCost(agg.mean_cost_usd) || 'N/A')}
         ${_statRow('Avg duration', formatDuration(agg.mean_wall_s))}
         ${_statRow('Avg iterations', num(agg.mean_iterations, 2))}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -39,6 +39,8 @@ function _runOptionsView(agg, onRun) {
     const reps = box.querySelector('.run-opt-reps').value.trim();
     const maxInstances = box.querySelector('.run-opt-instances').value.trim();
     const maxParallel = box.querySelector('.run-opt-parallel').value.trim();
+    const canaryVal = box.querySelector('.run-opt-canary')?.value;
+    const canary = canaryVal !== 'off';
     const gfxVal = box.querySelector('.run-opt-graphify')?.value;
     const graphify = gfxVal && gfxVal !== 'off' ? gfxVal : undefined;
     const crgVal = box.querySelector('.run-opt-crg')?.value;
@@ -49,6 +51,7 @@ function _runOptionsView(agg, onRun) {
         ? Number.parseInt(maxInstances, 10)
         : undefined,
       maxParallel: maxParallel ? Number.parseInt(maxParallel, 10) : undefined,
+      canary,
       graphify,
       codeReviewGraph,
     });
@@ -80,6 +83,13 @@ function _runOptionsView(agg, onRun) {
           min="1"
           placeholder="default"
       /></label>
+      <div class="run-opt run-opt-engine">
+        <span class="run-opt-label">Canary</span>
+        <sl-radio-group class="run-opt-canary" size="small" value="on">
+          <sl-radio-button value="off">Off</sl-radio-button>
+          <sl-radio-button value="on">On</sl-radio-button>
+        </sl-radio-group>
+      </div>
       <div class="run-opt run-opt-engine">
         <span class="run-opt-label">Graphify</span>
         <sl-radio-group class="run-opt-graphify" size="small" value="off">

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -1,11 +1,5 @@
-import { html, nothing } from 'lit-html';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import {
-  outcomeIcon,
-  outcomeOf,
-  profileOutcome,
-  variantFor,
-} from '../utils/badge.js';
+import { html } from 'lit-html';
+import { outcomeOf, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
 
 function _median(values) {
@@ -34,20 +28,18 @@ function _statRow(label, value) {
 }
 
 /**
- * Detail view for one profile: aggregate stat tiles + a per-rep table.
+ * Detail view body for one profile: aggregate stat tiles + a per-rep table.
+ * The profile name, outcome badge, back button, and "Run profile" action now
+ * live in main.js's shared content header.
  *
  * @param {object} data  { aggregate, reps }
- * @param {object} [handlers]
- * @param {() => void} [handlers.onBack]
- * @param {(name: string) => void} [handlers.onRun]
  */
-export function profileDetailView(data, { onBack, onRun } = {}) {
+export function profileDetailView(data) {
   if (!data?.aggregate) {
     return html`<section class="page"><p class="empty-state">Profile not found.</p></section>`;
   }
   const agg = data.aggregate;
   const reps = data.reps || [];
-  const outcome = profileOutcome(agg);
 
   const costs = reps
     .map((r) => r.cost_usd)
@@ -56,18 +48,6 @@ export function profileDetailView(data, { onBack, onRun } = {}) {
 
   return html`
     <section class="page">
-      <div class="page-head">
-        <div class="page-head-title">
-          <span class="run-card-status">${unsafeHTML(outcomeIcon(outcome, 18))}</span>
-          <h1>${agg.name}</h1>
-          <sl-badge variant="${variantFor(outcome)}" pill>${outcome}</sl-badge>
-        </div>
-        <div class="page-head-actions">
-          ${onBack ? html`<button class="action-btn" @click=${onBack}>Back</button>` : nothing}
-          ${onRun ? html`<button class="action-btn action-btn--primary" @click=${() => onRun(agg.name)}>Run</button>` : nothing}
-        </div>
-      </div>
-
       <div class="stat-grid">
         ${_statRow('Benchmark', agg.benchmark || 'N/A')}
         ${_statRow('Reps', String(agg.reps))}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -104,6 +104,9 @@ function _runOptionsView(agg, onRun, onNotes) {
   // resolved default isn't valid for this benchmark, fall back to the first option.
   let grader = saved.grader || agg.grade_mode || 'modal';
   if (!graderOpts.some((m) => m.value === grader)) grader = graderOpts[0].value;
+  // Canary radio default: the user's saved pref wins; otherwise the profile's
+  // `canary` flag (only an explicit `false` means Off — unspecified => On).
+  const canaryDefault = saved.canary || (agg.canary === false ? 'off' : 'on');
   return html`
     <div class="run-options">
       <div class="run-options-title">Run options</div>
@@ -143,7 +146,7 @@ function _runOptionsView(agg, onRun, onNotes) {
         <sl-radio-group
           class="run-opt-canary"
           size="small"
-          value=${saved.canary || 'on'}
+          value=${canaryDefault}
           @sl-change=${persist}
         >
           <sl-radio-button value="off">Off</sl-radio-button>

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -1,0 +1,112 @@
+import { html, nothing } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import {
+  outcomeIcon,
+  outcomeOf,
+  profileOutcome,
+  variantFor,
+} from '../utils/badge.js';
+import { formatCost, formatDuration, num, pct } from '../utils/format.js';
+
+function _median(values) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function _iterations(row) {
+  const c = row.loop_counters;
+  if (!c || typeof c !== 'object') return 0;
+  return Object.values(c).reduce(
+    (a, b) => a + (typeof b === 'number' ? b : 0),
+    0,
+  );
+}
+
+function _statRow(label, value) {
+  return html`
+    <div class="stat">
+      <div class="stat-label">${label}</div>
+      <div class="stat-value">${value}</div>
+    </div>
+  `;
+}
+
+/**
+ * Detail view for one profile: aggregate stat tiles + a per-rep table.
+ *
+ * @param {object} data  { aggregate, reps }
+ * @param {object} [handlers]
+ * @param {() => void} [handlers.onBack]
+ * @param {(name: string) => void} [handlers.onRun]
+ */
+export function profileDetailView(data, { onBack, onRun } = {}) {
+  if (!data?.aggregate) {
+    return html`<section class="page"><p class="empty-state">Profile not found.</p></section>`;
+  }
+  const agg = data.aggregate;
+  const reps = data.reps || [];
+  const outcome = profileOutcome(agg);
+
+  const costs = reps
+    .map((r) => r.cost_usd)
+    .filter((c) => typeof c === 'number');
+  const medianCost = _median(costs);
+
+  return html`
+    <section class="page">
+      <div class="page-head">
+        <div class="page-head-title">
+          <span class="run-card-status">${unsafeHTML(outcomeIcon(outcome, 18))}</span>
+          <h1>${agg.name}</h1>
+          <sl-badge variant="${variantFor(outcome)}" pill>${outcome}</sl-badge>
+        </div>
+        <div class="page-head-actions">
+          ${onBack ? html`<button class="action-btn" @click=${onBack}>Back</button>` : nothing}
+          ${onRun ? html`<button class="action-btn action-btn--primary" @click=${() => onRun(agg.name)}>Run</button>` : nothing}
+        </div>
+      </div>
+
+      <div class="stat-grid">
+        ${_statRow('Benchmark', agg.benchmark || 'N/A')}
+        ${_statRow('Reps', String(agg.reps))}
+        ${_statRow('Resolved rate', pct(agg.resolved_rate))}
+        ${_statRow('Mean cost', formatCost(agg.mean_cost_usd) || 'N/A')}
+        ${_statRow('Median cost', formatCost(medianCost) || 'N/A')}
+        ${_statRow('Mean wall time', formatDuration(agg.mean_wall_s))}
+        ${_statRow('Mean iterations', num(agg.mean_iterations, 2))}
+      </div>
+
+      <table class="reps-table">
+        <thead>
+          <tr>
+            <th>Instance</th>
+            <th>Rep</th>
+            <th>Status</th>
+            <th>Score</th>
+            <th>Cost</th>
+            <th>Wall</th>
+            <th>Iters</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${reps.map((r) => {
+            const ro = outcomeOf(r);
+            return html`
+              <tr>
+                <td class="reps-instance" title=${r.instance_id || ''}>${r.instance_id || '—'}</td>
+                <td>${r.rep ?? '—'}</td>
+                <td><sl-badge variant="${variantFor(ro)}" pill>${ro}</sl-badge></td>
+                <td>${typeof r.score === 'number' ? num(r.score, 2) : '—'}</td>
+                <td>${formatCost(r.cost_usd) || '—'}</td>
+                <td>${typeof r.wall_time_s === 'number' ? formatDuration(r.wall_time_s) : '—'}</td>
+                <td>${_iterations(r)}</td>
+              </tr>
+            `;
+          })}
+        </tbody>
+      </table>
+    </section>
+  `;
+}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -70,6 +70,52 @@ function _runOptionsView(agg, onRun) {
   `;
 }
 
+const _STAGE_CLASS = {
+  completed: 'stage-chip--done',
+  in_progress: 'stage-chip--active',
+  failed: 'stage-chip--failed',
+  error: 'stage-chip--failed',
+};
+
+/**
+ * Live progress for in-flight reps (read from worca status.json under work/).
+ * Renders nothing when there are no active runs. The dashboard's auto-refresh
+ * keeps the stage chips current.
+ */
+function _liveView(active) {
+  if (!active || active.length === 0) return '';
+  return html`
+    <div class="live-runs">
+      ${active.map(
+        (run) => html`
+          <div class="live-run">
+            <div class="live-run-head">
+              <span class="running-dot"></span>
+              <span class="live-run-label"
+                >${run.kind === 'canary' ? 'Canary' : 'Running'}</span
+              >
+              <span class="live-run-status">${run.pipeline_status || 'running'}</span>
+            </div>
+            <div class="stage-chips">
+              ${(run.stages || []).map((s) => {
+                const cls = s.skipped
+                  ? 'stage-chip--skipped'
+                  : _STAGE_CLASS[s.status] || 'stage-chip--pending';
+                const title = [s.agent, s.model].filter(Boolean).join(' · ');
+                return html`<span
+                  class="stage-chip ${cls}"
+                  title=${title || s.status}
+                  >${s.name}</span
+                >`;
+              })}
+            </div>
+          </div>
+        `,
+      )}
+    </div>
+  `;
+}
+
 /**
  * Configuration metadata — what pipeline/worca this profile benchmarks. Reads
  * from results rows once run (worca_version, worca_ref, template, grade_mode);
@@ -127,6 +173,7 @@ export function profileDetailView(data, { onRun } = {}) {
 
   return html`
     <section class="page">
+      ${_liveView(data.active)}
       ${onRun ? _runOptionsView(agg, onRun) : ''}
       ${_configView(agg)}
       <div class="stat-grid">

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -43,6 +43,8 @@ function _readControls(box) {
     canary: box.querySelector('.run-opt-canary')?.value ?? 'on',
     graphify: box.querySelector('.run-opt-graphify')?.value ?? 'off',
     codeReviewGraph: box.querySelector('.run-opt-crg')?.value ?? 'off',
+    preflight: box.querySelector('.run-opt-preflight')?.value ?? 'on',
+    claudeMd: box.querySelector('.run-opt-claudemd')?.value ?? 'project',
   };
 }
 
@@ -53,7 +55,7 @@ function _readControls(box) {
  * persists them per-profile to localStorage so a page reload restores the last
  * set values instead of snapping back to the profile defaults.
  */
-function _runOptionsView(agg, onRun) {
+function _runOptionsView(agg, onRun, onNotes) {
   const saved = loadRunPrefs(agg.name);
   const persist = (e) => {
     const box = e.target.closest('.run-options');
@@ -77,6 +79,8 @@ function _runOptionsView(agg, onRun) {
       canary: c.canary !== 'off',
       graphify,
       codeReviewGraph,
+      preflight: c.preflight !== 'off',
+      claudeMdMode: c.claudeMd,
     });
   };
   return html`
@@ -125,6 +129,31 @@ function _runOptionsView(agg, onRun) {
         </sl-radio-group>
       </div>
       <div class="run-opt run-opt-engine">
+        <span class="run-opt-label">Preflight</span>
+        <sl-radio-group
+          class="run-opt-preflight"
+          size="small"
+          value=${saved.preflight || 'on'}
+          @sl-change=${persist}
+        >
+          <sl-radio-button value="off">Off</sl-radio-button>
+          <sl-radio-button value="on">On</sl-radio-button>
+        </sl-radio-group>
+      </div>
+      <label class="run-opt"
+        >CLAUDE.md
+        <select
+          class="run-opt-claudemd run-opt-select"
+          .value=${saved.claudeMd || 'project'}
+          @change=${persist}
+        >
+          <option value="none">none</option>
+          <option value="project">project</option>
+          <option value="project+local">project+local</option>
+          <option value="all">all</option>
+        </select>
+      </label>
+      <div class="run-opt run-opt-engine">
         <span class="run-opt-label">Graphify</span>
         <sl-radio-group
           class="run-opt-graphify"
@@ -149,6 +178,14 @@ function _runOptionsView(agg, onRun) {
           <sl-radio-button value="structural">Structural</sl-radio-button>
         </sl-radio-group>
       </div>
+      ${
+        onNotes
+          ? html`<button
+              class="action-btn run-opt-notes"
+              @click=${() => onNotes(agg.name)}
+            >Notes</button>`
+          : ''
+      }
       <button class="action-btn action-btn--primary run-opt-launch" @click=${launch}>
         Run
       </button>
@@ -357,7 +394,7 @@ function _configView(agg) {
  * @param {object} [handlers]
  * @param {(name: string, opts: {reps?: number, maxInstances?: number}) => void} [handlers.onRun]
  */
-export function profileDetailView(data, { onRun, onRegrade } = {}) {
+export function profileDetailView(data, { onRun, onRegrade, onNotes } = {}) {
   if (!data?.aggregate) {
     return html`<section class="page"><p class="empty-state">Profile not found.</p></section>`;
   }
@@ -371,7 +408,7 @@ export function profileDetailView(data, { onRun, onRegrade } = {}) {
     <section class="page">
       ${_liveView(data.active)}
       ${_regradeProgressView(regrade)}
-      ${onRun ? _runOptionsView(agg, onRun) : ''}
+      ${onRun ? _runOptionsView(agg, onRun, onNotes) : ''}
       ${_configView(agg)}
       <div class="stat-grid">
         ${_statRow('Benchmark', agg.benchmark || 'N/A')}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -1,6 +1,7 @@
 import { html, nothing } from 'lit-html';
 import { outcomeOf, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
+import { loadRunPrefs, saveRunPrefs } from '../utils/run-prefs.js';
 
 /** Colored engine badge (graphify cyan / crg indigo) or a gray OFF. */
 function _engineBadge(value, kind) {
@@ -28,30 +29,47 @@ function _statRow(label, value) {
   `;
 }
 
+/** Read the raw control values from the `.run-options` container. */
+function _readControls(box) {
+  return {
+    reps: box.querySelector('.run-opt-reps').value.trim(),
+    maxInstances: box.querySelector('.run-opt-instances').value.trim(),
+    maxParallel: box.querySelector('.run-opt-parallel').value.trim(),
+    canary: box.querySelector('.run-opt-canary')?.value ?? 'on',
+    graphify: box.querySelector('.run-opt-graphify')?.value ?? 'off',
+    codeReviewGraph: box.querySelector('.run-opt-crg')?.value ?? 'off',
+  };
+}
+
 /**
- * "Run options" launcher: per-run overrides for reps and instance cap. Empty
- * inputs fall back to the profile's defaults. Reads input values at click time
- * (lit-html is stateless) from the enclosing `.run-options` container.
+ * "Run options" launcher: per-run overrides for reps, caps, parallelism, the
+ * canary preflight, and the engine modes. Reads control values at click time
+ * (lit-html is stateless) from the enclosing `.run-options` container, and
+ * persists them per-profile to localStorage so a page reload restores the last
+ * set values instead of snapping back to the profile defaults.
  */
 function _runOptionsView(agg, onRun) {
+  const saved = loadRunPrefs(agg.name);
+  const persist = (e) => {
+    const box = e.target.closest('.run-options');
+    if (box) saveRunPrefs(agg.name, _readControls(box));
+  };
   const launch = (e) => {
     const box = e.target.closest('.run-options');
-    const reps = box.querySelector('.run-opt-reps').value.trim();
-    const maxInstances = box.querySelector('.run-opt-instances').value.trim();
-    const maxParallel = box.querySelector('.run-opt-parallel').value.trim();
-    const canaryVal = box.querySelector('.run-opt-canary')?.value;
-    const canary = canaryVal !== 'off';
-    const gfxVal = box.querySelector('.run-opt-graphify')?.value;
-    const graphify = gfxVal && gfxVal !== 'off' ? gfxVal : undefined;
-    const crgVal = box.querySelector('.run-opt-crg')?.value;
-    const codeReviewGraph = crgVal && crgVal !== 'off' ? crgVal : undefined;
+    const c = _readControls(box);
+    saveRunPrefs(agg.name, c);
+    const graphify = c.graphify !== 'off' ? c.graphify : undefined;
+    const codeReviewGraph =
+      c.codeReviewGraph !== 'off' ? c.codeReviewGraph : undefined;
     onRun(agg.name, {
-      reps: reps ? Number.parseInt(reps, 10) : undefined,
-      maxInstances: maxInstances
-        ? Number.parseInt(maxInstances, 10)
+      reps: c.reps ? Number.parseInt(c.reps, 10) : undefined,
+      maxInstances: c.maxInstances
+        ? Number.parseInt(c.maxInstances, 10)
         : undefined,
-      maxParallel: maxParallel ? Number.parseInt(maxParallel, 10) : undefined,
-      canary,
+      maxParallel: c.maxParallel
+        ? Number.parseInt(c.maxParallel, 10)
+        : undefined,
+      canary: c.canary !== 'off',
       graphify,
       codeReviewGraph,
     });
@@ -66,6 +84,8 @@ function _runOptionsView(agg, onRun) {
           type="number"
           min="1"
           placeholder=${String(agg.reps || 1)}
+          .value=${saved.reps ?? ''}
+          @input=${persist}
       /></label>
       <label class="run-opt"
         >Max tests
@@ -74,6 +94,8 @@ function _runOptionsView(agg, onRun) {
           type="number"
           min="1"
           placeholder="all"
+          .value=${saved.maxInstances ?? ''}
+          @input=${persist}
       /></label>
       <label class="run-opt"
         >Max parallel
@@ -82,17 +104,29 @@ function _runOptionsView(agg, onRun) {
           type="number"
           min="1"
           placeholder="default"
+          .value=${saved.maxParallel ?? ''}
+          @input=${persist}
       /></label>
       <div class="run-opt run-opt-engine">
         <span class="run-opt-label">Canary</span>
-        <sl-radio-group class="run-opt-canary" size="small" value="on">
+        <sl-radio-group
+          class="run-opt-canary"
+          size="small"
+          value=${saved.canary || 'on'}
+          @sl-change=${persist}
+        >
           <sl-radio-button value="off">Off</sl-radio-button>
           <sl-radio-button value="on">On</sl-radio-button>
         </sl-radio-group>
       </div>
       <div class="run-opt run-opt-engine">
         <span class="run-opt-label">Graphify</span>
-        <sl-radio-group class="run-opt-graphify" size="small" value="off">
+        <sl-radio-group
+          class="run-opt-graphify"
+          size="small"
+          value=${saved.graphify || 'off'}
+          @sl-change=${persist}
+        >
           <sl-radio-button value="off">Off</sl-radio-button>
           <sl-radio-button value="structural">Structural</sl-radio-button>
           <sl-radio-button value="full">Full</sl-radio-button>
@@ -100,7 +134,12 @@ function _runOptionsView(agg, onRun) {
       </div>
       <div class="run-opt run-opt-engine">
         <span class="run-opt-label">Code Review Graph</span>
-        <sl-radio-group class="run-opt-crg" size="small" value="off">
+        <sl-radio-group
+          class="run-opt-crg"
+          size="small"
+          value=${saved.codeReviewGraph || 'off'}
+          @sl-change=${persist}
+        >
           <sl-radio-button value="off">Off</sl-radio-button>
           <sl-radio-button value="structural">Structural</sl-radio-button>
         </sl-radio-group>

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -396,8 +396,10 @@ function _liveView(active) {
   return html`
     <div class="live-runs">
       ${active.map((run) => {
+        // The instance (test) name is the run's primary identifier, so it sits
+        // prominently next to the status. The active pipeline stage is already
+        // highlighted in the stage-chips row below, so we don't repeat it here.
         const meta = [
-          run.instance,
           run.rep != null ? `rep ${run.rep}` : null,
           _elapsedSince(run.started_at),
         ]
@@ -410,8 +412,8 @@ function _liveView(active) {
               <span class="running-dot"></span>
               <span class="live-run-label">${_phaseLabel(run)}</span>
               ${
-                run.stage && !grading
-                  ? html`<span class="live-run-stage">${stageLabel(run.stage)}</span>`
+                run.instance
+                  ? html`<span class="live-run-instance">${run.instance}</span>`
                   : nothing
               }
               ${meta ? html`<span class="live-run-meta">${meta}</span>` : nothing}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -58,6 +58,7 @@ function _readControls(box) {
     preflight: box.querySelector('.run-opt-preflight')?.value ?? 'on',
     claudeMd: box.querySelector('.run-opt-claudemd')?.value ?? 'project',
     grader: box.querySelector('.run-opt-grader')?.value ?? '',
+    timeout: box.querySelector('.run-opt-timeout')?.value.trim() ?? '',
   };
 }
 
@@ -95,6 +96,9 @@ function _runOptionsView(agg, onRun, onNotes) {
       preflight: c.preflight !== 'off',
       claudeMdMode: c.claudeMd,
       gradeMode: c.grader || undefined,
+      // Empty => no override (use the profile's timeout). A number (incl. 0,
+      // which means no limit) is sent through as an explicit per-run override.
+      timeout: c.timeout === '' ? undefined : Number.parseInt(c.timeout, 10),
     });
   };
   // Grader options depend on the benchmark (commit0 has no sb-cli backend).
@@ -111,6 +115,9 @@ function _runOptionsView(agg, onRun, onNotes) {
   // so the field reflects what the run will actually use (else the runner default).
   const maxParallelPlaceholder =
     agg.max_parallel != null ? String(agg.max_parallel) : 'default';
+  // Timeout field prefills with the profile's own timeout (seconds) when defined,
+  // else an empty placeholder. Empty = use the profile; 0 = no limit.
+  const timeoutPlaceholder = agg.timeout != null ? String(agg.timeout) : '';
   return html`
     <div class="run-options">
       <div class="run-options-title">Run options</div>
@@ -218,6 +225,21 @@ function _runOptionsView(agg, onRun, onNotes) {
           <sl-radio-button value="structural">Structural</sl-radio-button>
         </sl-radio-group>
       </div>
+      </div>
+      <div class="run-options-row">
+      <label class="run-opt"
+        ><sl-tooltip
+          content="Max build seconds per instance. Empty = use the profile's value; 0 = no limit; otherwise the cap in seconds."
+          ><span class="run-opt-label-inline">Timeout (s)</span></sl-tooltip
+        >
+        <input
+          class="run-opt-timeout"
+          type="number"
+          min="0"
+          placeholder=${timeoutPlaceholder}
+          .value=${saved.timeout ?? ''}
+          @input=${persist}
+      /></label>
       ${
         onNotes
           ? html`<button

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -2,11 +2,12 @@ import { html, nothing } from 'lit-html';
 import { outcomeOf, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
 
-function _median(values) {
-  if (!values.length) return null;
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+/** Colored engine badge (graphify cyan / crg indigo) or a gray OFF. */
+function _engineBadge(value, kind) {
+  if (!value) {
+    return html`<span class="engine-badge engine-badge--off">OFF</span>`;
+  }
+  return html`<span class="engine-badge engine-badge--${kind}">${value}</span>`;
 }
 
 function _iterations(row) {
@@ -37,12 +38,10 @@ function _runOptionsView(agg, onRun) {
     const box = e.target.closest('.run-options');
     const reps = box.querySelector('.run-opt-reps').value.trim();
     const maxInstances = box.querySelector('.run-opt-instances').value.trim();
-    const graphify = box.querySelector('.run-opt-graphify')?.checked
-      ? 'structural'
-      : undefined;
-    const codeReviewGraph = box.querySelector('.run-opt-crg')?.checked
-      ? 'structural'
-      : undefined;
+    const gfxVal = box.querySelector('.run-opt-graphify')?.value;
+    const graphify = gfxVal && gfxVal !== 'off' ? gfxVal : undefined;
+    const crgVal = box.querySelector('.run-opt-crg')?.value;
+    const codeReviewGraph = crgVal && crgVal !== 'off' ? crgVal : undefined;
     onRun(agg.name, {
       reps: reps ? Number.parseInt(reps, 10) : undefined,
       maxInstances: maxInstances
@@ -71,14 +70,21 @@ function _runOptionsView(agg, onRun) {
           min="1"
           placeholder="all"
       /></label>
-      <label class="run-opt run-opt-toggle">
-        <sl-switch class="run-opt-graphify" size="small"></sl-switch>
-        <span>Graphify</span>
-      </label>
-      <label class="run-opt run-opt-toggle">
-        <sl-switch class="run-opt-crg" size="small"></sl-switch>
-        <span>Code Review Graph</span>
-      </label>
+      <div class="run-opt run-opt-engine">
+        <span class="run-opt-label">Graphify</span>
+        <sl-radio-group class="run-opt-graphify" size="small" value="off">
+          <sl-radio-button value="off">Off</sl-radio-button>
+          <sl-radio-button value="structural">Structural</sl-radio-button>
+          <sl-radio-button value="full">Full</sl-radio-button>
+        </sl-radio-group>
+      </div>
+      <div class="run-opt run-opt-engine">
+        <span class="run-opt-label">Code Review Graph</span>
+        <sl-radio-group class="run-opt-crg" size="small" value="off">
+          <sl-radio-button value="off">Off</sl-radio-button>
+          <sl-radio-button value="structural">Structural</sl-radio-button>
+        </sl-radio-group>
+      </div>
       <button class="action-btn action-btn--primary run-opt-launch" @click=${launch}>
         Run
       </button>
@@ -213,11 +219,6 @@ export function profileDetailView(data, { onRun } = {}) {
   const agg = data.aggregate;
   const reps = data.reps || [];
 
-  const costs = reps
-    .map((r) => r.cost_usd)
-    .filter((c) => typeof c === 'number');
-  const medianCost = _median(costs);
-
   return html`
     <section class="page">
       ${_liveView(data.active)}
@@ -227,10 +228,9 @@ export function profileDetailView(data, { onRun } = {}) {
         ${_statRow('Benchmark', agg.benchmark || 'N/A')}
         ${_statRow('Reps', String(agg.reps))}
         ${_statRow('Resolved rate', pct(agg.resolved_rate))}
-        ${_statRow('Mean cost', formatCost(agg.mean_cost_usd) || 'N/A')}
-        ${_statRow('Median cost', formatCost(medianCost) || 'N/A')}
-        ${_statRow('Mean wall time', formatDuration(agg.mean_wall_s))}
-        ${_statRow('Mean iterations', num(agg.mean_iterations, 2))}
+        ${_statRow('Avg cost', formatCost(agg.mean_cost_usd) || 'N/A')}
+        ${_statRow('Avg duration', formatDuration(agg.mean_wall_s))}
+        ${_statRow('Avg iterations', num(agg.mean_iterations, 2))}
       </div>
 
       <table class="reps-table">
@@ -259,8 +259,8 @@ export function profileDetailView(data, { onRun } = {}) {
                 <td>${formatCost(r.cost_usd) || '—'}</td>
                 <td>${typeof r.wall_time_s === 'number' ? formatDuration(r.wall_time_s) : '—'}</td>
                 <td>${_iterations(r)}</td>
-                <td>${r.graphify || '—'}</td>
-                <td>${r.code_review_graph || '—'}</td>
+                <td>${_engineBadge(r.graphify, 'graphify')}</td>
+                <td>${_engineBadge(r.code_review_graph, 'crg')}</td>
               </tr>
             `;
           })}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -335,7 +335,7 @@ export function profileDetailView(data, { onRun, onRegrade } = {}) {
                   ${
                     onRegrade && r.instance_id
                       ? html`<sl-tooltip
-                          content="Re-grade this instance from its saved diff via the hosted SWE-bench grader (sb-cli) — no pipeline re-run"
+                          content="Re-grade this instance from its saved diff — pick the backend (local Docker / SWE-bench cloud / Modal). No pipeline re-run."
                         >
                           <button
                             class="icon-btn reps-regrade-btn"

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -123,7 +123,10 @@ function _runOptionsView(agg, onRun, onNotes, runDisabled = false) {
       <div class="run-options-title">Run options</div>
       <div class="run-options-row">
       <label class="run-opt"
-        >Reps
+        ><sl-tooltip
+          content="How many times each instance is run. Total runs = instances × this. Empty = use the profile's value."
+          ><span class="run-opt-label-inline">Reps / instance</span></sl-tooltip
+        >
         <input
           class="run-opt-reps"
           type="number"
@@ -494,6 +497,9 @@ export function profileDetailView(
   }
   const agg = data.aggregate;
   const reps = data.reps || [];
+  // True planned reps-per-instance = the highest rep index across rows (NOT
+  // agg.reps, which is the total row count). Only used to annotate "Rep #".
+  const repsPlanned = reps.reduce((m, r) => Math.max(m, r.rep || 0), 0);
 
   const regrade = data.regrade;
   const grading = regrade?.active ? regrade.current : null;
@@ -506,7 +512,7 @@ export function profileDetailView(
       ${_configView(agg)}
       <div class="stat-grid">
         ${_statRow('Benchmark', agg.benchmark || 'N/A')}
-        ${_statRow('Reps', String(agg.reps))}
+        ${_statRow('Runs', String(agg.reps))}
         ${_statRow('Resolved rate', pct(agg.resolved_rate))}
         ${_statRow('Avg score', typeof agg.mean_score === 'number' ? num(agg.mean_score, 2) : 'N/A')}
         ${_statRow('Avg cost', formatCost(agg.mean_cost_usd) || 'N/A')}
@@ -518,7 +524,7 @@ export function profileDetailView(
         <thead>
           <tr>
             <th>Instance</th>
-            <th>Rep</th>
+            <th>Rep #</th>
             <th>Status</th>
             <th>Score</th>
             <th>Cost</th>
@@ -536,7 +542,7 @@ export function profileDetailView(
             return html`
               <tr class=${isGrading ? 'reps-row--grading' : nothing}>
                 <td class="reps-instance" title=${r.instance_id || ''}>${r.instance_id || '—'}</td>
-                <td>${r.rep ?? '—'}</td>
+                <td>${r.rep ? (repsPlanned > 1 ? `${r.rep} / ${repsPlanned}` : r.rep) : '—'}</td>
                 <td>
                   <sl-tooltip content=${_gradeTooltip(r)}>
                     <sl-badge variant="${variantFor(ro)}" pill>${ro}</sl-badge>

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -156,6 +156,83 @@ function _runOptionsView(agg, onRun) {
   `;
 }
 
+/** Compact UTC timestamp: "2026-06-17 06:12 UTC" (guarded). */
+function _fmtTs(iso) {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return `${new Date(t).toISOString().replace('T', ' ').slice(0, 16)} UTC`;
+}
+
+/** One-line grading-provenance string for the status-badge tooltip. */
+function _gradeTooltip(r) {
+  const env = r.grade_mode ? ` via ${r.grade_mode}` : '';
+  const parts = [];
+  if (r.status === 'graded') {
+    parts.push(`${r.resolved ? 'resolved' : 'unresolved'}${env}`);
+    if (typeof r.score === 'number') parts.push(`score ${num(r.score, 2)}`);
+  } else if (r.status === 'error') {
+    parts.push(`error${env}`);
+    if (r.error || r.grade_detail) {
+      parts.push(String(r.error || r.grade_detail).slice(0, 160));
+    }
+  } else {
+    parts.push(`${r.status}${env}`);
+  }
+  const ts = r.regraded_at || r.graded_at || r.completed_at;
+  if (ts) parts.push(`${r.regraded_at ? 'regraded' : 'graded'} ${_fmtTs(ts)}`);
+  if (r.report_path) parts.push(`report: ${r.report_path}`);
+  return parts.join(' · ');
+}
+
+/** Rough "time left" for a running sweep from elapsed ÷ done × remaining. */
+function _regradeEta(rg) {
+  if (!rg?.started_at || !rg.done || !rg.total) return null;
+  const start = Date.parse(rg.started_at);
+  if (Number.isNaN(start) || rg.done <= 0) return null;
+  const per = (Date.now() - start) / 1000 / rg.done;
+  return formatDuration(Math.round(per * Math.max(0, rg.total - rg.done)));
+}
+
+/**
+ * Live regrade-sweep progress (from the heartbeat the runner writes). Renders
+ * nothing unless a sweep is active. The dashboard auto-refresh keeps it current.
+ */
+function _regradeProgressView(rg) {
+  if (!rg || !rg.active) return '';
+  const total = rg.total || 0;
+  const done = rg.done || 0;
+  const pct = total ? Math.round((done / total) * 100) : 0;
+  const c = rg.counts || {};
+  const eta = _regradeEta(rg);
+  return html`
+    <div class="regrade-progress">
+      <div class="regrade-progress-head">
+        <span class="running-dot"></span>
+        <span class="regrade-progress-label"
+          >Regrading ${done}/${total} via ${rg.mode || '—'}</span
+        >
+        ${
+          rg.current
+            ? html`<span class="regrade-progress-current">${rg.current}</span>`
+            : nothing
+        }
+        ${
+          eta
+            ? html`<span class="regrade-progress-eta">~${eta} left</span>`
+            : nothing
+        }
+      </div>
+      <div class="regrade-progress-bar">
+        <div class="regrade-progress-fill" style="width:${pct}%"></div>
+      </div>
+      <div class="regrade-progress-counts">
+        ${c.resolved ?? 0} resolved · ${c.graded ?? 0} graded · ${c.error ?? 0} error
+      </div>
+    </div>
+  `;
+}
+
 const _STAGE_CLASS = {
   completed: 'stage-chip--done',
   in_progress: 'stage-chip--active',
@@ -287,9 +364,13 @@ export function profileDetailView(data, { onRun, onRegrade } = {}) {
   const agg = data.aggregate;
   const reps = data.reps || [];
 
+  const regrade = data.regrade;
+  const grading = regrade?.active ? regrade.current : null;
+
   return html`
     <section class="page">
       ${_liveView(data.active)}
+      ${_regradeProgressView(regrade)}
       ${onRun ? _runOptionsView(agg, onRun) : ''}
       ${_configView(agg)}
       <div class="stat-grid">
@@ -320,11 +401,16 @@ export function profileDetailView(data, { onRun, onRegrade } = {}) {
         <tbody>
           ${reps.map((r) => {
             const ro = outcomeOf(r);
+            const isGrading = grading && r.instance_id === grading;
             return html`
-              <tr>
+              <tr class=${isGrading ? 'reps-row--grading' : nothing}>
                 <td class="reps-instance" title=${r.instance_id || ''}>${r.instance_id || '—'}</td>
                 <td>${r.rep ?? '—'}</td>
-                <td><sl-badge variant="${variantFor(ro)}" pill>${ro}</sl-badge></td>
+                <td>
+                  <sl-tooltip content=${_gradeTooltip(r)}>
+                    <sl-badge variant="${variantFor(ro)}" pill>${ro}</sl-badge>
+                  </sl-tooltip>
+                </td>
                 <td>${typeof r.score === 'number' ? num(r.score, 2) : '—'}</td>
                 <td>${formatCost(r.cost_usd) || '—'}</td>
                 <td>${typeof r.wall_time_s === 'number' ? formatDuration(r.wall_time_s) : '—'}</td>

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -162,7 +162,7 @@ function _runOptionsView(agg, onRun, onNotes) {
         <sl-radio-group
           class="run-opt-preflight"
           size="small"
-          value=${saved.preflight || 'on'}
+          value=${saved.preflight || agg.preflight || 'on'}
           @sl-change=${persist}
         >
           <sl-radio-button value="off">Off</sl-radio-button>
@@ -198,7 +198,7 @@ function _runOptionsView(agg, onRun, onNotes) {
         <sl-radio-group
           class="run-opt-graphify"
           size="small"
-          value=${saved.graphify || 'off'}
+          value=${saved.graphify || agg.graphify || 'off'}
           @sl-change=${persist}
         >
           <sl-radio-button value="off">Off</sl-radio-button>
@@ -211,7 +211,7 @@ function _runOptionsView(agg, onRun, onNotes) {
         <sl-radio-group
           class="run-opt-crg"
           size="small"
-          value=${saved.codeReviewGraph || 'off'}
+          value=${saved.codeReviewGraph || agg.code_review_graph || 'off'}
           @sl-change=${persist}
         >
           <sl-radio-button value="off">Off</sl-radio-button>

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -5,13 +5,16 @@ import { formatCost, formatDuration, num, pct } from '../utils/format.js';
 import { REGRADE_MODES } from '../utils/regrade-dialog.js';
 import { loadRunPrefs, saveRunPrefs } from '../utils/run-prefs.js';
 
-// Grader backends offered in the Run options dropdown. Reuses the regrade
-// backends (local-docker / sb-cli / modal) plus `stub` (record diff, no grade)
-// so any profile's own grade.mode is representable as the default selection.
-const GRADER_OPTIONS = [
-  ...REGRADE_MODES.map((m) => ({ value: m.value, label: m.label })),
-  { value: 'stub', label: 'Stub (no grade)' },
-];
+// Grader backends offered in the Run options dropdown, per benchmark. Reuses the
+// regrade backends (local-docker / sb-cli / modal) plus `stub` (record diff, no
+// grade). Commit0 has no hosted (`sb-cli`) backend — it grades via `commit0 test`
+// on local Docker or Modal — so that option is dropped for commit0 profiles.
+function graderOptions(benchmark) {
+  const base = REGRADE_MODES.filter(
+    (m) => benchmark !== 'commit0' || m.value !== 'sb-cli',
+  ).map((m) => ({ value: m.value, label: m.label }));
+  return [...base, { value: 'stub', label: 'Stub (no grade)' }];
+}
 
 // Lucide "refresh-cw" — the regrade action icon.
 const REGRADE_ICON =
@@ -94,9 +97,13 @@ function _runOptionsView(agg, onRun, onNotes) {
       gradeMode: c.grader || undefined,
     });
   };
+  // Grader options depend on the benchmark (commit0 has no sb-cli backend).
+  const graderOpts = graderOptions(agg.benchmark);
   // Grader dropdown defaults to the profile's own grade.mode (falling back to
-  // modal), unless the user has picked one before (persisted per profile).
-  const grader = saved.grader || agg.grade_mode || 'modal';
+  // modal), unless the user has picked one before (persisted per profile). If the
+  // resolved default isn't valid for this benchmark, fall back to the first option.
+  let grader = saved.grader || agg.grade_mode || 'modal';
+  if (!graderOpts.some((m) => m.value === grader)) grader = graderOpts[0].value;
   return html`
     <div class="run-options">
       <div class="run-options-title">Run options</div>
@@ -171,7 +178,7 @@ function _runOptionsView(agg, onRun, onNotes) {
       <label class="run-opt"
         >Grader
         <select class="run-opt-grader run-opt-select" @change=${persist}>
-          ${GRADER_OPTIONS.map(
+          ${graderOpts.map(
             (m) => html`<option
               value=${m.value}
               ?selected=${m.value === grader}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -1,7 +1,12 @@
 import { html, nothing } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { outcomeOf, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
 import { loadRunPrefs, saveRunPrefs } from '../utils/run-prefs.js';
+
+// Lucide "refresh-cw" — the regrade action icon.
+const REGRADE_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg>';
 
 /** Colored engine badge (graphify cyan / crg indigo) or a gray OFF. */
 function _engineBadge(value, kind) {
@@ -275,7 +280,7 @@ function _configView(agg) {
  * @param {object} [handlers]
  * @param {(name: string, opts: {reps?: number, maxInstances?: number}) => void} [handlers.onRun]
  */
-export function profileDetailView(data, { onRun } = {}) {
+export function profileDetailView(data, { onRun, onRegrade } = {}) {
   if (!data?.aggregate) {
     return html`<section class="page"><p class="empty-state">Profile not found.</p></section>`;
   }
@@ -309,6 +314,7 @@ export function profileDetailView(data, { onRun } = {}) {
             <th>Iters</th>
             <th>Graphify</th>
             <th>CRG</th>
+            <th>Action</th>
           </tr>
         </thead>
         <tbody>
@@ -325,6 +331,23 @@ export function profileDetailView(data, { onRun } = {}) {
                 <td>${_iterations(r)}</td>
                 <td>${_engineBadge(r.graphify, 'graphify')}</td>
                 <td>${_engineBadge(r.code_review_graph, 'crg')}</td>
+                <td class="reps-action">
+                  ${
+                    onRegrade && r.instance_id
+                      ? html`<sl-tooltip
+                          content="Re-grade this instance from its saved diff via the hosted SWE-bench grader (sb-cli) — no pipeline re-run"
+                        >
+                          <button
+                            class="icon-btn reps-regrade-btn"
+                            aria-label="Re-grade ${r.instance_id}"
+                            @click=${() => onRegrade(agg.name, r.instance_id)}
+                          >
+                            ${unsafeHTML(REGRADE_ICON)}
+                          </button>
+                        </sl-tooltip>`
+                      : nothing
+                  }
+                </td>
               </tr>
             `;
           })}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -4,6 +4,7 @@ import { outcomeOf, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
 import { REGRADE_MODES } from '../utils/regrade-dialog.js';
 import { loadRunPrefs, saveRunPrefs } from '../utils/run-prefs.js';
+import { sortStagesByOrder, stageLabel } from '../utils/stages.js';
 
 // Grader backends offered in the Run options dropdown, per benchmark. Reuses the
 // regrade backends (local-docker / sb-cli / modal) plus `stub` (record diff, no
@@ -410,13 +411,13 @@ function _liveView(active) {
               <span class="live-run-label">${_phaseLabel(run)}</span>
               ${
                 run.stage && !grading
-                  ? html`<span class="live-run-stage">${run.stage}</span>`
+                  ? html`<span class="live-run-stage">${stageLabel(run.stage)}</span>`
                   : nothing
               }
               ${meta ? html`<span class="live-run-meta">${meta}</span>` : nothing}
             </div>
             <div class="stage-chips">
-              ${(run.stages || []).map((s) => {
+              ${sortStagesByOrder(run.stages).map((s) => {
                 const cls = s.skipped
                   ? 'stage-chip--skipped'
                   : _STAGE_CLASS[s.status] || 'stage-chip--pending';
@@ -424,14 +425,19 @@ function _liveView(active) {
                 return html`<span
                   class="stage-chip ${cls}"
                   title=${title || s.status}
-                  >${s.name}</span
+                  >${stageLabel(s.name)}</span
                 >`;
               })}
-              <!-- Grading is a worca-bench step after the pipeline, not a worca stage. -->
+              <!-- Grading is a worca-bench step AFTER the pipeline, not a worca
+                   stage — set it apart with a spacer. While the run is live it's
+                   either pending (grey) or, once the pipeline finishes, active
+                   (blue, phase=grading); a finished "done" grade only shows in
+                   the per-rep table, not here. -->
+              <span class="stage-chip-sep" aria-hidden="true"></span>
               <span
-                class="stage-chip ${grading ? 'stage-chip--active' : 'stage-chip--done'}"
-                title="benchmark grading"
-                >grade</span
+                class="stage-chip ${grading ? 'stage-chip--active' : 'stage-chip--pending'}"
+                title="benchmark grading (not a pipeline stage)"
+                >Grade</span
               >
             </div>
           </div>

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -37,11 +37,19 @@ function _runOptionsView(agg, onRun) {
     const box = e.target.closest('.run-options');
     const reps = box.querySelector('.run-opt-reps').value.trim();
     const maxInstances = box.querySelector('.run-opt-instances').value.trim();
+    const graphify = box.querySelector('.run-opt-graphify')?.checked
+      ? 'structural'
+      : undefined;
+    const codeReviewGraph = box.querySelector('.run-opt-crg')?.checked
+      ? 'structural'
+      : undefined;
     onRun(agg.name, {
       reps: reps ? Number.parseInt(reps, 10) : undefined,
       maxInstances: maxInstances
         ? Number.parseInt(maxInstances, 10)
         : undefined,
+      graphify,
+      codeReviewGraph,
     });
   };
   return html`
@@ -63,6 +71,14 @@ function _runOptionsView(agg, onRun) {
           min="1"
           placeholder="all"
       /></label>
+      <label class="run-opt run-opt-toggle">
+        <sl-switch class="run-opt-graphify" size="small"></sl-switch>
+        <span>Graphify</span>
+      </label>
+      <label class="run-opt run-opt-toggle">
+        <sl-switch class="run-opt-crg" size="small"></sl-switch>
+        <span>Code Review Graph</span>
+      </label>
       <button class="action-btn action-btn--primary run-opt-launch" @click=${launch}>
         Run
       </button>
@@ -225,8 +241,10 @@ export function profileDetailView(data, { onRun } = {}) {
             <th>Status</th>
             <th>Score</th>
             <th>Cost</th>
-            <th>Wall</th>
+            <th>Duration</th>
             <th>Iters</th>
+            <th>Graphify</th>
+            <th>CRG</th>
           </tr>
         </thead>
         <tbody>
@@ -241,6 +259,8 @@ export function profileDetailView(data, { onRun } = {}) {
                 <td>${formatCost(r.cost_usd) || '—'}</td>
                 <td>${typeof r.wall_time_s === 'number' ? formatDuration(r.wall_time_s) : '—'}</td>
                 <td>${_iterations(r)}</td>
+                <td>${r.graphify || '—'}</td>
+                <td>${r.code_review_graph || '—'}</td>
               </tr>
             `;
           })}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -69,7 +69,7 @@ function _readControls(box) {
  * persists them per-profile to localStorage so a page reload restores the last
  * set values instead of snapping back to the profile defaults.
  */
-function _runOptionsView(agg, onRun, onNotes) {
+function _runOptionsView(agg, onRun, onNotes, runDisabled = false) {
   const saved = loadRunPrefs(agg.name);
   const persist = (e) => {
     const box = e.target.closest('.run-options');
@@ -248,8 +248,13 @@ function _runOptionsView(agg, onRun, onNotes) {
             >Notes</button>`
           : ''
       }
-      <button class="action-btn action-btn--primary run-opt-launch" @click=${launch}>
-        Run
+      <button
+        class="action-btn action-btn--primary run-opt-launch"
+        ?disabled=${runDisabled}
+        title=${runDisabled ? 'A run is already in progress for this profile' : 'Launch a run'}
+        @click=${runDisabled ? () => {} : launch}
+      >
+        ${runDisabled ? 'Running…' : 'Run'}
       </button>
       </div>
     </div>
@@ -480,7 +485,10 @@ function _configView(agg) {
  * @param {object} [handlers]
  * @param {(name: string, opts: {reps?: number, maxInstances?: number}) => void} [handlers.onRun]
  */
-export function profileDetailView(data, { onRun, onRegrade, onNotes } = {}) {
+export function profileDetailView(
+  data,
+  { onRun, onRegrade, onNotes, runDisabled = false } = {},
+) {
   if (!data?.aggregate) {
     return html`<section class="page"><p class="empty-state">Profile not found.</p></section>`;
   }
@@ -494,7 +502,7 @@ export function profileDetailView(data, { onRun, onRegrade, onNotes } = {}) {
     <section class="page">
       ${_liveView(data.active)}
       ${_regradeProgressView(regrade)}
-      ${onRun ? _runOptionsView(agg, onRun, onNotes) : ''}
+      ${onRun ? _runOptionsView(agg, onRun, onNotes, runDisabled) : ''}
       ${_configView(agg)}
       <div class="stat-grid">
         ${_statRow('Benchmark', agg.benchmark || 'N/A')}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html, nothing } from 'lit-html';
 import { outcomeOf, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
 
@@ -77,24 +77,49 @@ const _STAGE_CLASS = {
   error: 'stage-chip--failed',
 };
 
+function _phaseLabel(run) {
+  if (run.kind === 'canary') return 'Canary';
+  if (run.phase === 'grading') return 'Grading';
+  if (run.phase === 'failed') return 'Failed';
+  return 'Running';
+}
+
+function _elapsedSince(iso) {
+  if (!iso) return null;
+  const start = Date.parse(iso);
+  if (Number.isNaN(start)) return null;
+  return formatDuration(Math.max(0, Math.round((Date.now() - start) / 1000)));
+}
+
 /**
  * Live progress for in-flight reps (read from worca status.json under work/).
  * Renders nothing when there are no active runs. The dashboard's auto-refresh
- * keeps the stage chips current.
+ * keeps the phase/stage chips and elapsed time current.
  */
 function _liveView(active) {
   if (!active || active.length === 0) return '';
   return html`
     <div class="live-runs">
-      ${active.map(
-        (run) => html`
-          <div class="live-run">
+      ${active.map((run) => {
+        const meta = [
+          run.instance,
+          run.rep != null ? `rep ${run.rep}` : null,
+          _elapsedSince(run.started_at),
+        ]
+          .filter(Boolean)
+          .join(' · ');
+        const grading = run.phase === 'grading';
+        return html`
+          <div class="live-run ${run.phase === 'failed' ? 'live-run--failed' : ''}">
             <div class="live-run-head">
               <span class="running-dot"></span>
-              <span class="live-run-label"
-                >${run.kind === 'canary' ? 'Canary' : 'Running'}</span
-              >
-              <span class="live-run-status">${run.pipeline_status || 'running'}</span>
+              <span class="live-run-label">${_phaseLabel(run)}</span>
+              ${
+                run.stage && !grading
+                  ? html`<span class="live-run-stage">${run.stage}</span>`
+                  : nothing
+              }
+              ${meta ? html`<span class="live-run-meta">${meta}</span>` : nothing}
             </div>
             <div class="stage-chips">
               ${(run.stages || []).map((s) => {
@@ -108,10 +133,16 @@ function _liveView(active) {
                   >${s.name}</span
                 >`;
               })}
+              <!-- Grading is a worca-bench step after the pipeline, not a worca stage. -->
+              <span
+                class="stage-chip ${grading ? 'stage-chip--active' : 'stage-chip--done'}"
+                title="benchmark grading"
+                >grade</span
+              >
             </div>
           </div>
-        `,
-      )}
+        `;
+      })}
     </div>
   `;
 }

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -107,6 +107,10 @@ function _runOptionsView(agg, onRun, onNotes) {
   // Canary radio default: the user's saved pref wins; otherwise the profile's
   // `canary` flag (only an explicit `false` means Off — unspecified => On).
   const canaryDefault = saved.canary || (agg.canary === false ? 'off' : 'on');
+  // Max-parallel placeholder shows the profile's own concurrency.worca when set,
+  // so the field reflects what the run will actually use (else the runner default).
+  const maxParallelPlaceholder =
+    agg.max_parallel != null ? String(agg.max_parallel) : 'default';
   return html`
     <div class="run-options">
       <div class="run-options-title">Run options</div>
@@ -137,7 +141,7 @@ function _runOptionsView(agg, onRun, onNotes) {
           class="run-opt-parallel"
           type="number"
           min="1"
-          placeholder="default"
+          placeholder=${maxParallelPlaceholder}
           .value=${saved.maxParallel ?? ''}
           @input=${persist}
       /></label>

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -422,10 +422,21 @@ function _liveView(active) {
                   ? 'stage-chip--skipped'
                   : _STAGE_CLASS[s.status] || 'stage-chip--pending';
                 const title = [s.agent, s.model].filter(Boolean).join(' · ');
+                // Bead progress (completed/dispatched) rides inside the chip for
+                // the implementer, e.g. "Implement 1/3"; the loop-back count is
+                // appended as "×N" when a stage ran more than once.
+                const beads = s.beads
+                  ? html`<span class="stage-chip-beads"
+                      >${s.beads.done}/${s.beads.total}</span
+                    >`
+                  : nothing;
+                const iters = s.iters
+                  ? html`<span class="stage-chip-iters">×${s.iters}</span>`
+                  : nothing;
                 return html`<span
                   class="stage-chip ${cls}"
                   title=${title || s.status}
-                  >${stageLabel(s.name)}</span
+                  >${stageLabel(s.name)}${beads}${iters}</span
                 >`;
               })}
               <!-- Grading is a worca-bench step AFTER the pipeline, not a worca

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -28,13 +28,58 @@ function _statRow(label, value) {
 }
 
 /**
+ * "Run options" launcher: per-run overrides for reps and instance cap. Empty
+ * inputs fall back to the profile's defaults. Reads input values at click time
+ * (lit-html is stateless) from the enclosing `.run-options` container.
+ */
+function _runOptionsView(agg, onRun) {
+  const launch = (e) => {
+    const box = e.target.closest('.run-options');
+    const reps = box.querySelector('.run-opt-reps').value.trim();
+    const maxInstances = box.querySelector('.run-opt-instances').value.trim();
+    onRun(agg.name, {
+      reps: reps ? Number.parseInt(reps, 10) : undefined,
+      maxInstances: maxInstances
+        ? Number.parseInt(maxInstances, 10)
+        : undefined,
+    });
+  };
+  return html`
+    <div class="run-options">
+      <span class="run-options-title">Run options</span>
+      <label class="run-opt"
+        >Reps
+        <input
+          class="run-opt-reps"
+          type="number"
+          min="1"
+          placeholder=${String(agg.reps || 1)}
+      /></label>
+      <label class="run-opt"
+        >Max instances
+        <input
+          class="run-opt-instances"
+          type="number"
+          min="1"
+          placeholder="all"
+      /></label>
+      <button class="action-btn action-btn--primary run-opt-launch" @click=${launch}>
+        Run
+      </button>
+    </div>
+  `;
+}
+
+/**
  * Detail view body for one profile: aggregate stat tiles + a per-rep table.
  * The profile name, outcome badge, back button, and "Run profile" action now
  * live in main.js's shared content header.
  *
  * @param {object} data  { aggregate, reps }
+ * @param {object} [handlers]
+ * @param {(name: string, opts: {reps?: number, maxInstances?: number}) => void} [handlers.onRun]
  */
-export function profileDetailView(data) {
+export function profileDetailView(data, { onRun } = {}) {
   if (!data?.aggregate) {
     return html`<section class="page"><p class="empty-state">Profile not found.</p></section>`;
   }
@@ -48,6 +93,7 @@ export function profileDetailView(data) {
 
   return html`
     <section class="page">
+      ${onRun ? _runOptionsView(agg, onRun) : ''}
       <div class="stat-grid">
         ${_statRow('Benchmark', agg.benchmark || 'N/A')}
         ${_statRow('Reps', String(agg.reps))}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -2,7 +2,16 @@ import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { outcomeOf, variantFor } from '../utils/badge.js';
 import { formatCost, formatDuration, num, pct } from '../utils/format.js';
+import { REGRADE_MODES } from '../utils/regrade-dialog.js';
 import { loadRunPrefs, saveRunPrefs } from '../utils/run-prefs.js';
+
+// Grader backends offered in the Run options dropdown. Reuses the regrade
+// backends (local-docker / sb-cli / modal) plus `stub` (record diff, no grade)
+// so any profile's own grade.mode is representable as the default selection.
+const GRADER_OPTIONS = [
+  ...REGRADE_MODES.map((m) => ({ value: m.value, label: m.label })),
+  { value: 'stub', label: 'Stub (no grade)' },
+];
 
 // Lucide "refresh-cw" — the regrade action icon.
 const REGRADE_ICON =
@@ -45,6 +54,7 @@ function _readControls(box) {
     codeReviewGraph: box.querySelector('.run-opt-crg')?.value ?? 'off',
     preflight: box.querySelector('.run-opt-preflight')?.value ?? 'on',
     claudeMd: box.querySelector('.run-opt-claudemd')?.value ?? 'project',
+    grader: box.querySelector('.run-opt-grader')?.value ?? '',
   };
 }
 
@@ -81,11 +91,16 @@ function _runOptionsView(agg, onRun, onNotes) {
       codeReviewGraph,
       preflight: c.preflight !== 'off',
       claudeMdMode: c.claudeMd,
+      gradeMode: c.grader || undefined,
     });
   };
+  // Grader dropdown defaults to the profile's own grade.mode (falling back to
+  // modal), unless the user has picked one before (persisted per profile).
+  const grader = saved.grader || agg.grade_mode || 'modal';
   return html`
     <div class="run-options">
-      <span class="run-options-title">Run options</span>
+      <div class="run-options-title">Run options</div>
+      <div class="run-options-row">
       <label class="run-opt"
         >Reps
         <input
@@ -153,6 +168,17 @@ function _runOptionsView(agg, onRun, onNotes) {
           <option value="all">all</option>
         </select>
       </label>
+      <label class="run-opt"
+        >Grader
+        <select class="run-opt-grader run-opt-select" @change=${persist}>
+          ${GRADER_OPTIONS.map(
+            (m) => html`<option
+              value=${m.value}
+              ?selected=${m.value === grader}
+            >${m.label}</option>`,
+          )}
+        </select>
+      </label>
       <div class="run-opt run-opt-engine">
         <span class="run-opt-label">Graphify</span>
         <sl-radio-group
@@ -189,6 +215,7 @@ function _runOptionsView(agg, onRun, onNotes) {
       <button class="action-btn action-btn--primary run-opt-launch" @click=${launch}>
         Run
       </button>
+      </div>
     </div>
   `;
 }

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -38,6 +38,7 @@ function _runOptionsView(agg, onRun) {
     const box = e.target.closest('.run-options');
     const reps = box.querySelector('.run-opt-reps').value.trim();
     const maxInstances = box.querySelector('.run-opt-instances').value.trim();
+    const maxParallel = box.querySelector('.run-opt-parallel').value.trim();
     const gfxVal = box.querySelector('.run-opt-graphify')?.value;
     const graphify = gfxVal && gfxVal !== 'off' ? gfxVal : undefined;
     const crgVal = box.querySelector('.run-opt-crg')?.value;
@@ -47,6 +48,7 @@ function _runOptionsView(agg, onRun) {
       maxInstances: maxInstances
         ? Number.parseInt(maxInstances, 10)
         : undefined,
+      maxParallel: maxParallel ? Number.parseInt(maxParallel, 10) : undefined,
       graphify,
       codeReviewGraph,
     });
@@ -63,12 +65,20 @@ function _runOptionsView(agg, onRun) {
           placeholder=${String(agg.reps || 1)}
       /></label>
       <label class="run-opt"
-        >Max instances
+        >Max tests
         <input
           class="run-opt-instances"
           type="number"
           min="1"
           placeholder="all"
+      /></label>
+      <label class="run-opt"
+        >Max parallel
+        <input
+          class="run-opt-parallel"
+          type="number"
+          min="1"
+          placeholder="default"
       /></label>
       <div class="run-opt run-opt-engine">
         <span class="run-opt-label">Graphify</span>
@@ -180,11 +190,15 @@ function _configView(agg) {
       ? `${agg.worca_version} (${agg.worca_ref})`
       : agg.worca_version
     : agg.worca_ref || '—';
+  // No explicit instance_ids selection → the benchmark runs its full set ("All").
+  const instances =
+    typeof agg.instance_count === 'number' ? String(agg.instance_count) : 'All';
   const items = [
     ['Worca', worca],
     ['Template', agg.template || '—'],
     ['Benchmark', agg.benchmark || '—'],
     ['Grade', agg.grade_mode || '—'],
+    ['Test Count', instances],
   ];
   return html`
     <div class="config-meta">

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -71,6 +71,40 @@ function _runOptionsView(agg, onRun) {
 }
 
 /**
+ * Configuration metadata — what pipeline/worca this profile benchmarks. Reads
+ * from results rows once run (worca_version, worca_ref, template, grade_mode);
+ * falls back to the YAML def's fields before the first run.
+ */
+function _configView(agg) {
+  const worca = agg.worca_version
+    ? agg.worca_ref
+      ? `${agg.worca_version} (${agg.worca_ref})`
+      : agg.worca_version
+    : agg.worca_ref || '—';
+  const items = [
+    ['Worca', worca],
+    ['Template', agg.template || '—'],
+    ['Benchmark', agg.benchmark || '—'],
+    ['Grade', agg.grade_mode || '—'],
+  ];
+  return html`
+    <div class="config-meta">
+      <div class="config-meta-title">Configuration</div>
+      <div class="config-meta-grid">
+        ${items.map(
+          ([label, value]) => html`
+            <div class="config-meta-item">
+              <span class="config-meta-label">${label}</span>
+              <span class="config-meta-value" title=${String(value)}>${value}</span>
+            </div>
+          `,
+        )}
+      </div>
+    </div>
+  `;
+}
+
+/**
  * Detail view body for one profile: aggregate stat tiles + a per-rep table.
  * The profile name, outcome badge, back button, and "Run profile" action now
  * live in main.js's shared content header.
@@ -94,6 +128,7 @@ export function profileDetailView(data, { onRun } = {}) {
   return html`
     <section class="page">
       ${onRun ? _runOptionsView(agg, onRun) : ''}
+      ${_configView(agg)}
       <div class="stat-grid">
         ${_statRow('Benchmark', agg.benchmark || 'N/A')}
         ${_statRow('Reps', String(agg.reps))}

--- a/worca-bench/app/views/profile-detail.js
+++ b/worca-bench/app/views/profile-detail.js
@@ -235,12 +235,35 @@ function _fmtTs(iso) {
   return `${new Date(t).toISOString().replace('T', ' ').slice(0, 16)} UTC`;
 }
 
+/**
+ * Score cell: the numeric score, plus the fine-grained test count when the
+ * grader ran a real suite (Commit0 held-out tests, e.g. "38/38"). Counts are
+ * null for pass/fail-only graders (SWE-bench, stub), which show score alone.
+ */
+function _scoreCell(r) {
+  if (typeof r.score !== 'number') return '—';
+  const score = num(r.score, 2);
+  if (typeof r.tests_passed === 'number' && typeof r.tests_total === 'number') {
+    return html`${score}
+      <span class="reps-testcount" title="held-out tests passed / total"
+        >${r.tests_passed}/${r.tests_total}</span
+      >`;
+  }
+  return score;
+}
+
 /** One-line grading-provenance string for the status-badge tooltip. */
 function _gradeTooltip(r) {
   const env = r.grade_mode ? ` via ${r.grade_mode}` : '';
   const parts = [];
   if (r.status === 'graded') {
     parts.push(`${r.resolved ? 'resolved' : 'unresolved'}${env}`);
+    if (
+      typeof r.tests_passed === 'number' &&
+      typeof r.tests_total === 'number'
+    ) {
+      parts.push(`${r.tests_passed}/${r.tests_total} tests`);
+    }
     if (typeof r.score === 'number') parts.push(`score ${num(r.score, 2)}`);
   } else if (r.status === 'error') {
     parts.push(`error${env}`);
@@ -482,7 +505,7 @@ export function profileDetailView(data, { onRun, onRegrade, onNotes } = {}) {
                     <sl-badge variant="${variantFor(ro)}" pill>${ro}</sl-badge>
                   </sl-tooltip>
                 </td>
-                <td>${typeof r.score === 'number' ? num(r.score, 2) : '—'}</td>
+                <td>${_scoreCell(r)}</td>
                 <td>${formatCost(r.cost_usd) || '—'}</td>
                 <td>${typeof r.wall_time_s === 'number' ? formatDuration(r.wall_time_s) : '—'}</td>
                 <td>${_iterations(r)}</td>

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -288,10 +288,51 @@ describe('profileDetailView', () => {
     expect(out).toContain('stage-chip--active'); // coordinate
     expect(out).toContain('stage-chip--pending'); // implement
     expect(out).toContain('stage-chip--skipped'); // test
-    expect(out).toContain('coordinate');
+    expect(out).toContain('Coordinate'); // human label (worca-ui parity)
     expect(out).toContain('astropy__astropy-12907'); // instance shown
     expect(out).toContain('rep 1');
-    expect(out).toContain('grade'); // grading pseudo-chip
+    expect(out).toContain('Grade'); // grading pseudo-chip, set-apart
+    expect(out).toContain('stage-chip-sep'); // spacer before Grade
+  });
+
+  it('orders live stage chips by canonical worca order, not status.json order', () => {
+    const out = renderToString(
+      profileDetailView({
+        aggregate: { ...data.aggregate, active: true },
+        reps: [],
+        active: [
+          {
+            kind: 'rep',
+            phase: 'running',
+            stage: 'plan_review',
+            instance: 'x',
+            rep: 1,
+            // Deliberately scrambled (plan_review last, like the raw payload).
+            stages: [
+              { name: 'pr', status: 'pending' },
+              { name: 'preflight', status: 'completed' },
+              { name: 'plan_review', status: 'in_progress' },
+              { name: 'plan', status: 'completed' },
+            ],
+          },
+        ],
+      }),
+    );
+    // Scope to the chips container so the "Running Plan Review" head label
+    // doesn't confound the index comparison.
+    const chips = out.slice(out.indexOf('stage-chips'));
+    // Canonical order: Preflight < Plan < Plan Review < PR.
+    const iPreflight = chips.indexOf('>Preflight<');
+    const iPlan = chips.indexOf('>Plan<');
+    const iPlanReview = chips.indexOf('>Plan Review<');
+    const iPr = chips.indexOf('>PR<');
+    expect(iPreflight).toBeGreaterThanOrEqual(0);
+    expect(iPreflight).toBeLessThan(iPlan);
+    expect(iPlan).toBeLessThan(iPlanReview);
+    expect(iPlanReview).toBeLessThan(iPr);
+    // The "Running <stage>" label is humanized too, never the raw key.
+    expect(out).toContain('Plan Review');
+    expect(out).not.toMatch(/>plan_review</); // raw key never shown
   });
 
   it('labels the grading phase and marks the grade chip active', () => {
@@ -311,7 +352,7 @@ describe('profileDetailView', () => {
       }),
     );
     expect(out).toContain('Grading');
-    expect(out).toContain('grade');
+    expect(out).toContain('Grade');
   });
 
   it('renders no live section when there are no active runs', () => {

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -276,7 +276,12 @@ describe('profileDetailView', () => {
             stages: [
               { name: 'plan', status: 'completed' },
               { name: 'coordinate', status: 'in_progress' },
-              { name: 'implement', status: 'pending' },
+              {
+                name: 'implement',
+                status: 'pending',
+                beads: { done: 1, total: 3 },
+                iters: 6,
+              },
               { name: 'test', status: 'completed', skipped: true },
             ],
           },
@@ -293,6 +298,8 @@ describe('profileDetailView', () => {
     expect(out).toContain('rep 1');
     expect(out).toContain('Grade'); // grading pseudo-chip, set-apart
     expect(out).toContain('stage-chip-sep'); // spacer before Grade
+    expect(out).toContain('1/3'); // bead progress inside the Implement chip
+    expect(out).toContain('×6'); // loop-back count
   });
 
   it('orders live stage chips by canonical worca order, not status.json order', () => {

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -93,6 +93,25 @@ describe('profileDetailView', () => {
     expect(without).not.toContain('run-opt-notes');
   });
 
+  it("shows the profile's concurrency.worca as the Max parallel placeholder", () => {
+    const withMp = renderToString(
+      profileDetailView(
+        { aggregate: { ...data.aggregate, max_parallel: 1 }, reps: [] },
+        { onRun: () => {} },
+      ),
+    );
+    // unquoted lit attribute binding -> `placeholder=1`
+    expect(withMp).toMatch(/run-opt-parallel[\s\S]*?placeholder=1/);
+    // Unspecified => generic "default".
+    const noMp = renderToString(
+      profileDetailView(
+        { aggregate: { ...data.aggregate }, reps: [] },
+        { onRun: () => {} },
+      ),
+    );
+    expect(noMp).toMatch(/run-opt-parallel[\s\S]*?placeholder=default/);
+  });
+
   it('defaults the Canary toggle to Off when the profile sets canary:false', () => {
     // The first `value=` after the canary radio-group's class is its default.
     const canaryVal = (out) =>

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -93,6 +93,27 @@ describe('profileDetailView', () => {
     expect(without).not.toContain('run-opt-notes');
   });
 
+  it('defaults the Canary toggle to Off when the profile sets canary:false', () => {
+    // The first `value=` after the canary radio-group's class is its default.
+    const canaryVal = (out) =>
+      out.match(/run-opt-canary[\s\S]*?value=(\w+)/)[1];
+    const off = renderToString(
+      profileDetailView(
+        { aggregate: { ...data.aggregate, canary: false }, reps: [] },
+        { onRun: () => {} },
+      ),
+    );
+    expect(canaryVal(off)).toBe('off');
+    // Unspecified (or true) => On.
+    const on = renderToString(
+      profileDetailView(
+        { aggregate: { ...data.aggregate }, reps: [] },
+        { onRun: () => {} },
+      ),
+    );
+    expect(canaryVal(on)).toBe('on');
+  });
+
   it('shows the fine-grained test count beside the score for Commit0 reps', () => {
     const withCount = {
       aggregate: { ...data.aggregate, benchmark: 'commit0' },

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -93,6 +93,43 @@ describe('profileDetailView', () => {
     expect(without).not.toContain('run-opt-notes');
   });
 
+  it('shows the fine-grained test count beside the score for Commit0 reps', () => {
+    const withCount = {
+      aggregate: { ...data.aggregate, benchmark: 'commit0' },
+      reps: [
+        {
+          instance_id: 'wcwidth',
+          rep: 1,
+          status: 'graded',
+          resolved: true,
+          score: 1,
+          tests_passed: 38,
+          tests_total: 38,
+          grade_mode: 'modal',
+        },
+      ],
+    };
+    const out = renderToString(profileDetailView(withCount, {}));
+    expect(out).toContain('reps-testcount');
+    expect(out).toContain('38/38');
+  });
+
+  it('shows score alone when no test counts are present', () => {
+    const noCount = {
+      aggregate: data.aggregate,
+      reps: [
+        {
+          instance_id: 'astropy__astropy-12907',
+          rep: 1,
+          status: 'graded',
+          score: 1,
+        },
+      ],
+    };
+    const out = renderToString(profileDetailView(noCount, {}));
+    expect(out).not.toContain('reps-testcount');
+  });
+
   it('renders a per-row regrade button when onRegrade is provided', () => {
     const withRep = {
       aggregate: data.aggregate,

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -49,10 +49,24 @@ describe('profileDetailView', () => {
     expect(out).toContain('run-opt-canary'); // canary toggle (on by default)
     expect(out).toContain('run-opt-graphify'); // graphify toggle
     expect(out).toContain('run-opt-crg'); // code-review-graph toggle
+    expect(out).toContain('run-opt-preflight'); // preflight toggle (on by default)
+    expect(out).toContain('run-opt-claudemd'); // CLAUDE.md dropdown
+    expect(out).toContain('project+local'); // a CLAUDE.md option
     // reps input is seeded with the profile's default as a placeholder
     // (unquoted lit attribute binding -> `placeholder=4`)
     expect(out).toContain('placeholder=4');
     expect(out).toContain('placeholder="all"');
+  });
+
+  it('shows the Notes button only when onNotes is provided', () => {
+    const withNotes = renderToString(
+      profileDetailView(data, { onRun: () => {}, onNotes: () => {} }),
+    );
+    expect(withNotes).toContain('run-opt-notes');
+    const without = renderToString(
+      profileDetailView(data, { onRun: () => {} }),
+    );
+    expect(without).not.toContain('run-opt-notes');
   });
 
   it('renders a per-row regrade button when onRegrade is provided', () => {

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -50,4 +50,24 @@ describe('profileDetailView', () => {
     expect(out).toContain('placeholder=4');
     expect(out).toContain('placeholder="all"');
   });
+
+  it('renders a Configuration block with worca/template/benchmark/grade', () => {
+    const out = renderToString(
+      profileDetailView({
+        aggregate: {
+          ...data.aggregate,
+          worca_version: '0.58.0',
+          worca_ref: 'local@abc',
+          template: 'builtin:quick-fix',
+          grade_mode: 'local-docker',
+        },
+        reps: [],
+      }),
+    );
+    expect(out).toContain('config-meta');
+    expect(out).toContain('Configuration');
+    expect(out).toContain('0.58.0 (local@abc)');
+    expect(out).toContain('builtin:quick-fix');
+    expect(out).toContain('local-docker');
+  });
 });

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -53,6 +53,7 @@ describe('profileDetailView', () => {
     expect(out).toContain('run-opt-claudemd'); // CLAUDE.md dropdown
     expect(out).toContain('project+local'); // a CLAUDE.md option
     expect(out).toContain('run-opt-grader'); // grader dropdown
+    expect(out).toContain('run-opt-timeout'); // per-build timeout field
     expect(out).toContain('run-options-title'); // card-style header
     expect(out).toContain('run-options-row'); // controls row wrapper
     // reps input is seeded with the profile's default as a placeholder
@@ -165,6 +166,22 @@ describe('profileDetailView', () => {
     expect(valAfter(bare, 'run-opt-graphify')).toBe('off');
     expect(valAfter(bare, 'run-opt-crg')).toBe('off');
     expect(valAfter(bare, 'run-opt-preflight')).toBe('on');
+  });
+
+  it('seeds the Timeout field from the profile and tooltip-wraps the label', () => {
+    const withTo = renderToString(
+      profileDetailView(
+        { aggregate: { ...data.aggregate, timeout: 1800 }, reps: [] },
+        { onRun: () => {} },
+      ),
+    );
+    expect(withTo).toContain('run-opt-timeout');
+    // unquoted lit attribute binding -> `placeholder=1800` (prefilled from profile)
+    expect(withTo).toMatch(/run-opt-timeout[\s\S]*?placeholder=1800/);
+    // label carries an sl-tooltip explaining the value semantics
+    expect(withTo).toContain('sl-tooltip');
+    expect(withTo).toContain('Timeout (s)');
+    expect(withTo).toContain('0 = no limit');
   });
 
   it('shows the fine-grained test count beside the score for Commit0 reps', () => {

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -40,11 +40,13 @@ describe('profileDetailView', () => {
     );
   });
 
-  it('renders Run options (reps + max instances) when onRun is provided', () => {
+  it('renders Run options (reps + max instances + engine toggles) when onRun is provided', () => {
     const out = renderToString(profileDetailView(data, { onRun: () => {} }));
     expect(out).toContain('run-options');
     expect(out).toContain('run-opt-reps');
     expect(out).toContain('run-opt-instances');
+    expect(out).toContain('run-opt-graphify'); // graphify toggle
+    expect(out).toContain('run-opt-crg'); // code-review-graph toggle
     // reps input is seeded with the profile's default as a placeholder
     // (unquoted lit attribute binding -> `placeholder=4`)
     expect(out).toContain('placeholder=4');
@@ -107,6 +109,33 @@ describe('profileDetailView', () => {
   it('renders no live section when there are no active runs', () => {
     const out = renderToString(profileDetailView({ ...data, active: [] }));
     expect(out).not.toContain('live-runs');
+  });
+
+  it('shows per-rep engine metadata columns + the Duration header', () => {
+    const out = renderToString(
+      profileDetailView({
+        aggregate: data.aggregate,
+        reps: [
+          {
+            instance_id: 'astropy__astropy-1',
+            rep: 1,
+            status: 'graded',
+            score: 1,
+            cost_usd: 0.4,
+            wall_time_s: 200,
+            loop_counters: {},
+            graphify: 'full',
+            code_review_graph: 'structural',
+          },
+        ],
+      }),
+    );
+    expect(out).toContain('Duration'); // renamed from Wall
+    expect(out).not.toContain('<th>Wall</th>');
+    expect(out).toContain('Graphify');
+    expect(out).toContain('CRG');
+    expect(out).toContain('full'); // graphify value
+    expect(out).toContain('structural'); // crg value
   });
 
   it('renders a Configuration block with worca/template/benchmark/grade', () => {

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -51,6 +51,38 @@ describe('profileDetailView', () => {
     expect(out).toContain('placeholder="all"');
   });
 
+  it('renders live stage chips for active runs', () => {
+    const out = renderToString(
+      profileDetailView({
+        aggregate: { ...data.aggregate, active: true },
+        reps: [],
+        active: [
+          {
+            kind: 'rep',
+            pipeline_status: 'running',
+            stages: [
+              { name: 'plan', status: 'completed' },
+              { name: 'coordinate', status: 'in_progress' },
+              { name: 'implement', status: 'pending' },
+              { name: 'test', status: 'completed', skipped: true },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(out).toContain('live-runs');
+    expect(out).toContain('stage-chip--done'); // plan
+    expect(out).toContain('stage-chip--active'); // coordinate
+    expect(out).toContain('stage-chip--pending'); // implement
+    expect(out).toContain('stage-chip--skipped'); // test
+    expect(out).toContain('coordinate');
+  });
+
+  it('renders no live section when there are no active runs', () => {
+    const out = renderToString(profileDetailView({ ...data, active: [] }));
+    expect(out).not.toContain('live-runs');
+  });
+
   it('renders a Configuration block with worca/template/benchmark/grade', () => {
     const out = renderToString(
       profileDetailView({

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -55,6 +55,33 @@ describe('profileDetailView', () => {
     expect(out).toContain('placeholder="all"');
   });
 
+  it('renders a per-row regrade button when onRegrade is provided', () => {
+    const withRep = {
+      aggregate: data.aggregate,
+      reps: [
+        { instance_id: 'astropy__astropy-12907', rep: 1, status: 'error' },
+      ],
+    };
+    const out = renderToString(
+      profileDetailView(withRep, { onRegrade: () => {} }),
+    );
+    expect(out).toContain('<th>Action</th>');
+    expect(out).toContain('reps-regrade-btn');
+    expect(out).toContain('sl-tooltip');
+  });
+
+  it('omits the regrade button when no onRegrade handler is given', () => {
+    const withRep = {
+      aggregate: data.aggregate,
+      reps: [
+        { instance_id: 'astropy__astropy-12907', rep: 1, status: 'error' },
+      ],
+    };
+    const out = renderToString(profileDetailView(withRep, {}));
+    expect(out).toContain('<th>Action</th>'); // column header always present
+    expect(out).not.toContain('reps-regrade-btn');
+  });
+
   it('renders live stage chips for active runs', () => {
     const out = renderToString(
       profileDetailView({

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -167,6 +167,67 @@ describe('profileDetailView', () => {
     expect(out).toContain('structural'); // crg value
   });
 
+  it('renders the regrade progress block while a sweep is active', () => {
+    const out = renderToString(
+      profileDetailView({
+        aggregate: data.aggregate,
+        reps: [
+          { instance_id: 'astropy__astropy-14539', rep: 1, status: 'error' },
+        ],
+        regrade: {
+          active: true,
+          mode: 'modal',
+          total: 20,
+          done: 7,
+          current: 'astropy__astropy-14539',
+          counts: { graded: 7, resolved: 4, error: 0 },
+          started_at: '2026-06-17T06:00:00Z',
+        },
+      }),
+    );
+    expect(out).toContain('regrade-progress');
+    expect(out).toContain('Regrading 7/20 via modal');
+    expect(out).toContain('astropy__astropy-14539');
+    expect(out).toContain('4 resolved');
+    expect(out).toContain('reps-row--grading'); // the in-flight row is highlighted
+  });
+
+  it('omits the regrade progress block when no sweep is active', () => {
+    const out = renderToString(
+      profileDetailView({
+        aggregate: data.aggregate,
+        reps: [],
+        regrade: { active: false, status: 'done' },
+      }),
+    );
+    expect(out).not.toContain('regrade-progress');
+  });
+
+  it('wraps the status badge in a tooltip carrying grade provenance', () => {
+    const out = renderToString(
+      profileDetailView({
+        aggregate: data.aggregate,
+        reps: [
+          {
+            instance_id: 'astropy__astropy-12907',
+            rep: 1,
+            status: 'graded',
+            resolved: true,
+            score: 1,
+            grade_mode: 'modal',
+            regraded_at: '2026-06-17T06:12:00Z',
+            report_path: '/logs/run/report.json',
+          },
+        ],
+      }),
+    );
+    // The status cell is now tooltip-wrapped with a one-line provenance string.
+    expect(out).toContain('resolved via modal');
+    expect(out).toContain('score 1');
+    expect(out).toContain('regraded 2026-06-17 06:12 UTC');
+    expect(out).toContain('report: /logs/run/report.json');
+  });
+
   it('renders a Configuration block with worca/template/benchmark/grade', () => {
     const out = renderToString(
       profileDetailView({

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { profileDetailView } from './profile-detail.js';
+
+// Same renderToString helper used across the worca-bench view tests.
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+const data = {
+  aggregate: {
+    name: 'demo',
+    benchmark: 'swe-bench-verified',
+    reps: 4,
+    resolved_rate: 0.5,
+    mean_cost_usd: 0.4,
+    mean_wall_s: 600,
+    mean_iterations: 2,
+  },
+  reps: [],
+};
+
+describe('profileDetailView', () => {
+  it('omits the Run options block when no onRun handler is given', () => {
+    expect(renderToString(profileDetailView(data))).not.toContain(
+      'run-options',
+    );
+  });
+
+  it('renders Run options (reps + max instances) when onRun is provided', () => {
+    const out = renderToString(profileDetailView(data, { onRun: () => {} }));
+    expect(out).toContain('run-options');
+    expect(out).toContain('run-opt-reps');
+    expect(out).toContain('run-opt-instances');
+    // reps input is seeded with the profile's default as a placeholder
+    // (unquoted lit attribute binding -> `placeholder=4`)
+    expect(out).toContain('placeholder=4');
+    expect(out).toContain('placeholder="all"');
+  });
+});

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -133,6 +133,40 @@ describe('profileDetailView', () => {
     expect(canaryVal(on)).toBe('on');
   });
 
+  it('seeds the Graphify/CRG/Preflight run-option defaults from the profile', () => {
+    const valAfter = (out, cls) =>
+      out.match(new RegExp(`${cls}[\\s\\S]*?value=(\\w+)`))[1];
+    const out = renderToString(
+      profileDetailView(
+        {
+          aggregate: {
+            ...data.aggregate,
+            graphify: 'structural',
+            code_review_graph: 'structural',
+            preflight: 'off',
+          },
+          reps: [],
+        },
+        { onRun: () => {} },
+      ),
+    );
+    expect(valAfter(out, 'run-opt-graphify')).toBe('structural');
+    expect(valAfter(out, 'run-opt-crg')).toBe('structural');
+    expect(valAfter(out, 'run-opt-preflight')).toBe('off');
+    // Unspecified in the profile => the prior hardcoded fallbacks.
+    const bare = renderToString(
+      profileDetailView(
+        { aggregate: { ...data.aggregate }, reps: [] },
+        {
+          onRun: () => {},
+        },
+      ),
+    );
+    expect(valAfter(bare, 'run-opt-graphify')).toBe('off');
+    expect(valAfter(bare, 'run-opt-crg')).toBe('off');
+    expect(valAfter(bare, 'run-opt-preflight')).toBe('on');
+  });
+
   it('shows the fine-grained test count beside the score for Commit0 reps', () => {
     const withCount = {
       aggregate: { ...data.aggregate, benchmark: 'commit0' },

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -52,10 +52,21 @@ describe('profileDetailView', () => {
     expect(out).toContain('run-opt-preflight'); // preflight toggle (on by default)
     expect(out).toContain('run-opt-claudemd'); // CLAUDE.md dropdown
     expect(out).toContain('project+local'); // a CLAUDE.md option
+    expect(out).toContain('run-opt-grader'); // grader dropdown
+    expect(out).toContain('run-options-title'); // card-style header
+    expect(out).toContain('run-options-row'); // controls row wrapper
     // reps input is seeded with the profile's default as a placeholder
     // (unquoted lit attribute binding -> `placeholder=4`)
     expect(out).toContain('placeholder=4');
     expect(out).toContain('placeholder="all"');
+  });
+
+  it('offers every grader backend in the grader dropdown', () => {
+    const out = renderToString(profileDetailView(data, { onRun: () => {} }));
+    expect(out).toContain('Local (Docker)');
+    expect(out).toContain('SWE-bench Cloud (sb-cli)');
+    expect(out).toContain('Modal (serverless x86)');
+    expect(out).toContain('Stub (no grade)');
   });
 
   it('shows the Notes button only when onNotes is provided', () => {

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -168,6 +168,19 @@ describe('profileDetailView', () => {
     expect(valAfter(bare, 'run-opt-preflight')).toBe('on');
   });
 
+  it('disables the Run button (label + title) when a run is already in progress', () => {
+    const disabled = renderToString(
+      profileDetailView(data, { onRun: () => {}, runDisabled: true }),
+    );
+    expect(disabled).toContain('Running…');
+    expect(disabled).toContain('A run is already in progress');
+    const enabled = renderToString(
+      profileDetailView(data, { onRun: () => {} }),
+    );
+    expect(enabled).not.toContain('Running…');
+    expect(enabled).toContain('Launch a run'); // enabled title
+  });
+
   it('seeds the Timeout field from the profile and tooltip-wraps the label', () => {
     const withTo = renderToString(
       profileDetailView(

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -45,6 +45,8 @@ describe('profileDetailView', () => {
     expect(out).toContain('run-options');
     expect(out).toContain('run-opt-reps');
     expect(out).toContain('run-opt-instances');
+    expect(out).toContain('run-opt-parallel'); // max parallel
+    expect(out).toContain('run-opt-canary'); // canary toggle (on by default)
     expect(out).toContain('run-opt-graphify'); // graphify toggle
     expect(out).toContain('run-opt-crg'); // code-review-graph toggle
     // reps input is seeded with the profile's default as a placeholder

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -59,7 +59,10 @@ describe('profileDetailView', () => {
         active: [
           {
             kind: 'rep',
-            pipeline_status: 'running',
+            phase: 'running',
+            instance: 'astropy__astropy-12907',
+            rep: 1,
+            started_at: '2026-06-16T10:00:00Z',
             stages: [
               { name: 'plan', status: 'completed' },
               { name: 'coordinate', status: 'in_progress' },
@@ -76,6 +79,29 @@ describe('profileDetailView', () => {
     expect(out).toContain('stage-chip--pending'); // implement
     expect(out).toContain('stage-chip--skipped'); // test
     expect(out).toContain('coordinate');
+    expect(out).toContain('astropy__astropy-12907'); // instance shown
+    expect(out).toContain('rep 1');
+    expect(out).toContain('grade'); // grading pseudo-chip
+  });
+
+  it('labels the grading phase and marks the grade chip active', () => {
+    const out = renderToString(
+      profileDetailView({
+        aggregate: { ...data.aggregate, active: true },
+        reps: [],
+        active: [
+          {
+            kind: 'rep',
+            phase: 'grading',
+            instance: 'x',
+            rep: 1,
+            stages: [{ name: 'implement', status: 'completed' }],
+          },
+        ],
+      }),
+    );
+    expect(out).toContain('Grading');
+    expect(out).toContain('grade');
   });
 
   it('renders no live section when there are no active runs', () => {

--- a/worca-bench/app/views/profile-detail.test.js
+++ b/worca-bench/app/views/profile-detail.test.js
@@ -61,12 +61,25 @@ describe('profileDetailView', () => {
     expect(out).toContain('placeholder="all"');
   });
 
-  it('offers every grader backend in the grader dropdown', () => {
+  it('offers every grader backend in the grader dropdown (SWE-bench)', () => {
     const out = renderToString(profileDetailView(data, { onRun: () => {} }));
     expect(out).toContain('Local (Docker)');
     expect(out).toContain('SWE-bench Cloud (sb-cli)');
     expect(out).toContain('Modal (serverless x86)');
     expect(out).toContain('Stub (no grade)');
+  });
+
+  it('drops the sb-cli grader option for commit0 profiles', () => {
+    const c0 = {
+      aggregate: { ...data.aggregate, benchmark: 'commit0' },
+      reps: [],
+    };
+    const out = renderToString(profileDetailView(c0, { onRun: () => {} }));
+    // commit0 grades via `commit0 test` on local Docker or Modal — no hosted backend.
+    expect(out).toContain('Local (Docker)');
+    expect(out).toContain('Modal (serverless x86)');
+    expect(out).toContain('Stub (no grade)');
+    expect(out).not.toContain('SWE-bench Cloud (sb-cli)');
   });
 
   it('shows the Notes button only when onNotes is provided', () => {

--- a/worca-bench/app/views/profile-list.js
+++ b/worca-bench/app/views/profile-list.js
@@ -1,0 +1,47 @@
+import { html, nothing } from 'lit-html';
+import { profileCardView } from './profile-card.js';
+
+/**
+ * Dashboard landing view: a grid of profile cards.
+ *
+ * @param {object[]} profiles  aggregate summaries
+ * @param {object} [handlers]  forwarded to each profile card
+ */
+export function profileListView(profiles, handlers = {}) {
+  if (!profiles || profiles.length === 0) {
+    return html`
+      <div class="empty-state">
+        <p>No benchmark results yet.</p>
+        <p class="empty-state-hint">Run a profile to populate <code>results.jsonl</code> in the target directory.</p>
+      </div>
+    `;
+  }
+  return html`
+    <div class="profile-grid">
+      ${profiles.map((p) => profileCardView(p, handlers))}
+    </div>
+  `;
+}
+
+/**
+ * The dashboard section header with a compare shortcut.
+ *
+ * @param {object[]} profiles
+ * @param {object} [handlers]
+ * @param {() => void} [handlers.onCompare]
+ */
+export function dashboardView(profiles, handlers = {}) {
+  return html`
+    <section class="page">
+      <div class="page-head">
+        <h1>Benchmark Profiles</h1>
+        ${
+          profiles && profiles.length > 1 && handlers.onCompare
+            ? html`<button class="action-btn" @click=${handlers.onCompare}>Compare all</button>`
+            : nothing
+        }
+      </div>
+      ${profileListView(profiles, handlers)}
+    </section>
+  `;
+}

--- a/worca-bench/app/views/profile-list.js
+++ b/worca-bench/app/views/profile-list.js
@@ -1,4 +1,4 @@
-import { html, nothing } from 'lit-html';
+import { html } from 'lit-html';
 import { profileCardView } from './profile-card.js';
 
 /**
@@ -24,24 +24,12 @@ export function profileListView(profiles, handlers = {}) {
 }
 
 /**
- * The dashboard section header with a compare shortcut.
+ * The dashboard body — the profile card grid. The page title and the
+ * "Compare all" action now live in main.js's shared content header.
  *
  * @param {object[]} profiles
- * @param {object} [handlers]
- * @param {() => void} [handlers.onCompare]
+ * @param {object} [handlers]  forwarded to each profile card (onOpen, onRun)
  */
 export function dashboardView(profiles, handlers = {}) {
-  return html`
-    <section class="page">
-      <div class="page-head">
-        <h1>Benchmark Profiles</h1>
-        ${
-          profiles && profiles.length > 1 && handlers.onCompare
-            ? html`<button class="action-btn" @click=${handlers.onCompare}>Compare all</button>`
-            : nothing
-        }
-      </div>
-      ${profileListView(profiles, handlers)}
-    </section>
-  `;
+  return html`<section class="page">${profileListView(profiles, handlers)}</section>`;
 }

--- a/worca-bench/app/views/profile-list.js
+++ b/worca-bench/app/views/profile-list.js
@@ -16,9 +16,15 @@ export function profileListView(profiles, handlers = {}) {
       </div>
     `;
   }
+  // Show the source dir only when a profile name appears in >1 result dir,
+  // so the duplicates are distinguishable without cluttering the common case.
+  const counts = new Map();
+  for (const p of profiles) counts.set(p.name, (counts.get(p.name) || 0) + 1);
   return html`
     <div class="profile-grid">
-      ${profiles.map((p) => profileCardView(p, handlers))}
+      ${profiles.map((p) =>
+        profileCardView(p, { ...handlers, showSource: counts.get(p.name) > 1 }),
+      )}
     </div>
   `;
 }

--- a/worca-bench/app/views/profile-list.js
+++ b/worca-bench/app/views/profile-list.js
@@ -1,40 +1,119 @@
-import { html } from 'lit-html';
+import { html, nothing } from 'lit-html';
 import { profileCardView } from './profile-card.js';
 
+/** Does a profile match the free-text search (name / benchmark / template / ref)? */
+function _matchesSearch(p, q) {
+  if (!q) return true;
+  const hay =
+    `${p.name} ${p.benchmark || ''} ${p.template || ''} ${p.worca_ref || ''}`.toLowerCase();
+  return hay.includes(q);
+}
+
+/** Apply the visibility filter (all | active | archived) to a profile. */
+function _matchesFilter(p, filter) {
+  if (filter === 'archived') return !!p.archived;
+  if (filter === 'all') return true;
+  return !p.archived; // 'active' (default): non-archived only
+}
+
 /**
- * Dashboard landing view: a grid of profile cards.
+ * Filter toggle + search, mirroring worca-ui's history page: a row of
+ * mutually-exclusive pills (with counts) over a free-text filter box.
+ */
+function _filterBarView(profiles, { filter, search, onFilter, onSearch }) {
+  const counts = {
+    all: profiles.length,
+    active: profiles.filter((p) => !p.archived).length,
+    archived: profiles.filter((p) => p.archived).length,
+  };
+  const pill = (key, label) => html`<button
+    class="filter-pill ${filter === key ? 'filter-pill--active' : ''}"
+    @click=${() => onFilter(key)}
+  >${label} <span class="filter-pill-count">${counts[key]}</span></button>`;
+
+  return html`
+    <div class="profile-filter">
+      <div class="filter-pills">
+        ${pill('all', 'All')}
+        ${pill('active', 'Active')}
+        ${pill('archived', 'Archived')}
+      </div>
+      <input
+        class="filter-search"
+        type="search"
+        placeholder="Filter by name, benchmark, or template…"
+        .value=${search || ''}
+        @input=${(e) => onSearch(e.target.value)}
+      />
+    </div>
+  `;
+}
+
+/**
+ * Dashboard landing view: a filter bar + a grid of profile cards.
  *
- * @param {object[]} profiles  aggregate summaries
- * @param {object} [handlers]  forwarded to each profile card
+ * @param {object[]} profiles  aggregate summaries (each tagged `.archived`)
+ * @param {object} [handlers]  forwarded to each profile card, plus the filter
+ *   state/handlers: `{ filter, search, onFilter, onSearch }`.
  */
 export function profileListView(profiles, handlers = {}) {
-  if (!profiles || profiles.length === 0) {
+  const all = profiles || [];
+  const { filter = 'active', search = '', onFilter, onSearch } = handlers;
+  const q = (search || '').trim().toLowerCase();
+
+  const bar =
+    onFilter && onSearch
+      ? _filterBarView(all, { filter, search, onFilter, onSearch })
+      : nothing;
+
+  if (all.length === 0) {
     return html`
+      ${bar}
       <div class="empty-state">
         <p>No benchmark results yet.</p>
         <p class="empty-state-hint">Run a profile to populate <code>results.jsonl</code> in the target directory.</p>
       </div>
     `;
   }
+
+  const shown = all.filter(
+    (p) => _matchesFilter(p, filter) && _matchesSearch(p, q),
+  );
+
   // Show the source dir only when a profile name appears in >1 result dir,
   // so the duplicates are distinguishable without cluttering the common case.
-  const counts = new Map();
-  for (const p of profiles) counts.set(p.name, (counts.get(p.name) || 0) + 1);
+  const dupCounts = new Map();
+  for (const p of all) dupCounts.set(p.name, (dupCounts.get(p.name) || 0) + 1);
+
   return html`
-    <div class="profile-grid">
-      ${profiles.map((p) =>
-        profileCardView(p, { ...handlers, showSource: counts.get(p.name) > 1 }),
-      )}
-    </div>
+    ${bar}
+    ${
+      shown.length === 0
+        ? html`<div class="empty-state"><p>No profiles match.</p>
+            <p class="empty-state-hint">${
+              filter === 'archived'
+                ? 'No archived profiles.'
+                : 'Try a different filter or search.'
+            }</p></div>`
+        : html`<div class="profile-grid">
+            ${shown.map((p) =>
+              profileCardView(p, {
+                ...handlers,
+                showSource: dupCounts.get(p.name) > 1,
+              }),
+            )}
+          </div>`
+    }
   `;
 }
 
 /**
- * The dashboard body — the profile card grid. The page title and the
- * "Compare all" action now live in main.js's shared content header.
+ * The dashboard body — the filter bar + profile card grid. The page title and
+ * the header actions (Compare / Archive) live in main.js's content header.
  *
  * @param {object[]} profiles
- * @param {object} [handlers]  forwarded to each profile card (onOpen, onRun)
+ * @param {object} [handlers]  forwarded to each profile card (onOpen, onRun) +
+ *   filter state/handlers (filter, search, onFilter, onSearch).
  */
 export function dashboardView(profiles, handlers = {}) {
   return html`<section class="page">${profileListView(profiles, handlers)}</section>`;

--- a/worca-bench/app/views/profile-list.test.js
+++ b/worca-bench/app/views/profile-list.test.js
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { profileListView } from './profile-list.js';
+
+// Same renderToString walker the other view tests use: inline strings/numbers/
+// arrays/nested templates; functions and unsafeHTML directives are skipped.
+function renderToString(template) {
+  if (!template) return '';
+  if (typeof template === 'string') return template;
+  if (typeof template === 'symbol') return ''; // lit `nothing`
+  if (!template.strings) return String(template);
+  let result = '';
+  template.strings.forEach((s, i) => {
+    result += s;
+    if (i < template.values.length) {
+      const v = template.values[i];
+      if (typeof v === 'string') result += v;
+      else if (typeof v === 'number') result += String(v);
+      else if (Array.isArray(v)) result += v.map(renderToString).join('');
+      else if (v?.strings) result += renderToString(v);
+    }
+  });
+  return result;
+}
+
+function agg(name, overrides = {}) {
+  return {
+    name,
+    src: `src-${name}`,
+    benchmark: 'swe-bench-verified',
+    template: 'builtin:feature',
+    reps: 1,
+    resolved_rate: 1,
+    ...overrides,
+  };
+}
+
+const profiles = [
+  agg('alpha'),
+  agg('beta', { archived: true }),
+  agg('gamma', { benchmark: 'commit0' }),
+];
+
+const handlers = {
+  onFilter: () => {},
+  onSearch: () => {},
+};
+
+describe('profileListView filtering', () => {
+  it('omits the filter bar when no filter handlers are passed', () => {
+    const out = renderToString(profileListView(profiles));
+    expect(out).not.toContain('filter-pills');
+    // …but still renders the grid (legacy callers).
+    expect(out).toContain('profile-grid');
+  });
+
+  it('renders pills with per-category counts', () => {
+    const out = renderToString(
+      profileListView(profiles, { ...handlers, filter: 'all' }),
+    );
+    expect(out).toContain('filter-pills');
+    // All=3, Active(non-archived)=2, Archived=1.
+    expect(out).toMatch(/All\s*<span class="filter-pill-count">3/);
+    expect(out).toMatch(/Active\s*<span class="filter-pill-count">2/);
+    expect(out).toMatch(/Archived\s*<span class="filter-pill-count">1/);
+  });
+
+  it("default 'active' filter hides archived profiles", () => {
+    const out = renderToString(
+      profileListView(profiles, { ...handlers, filter: 'active' }),
+    );
+    expect(out).toContain('alpha');
+    expect(out).toContain('gamma');
+    expect(out).not.toContain('>beta<');
+  });
+
+  it("'archived' filter shows only archived profiles", () => {
+    const out = renderToString(
+      profileListView(profiles, { ...handlers, filter: 'archived' }),
+    );
+    expect(out).toContain('beta');
+    expect(out).not.toContain('>alpha<');
+  });
+
+  it('search narrows by name within the active filter', () => {
+    const out = renderToString(
+      profileListView(profiles, {
+        ...handlers,
+        filter: 'all',
+        search: 'gam',
+      }),
+    );
+    expect(out).toContain('gamma');
+    expect(out).not.toContain('>alpha<');
+    expect(out).not.toContain('>beta<');
+  });
+
+  it('search matches benchmark too', () => {
+    const out = renderToString(
+      profileListView(profiles, {
+        ...handlers,
+        filter: 'all',
+        search: 'commit0',
+      }),
+    );
+    expect(out).toContain('gamma');
+    expect(out).not.toContain('>alpha<');
+  });
+
+  it('shows an empty-state when nothing matches', () => {
+    const out = renderToString(
+      profileListView(profiles, {
+        ...handlers,
+        filter: 'all',
+        search: 'zzz-nope',
+      }),
+    );
+    expect(out).toContain('No profiles match');
+    expect(out).not.toContain('profile-grid');
+  });
+
+  it('keeps the filter bar when the list is empty', () => {
+    const out = renderToString(profileListView([], handlers));
+    expect(out).toContain('filter-pills');
+    expect(out).toContain('No benchmark results yet');
+  });
+});

--- a/worca-bench/app/views/settings.js
+++ b/worca-bench/app/views/settings.js
@@ -6,6 +6,7 @@
 
 import { html, nothing } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import { SECRET_FIELDS, secretStatus } from '../utils/secrets.js';
 
 // Lucide icons, inlined to keep worca-bench dependency-light.
 const FOLDER =
@@ -23,15 +24,41 @@ const TRASH =
  * @param {(dir: string) => void} [handlers.onSetCache]
  * @param {() => void} [handlers.onBrowseAdd]
  * @param {() => void} [handlers.onBrowseCache]
+ * @param {(patch: object) => void} [handlers.onSaveSecrets]  browser-only credentials
+ * @param {(name: string) => void} [handlers.onClearSecret]
  */
 export function settingsView(
   data,
-  { onAddDir, onRemoveDir, onSetCache, onBrowseAdd, onBrowseCache } = {},
+  {
+    onAddDir,
+    onRemoveDir,
+    onSetCache,
+    onBrowseAdd,
+    onBrowseCache,
+    onSaveSecrets,
+    onClearSecret,
+  } = {},
 ) {
   const primary = data?.primary || null;
   const configured = data?.configured || [];
   const effective = data?.effective || [];
   const cache = data?.cache || null;
+  const secretsSet = secretStatus();
+
+  // Collect non-empty credential inputs into a patch and hand off to the
+  // browser-only store. Inputs are cleared after save (we never echo a secret).
+  const submitSecrets = (e) => {
+    e.preventDefault();
+    const patch = {};
+    for (const input of e.currentTarget.querySelectorAll(
+      '.settings-secret-input',
+    )) {
+      const v = (input.value || '').trim();
+      if (v) patch[input.dataset.key] = v;
+      input.value = '';
+    }
+    if (Object.keys(patch).length) onSaveSecrets?.(patch);
+  };
 
   const submitAdd = (e) => {
     e.preventDefault();
@@ -161,6 +188,62 @@ export function settingsView(
             @click=${() => onBrowseCache?.()}
           >Browse…</button>
           <button class="action-btn action-btn--primary" type="submit">Set</button>
+        </form>
+      </section>
+
+      <section class="settings-card">
+        <div class="settings-card-head">
+          <h2 class="settings-card-title">Grader credentials</h2>
+          <p class="settings-card-desc">
+            Keys for the SWE-bench cloud (<code>sb-cli</code>) and Modal graders.
+            Stored <strong>only in this browser</strong> (never in the repo or on
+            the server) and forwarded into the runner's environment on launch and
+            regrade. Leave a field blank to keep its current value.
+          </p>
+        </div>
+        <form class="settings-secrets-form" @submit=${submitSecrets}>
+          ${SECRET_FIELDS.map(
+            (f) => html`<div class="settings-secret-row">
+              <label class="settings-secret-label" for=${`secret-${f.key}`}>
+                ${f.label}
+                ${
+                  secretsSet[f.key]
+                    ? html`<sl-badge variant="success" pill>Set</sl-badge>`
+                    : html`<sl-badge variant="neutral" pill>Not set</sl-badge>`
+                }
+              </label>
+              <div class="settings-secret-controls">
+                <input
+                  id=${`secret-${f.key}`}
+                  class="settings-input settings-secret-input"
+                  type="password"
+                  autocomplete="off"
+                  data-key=${f.key}
+                  placeholder=${secretsSet[f.key] ? '•••••••• (set)' : 'not set'}
+                  aria-label=${f.label}
+                />
+                ${
+                  secretsSet[f.key]
+                    ? html`<button
+                        class="icon-btn icon-btn--danger"
+                        type="button"
+                        aria-label=${`Clear ${f.label}`}
+                        title="Clear"
+                        @click=${() => onClearSecret?.(f.key)}
+                      >
+                        ${unsafeHTML(TRASH)}
+                      </button>`
+                    : nothing
+                }
+              </div>
+              <p class="settings-secret-hint">${f.hint}</p>
+            </div>`,
+          )}
+          <div class="settings-secrets-actions">
+            <button class="action-btn action-btn--primary" type="submit">
+              Save credentials
+            </button>
+          </div>
         </form>
       </section>
     </div>

--- a/worca-bench/app/views/settings.js
+++ b/worca-bench/app/views/settings.js
@@ -8,15 +8,17 @@
 import { html, nothing } from 'lit-html';
 
 /**
- * @param {object} data  { primary, configured, effective, error? }
+ * @param {object} data  { primary, configured, effective, cache?, error? }
  * @param {object} [handlers]
  * @param {(dir: string) => void} [handlers.onAddDir]
  * @param {(dir: string) => void} [handlers.onRemoveDir]
+ * @param {(dir: string) => void} [handlers.onSetCache]
  */
-export function settingsView(data, { onAddDir, onRemoveDir } = {}) {
+export function settingsView(data, { onAddDir, onRemoveDir, onSetCache } = {}) {
   const primary = data?.primary || null;
   const configured = data?.configured || [];
   const effective = data?.effective || [];
+  const cache = data?.cache || null;
 
   const submit = (e) => {
     e.preventDefault();
@@ -26,6 +28,12 @@ export function settingsView(data, { onAddDir, onRemoveDir } = {}) {
       onAddDir?.(value);
       input.value = '';
     }
+  };
+
+  const submitCache = (e) => {
+    e.preventDefault();
+    const input = e.currentTarget.querySelector('.settings-cache-input');
+    onSetCache?.((input?.value || '').trim());
   };
 
   return html`
@@ -94,6 +102,32 @@ export function settingsView(data, { onAddDir, onRemoveDir } = {}) {
             ? html`<p class="settings-error">${data.error}</p>`
             : nothing
         }
+      </section>
+
+      <section class="settings-block">
+        <h3 class="settings-h">Benchmark cache directory</h3>
+        <p class="settings-note">
+          Large HuggingFace datasets and repo mirrors are stored here — keep it
+          off your home volume. Resolves from
+          <code>cache_dir</code> → <code>WORCA_BENCH_CACHE</code> →
+          <code>~/.worca-bench/cache</code>.
+        </p>
+        <table class="settings-dirs">
+          <tbody>
+            <tr class="settings-dir settings-dir--cache">
+              <td class="settings-dir-path">${cache?.dir || '—'}</td>
+              <td class="settings-dir-tag">${cache?.source || 'default'}</td>
+            </tr>
+          </tbody>
+        </table>
+        <form class="settings-add" @submit=${submitCache}>
+          <input
+            class="settings-cache-input settings-add-input"
+            type="text"
+            placeholder="/absolute/path/to/cache (blank to reset)"
+          />
+          <button class="settings-add-btn" type="submit">Set</button>
+        </form>
       </section>
     </div>
   `;

--- a/worca-bench/app/views/settings.js
+++ b/worca-bench/app/views/settings.js
@@ -1,11 +1,19 @@
-// app/views/settings.js — manage the result directories the dashboard reads.
+// app/views/settings.js — workspace settings (result dirs + benchmark cache).
 //
-// The dashboard aggregates results.jsonl from the launch --target-dir (always
-// included) plus any directories configured in ~/.worca-bench/settings.json.
-// This page lists them and lets you add/remove the configured ones. The page
-// title + back button live in main.js's shared content header.
+// Card-based layout: each concern is a card with a header/description, a list of
+// current values (path + status badge + inline remove), and an inline add/set
+// form. The page title + back button live in main.js's shared content header.
 
 import { html, nothing } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+
+// Lucide icons, inlined to keep worca-bench dependency-light.
+const FOLDER =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>';
+const DATABASE =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/></svg>';
+const TRASH =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg>';
 
 /**
  * @param {object} data  { primary, configured, effective, cache?, error? }
@@ -13,14 +21,19 @@ import { html, nothing } from 'lit-html';
  * @param {(dir: string) => void} [handlers.onAddDir]
  * @param {(dir: string) => void} [handlers.onRemoveDir]
  * @param {(dir: string) => void} [handlers.onSetCache]
+ * @param {() => void} [handlers.onBrowseAdd]
+ * @param {() => void} [handlers.onBrowseCache]
  */
-export function settingsView(data, { onAddDir, onRemoveDir, onSetCache } = {}) {
+export function settingsView(
+  data,
+  { onAddDir, onRemoveDir, onSetCache, onBrowseAdd, onBrowseCache } = {},
+) {
   const primary = data?.primary || null;
   const configured = data?.configured || [];
   const effective = data?.effective || [];
   const cache = data?.cache || null;
 
-  const submit = (e) => {
+  const submitAdd = (e) => {
     e.preventDefault();
     const input = e.currentTarget.querySelector('.settings-add-input');
     const value = (input?.value || '').trim();
@@ -34,99 +47,120 @@ export function settingsView(data, { onAddDir, onRemoveDir, onSetCache } = {}) {
     e.preventDefault();
     const input = e.currentTarget.querySelector('.settings-cache-input');
     onSetCache?.((input?.value || '').trim());
+    if (input) input.value = '';
   };
 
   return html`
     <div class="settings-view">
-      <p class="settings-note">
-        The dashboard aggregates <code>results.jsonl</code> from the directories
-        below. The launch directory is always included; add more to view results
-        produced by other runs. Configuration is stored in
-        <code>~/.worca-bench/settings.json</code>.
-      </p>
+      ${
+        data?.error
+          ? html`<div class="settings-alert" role="alert">${data.error}</div>`
+          : nothing
+      }
 
-      <section class="settings-block">
-        <h3 class="settings-h">Result directories</h3>
-        <table class="settings-dirs">
-          <tbody>
-            ${
-              primary
-                ? html`<tr class="settings-dir settings-dir--primary">
-                    <td class="settings-dir-path">${primary}</td>
-                    <td class="settings-dir-tag">launch dir · always included</td>
-                    <td></td>
-                  </tr>`
-                : nothing
-            }
-            ${
-              configured.length === 0 && !primary
-                ? html`<tr>
-                    <td class="empty-state" colspan="3">
-                      No directories configured.
-                    </td>
-                  </tr>`
-                : nothing
-            }
-            ${configured.map(
-              (dir) => html`<tr class="settings-dir">
-                <td class="settings-dir-path">${dir}</td>
-                <td class="settings-dir-tag">
-                  ${effective.includes(dir) ? 'configured' : 'missing'}
-                </td>
-                <td>
-                  <button
-                    class="settings-remove"
-                    @click=${() => onRemoveDir?.(dir)}
-                  >
-                    Remove
-                  </button>
-                </td>
-              </tr>`,
-            )}
-          </tbody>
-        </table>
-      </section>
-
-      <section class="settings-block">
-        <h3 class="settings-h">Add a directory</h3>
-        <form class="settings-add" @submit=${submit}>
+      <section class="settings-card">
+        <div class="settings-card-head">
+          <h2 class="settings-card-title">Result directories</h2>
+          <p class="settings-card-desc">
+            The dashboard aggregates <code>results.jsonl</code> from these
+            directories. The launch directory is always included; add more to
+            view results from other runs. Stored in
+            <code>~/.worca-bench/settings.json</code>.
+          </p>
+        </div>
+        <div class="settings-list settings-dirs">
+          ${
+            primary
+              ? html`<div class="settings-row settings-dir--primary">
+                  <span class="settings-row-icon">${unsafeHTML(FOLDER)}</span>
+                  <span class="settings-row-path">${primary}</span>
+                  <span class="settings-row-hint">always included</span>
+                </div>`
+              : nothing
+          }
+          ${configured.map((dir) => {
+            const present = effective.includes(dir);
+            return html`<div class="settings-row">
+              <span class="settings-row-icon">${unsafeHTML(FOLDER)}</span>
+              <span class="settings-row-path">${dir}</span>
+              ${
+                present
+                  ? nothing
+                  : html`<sl-badge variant="warning" pill>missing</sl-badge>`
+              }
+              <button
+                class="icon-btn icon-btn--danger settings-row-remove"
+                aria-label=${`Remove ${dir}`}
+                title="Remove"
+                @click=${() => onRemoveDir?.(dir)}
+              >
+                ${unsafeHTML(TRASH)}
+              </button>
+            </div>`;
+          })}
+          ${
+            configured.length === 0
+              ? html`<div class="settings-empty">
+                  No additional directories.
+                </div>`
+              : nothing
+          }
+        </div>
+        <form class="settings-inline-form" @submit=${submitAdd}>
           <input
-            class="settings-add-input"
+            class="settings-input settings-add-input"
             type="text"
-            placeholder="/absolute/path/to/target-dir"
+            placeholder="/absolute/path/to/results-dir"
+            aria-label="Directory path to add"
           />
-          <button class="settings-add-btn" type="submit">Add</button>
+          <button
+            class="action-btn settings-browse-btn"
+            type="button"
+            @click=${() => onBrowseAdd?.()}
+          >Browse…</button>
+          <button class="action-btn action-btn--primary" type="submit">Add</button>
         </form>
-        ${
-          data?.error
-            ? html`<p class="settings-error">${data.error}</p>`
-            : nothing
-        }
       </section>
 
-      <section class="settings-block">
-        <h3 class="settings-h">Benchmark cache directory</h3>
-        <p class="settings-note">
-          Large HuggingFace datasets and repo mirrors are stored here — keep it
-          off your home volume. Resolves from
-          <code>cache_dir</code> → <code>WORCA_BENCH_CACHE</code> →
-          <code>~/.worca-bench/cache</code>.
-        </p>
-        <table class="settings-dirs">
-          <tbody>
-            <tr class="settings-dir settings-dir--cache">
-              <td class="settings-dir-path">${cache?.dir || '—'}</td>
-              <td class="settings-dir-tag">${cache?.source || 'default'}</td>
-            </tr>
-          </tbody>
-        </table>
-        <form class="settings-add" @submit=${submitCache}>
+      <section class="settings-card">
+        <div class="settings-card-head">
+          <h2 class="settings-card-title">Benchmark cache directory</h2>
+          <p class="settings-card-desc">
+            Large HuggingFace datasets and repo mirrors live here — keep it off
+            your home volume. Resolves <code>cache_dir</code> →
+            <code>WORCA_BENCH_CACHE</code> → <code>~/.worca-bench/cache</code>.
+          </p>
+        </div>
+        <div class="settings-list">
+          <div class="settings-row settings-dir--cache">
+            <span class="settings-row-icon">${unsafeHTML(DATABASE)}</span>
+            <span class="settings-row-path">${cache?.dir || '—'}</span>
+            ${
+              cache?.source && cache.source !== 'settings'
+                ? html`<span class="settings-row-hint">${cache.source}</span>`
+                : nothing
+            }
+          </div>
+        </div>
+        <form class="settings-inline-form" @submit=${submitCache}>
           <input
-            class="settings-cache-input settings-add-input"
+            class="settings-input settings-cache-input"
             type="text"
-            placeholder="/absolute/path/to/cache (blank to reset)"
+            placeholder="/absolute/path/to/cache"
+            aria-label="Cache directory path"
           />
-          <button class="settings-add-btn" type="submit">Set</button>
+          <button
+            class="action-btn"
+            type="button"
+            title="Reset to default"
+            @click=${() => onSetCache?.('')}
+          >Reset</button>
+          <button
+            class="action-btn settings-browse-btn"
+            type="button"
+            @click=${() => onBrowseCache?.()}
+          >Browse…</button>
+          <button class="action-btn action-btn--primary" type="submit">Set</button>
         </form>
       </section>
     </div>

--- a/worca-bench/app/views/settings.js
+++ b/worca-bench/app/views/settings.js
@@ -1,0 +1,100 @@
+// app/views/settings.js — manage the result directories the dashboard reads.
+//
+// The dashboard aggregates results.jsonl from the launch --target-dir (always
+// included) plus any directories configured in ~/.worca-bench/settings.json.
+// This page lists them and lets you add/remove the configured ones. The page
+// title + back button live in main.js's shared content header.
+
+import { html, nothing } from 'lit-html';
+
+/**
+ * @param {object} data  { primary, configured, effective, error? }
+ * @param {object} [handlers]
+ * @param {(dir: string) => void} [handlers.onAddDir]
+ * @param {(dir: string) => void} [handlers.onRemoveDir]
+ */
+export function settingsView(data, { onAddDir, onRemoveDir } = {}) {
+  const primary = data?.primary || null;
+  const configured = data?.configured || [];
+  const effective = data?.effective || [];
+
+  const submit = (e) => {
+    e.preventDefault();
+    const input = e.currentTarget.querySelector('.settings-add-input');
+    const value = (input?.value || '').trim();
+    if (value) {
+      onAddDir?.(value);
+      input.value = '';
+    }
+  };
+
+  return html`
+    <div class="settings-view">
+      <p class="settings-note">
+        The dashboard aggregates <code>results.jsonl</code> from the directories
+        below. The launch directory is always included; add more to view results
+        produced by other runs. Configuration is stored in
+        <code>~/.worca-bench/settings.json</code>.
+      </p>
+
+      <section class="settings-block">
+        <h3 class="settings-h">Result directories</h3>
+        <table class="settings-dirs">
+          <tbody>
+            ${
+              primary
+                ? html`<tr class="settings-dir settings-dir--primary">
+                    <td class="settings-dir-path">${primary}</td>
+                    <td class="settings-dir-tag">launch dir · always included</td>
+                    <td></td>
+                  </tr>`
+                : nothing
+            }
+            ${
+              configured.length === 0 && !primary
+                ? html`<tr>
+                    <td class="empty-state" colspan="3">
+                      No directories configured.
+                    </td>
+                  </tr>`
+                : nothing
+            }
+            ${configured.map(
+              (dir) => html`<tr class="settings-dir">
+                <td class="settings-dir-path">${dir}</td>
+                <td class="settings-dir-tag">
+                  ${effective.includes(dir) ? 'configured' : 'missing'}
+                </td>
+                <td>
+                  <button
+                    class="settings-remove"
+                    @click=${() => onRemoveDir?.(dir)}
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>`,
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <section class="settings-block">
+        <h3 class="settings-h">Add a directory</h3>
+        <form class="settings-add" @submit=${submit}>
+          <input
+            class="settings-add-input"
+            type="text"
+            placeholder="/absolute/path/to/target-dir"
+          />
+          <button class="settings-add-btn" type="submit">Add</button>
+        </form>
+        ${
+          data?.error
+            ? html`<p class="settings-error">${data.error}</p>`
+            : nothing
+        }
+      </section>
+    </div>
+  `;
+}

--- a/worca-bench/app/views/settings.test.js
+++ b/worca-bench/app/views/settings.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { settingsView } from './settings.js';
+
+// Minimal lit-html template stringifier (mirrors worca-ui's renderToString).
+function renderToString(template) {
+  if (template == null || template === false) return '';
+  if (typeof template === 'string') return template;
+  if (typeof template === 'number') return String(template);
+  if (Array.isArray(template)) return template.map(renderToString).join('');
+  if (!template.strings) return '';
+  let out = '';
+  template.strings.forEach((s, i) => {
+    out += s;
+    if (i < template.values.length) out += renderToString(template.values[i]);
+  });
+  return out;
+}
+
+describe('settingsView', () => {
+  it('renders the primary dir as always-included and lists configured dirs', () => {
+    const out = renderToString(
+      settingsView({
+        primary: '/runs/primary',
+        configured: ['/runs/extra'],
+        effective: ['/runs/primary', '/runs/extra'],
+      }),
+    );
+    expect(out).toContain('/runs/primary');
+    expect(out).toContain('always included');
+    expect(out).toContain('/runs/extra');
+    expect(out).toContain('Remove');
+    expect(out).toContain('settings-add'); // add form present
+  });
+
+  it('marks a configured dir that is not in the effective set as missing', () => {
+    const out = renderToString(
+      settingsView({
+        primary: '/p',
+        configured: ['/gone'],
+        effective: ['/p'],
+      }),
+    );
+    expect(out).toContain('missing');
+  });
+
+  it('surfaces an error message when present', () => {
+    const out = renderToString(
+      settingsView({
+        primary: '/p',
+        configured: [],
+        effective: ['/p'],
+        error: 'boom',
+      }),
+    );
+    expect(out).toContain('boom');
+  });
+});

--- a/worca-bench/app/views/settings.test.js
+++ b/worca-bench/app/views/settings.test.js
@@ -54,4 +54,17 @@ describe('settingsView', () => {
     );
     expect(out).toContain('boom');
   });
+
+  it('renders the grader credentials card with all three fields', () => {
+    const out = renderToString(
+      settingsView({ primary: '/p', configured: [], effective: ['/p'] }),
+    );
+    expect(out).toContain('Grader credentials');
+    expect(out).toContain('SWE-bench API key');
+    expect(out).toContain('Modal token ID');
+    expect(out).toContain('Modal token secret');
+    // Browser-only with no secrets stored → all show "Not set".
+    expect(out).toContain('Not set');
+    expect(out).toContain('only in this browser');
+  });
 });

--- a/worca-bench/app/views/sidebar.js
+++ b/worca-bench/app/views/sidebar.js
@@ -42,10 +42,6 @@ const NAV_ITEMS = Object.freeze([
   { key: 'leaderboard', label: 'Leaderboard', icon: 'leaderboard' },
 ]);
 
-const WORKSPACE_ITEMS = Object.freeze([
-  { key: 'settings', label: 'Settings', icon: 'settings' },
-]);
-
 function navItem(item, activeKey, onNavigate) {
   return html`
     <div
@@ -60,14 +56,37 @@ function navItem(item, activeKey, onNavigate) {
   `;
 }
 
+/** Backend connection indicator (mirrors worca-ui's conn-dot footer). */
+function connectionIndicator(connection) {
+  const cls =
+    connection === 'connected'
+      ? 'connected'
+      : connection === 'connecting'
+        ? 'connecting'
+        : 'disconnected';
+  const label =
+    connection === 'connected'
+      ? 'Connected'
+      : connection === 'connecting'
+        ? 'Connecting…'
+        : 'Disconnected';
+  return html`
+    <div class="connection-indicator ${cls}" title=${label}>
+      <span class="conn-dot"></span>
+      <span class="conn-label">${label}</span>
+    </div>
+  `;
+}
+
 /**
  * The left-rail navigation.
  *
- * @param {string} activeKey   one of 'dashboard' | 'compare' | 'leaderboard'
+ * @param {string} activeKey   one of 'dashboard' | 'compare' | 'leaderboard' | 'settings'
  * @param {object} [handlers]
  * @param {(key: string) => void} [handlers.onNavigate]
+ * @param {'connected'|'connecting'|'disconnected'} [handlers.connection]
  */
-export function sidebarView(activeKey, { onNavigate } = {}) {
+export function sidebarView(activeKey, { onNavigate, connection } = {}) {
   return html`
     <aside class="sidebar">
       <div class="sidebar-logo">
@@ -83,9 +102,16 @@ export function sidebarView(activeKey, { onNavigate } = {}) {
         ${NAV_ITEMS.map((item) => navItem(item, activeKey, onNavigate))}
       </div>
 
-      <div class="sidebar-section">
-        <div class="sidebar-section-header">Workspace</div>
-        ${WORKSPACE_ITEMS.map((item) => navItem(item, activeKey, onNavigate))}
+      <div class="sidebar-footer">
+        ${connectionIndicator(connection)}
+        <button
+          class="icon-btn sidebar-settings-btn ${activeKey === 'settings' ? 'active' : ''}"
+          aria-label="Settings"
+          title="Settings"
+          @click=${() => onNavigate?.('settings')}
+        >
+          ${unsafeHTML(iconSvg('settings', 18))}
+        </button>
       </div>
     </aside>
   `;

--- a/worca-bench/app/views/sidebar.js
+++ b/worca-bench/app/views/sidebar.js
@@ -5,10 +5,10 @@
 // `.sidebar` with a logo block and `.sidebar-section` / `.sidebar-item`
 // nav entries. The active section is highlighted via the `.active` class.
 //
-// Unlike worca-ui this rail is stateless and collapse-free — it only owns
-// the three benchmark sections (Dashboard, Compare, Leaderboard). Dashboard
-// is the home item; Compare and Leaderboard are reachable from here and from
-// the per-page back button in the content header.
+// Unlike worca-ui this rail is stateless and collapse-free. Dashboard,
+// Compare, Leaderboard, and Settings are all top-level sections reached from
+// here; only true drill-downs (profile detail) get a content-header back
+// button — the peer sections rely on the sidebar to navigate.
 
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';

--- a/worca-bench/app/views/sidebar.js
+++ b/worca-bench/app/views/sidebar.js
@@ -1,0 +1,92 @@
+// app/views/sidebar.js — worca-bench left-rail navigation.
+//
+// Mirrors worca-ui/app/views/sidebar.js structure + class names so the
+// benchmark dashboard shares the real app shell's look: a fixed-width
+// `.sidebar` with a logo block and `.sidebar-section` / `.sidebar-item`
+// nav entries. The active section is highlighted via the `.active` class.
+//
+// Unlike worca-ui this rail is stateless and collapse-free — it only owns
+// the three benchmark sections (Dashboard, Compare, Leaderboard). Dashboard
+// is the home item; Compare and Leaderboard are reachable from here and from
+// the per-page back button in the content header.
+
+import { html } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+
+// Lucide-derived icon paths, rendered inline via unsafeHTML to keep
+// worca-bench dependency-light (no lucide package) while matching worca-ui's
+// `iconSvg()` affordance in the sidebar items.
+const ICON_PATHS = Object.freeze({
+  // LayoutDashboard
+  dashboard:
+    '<rect width="7" height="9" x="3" y="3" rx="1"/><rect width="7" height="5" x="14" y="3" rx="1"/><rect width="7" height="9" x="14" y="12" rx="1"/><rect width="7" height="5" x="3" y="16" rx="1"/>',
+  // GitCompare
+  compare:
+    '<circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M11 18H8a2 2 0 0 1-2-2V9"/>',
+  // Trophy
+  leaderboard:
+    '<path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/><path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18"/><path d="M4 22h16"/><path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22"/><path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22"/><path d="M18 2H6v7a6 6 0 0 0 12 0V2Z"/>',
+  // Settings (gear)
+  settings:
+    '<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/>',
+});
+
+function iconSvg(name, size = 16) {
+  const path = ICON_PATHS[name] || '';
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${path}</svg>`;
+}
+
+const NAV_ITEMS = Object.freeze([
+  { key: 'dashboard', label: 'Dashboard', icon: 'dashboard' },
+  { key: 'compare', label: 'Compare', icon: 'compare' },
+  { key: 'leaderboard', label: 'Leaderboard', icon: 'leaderboard' },
+]);
+
+const WORKSPACE_ITEMS = Object.freeze([
+  { key: 'settings', label: 'Settings', icon: 'settings' },
+]);
+
+function navItem(item, activeKey, onNavigate) {
+  return html`
+    <div
+      class="sidebar-item ${activeKey === item.key ? 'active' : ''}"
+      @click=${() => onNavigate?.(item.key)}
+    >
+      <span class="sidebar-item-left">
+        ${unsafeHTML(iconSvg(item.icon, 16))}
+        <span>${item.label}</span>
+      </span>
+    </div>
+  `;
+}
+
+/**
+ * The left-rail navigation.
+ *
+ * @param {string} activeKey   one of 'dashboard' | 'compare' | 'leaderboard'
+ * @param {object} [handlers]
+ * @param {(key: string) => void} [handlers.onNavigate]
+ */
+export function sidebarView(activeKey, { onNavigate } = {}) {
+  return html`
+    <aside class="sidebar">
+      <div class="sidebar-logo">
+        <span
+          class="logo-text"
+          style="cursor:pointer"
+          @click=${() => onNavigate?.('dashboard')}
+        >worca-bench</span>
+      </div>
+
+      <div class="sidebar-section">
+        <div class="sidebar-section-header">Benchmarks</div>
+        ${NAV_ITEMS.map((item) => navItem(item, activeKey, onNavigate))}
+      </div>
+
+      <div class="sidebar-section">
+        <div class="sidebar-section-header">Workspace</div>
+        ${WORKSPACE_ITEMS.map((item) => navItem(item, activeKey, onNavigate))}
+      </div>
+    </aside>
+  `;
+}

--- a/worca-bench/bin/worca-bench-ui.js
+++ b/worca-bench/bin/worca-bench-ui.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// bin/worca-bench-ui.js
+//
+// Launches the worca-bench dashboard server. Resolves the results target
+// directory from --target-dir, then WORCA_BENCH_DIR, then ./worca-bench-out.
+
+import { createServer } from 'node:http';
+import { isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createApp } from '../server/app.js';
+
+/** Parse argv into { port, host, targetDir }. Exported for testing. */
+export function parseArgs(argv) {
+  const args = {
+    port: Number(process.env.PORT) || 3500,
+    host: process.env.HOST || '127.0.0.1',
+    targetDir: process.env.WORCA_BENCH_DIR || './worca-bench-out',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--port' && argv[i + 1]) {
+      args.port = Number(argv[++i]);
+    } else if (a === '--host' && argv[i + 1]) {
+      args.host = argv[++i];
+    } else if ((a === '--target-dir' || a === '--target') && argv[i + 1]) {
+      args.targetDir = argv[++i];
+    }
+  }
+  args.targetDir = isAbsolute(args.targetDir)
+    ? args.targetDir
+    : resolve(process.cwd(), args.targetDir);
+  return args;
+}
+
+export function startServer({ port, host, targetDir }) {
+  const app = createApp({ targetDir });
+  const server = createServer(app);
+  return new Promise((res) => {
+    server.listen(port, host, () => res(server));
+  });
+}
+
+// Only auto-run when invoked as a script (not when imported by tests).
+const invokedDirectly =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const args = parseArgs(process.argv.slice(2));
+  startServer(args).then(() => {
+    console.log(`worca-bench-ui listening on http://${args.host}:${args.port}`);
+    console.log(`reading results from ${args.targetDir}`);
+  });
+}

--- a/worca-bench/biome.json
+++ b/worca-bench/biome.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "root": ".."
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "app/**/*.js",
+      "server/**/*.js",
+      "bin/**/*.js",
+      "scripts/**/*.js",
+      "e2e/**/*.js",
+      "!app/main.bundle.js",
+      "!node_modules"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "json": {
+    "formatter": {
+      "enabled": false
+    }
+  }
+}

--- a/worca-bench/conftest.py
+++ b/worca-bench/conftest.py
@@ -1,0 +1,7 @@
+"""Make the ``worca_bench`` package importable when running tests in-tree
+without an editable install."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))

--- a/worca-bench/e2e/dashboard.spec.js
+++ b/worca-bench/e2e/dashboard.spec.js
@@ -180,13 +180,50 @@ test('dashboard auto-refreshes when new results land', async ({ page }) => {
   await expect(page.locator('.run-card')).toHaveCount(3);
 });
 
-test('settings page lists result directories from the sidebar', async ({
-  page,
-}) => {
+test('settings opens from the sidebar gear button', async ({ page }) => {
   await page.goto(srv.url);
-  await page.locator('.sidebar-item', { hasText: 'Settings' }).click();
+  await page.locator('.sidebar-settings-btn').click();
   await expect(page.locator('.content-header-title')).toContainText('Settings');
   await expect(page.locator('.settings-dirs')).toBeVisible();
   // the launch dir is always shown as primary
   await expect(page.locator('.settings-dir--primary')).toBeVisible();
+});
+
+test('sidebar footer shows the backend connection indicator', async ({
+  page,
+}) => {
+  await page.goto(srv.url);
+  const conn = page.locator('.connection-indicator');
+  await expect(conn).toBeVisible();
+  await expect(conn).toHaveClass(/connected/, { timeout: 4000 });
+  await expect(conn).toContainText('Connected');
+});
+
+test('Browse opens the folder picker and lists directories', async ({
+  page,
+}) => {
+  await page.goto(srv.url);
+  await page.locator('.sidebar-settings-btn').click();
+  await page.locator('.settings-browse-btn').first().click();
+  await expect(page.locator('#folder-picker-dialog')).toBeVisible();
+  // The picker lists subfolders of the home dir (at least the "up" entry shows).
+  await expect(page.locator('.folder-picker-path')).toBeVisible();
+});
+
+test('removing a result dir requires confirmation', async ({ page }) => {
+  // Seed a configured dir so a removable row exists.
+  await page.request.post(`${srv.url}/api/settings/dirs`, {
+    data: { dir: srv.targetDir },
+  });
+  await page.goto(srv.url);
+  await page.locator('.sidebar-settings-btn').click();
+  const removeBtn = page.locator('.settings-row-remove').first();
+  await expect(removeBtn).toBeVisible();
+  await removeBtn.click();
+  // Confirm dialog appears; cancel leaves the row in place.
+  await expect(page.locator('#global-confirm-dialog')).toBeVisible();
+  await page
+    .locator('#global-confirm-dialog sl-button[variant="default"]')
+    .click();
+  await expect(page.locator('.settings-row-remove')).toHaveCount(1);
 });

--- a/worca-bench/e2e/dashboard.spec.js
+++ b/worca-bench/e2e/dashboard.spec.js
@@ -121,6 +121,19 @@ test('select profiles and compare the chosen subset', async ({ page }) => {
   await expect(page.locator('.compare-table thead th')).toHaveCount(3);
 });
 
+test('clicking Run surfaces a launch toast with the pid', async ({ page }) => {
+  await page.goto(srv.url);
+  await expect(page.locator('.run-card').first()).toBeVisible();
+  // The stubbed launcher returns pid 1 (see fixtures.js).
+  await page
+    .locator('.run-card', { hasText: 'smoke-feature-opus' })
+    .getByRole('button', { name: 'Run' })
+    .click();
+  const toast = page.locator('.launch-toast--success');
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText('pid 1');
+});
+
 test('settings page lists result directories from the sidebar', async ({
   page,
 }) => {

--- a/worca-bench/e2e/dashboard.spec.js
+++ b/worca-bench/e2e/dashboard.spec.js
@@ -1,3 +1,5 @@
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { startServer } from './fixtures.js';
 
@@ -132,6 +134,50 @@ test('clicking Run surfaces a launch toast with the pid', async ({ page }) => {
   const toast = page.locator('.launch-toast--success');
   await expect(toast).toBeVisible();
   await expect(toast).toContainText('pid 1');
+});
+
+test('profile detail Run options launch reflects the reps override', async ({
+  page,
+}) => {
+  await page.goto(srv.url);
+  await page
+    .locator('.run-card-title', { hasText: 'smoke-feature-opus' })
+    .click();
+  await expect(page.locator('.run-options')).toBeVisible();
+  await page.locator('.run-opt-reps').fill('2');
+  await page.locator('.run-opt-launch').click();
+  const toast = page.locator('.launch-toast--success');
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText('2 reps');
+});
+
+test('dashboard auto-refreshes when new results land', async ({ page }) => {
+  // Fast poll so the test doesn't wait the default 5s tick.
+  await page.goto(`${srv.url}/?poll=400`);
+  await expect(page.locator('.run-card')).toHaveCount(2);
+  // A new profile's result row lands on disk out-of-band (as a real run would).
+  appendFileSync(
+    join(srv.targetDir, 'results.jsonl'),
+    `${JSON.stringify({
+      schema_version: 1,
+      profile: 'late-arrival',
+      benchmark: 'swe-bench-verified',
+      instance_id: 'inst-late',
+      rep: 1,
+      status: 'graded',
+      resolved: true,
+      score: 1.0,
+      cost_usd: 0.2,
+      wall_time_s: 300,
+      loop_counters: { implement_test: 1 },
+      completed_at: '2026-06-16T12:00:00Z',
+    })}\n`,
+  );
+  // The background poll picks it up and the new card appears without a reload.
+  await expect(
+    page.locator('.run-card-title', { hasText: 'late-arrival' }),
+  ).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('.run-card')).toHaveCount(3);
 });
 
 test('settings page lists result directories from the sidebar', async ({

--- a/worca-bench/e2e/dashboard.spec.js
+++ b/worca-bench/e2e/dashboard.spec.js
@@ -52,9 +52,48 @@ test('compare view renders a side-by-side table', async ({ page }) => {
   ]);
 });
 
-test('navigates from dashboard to leaderboard', async ({ page }) => {
+test('sidebar nav highlights the active section', async ({ page }) => {
   await page.goto(srv.url);
-  await page.locator('.nav-link', { hasText: 'Leaderboard' }).click();
+  // Dashboard is the home item and starts active.
+  await expect(
+    page.locator('.sidebar-item', { hasText: 'Dashboard' }),
+  ).toHaveClass(/active/);
+});
+
+test('navigates from dashboard to leaderboard via the sidebar', async ({
+  page,
+}) => {
+  await page.goto(srv.url);
+  await page.locator('.sidebar-item', { hasText: 'Leaderboard' }).click();
   await expect(page.locator('.leaderboard-table')).toBeVisible();
-  await expect(page.locator('h1')).toContainText('Leaderboard');
+  await expect(page.locator('.content-header-title')).toContainText(
+    'Leaderboard',
+  );
+  await expect(
+    page.locator('.sidebar-item', { hasText: 'Leaderboard' }),
+  ).toHaveClass(/active/);
+});
+
+test('sub-pages render a back button that returns to the dashboard', async ({
+  page,
+}) => {
+  await page.goto(srv.url);
+  await page
+    .locator('.run-card-title', { hasText: 'smoke-feature-opus' })
+    .click();
+  await expect(page.locator('.reps-table')).toBeVisible();
+  await expect(page.locator('.content-header-back')).toBeVisible();
+  await page.locator('.content-header-back').click();
+  await expect(page.locator('.profile-grid')).toBeVisible();
+});
+
+test('settings page lists result directories from the sidebar', async ({
+  page,
+}) => {
+  await page.goto(srv.url);
+  await page.locator('.sidebar-item', { hasText: 'Settings' }).click();
+  await expect(page.locator('.content-header-title')).toContainText('Settings');
+  await expect(page.locator('.settings-dirs')).toBeVisible();
+  // the launch dir is always shown as primary
+  await expect(page.locator('.settings-dir--primary')).toBeVisible();
 });

--- a/worca-bench/e2e/dashboard.spec.js
+++ b/worca-bench/e2e/dashboard.spec.js
@@ -87,6 +87,18 @@ test('sub-pages render a back button that returns to the dashboard', async ({
   await expect(page.locator('.profile-grid')).toBeVisible();
 });
 
+test('select profiles and compare the chosen subset', async ({ page }) => {
+  await page.goto(srv.url);
+  const checks = page.locator('.run-card-select');
+  await expect(checks).toHaveCount(2);
+  await checks.nth(0).check();
+  await checks.nth(1).check();
+  await page.getByRole('button', { name: /Compare selected/ }).click();
+  await expect(page.locator('.compare-table')).toBeVisible();
+  // Metric column + 2 profile columns.
+  await expect(page.locator('.compare-table thead th')).toHaveCount(3);
+});
+
 test('settings page lists result directories from the sidebar', async ({
   page,
 }) => {

--- a/worca-bench/e2e/dashboard.spec.js
+++ b/worca-bench/e2e/dashboard.spec.js
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+import { startServer } from './fixtures.js';
+
+let srv;
+
+test.beforeAll(async () => {
+  srv = await startServer();
+});
+
+test.afterAll(async () => {
+  await srv?.close();
+});
+
+test('dashboard renders profile cards', async ({ page }) => {
+  await page.goto(srv.url);
+  await expect(page.locator('.run-card').first()).toBeVisible();
+  const cards = page.locator('.run-card');
+  await expect(cards).toHaveCount(2);
+  await expect(page.locator('.run-card-title').first()).toContainText(
+    'smoke-feature-opus',
+  );
+});
+
+test('profile card shows a resolved-rate badge', async ({ page }) => {
+  await page.goto(srv.url);
+  await expect(page.locator('.run-card').first()).toBeVisible();
+  await expect(
+    page.locator('.run-card-stage-badge', { hasText: 'Resolved' }).first(),
+  ).toBeVisible();
+});
+
+test('navigating to a profile shows the detail reps table', async ({
+  page,
+}) => {
+  await page.goto(srv.url);
+  await page
+    .locator('.run-card-title', { hasText: 'smoke-feature-opus' })
+    .click();
+  await expect(page.locator('.reps-table')).toBeVisible();
+  await expect(page.locator('.reps-table tbody tr')).toHaveCount(2);
+});
+
+test('compare view renders a side-by-side table', async ({ page }) => {
+  await page.goto(
+    `${srv.url}/#/compare?profiles=smoke-feature-opus,smoke-quickfix-sonnet`,
+  );
+  await expect(page.locator('.compare-table')).toBeVisible();
+  await expect(page.locator('.compare-table th')).toContainText([
+    'Metric',
+    'smoke-feature-opus',
+    'smoke-quickfix-sonnet',
+  ]);
+});
+
+test('navigates from dashboard to leaderboard', async ({ page }) => {
+  await page.goto(srv.url);
+  await page.locator('.nav-link', { hasText: 'Leaderboard' }).click();
+  await expect(page.locator('.leaderboard-table')).toBeVisible();
+  await expect(page.locator('h1')).toContainText('Leaderboard');
+});

--- a/worca-bench/e2e/dashboard.spec.js
+++ b/worca-bench/e2e/dashboard.spec.js
@@ -74,6 +74,28 @@ test('navigates from dashboard to leaderboard via the sidebar', async ({
   ).toHaveClass(/active/);
 });
 
+test('leaderboard ranks local profile runs into the table', async ({
+  page,
+}) => {
+  await page.goto(`${srv.url}/#/leaderboard`);
+  await expect(page.locator('.leaderboard-table')).toBeVisible();
+  // Both seeded swe-bench-verified profiles surface as highlighted local rows…
+  await expect(page.locator('.leaderboard-row--local')).toHaveCount(2);
+  await expect(
+    page.locator('.leaderboard-row--local', {
+      hasText: 'smoke-quickfix-sonnet',
+    }),
+  ).toBeVisible();
+  // …and the "this run" placeholder is gone once real local rows exist.
+  await expect(page.getByText('worca (this run)')).toHaveCount(0);
+});
+
+test('top-level sidebar sections render no back button', async ({ page }) => {
+  await page.goto(`${srv.url}/#/leaderboard`);
+  await expect(page.locator('.leaderboard-table')).toBeVisible();
+  await expect(page.locator('.content-header-back')).toHaveCount(0);
+});
+
 test('sub-pages render a back button that returns to the dashboard', async ({
   page,
 }) => {

--- a/worca-bench/e2e/dashboard.spec.js
+++ b/worca-bench/e2e/dashboard.spec.js
@@ -123,19 +123,12 @@ test('select profiles and compare the chosen subset', async ({ page }) => {
   await expect(page.locator('.compare-table thead th')).toHaveCount(3);
 });
 
-test('clicking Run surfaces a launch toast with the pid', async ({ page }) => {
-  await page.goto(srv.url);
-  await expect(page.locator('.run-card').first()).toBeVisible();
-  // The stubbed launcher returns pid 1 (see fixtures.js).
-  await page
-    .locator('.run-card', { hasText: 'smoke-feature-opus' })
-    .getByRole('button', { name: 'Run' })
-    .click();
-  const toast = page.locator('.launch-toast--success');
-  await expect(toast).toBeVisible();
-  await expect(toast).toContainText('pid 1');
-});
-
+// NOTE: this detail-page launch test runs BEFORE the card-launch test below.
+// The detail-page Run button carries a `runDisabled` guard that fires when the
+// profile has a live `running` action; the stub launcher returns pid 1 (always
+// alive on POSIX), so a prior launch's action never reconciles to completed and
+// would leave this button disabled. Launching from here first keeps the action
+// state clean; the card Run button (next test) has no such guard.
 test('profile detail Run options launch reflects the reps override', async ({
   page,
 }) => {
@@ -149,6 +142,19 @@ test('profile detail Run options launch reflects the reps override', async ({
   const toast = page.locator('.launch-toast--success');
   await expect(toast).toBeVisible();
   await expect(toast).toContainText('2 reps');
+});
+
+test('clicking Run surfaces a launch toast with the pid', async ({ page }) => {
+  await page.goto(srv.url);
+  await expect(page.locator('.run-card').first()).toBeVisible();
+  // The stubbed launcher returns pid 1 (see fixtures.js).
+  await page
+    .locator('.run-card', { hasText: 'smoke-feature-opus' })
+    .getByRole('button', { name: 'Run' })
+    .click();
+  const toast = page.locator('.launch-toast--success');
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText('pid 1');
 });
 
 test('dashboard auto-refreshes when new results land', async ({ page }) => {
@@ -208,6 +214,41 @@ test('Browse opens the folder picker and lists directories', async ({
   await expect(page.locator('#folder-picker-dialog')).toBeVisible();
   // The picker lists subfolders of the home dir (at least the "up" entry shows).
   await expect(page.locator('.folder-picker-path')).toBeVisible();
+});
+
+// Runs late so the server-persisted archive state doesn't perturb the
+// card-count assertions in earlier tests. Restores state (un-archives) at the end.
+test('archive hides a profile, the Archived filter reveals it', async ({
+  page,
+}) => {
+  await page.goto(srv.url);
+  await expect(page.locator('.profile-filter')).toBeVisible();
+  const card = page.locator('.run-card', { hasText: 'smoke-feature-opus' });
+  await expect(card).toBeVisible();
+
+  // Select it and archive via the leftmost header action.
+  await card.locator('.run-card-select').check();
+  await page.getByRole('button', { name: /^Archive \(1\)/ }).click();
+
+  // Gone from the default (Active) view.
+  await expect(
+    page.locator('.run-card', { hasText: 'smoke-feature-opus' }),
+  ).toHaveCount(0);
+
+  // The Archived pill reveals it.
+  await page.locator('.filter-pill', { hasText: 'Archived' }).click();
+  const archivedCard = page.locator('.run-card', {
+    hasText: 'smoke-feature-opus',
+  });
+  await expect(archivedCard).toBeVisible();
+  await expect(archivedCard).toHaveClass(/run-card--archived/);
+
+  // Restore: un-archive so the persisted state is clean for re-runs.
+  await archivedCard.locator('.run-card-select').check();
+  await page.getByRole('button', { name: /^Unarchive \(1\)/ }).click();
+  await expect(
+    page.locator('.run-card', { hasText: 'smoke-feature-opus' }),
+  ).toHaveCount(0); // gone from the Archived view now
 });
 
 test('removing a result dir requires confirmation', async ({ page }) => {

--- a/worca-bench/e2e/fixtures.js
+++ b/worca-bench/e2e/fixtures.js
@@ -1,0 +1,80 @@
+/**
+ * Playwright fixtures for worca-bench. Spins up an isolated dashboard server
+ * on a random port backed by a temp target-dir seeded with a results.jsonl
+ * fixture. Mirrors worca-ui/e2e/fixtures.js startServer pattern.
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createApp } from '../server/app.js';
+
+function row(overrides = {}) {
+  return {
+    schema_version: 1,
+    profile: 'p1',
+    benchmark: 'swe-bench-verified',
+    instance_id: 'astropy__astropy-12907',
+    worca_ref: 'local',
+    template: 'builtin:feature',
+    rep: 1,
+    run_id: 'r1',
+    status: 'graded',
+    resolved: true,
+    score: 1.0,
+    cost_usd: 0.42,
+    wall_time_s: 612,
+    loop_counters: { implement_test: 2, pr_changes: 0 },
+    completed_at: '2026-06-16T10:00:00Z',
+    ...overrides,
+  };
+}
+
+/** The default seeded fixture: two profiles so Compare is exercised. */
+export const FIXTURE_ROWS = [
+  row({ profile: 'smoke-feature-opus', rep: 1, resolved: true }),
+  row({ profile: 'smoke-feature-opus', rep: 2, resolved: false, score: 0.0 }),
+  row({
+    profile: 'smoke-quickfix-sonnet',
+    rep: 1,
+    resolved: true,
+    cost_usd: 0.12,
+  }),
+];
+
+/**
+ * Start an isolated worca-bench server on a random port.
+ *
+ * @param {object[]} [rows] results rows to seed (defaults to FIXTURE_ROWS)
+ * @returns {Promise<{ url: string, port: number, targetDir: string, close: () => Promise<void> }>}
+ */
+export async function startServer(rows = FIXTURE_ROWS) {
+  const targetDir = join(
+    tmpdir(),
+    `worca-bench-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(targetDir, { recursive: true });
+  writeFileSync(
+    join(targetDir, 'results.jsonl'),
+    `${rows.map((r) => JSON.stringify(r)).join('\n')}\n`,
+  );
+
+  const app = createApp({
+    targetDir,
+    // Don't actually spawn python in e2e — stub the launcher.
+    _runBenchmark: async () => ({ pid: 1 }),
+  });
+  const server = createServer(app);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    port,
+    targetDir,
+    close: () =>
+      new Promise((resolve) => server.close(resolve)).finally(() =>
+        rmSync(targetDir, { recursive: true, force: true }),
+      ),
+  };
+}

--- a/worca-bench/e2e/fixtures.js
+++ b/worca-bench/e2e/fixtures.js
@@ -63,6 +63,10 @@ export async function startServer(rows = FIXTURE_ROWS) {
     targetDir,
     // Don't actually spawn python in e2e — stub the launcher.
     _runBenchmark: async () => ({ pid: 1 }),
+    // Keep the leaderboard hermetic (no live network fetch) in e2e.
+    leaderboardOffline: true,
+    // Isolate settings under the temp target dir (never the real ~/.worca-bench).
+    settingsHome: join(targetDir, '.worca-bench-home'),
   });
   const server = createServer(app);
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));

--- a/worca-bench/package-lock.json
+++ b/worca-bench/package-lock.json
@@ -1,0 +1,3771 @@
+{
+  "name": "@worca/bench-ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@worca/bench-ui",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@shoelace-style/shoelace": "^2.20.1",
+        "express": "^5.2.1",
+        "lit-html": "^3.3.1"
+      },
+      "bin": {
+        "worca-bench-ui": "bin/worca-bench-ui.js"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.2.4",
+        "@playwright/test": "^1.60.0",
+        "@vitest/coverage-v8": "^4.0.15",
+        "esbuild": "^0.27.1",
+        "jsdom": "^29.0.1",
+        "vitest": "^4.0.15"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.0.tgz",
+      "integrity": "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.0",
+        "@biomejs/cli-darwin-x64": "2.5.0",
+        "@biomejs/cli-linux-arm64": "2.5.0",
+        "@biomejs/cli-linux-arm64-musl": "2.5.0",
+        "@biomejs/cli-linux-x64": "2.5.0",
+        "@biomejs/cli-linux-x64-musl": "2.5.0",
+        "@biomejs/cli-win32-arm64": "2.5.0",
+        "@biomejs/cli-win32-x64": "2.5.0"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.0.tgz",
+      "integrity": "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.0.tgz",
+      "integrity": "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.0.tgz",
+      "integrity": "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.0.tgz",
+      "integrity": "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.0.tgz",
+      "integrity": "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.0.tgz",
+      "integrity": "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.0.tgz",
+      "integrity": "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.0.tgz",
+      "integrity": "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shoelace-style/animations": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.2.0.tgz",
+      "integrity": "sha512-avvo1xxkLbv2dgtabdewBbqcJfV0e0zCwFqkPMnHFGbJbBHorRFfMAHh1NG9ymmXn0jW95ibUVH03E1NYXD6Gw==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/claviska"
+      }
+    },
+    "node_modules/@shoelace-style/localize": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.2.tgz",
+      "integrity": "sha512-h3+2/cFWGaw3KQUwintkP4Cy3PtrVW//ysr9DM5nOfIXYekgrHwsELk/nyxc8hmjVP/Kcon7KCzvUtSwUBipfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@shoelace-style/shoelace": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.20.1.tgz",
+      "integrity": "sha512-FSghU95jZPGbwr/mybVvk66qRZYpx5FkXL+vLNpy1Vp8UsdwSxXjIHE3fsvMbKWTKi9UFfewHTkc5e7jAqRYoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.1.0",
+        "@floating-ui/dom": "^1.6.12",
+        "@lit/react": "^1.0.6",
+        "@shoelace-style/animations": "^1.2.0",
+        "@shoelace-style/localize": "^3.2.1",
+        "composed-offset-position": "^0.0.6",
+        "lit": "^3.2.1",
+        "qr-creator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14.17.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/claviska"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/composed-offset-position": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.6.tgz",
+      "integrity": "sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@floating-ui/utils": "^0.2.5"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qr-creator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
+      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+      "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.3"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/worca-bench/package.json
+++ b/worca-bench/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@worca/bench-ui",
+  "version": "0.1.0",
+  "description": "Benchmark results dashboard for worca-bench",
+  "license": "MIT",
+  "author": "Sinisha Djukic",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SinishaDjukic/worca-cc.git",
+    "directory": "worca-bench"
+  },
+  "keywords": [
+    "worca",
+    "benchmark",
+    "swe-bench",
+    "dashboard",
+    "ai-agents",
+    "leaderboard"
+  ],
+  "type": "module",
+  "bin": {
+    "worca-bench-ui": "./bin/worca-bench-ui.js"
+  },
+  "files": [
+    "bin/",
+    "server/**/*.js",
+    "!server/**/*.test.js",
+    "app/index.html",
+    "app/styles.css",
+    "app/main.bundle.js",
+    "app/main.bundle.js.map",
+    "app/vendor/",
+    "scripts/"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "node scripts/build-frontend.js",
+    "start": "node bin/worca-bench-ui.js",
+    "prepublishOnly": "npm run build && npm test",
+    "test": "vitest run",
+    "test:browser": "playwright test",
+    "lint": "biome check",
+    "lint:fix": "biome check --write"
+  },
+  "dependencies": {
+    "@shoelace-style/shoelace": "^2.20.1",
+    "express": "^5.2.1",
+    "lit-html": "^3.3.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.2.4",
+    "@playwright/test": "^1.60.0",
+    "@vitest/coverage-v8": "^4.0.15",
+    "esbuild": "^0.27.1",
+    "jsdom": "^29.0.1",
+    "vitest": "^4.0.15"
+  }
+}

--- a/worca-bench/playwright.config.js
+++ b/worca-bench/playwright.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60000,
+  expect: {
+    timeout: 15000,
+  },
+  use: {
+    screenshot: 'only-on-failure',
+    navigationTimeout: 15000,
+    actionTimeout: 15000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/worca-bench/profiles/commit0-feature.yaml
+++ b/worca-bench/profiles/commit0-feature.yaml
@@ -1,0 +1,20 @@
+# Example: Commit0 greenfield library build. Gold tests are hidden during the run and
+# the source-only diff is graded on a pristine tree (see W-075 §3).
+# Requires `commit0 setup lite` to produce skeletons + a generated instances file.
+name: commit0-feature
+benchmark: commit0
+worca:
+  ref: master
+selection:
+  instances_file: ./out/commit0-instances.json   # [{instance_id, local_repo, spec, gold_test_paths}]
+template: builtin:feature
+reps: 3
+grade:
+  mode: local-docker            # commit0 runs its tests in Docker
+concurrency:
+  worca: 3
+  grade: 2
+settings:
+  models:
+    opus: claude-opus-4-8
+    sonnet: claude-sonnet-4-6

--- a/worca-bench/profiles/swebench-feature-opus.yaml
+++ b/worca-bench/profiles/swebench-feature-opus.yaml
@@ -1,0 +1,22 @@
+# Example: SWE-bench Verified, a small fixed subset, graded via sb-cli (no local Docker).
+# Run:  worca-bench run --profile swebench-feature-opus --target-dir ./out
+name: swebench-feature-opus
+benchmark: swe-bench-verified
+worca:
+  ref: master                 # branch | tag | commit | "0.58.0" (released) | local
+selection:
+  instance_ids:
+    - astropy__astropy-12907
+    - django__django-11099
+template: builtin:feature      # tier:name
+reps: 3                        # samples per instance to beat run-to-run noise
+grade:
+  mode: sb-cli                 # stub | sb-cli | modal | local-docker
+concurrency:
+  worca: 4
+  grade: 4
+# Model aliases (cross-template; secrets come from the environment, never here).
+settings:
+  models:
+    opus: claude-opus-4-8
+    sonnet: claude-sonnet-4-6

--- a/worca-bench/pyproject.toml
+++ b/worca-bench/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "worca-bench"
+version = "0.1.0"
+description = "Config-evaluation harness for worca pipelines against SWE-bench Verified and Commit0 (W-075)"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+dependencies = [
+    "PyYAML>=6.0",
+]
+
+[project.optional-dependencies]
+# Real benchmark grading. Kept optional so unit tests run without Docker/HF/network.
+swebench = ["datasets>=2.0", "sb-cli>=0.1"]
+commit0 = ["commit0"]
+dev = ["pytest>=7.0", "pytest-timeout>=2.0", "PyYAML>=6.0"]
+
+[project.scripts]
+worca-bench = "worca_bench.cli:main"
+
+[tool.setuptools]
+packages = ["worca_bench", "worca_bench.plugins"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+worca_bench = ["overlays/*.json"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+timeout = 300
+markers = [
+    "live_worca: end-to-end test that spawns a real worca pipeline with mock Claude (slow; skipped if worca is not importable)",
+]

--- a/worca-bench/scripts/build-frontend.js
+++ b/worca-bench/scripts/build-frontend.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import { copyFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+async function run() {
+  const thisFile = fileURLToPath(new URL(import.meta.url));
+  const repoRoot = path.resolve(path.dirname(thisFile), '..');
+  const appDir = path.join(repoRoot, 'app');
+  const entry = path.join(appDir, 'main.js');
+  const outfile = path.join(appDir, 'main.bundle.js');
+  const vendorDir = path.join(appDir, 'vendor');
+
+  mkdirSync(appDir, { recursive: true });
+  mkdirSync(vendorDir, { recursive: true });
+
+  // Copy vendor CSS assets — Shoelace light/dark themes.
+  const vendorAssets = [
+    ['@shoelace-style/shoelace/dist/themes/light.css', 'shoelace-light.css'],
+    ['@shoelace-style/shoelace/dist/themes/dark.css', 'shoelace-dark.css'],
+  ];
+  for (const [src, dest] of vendorAssets) {
+    const srcPath = path.join(repoRoot, 'node_modules', src);
+    copyFileSync(srcPath, path.join(vendorDir, dest));
+    console.log('copied', dest);
+  }
+
+  try {
+    const esbuild = await import('esbuild');
+    await esbuild.build({
+      entryPoints: [entry],
+      bundle: true,
+      format: 'esm',
+      platform: 'browser',
+      target: 'es2020',
+      outfile,
+      sourcemap: true,
+      minify: true,
+      legalComments: 'none',
+    });
+    console.log('built', path.relative(repoRoot, outfile));
+  } catch (err) {
+    console.error('bundle error', err);
+    process.exitCode = 1;
+  }
+}
+
+run();

--- a/worca-bench/scripts/cleanup-work.sh
+++ b/worca-bench/scripts/cleanup-work.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# cleanup-work.sh — remove transient per-rep work trees from a worca-bench
+# results dir. The `work/` checkouts (one git clone per rep) are large and safe
+# to delete — the runner recreates them on the next run. Killed/interrupted runs
+# leave them behind, where their stale status.json can also show up as phantom
+# "active" runs in the dashboard.
+#
+# Usage:
+#   scripts/cleanup-work.sh <results-dir>            # remove work/ only
+#   scripts/cleanup-work.sh <results-dir> --runs     # also remove archived runs/
+#   scripts/cleanup-work.sh <results-dir> --results  # also clear results.jsonl (DESTRUCTIVE)
+set -euo pipefail
+
+DIR=${1:-}
+if [ -z "$DIR" ] || [ ! -d "$DIR" ]; then
+  echo "usage: cleanup-work.sh <results-dir> [--runs] [--results]" >&2
+  exit 2
+fi
+DIR=${DIR%/}
+shift || true
+
+# Safety: refuse anything that does not look like a worca-bench results dir.
+case "$DIR" in
+  "" | "/" | "$HOME")
+    echo "refusing to operate on '$DIR'" >&2; exit 2 ;;
+esac
+if [ ! -d "$DIR/work" ] && [ ! -d "$DIR/profiles" ] && [ ! -f "$DIR/results.jsonl" ]; then
+  echo "refusing: '$DIR' has no work/ | profiles/ | results.jsonl (not a results dir)" >&2
+  exit 2
+fi
+
+if [ -d "$DIR/work" ]; then
+  rm -rf "$DIR/work"
+  echo "removed $DIR/work"
+else
+  echo "no $DIR/work to remove"
+fi
+
+for arg in "$@"; do
+  case "$arg" in
+    --runs)
+      [ -d "$DIR/runs" ] && rm -rf "$DIR/runs" && echo "removed $DIR/runs" ;;
+    --results)
+      [ -f "$DIR/results.jsonl" ] && rm -f "$DIR/results.jsonl" && echo "cleared $DIR/results.jsonl" ;;
+    *) echo "ignoring unknown arg: $arg" >&2 ;;
+  esac
+done
+echo "done."

--- a/worca-bench/scripts/teardown-runs.sh
+++ b/worca-bench/scripts/teardown-runs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# teardown-runs.sh — stop all worca-bench run processes and their descendants.
+#
+# Kills the process TREES rooted at a worca-bench run (the runner CLI, the
+# run_pipeline subprocess, and the agent / claude / git children they spawned).
+# It targets only descendants of a worca-bench run, so an interactive `claude`
+# session and the dashboard server (`worca-bench-ui.js`) are left untouched.
+#
+# Usage: scripts/teardown-runs.sh [--dry-run]
+set -euo pipefail
+
+PATTERN='worca_bench\.cli run|worca\.scripts\.run_pipeline'
+DRY=0
+[ "${1:-}" = "--dry-run" ] && DRY=1
+
+# Emit a pid and all of its descendants (depth-first).
+descendants() {
+  local pid=$1
+  echo "$pid"
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    descendants "$child"
+  done
+}
+
+roots=$(pgrep -f "$PATTERN" 2>/dev/null || true)
+if [ -z "$roots" ]; then
+  echo "No worca-bench run processes found."
+  exit 0
+fi
+
+all=$(for r in $roots; do descendants "$r"; done | sort -un)
+echo "Run process trees:"
+ps -o pid,command -p $(echo "$all" | tr '\n' ',' | sed 's/,$//') 2>/dev/null || true
+
+if [ "$DRY" = 1 ]; then
+  echo "(dry-run: nothing killed)"
+  exit 0
+fi
+
+# Graceful, then force.
+for p in $all; do kill -TERM "$p" 2>/dev/null || true; done
+sleep 2
+for p in $all; do kill -KILL "$p" 2>/dev/null || true; done
+# Sweep stragglers that orphaned after their parent died.
+pkill -KILL -f "$PATTERN" 2>/dev/null || true
+sleep 1
+
+remaining=$(pgrep -f "$PATTERN" 2>/dev/null || true)
+if [ -n "$remaining" ]; then
+  echo "WARNING: still running: $remaining" >&2
+  exit 1
+fi
+echo "All worca-bench run processes stopped."
+echo "(Note: a fully-orphaned agent/claude process — parent already gone — is"
+echo " not a descendant of any run and will wind down on its own.)"

--- a/worca-bench/server/actions-store.js
+++ b/worca-bench/server/actions-store.js
@@ -1,0 +1,136 @@
+// server/actions-store.js
+//
+// A persistent, self-healing ledger of long-running *actions* (a Run launch or a
+// Regrade sweep) so the UI can show "started / running / completed / failed" with
+// start+end times — visible at all times and surviving a page reload. Mirrors the
+// append-only, dependency-free pattern of results-store.js: the source of truth is
+// `<target-dir>/actions.jsonl`, one JSON object per write; the latest line for a
+// given `id` wins, so a lifecycle transition is just another append.
+//
+// The server spawns Run/Regrade as *detached* subprocesses (it never waits for
+// exit), so terminal state is detected by reconciling pid liveness on read: a
+// `running` action whose pid is no longer alive is marked `completed` and that
+// terminal record is persisted (stable `ended_at`). Progress (instances done /
+// regrade counts) is NOT stored here — app.js derives it by joining results.jsonl
+// and the regrade heartbeat at read time, keeping this ledger pure identity+state.
+
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FILE = 'actions.jsonl';
+
+/** Terminal statuses — a pid is no longer expected to be alive for these. */
+const TERMINAL = new Set(['completed', 'failed', 'stopped']);
+
+/** POSIX liveness probe. `kill(pid, 0)` throws ESRCH if gone, EPERM if alive
+ *  but not ours (still counts as alive). Never actually signals the process. */
+export function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code === 'EPERM';
+  }
+}
+
+function _file(targetDir) {
+  return join(targetDir, FILE);
+}
+
+/** Append one ledger record (a create or a patch). */
+export function appendAction(targetDir, rec) {
+  appendFileSync(_file(targetDir), `${JSON.stringify(rec)}\n`, 'utf8');
+}
+
+/** Record a freshly-spawned action as `running`. Returns the stored record. */
+export function recordAction(
+  targetDir,
+  { type, profile, src, pid, params, startedAt },
+) {
+  const started = startedAt || new Date().toISOString();
+  const rec = {
+    id: `${type}-${profile}-${pid}-${Date.parse(started)}`,
+    type,
+    profile,
+    src: src ?? null,
+    pid: pid ?? null,
+    params: params ?? {},
+    status: 'running',
+    started_at: started,
+    updated_at: started,
+  };
+  appendAction(targetDir, rec);
+  return rec;
+}
+
+/** Append a lifecycle/field patch for an existing action id. */
+export function patchAction(targetDir, id, patch) {
+  appendAction(targetDir, {
+    id,
+    ...patch,
+    updated_at: new Date().toISOString(),
+  });
+}
+
+function _collapse(targetDir) {
+  const path = _file(targetDir);
+  if (!existsSync(path)) return new Map();
+  const byId = new Map();
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    let rec;
+    try {
+      rec = JSON.parse(t);
+    } catch {
+      continue; // skip a torn append, never blank the ledger
+    }
+    if (!rec.id) continue;
+    const prev = byId.get(rec.id);
+    byId.set(rec.id, prev ? { ...prev, ...rec } : rec);
+  }
+  return byId;
+}
+
+/**
+ * Read all actions (latest record per id), reconciling dead pids to a terminal
+ * `completed` state. Returns newest-first.
+ *
+ * @param {string} targetDir
+ * @param {{_pidAlive?: (pid:number)=>boolean, reconcile?: boolean, now?: string}} [opts]
+ *   `_pidAlive` is injectable for tests; `reconcile:false` skips the write-back.
+ */
+export function readActions(targetDir, opts = {}) {
+  const { _pidAlive = pidAlive, reconcile = true, now } = opts;
+  const byId = _collapse(targetDir);
+  const out = [];
+  for (const rec of byId.values()) {
+    let a = rec;
+    if (!TERMINAL.has(a.status) && !_pidAlive(a.pid)) {
+      // The detached subprocess is gone with no explicit terminal write —
+      // mark it completed (per-instance errors surface via derived progress).
+      const ended = now || new Date().toISOString();
+      a = { ...a, status: 'completed', ended_at: ended, updated_at: ended };
+      if (reconcile)
+        appendAction(targetDir, {
+          id: a.id,
+          status: 'completed',
+          ended_at: ended,
+          updated_at: ended,
+        });
+    }
+    out.push(a);
+  }
+  out.sort((x, y) => (y.started_at || '').localeCompare(x.started_at || ''));
+  return out;
+}
+
+/** Find one action by id (no reconcile write-back). */
+export function findAction(targetDir, id, opts = {}) {
+  return (
+    readActions(targetDir, { ...opts, reconcile: false }).find(
+      (a) => a.id === id,
+    ) || null
+  );
+}

--- a/worca-bench/server/actions-store.js
+++ b/worca-bench/server/actions-store.js
@@ -43,16 +43,23 @@ export function appendAction(targetDir, rec) {
   appendFileSync(_file(targetDir), `${JSON.stringify(rec)}\n`, 'utf8');
 }
 
-/** Record a freshly-spawned action as `running`. Returns the stored record. */
+/**
+ * Record a freshly-spawned action as `running`. Returns the stored record.
+ *
+ * The real CLI (worca_bench/actions.py) is the production writer; this mirrors its
+ * schema (incl. `source_dir`, from which the server backfills `src`). Kept here
+ * for tests + as a JS reference of the on-disk format.
+ */
 export function recordAction(
   targetDir,
-  { type, profile, src, pid, params, startedAt },
+  { type, profile, src, source_dir, pid, params, startedAt },
 ) {
   const started = startedAt || new Date().toISOString();
   const rec = {
     id: `${type}-${profile}-${pid}-${Date.parse(started)}`,
     type,
     profile,
+    source_dir: source_dir ?? null,
     src: src ?? null,
     pid: pid ?? null,
     params: params ?? {},

--- a/worca-bench/server/actions-store.test.js
+++ b/worca-bench/server/actions-store.test.js
@@ -1,0 +1,125 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  findAction,
+  patchAction,
+  pidAlive,
+  readActions,
+  recordAction,
+} from './actions-store.js';
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'wb-actions-'));
+});
+
+const ALIVE = () => true;
+const DEAD = () => false;
+
+describe('recordAction / readActions', () => {
+  it('records a running action with id + timestamps', () => {
+    const rec = recordAction(dir, {
+      type: 'run',
+      profile: 'demo',
+      src: 'abc123',
+      pid: 4242,
+      params: { reps: 1 },
+      startedAt: '2026-06-18T10:00:00.000Z',
+    });
+    expect(rec.status).toBe('running');
+    expect(rec.type).toBe('run');
+    expect(rec.id).toContain('run-demo-4242');
+    const [a] = readActions(dir, { _pidAlive: ALIVE });
+    expect(a.id).toBe(rec.id);
+    expect(a.status).toBe('running');
+    expect(a.params.reps).toBe(1);
+  });
+
+  it('collapses to the latest record per id (patch wins)', () => {
+    const rec = recordAction(dir, { type: 'regrade', profile: 'p', pid: 7 });
+    patchAction(dir, rec.id, {
+      status: 'stopped',
+      ended_at: '2026-06-18T11:00:00Z',
+    });
+    const [a] = readActions(dir, { _pidAlive: ALIVE });
+    expect(a.status).toBe('stopped');
+    expect(a.ended_at).toBe('2026-06-18T11:00:00Z');
+  });
+
+  it('reconciles a dead pid to completed and persists the terminal record', () => {
+    const rec = recordAction(dir, { type: 'run', profile: 'p', pid: 999999 });
+    const [a] = readActions(dir, {
+      _pidAlive: DEAD,
+      now: '2026-06-18T12:00:00Z',
+    });
+    expect(a.status).toBe('completed');
+    expect(a.ended_at).toBe('2026-06-18T12:00:00Z');
+    // persisted: a fresh read (even claiming alive) stays completed
+    const [b] = readActions(dir, { _pidAlive: ALIVE });
+    expect(b.status).toBe('completed');
+    expect(b.id).toBe(rec.id);
+  });
+
+  it('keeps an action running while its pid is alive', () => {
+    recordAction(dir, { type: 'run', profile: 'p', pid: 123 });
+    const [a] = readActions(dir, { _pidAlive: ALIVE });
+    expect(a.status).toBe('running');
+    expect(a.ended_at).toBeUndefined();
+  });
+
+  it('does not resurrect an explicitly stopped action even if pid looks dead', () => {
+    const rec = recordAction(dir, { type: 'run', profile: 'p', pid: 5 });
+    patchAction(dir, rec.id, {
+      status: 'stopped',
+      ended_at: '2026-06-18T11:00:00Z',
+    });
+    const [a] = readActions(dir, { _pidAlive: DEAD });
+    expect(a.status).toBe('stopped'); // terminal, untouched by reconciliation
+  });
+
+  it('skips malformed lines without throwing', () => {
+    recordAction(dir, { type: 'run', profile: 'good', pid: 1 });
+    const f = join(dir, 'actions.jsonl');
+    writeFileSync(f, `${readFileSync(f, 'utf8')}{torn\n`);
+    const all = readActions(dir, { _pidAlive: ALIVE });
+    expect(all.length).toBe(1);
+    expect(all[0].profile).toBe('good');
+  });
+
+  it('returns actions newest-first by started_at', () => {
+    recordAction(dir, {
+      type: 'run',
+      profile: 'old',
+      pid: 1,
+      startedAt: '2026-06-18T09:00:00Z',
+    });
+    recordAction(dir, {
+      type: 'run',
+      profile: 'new',
+      pid: 2,
+      startedAt: '2026-06-18T10:00:00Z',
+    });
+    const order = readActions(dir, { _pidAlive: ALIVE }).map((a) => a.profile);
+    expect(order).toEqual(['new', 'old']);
+  });
+
+  it('findAction returns one by id without a reconcile write-back', () => {
+    const rec = recordAction(dir, { type: 'regrade', profile: 'p', pid: 3 });
+    const before = readFileSync(join(dir, 'actions.jsonl'), 'utf8');
+    const a = findAction(dir, rec.id, { _pidAlive: DEAD });
+    expect(a.id).toBe(rec.id);
+    // no extra terminal line appended (reconcile suppressed)
+    expect(readFileSync(join(dir, 'actions.jsonl'), 'utf8')).toBe(before);
+  });
+});
+
+describe('pidAlive', () => {
+  it('is true for the current process and false for an invalid pid', () => {
+    expect(pidAlive(process.pid)).toBe(true);
+    expect(pidAlive(0)).toBe(false);
+    expect(pidAlive(-1)).toBe(false);
+    expect(pidAlive(undefined)).toBe(false);
+  });
+});

--- a/worca-bench/server/active-runs.js
+++ b/worca-bench/server/active-runs.js
@@ -187,6 +187,58 @@ export function discoverActiveMulti(dirs) {
   return out;
 }
 
+/** True if `pid` names a live process we can see (EPERM = alive but not ours). */
+function pidAlive(pid) {
+  if (!Number.isInteger(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code === 'EPERM';
+  }
+}
+
+/**
+ * Discover regrade sweeps under one target dir from their heartbeat files
+ * (<dir>/runs/<profile>/regrade-status.json). A `running` heartbeat whose pid is
+ * gone is reclassified `ended` so a crashed sweep never shows as live forever.
+ *
+ * @returns {Array<{profile, src, mode, total, done, current, counts, status, active, started_at, updated_at, pid}>}
+ */
+export function discoverRegrades(dir) {
+  const runsRoot = join(dir, 'runs');
+  if (!existsSync(runsRoot)) return [];
+  const out = [];
+  for (const p of safeReaddir(runsRoot)) {
+    if (!p.isDirectory()) continue;
+    const f = join(runsRoot, p.name, 'regrade-status.json');
+    if (!existsSync(f)) continue;
+    let s;
+    try {
+      s = JSON.parse(readFileSync(f, 'utf8'));
+    } catch {
+      continue;
+    }
+    s.src = srcHash(dir);
+    if (s.status === 'running' && !pidAlive(s.pid)) s.status = 'ended';
+    s.active = s.status === 'running';
+    out.push(s);
+  }
+  return out;
+}
+
+/** Discover regrade sweeps across several dirs (deduped by dir). */
+export function discoverRegradesMulti(dirs) {
+  const out = [];
+  const seen = new Set();
+  for (const dir of dirs) {
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    out.push(...discoverRegrades(dir));
+  }
+  return out;
+}
+
 /** Map `<src>::<profile>` -> its most-recently-updated active run (card badges). */
 export function activeByProfile(active) {
   const map = new Map();

--- a/worca-bench/server/active-runs.js
+++ b/worca-bench/server/active-runs.js
@@ -11,7 +11,7 @@
 // work/" IS the live window.
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { basename, join, relative, sep } from 'node:path';
+import { basename, dirname, join, relative, sep } from 'node:path';
 
 const STATUS_SEG = `${'.worca'}/runs`; // status.json lives at .worca/runs/<id>/status.json
 
@@ -86,6 +86,40 @@ function instanceRep(profileWorkDir, statusFile) {
 }
 
 /**
+ * Read the template's per-stage enabled flags from the work tree (the
+ * template-resolved truth, not the all-enabled base settings.json). Returns a
+ * `{stage: enabled}` map, or null if it can't be resolved (then show all).
+ * status.json lives at <repRoot>/.worca/runs/<id>/status.json.
+ */
+function enabledStageMap(statusFile, pipelineTemplate) {
+  if (!pipelineTemplate) return null;
+  const id = String(pipelineTemplate).replace(/^(builtin|project|user):/, '');
+  const repRoot = dirname(dirname(dirname(dirname(statusFile))));
+  const f = join(repRoot, '.claude', 'worca', 'templates', id, 'template.json');
+  try {
+    const stages = JSON.parse(readFileSync(f, 'utf8'))?.config?.stages;
+    if (!stages || typeof stages !== 'object') return null;
+    const map = {};
+    for (const [k, v] of Object.entries(stages)) map[k] = v?.enabled !== false;
+    return map;
+  } catch {
+    return null;
+  }
+}
+
+/** Keep stages the template enables — plus any that actually ran/are running. */
+function filterEnabledStages(stages, enabledMap) {
+  if (!enabledMap) return stages;
+  return stages.filter(
+    (s) =>
+      enabledMap[s.name] !== false ||
+      s.skipped ||
+      s.status === 'completed' ||
+      s.status === 'in_progress',
+  );
+}
+
+/**
  * Discover active (in-flight) runs under one target dir.
  *
  * @param {string} dir
@@ -107,7 +141,10 @@ export function discoverActive(dir) {
         continue;
       }
       const runId = s.run_id || basename(join(file, '..'));
-      const stages = summarizeStages(s.stages);
+      const stages = filterEnabledStages(
+        summarizeStages(s.stages),
+        enabledStageMap(file, s.pipeline_template),
+      );
       const pipelineStatus = s.pipeline_status || 'running';
       const { instance, rep } = instanceRep(profileWorkDir, file);
       out.push({

--- a/worca-bench/server/active-runs.js
+++ b/worca-bench/server/active-runs.js
@@ -120,6 +120,21 @@ function filterEnabledStages(stages, enabledMap) {
   );
 }
 
+// Pipeline statuses that mean a run is genuinely in-flight — or, for `completed`,
+// that worca-bench is still grading it (the work tree lingers until the grader
+// finishes, then it's removed). Anything else is terminal: interrupted/cancelled
+// (stopped), failed/setup_failed/unrecoverable (errored). A terminal run's work
+// tree can persist until cleanup, but it must NOT be reported as active — else a
+// stopped/crashed run leaves a stale "running" card in the live block. Mirrors
+// the dead-run reconciliation discoverRegrades() does via pidAlive().
+const ACTIVE_PIPELINE_STATUS = new Set([
+  'pending',
+  'running',
+  'resuming',
+  'paused',
+  'completed',
+]);
+
 /**
  * Discover active (in-flight) runs under one target dir.
  *
@@ -141,12 +156,15 @@ export function discoverActive(dir) {
       } catch {
         continue;
       }
+      const pipelineStatus = s.pipeline_status || 'running';
+      // Skip terminal runs (stopped/failed) whose work tree lingers — they are
+      // not active and would otherwise render as a stale live card.
+      if (!ACTIVE_PIPELINE_STATUS.has(pipelineStatus)) continue;
       const runId = s.run_id || basename(join(file, '..'));
       const stages = filterEnabledStages(
         summarizeStages(s.stages),
         enabledStageMap(file, s.pipeline_template),
       );
-      const pipelineStatus = s.pipeline_status || 'running';
       const { instance, rep } = instanceRep(profileWorkDir, file);
       out.push({
         profile,

--- a/worca-bench/server/active-runs.js
+++ b/worca-bench/server/active-runs.js
@@ -10,11 +10,50 @@
 // status). The work tree is removed when the rep finishes, so "a status.json under
 // work/" IS the live window.
 
+import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, join, relative, sep } from 'node:path';
 import { srcHash } from './results-store.js';
 
 const STATUS_SEG = `${'.worca'}/runs`; // status.json lives at .worca/runs/<id>/status.json
+
+// Authoritative bead progress comes from the run's own beads DB (the coordinator
+// creates ALL beads up front; status.json iterations only ever show the ones the
+// implementer has *dispatched*). We shell out to `bd stats --json` in the run
+// worktree. Cached briefly per worktree so the dashboard's overlapping polls
+// (/api/active + /api/profiles) don't spawn `bd` twice per tick.
+const _BEAD_TTL_MS = 4000;
+const _beadCache = new Map(); // repRoot -> { ts, value }
+
+/**
+ * { done, total } beads for the run rooted at `repRoot` (the dir holding
+ * `.beads/`), or null when there's no beads DB, `bd` is unavailable, or the DB
+ * is empty. `done` = closed issues, `total` = all issues.
+ */
+function beadCounts(repRoot, now = Date.now()) {
+  const cached = _beadCache.get(repRoot);
+  if (cached && now - cached.ts < _BEAD_TTL_MS) return cached.value;
+  let value = null;
+  if (existsSync(join(repRoot, '.beads', 'beads.db'))) {
+    try {
+      const out = execFileSync('bd', ['stats', '--json'], {
+        cwd: repRoot,
+        timeout: 2500,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const sum = JSON.parse(out)?.summary;
+      const total = Number(sum?.total_issues);
+      if (Number.isInteger(total) && total > 0) {
+        value = { done: Number(sum?.closed_issues) || 0, total };
+      }
+    } catch {
+      value = null; // bd missing / errored / timed out — show no count, not a wrong one
+    }
+  }
+  _beadCache.set(repRoot, { ts: now, value });
+  return value;
+}
 
 function safeReaddir(dir) {
   try {
@@ -46,26 +85,6 @@ function findStatusFiles(root, maxDepth = 7) {
   return found;
 }
 
-/**
- * Bead progress for a stage that dispatches beads (the implementer): completed /
- * dispatched. Derived from the stage's per-bead `iterations` — the latest
- * iteration status per `bead_id` wins (the implementer retries the same bead on
- * test failures). `total` is beads dispatched so far, NOT the coordinator's full
- * count (that lives only in the bead DB, which worca-bench doesn't read). Returns
- * null when the stage has no bead iterations yet.
- */
-function beadProgress(s) {
-  const its = Array.isArray(s?.iterations) ? s.iterations : [];
-  const latest = new Map(); // bead_id -> latest iteration status (insertion order)
-  for (const it of its) {
-    if (it?.bead_id) latest.set(it.bead_id, it?.status || 'pending');
-  }
-  if (latest.size === 0) return null;
-  let done = 0;
-  for (const st of latest.values()) if (st === 'completed') done += 1;
-  return { done, total: latest.size };
-}
-
 /** Ordered per-stage summary. status.json `stages` preserves insertion order. */
 function summarizeStages(stages) {
   if (!stages || typeof stages !== 'object') return [];
@@ -77,8 +96,6 @@ function summarizeStages(stages) {
       model: s?.model_alias || s?.model || null,
       skipped: !!s?.skipped,
     };
-    const beads = beadProgress(s);
-    if (beads) entry.beads = beads;
     // How many times the stage ran (a loop-back re-runs the stage). Prefer the
     // explicit `iteration` counter, else the iterations array length. Surfaced
     // only when > 1 so single-pass stages stay clean.
@@ -200,6 +217,14 @@ export function discoverActive(dir) {
         summarizeStages(s.stages),
         enabledStageMap(file, s.pipeline_template),
       );
+      // Authoritative bead progress (closed/total) from the run's beads DB,
+      // surfaced on the implementer chip. repRoot is <.../rep<N>/...> holding
+      // .beads/ — the dir 4 levels up from .worca/runs/<id>/status.json.
+      const implementStage = stages.find((x) => x.name === 'implement');
+      if (implementStage) {
+        const beads = beadCounts(dirname(dirname(dirname(dirname(file)))));
+        if (beads) implementStage.beads = beads;
+      }
       const { instance, rep } = instanceRep(profileWorkDir, file);
       out.push({
         profile,

--- a/worca-bench/server/active-runs.js
+++ b/worca-bench/server/active-runs.js
@@ -11,7 +11,7 @@
 // work/" IS the live window.
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, join, relative, sep } from 'node:path';
 
 const STATUS_SEG = `${'.worca'}/runs`; // status.json lives at .worca/runs/<id>/status.json
 
@@ -66,6 +66,26 @@ function currentStage(stageList) {
 }
 
 /**
+ * worca-bench phase. The pipeline subprocess writes status.json; once it
+ * reports `completed` but the work tree still exists, worca-bench is grading
+ * (diff extraction + the grader), which is not a worca pipeline stage.
+ */
+function phaseOf(pipelineStatus) {
+  if (pipelineStatus === 'failed' || pipelineStatus === 'error')
+    return 'failed';
+  if (pipelineStatus === 'completed') return 'grading';
+  return 'running';
+}
+
+/** Derive { instance, rep } from the work-tree path under work/<profile>/. */
+function instanceRep(profileWorkDir, statusFile) {
+  const segs = relative(profileWorkDir, statusFile).split(sep);
+  const instance = segs[0] || null;
+  const m = (segs[1] || '').match(/^rep(\d+)$/);
+  return { instance, rep: m ? Number(m[1]) : null };
+}
+
+/**
  * Discover active (in-flight) runs under one target dir.
  *
  * @param {string} dir
@@ -78,7 +98,8 @@ export function discoverActive(dir) {
   for (const p of safeReaddir(workRoot)) {
     if (!p.isDirectory()) continue;
     const profile = p.name;
-    for (const file of findStatusFiles(join(workRoot, profile))) {
+    const profileWorkDir = join(workRoot, profile);
+    for (const file of findStatusFiles(profileWorkDir)) {
       let s;
       try {
         s = JSON.parse(readFileSync(file, 'utf8'));
@@ -87,11 +108,16 @@ export function discoverActive(dir) {
       }
       const runId = s.run_id || basename(join(file, '..'));
       const stages = summarizeStages(s.stages);
+      const pipelineStatus = s.pipeline_status || 'running';
+      const { instance, rep } = instanceRep(profileWorkDir, file);
       out.push({
         profile,
+        instance,
+        rep,
         run_id: runId,
         kind: String(runId).startsWith('canary') ? 'canary' : 'rep',
-        pipeline_status: s.pipeline_status || 'running',
+        pipeline_status: pipelineStatus,
+        phase: phaseOf(pipelineStatus),
         stage: currentStage(stages),
         stages,
         started_at: s.started_at || null,

--- a/worca-bench/server/active-runs.js
+++ b/worca-bench/server/active-runs.js
@@ -46,16 +46,51 @@ function findStatusFiles(root, maxDepth = 7) {
   return found;
 }
 
+/**
+ * Bead progress for a stage that dispatches beads (the implementer): completed /
+ * dispatched. Derived from the stage's per-bead `iterations` — the latest
+ * iteration status per `bead_id` wins (the implementer retries the same bead on
+ * test failures). `total` is beads dispatched so far, NOT the coordinator's full
+ * count (that lives only in the bead DB, which worca-bench doesn't read). Returns
+ * null when the stage has no bead iterations yet.
+ */
+function beadProgress(s) {
+  const its = Array.isArray(s?.iterations) ? s.iterations : [];
+  const latest = new Map(); // bead_id -> latest iteration status (insertion order)
+  for (const it of its) {
+    if (it?.bead_id) latest.set(it.bead_id, it?.status || 'pending');
+  }
+  if (latest.size === 0) return null;
+  let done = 0;
+  for (const st of latest.values()) if (st === 'completed') done += 1;
+  return { done, total: latest.size };
+}
+
 /** Ordered per-stage summary. status.json `stages` preserves insertion order. */
 function summarizeStages(stages) {
   if (!stages || typeof stages !== 'object') return [];
-  return Object.entries(stages).map(([name, s]) => ({
-    name,
-    status: s?.status || 'pending',
-    agent: s?.agent || null,
-    model: s?.model_alias || s?.model || null,
-    skipped: !!s?.skipped,
-  }));
+  return Object.entries(stages).map(([name, s]) => {
+    const entry = {
+      name,
+      status: s?.status || 'pending',
+      agent: s?.agent || null,
+      model: s?.model_alias || s?.model || null,
+      skipped: !!s?.skipped,
+    };
+    const beads = beadProgress(s);
+    if (beads) entry.beads = beads;
+    // How many times the stage ran (a loop-back re-runs the stage). Prefer the
+    // explicit `iteration` counter, else the iterations array length. Surfaced
+    // only when > 1 so single-pass stages stay clean.
+    const iters =
+      Number.isInteger(s?.iteration) && s.iteration > 0
+        ? s.iteration
+        : Array.isArray(s?.iterations)
+          ? s.iterations.length
+          : 0;
+    if (iters > 1) entry.iters = iters;
+    return entry;
+  });
 }
 
 /** The stage currently in progress, else the last completed one. */

--- a/worca-bench/server/active-runs.js
+++ b/worca-bench/server/active-runs.js
@@ -12,6 +12,7 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, dirname, join, relative, sep } from 'node:path';
+import { srcHash } from './results-store.js';
 
 const STATUS_SEG = `${'.worca'}/runs`; // status.json lives at .worca/runs/<id>/status.json
 
@@ -149,6 +150,7 @@ export function discoverActive(dir) {
       const { instance, rep } = instanceRep(profileWorkDir, file);
       out.push({
         profile,
+        src: srcHash(dir),
         instance,
         rep,
         run_id: runId,
@@ -185,13 +187,14 @@ export function discoverActiveMulti(dirs) {
   return out;
 }
 
-/** Map profile name -> its most-recently-updated active run (for card badges). */
+/** Map `<src>::<profile>` -> its most-recently-updated active run (card badges). */
 export function activeByProfile(active) {
   const map = new Map();
   for (const run of active) {
-    const cur = map.get(run.profile);
+    const key = `${run.src}::${run.profile}`;
+    const cur = map.get(key);
     if (!cur || (run._mtime || 0) > (cur._mtime || 0)) {
-      map.set(run.profile, run);
+      map.set(key, run);
     }
   }
   return map;

--- a/worca-bench/server/active-runs.js
+++ b/worca-bench/server/active-runs.js
@@ -1,0 +1,135 @@
+// server/active-runs.js
+//
+// Live run discovery. A results.jsonl row only appears once a rep COMPLETES, so
+// to reflect in-flight progress the dashboard reads worca's status.json from the
+// transient per-rep work tree:
+//
+//   <target>/work/<profile>/<instance|__canary__>/rep<N>/.../.worca/runs/<run_id>/status.json
+//
+// Each status.json carries the pipeline status + per-stage progress (agent, model,
+// status). The work tree is removed when the rep finishes, so "a status.json under
+// work/" IS the live window.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+const STATUS_SEG = `${'.worca'}/runs`; // status.json lives at .worca/runs/<id>/status.json
+
+function safeReaddir(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+// Recursively collect status.json files nested under a `.worca/runs/<id>/` path.
+function findStatusFiles(root, maxDepth = 7) {
+  const found = [];
+  const walk = (dir, depth) => {
+    if (depth > maxDepth) return;
+    for (const e of safeReaddir(dir)) {
+      if (!e.isDirectory()) continue;
+      const child = join(dir, e.name);
+      const candidate = join(child, 'status.json');
+      if (
+        child.replaceAll('\\', '/').includes(STATUS_SEG) &&
+        existsSync(candidate)
+      ) {
+        found.push(candidate);
+      }
+      walk(child, depth + 1);
+    }
+  };
+  walk(root, 0);
+  return found;
+}
+
+/** Ordered per-stage summary. status.json `stages` preserves insertion order. */
+function summarizeStages(stages) {
+  if (!stages || typeof stages !== 'object') return [];
+  return Object.entries(stages).map(([name, s]) => ({
+    name,
+    status: s?.status || 'pending',
+    agent: s?.agent || null,
+    model: s?.model_alias || s?.model || null,
+    skipped: !!s?.skipped,
+  }));
+}
+
+/** The stage currently in progress, else the last completed one. */
+function currentStage(stageList) {
+  const running = stageList.find((s) => s.status === 'in_progress');
+  if (running) return running.name;
+  const done = stageList.filter((s) => s.status === 'completed');
+  return done.length ? done[done.length - 1].name : null;
+}
+
+/**
+ * Discover active (in-flight) runs under one target dir.
+ *
+ * @param {string} dir
+ * @returns {Array<{profile, run_id, kind, pipeline_status, stage, stages, started_at}>}
+ */
+export function discoverActive(dir) {
+  const workRoot = join(dir, 'work');
+  if (!existsSync(workRoot)) return [];
+  const out = [];
+  for (const p of safeReaddir(workRoot)) {
+    if (!p.isDirectory()) continue;
+    const profile = p.name;
+    for (const file of findStatusFiles(join(workRoot, profile))) {
+      let s;
+      try {
+        s = JSON.parse(readFileSync(file, 'utf8'));
+      } catch {
+        continue;
+      }
+      const runId = s.run_id || basename(join(file, '..'));
+      const stages = summarizeStages(s.stages);
+      out.push({
+        profile,
+        run_id: runId,
+        kind: String(runId).startsWith('canary') ? 'canary' : 'rep',
+        pipeline_status: s.pipeline_status || 'running',
+        stage: currentStage(stages),
+        stages,
+        started_at: s.started_at || null,
+        _mtime: _safeMtime(file),
+      });
+    }
+  }
+  return out;
+}
+
+function _safeMtime(file) {
+  try {
+    return statSync(file).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+/** Discover active runs across several dirs (deduped by dir). */
+export function discoverActiveMulti(dirs) {
+  const out = [];
+  const seen = new Set();
+  for (const dir of dirs) {
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    out.push(...discoverActive(dir));
+  }
+  return out;
+}
+
+/** Map profile name -> its most-recently-updated active run (for card badges). */
+export function activeByProfile(active) {
+  const map = new Map();
+  for (const run of active) {
+    const cur = map.get(run.profile);
+    if (!cur || (run._mtime || 0) > (cur._mtime || 0)) {
+      map.set(run.profile, run);
+    }
+  }
+  return map;
+}

--- a/worca-bench/server/active-runs.test.js
+++ b/worca-bench/server/active-runs.test.js
@@ -43,8 +43,11 @@ describe('discoverActive', () => {
     });
     const [run] = discoverActive(dir);
     expect(run.profile).toBe('p1');
+    expect(run.instance).toBe('astropy__astropy-1');
+    expect(run.rep).toBe(1);
     expect(run.kind).toBe('rep');
     expect(run.pipeline_status).toBe('running');
+    expect(run.phase).toBe('running');
     expect(run.stage).toBe('coordinate'); // the in_progress stage
     expect(run.stages.map((s) => `${s.name}:${s.status}`)).toEqual([
       'preflight:completed',
@@ -53,6 +56,18 @@ describe('discoverActive', () => {
       'implement:pending',
     ]);
     expect(run.stages[1].model).toBe('opus'); // model_alias preferred
+  });
+
+  it('reports the grading phase when the pipeline is completed but still active', () => {
+    seedStatus('p1', 'i', 1, 'p1__i__rep1', {
+      run_id: 'p1__i__rep1',
+      pipeline_status: 'completed',
+      stages: {
+        plan: { status: 'completed' },
+        implement: { status: 'completed' },
+      },
+    });
+    expect(discoverActive(dir)[0].phase).toBe('grading');
   });
 
   it('flags a canary run by its run_id', () => {

--- a/worca-bench/server/active-runs.test.js
+++ b/worca-bench/server/active-runs.test.js
@@ -126,6 +126,32 @@ describe('discoverActive', () => {
     expect(run.stages[1].model).toBe('opus'); // model_alias preferred
   });
 
+  it('excludes terminal runs (interrupted/failed) whose work tree lingers', () => {
+    // A stopped run leaves an `interrupted` status.json on disk until cleanup;
+    // it must NOT surface as an active run (no stale "running" live card).
+    seedStatus('p1', 'astropy__astropy-stopped', 1, 'p1__stopped__rep1', {
+      run_id: 'p1__stopped__rep1',
+      pipeline_status: 'interrupted',
+      stages: { plan: { status: 'interrupted' } },
+    });
+    seedStatus('p1', 'astropy__astropy-broke', 1, 'p1__broke__rep1', {
+      run_id: 'p1__broke__rep1',
+      pipeline_status: 'failed',
+      stages: {
+        plan: { status: 'completed' },
+        implement: { status: 'failed' },
+      },
+    });
+    // A genuinely running one alongside them is still reported.
+    seedStatus('p1', 'astropy__astropy-live', 1, 'p1__live__rep1', {
+      run_id: 'p1__live__rep1',
+      pipeline_status: 'running',
+      stages: { plan: { status: 'in_progress' } },
+    });
+    const runs = discoverActive(dir);
+    expect(runs.map((r) => r.instance)).toEqual(['astropy__astropy-live']);
+  });
+
   it('reports the grading phase when the pipeline is completed but still active', () => {
     seedStatus('p1', 'i', 1, 'p1__i__rep1', {
       run_id: 'p1__i__rep1',

--- a/worca-bench/server/active-runs.test.js
+++ b/worca-bench/server/active-runs.test.js
@@ -1,7 +1,13 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `bd stats --json` is shelled out for authoritative bead counts; mock it so the
+// suite is hermetic (no bd binary, no real beads DB needed).
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+
+import { execFileSync } from 'node:child_process';
 import {
   activeByProfile,
   discoverActive,
@@ -126,54 +132,66 @@ describe('discoverActive', () => {
     expect(run.stages[1].model).toBe('opus'); // model_alias preferred
   });
 
-  it('derives bead progress + loop-back counts from stage iterations', () => {
+  it('derives loop-back counts (×N) from the stage iteration counter', () => {
     seedStatus('p1', 'lib', 1, 'p1__lib__rep1', {
       run_id: 'p1__lib__rep1',
       pipeline_status: 'running',
       stages: {
         plan: { status: 'completed', iteration: 1 },
-        implement: {
-          status: 'in_progress',
-          iteration: 4,
-          iterations: [
-            {
-              number: 1,
-              bead_id: 'b1',
-              status: 'completed',
-              trigger: 'initial',
-            },
-            {
-              number: 2,
-              bead_id: 'b2',
-              status: 'completed',
-              trigger: 'initial',
-            },
-            {
-              number: 3,
-              bead_id: 'b3',
-              status: 'in_progress',
-              trigger: 'initial',
-            },
-            {
-              number: 4,
-              bead_id: 'b3',
-              status: 'in_progress',
-              trigger: 'test_failure',
-            },
-          ],
-        },
+        implement: { status: 'in_progress', iteration: 4 },
         test: { status: 'completed', iteration: 3 },
       },
     });
     const [run] = discoverActive(dir);
     const byName = Object.fromEntries(run.stages.map((s) => [s.name, s]));
-    // 3 distinct beads dispatched (b1,b2,b3); b1+b2 done, b3 in progress → 2/3.
-    expect(byName.implement.beads).toEqual({ done: 2, total: 3 });
     expect(byName.implement.iters).toBe(4); // ran 4 times (loop-backs)
     expect(byName.test.iters).toBe(3);
-    // Single-pass stages carry neither field.
-    expect(byName.plan.iters).toBeUndefined();
-    expect(byName.plan.beads).toBeUndefined();
+    expect(byName.plan.iters).toBeUndefined(); // single-pass → no suffix
+    // No beads DB seeded → no bead count attached.
+    expect(byName.implement.beads).toBeUndefined();
+  });
+
+  it('attaches authoritative bead counts from `bd stats` (closed/total)', () => {
+    execFileSync.mockReturnValue(
+      JSON.stringify({ summary: { total_issues: 5, closed_issues: 1 } }),
+    );
+    seedStatus('p2', 'lib2', 1, 'p2__lib2__rep1', {
+      run_id: 'p2__lib2__rep1',
+      pipeline_status: 'running',
+      stages: { implement: { status: 'in_progress' } },
+    });
+    // Seed a beads DB so the existsSync guard passes and bd is consulted.
+    const beadsDir = join(dir, 'work', 'p2', 'lib2', 'rep1', '.beads');
+    mkdirSync(beadsDir, { recursive: true });
+    writeFileSync(join(beadsDir, 'beads.db'), 'x');
+
+    const [run] = discoverActive(dir);
+    const imp = run.stages.find((s) => s.name === 'implement');
+    expect(imp.beads).toEqual({ done: 1, total: 5 });
+    expect(execFileSync).toHaveBeenCalledWith(
+      'bd',
+      ['stats', '--json'],
+      expect.objectContaining({ cwd: expect.stringContaining('rep1') }),
+    );
+  });
+
+  it('shows no bead count when `bd` fails (never a wrong number)', () => {
+    execFileSync.mockImplementation(() => {
+      throw new Error('bd not found');
+    });
+    seedStatus('p3', 'lib3', 1, 'p3__lib3__rep1', {
+      run_id: 'p3__lib3__rep1',
+      pipeline_status: 'running',
+      stages: { implement: { status: 'in_progress' } },
+    });
+    const beadsDir = join(dir, 'work', 'p3', 'lib3', 'rep1', '.beads');
+    mkdirSync(beadsDir, { recursive: true });
+    writeFileSync(join(beadsDir, 'beads.db'), 'x');
+
+    const [run] = discoverActive(dir);
+    expect(
+      run.stages.find((s) => s.name === 'implement').beads,
+    ).toBeUndefined();
   });
 
   it('excludes terminal runs (interrupted/failed) whose work tree lingers', () => {

--- a/worca-bench/server/active-runs.test.js
+++ b/worca-bench/server/active-runs.test.js
@@ -25,6 +25,25 @@ function seedStatus(profile, inst, rep, runId, status) {
   writeFileSync(join(runDir, 'status.json'), JSON.stringify(status));
 }
 
+function seedTemplate(profile, inst, rep, id, stagesCfg) {
+  const tdir = join(
+    dir,
+    'work',
+    profile,
+    inst,
+    `rep${rep}`,
+    '.claude',
+    'worca',
+    'templates',
+    id,
+  );
+  mkdirSync(tdir, { recursive: true });
+  writeFileSync(
+    join(tdir, 'template.json'),
+    JSON.stringify({ config: { stages: stagesCfg } }),
+  );
+}
+
 describe('discoverActive', () => {
   it('returns nothing when there is no work/ dir', () => {
     expect(discoverActive(dir)).toEqual([]);
@@ -68,6 +87,48 @@ describe('discoverActive', () => {
       },
     });
     expect(discoverActive(dir)[0].phase).toBe('grading');
+  });
+
+  it('hides template-disabled stages but keeps ones that ran', () => {
+    seedStatus('p1', 'i', 1, 'p1__i__rep1', {
+      run_id: 'p1__i__rep1',
+      pipeline_status: 'running',
+      pipeline_template: 'builtin:quick-fix',
+      stages: {
+        preflight: { status: 'completed', skipped: true },
+        plan: { status: 'completed' },
+        coordinate: { status: 'in_progress' },
+        implement: { status: 'pending' },
+        test: { status: 'pending' },
+        review: { status: 'pending' },
+        pr: { status: 'pending' },
+      },
+    });
+    seedTemplate('p1', 'i', 1, 'quick-fix', {
+      plan: { enabled: true },
+      coordinate: { enabled: true },
+      implement: { enabled: true },
+      test: { enabled: false },
+      review: { enabled: false },
+      pr: { enabled: false },
+    });
+    const names = discoverActive(dir)[0].stages.map((s) => s.name);
+    // test/review/pr disabled + never ran -> hidden; preflight (skipped) kept.
+    expect(names).toEqual(['preflight', 'plan', 'coordinate', 'implement']);
+  });
+
+  it('shows all stages when the template config is unavailable', () => {
+    seedStatus('p1', 'i', 1, 'p1__i__rep1', {
+      run_id: 'p1__i__rep1',
+      pipeline_status: 'running',
+      pipeline_template: 'builtin:quick-fix',
+      stages: { plan: { status: 'completed' }, test: { status: 'pending' } },
+    });
+    // no seedTemplate -> can't resolve -> show everything
+    expect(discoverActive(dir)[0].stages.map((s) => s.name)).toEqual([
+      'plan',
+      'test',
+    ]);
   });
 
   it('flags a canary run by its run_id', () => {

--- a/worca-bench/server/active-runs.test.js
+++ b/worca-bench/server/active-runs.test.js
@@ -126,6 +126,56 @@ describe('discoverActive', () => {
     expect(run.stages[1].model).toBe('opus'); // model_alias preferred
   });
 
+  it('derives bead progress + loop-back counts from stage iterations', () => {
+    seedStatus('p1', 'lib', 1, 'p1__lib__rep1', {
+      run_id: 'p1__lib__rep1',
+      pipeline_status: 'running',
+      stages: {
+        plan: { status: 'completed', iteration: 1 },
+        implement: {
+          status: 'in_progress',
+          iteration: 4,
+          iterations: [
+            {
+              number: 1,
+              bead_id: 'b1',
+              status: 'completed',
+              trigger: 'initial',
+            },
+            {
+              number: 2,
+              bead_id: 'b2',
+              status: 'completed',
+              trigger: 'initial',
+            },
+            {
+              number: 3,
+              bead_id: 'b3',
+              status: 'in_progress',
+              trigger: 'initial',
+            },
+            {
+              number: 4,
+              bead_id: 'b3',
+              status: 'in_progress',
+              trigger: 'test_failure',
+            },
+          ],
+        },
+        test: { status: 'completed', iteration: 3 },
+      },
+    });
+    const [run] = discoverActive(dir);
+    const byName = Object.fromEntries(run.stages.map((s) => [s.name, s]));
+    // 3 distinct beads dispatched (b1,b2,b3); b1+b2 done, b3 in progress → 2/3.
+    expect(byName.implement.beads).toEqual({ done: 2, total: 3 });
+    expect(byName.implement.iters).toBe(4); // ran 4 times (loop-backs)
+    expect(byName.test.iters).toBe(3);
+    // Single-pass stages carry neither field.
+    expect(byName.plan.iters).toBeUndefined();
+    expect(byName.plan.beads).toBeUndefined();
+  });
+
   it('excludes terminal runs (interrupted/failed) whose work tree lingers', () => {
     // A stopped run leaves an `interrupted` status.json on disk until cleanup;
     // it must NOT surface as an active run (no stale "running" live card).

--- a/worca-bench/server/active-runs.test.js
+++ b/worca-bench/server/active-runs.test.js
@@ -1,0 +1,90 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { activeByProfile, discoverActive } from './active-runs.js';
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'bench-active-'));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function seedStatus(profile, inst, rep, runId, status) {
+  const runDir = join(
+    dir,
+    'work',
+    profile,
+    inst,
+    `rep${rep}`,
+    '.worca',
+    'runs',
+    runId,
+  );
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(join(runDir, 'status.json'), JSON.stringify(status));
+}
+
+describe('discoverActive', () => {
+  it('returns nothing when there is no work/ dir', () => {
+    expect(discoverActive(dir)).toEqual([]);
+  });
+
+  it('reads stage progress from an in-flight status.json', () => {
+    seedStatus('p1', 'astropy__astropy-1', 1, 'p1__astropy__astropy-1__rep1', {
+      run_id: 'p1__astropy__astropy-1__rep1',
+      pipeline_status: 'running',
+      stages: {
+        preflight: { status: 'completed', skipped: true },
+        plan: { status: 'completed', agent: 'planner', model_alias: 'opus' },
+        coordinate: { status: 'in_progress', agent: 'coordinator' },
+        implement: { status: 'pending' },
+      },
+    });
+    const [run] = discoverActive(dir);
+    expect(run.profile).toBe('p1');
+    expect(run.kind).toBe('rep');
+    expect(run.pipeline_status).toBe('running');
+    expect(run.stage).toBe('coordinate'); // the in_progress stage
+    expect(run.stages.map((s) => `${s.name}:${s.status}`)).toEqual([
+      'preflight:completed',
+      'plan:completed',
+      'coordinate:in_progress',
+      'implement:pending',
+    ]);
+    expect(run.stages[1].model).toBe('opus'); // model_alias preferred
+  });
+
+  it('flags a canary run by its run_id', () => {
+    seedStatus('p1', '__canary__', 0, 'canary-quick-fix', {
+      run_id: 'canary-quick-fix',
+      pipeline_status: 'running',
+      stages: { plan: { status: 'in_progress' } },
+    });
+    expect(discoverActive(dir)[0].kind).toBe('canary');
+  });
+
+  it('falls back to the last completed stage when none is in progress', () => {
+    seedStatus('p1', 'i', 1, 'p1__i__rep1', {
+      run_id: 'p1__i__rep1',
+      stages: {
+        plan: { status: 'completed' },
+        coordinate: { status: 'completed' },
+        implement: { status: 'pending' },
+      },
+    });
+    expect(discoverActive(dir)[0].stage).toBe('coordinate');
+  });
+});
+
+describe('activeByProfile', () => {
+  it('keeps the most recently updated run per profile', () => {
+    const map = activeByProfile([
+      { profile: 'a', stage: 'plan', _mtime: 1 },
+      { profile: 'a', stage: 'test', _mtime: 5 },
+      { profile: 'b', stage: 'review', _mtime: 2 },
+    ]);
+    expect(map.get('a').stage).toBe('test');
+    expect(map.get('b').stage).toBe('review');
+  });
+});

--- a/worca-bench/server/active-runs.test.js
+++ b/worca-bench/server/active-runs.test.js
@@ -154,13 +154,16 @@ describe('discoverActive', () => {
 });
 
 describe('activeByProfile', () => {
-  it('keeps the most recently updated run per profile', () => {
+  it('keeps the most recently updated run per (src, profile)', () => {
     const map = activeByProfile([
-      { profile: 'a', stage: 'plan', _mtime: 1 },
-      { profile: 'a', stage: 'test', _mtime: 5 },
-      { profile: 'b', stage: 'review', _mtime: 2 },
+      { profile: 'a', src: 's1', stage: 'plan', _mtime: 1 },
+      { profile: 'a', src: 's1', stage: 'test', _mtime: 5 },
+      { profile: 'b', src: 's1', stage: 'review', _mtime: 2 },
+      // same name, different src — tracked separately
+      { profile: 'a', src: 's2', stage: 'implement', _mtime: 9 },
     ]);
-    expect(map.get('a').stage).toBe('test');
-    expect(map.get('b').stage).toBe('review');
+    expect(map.get('s1::a').stage).toBe('test');
+    expect(map.get('s1::b').stage).toBe('review');
+    expect(map.get('s2::a').stage).toBe('implement');
   });
 });

--- a/worca-bench/server/active-runs.test.js
+++ b/worca-bench/server/active-runs.test.js
@@ -2,7 +2,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { activeByProfile, discoverActive } from './active-runs.js';
+import {
+  activeByProfile,
+  discoverActive,
+  discoverRegrades,
+} from './active-runs.js';
 
 let dir;
 beforeEach(() => {
@@ -24,6 +28,51 @@ function seedStatus(profile, inst, rep, runId, status) {
   mkdirSync(runDir, { recursive: true });
   writeFileSync(join(runDir, 'status.json'), JSON.stringify(status));
 }
+
+function seedRegrade(profile, hb) {
+  const d = join(dir, 'runs', profile);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, 'regrade-status.json'), JSON.stringify(hb));
+}
+
+describe('discoverRegrades', () => {
+  it('surfaces a running heartbeat with a live pid as active', () => {
+    seedRegrade('demo', {
+      profile: 'demo',
+      mode: 'modal',
+      pid: process.pid, // this test process is alive
+      total: 20,
+      done: 7,
+      current: 'astropy__astropy-14539',
+      counts: { graded: 7, resolved: 4, error: 0 },
+      status: 'running',
+    });
+    const [r] = discoverRegrades(dir);
+    expect(r.active).toBe(true);
+    expect(r.done).toBe(7);
+    expect(r.current).toBe('astropy__astropy-14539');
+    expect(typeof r.src).toBe('string');
+  });
+
+  it('reclassifies a running heartbeat with a dead pid as ended (not active)', () => {
+    seedRegrade('demo', {
+      profile: 'demo',
+      pid: 2147483000, // implausible pid → not alive
+      status: 'running',
+      total: 20,
+      done: 13,
+    });
+    const [r] = discoverRegrades(dir);
+    expect(r.status).toBe('ended');
+    expect(r.active).toBe(false);
+  });
+
+  it('keeps a done heartbeat inactive', () => {
+    seedRegrade('demo', { profile: 'demo', pid: process.pid, status: 'done' });
+    const [r] = discoverRegrades(dir);
+    expect(r.active).toBe(false);
+  });
+});
 
 function seedTemplate(profile, inst, rep, id, stagesCfg) {
   const tdir = join(

--- a/worca-bench/server/app-settings.test.js
+++ b/worca-bench/server/app-settings.test.js
@@ -1,0 +1,134 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from './app.js';
+
+function writeResults(dir, rows) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'results.jsonl'),
+    `${rows.map((r) => JSON.stringify(r)).join('\n')}\n`,
+  );
+}
+
+function row(profile) {
+  return {
+    schema_version: 1,
+    profile,
+    benchmark: 'swe-bench-verified',
+    instance_id: 'i1',
+    worca_ref: 'local',
+    template: 'builtin:feature',
+    rep: 1,
+    status: 'graded',
+    resolved: true,
+    score: 1.0,
+    cost_usd: 0.1,
+    wall_time_s: 1,
+    loop_counters: {},
+    completed_at: '2026-06-16T10:00:00Z',
+  };
+}
+
+async function withServer(opts, fn) {
+  const server = createServer(createApp(opts));
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await fn(base);
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+}
+
+let home;
+let primaryDir;
+let extraDir;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'wb-home-'));
+  primaryDir = mkdtempSync(join(tmpdir(), 'wb-primary-'));
+  extraDir = mkdtempSync(join(tmpdir(), 'wb-extra-'));
+});
+
+describe('settings API + multi-dir aggregation', () => {
+  it('GET /api/settings reports primary, configured, effective', async () => {
+    await withServer(
+      { targetDir: primaryDir, settingsHome: home },
+      async (base) => {
+        const s = await (await fetch(`${base}/api/settings`)).json();
+        expect(s.ok).toBe(true);
+        expect(s.primary).toBe(resolve(primaryDir));
+        expect(s.configured).toEqual([]);
+        expect(s.effective).toEqual([resolve(primaryDir)]);
+      },
+    );
+  });
+
+  it('POST adds a dir, DELETE removes it', async () => {
+    await withServer(
+      { targetDir: primaryDir, settingsHome: home },
+      async (base) => {
+        const added = await (
+          await fetch(`${base}/api/settings/dirs`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ dir: extraDir }),
+          })
+        ).json();
+        expect(added.configured).toEqual([resolve(extraDir)]);
+        expect(added.effective).toContain(resolve(extraDir));
+
+        const removed = await (
+          await fetch(`${base}/api/settings/dirs`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ dir: extraDir }),
+          })
+        ).json();
+        expect(removed.configured).toEqual([]);
+      },
+    );
+  });
+
+  it('POST a non-existent dir returns 400', async () => {
+    await withServer(
+      { targetDir: primaryDir, settingsHome: home },
+      async (base) => {
+        const res = await fetch(`${base}/api/settings/dirs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dir: '/no/such/dir' }),
+        });
+        expect(res.status).toBe(400);
+      },
+    );
+  });
+
+  it('aggregates profiles across primary + configured dirs', async () => {
+    writeResults(primaryDir, [row('alpha')]);
+    writeResults(extraDir, [row('beta')]);
+    await withServer(
+      { targetDir: primaryDir, settingsHome: home },
+      async (base) => {
+        // before adding the extra dir: only alpha
+        let profiles = (await (await fetch(`${base}/api/profiles`)).json())
+          .profiles;
+        expect(profiles.map((p) => p.name)).toEqual(['alpha']);
+
+        await fetch(`${base}/api/settings/dirs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dir: extraDir }),
+        });
+
+        // after: both, aggregated
+        profiles = (await (await fetch(`${base}/api/profiles`)).json())
+          .profiles;
+        expect(profiles.map((p) => p.name).sort()).toEqual(['alpha', 'beta']);
+      },
+    );
+  });
+});

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -11,7 +11,11 @@ import { homedir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
-import { activeByProfile, discoverActiveMulti } from './active-runs.js';
+import {
+  activeByProfile,
+  discoverActiveMulti,
+  discoverRegradesMulti,
+} from './active-runs.js';
 import {
   getLeaderboard,
   leaderboardBenchmarks,
@@ -27,7 +31,11 @@ import {
   readResultsMulti,
   srcHash,
 } from './results-store.js';
-import { clearProfileResults, stopProfileRuns } from './run-control.js';
+import {
+  clearProfileResults,
+  stopProfileRuns,
+  stopRegrade,
+} from './run-control.js';
 import {
   addResultDir,
   loadSettings,
@@ -69,6 +77,11 @@ export function createApp(options = {}) {
   const readRows = () => readResultsMulti(effectiveDirs());
   const readDefs = () => readProfileDefsMulti(effectiveDirs());
   const readActive = () => discoverActiveMulti(effectiveDirs());
+  const readRegrades = () => discoverRegradesMulti(effectiveDirs());
+  // The latest regrade heartbeat for one profile (scoped by src when given).
+  const regradeFor = (name, src) =>
+    readRegrades().find((r) => r.profile === name && (!src || r.src === src)) ||
+    null;
 
   app.use(express.json());
 
@@ -122,6 +135,10 @@ export function createApp(options = {}) {
       // Fold in live status from in-flight work trees (running profiles surface
       // a current stage before any results.jsonl row exists).
       const active = activeByProfile(readActive());
+      const regradeMap = new Map();
+      for (const r of readRegrades()) {
+        if (r.active) regradeMap.set(`${r.src}::${r.profile}`, r);
+      }
       for (const agg of aggregates) {
         const run = active.get(`${agg.src}::${agg.name}`);
         if (run) {
@@ -130,6 +147,15 @@ export function createApp(options = {}) {
           agg.phase = run.phase;
           agg.pipeline_status = run.pipeline_status;
           agg.active_kind = run.kind;
+        }
+        const rg = regradeMap.get(`${agg.src}::${agg.name}`);
+        if (rg) {
+          agg.regrade = {
+            done: rg.done,
+            total: rg.total,
+            mode: rg.mode,
+            current: rg.current,
+          };
         }
       }
       aggregates.sort((a, b) => a.name.localeCompare(b.name));
@@ -170,6 +196,7 @@ export function createApp(options = {}) {
           },
           reps: dedupeReps(rows), // collapse re-runs in the per-rep table
           active,
+          regrade: regradeFor(name, src),
         });
       }
       if (!def && active.length === 0) {
@@ -191,6 +218,7 @@ export function createApp(options = {}) {
         },
         reps: [],
         active,
+        regrade: regradeFor(name, src),
       });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
@@ -339,6 +367,14 @@ export function createApp(options = {}) {
     ) {
       return res.status(400).json({ ok: false, error: 'invalid grade mode' });
     }
+    // Refuse a second sweep while one is live — two processes racing the same
+    // results.jsonl would clobber each other's verdicts.
+    if (readRegrades().some((r) => r.profile === profile && r.active)) {
+      return res.status(409).json({
+        ok: false,
+        error: 'a regrade is already running for this profile',
+      });
+    }
     try {
       const def = readDefs().find((d) => d.name === profile);
       const { pid } = await regrade({
@@ -348,9 +384,24 @@ export function createApp(options = {}) {
         instance: instance || undefined,
         mode: mode || undefined,
         onlyErrors: req.body?.onlyErrors === true,
+        sequential: req.body?.sequential === true,
+        logPath: join(targetDir, 'runs', profile, 'regrade.log'),
         secrets: req.body?.secrets,
       });
       res.json({ ok: true, pid });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Stop an in-flight regrade sweep for a profile (kills the runner tree).
+  app.post('/api/profiles/:name/regrade/stop', async (req, res) => {
+    if (_badName(req.params.name)) {
+      return res.status(400).json({ ok: false, error: 'invalid profile name' });
+    }
+    try {
+      const stopped = await stopRegrade(req.params.name, effectiveDirs());
+      res.json({ ok: true, stopped });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -6,7 +6,9 @@
 // catch-all. The app reads benchmark results from a target directory passed in
 // via options.targetDir (the runner's --target-dir / WORCA_BENCH_DIR).
 
-import { dirname, join } from 'node:path';
+import { readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
 
@@ -246,6 +248,30 @@ export function createApp(options = {}) {
       res.json(settingsPayload());
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Directory browser for the folder picker. Lists immediate subdirectories of
+  // ?path (default: home). Dirs only — a low-risk read for a localhost tool.
+  app.get('/api/fs/list', (req, res) => {
+    try {
+      const abs = resolve(req.query.path ? String(req.query.path) : homedir());
+      const dirs = readdirSync(abs, { withFileTypes: true })
+        .filter((e) => {
+          if (!e.name.startsWith('.')) return e.isDirectory();
+          return false;
+        })
+        .map((e) => ({ name: e.name, path: join(abs, e.name) }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const parent = dirname(abs);
+      res.json({
+        ok: true,
+        path: abs,
+        parent: parent === abs ? null : parent,
+        dirs,
+      });
+    } catch (err) {
+      res.status(400).json({ ok: false, error: err.message });
     }
   });
 

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -11,7 +11,7 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
-
+import { activeByProfile, discoverActiveMulti } from './active-runs.js';
 import {
   getLeaderboard,
   leaderboardBenchmarks,
@@ -57,6 +57,7 @@ export function createApp(options = {}) {
   const effectiveDirs = () => resolveResultDirs(targetDir, settingsHome).dirs;
   const readRows = () => readResultsMulti(effectiveDirs());
   const readDefs = () => readProfileDefsMulti(effectiveDirs());
+  const readActive = () => discoverActiveMulti(effectiveDirs());
 
   app.use(express.json());
 
@@ -100,6 +101,18 @@ export function createApp(options = {}) {
           last_run: null,
         });
       }
+      // Fold in live status from in-flight work trees (running profiles surface
+      // a current stage before any results.jsonl row exists).
+      const active = activeByProfile(readActive());
+      for (const agg of aggregates) {
+        const run = active.get(agg.name);
+        if (run) {
+          agg.active = true;
+          agg.stage = run.stage;
+          agg.pipeline_status = run.pipeline_status;
+          agg.active_kind = run.kind;
+        }
+      }
       aggregates.sort((a, b) => a.name.localeCompare(b.name));
       res.json({ ok: true, profiles: aggregates });
     } catch (err) {
@@ -116,27 +129,40 @@ export function createApp(options = {}) {
       const name = req.params.name;
       const rows = readRows();
       const reps = rows.filter((r) => (r.profile || '(unknown)') === name);
+      const active = readActive().filter((r) => r.profile === name);
       if (reps.length > 0) {
         return res.json({
           ok: true,
           aggregate: aggregateProfile(name, reps),
           reps,
+          active,
         });
       }
       const def = readDefs().find((d) => d.name === name);
-      if (!def) {
+      if (!def && active.length === 0) {
         return res.status(404).json({ ok: false, error: 'profile not found' });
       }
       res.json({
         ok: true,
         aggregate: {
           ...aggregateProfile(name, []),
-          benchmark: def.benchmark,
-          template: def.template,
-          grade_mode: def.grade_mode,
+          benchmark: def?.benchmark || null,
+          template: def?.template || null,
+          grade_mode: def?.grade_mode || null,
+          active: active.length > 0,
         },
         reps: [],
+        active,
       });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Live in-flight runs (read from worca status.json under work/).
+  app.get('/api/active', (_req, res) => {
+    try {
+      res.json({ ok: true, active: readActive() });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -26,6 +26,7 @@ import {
   readProfileDefsMulti,
   readResultsMulti,
 } from './results-store.js';
+import { clearProfileResults, stopProfileRuns } from './run-control.js';
 import {
   addResultDir,
   loadSettings,
@@ -163,6 +164,33 @@ export function createApp(options = {}) {
         reps: [],
         active,
       });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Stop all active runs for a profile (kills the runner process tree).
+  app.post('/api/profiles/:name/stop', async (req, res) => {
+    try {
+      const stopped = await stopProfileRuns(req.params.name);
+      res.json({ ok: true, stopped });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Clear a profile's recorded results — refused while it has active runs.
+  app.post('/api/profiles/:name/clear', (req, res) => {
+    try {
+      const active = readActive().filter((r) => r.profile === req.params.name);
+      if (active.length > 0) {
+        return res.status(409).json({
+          ok: false,
+          error: 'profile has active runs — stop them first',
+        });
+      }
+      const removed = clearProfileResults(req.params.name, effectiveDirs());
+      res.json({ ok: true, removed });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -27,7 +27,9 @@ import {
   addResultDir,
   loadSettings,
   removeResultDir,
+  resolveCacheDir,
   resolveResultDirs,
+  setCacheDir,
 } from './settings-store.js';
 
 /**
@@ -111,7 +113,11 @@ export function createApp(options = {}) {
       const rows = readRows();
       const reps = rows.filter((r) => (r.profile || '(unknown)') === name);
       if (reps.length > 0) {
-        return res.json({ ok: true, aggregate: aggregateProfile(name, reps), reps });
+        return res.json({
+          ok: true,
+          aggregate: aggregateProfile(name, reps),
+          reps,
+        });
       }
       const def = readDefs().find((d) => d.name === name);
       if (!def) {
@@ -188,6 +194,7 @@ export function createApp(options = {}) {
         profilesDir: def?._source_dir,
         reps: _posInt(req.body?.reps),
         maxInstances: _posInt(req.body?.maxInstances),
+        cacheDir: resolveCacheDir(settingsHome).dir,
       });
       res.json({ ok: true, pid });
     } catch (err) {
@@ -204,6 +211,7 @@ export function createApp(options = {}) {
       primary: resolved.primary, // launch --target-dir, always included
       configured: loadSettings(settingsHome).result_dirs,
       effective: resolved.dirs, // what the dashboard actually reads
+      cache: resolveCacheDir(settingsHome), // { dir, source } for HF/repo blobs
     };
   };
 
@@ -238,6 +246,16 @@ export function createApp(options = {}) {
       res.json(settingsPayload());
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Set (body.dir) or clear (empty body.dir) the benchmark cache dir.
+  app.post('/api/settings/cache-dir', (req, res) => {
+    try {
+      setCacheDir(req.body?.dir, settingsHome);
+      res.json(settingsPayload());
+    } catch (err) {
+      res.status(400).json({ ok: false, error: err.message });
     }
   });
 

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -20,8 +20,8 @@ import express from 'express';
 import {
   findAction,
   patchAction,
+  pidAlive,
   readActions,
-  recordAction,
 } from './actions-store.js';
 import {
   activeByProfile,
@@ -83,6 +83,25 @@ export function createApp(options = {}) {
   const _engineMode = (v) => {
     if (v === true) return 'structural';
     return typeof v === 'string' && v.trim() ? v.trim() : undefined;
+  };
+
+  // In-memory spawn overlay for the Activity dock. The CLI is the authoritative
+  // ledger writer (it records its own lifecycle to actions.jsonl), but it takes
+  // ~1s to boot before it can write — so on spawn we remember the pid here to (a)
+  // show an instant 'starting' row and (b) catch a crash-on-boot (pid dies before
+  // the CLI records anything). Pruned once the CLI's record appears (matched by
+  // pid) or it ages out. Not persisted — it only covers the brief boot window.
+  const pendingSpawns = new Map();
+  const SPAWN_GRACE_MS = 30_000;
+  const notePendingSpawn = (pid, kind, profile) => {
+    if (Number.isInteger(pid)) {
+      pendingSpawns.set(pid, {
+        type: kind,
+        profile,
+        source_dir: targetDir,
+        started_at: new Date().toISOString(),
+      });
+    }
   };
 
   // Effective read set = launch dir (always) + configured dirs (settings.json).
@@ -402,26 +421,10 @@ export function createApp(options = {}) {
         // and merges them into the runner's env (never persisted server-side).
         secrets: req.body?.secrets,
       });
-      // Record the launch in the actions ledger so the Activity dock shows it
-      // immediately (closing the gap before the first status.json appears) and
-      // survives a page reload. Best-effort — a ledger write must never fail a run.
-      let action = null;
-      try {
-        action = recordAction(targetDir, {
-          type: 'run',
-          profile,
-          src: def ? srcHash(dirname(def._source_dir)) : undefined,
-          pid,
-          params: {
-            reps: _posInt(req.body?.reps),
-            maxInstances: _posInt(req.body?.maxInstances),
-            timeout: req.body?.timeout,
-          },
-        });
-      } catch {
-        /* ledger write failed — the run still launched */
-      }
-      res.json({ ok: true, pid, action });
+      // The spawned CLI records its own lifecycle to actions.jsonl; note the pid
+      // so the dock shows an instant 'starting' row during the CLI's boot window.
+      notePendingSpawn(pid, 'run', profile);
+      res.json({ ok: true, pid });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }
@@ -468,23 +471,10 @@ export function createApp(options = {}) {
         logPath: join(targetDir, 'runs', profile, 'regrade.log'),
         secrets: req.body?.secrets,
       });
-      let action = null;
-      try {
-        action = recordAction(targetDir, {
-          type: 'regrade',
-          profile,
-          src: def ? srcHash(dirname(def._source_dir)) : undefined,
-          pid,
-          params: {
-            mode: mode || undefined,
-            instance: instance || undefined,
-            onlyErrors: req.body?.onlyErrors === true,
-          },
-        });
-      } catch {
-        /* ledger write failed — the regrade still launched */
-      }
-      res.json({ ok: true, pid, action });
+      // The spawned regrade CLI records its own lifecycle; note the pid for the
+      // instant 'starting' row during boot.
+      notePendingSpawn(pid, 'regrade', profile);
+      res.json({ ok: true, pid });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }
@@ -495,14 +485,17 @@ export function createApp(options = {}) {
   // derived progress. Reconciles dead pids to a terminal state on read.
   app.get('/api/actions', (_req, res) => {
     try {
-      const actions = readActions(targetDir);
+      const actions = readActions(targetDir); // dead pids reconciled to terminal
       const rows = readRows();
       const regrades = readRegrades();
       const defs = readDefs();
+      // src is backfilled here (the CLI records source_dir, not src, to avoid a
+      // JS/Python hash mismatch). Progress is whatever the CLI wrote; only when a
+      // record predates progress-writing do we derive it from results/heartbeats.
       const enriched = actions.map((a) => {
+        const src = a.src ?? (a.source_dir ? srcHash(a.source_dir) : null);
+        if (a.progress) return { ...a, src };
         if (a.type === 'run') {
-          // done = terminal result rows for this profile produced since launch;
-          // total = the profile's selected instance count (null => "all").
           const since = a.started_at || '';
           const mine = rows.filter(
             (r) => r.profile === a.profile && (r.completed_at || '') >= since,
@@ -514,6 +507,7 @@ export function createApp(options = {}) {
           const def = defs.find((d) => d.name === a.profile);
           return {
             ...a,
+            src,
             progress: {
               unit: 'instances',
               done,
@@ -522,11 +516,11 @@ export function createApp(options = {}) {
             },
           };
         }
-        // regrade: pull live counts from the heartbeat when present.
         const rg = regrades.find((r) => r.profile === a.profile);
         if (rg) {
           return {
             ...a,
+            src,
             progress: {
               unit: 'regraded',
               done: rg.done,
@@ -535,8 +529,49 @@ export function createApp(options = {}) {
             },
           };
         }
-        return { ...a, progress: null };
+        return { ...a, src, progress: null };
       });
+
+      // Overlay the spawn map for the boot window: a pid not yet in the ledger is
+      // either still booting (→ instant 'starting' row) or crashed before
+      // recording (→ synthetic 'failed'). Prune once the CLI takes over (its
+      // record carries the same pid) or after the grace window.
+      const ledgerPids = new Set(actions.map((a) => a.pid).filter(Boolean));
+      const now = Date.now();
+      for (const [pid, sp] of pendingSpawns) {
+        if (ledgerPids.has(pid)) {
+          pendingSpawns.delete(pid); // CLI recorded it — drop the placeholder
+          continue;
+        }
+        const ageMs = now - Date.parse(sp.started_at);
+        const alive = pidAlive(pid);
+        const base = {
+          id: `pending-${pid}`,
+          type: sp.type,
+          profile: sp.profile,
+          src: srcHash(sp.source_dir),
+          pid,
+          started_at: sp.started_at,
+        };
+        if (alive) {
+          enriched.unshift({ ...base, status: 'running', progress: null });
+          if (ageMs > SPAWN_GRACE_MS) pendingSpawns.delete(pid); // CLI never recorded
+        } else {
+          if (ageMs < SPAWN_GRACE_MS) {
+            enriched.unshift({
+              ...base,
+              status: 'failed',
+              error: 'launch failed — process exited before recording',
+              ended_at: new Date().toISOString(),
+              progress: null,
+            });
+          }
+          pendingSpawns.delete(pid);
+        }
+      }
+      enriched.sort((x, y) =>
+        (y.started_at || '').localeCompare(x.started_at || ''),
+      );
       res.json({ ok: true, actions: enriched });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
@@ -547,14 +582,24 @@ export function createApp(options = {}) {
   app.post('/api/actions/:id/stop', async (req, res) => {
     try {
       const a = findAction(targetDir, req.params.id);
-      if (!a)
-        return res.status(404).json({ ok: false, error: 'action not found' });
-      const stopped = await stopPidTree(a.pid);
-      patchAction(targetDir, a.id, {
-        status: 'stopped',
-        ended_at: new Date().toISOString(),
-      });
-      res.json({ ok: true, stopped });
+      if (a) {
+        const stopped = await stopPidTree(a.pid);
+        patchAction(targetDir, a.id, {
+          status: 'stopped',
+          ended_at: new Date().toISOString(),
+        });
+        return res.json({ ok: true, stopped });
+      }
+      // A still-booting action exists only as a `pending-<pid>` overlay row (the
+      // CLI hasn't written its ledger record yet) — stop it by pid directly.
+      const m = /^pending-(\d+)$/.exec(req.params.id);
+      if (m) {
+        const pid = Number(m[1]);
+        const stopped = await stopPidTree(pid);
+        pendingSpawns.delete(pid);
+        return res.json({ ok: true, stopped });
+      }
+      return res.status(404).json({ ok: false, error: 'action not found' });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -128,6 +128,7 @@ export function createApp(options = {}) {
           template: def.template,
           grade_mode: def.grade_mode,
           canary: def.canary,
+          max_parallel: def.max_parallel,
           reps: 0,
           graded: 0,
           resolved: 0,
@@ -200,8 +201,9 @@ export function createApp(options = {}) {
           aggregate: {
             ...aggregateProfile(name, rows),
             instance_count: instanceCount,
-            // canary is a launch flag (never in results rows) — read from the def.
+            // canary + max_parallel are config (never in results rows) — read from the def.
             canary: def?.canary ?? null,
+            max_parallel: def?.max_parallel ?? null,
           },
           reps: dedupeReps(rows), // collapse re-runs in the per-rep table
           active,
@@ -223,6 +225,7 @@ export function createApp(options = {}) {
           template: def?.template || null,
           grade_mode: def?.grade_mode || null,
           canary: def?.canary ?? null,
+          max_parallel: def?.max_parallel ?? null,
           instance_count: instanceCount,
           active: active.length > 0,
         },

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -6,7 +6,13 @@
 // catch-all. The app reads benchmark results from a target directory passed in
 // via options.targetDir (the runner's --target-dir / WORCA_BENCH_DIR).
 
-import { readdirSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -337,6 +343,17 @@ export function createApp(options = {}) {
         cacheDir: resolveCacheDir(settingsHome).dir,
         graphify: _engineMode(req.body?.graphify),
         codeReviewGraph: _engineMode(req.body?.codeReviewGraph),
+        // Preflight on/off (only when an explicit boolean is sent) + CLAUDE.md
+        // load mode (allowlisted; ignored otherwise).
+        preflight:
+          typeof req.body?.preflight === 'boolean'
+            ? req.body.preflight
+            : undefined,
+        claudeMdMode: ['none', 'project', 'project+local', 'all'].includes(
+          req.body?.claudeMdMode,
+        )
+          ? req.body.claudeMdMode
+          : undefined,
         // Grader credentials forwarded from the browser; the launcher allowlists
         // and merges them into the runner's env (never persisted server-side).
         secrets: req.body?.secrets,
@@ -389,6 +406,42 @@ export function createApp(options = {}) {
         secrets: req.body?.secrets,
       });
       res.json({ ok: true, pid });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // ─── Per-profile human notes (stored alongside results) ─────────────────
+  // Free-text notes saved at <targetDir>/notes/<profile>.md so they persist with
+  // the run data and survive reloads. Capped to keep a localhost tool sane.
+  const NOTES_CAP = 200_000;
+  const notesPath = (name) => join(targetDir, 'notes', `${name}.md`);
+
+  app.get('/api/profiles/:name/notes', (req, res) => {
+    if (_badName(req.params.name)) {
+      return res.status(400).json({ ok: false, error: 'invalid profile name' });
+    }
+    try {
+      const f = notesPath(req.params.name);
+      const notes = existsSync(f) ? readFileSync(f, 'utf8') : '';
+      res.json({ ok: true, notes });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  app.put('/api/profiles/:name/notes', (req, res) => {
+    if (_badName(req.params.name)) {
+      return res.status(400).json({ ok: false, error: 'invalid profile name' });
+    }
+    const notes = typeof req.body?.notes === 'string' ? req.body.notes : '';
+    if (notes.length > NOTES_CAP) {
+      return res.status(413).json({ ok: false, error: 'notes too large' });
+    }
+    try {
+      mkdirSync(join(targetDir, 'notes'), { recursive: true });
+      writeFileSync(notesPath(req.params.name), notes);
+      res.json({ ok: true });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -309,6 +309,9 @@ export function createApp(options = {}) {
         cacheDir: resolveCacheDir(settingsHome).dir,
         graphify: _engineMode(req.body?.graphify),
         codeReviewGraph: _engineMode(req.body?.codeReviewGraph),
+        // Grader credentials forwarded from the browser; the launcher allowlists
+        // and merges them into the runner's env (never persisted server-side).
+        secrets: req.body?.secrets,
       });
       res.json({ ok: true, pid });
     } catch (err) {
@@ -345,6 +348,7 @@ export function createApp(options = {}) {
         instance: instance || undefined,
         mode: mode || undefined,
         onlyErrors: req.body?.onlyErrors === true,
+        secrets: req.body?.secrets,
       });
       res.json({ ok: true, pid });
     } catch (err) {

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -132,6 +132,7 @@ export function createApp(options = {}) {
           graphify: def.graphify,
           code_review_graph: def.code_review_graph,
           preflight: def.preflight,
+          timeout: def.timeout,
           reps: 0,
           graded: 0,
           resolved: 0,
@@ -211,6 +212,7 @@ export function createApp(options = {}) {
             graphify: def?.graphify ?? null,
             code_review_graph: def?.code_review_graph ?? null,
             preflight: def?.preflight ?? null,
+            timeout: def?.timeout ?? null,
           },
           reps: dedupeReps(rows), // collapse re-runs in the per-rep table
           active,
@@ -236,6 +238,7 @@ export function createApp(options = {}) {
           graphify: def?.graphify ?? null,
           code_review_graph: def?.code_review_graph ?? null,
           preflight: def?.preflight ?? null,
+          timeout: def?.timeout ?? null,
           instance_count: instanceCount,
           active: active.length > 0,
         },
@@ -380,6 +383,14 @@ export function createApp(options = {}) {
         )
           ? req.body.gradeMode
           : undefined,
+        // Per-build timeout override (seconds). A non-negative integer is
+        // authoritative (0 = no limit); omit to use the profile's own value.
+        timeout:
+          typeof req.body?.timeout === 'number' &&
+          Number.isInteger(req.body.timeout) &&
+          req.body.timeout >= 0
+            ? req.body.timeout
+            : undefined,
         // Grader credentials forwarded from the browser; the launcher allowlists
         // and merges them into the runner's env (never persisted server-side).
         secrets: req.body?.secrets,

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -17,7 +17,7 @@ import {
   leaderboardBenchmarks,
   localLeaderboardRows,
 } from './leaderboard.js';
-import { runBenchmark } from './process-manager.js';
+import { runBenchmark, runRegrade } from './process-manager.js';
 import {
   aggregateByProfile,
   aggregateProfile,
@@ -48,6 +48,7 @@ export function createApp(options = {}) {
   const appDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'app');
   const targetDir = options.targetDir || process.cwd();
   const launch = options._runBenchmark || runBenchmark;
+  const regrade = options._runRegrade || runRegrade;
   const settingsHome = options.settingsHome;
 
   // Coerce a request value to a positive integer, else undefined (use default).
@@ -308,6 +309,42 @@ export function createApp(options = {}) {
         cacheDir: resolveCacheDir(settingsHome).dir,
         graphify: _engineMode(req.body?.graphify),
         codeReviewGraph: _engineMode(req.body?.codeReviewGraph),
+      });
+      res.json({ ok: true, pid });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Fire-and-forget: re-grade a profile's saved diffs (no pipeline re-run).
+  app.post('/api/regrade', async (req, res) => {
+    const profile = req.body?.profile;
+    if (!profile) {
+      return res.status(400).json({ ok: false, error: 'profile is required' });
+    }
+    if (_badName(profile)) {
+      return res.status(400).json({ ok: false, error: 'invalid profile name' });
+    }
+    const instance = req.body?.instance;
+    if (instance != null && _badName(instance)) {
+      return res.status(400).json({ ok: false, error: 'invalid instance id' });
+    }
+    const mode = req.body?.mode;
+    if (
+      mode != null &&
+      !['sb-cli', 'local-docker', 'modal', 'stub'].includes(mode)
+    ) {
+      return res.status(400).json({ ok: false, error: 'invalid grade mode' });
+    }
+    try {
+      const def = readDefs().find((d) => d.name === profile);
+      const { pid } = await regrade({
+        profile,
+        targetDir,
+        profilesDir: def?._source_dir,
+        instance: instance || undefined,
+        mode: mode || undefined,
+        onlyErrors: req.body?.onlyErrors === true,
       });
       res.json({ ok: true, pid });
     } catch (err) {

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -101,20 +101,26 @@ export function createApp(options = {}) {
     }
   });
 
-  // One profile: aggregate + the individual reps for the detail table.
+  // One profile: aggregate + the individual reps for the detail table. A
+  // profile that has a YAML def but no results yet (reps: 0) is still openable —
+  // we synthesize a def-based aggregate so the detail page (and its Run options)
+  // render. Only 404 when neither results nor a def exist for the name.
   app.get('/api/profiles/:name', (req, res) => {
     try {
+      const name = req.params.name;
       const rows = readRows();
-      const reps = rows.filter(
-        (r) => (r.profile || '(unknown)') === req.params.name,
-      );
-      if (reps.length === 0) {
+      const reps = rows.filter((r) => (r.profile || '(unknown)') === name);
+      if (reps.length > 0) {
+        return res.json({ ok: true, aggregate: aggregateProfile(name, reps), reps });
+      }
+      const def = readDefs().find((d) => d.name === name);
+      if (!def) {
         return res.status(404).json({ ok: false, error: 'profile not found' });
       }
       res.json({
         ok: true,
-        aggregate: aggregateProfile(req.params.name, reps),
-        reps,
+        aggregate: { ...aggregateProfile(name, []), benchmark: def.benchmark },
+        reps: [],
       });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -303,6 +303,8 @@ export function createApp(options = {}) {
         reps: _posInt(req.body?.reps),
         maxInstances: _posInt(req.body?.maxInstances),
         maxParallel: _posInt(req.body?.maxParallel),
+        // Canary is on by default; only an explicit `false` disables it.
+        noCanary: req.body?.canary === false,
         cacheDir: resolveCacheDir(settingsHome).dir,
         graphify: _engineMode(req.body?.graphify),
         codeReviewGraph: _engineMode(req.body?.codeReviewGraph),

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -8,7 +8,7 @@
 
 import { readdirSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
 import { activeByProfile, discoverActiveMulti } from './active-runs.js';
@@ -25,6 +25,7 @@ import {
   dedupeReps,
   readProfileDefsMulti,
   readResultsMulti,
+  srcHash,
 } from './results-store.js';
 import { clearProfileResults, stopProfileRuns } from './run-control.js';
 import {
@@ -89,11 +90,18 @@ export function createApp(options = {}) {
     try {
       const rows = readRows();
       const aggregates = aggregateByProfile(rows);
-      const known = new Set(aggregates.map((a) => a.name));
+      const known = new Set(aggregates.map((a) => `${a.src}::${a.name}`));
       for (const def of readDefs()) {
-        if (known.has(def.name)) continue;
+        // def._source_dir is <dir>/profiles; the result-dir src is its parent.
+        const dir = dirname(def._source_dir);
+        const src = srcHash(dir);
+        if (known.has(`${src}::${def.name}`)) continue;
+        known.add(`${src}::${def.name}`);
         aggregates.push({
           name: def.name,
+          src,
+          source_dir: dir,
+          source_label: basename(dir),
           benchmark: def.benchmark,
           worca_ref: null,
           worca_version: null,
@@ -114,7 +122,7 @@ export function createApp(options = {}) {
       // a current stage before any results.jsonl row exists).
       const active = activeByProfile(readActive());
       for (const agg of aggregates) {
-        const run = active.get(agg.name);
+        const run = active.get(`${agg.src}::${agg.name}`);
         if (run) {
           agg.active = true;
           agg.stage = run.stage;
@@ -137,25 +145,37 @@ export function createApp(options = {}) {
   app.get('/api/profiles/:name', (req, res) => {
     try {
       const name = req.params.name;
-      const rows = readRows();
-      const reps = rows.filter((r) => (r.profile || '(unknown)') === name);
-      const active = readActive().filter((r) => r.profile === name);
-      if (reps.length > 0) {
+      // Optional src scopes to one result dir (same name can exist in several).
+      const src = req.query.src ? String(req.query.src) : null;
+      const matchSrc = (dir) => !src || srcHash(dir) === src;
+      const rows = readRows().filter(
+        (r) => (r.profile || '(unknown)') === name && matchSrc(r._source_dir),
+      );
+      const active = readActive().filter(
+        (r) => r.profile === name && (!src || r.src === src),
+      );
+      if (rows.length > 0) {
         return res.json({
           ok: true,
-          aggregate: aggregateProfile(name, reps),
-          reps: dedupeReps(reps), // collapse re-runs in the per-rep table
+          aggregate: aggregateProfile(name, rows),
+          reps: dedupeReps(rows), // collapse re-runs in the per-rep table
           active,
         });
       }
-      const def = readDefs().find((d) => d.name === name);
+      const def = readDefs().find(
+        (d) => d.name === name && matchSrc(dirname(d._source_dir)),
+      );
       if (!def && active.length === 0) {
         return res.status(404).json({ ok: false, error: 'profile not found' });
       }
+      const defDir = def ? dirname(def._source_dir) : null;
       res.json({
         ok: true,
         aggregate: {
           ...aggregateProfile(name, []),
+          src: def ? srcHash(defDir) : src,
+          source_dir: defDir,
+          source_label: defDir ? basename(defDir) : null,
           benchmark: def?.benchmark || null,
           template: def?.template || null,
           grade_mode: def?.grade_mode || null,

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -154,17 +154,23 @@ export function createApp(options = {}) {
       const active = readActive().filter(
         (r) => r.profile === name && (!src || r.src === src),
       );
+      // The selected-instance count lives in the YAML def, not in results rows;
+      // look it up regardless of whether the profile has run yet.
+      const def = readDefs().find(
+        (d) => d.name === name && matchSrc(dirname(d._source_dir)),
+      );
+      const instanceCount = def ? (def.instance_count ?? null) : null;
       if (rows.length > 0) {
         return res.json({
           ok: true,
-          aggregate: aggregateProfile(name, rows),
+          aggregate: {
+            ...aggregateProfile(name, rows),
+            instance_count: instanceCount,
+          },
           reps: dedupeReps(rows), // collapse re-runs in the per-rep table
           active,
         });
       }
-      const def = readDefs().find(
-        (d) => d.name === name && matchSrc(dirname(d._source_dir)),
-      );
       if (!def && active.length === 0) {
         return res.status(404).json({ ok: false, error: 'profile not found' });
       }
@@ -179,6 +185,7 @@ export function createApp(options = {}) {
           benchmark: def?.benchmark || null,
           template: def?.template || null,
           grade_mode: def?.grade_mode || null,
+          instance_count: instanceCount,
           active: active.length > 0,
         },
         reps: [],
@@ -295,6 +302,7 @@ export function createApp(options = {}) {
         profilesDir: def?._source_dir,
         reps: _posInt(req.body?.reps),
         maxInstances: _posInt(req.body?.maxInstances),
+        maxParallel: _posInt(req.body?.maxParallel),
         cacheDir: resolveCacheDir(settingsHome).dir,
         graphify: _engineMode(req.body?.graphify),
         codeReviewGraph: _engineMode(req.body?.codeReviewGraph),

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -127,6 +127,7 @@ export function createApp(options = {}) {
           worca_version: null,
           template: def.template,
           grade_mode: def.grade_mode,
+          canary: def.canary,
           reps: 0,
           graded: 0,
           resolved: 0,
@@ -199,6 +200,8 @@ export function createApp(options = {}) {
           aggregate: {
             ...aggregateProfile(name, rows),
             instance_count: instanceCount,
+            // canary is a launch flag (never in results rows) — read from the def.
+            canary: def?.canary ?? null,
           },
           reps: dedupeReps(rows), // collapse re-runs in the per-rep table
           active,
@@ -219,6 +222,7 @@ export function createApp(options = {}) {
           benchmark: def?.benchmark || null,
           template: def?.template || null,
           grade_mode: def?.grade_mode || null,
+          canary: def?.canary ?? null,
           instance_count: instanceCount,
           active: active.length > 0,
         },
@@ -338,8 +342,10 @@ export function createApp(options = {}) {
         reps: _posInt(req.body?.reps),
         maxInstances: _posInt(req.body?.maxInstances),
         maxParallel: _posInt(req.body?.maxParallel),
-        // Canary is on by default; only an explicit `false` disables it.
-        noCanary: req.body?.canary === false,
+        // Canary override: an explicit boolean from the UI toggle is authoritative
+        // (overrides the profile's canary flag); omit to leave the profile default.
+        canary:
+          typeof req.body?.canary === 'boolean' ? req.body.canary : undefined,
         cacheDir: resolveCacheDir(settingsHome).dir,
         graphify: _engineMode(req.body?.graphify),
         codeReviewGraph: _engineMode(req.body?.codeReviewGraph),

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -139,10 +139,14 @@ export function createApp(options = {}) {
       const rows = readRows();
       const aggregates = aggregateByProfile(rows);
       const known = new Set(aggregates.map((a) => `${a.src}::${a.name}`));
+      // Keyed defs so we can attach the configured test count (instance_count)
+      // to results-based aggregates too, not just def-only ones.
+      const defByKey = new Map();
       for (const def of readDefs()) {
         // def._source_dir is <dir>/profiles; the result-dir src is its parent.
         const dir = dirname(def._source_dir);
         const src = srcHash(dir);
+        defByKey.set(`${src}::${def.name}`, def);
         if (known.has(`${src}::${def.name}`)) continue;
         known.add(`${src}::${def.name}`);
         aggregates.push({
@@ -161,6 +165,7 @@ export function createApp(options = {}) {
           code_review_graph: def.code_review_graph,
           preflight: def.preflight,
           timeout: def.timeout,
+          instance_count: def.instance_count ?? null,
           reps: 0,
           graded: 0,
           resolved: 0,
@@ -180,6 +185,11 @@ export function createApp(options = {}) {
         if (r.active) regradeMap.set(`${r.src}::${r.profile}`, r);
       }
       for (const agg of aggregates) {
+        // Configured test count from the YAML def (null = full benchmark set).
+        if (agg.instance_count == null) {
+          const def = defByKey.get(`${agg.src}::${agg.name}`);
+          agg.instance_count = def?.instance_count ?? null;
+        }
         const run = active.get(`${agg.src}::${agg.name}`);
         if (run) {
           agg.active = true;

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -354,6 +354,13 @@ export function createApp(options = {}) {
         )
           ? req.body.claudeMdMode
           : undefined,
+        // Grader backend override (allowlisted; ignored otherwise). Defaults to
+        // the profile's own grade.mode when omitted.
+        gradeMode: ['stub', 'sb-cli', 'local-docker', 'modal'].includes(
+          req.body?.gradeMode,
+        )
+          ? req.body.gradeMode
+          : undefined,
         // Grader credentials forwarded from the browser; the launcher allowlists
         // and merges them into the runner's env (never persisted server-side).
         secrets: req.body?.secrets,

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -169,8 +169,14 @@ export function createApp(options = {}) {
     }
   });
 
+  // Reject anything that isn't a safe profile-name identifier.
+  const _badName = (name) => !/^[A-Za-z0-9_.-]+$/.test(name);
+
   // Stop all active runs for a profile (kills the runner process tree).
   app.post('/api/profiles/:name/stop', async (req, res) => {
+    if (_badName(req.params.name)) {
+      return res.status(400).json({ ok: false, error: 'invalid profile name' });
+    }
     try {
       const stopped = await stopProfileRuns(req.params.name);
       res.json({ ok: true, stopped });
@@ -181,6 +187,9 @@ export function createApp(options = {}) {
 
   // Clear a profile's recorded results — refused while it has active runs.
   app.post('/api/profiles/:name/clear', (req, res) => {
+    if (_badName(req.params.name)) {
+      return res.status(400).json({ ok: false, error: 'invalid profile name' });
+    }
     try {
       const active = readActive().filter((r) => r.profile === req.params.name);
       if (active.length > 0) {

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -43,6 +43,12 @@ export function createApp(options = {}) {
   const launch = options._runBenchmark || runBenchmark;
   const settingsHome = options.settingsHome;
 
+  // Coerce a request value to a positive integer, else undefined (use default).
+  const _posInt = (v) => {
+    const n = Number.parseInt(v, 10);
+    return Number.isInteger(n) && n >= 1 ? n : undefined;
+  };
+
   // Effective read set = launch dir (always) + configured dirs (settings.json).
   const effectiveDirs = () => resolveResultDirs(targetDir, settingsHome).dirs;
   const readRows = () => readResultsMulti(effectiveDirs());
@@ -174,6 +180,8 @@ export function createApp(options = {}) {
         profile,
         targetDir,
         profilesDir: def?._source_dir,
+        reps: _posInt(req.body?.reps),
+        maxInstances: _posInt(req.body?.maxInstances),
       });
       res.json({ ok: true, pid });
     } catch (err) {

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -18,6 +18,12 @@ import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
 import {
+  findAction,
+  patchAction,
+  readActions,
+  recordAction,
+} from './actions-store.js';
+import {
   activeByProfile,
   discoverActiveMulti,
   discoverRegradesMulti,
@@ -39,6 +45,7 @@ import {
 } from './results-store.js';
 import {
   clearProfileResults,
+  stopPidTree,
   stopProfileRuns,
   stopRegrade,
 } from './run-control.js';
@@ -395,7 +402,26 @@ export function createApp(options = {}) {
         // and merges them into the runner's env (never persisted server-side).
         secrets: req.body?.secrets,
       });
-      res.json({ ok: true, pid });
+      // Record the launch in the actions ledger so the Activity dock shows it
+      // immediately (closing the gap before the first status.json appears) and
+      // survives a page reload. Best-effort — a ledger write must never fail a run.
+      let action = null;
+      try {
+        action = recordAction(targetDir, {
+          type: 'run',
+          profile,
+          src: def ? srcHash(dirname(def._source_dir)) : undefined,
+          pid,
+          params: {
+            reps: _posInt(req.body?.reps),
+            maxInstances: _posInt(req.body?.maxInstances),
+            timeout: req.body?.timeout,
+          },
+        });
+      } catch {
+        /* ledger write failed — the run still launched */
+      }
+      res.json({ ok: true, pid, action });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }
@@ -442,7 +468,93 @@ export function createApp(options = {}) {
         logPath: join(targetDir, 'runs', profile, 'regrade.log'),
         secrets: req.body?.secrets,
       });
-      res.json({ ok: true, pid });
+      let action = null;
+      try {
+        action = recordAction(targetDir, {
+          type: 'regrade',
+          profile,
+          src: def ? srcHash(dirname(def._source_dir)) : undefined,
+          pid,
+          params: {
+            mode: mode || undefined,
+            instance: instance || undefined,
+            onlyErrors: req.body?.onlyErrors === true,
+          },
+        });
+      } catch {
+        /* ledger write failed — the regrade still launched */
+      }
+      res.json({ ok: true, pid, action });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // ─── Actions ledger (Activity dock) ─────────────────────────────────────
+  // Persistent, reload-surviving list of Run/Regrade launches with lifecycle +
+  // derived progress. Reconciles dead pids to a terminal state on read.
+  app.get('/api/actions', (_req, res) => {
+    try {
+      const actions = readActions(targetDir);
+      const rows = readRows();
+      const regrades = readRegrades();
+      const defs = readDefs();
+      const enriched = actions.map((a) => {
+        if (a.type === 'run') {
+          // done = terminal result rows for this profile produced since launch;
+          // total = the profile's selected instance count (null => "all").
+          const since = a.started_at || '';
+          const mine = rows.filter(
+            (r) => r.profile === a.profile && (r.completed_at || '') >= since,
+          );
+          const done = mine.filter((r) =>
+            ['graded', 'error', 'skipped'].includes(r.status),
+          ).length;
+          const errors = mine.filter((r) => r.status === 'error').length;
+          const def = defs.find((d) => d.name === a.profile);
+          return {
+            ...a,
+            progress: {
+              unit: 'instances',
+              done,
+              errors,
+              total: def?.instance_count ?? null,
+            },
+          };
+        }
+        // regrade: pull live counts from the heartbeat when present.
+        const rg = regrades.find((r) => r.profile === a.profile);
+        if (rg) {
+          return {
+            ...a,
+            progress: {
+              unit: 'regraded',
+              done: rg.done,
+              total: rg.total,
+              errors: rg.counts?.error ?? 0,
+            },
+          };
+        }
+        return { ...a, progress: null };
+      });
+      res.json({ ok: true, actions: enriched });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Stop one action by id: SIGTERM→SIGKILL its runner tree, mark it stopped.
+  app.post('/api/actions/:id/stop', async (req, res) => {
+    try {
+      const a = findAction(targetDir, req.params.id);
+      if (!a)
+        return res.status(404).json({ ok: false, error: 'action not found' });
+      const stopped = await stopPidTree(a.pid);
+      patchAction(targetDir, a.id, {
+        status: 'stopped',
+        ended_at: new Date().toISOString(),
+      });
+      res.json({ ok: true, stopped });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -167,7 +167,14 @@ export function createApp(options = {}) {
       return res.status(400).json({ ok: false, error: 'profile is required' });
     }
     try {
-      const { pid } = await launch({ profile, targetDir });
+      // Find where this profile's YAML lives so a profile authored in a
+      // configured (non-primary) dir is still findable by the runner.
+      const def = readDefs().find((d) => d.name === profile);
+      const { pid } = await launch({
+        profile,
+        targetDir,
+        profilesDir: def?._source_dir,
+      });
       res.json({ ok: true, pid });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -16,9 +16,15 @@ import {
   aggregateByProfile,
   aggregateProfile,
   compareProfiles,
-  readProfileDefs,
-  readResults,
+  readProfileDefsMulti,
+  readResultsMulti,
 } from './results-store.js';
+import {
+  addResultDir,
+  loadSettings,
+  removeResultDir,
+  resolveResultDirs,
+} from './settings-store.js';
 
 /**
  * @param {object} options
@@ -31,6 +37,12 @@ export function createApp(options = {}) {
   const appDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'app');
   const targetDir = options.targetDir || process.cwd();
   const launch = options._runBenchmark || runBenchmark;
+  const settingsHome = options.settingsHome;
+
+  // Effective read set = launch dir (always) + configured dirs (settings.json).
+  const effectiveDirs = () => resolveResultDirs(targetDir, settingsHome).dirs;
+  const readRows = () => readResultsMulti(effectiveDirs());
+  const readDefs = () => readProfileDefsMulti(effectiveDirs());
 
   app.use(express.json());
 
@@ -51,10 +63,10 @@ export function createApp(options = {}) {
   // (benchmark) for profiles that have a YAML definition but no results yet.
   app.get('/api/profiles', (_req, res) => {
     try {
-      const rows = readResults(targetDir);
+      const rows = readRows();
       const aggregates = aggregateByProfile(rows);
       const known = new Set(aggregates.map((a) => a.name));
-      for (const def of readProfileDefs(targetDir)) {
+      for (const def of readDefs()) {
         if (known.has(def.name)) continue;
         aggregates.push({
           name: def.name,
@@ -82,7 +94,7 @@ export function createApp(options = {}) {
   // One profile: aggregate + the individual reps for the detail table.
   app.get('/api/profiles/:name', (req, res) => {
     try {
-      const rows = readResults(targetDir);
+      const rows = readRows();
       const reps = rows.filter(
         (r) => (r.profile || '(unknown)') === req.params.name,
       );
@@ -102,7 +114,7 @@ export function createApp(options = {}) {
   // Raw rows — escape hatch for ad-hoc inspection.
   app.get('/api/results', (_req, res) => {
     try {
-      res.json({ ok: true, results: readResults(targetDir) });
+      res.json({ ok: true, results: readRows() });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }
@@ -115,21 +127,23 @@ export function createApp(options = {}) {
         .split(',')
         .map((s) => s.trim())
         .filter(Boolean);
-      const rows = readResults(targetDir);
+      const rows = readRows();
       res.json({ ok: true, compare: compareProfiles(rows, names) });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }
   });
 
-  // Public cross-agent leaderboard (static fixture for now — see leaderboard.js).
-  app.get('/api/leaderboard', (req, res) => {
+  // Public cross-agent leaderboard — live fetch + cache + offline fallback (leaderboard.js).
+  app.get('/api/leaderboard', async (req, res) => {
     try {
       const benchmark = String(req.query.benchmark || 'swe-bench-verified');
       res.json({
         ok: true,
         benchmark,
-        rows: getLeaderboard(benchmark),
+        rows: await getLeaderboard(benchmark, {
+          offline: options.leaderboardOffline,
+        }),
         benchmarks: leaderboardBenchmarks(),
       });
     } catch (err) {
@@ -146,6 +160,52 @@ export function createApp(options = {}) {
     try {
       const { pid } = await launch({ profile, targetDir });
       res.json({ ok: true, pid });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // ─── Settings: result-dir management (~/.worca-bench/settings.json) ──────
+
+  const settingsPayload = () => {
+    const resolved = resolveResultDirs(targetDir, settingsHome);
+    return {
+      ok: true,
+      primary: resolved.primary, // launch --target-dir, always included
+      configured: loadSettings(settingsHome).result_dirs,
+      effective: resolved.dirs, // what the dashboard actually reads
+    };
+  };
+
+  app.get('/api/settings', (_req, res) => {
+    try {
+      res.json(settingsPayload());
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  app.post('/api/settings/dirs', (req, res) => {
+    const dir = req.body?.dir;
+    if (!dir) {
+      return res.status(400).json({ ok: false, error: 'dir is required' });
+    }
+    try {
+      addResultDir(dir, settingsHome);
+      res.json(settingsPayload());
+    } catch (err) {
+      res.status(400).json({ ok: false, error: err.message });
+    }
+  });
+
+  app.delete('/api/settings/dirs', (req, res) => {
+    const dir = req.body?.dir;
+    if (!dir) {
+      return res.status(400).json({ ok: false, error: 'dir is required' });
+    }
+    try {
+      removeResultDir(dir, settingsHome);
+      res.json(settingsPayload());
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -1,0 +1,161 @@
+// server/app.js
+//
+// Express app for the worca-bench dashboard. Structure mirrors
+// worca-ui/server/app.js: createApp() returns a configured app with security
+// headers, JSON body parsing, the JSON API, static asset serving, and a SPA
+// catch-all. The app reads benchmark results from a target directory passed in
+// via options.targetDir (the runner's --target-dir / WORCA_BENCH_DIR).
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express from 'express';
+
+import { getLeaderboard, leaderboardBenchmarks } from './leaderboard.js';
+import { runBenchmark } from './process-manager.js';
+import {
+  aggregateByProfile,
+  aggregateProfile,
+  compareProfiles,
+  readProfileDefs,
+  readResults,
+} from './results-store.js';
+
+/**
+ * @param {object} options
+ * @param {string} options.targetDir  directory holding results.jsonl + profiles/
+ * @param {(opts: object) => Promise<{pid: number}>} [options._runBenchmark]  injectable for tests
+ * @returns {import('express').Express}
+ */
+export function createApp(options = {}) {
+  const app = express();
+  const appDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'app');
+  const targetDir = options.targetDir || process.cwd();
+  const launch = options._runBenchmark || runBenchmark;
+
+  app.use(express.json());
+
+  // ─── Security headers ──────────────────────────────────────────────────
+  app.use((_req, res, next) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'DENY');
+    next();
+  });
+
+  // ─── API ───────────────────────────────────────────────────────────────
+
+  app.get('/api/health', (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  // Aggregated per-profile summaries. Surfaces the cheap profile-def fields
+  // (benchmark) for profiles that have a YAML definition but no results yet.
+  app.get('/api/profiles', (_req, res) => {
+    try {
+      const rows = readResults(targetDir);
+      const aggregates = aggregateByProfile(rows);
+      const known = new Set(aggregates.map((a) => a.name));
+      for (const def of readProfileDefs(targetDir)) {
+        if (known.has(def.name)) continue;
+        aggregates.push({
+          name: def.name,
+          benchmark: def.benchmark,
+          worca_ref: null,
+          template: null,
+          reps: 0,
+          graded: 0,
+          resolved: 0,
+          resolved_rate: 0,
+          mean_cost_usd: null,
+          mean_wall_s: null,
+          mean_iterations: null,
+          n: 0,
+          last_run: null,
+        });
+      }
+      aggregates.sort((a, b) => a.name.localeCompare(b.name));
+      res.json({ ok: true, profiles: aggregates });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // One profile: aggregate + the individual reps for the detail table.
+  app.get('/api/profiles/:name', (req, res) => {
+    try {
+      const rows = readResults(targetDir);
+      const reps = rows.filter(
+        (r) => (r.profile || '(unknown)') === req.params.name,
+      );
+      if (reps.length === 0) {
+        return res.status(404).json({ ok: false, error: 'profile not found' });
+      }
+      res.json({
+        ok: true,
+        aggregate: aggregateProfile(req.params.name, reps),
+        reps,
+      });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Raw rows — escape hatch for ad-hoc inspection.
+  app.get('/api/results', (_req, res) => {
+    try {
+      res.json({ ok: true, results: readResults(targetDir) });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Side-by-side config comparison. ?profiles=a,b,c
+  app.get('/api/compare', (req, res) => {
+    try {
+      const names = String(req.query.profiles || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const rows = readResults(targetDir);
+      res.json({ ok: true, compare: compareProfiles(rows, names) });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Public cross-agent leaderboard (static fixture for now — see leaderboard.js).
+  app.get('/api/leaderboard', (req, res) => {
+    try {
+      const benchmark = String(req.query.benchmark || 'swe-bench-verified');
+      res.json({
+        ok: true,
+        benchmark,
+        rows: getLeaderboard(benchmark),
+        benchmarks: leaderboardBenchmarks(),
+      });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Fire-and-forget: spawn the Python runner for a profile.
+  app.post('/api/run', async (req, res) => {
+    const profile = req.body?.profile;
+    if (!profile) {
+      return res.status(400).json({ ok: false, error: 'profile is required' });
+    }
+    try {
+      const { pid } = await launch({ profile, targetDir });
+      res.json({ ok: true, pid });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // ─── Static + SPA catch-all ────────────────────────────────────────────
+  app.use(express.static(appDir));
+  app.get('/{*splat}', (_req, res) => {
+    res.sendFile('index.html', { root: appDir });
+  });
+
+  return app;
+}

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -45,6 +45,7 @@ import {
 } from './results-store.js';
 import {
   clearProfileResults,
+  killTrackedGroups,
   stopPidTree,
   stopProfileRuns,
   stopRegrade,
@@ -320,7 +321,7 @@ export function createApp(options = {}) {
       return res.status(400).json({ ok: false, error: 'invalid profile name' });
     }
     try {
-      const stopped = await stopProfileRuns(req.params.name);
+      const stopped = await stopProfileRuns(req.params.name, effectiveDirs());
       res.json({ ok: true, stopped });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
@@ -618,6 +619,15 @@ export function createApp(options = {}) {
       const a = findAction(targetDir, req.params.id);
       if (a) {
         const stopped = await stopPidTree(a.pid);
+        // A pipeline run also has session-detached agent groups the pid tree
+        // can't reach — reap them via worca's procs/ registry so none orphan.
+        if (a.type === 'run' && a.profile) {
+          try {
+            await killTrackedGroups(effectiveDirs(), a.profile);
+          } catch {
+            /* best-effort orphan reap */
+          }
+        }
         patchAction(targetDir, a.id, {
           status: 'stopped',
           ended_at: new Date().toISOString(),

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -51,10 +51,12 @@ import {
 } from './run-control.js';
 import {
   addResultDir,
+  loadArchived,
   loadSettings,
   removeResultDir,
   resolveCacheDir,
   resolveResultDirs,
+  setArchived,
   setCacheDir,
 } from './settings-store.js';
 
@@ -196,8 +198,30 @@ export function createApp(options = {}) {
           };
         }
       }
+      // Tag visibility: archived profiles are hidden by default on the dashboard
+      // (the operator manages them via the filter pills + Archive action).
+      const archivedSet = loadArchived(settingsHome);
+      for (const agg of aggregates) {
+        agg.archived = archivedSet.has(`${agg.name}@${agg.src}`);
+      }
       aggregates.sort((a, b) => a.name.localeCompare(b.name));
       res.json({ ok: true, profiles: aggregates });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  // Archive / un-archive a batch of profiles. Body: { keys: ["name@src", …],
+  // archived: bool }. Visibility is persisted dashboard-wide (settings.json).
+  app.post('/api/profiles/archive', (req, res) => {
+    try {
+      const { keys, archived } = req.body || {};
+      const list = Array.isArray(keys) ? keys : keys ? [keys] : [];
+      if (list.length === 0) {
+        return res.status(400).json({ ok: false, error: 'keys is required' });
+      }
+      const updated = setArchived(list, archived !== false, settingsHome);
+      res.json({ ok: true, archived: updated });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -22,6 +22,7 @@ import {
   aggregateByProfile,
   aggregateProfile,
   compareProfiles,
+  dedupeReps,
   readProfileDefsMulti,
   readResultsMulti,
 } from './results-store.js';
@@ -109,6 +110,7 @@ export function createApp(options = {}) {
         if (run) {
           agg.active = true;
           agg.stage = run.stage;
+          agg.phase = run.phase;
           agg.pipeline_status = run.pipeline_status;
           agg.active_kind = run.kind;
         }
@@ -134,7 +136,7 @@ export function createApp(options = {}) {
         return res.json({
           ok: true,
           aggregate: aggregateProfile(name, reps),
-          reps,
+          reps: dedupeReps(reps), // collapse re-runs in the per-rep table
           active,
         });
       }

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -10,7 +10,11 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import express from 'express';
 
-import { getLeaderboard, leaderboardBenchmarks } from './leaderboard.js';
+import {
+  getLeaderboard,
+  leaderboardBenchmarks,
+  localLeaderboardRows,
+} from './leaderboard.js';
 import { runBenchmark } from './process-manager.js';
 import {
   aggregateByProfile,
@@ -138,11 +142,16 @@ export function createApp(options = {}) {
   app.get('/api/leaderboard', async (req, res) => {
     try {
       const benchmark = String(req.query.benchmark || 'swe-bench-verified');
+      const localRows = localLeaderboardRows(
+        aggregateByProfile(readRows()),
+        benchmark,
+      );
       res.json({
         ok: true,
         benchmark,
         rows: await getLeaderboard(benchmark, {
           offline: options.leaderboardOffline,
+          localRows,
         }),
         benchmarks: leaderboardBenchmarks(),
       });

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -129,6 +129,9 @@ export function createApp(options = {}) {
           grade_mode: def.grade_mode,
           canary: def.canary,
           max_parallel: def.max_parallel,
+          graphify: def.graphify,
+          code_review_graph: def.code_review_graph,
+          preflight: def.preflight,
           reps: 0,
           graded: 0,
           resolved: 0,
@@ -201,9 +204,13 @@ export function createApp(options = {}) {
           aggregate: {
             ...aggregateProfile(name, rows),
             instance_count: instanceCount,
-            // canary + max_parallel are config (never in results rows) — read from the def.
+            // config-only fields (never in results rows) — read from the profile def
+            // so the run-options panel can seed its defaults from the profile.
             canary: def?.canary ?? null,
             max_parallel: def?.max_parallel ?? null,
+            graphify: def?.graphify ?? null,
+            code_review_graph: def?.code_review_graph ?? null,
+            preflight: def?.preflight ?? null,
           },
           reps: dedupeReps(rows), // collapse re-runs in the per-rep table
           active,
@@ -226,6 +233,9 @@ export function createApp(options = {}) {
           grade_mode: def?.grade_mode || null,
           canary: def?.canary ?? null,
           max_parallel: def?.max_parallel ?? null,
+          graphify: def?.graphify ?? null,
+          code_review_graph: def?.code_review_graph ?? null,
+          preflight: def?.preflight ?? null,
           instance_count: instanceCount,
           active: active.length > 0,
         },

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -86,7 +86,9 @@ export function createApp(options = {}) {
           name: def.name,
           benchmark: def.benchmark,
           worca_ref: null,
-          template: null,
+          worca_version: null,
+          template: def.template,
+          grade_mode: def.grade_mode,
           reps: 0,
           graded: 0,
           resolved: 0,
@@ -127,7 +129,12 @@ export function createApp(options = {}) {
       }
       res.json({
         ok: true,
-        aggregate: { ...aggregateProfile(name, []), benchmark: def.benchmark },
+        aggregate: {
+          ...aggregateProfile(name, []),
+          benchmark: def.benchmark,
+          template: def.template,
+          grade_mode: def.grade_mode,
+        },
         reps: [],
       });
     } catch (err) {

--- a/worca-bench/server/app.js
+++ b/worca-bench/server/app.js
@@ -54,6 +54,13 @@ export function createApp(options = {}) {
     return Number.isInteger(n) && n >= 1 ? n : undefined;
   };
 
+  // Coerce an engine toggle to a mode string: `true` -> 'structural', a non-empty
+  // string -> that mode, anything else -> undefined (engine stays off).
+  const _engineMode = (v) => {
+    if (v === true) return 'structural';
+    return typeof v === 'string' && v.trim() ? v.trim() : undefined;
+  };
+
   // Effective read set = launch dir (always) + configured dirs (settings.json).
   const effectiveDirs = () => resolveResultDirs(targetDir, settingsHome).dirs;
   const readRows = () => readResultsMulti(effectiveDirs());
@@ -232,6 +239,8 @@ export function createApp(options = {}) {
         reps: _posInt(req.body?.reps),
         maxInstances: _posInt(req.body?.maxInstances),
         cacheDir: resolveCacheDir(settingsHome).dir,
+        graphify: _engineMode(req.body?.graphify),
+        codeReviewGraph: _engineMode(req.body?.codeReviewGraph),
       });
       res.json({ ok: true, pid });
     } catch (err) {

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -320,6 +320,53 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/run forwards browser secrets to the launcher', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 21 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: 'p1',
+          secrets: { SWEBENCH_API_KEY: 'swb', MODAL_TOKEN_ID: 'mid' },
+        }),
+      });
+      expect(captured.secrets).toEqual({
+        SWEBENCH_API_KEY: 'swb',
+        MODAL_TOKEN_ID: 'mid',
+      });
+    });
+  });
+
+  it('POST /api/regrade forwards mode + secrets to the regrader', async () => {
+    let captured = null;
+    const fakeRegrade = async (opts) => {
+      captured = opts;
+      return { pid: 22 };
+    };
+    await withServer(dir, { _runRegrade: fakeRegrade }, async (base) => {
+      await fetch(`${base}/api/regrade`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: 'p1',
+          instance: 'astropy__astropy-12907',
+          mode: 'modal',
+          secrets: { MODAL_TOKEN_ID: 'mid', MODAL_TOKEN_SECRET: 'msec' },
+        }),
+      });
+      expect(captured.mode).toBe('modal');
+      expect(captured.secrets).toEqual({
+        MODAL_TOKEN_ID: 'mid',
+        MODAL_TOKEN_SECRET: 'msec',
+      });
+    });
+  });
+
   it('POST /api/regrade rejects a bad instance id and bad mode', async () => {
     await withServer(
       dir,

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -296,6 +296,31 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/run maps canary:false to noCanary (default keeps canary on)', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 10 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      // Explicit opt-out disables the canary.
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', canary: false }),
+      });
+      expect(captured.noCanary).toBe(true);
+
+      // Omitted (or true) leaves the canary on.
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1' }),
+      });
+      expect(captured.noCanary).toBe(false);
+    });
+  });
+
   it('POST /api/run rejects a missing profile with 400', async () => {
     await withServer(dir, {}, async (base) => {
       const res = await fetch(`${base}/api/run`, {

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -296,6 +296,66 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/regrade forwards profile/instance/mode to the regrader', async () => {
+    let captured = null;
+    const fakeRegrade = async (opts) => {
+      captured = opts;
+      return { pid: 77 };
+    };
+    await withServer(dir, { _runRegrade: fakeRegrade }, async (base) => {
+      const res = await fetch(`${base}/api/regrade`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: 'p1',
+          instance: 'astropy__astropy-12907',
+          mode: 'sb-cli',
+        }),
+      });
+      const data = await res.json();
+      expect(data).toEqual({ ok: true, pid: 77 });
+      expect(captured.profile).toBe('p1');
+      expect(captured.instance).toBe('astropy__astropy-12907');
+      expect(captured.mode).toBe('sb-cli');
+    });
+  });
+
+  it('POST /api/regrade rejects a bad instance id and bad mode', async () => {
+    await withServer(
+      dir,
+      { _runRegrade: async () => ({ pid: 1 }) },
+      async (base) => {
+        const bad = await fetch(`${base}/api/regrade`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ profile: 'p1', instance: 'a; rm -rf /' }),
+        });
+        expect(bad.status).toBe(400);
+        const badMode = await fetch(`${base}/api/regrade`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ profile: 'p1', mode: 'evil' }),
+        });
+        expect(badMode.status).toBe(400);
+      },
+    );
+  });
+
+  it('POST /api/regrade requires a profile', async () => {
+    await withServer(
+      dir,
+      { _runRegrade: async () => ({ pid: 1 }) },
+      async (base) => {
+        const res = await fetch(`${base}/api/regrade`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+        expect(res.status).toBe(400);
+      },
+    );
+  });
+
   it('POST /api/run maps canary:false to noCanary (default keeps canary on)', async () => {
     let captured = null;
     const fakeRun = async (opts) => {

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -110,6 +110,55 @@ describe('createApp API', () => {
     });
   });
 
+  it('GET /api/settings exposes the resolved cache dir', async () => {
+    await withServer(dir, {}, async (base) => {
+      const data = await (await fetch(`${base}/api/settings`)).json();
+      expect(data.cache).toBeTruthy();
+      expect(typeof data.cache.dir).toBe('string');
+      expect(['settings', 'env', 'default']).toContain(data.cache.source);
+    });
+  });
+
+  it('POST /api/settings/cache-dir sets then clears the cache dir', async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), 'bench-cache-'));
+    await withServer(dir, {}, async (base) => {
+      let res = await fetch(`${base}/api/settings/cache-dir`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dir: cacheDir }),
+      });
+      let data = await res.json();
+      expect(data.cache.source).toBe('settings');
+      expect(data.cache.dir).toBe(cacheDir);
+      // empty value resets to default
+      res = await fetch(`${base}/api/settings/cache-dir`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dir: '' }),
+      });
+      data = await res.json();
+      expect(data.cache.source).toBe('default');
+    });
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it('POST /api/run forwards the resolved cacheDir to the launcher', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 8 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1' }),
+      });
+      expect(typeof captured.cacheDir).toBe('string');
+      expect(captured.cacheDir.length).toBeGreaterThan(0);
+    });
+  });
+
   it('GET /api/leaderboard returns rows (offline fallback, hermetic)', async () => {
     await withServer(dir, { leaderboardOffline: true }, async (base) => {
       const { ok, rows, benchmark } = await (

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -80,6 +80,48 @@ describe('createApp API', () => {
     });
   });
 
+  it('GET /api/profiles tags archived (default false) and POST archive flips it', async () => {
+    writeFileSync(join(dir, 'results.jsonl'), JSON.stringify(row()));
+    await withServer(dir, {}, async (base) => {
+      // Default: not archived.
+      let { profiles } = await (await fetch(`${base}/api/profiles`)).json();
+      expect(profiles[0].archived).toBe(false);
+      const key = `${profiles[0].name}@${profiles[0].src}`;
+
+      // Archive it.
+      const arch = await fetch(`${base}/api/profiles/archive`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keys: [key], archived: true }),
+      });
+      expect(arch.status).toBe(200);
+      expect((await arch.json()).archived).toEqual([key]);
+
+      ({ profiles } = await (await fetch(`${base}/api/profiles`)).json());
+      expect(profiles[0].archived).toBe(true);
+
+      // Un-archive it.
+      await fetch(`${base}/api/profiles/archive`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keys: [key], archived: false }),
+      });
+      ({ profiles } = await (await fetch(`${base}/api/profiles`)).json());
+      expect(profiles[0].archived).toBe(false);
+    });
+  });
+
+  it('POST /api/profiles/archive 400s when keys is missing', async () => {
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/profiles/archive`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ archived: true }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
   it('GET /api/profiles/:name returns aggregate + reps, 404 for unknown', async () => {
     writeFileSync(join(dir, 'results.jsonl'), JSON.stringify(row()));
     await withServer(dir, {}, async (base) => {

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -336,6 +336,33 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/profiles/:name/stop returns 0 when nothing is running', async () => {
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/profiles/p1/stop`, {
+        method: 'POST',
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, stopped: 0 });
+    });
+  });
+
+  it('POST /api/profiles/:name/clear drops that profile rows', async () => {
+    writeFileSync(
+      join(dir, 'results.jsonl'),
+      `${JSON.stringify(row({ profile: 'p1' }))}\n${JSON.stringify(row({ profile: 'p2' }))}\n`,
+    );
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/profiles/p1/clear`, {
+        method: 'POST',
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).removed).toBe(1);
+      // p1 gone from the aggregate, p2 stays.
+      const { profiles } = await (await fetch(`${base}/api/profiles`)).json();
+      expect(profiles.map((p) => p.name)).toEqual(['p2']);
+    });
+  });
+
   it('sets security headers', async () => {
     await withServer(dir, {}, async (base) => {
       const res = await fetch(`${base}/api/health`);

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -231,6 +231,27 @@ describe('createApp API', () => {
     });
   });
 
+  it('GET /api/profiles exposes the configured test count (instance_count)', async () => {
+    mkdirSync(join(dir, 'profiles'), { recursive: true });
+    // def-only profile with an explicit 3-instance selection.
+    writeFileSync(
+      join(dir, 'profiles', 'sel.yaml'),
+      'name: sel\nbenchmark: commit0\nselection:\n  instance_ids:\n    - a\n    - b\n    - c\n',
+    );
+    // a profile that has results AND a def — instance_count must still attach.
+    writeFileSync(
+      join(dir, 'profiles', 'p1.yaml'),
+      'name: p1\nbenchmark: swe-bench-verified\nselection:\n  instance_ids:\n    - x\n',
+    );
+    writeFileSync(join(dir, 'results.jsonl'), JSON.stringify(row()));
+    await withServer(dir, {}, async (base) => {
+      const { profiles } = await (await fetch(`${base}/api/profiles`)).json();
+      const byName = Object.fromEntries(profiles.map((p) => [p.name, p]));
+      expect(byName.sel.instance_count).toBe(3);
+      expect(byName.p1.instance_count).toBe(1); // results-based agg, def-joined
+    });
+  });
+
   it('GET /api/profiles/:name 404s when neither results nor a def exist', async () => {
     await withServer(dir, {}, async (base) => {
       const res = await fetch(`${base}/api/profiles/ghost`);

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -26,7 +26,13 @@ function row(overrides = {}) {
 }
 
 async function withServer(targetDir, opts, fn) {
-  const app = createApp({ targetDir, ...opts });
+  // Isolate settings under the per-test temp dir so the suite never reads (or
+  // is perturbed by) the developer's real ~/.worca-bench/settings.json.
+  const app = createApp({
+    targetDir,
+    settingsHome: join(targetDir, '.worca-bench-home'),
+    ...opts,
+  });
   const server = createServer(app);
   await new Promise((res) => server.listen(0, '127.0.0.1', res));
   const { port } = server.address();
@@ -133,6 +139,31 @@ describe('createApp API', () => {
       expect(await res.json()).toEqual({ ok: true, pid: 4242 });
       expect(captured.profile).toBe('p1');
       expect(captured.targetDir).toBe(dir);
+    });
+  });
+
+  it('POST /api/run passes --profiles-dir for a YAML-defined profile', async () => {
+    // A profile authored as a YAML def (no results yet) must be findable by the
+    // runner via its source dir.
+    mkdirSync(join(dir, 'profiles'), { recursive: true });
+    writeFileSync(
+      join(dir, 'profiles', 'authored.yaml'),
+      'name: authored\nbenchmark: swe-bench-verified\n',
+    );
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 7 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      const res = await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'authored' }),
+      });
+      expect(res.status).toBe(200);
+      expect(captured.profile).toBe('authored');
+      expect(captured.profilesDir).toBe(join(dir, 'profiles'));
     });
   });
 

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -320,6 +320,60 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/run forwards preflight + claudeMdMode (validated)', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 31 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: 'p1',
+          preflight: true,
+          claudeMdMode: 'project',
+        }),
+      });
+      expect(captured.preflight).toBe(true);
+      expect(captured.claudeMdMode).toBe('project');
+
+      // An invalid claude-md mode is dropped (not forwarded).
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', claudeMdMode: 'evil' }),
+      });
+      expect(captured.claudeMdMode).toBeUndefined();
+    });
+  });
+
+  it('GET/PUT /api/profiles/:name/notes round-trips', async () => {
+    await withServer(dir, {}, async (base) => {
+      // Empty before anything is written.
+      let r = await (await fetch(`${base}/api/profiles/p1/notes`)).json();
+      expect(r).toEqual({ ok: true, notes: '' });
+
+      const put = await fetch(`${base}/api/profiles/p1/notes`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes: 'ran with opus, effort high' }),
+      });
+      expect((await put.json()).ok).toBe(true);
+
+      r = await (await fetch(`${base}/api/profiles/p1/notes`)).json();
+      expect(r.notes).toBe('ran with opus, effort high');
+    });
+  });
+
+  it('rejects notes for a bad profile name', async () => {
+    await withServer(dir, {}, async (base) => {
+      const r = await fetch(`${base}/api/profiles/..%2Fetc/notes`);
+      expect([400, 404]).toContain(r.status);
+    });
+  });
+
   it('POST /api/run forwards browser secrets to the launcher', async () => {
     let captured = null;
     const fakeRun = async (opts) => {

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -274,6 +274,38 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/run forwards the timeout override (incl. 0 = no limit)', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 11 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', timeout: 3600 }),
+      });
+      expect(captured.timeout).toBe(3600);
+
+      // 0 is a valid explicit override (no limit), not dropped.
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', timeout: 0 }),
+      });
+      expect(captured.timeout).toBe(0);
+
+      // Non-integer / negative => dropped (use profile default).
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', timeout: -5 }),
+      });
+      expect(captured.timeout).toBeUndefined();
+    });
+  });
+
   it('POST /api/run forwards graphify + code-review-graph engine modes', async () => {
     let captured = null;
     const fakeRun = async (opts) => {

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -167,6 +167,40 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/run forwards reps + maxInstances overrides (coerced)', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 5 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', reps: '4', maxInstances: 2 }),
+      });
+      expect(captured.reps).toBe(4); // string coerced to int
+      expect(captured.maxInstances).toBe(2);
+    });
+  });
+
+  it('POST /api/run drops invalid overrides (undefined, not 0/NaN)', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 6 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', reps: 0, maxInstances: 'abc' }),
+      });
+      expect(captured.reps).toBeUndefined();
+      expect(captured.maxInstances).toBeUndefined();
+    });
+  });
+
   it('POST /api/run rejects a missing profile with 400', async () => {
     await withServer(dir, {}, async (base) => {
       const res = await fetch(`${base}/api/run`, {

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -104,8 +104,8 @@ describe('createApp API', () => {
     });
   });
 
-  it('GET /api/leaderboard returns static fixture rows', async () => {
-    await withServer(dir, {}, async (base) => {
+  it('GET /api/leaderboard returns rows (offline fallback, hermetic)', async () => {
+    await withServer(dir, { leaderboardOffline: true }, async (base) => {
       const { ok, rows, benchmark } = await (
         await fetch(`${base}/api/leaderboard?benchmark=swe-bench-verified`)
       ).json();

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -1,0 +1,157 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from './app.js';
+
+function row(overrides = {}) {
+  return {
+    schema_version: 1,
+    profile: 'p1',
+    benchmark: 'swe-bench-verified',
+    instance_id: 'inst-1',
+    worca_ref: 'local',
+    template: 'builtin:feature',
+    rep: 1,
+    status: 'graded',
+    resolved: true,
+    score: 1.0,
+    cost_usd: 0.4,
+    wall_time_s: 600,
+    loop_counters: { implement_test: 1 },
+    completed_at: '2026-06-16T10:00:00Z',
+    ...overrides,
+  };
+}
+
+async function withServer(targetDir, opts, fn) {
+  const app = createApp({ targetDir, ...opts });
+  const server = createServer(app);
+  await new Promise((res) => server.listen(0, '127.0.0.1', res));
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    return await fn(base);
+  } finally {
+    await new Promise((res) => server.close(res));
+  }
+}
+
+describe('createApp API', () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'bench-app-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('GET /api/health returns ok', async () => {
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/health`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+    });
+  });
+
+  it('GET /api/profiles aggregates results.jsonl', async () => {
+    writeFileSync(
+      join(dir, 'results.jsonl'),
+      [
+        JSON.stringify(row({ profile: 'p1', resolved: true })),
+        JSON.stringify(row({ profile: 'p1', rep: 2, resolved: false })),
+      ].join('\n'),
+    );
+    await withServer(dir, {}, async (base) => {
+      const { ok, profiles } = await (
+        await fetch(`${base}/api/profiles`)
+      ).json();
+      expect(ok).toBe(true);
+      expect(profiles).toHaveLength(1);
+      expect(profiles[0].name).toBe('p1');
+      expect(profiles[0].resolved_rate).toBeCloseTo(0.5);
+    });
+  });
+
+  it('GET /api/profiles/:name returns aggregate + reps, 404 for unknown', async () => {
+    writeFileSync(join(dir, 'results.jsonl'), JSON.stringify(row()));
+    await withServer(dir, {}, async (base) => {
+      const found = await fetch(`${base}/api/profiles/p1`);
+      expect(found.status).toBe(200);
+      const body = await found.json();
+      expect(body.aggregate.name).toBe('p1');
+      expect(body.reps).toHaveLength(1);
+
+      const missing = await fetch(`${base}/api/profiles/nope`);
+      expect(missing.status).toBe(404);
+    });
+  });
+
+  it('GET /api/compare returns side-by-side aggregates', async () => {
+    writeFileSync(
+      join(dir, 'results.jsonl'),
+      [
+        JSON.stringify(row({ profile: 'a', resolved: true })),
+        JSON.stringify(row({ profile: 'b', resolved: false })),
+      ].join('\n'),
+    );
+    await withServer(dir, {}, async (base) => {
+      const { compare } = await (
+        await fetch(`${base}/api/compare?profiles=a,b`)
+      ).json();
+      expect(compare.map((c) => c.name)).toEqual(['a', 'b']);
+    });
+  });
+
+  it('GET /api/leaderboard returns static fixture rows', async () => {
+    await withServer(dir, {}, async (base) => {
+      const { ok, rows, benchmark } = await (
+        await fetch(`${base}/api/leaderboard?benchmark=swe-bench-verified`)
+      ).json();
+      expect(ok).toBe(true);
+      expect(benchmark).toBe('swe-bench-verified');
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows[0]).toHaveProperty('agent');
+      expect(rows[0]).toHaveProperty('source');
+    });
+  });
+
+  it('POST /api/run launches the runner and returns pid', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 4242 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      const res = await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1' }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, pid: 4242 });
+      expect(captured.profile).toBe('p1');
+      expect(captured.targetDir).toBe(dir);
+    });
+  });
+
+  it('POST /api/run rejects a missing profile with 400', async () => {
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  it('sets security headers', async () => {
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/health`);
+      expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+      expect(res.headers.get('x-frame-options')).toBe('DENY');
+    });
+  });
+});

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -209,7 +209,8 @@ describe('createApp API', () => {
         body: JSON.stringify({ profile: 'p1' }),
       });
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ ok: true, pid: 4242 });
+      // Response also carries the recorded `action` now; match the core fields.
+      expect(await res.json()).toMatchObject({ ok: true, pid: 4242 });
       expect(captured.profile).toBe('p1');
       expect(captured.targetDir).toBe(dir);
     });
@@ -271,6 +272,51 @@ describe('createApp API', () => {
       });
       expect(captured.reps).toBeUndefined();
       expect(captured.maxInstances).toBeUndefined();
+    });
+  });
+
+  it('POST /api/run records a running action surfaced by GET /api/actions', async () => {
+    // A live pid keeps the action 'running' through the read-time reconciliation.
+    const fakeRun = async () => ({ pid: process.pid });
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      const launched = await (
+        await fetch(`${base}/api/run`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ profile: 'p1', reps: 2 }),
+        })
+      ).json();
+      expect(launched.ok).toBe(true);
+      expect(launched.action.type).toBe('run');
+      expect(launched.action.profile).toBe('p1');
+
+      const list = await (await fetch(`${base}/api/actions`)).json();
+      const a = list.actions.find((x) => x.id === launched.action.id);
+      expect(a).toBeTruthy();
+      expect(a.status).toBe('running');
+      expect(a.progress.unit).toBe('instances');
+    });
+  });
+
+  it('POST /api/actions/:id/stop marks the action stopped', async () => {
+    const fakeRun = async () => ({ pid: 999999 }); // dead pid: stop is a no-op kill
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      const launched = await (
+        await fetch(`${base}/api/run`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ profile: 'p1' }),
+        })
+      ).json();
+      const stop = await (
+        await fetch(`${base}/api/actions/${launched.action.id}/stop`, {
+          method: 'POST',
+        })
+      ).json();
+      expect(stop.ok).toBe(true);
+      const list = await (await fetch(`${base}/api/actions`)).json();
+      const a = list.actions.find((x) => x.id === launched.action.id);
+      expect(a.status).toBe('stopped');
     });
   });
 
@@ -345,7 +391,7 @@ describe('createApp API', () => {
         }),
       });
       const data = await res.json();
-      expect(data).toEqual({ ok: true, pid: 77 });
+      expect(data).toMatchObject({ ok: true, pid: 77 });
       expect(captured.profile).toBe('p1');
       expect(captured.instance).toBe('astropy__astropy-12907');
       expect(captured.mode).toBe('sb-cli');

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -209,7 +209,6 @@ describe('createApp API', () => {
         body: JSON.stringify({ profile: 'p1' }),
       });
       expect(res.status).toBe(200);
-      // Response also carries the recorded `action` now; match the core fields.
       expect(await res.json()).toMatchObject({ ok: true, pid: 4242 });
       expect(captured.profile).toBe('p1');
       expect(captured.targetDir).toBe(dir);
@@ -275,8 +274,9 @@ describe('createApp API', () => {
     });
   });
 
-  it('POST /api/run records a running action surfaced by GET /api/actions', async () => {
-    // A live pid keeps the action 'running' through the read-time reconciliation.
+  it('POST /api/run shows an instant pending action (boot-window overlay)', async () => {
+    // The CLI records the ledger itself; during its boot window the server
+    // overlays a synthetic 'running' row keyed by the spawned (live) pid.
     const fakeRun = async () => ({ pid: process.pid });
     await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
       const launched = await (
@@ -287,36 +287,60 @@ describe('createApp API', () => {
         })
       ).json();
       expect(launched.ok).toBe(true);
-      expect(launched.action.type).toBe('run');
-      expect(launched.action.profile).toBe('p1');
+      expect(launched.action).toBeUndefined(); // server no longer records
 
       const list = await (await fetch(`${base}/api/actions`)).json();
-      const a = list.actions.find((x) => x.id === launched.action.id);
+      const a = list.actions.find((x) => x.profile === 'p1');
       expect(a).toBeTruthy();
       expect(a.status).toBe('running');
-      expect(a.progress.unit).toBe('instances');
+      expect(a.id).toBe(`pending-${process.pid}`);
     });
   });
 
-  it('POST /api/actions/:id/stop marks the action stopped', async () => {
-    const fakeRun = async () => ({ pid: 999999 }); // dead pid: stop is a no-op kill
-    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
-      const launched = await (
-        await fetch(`${base}/api/run`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ profile: 'p1' }),
-        })
-      ).json();
+  it('GET /api/actions surfaces a CLI-written ledger record and backfills src', async () => {
+    const { recordAction } = await import('./actions-store.js');
+    await withServer(dir, {}, async (base) => {
+      // CLI-written running record (live pid → read-only; never stopped here, so
+      // the test runner is never signalled).
+      const rec = recordAction(dir, {
+        type: 'run',
+        profile: 'p1',
+        source_dir: dir,
+        pid: process.pid,
+      });
+      const list = await (await fetch(`${base}/api/actions`)).json();
+      const a = list.actions.find((x) => x.id === rec.id);
+      expect(a.status).toBe('running');
+      expect(a.src).toBeTruthy(); // backfilled from source_dir via srcHash
+    });
+  });
+
+  it('POST /api/actions/:id/stop marks a ledger action stopped (dead pid, no real kill)', async () => {
+    const { recordAction } = await import('./actions-store.js');
+    await withServer(dir, {}, async (base) => {
+      const rec = recordAction(dir, {
+        type: 'run',
+        profile: 'p1',
+        source_dir: dir,
+        pid: 999999, // dead → stopPidTree is a no-op, kills nothing real
+      });
       const stop = await (
-        await fetch(`${base}/api/actions/${launched.action.id}/stop`, {
-          method: 'POST',
-        })
+        await fetch(`${base}/api/actions/${rec.id}/stop`, { method: 'POST' })
       ).json();
       expect(stop.ok).toBe(true);
-      const list = await (await fetch(`${base}/api/actions`)).json();
-      const a = list.actions.find((x) => x.id === launched.action.id);
-      expect(a.status).toBe('stopped');
+      const after = await (await fetch(`${base}/api/actions`)).json();
+      expect(after.actions.find((x) => x.id === rec.id).status).toBe('stopped');
+    });
+  });
+
+  it('POST /api/actions/pending-<pid>/stop stops a still-booting action by pid', async () => {
+    await withServer(dir, {}, async (base) => {
+      const stop = await (
+        await fetch(`${base}/api/actions/pending-999999/stop`, {
+          method: 'POST',
+        })
+      ).json();
+      expect(stop.ok).toBe(true); // dead pid -> no-op kill, still ok
     });
   });
 

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -551,28 +551,36 @@ describe('createApp API', () => {
     );
   });
 
-  it('POST /api/run maps canary:false to noCanary (default keeps canary on)', async () => {
+  it('POST /api/run forwards the canary toggle as an authoritative override', async () => {
     let captured = null;
     const fakeRun = async (opts) => {
       captured = opts;
       return { pid: 10 };
     };
     await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
-      // Explicit opt-out disables the canary.
+      // Explicit opt-out -> canary: false override.
       await fetch(`${base}/api/run`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ profile: 'p1', canary: false }),
       });
-      expect(captured.noCanary).toBe(true);
+      expect(captured.canary).toBe(false);
 
-      // Omitted (or true) leaves the canary on.
+      // Explicit opt-in -> canary: true override (re-enables a canary:false profile).
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', canary: true }),
+      });
+      expect(captured.canary).toBe(true);
+
+      // Omitted -> undefined (leave the profile's own canary default).
       await fetch(`${base}/api/run`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ profile: 'p1' }),
       });
-      expect(captured.noCanary).toBe(false);
+      expect(captured.canary).toBeUndefined();
     });
   });
 

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -367,6 +367,100 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/regrade supports a whole-profile sequential sweep (no instance)', async () => {
+    let captured = null;
+    const fakeRegrade = async (opts) => {
+      captured = opts;
+      return { pid: 88 };
+    };
+    await withServer(dir, { _runRegrade: fakeRegrade }, async (base) => {
+      const res = await fetch(`${base}/api/regrade`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: 'p1',
+          mode: 'modal',
+          sequential: true,
+          secrets: { MODAL_TOKEN_ID: 'mid', MODAL_TOKEN_SECRET: 'msec' },
+        }),
+      });
+      expect((await res.json()).ok).toBe(true);
+      expect(captured.instance).toBeUndefined();
+      expect(captured.mode).toBe('modal');
+      expect(captured.sequential).toBe(true);
+      expect(captured.secrets.MODAL_TOKEN_ID).toBe('mid');
+    });
+  });
+
+  // Write a regrade heartbeat under <dir>/runs/<profile>/regrade-status.json.
+  function seedRegradeHeartbeat(targetDir, profile, hb) {
+    const d = join(targetDir, 'runs', profile);
+    mkdirSync(d, { recursive: true });
+    writeFileSync(join(d, 'regrade-status.json'), JSON.stringify(hb));
+  }
+
+  it('GET /api/profiles/:name includes a live regrade heartbeat', async () => {
+    writeFileSync(join(dir, 'results.jsonl'), `${JSON.stringify(row())}\n`);
+    seedRegradeHeartbeat(dir, 'p1', {
+      profile: 'p1',
+      mode: 'modal',
+      pid: process.pid,
+      total: 20,
+      done: 7,
+      current: 'astropy__astropy-14539',
+      counts: { graded: 7, resolved: 4, error: 0 },
+      status: 'running',
+    });
+    await withServer(dir, {}, async (base) => {
+      const data = await (await fetch(`${base}/api/profiles/p1`)).json();
+      expect(data.regrade.active).toBe(true);
+      expect(data.regrade.done).toBe(7);
+      expect(data.regrade.current).toBe('astropy__astropy-14539');
+    });
+  });
+
+  it('POST /api/regrade returns 409 when a sweep is already running', async () => {
+    let launched = false;
+    const fakeRegrade = async () => {
+      launched = true;
+      return { pid: 1 };
+    };
+    seedRegradeHeartbeat(dir, 'p1', {
+      profile: 'p1',
+      pid: process.pid,
+      status: 'running',
+      total: 20,
+      done: 1,
+    });
+    await withServer(dir, { _runRegrade: fakeRegrade }, async (base) => {
+      const res = await fetch(`${base}/api/regrade`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: 'p1', mode: 'modal' }),
+      });
+      expect(res.status).toBe(409);
+      expect(launched).toBe(false); // never spawned a second sweep
+    });
+  });
+
+  it('POST /api/profiles/:name/regrade/stop stops a tracked sweep', async () => {
+    // Implausible pid → stopRegrade finds the heartbeat but kills nothing real.
+    seedRegradeHeartbeat(dir, 'p1', {
+      profile: 'p1',
+      pid: 2147483000,
+      status: 'running',
+    });
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/profiles/p1/regrade/stop`, {
+        method: 'POST',
+      });
+      const data = await res.json();
+      expect(res.status).toBe(200);
+      expect(data.ok).toBe(true);
+      expect(data.stopped).toBe(1);
+    });
+  });
+
   it('POST /api/regrade rejects a bad instance id and bad mode', async () => {
     await withServer(
       dir,

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -274,6 +274,28 @@ describe('createApp API', () => {
     });
   });
 
+  it('POST /api/run forwards graphify + code-review-graph engine modes', async () => {
+    let captured = null;
+    const fakeRun = async (opts) => {
+      captured = opts;
+      return { pid: 9 };
+    };
+    await withServer(dir, { _runBenchmark: fakeRun }, async (base) => {
+      await fetch(`${base}/api/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // `true` coerces to the default mode; a string passes through.
+        body: JSON.stringify({
+          profile: 'p1',
+          graphify: true,
+          codeReviewGraph: 'structural',
+        }),
+      });
+      expect(captured.graphify).toBe('structural');
+      expect(captured.codeReviewGraph).toBe('structural');
+    });
+  });
+
   it('POST /api/run rejects a missing profile with 400', async () => {
     await withServer(dir, {}, async (base) => {
       const res = await fetch(`${base}/api/run`, {

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createApp } from './app.js';
 
@@ -281,6 +281,35 @@ describe('createApp API', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  it('GET /api/fs/list lists subdirectories of a path', async () => {
+    mkdirSync(join(dir, 'sub-a'), { recursive: true });
+    mkdirSync(join(dir, 'sub-b'), { recursive: true });
+    mkdirSync(join(dir, '.hidden'), { recursive: true });
+    writeFileSync(join(dir, 'a-file.txt'), 'x');
+    await withServer(dir, {}, async (base) => {
+      const data = await (
+        await fetch(`${base}/api/fs/list?path=${encodeURIComponent(dir)}`)
+      ).json();
+      expect(data.ok).toBe(true);
+      expect(data.path).toBe(dir);
+      expect(data.parent).toBe(dirname(dir));
+      const names = data.dirs.map((d) => d.name);
+      expect(names).toContain('sub-a');
+      expect(names).toContain('sub-b');
+      expect(names).not.toContain('.hidden'); // dotfiles hidden
+      expect(names).not.toContain('a-file.txt'); // files excluded
+    });
+  });
+
+  it('GET /api/fs/list 400s on a non-existent path', async () => {
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(
+        `${base}/api/fs/list?path=${encodeURIComponent('/no/such/path/here')}`,
+      );
       expect(res.status).toBe(400);
     });
   });

--- a/worca-bench/server/app.test.js
+++ b/worca-bench/server/app.test.js
@@ -123,6 +123,30 @@ describe('createApp API', () => {
     });
   });
 
+  it('GET /api/profiles/:name opens a def-only profile (no results yet)', async () => {
+    mkdirSync(join(dir, 'profiles'), { recursive: true });
+    writeFileSync(
+      join(dir, 'profiles', 'fresh.yaml'),
+      'name: fresh\nbenchmark: swe-bench-verified\n',
+    );
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/profiles/fresh`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.aggregate.name).toBe('fresh');
+      expect(body.aggregate.benchmark).toBe('swe-bench-verified');
+      expect(body.aggregate.reps).toBe(0);
+      expect(body.reps).toEqual([]);
+    });
+  });
+
+  it('GET /api/profiles/:name 404s when neither results nor a def exist', async () => {
+    await withServer(dir, {}, async (base) => {
+      const res = await fetch(`${base}/api/profiles/ghost`);
+      expect(res.status).toBe(404);
+    });
+  });
+
   it('POST /api/run launches the runner and returns pid', async () => {
     let captured = null;
     const fakeRun = async (opts) => {

--- a/worca-bench/server/leaderboard.js
+++ b/worca-bench/server/leaderboard.js
@@ -86,6 +86,24 @@ function localRow() {
 
 // ----------------------------- pure parsers ------------------------------ //
 
+// Browsable per-submission result folder (predictions, logs, metadata) in the
+// SWE-bench experiments repo — the exact result/report for a Verified entry.
+const SWEBENCH_EXPERIMENTS =
+  'https://github.com/SWE-bench/experiments/tree/main/evaluation/verified/';
+
+/** Keep only http(s) URLs (XSS guard against javascript:/data: schemes). */
+function safeHttpUrl(href, base) {
+  if (!href) {
+    return null;
+  }
+  try {
+    const u = new URL(href, base);
+    return u.protocol === 'http:' || u.protocol === 'https:' ? u.href : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Parse the SWE-bench site leaderboards.json into Verified rows (descending). */
 export function parseSwebenchVerified(data) {
   const board = (data?.leaderboards || []).find((b) => b.name === 'Verified');
@@ -94,9 +112,11 @@ export function parseSwebenchVerified(data) {
     resolved_rate: typeof r.resolved === 'number' ? r.resolved / 100 : null,
     date: r.date || null,
     source: 'swebench.com',
-    // Per-entry deep link: the system's own result page (the same link the
-    // swebench.com leaderboard uses for that row).
-    url: r.site || null,
+    // Exact result/report: the submission's experiments-repo folder when known,
+    // else the system's own site (both scheme-validated).
+    url: r.folder
+      ? `${SWEBENCH_EXPERIMENTS}${encodeURIComponent(r.folder)}`
+      : safeHttpUrl(r.site),
   }));
   return rows.sort((a, b) => (b.resolved_rate ?? -1) - (a.resolved_rate ?? -1));
 }
@@ -111,22 +131,10 @@ function stripTags(s) {
     .trim();
 }
 
-/** Resolve a possibly-relative href against the page base; null on failure. */
-function resolveHref(href, base) {
-  if (!href) {
-    return null;
-  }
-  try {
-    return new URL(href, base).href;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Parse the Commit0 analysis HTML table(s) into rows (Tests-Passed % as the rate).
  * Per-row links (the "Analysis" link, else the first link) are captured as `url`,
- * resolved to absolute against `base`.
+ * resolved to absolute against `base` and scheme-validated.
  */
 export function parseCommit0Html(html, base = SOURCES.commit0.url) {
   const rows = [];
@@ -162,7 +170,7 @@ export function parseCommit0Html(html, base = SOURCES.commit0.url) {
         resolved_rate: rate,
         date: dateCell || null,
         source: 'commit-0.github.io',
-        url: resolveHref(pick, base),
+        url: safeHttpUrl(pick, base),
       });
     }
   }

--- a/worca-bench/server/leaderboard.js
+++ b/worca-bench/server/leaderboard.js
@@ -84,6 +84,43 @@ function localRow() {
   };
 }
 
+/**
+ * Turn local profile aggregates into leaderboard rows for `benchmark`. Only
+ * profiles that have actually run (reps > 0) and target this benchmark are
+ * included; each links to its profile-detail page in the dashboard.
+ *
+ * @param {object[]} aggregates  per-profile summaries (aggregateByProfile)
+ * @param {string} benchmark
+ * @returns {Array<{agent,resolved_rate,source,date,url}>}
+ */
+export function localLeaderboardRows(aggregates, benchmark) {
+  const key = normalizeKey(benchmark);
+  return (aggregates || [])
+    .filter((a) => a && a.reps > 0 && normalizeKey(a.benchmark) === key)
+    .map((a) => ({
+      agent: a.name,
+      resolved_rate:
+        typeof a.resolved_rate === 'number' ? a.resolved_rate : null,
+      source: 'local',
+      date: a.last_run ? String(a.last_run).slice(0, 10) : null,
+      url: `#/profile?name=${encodeURIComponent(a.name)}`,
+    }));
+}
+
+/**
+ * Combine local + public rows. With real local rows we rank them in by
+ * resolved rate (local rows are highlighted in the view); with none we keep
+ * the single "this run" placeholder pinned at the top as a hint.
+ */
+function mergeRows(localRows, publicRows) {
+  if (!localRows || localRows.length === 0) {
+    return [localRow(), ...publicRows];
+  }
+  return [...localRows, ...publicRows].sort(
+    (a, b) => (b.resolved_rate ?? -1) - (a.resolved_rate ?? -1),
+  );
+}
+
 // ----------------------------- pure parsers ------------------------------ //
 
 // Browsable per-submission result folder (predictions, logs, metadata) in the
@@ -207,10 +244,11 @@ async function fetchLive(key, fetchImpl, timeoutMs) {
 
 /**
  * Return leaderboard rows for a benchmark — live, cached, with offline fallback.
- * The first row is always the local "this run" placeholder.
+ * Local rows (this machine's runs) are passed via opts.localRows and ranked in
+ * by resolved rate; with none, a single "this run" placeholder is pinned on top.
  *
  * @param {string} benchmark
- * @param {{offline?: boolean, fetchImpl?: typeof fetch, now?: () => number, timeoutMs?: number}} [opts]
+ * @param {{offline?: boolean, fetchImpl?: typeof fetch, now?: () => number, timeoutMs?: number, localRows?: object[]}} [opts]
  * @returns {Promise<Array<{agent:string, resolved_rate:number|null, source:string, date:string|null}>>}
  */
 export async function getLeaderboard(benchmark, opts = {}) {
@@ -223,16 +261,17 @@ export async function getLeaderboard(benchmark, opts = {}) {
     fetchImpl = globalThis.fetch,
     now = Date.now,
     timeoutMs = 5000,
+    localRows = [],
   } = opts;
 
   if (offline) {
-    return [localRow(), ...FALLBACK[key]];
+    return mergeRows(localRows, FALLBACK[key]);
   }
 
   const ts = now();
   const cached = _cache.get(key);
   if (cached && ts - cached.fetchedAt < TTL_MS) {
-    return [localRow(), ...cached.rows];
+    return mergeRows(localRows, cached.rows);
   }
 
   try {
@@ -241,13 +280,13 @@ export async function getLeaderboard(benchmark, opts = {}) {
       throw new Error('no rows parsed');
     }
     _cache.set(key, { rows, fetchedAt: ts });
-    return [localRow(), ...rows];
+    return mergeRows(localRows, rows);
   } catch {
     // stale-on-error, then static fallback
     if (cached) {
-      return [localRow(), ...cached.rows];
+      return mergeRows(localRows, cached.rows);
     }
-    return [localRow(), ...FALLBACK[key]];
+    return mergeRows(localRows, FALLBACK[key]);
   }
 }
 

--- a/worca-bench/server/leaderboard.js
+++ b/worca-bench/server/leaderboard.js
@@ -1,0 +1,48 @@
+// server/leaderboard.js
+//
+// Public cross-agent leaderboard rows for a given benchmark.
+//
+// TODO(W-075 phase 2): fetch live standings instead of this static fixture.
+// The SWE-bench Verified leaderboard is published at https://www.swebench.com
+// (JSON at https://github.com/SWE-bench/experiments) and the Commit-0 analysis
+// lives at https://commit-0.github.io/analysis/. A later phase will fetch + cache
+// those (respecting rate limits) and merge the local profiles in. For now we
+// return a small, deliberately-static fixture and make NO network calls so the
+// dashboard renders offline and the unit tests stay hermetic.
+
+const FIXTURES = {
+  'swe-bench-verified': [
+    { agent: 'worca (local)', resolved_rate: null, source: 'local' },
+    { agent: 'TRAE', resolved_rate: 0.7026, source: 'swebench.com' },
+    { agent: 'Augment Agent', resolved_rate: 0.654, source: 'swebench.com' },
+    {
+      agent: 'OpenHands + CodeAct',
+      resolved_rate: 0.606,
+      source: 'swebench.com',
+    },
+    { agent: 'SWE-agent', resolved_rate: 0.335, source: 'swebench.com' },
+  ],
+  'commit-0': [
+    { agent: 'worca (local)', resolved_rate: null, source: 'local' },
+    { agent: 'reference', resolved_rate: 0.58, source: 'commit-0.github.io' },
+  ],
+};
+
+/**
+ * Return the leaderboard rows for a benchmark. Unknown benchmarks yield an
+ * empty array (the dashboard renders an explanatory empty state).
+ *
+ * @param {string} benchmark
+ * @returns {Array<{agent: string, resolved_rate: number|null, source: string}>}
+ */
+export function getLeaderboard(benchmark) {
+  return FIXTURES[benchmark] ? [...FIXTURES[benchmark]] : [];
+}
+
+/**
+ * List the benchmarks that have a static leaderboard fixture available.
+ * @returns {string[]}
+ */
+export function leaderboardBenchmarks() {
+  return Object.keys(FIXTURES);
+}

--- a/worca-bench/server/leaderboard.js
+++ b/worca-bench/server/leaderboard.js
@@ -1,48 +1,254 @@
 // server/leaderboard.js
 //
-// Public cross-agent leaderboard rows for a given benchmark.
+// Public cross-agent leaderboard rows for a given benchmark, fetched LIVE from the
+// upstream sources (W-075 phase 4), cached with a TTL, and falling back to a small
+// static fixture when offline/unreachable so the dashboard still renders.
 //
-// TODO(W-075 phase 2): fetch live standings instead of this static fixture.
-// The SWE-bench Verified leaderboard is published at https://www.swebench.com
-// (JSON at https://github.com/SWE-bench/experiments) and the Commit-0 analysis
-// lives at https://commit-0.github.io/analysis/. A later phase will fetch + cache
-// those (respecting rate limits) and merge the local profiles in. For now we
-// return a small, deliberately-static fixture and make NO network calls so the
-// dashboard renders offline and the unit tests stay hermetic.
+//   - SWE-bench Verified: clean JSON published by the site itself —
+//     https://raw.githubusercontent.com/SWE-bench/swe-bench.github.io/master/data/leaderboards.json
+//     (filter leaderboards[].name == "Verified"; each result has name/resolved(%)/date/tags).
+//   - Commit0: no scores JSON exists; the numbers live only in the static HTML table at
+//     https://commit-0.github.io/analysis/ , so we fetch + parse that table.
+//
+// Tests pass { offline: true } (via createApp) to stay hermetic; the running server
+// fetches live.
 
-const FIXTURES = {
+const SOURCES = {
+  'swe-bench-verified': {
+    url: 'https://raw.githubusercontent.com/SWE-bench/swe-bench.github.io/master/data/leaderboards.json',
+    source: 'swebench.com',
+    kind: 'swebench',
+  },
+  commit0: {
+    url: 'https://commit-0.github.io/analysis/',
+    source: 'commit-0.github.io',
+    kind: 'commit0',
+  },
+};
+
+// Offline/last-resort fixture (used only when a live fetch fails with no cache).
+const SWEBENCH_HOME = 'https://www.swebench.com';
+const COMMIT0_HOME = 'https://commit-0.github.io/analysis/';
+const FALLBACK = {
   'swe-bench-verified': [
-    { agent: 'worca (local)', resolved_rate: null, source: 'local' },
-    { agent: 'TRAE', resolved_rate: 0.7026, source: 'swebench.com' },
-    { agent: 'Augment Agent', resolved_rate: 0.654, source: 'swebench.com' },
     {
-      agent: 'OpenHands + CodeAct',
-      resolved_rate: 0.606,
+      agent: 'TRAE',
+      resolved_rate: 0.7026,
       source: 'swebench.com',
+      date: null,
+      url: SWEBENCH_HOME,
     },
-    { agent: 'SWE-agent', resolved_rate: 0.335, source: 'swebench.com' },
+    {
+      agent: 'Augment Agent',
+      resolved_rate: 0.654,
+      source: 'swebench.com',
+      date: null,
+      url: SWEBENCH_HOME,
+    },
+    {
+      agent: 'SWE-agent',
+      resolved_rate: 0.335,
+      source: 'swebench.com',
+      date: null,
+      url: SWEBENCH_HOME,
+    },
   ],
-  'commit-0': [
-    { agent: 'worca (local)', resolved_rate: null, source: 'local' },
-    { agent: 'reference', resolved_rate: 0.58, source: 'commit-0.github.io' },
+  commit0: [
+    {
+      agent: 'reference',
+      resolved_rate: 0.58,
+      source: 'commit-0.github.io',
+      date: null,
+      url: COMMIT0_HOME,
+    },
   ],
 };
 
-/**
- * Return the leaderboard rows for a benchmark. Unknown benchmarks yield an
- * empty array (the dashboard renders an explanatory empty state).
- *
- * @param {string} benchmark
- * @returns {Array<{agent: string, resolved_rate: number|null, source: string}>}
- */
-export function getLeaderboard(benchmark) {
-  return FIXTURES[benchmark] ? [...FIXTURES[benchmark]] : [];
+const TTL_MS = 30 * 60 * 1000; // 30 min
+const _cache = new Map(); // key -> { rows, fetchedAt }
+
+function normalizeKey(benchmark) {
+  if (benchmark === 'commit-0' || benchmark === 'commit0') {
+    return 'commit0';
+  }
+  return benchmark;
+}
+
+function localRow() {
+  return {
+    agent: 'worca (this run)',
+    resolved_rate: null,
+    source: 'local',
+    date: null,
+    url: null,
+  };
+}
+
+// ----------------------------- pure parsers ------------------------------ //
+
+/** Parse the SWE-bench site leaderboards.json into Verified rows (descending). */
+export function parseSwebenchVerified(data) {
+  const board = (data?.leaderboards || []).find((b) => b.name === 'Verified');
+  const rows = (board?.results || []).map((r) => ({
+    agent: r.name,
+    resolved_rate: typeof r.resolved === 'number' ? r.resolved / 100 : null,
+    date: r.date || null,
+    source: 'swebench.com',
+    // Per-entry deep link: the system's own result page (the same link the
+    // swebench.com leaderboard uses for that row).
+    url: r.site || null,
+  }));
+  return rows.sort((a, b) => (b.resolved_rate ?? -1) - (a.resolved_rate ?? -1));
+}
+
+function stripTags(s) {
+  return s
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&[a-z]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Resolve a possibly-relative href against the page base; null on failure. */
+function resolveHref(href, base) {
+  if (!href) {
+    return null;
+  }
+  try {
+    return new URL(href, base).href;
+  } catch {
+    return null;
+  }
 }
 
 /**
- * List the benchmarks that have a static leaderboard fixture available.
- * @returns {string[]}
+ * Parse the Commit0 analysis HTML table(s) into rows (Tests-Passed % as the rate).
+ * Per-row links (the "Analysis" link, else the first link) are captured as `url`,
+ * resolved to absolute against `base`.
  */
+export function parseCommit0Html(html, base = SOURCES.commit0.url) {
+  const rows = [];
+  const seen = new Set();
+  const bodies = html.match(/<tbody[\s\S]*?<\/tbody>/gi) || [];
+  for (const body of bodies) {
+    const trs = body.match(/<tr[\s\S]*?<\/tr>/gi) || [];
+    for (const tr of trs) {
+      const cells = (tr.match(/<td[\s\S]*?<\/td>/gi) || []).map(stripTags);
+      if (cells.length < 2) {
+        continue;
+      }
+      const agent = cells[0];
+      if (!agent || seen.has(agent)) {
+        continue;
+      }
+      const pctCell = cells.find((c) => c.includes('%'));
+      let rate = null;
+      if (pctCell) {
+        const m = pctCell.match(/([\d.]+)\s*%/);
+        if (m) {
+          rate = Number.parseFloat(m[1]) / 100;
+        }
+      }
+      const dateCell = cells.find((c) =>
+        /\d{1,2}\/\d{1,2}\/\d{2,4}|\d{4}-\d{2}-\d{2}/.test(c),
+      );
+      const hrefs = [...tr.matchAll(/href="([^"]*)"/gi)].map((m) => m[1]);
+      const pick = hrefs.find((h) => /analysis/i.test(h)) || hrefs[0] || null;
+      seen.add(agent);
+      rows.push({
+        agent,
+        resolved_rate: rate,
+        date: dateCell || null,
+        source: 'commit-0.github.io',
+        url: resolveHref(pick, base),
+      });
+    }
+  }
+  return rows.sort((a, b) => (b.resolved_rate ?? -1) - (a.resolved_rate ?? -1));
+}
+
+// ------------------------------- fetching -------------------------------- //
+
+async function fetchText(url, fetchImpl, timeoutMs) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      signal: ctrl.signal,
+      headers: { 'user-agent': 'worca-bench-dashboard' },
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return await res.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchLive(key, fetchImpl, timeoutMs) {
+  const src = SOURCES[key];
+  const text = await fetchText(src.url, fetchImpl, timeoutMs);
+  if (src.kind === 'swebench') {
+    return parseSwebenchVerified(JSON.parse(text));
+  }
+  return parseCommit0Html(text);
+}
+
+/**
+ * Return leaderboard rows for a benchmark — live, cached, with offline fallback.
+ * The first row is always the local "this run" placeholder.
+ *
+ * @param {string} benchmark
+ * @param {{offline?: boolean, fetchImpl?: typeof fetch, now?: () => number, timeoutMs?: number}} [opts]
+ * @returns {Promise<Array<{agent:string, resolved_rate:number|null, source:string, date:string|null}>>}
+ */
+export async function getLeaderboard(benchmark, opts = {}) {
+  const key = normalizeKey(benchmark);
+  if (!SOURCES[key]) {
+    return [];
+  }
+  const {
+    offline = false,
+    fetchImpl = globalThis.fetch,
+    now = Date.now,
+    timeoutMs = 5000,
+  } = opts;
+
+  if (offline) {
+    return [localRow(), ...FALLBACK[key]];
+  }
+
+  const ts = now();
+  const cached = _cache.get(key);
+  if (cached && ts - cached.fetchedAt < TTL_MS) {
+    return [localRow(), ...cached.rows];
+  }
+
+  try {
+    const rows = await fetchLive(key, fetchImpl, timeoutMs);
+    if (!rows.length) {
+      throw new Error('no rows parsed');
+    }
+    _cache.set(key, { rows, fetchedAt: ts });
+    return [localRow(), ...rows];
+  } catch {
+    // stale-on-error, then static fallback
+    if (cached) {
+      return [localRow(), ...cached.rows];
+    }
+    return [localRow(), ...FALLBACK[key]];
+  }
+}
+
+/** Benchmarks with a leaderboard source. */
 export function leaderboardBenchmarks() {
-  return Object.keys(FIXTURES);
+  return Object.keys(SOURCES);
+}
+
+/** Test seam: clear the in-memory cache. */
+export function _resetLeaderboardCache() {
+  _cache.clear();
 }

--- a/worca-bench/server/leaderboard.test.js
+++ b/worca-bench/server/leaderboard.test.js
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  _resetLeaderboardCache,
+  getLeaderboard,
+  leaderboardBenchmarks,
+  parseCommit0Html,
+  parseSwebenchVerified,
+} from './leaderboard.js';
+
+afterEach(() => _resetLeaderboardCache());
+
+describe('parseSwebenchVerified', () => {
+  it('extracts the Verified board, converts % to a rate, sorts desc', () => {
+    const data = {
+      leaderboards: [
+        { name: 'Lite', results: [{ name: 'x', resolved: 99 }] },
+        {
+          name: 'Verified',
+          results: [
+            { name: 'low', resolved: 33.5, date: '2025-01-01' },
+            {
+              name: 'high',
+              resolved: 79.2,
+              date: '2025-12-15',
+              site: 'https://sys.example/high',
+            },
+          ],
+        },
+      ],
+    };
+    const rows = parseSwebenchVerified(data);
+    expect(rows.map((r) => r.agent)).toEqual(['high', 'low']);
+    expect(rows[0].resolved_rate).toBeCloseTo(0.792);
+    expect(rows[0].source).toBe('swebench.com');
+    expect(rows[0].date).toBe('2025-12-15');
+    expect(rows[0].url).toBe('https://sys.example/high'); // per-entry deep link
+  });
+
+  it('is tolerant of a missing board', () => {
+    expect(parseSwebenchVerified({ leaderboards: [] })).toEqual([]);
+    expect(parseSwebenchVerified({})).toEqual([]);
+  });
+});
+
+describe('parseCommit0Html', () => {
+  it('parses table rows, reads Tests-Passed % as the rate', () => {
+    const html = `
+      <table><tbody>
+        <tr><td><a href="https://github.com/x">Claude Base</a></td><td>9/16</td><td>82.3% (179/215)</td><td>12m</td><td>09/25/2024</td><td><a href="../analysis/claude">view</a></td></tr>
+        <tr><td>Other Sys</td><td>4/16</td><td>40.0% (50/125)</td><td>5m</td><td>10/01/2024</td></tr>
+      </tbody></table>`;
+    const rows = parseCommit0Html(html, 'https://commit-0.github.io/analysis/');
+    expect(rows.map((r) => r.agent)).toEqual(['Claude Base', 'Other Sys']);
+    expect(rows[0].resolved_rate).toBeCloseTo(0.823);
+    expect(rows[0].date).toBe('09/25/2024');
+    expect(rows[0].source).toBe('commit-0.github.io');
+    // prefers the analysis link, resolved to absolute
+    expect(rows[0].url).toBe('https://commit-0.github.io/analysis/claude');
+  });
+
+  it('dedupes by agent name and tolerates empty html', () => {
+    expect(parseCommit0Html('<p>no tables</p>')).toEqual([]);
+  });
+});
+
+describe('getLeaderboard', () => {
+  it('offline returns the fallback with a local row prepended', async () => {
+    const rows = await getLeaderboard('swe-bench-verified', { offline: true });
+    expect(rows[0].source).toBe('local');
+    expect(rows.length).toBeGreaterThan(1);
+  });
+
+  it('fetches live, caches, then serves from cache without re-fetching', async () => {
+    const json = JSON.stringify({
+      leaderboards: [
+        { name: 'Verified', results: [{ name: 'A', resolved: 50 }] },
+      ],
+    });
+    const fetchImpl = vi.fn(async () => ({ ok: true, text: async () => json }));
+    let t = 1000;
+    const now = () => t;
+
+    const first = await getLeaderboard('swe-bench-verified', {
+      fetchImpl,
+      now,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(first.find((r) => r.agent === 'A').resolved_rate).toBeCloseTo(0.5);
+
+    t = 2000; // within TTL
+    await getLeaderboard('swe-bench-verified', { fetchImpl, now });
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // served from cache
+  });
+
+  it('falls back to the static fixture when the live fetch fails', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('offline');
+    });
+    const rows = await getLeaderboard('commit0', { fetchImpl });
+    expect(rows[0].source).toBe('local');
+    expect(rows.some((r) => r.source === 'commit-0.github.io')).toBe(true);
+  });
+
+  it('accepts the commit-0 alias and lists both benchmarks', async () => {
+    expect(leaderboardBenchmarks()).toEqual(['swe-bench-verified', 'commit0']);
+    const rows = await getLeaderboard('commit-0', { offline: true });
+    expect(rows.length).toBeGreaterThan(0);
+  });
+});

--- a/worca-bench/server/leaderboard.test.js
+++ b/worca-bench/server/leaderboard.test.js
@@ -40,6 +40,32 @@ describe('parseSwebenchVerified', () => {
     expect(parseSwebenchVerified({ leaderboards: [] })).toEqual([]);
     expect(parseSwebenchVerified({})).toEqual([]);
   });
+
+  it('links to the experiments result folder when present', () => {
+    const rows = parseSwebenchVerified({
+      leaderboards: [
+        {
+          name: 'Verified',
+          results: [{ name: 'x', resolved: 50, folder: '20260101_sys' }],
+        },
+      ],
+    });
+    expect(rows[0].url).toBe(
+      'https://github.com/SWE-bench/experiments/tree/main/evaluation/verified/20260101_sys',
+    );
+  });
+
+  it('drops a non-http(s) site URL (XSS guard)', () => {
+    const rows = parseSwebenchVerified({
+      leaderboards: [
+        {
+          name: 'Verified',
+          results: [{ name: 'x', resolved: 50, site: 'javascript:alert(1)' }],
+        },
+      ],
+    });
+    expect(rows[0].url).toBeNull();
+  });
 });
 
 describe('parseCommit0Html', () => {
@@ -60,6 +86,14 @@ describe('parseCommit0Html', () => {
 
   it('dedupes by agent name and tolerates empty html', () => {
     expect(parseCommit0Html('<p>no tables</p>')).toEqual([]);
+  });
+
+  it('drops a javascript: href (XSS guard)', () => {
+    const html =
+      '<table><tbody><tr><td>Sys</td><td>40% (1/2)</td>' +
+      '<td><a href="javascript:alert(1)">x</a></td></tr></tbody></table>';
+    const rows = parseCommit0Html(html, 'https://commit-0.github.io/analysis/');
+    expect(rows[0].url).toBeNull();
   });
 });
 

--- a/worca-bench/server/leaderboard.test.js
+++ b/worca-bench/server/leaderboard.test.js
@@ -3,6 +3,7 @@ import {
   _resetLeaderboardCache,
   getLeaderboard,
   leaderboardBenchmarks,
+  localLeaderboardRows,
   parseCommit0Html,
   parseSwebenchVerified,
 } from './leaderboard.js';
@@ -139,5 +140,76 @@ describe('getLeaderboard', () => {
     expect(leaderboardBenchmarks()).toEqual(['swe-bench-verified', 'commit0']);
     const rows = await getLeaderboard('commit-0', { offline: true });
     expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('ranks real local rows into the table (no placeholder) when present', async () => {
+    const localRows = localLeaderboardRows(
+      [
+        {
+          name: 'demo-mock',
+          benchmark: 'swe-bench-verified',
+          reps: 4,
+          resolved_rate: 0.99,
+          last_run: '2026-06-16T10:00:00Z',
+        },
+      ],
+      'swe-bench-verified',
+    );
+    const rows = await getLeaderboard('swe-bench-verified', {
+      offline: true,
+      localRows,
+    });
+    // No "this run" placeholder when we have a real local row…
+    expect(rows.some((r) => r.agent === 'worca (this run)')).toBe(false);
+    // …and the local row outranks the offline fallback (0.99 > 0.70).
+    expect(rows[0].source).toBe('local');
+    expect(rows[0].agent).toBe('demo-mock');
+    expect(rows[0].date).toBe('2026-06-16');
+    expect(rows[0].url).toBe('#/profile?name=demo-mock');
+  });
+});
+
+describe('localLeaderboardRows', () => {
+  const aggs = [
+    {
+      name: 'sweb-a',
+      benchmark: 'swe-bench-verified',
+      reps: 2,
+      resolved_rate: 0.5,
+      last_run: '2026-01-02T00:00:00Z',
+    },
+    {
+      name: 'c0-a',
+      benchmark: 'commit-0',
+      reps: 1,
+      resolved_rate: 1,
+      last_run: '2026-01-03',
+    },
+    {
+      name: 'no-runs',
+      benchmark: 'swe-bench-verified',
+      reps: 0,
+      resolved_rate: 0,
+      last_run: null,
+    },
+  ];
+
+  it('keeps only run profiles targeting the requested benchmark', () => {
+    const rows = localLeaderboardRows(aggs, 'swe-bench-verified');
+    expect(rows.map((r) => r.agent)).toEqual(['sweb-a']);
+    expect(rows[0].source).toBe('local');
+    expect(rows[0].date).toBe('2026-01-02');
+    expect(rows[0].url).toBe('#/profile?name=sweb-a');
+  });
+
+  it('normalizes the commit-0 / commit0 benchmark alias', () => {
+    expect(localLeaderboardRows(aggs, 'commit0').map((r) => r.agent)).toEqual([
+      'c0-a',
+    ]);
+  });
+
+  it('tolerates empty / missing aggregates', () => {
+    expect(localLeaderboardRows(undefined, 'commit0')).toEqual([]);
+    expect(localLeaderboardRows([], 'swe-bench-verified')).toEqual([]);
   });
 });

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -20,6 +20,8 @@ const HARD_CAP_MS = 180000;
  * @param {string} opts.targetDir   results target directory
  * @param {string} [opts.profilesDir]  extra dir to search for the profile YAML
  *        (so a profile authored in a configured, non-primary dir is findable)
+ * @param {number} [opts.reps]          per-run override of the profile's reps
+ * @param {number} [opts.maxInstances]  cap the instance count for this run
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  *        injectable spawn for tests
  * @returns {Promise<{pid: number}>}
@@ -28,6 +30,8 @@ export function runBenchmark({
   profile,
   targetDir,
   profilesDir,
+  reps,
+  maxInstances,
   _spawn = spawn,
 } = {}) {
   if (!profile) {
@@ -44,6 +48,12 @@ export function runBenchmark({
   ];
   if (profilesDir) {
     args.push('--profiles-dir', profilesDir);
+  }
+  if (Number.isInteger(reps) && reps >= 1) {
+    args.push('--reps', String(reps));
+  }
+  if (Number.isInteger(maxInstances) && maxInstances >= 1) {
+    args.push('--max-instances', String(maxInstances));
   }
 
   return new Promise((resolve, reject) => {

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -48,7 +48,8 @@ function sanitizeSecrets(secrets) {
  * @param {number} [opts.reps]          per-run override of the profile's reps
  * @param {number} [opts.maxInstances]  cap the instance count for this run
  * @param {number} [opts.maxParallel]   override pipeline parallelism (concurrency.worca)
- * @param {boolean} [opts.noCanary]     skip the per-template canary preflight
+ * @param {boolean} [opts.canary]       run the per-template canary (true) or skip it (false); overrides the profile's canary flag; omit to leave the profile default
+ * @param {boolean} [opts.noCanary]     back-compat one-way off (skip the canary); prefer `canary`
  * @param {string} [opts.cacheDir]      benchmark cache dir (HF datasets / mirrors)
  * @param {string} [opts.graphify]      enable graphify in this mode (structural|full)
  * @param {string} [opts.codeReviewGraph]  enable code-review-graph in this mode
@@ -67,6 +68,7 @@ export function runBenchmark({
   reps,
   maxInstances,
   maxParallel,
+  canary,
   noCanary,
   cacheDir,
   graphify,
@@ -101,7 +103,11 @@ export function runBenchmark({
   if (Number.isInteger(maxParallel) && maxParallel >= 1) {
     args.push('--max-parallel', String(maxParallel));
   }
-  if (noCanary) {
+  // Canary override: an explicit boolean is authoritative (overrides the
+  // profile's canary flag); `noCanary` stays as a back-compat one-way off.
+  if (typeof canary === 'boolean') {
+    args.push('--canary', canary ? 'on' : 'off');
+  } else if (noCanary) {
     args.push('--no-canary');
   }
   if (cacheDir) {

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -76,6 +76,7 @@ export function runBenchmark({
   preflight,
   claudeMdMode,
   gradeMode,
+  timeout,
   secrets,
   _spawn = spawn,
 } = {}) {
@@ -127,6 +128,11 @@ export function runBenchmark({
   }
   if (gradeMode) {
     args.push('--grade-mode', String(gradeMode));
+  }
+  // Per-build timeout (seconds). 0 is a valid explicit override (no limit), so
+  // accept any non-negative integer; omit to fall back to the profile's value.
+  if (Number.isInteger(timeout) && timeout >= 0) {
+    args.push('--timeout', String(timeout));
   }
 
   return _launchDetached(args, {

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -22,6 +22,7 @@ const HARD_CAP_MS = 180000;
  *        (so a profile authored in a configured, non-primary dir is findable)
  * @param {number} [opts.reps]          per-run override of the profile's reps
  * @param {number} [opts.maxInstances]  cap the instance count for this run
+ * @param {string} [opts.cacheDir]      benchmark cache dir (HF datasets / mirrors)
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  *        injectable spawn for tests
  * @returns {Promise<{pid: number}>}
@@ -32,6 +33,7 @@ export function runBenchmark({
   profilesDir,
   reps,
   maxInstances,
+  cacheDir,
   _spawn = spawn,
 } = {}) {
   if (!profile) {
@@ -54,6 +56,9 @@ export function runBenchmark({
   }
   if (Number.isInteger(maxInstances) && maxInstances >= 1) {
     args.push('--max-instances', String(maxInstances));
+  }
+  if (cacheDir) {
+    args.push('--cache-dir', cacheDir);
   }
 
   return new Promise((resolve, reject) => {

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -18,11 +18,18 @@ const HARD_CAP_MS = 180000;
  * @param {object} opts
  * @param {string} opts.profile     profile name to run
  * @param {string} opts.targetDir   results target directory
+ * @param {string} [opts.profilesDir]  extra dir to search for the profile YAML
+ *        (so a profile authored in a configured, non-primary dir is findable)
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  *        injectable spawn for tests
  * @returns {Promise<{pid: number}>}
  */
-export function runBenchmark({ profile, targetDir, _spawn = spawn } = {}) {
+export function runBenchmark({
+  profile,
+  targetDir,
+  profilesDir,
+  _spawn = spawn,
+} = {}) {
   if (!profile) {
     return Promise.reject(new Error('profile is required'));
   }
@@ -35,6 +42,9 @@ export function runBenchmark({ profile, targetDir, _spawn = spawn } = {}) {
     '--target-dir',
     targetDir,
   ];
+  if (profilesDir) {
+    args.push('--profiles-dir', profilesDir);
+  }
 
   return new Promise((resolve, reject) => {
     let child;

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -23,6 +23,7 @@ const HARD_CAP_MS = 180000;
  * @param {number} [opts.reps]          per-run override of the profile's reps
  * @param {number} [opts.maxInstances]  cap the instance count for this run
  * @param {number} [opts.maxParallel]   override pipeline parallelism (concurrency.worca)
+ * @param {boolean} [opts.noCanary]     skip the per-template canary preflight
  * @param {string} [opts.cacheDir]      benchmark cache dir (HF datasets / mirrors)
  * @param {string} [opts.graphify]      enable graphify in this mode (structural|full)
  * @param {string} [opts.codeReviewGraph]  enable code-review-graph in this mode
@@ -37,6 +38,7 @@ export function runBenchmark({
   reps,
   maxInstances,
   maxParallel,
+  noCanary,
   cacheDir,
   graphify,
   codeReviewGraph,
@@ -65,6 +67,9 @@ export function runBenchmark({
   }
   if (Number.isInteger(maxParallel) && maxParallel >= 1) {
     args.push('--max-parallel', String(maxParallel));
+  }
+  if (noCanary) {
+    args.push('--no-canary');
   }
   if (cacheDir) {
     args.push('--cache-dir', cacheDir);

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -81,6 +81,65 @@ export function runBenchmark({
     args.push('--code-review-graph', String(codeReviewGraph));
   }
 
+  return _launchDetached(args, { _spawn, label: 'benchmark' });
+}
+
+/**
+ * Spawn `python3 -m worca_bench.cli regrade …` detached and return its pid.
+ * Re-grades a profile's saved diffs without re-running the pipeline.
+ *
+ * @param {object} opts
+ * @param {string} opts.profile      profile name to re-grade
+ * @param {string} opts.targetDir    results target directory
+ * @param {string} [opts.profilesDir]  extra dir to search for the profile YAML
+ * @param {string} [opts.instance]   limit to a single instance id
+ * @param {string} [opts.mode]       grade backend (sb-cli|local-docker|modal|stub)
+ * @param {boolean} [opts.onlyErrors]  re-grade only rows currently marked error
+ * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
+ * @returns {Promise<{pid: number}>}
+ */
+export function runRegrade({
+  profile,
+  targetDir,
+  profilesDir,
+  instance,
+  mode,
+  onlyErrors,
+  _spawn = spawn,
+} = {}) {
+  if (!profile) {
+    return Promise.reject(new Error('profile is required'));
+  }
+  const args = [
+    '-m',
+    'worca_bench.cli',
+    'regrade',
+    '--profile',
+    profile,
+    '--target-dir',
+    targetDir,
+  ];
+  if (profilesDir) {
+    args.push('--profiles-dir', profilesDir);
+  }
+  if (mode) {
+    args.push('--mode', String(mode));
+  }
+  if (instance) {
+    args.push('--instance', String(instance));
+  }
+  if (onlyErrors) {
+    args.push('--only-errors');
+  }
+  return _launchDetached(args, { _spawn, label: 'regrade' });
+}
+
+/**
+ * Shared detached-spawn for the long-lived CLI runners: spawn `python3 <args>`,
+ * resolve `{pid}` as soon as the child is handed off (do NOT wait for exit), and
+ * reject on an early spawn error/exit or the hard-cap timeout.
+ */
+function _launchDetached(args, { _spawn = spawn, label = 'process' } = {}) {
   return new Promise((resolve, reject) => {
     let child;
     try {
@@ -90,7 +149,7 @@ export function runBenchmark({
         env: { ...process.env },
       });
     } catch (err) {
-      reject(new Error(`Failed to start benchmark: ${err.message}`));
+      reject(new Error(`Failed to start ${label}: ${err.message}`));
       return;
     }
 
@@ -104,7 +163,7 @@ export function runBenchmark({
       child.removeAllListeners?.('error');
       child.removeAllListeners?.('exit');
       const err = new Error(
-        'Benchmark launcher did not finish within 180s — aborting launch',
+        `${label} launcher did not finish within 180s — aborting launch`,
       );
       err.code = 'spawn_timeout';
       reject(err);
@@ -121,7 +180,7 @@ export function runBenchmark({
       if (settled) return;
       settled = true;
       clearTimeout(hardCap);
-      const err = new Error(`Failed to start benchmark: ${spawnErr.message}`);
+      const err = new Error(`Failed to start ${label}: ${spawnErr.message}`);
       err.code = 'spawn_error';
       reject(err);
     });
@@ -140,7 +199,7 @@ export function runBenchmark({
         settled = true;
         clearTimeout(hardCap);
         const err = new Error(
-          `Benchmark failed to start (exit code ${code})${stderr.trim() ? `:\n${stderr.trim()}` : ''}`,
+          `${label} failed to start (exit code ${code})${stderr.trim() ? `:\n${stderr.trim()}` : ''}`,
         );
         err.code = 'spawn_error';
         reject(err);

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -22,6 +22,7 @@ const HARD_CAP_MS = 180000;
  *        (so a profile authored in a configured, non-primary dir is findable)
  * @param {number} [opts.reps]          per-run override of the profile's reps
  * @param {number} [opts.maxInstances]  cap the instance count for this run
+ * @param {number} [opts.maxParallel]   override pipeline parallelism (concurrency.worca)
  * @param {string} [opts.cacheDir]      benchmark cache dir (HF datasets / mirrors)
  * @param {string} [opts.graphify]      enable graphify in this mode (structural|full)
  * @param {string} [opts.codeReviewGraph]  enable code-review-graph in this mode
@@ -35,6 +36,7 @@ export function runBenchmark({
   profilesDir,
   reps,
   maxInstances,
+  maxParallel,
   cacheDir,
   graphify,
   codeReviewGraph,
@@ -60,6 +62,9 @@ export function runBenchmark({
   }
   if (Number.isInteger(maxInstances) && maxInstances >= 1) {
     args.push('--max-instances', String(maxInstances));
+  }
+  if (Number.isInteger(maxParallel) && maxParallel >= 1) {
+    args.push('--max-parallel', String(maxParallel));
   }
   if (cacheDir) {
     args.push('--cache-dir', cacheDir);

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -23,6 +23,8 @@ const HARD_CAP_MS = 180000;
  * @param {number} [opts.reps]          per-run override of the profile's reps
  * @param {number} [opts.maxInstances]  cap the instance count for this run
  * @param {string} [opts.cacheDir]      benchmark cache dir (HF datasets / mirrors)
+ * @param {string} [opts.graphify]      enable graphify in this mode (structural|full)
+ * @param {string} [opts.codeReviewGraph]  enable code-review-graph in this mode
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  *        injectable spawn for tests
  * @returns {Promise<{pid: number}>}
@@ -34,6 +36,8 @@ export function runBenchmark({
   reps,
   maxInstances,
   cacheDir,
+  graphify,
+  codeReviewGraph,
   _spawn = spawn,
 } = {}) {
   if (!profile) {
@@ -59,6 +63,12 @@ export function runBenchmark({
   }
   if (cacheDir) {
     args.push('--cache-dir', cacheDir);
+  }
+  if (graphify) {
+    args.push('--graphify', String(graphify));
+  }
+  if (codeReviewGraph) {
+    args.push('--code-review-graph', String(codeReviewGraph));
   }
 
   return new Promise((resolve, reject) => {

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -1,0 +1,105 @@
+// server/process-manager.js
+//
+// Fire-and-forget launcher for the worca-bench Python runner. Mirrors the
+// pattern in worca-ui/server/process-manager.js: spawn detached, capture
+// stderr for diagnostics, resolve with {pid} once the child has been handed
+// off, and reject under a hard cap so a hung launch never blocks the request
+// forever. The benchmark run itself is long-lived — this only kicks it off.
+
+import { spawn } from 'node:child_process';
+
+const HARD_CAP_MS = 180000;
+
+/**
+ * Spawn `python3 -m worca_bench.cli run --profile <name> --target-dir <dir>`
+ * detached and return its pid. The grandchild owns its own stdio/logging; we
+ * only keep stderr open briefly to surface an immediate spawn failure.
+ *
+ * @param {object} opts
+ * @param {string} opts.profile     profile name to run
+ * @param {string} opts.targetDir   results target directory
+ * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
+ *        injectable spawn for tests
+ * @returns {Promise<{pid: number}>}
+ */
+export function runBenchmark({ profile, targetDir, _spawn = spawn } = {}) {
+  if (!profile) {
+    return Promise.reject(new Error('profile is required'));
+  }
+  const args = [
+    '-m',
+    'worca_bench.cli',
+    'run',
+    '--profile',
+    profile,
+    '--target-dir',
+    targetDir,
+  ];
+
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = _spawn('python3', args, {
+        detached: true,
+        stdio: ['ignore', 'ignore', 'pipe'],
+        env: { ...process.env },
+      });
+    } catch (err) {
+      reject(new Error(`Failed to start benchmark: ${err.message}`));
+      return;
+    }
+
+    let settled = false;
+    let stderr = '';
+    const STDERR_CAP = 8192;
+
+    const hardCap = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.removeAllListeners?.('error');
+      child.removeAllListeners?.('exit');
+      const err = new Error(
+        'Benchmark launcher did not finish within 180s — aborting launch',
+      );
+      err.code = 'spawn_timeout';
+      reject(err);
+    }, HARD_CAP_MS);
+    hardCap.unref?.();
+
+    if (child.stderr) {
+      child.stderr.on('data', (d) => {
+        if (stderr.length < STDERR_CAP) stderr += d.toString();
+      });
+    }
+
+    child.on('error', (spawnErr) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(hardCap);
+      const err = new Error(`Failed to start benchmark: ${spawnErr.message}`);
+      err.code = 'spawn_error';
+      reject(err);
+    });
+
+    // The runner is long-lived. Resolve as soon as we have a live pid and the
+    // child has been detached — we do NOT wait for exit (that's the whole run).
+    if (child.pid) {
+      settled = true;
+      clearTimeout(hardCap);
+      child.unref?.();
+      resolve({ pid: child.pid });
+    } else {
+      // No pid synchronously available — wait for an early error/exit instead.
+      child.on('exit', (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(hardCap);
+        const err = new Error(
+          `Benchmark failed to start (exit code ${code})${stderr.trim() ? `:\n${stderr.trim()}` : ''}`,
+        );
+        err.code = 'spawn_error';
+        reject(err);
+      });
+    }
+  });
+}

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -52,6 +52,8 @@ function sanitizeSecrets(secrets) {
  * @param {string} [opts.cacheDir]      benchmark cache dir (HF datasets / mirrors)
  * @param {string} [opts.graphify]      enable graphify in this mode (structural|full)
  * @param {string} [opts.codeReviewGraph]  enable code-review-graph in this mode
+ * @param {boolean} [opts.preflight]    run preflight (true) or skip it (false); omit to leave the profile default
+ * @param {string} [opts.claudeMdMode]  CLAUDE.md load mode (none|project|project+local|all)
  * @param {object} [opts.secrets]       grader credentials (allowlisted) merged into the child env
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  *        injectable spawn for tests
@@ -68,6 +70,8 @@ export function runBenchmark({
   cacheDir,
   graphify,
   codeReviewGraph,
+  preflight,
+  claudeMdMode,
   secrets,
   _spawn = spawn,
 } = {}) {
@@ -106,6 +110,12 @@ export function runBenchmark({
   }
   if (codeReviewGraph) {
     args.push('--code-review-graph', String(codeReviewGraph));
+  }
+  if (typeof preflight === 'boolean') {
+    args.push('--preflight', preflight ? 'on' : 'off');
+  }
+  if (claudeMdMode) {
+    args.push('--claude-md-mode', String(claudeMdMode));
   }
 
   return _launchDetached(args, {

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -54,6 +54,7 @@ function sanitizeSecrets(secrets) {
  * @param {string} [opts.codeReviewGraph]  enable code-review-graph in this mode
  * @param {boolean} [opts.preflight]    run preflight (true) or skip it (false); omit to leave the profile default
  * @param {string} [opts.claudeMdMode]  CLAUDE.md load mode (none|project|project+local|all)
+ * @param {string} [opts.gradeMode]     grade backend override (stub|sb-cli|local-docker|modal); omit to keep the profile's
  * @param {object} [opts.secrets]       grader credentials (allowlisted) merged into the child env
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  *        injectable spawn for tests
@@ -72,6 +73,7 @@ export function runBenchmark({
   codeReviewGraph,
   preflight,
   claudeMdMode,
+  gradeMode,
   secrets,
   _spawn = spawn,
 } = {}) {
@@ -116,6 +118,9 @@ export function runBenchmark({
   }
   if (claudeMdMode) {
     args.push('--claude-md-mode', String(claudeMdMode));
+  }
+  if (gradeMode) {
+    args.push('--grade-mode', String(gradeMode));
   }
 
   return _launchDetached(args, {

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -10,6 +10,29 @@ import { spawn } from 'node:child_process';
 
 const HARD_CAP_MS = 180000;
 
+// Grader credentials the dashboard may forward from the browser. The browser is
+// the only at-rest store for these — they reach the runner through the spawned
+// subprocess's *environment* (never argv, so they stay out of `ps`), where the
+// Python side's collect_secret_env() picks them up. Strictly allowlisted so a
+// crafted request can't inject an arbitrary env var into the child.
+export const GRADER_SECRET_KEYS = [
+  'SWEBENCH_API_KEY',
+  'MODAL_TOKEN_ID',
+  'MODAL_TOKEN_SECRET',
+];
+
+/** Keep only allowlisted, non-empty string secrets — safe to merge into env. */
+function sanitizeSecrets(secrets) {
+  const out = {};
+  if (secrets && typeof secrets === 'object') {
+    for (const k of GRADER_SECRET_KEYS) {
+      const v = secrets[k];
+      if (typeof v === 'string' && v.trim()) out[k] = v;
+    }
+  }
+  return out;
+}
+
 /**
  * Spawn `python3 -m worca_bench.cli run --profile <name> --target-dir <dir>`
  * detached and return its pid. The grandchild owns its own stdio/logging; we
@@ -27,6 +50,7 @@ const HARD_CAP_MS = 180000;
  * @param {string} [opts.cacheDir]      benchmark cache dir (HF datasets / mirrors)
  * @param {string} [opts.graphify]      enable graphify in this mode (structural|full)
  * @param {string} [opts.codeReviewGraph]  enable code-review-graph in this mode
+ * @param {object} [opts.secrets]       grader credentials (allowlisted) merged into the child env
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  *        injectable spawn for tests
  * @returns {Promise<{pid: number}>}
@@ -42,6 +66,7 @@ export function runBenchmark({
   cacheDir,
   graphify,
   codeReviewGraph,
+  secrets,
   _spawn = spawn,
 } = {}) {
   if (!profile) {
@@ -81,7 +106,11 @@ export function runBenchmark({
     args.push('--code-review-graph', String(codeReviewGraph));
   }
 
-  return _launchDetached(args, { _spawn, label: 'benchmark' });
+  return _launchDetached(args, {
+    _spawn,
+    label: 'benchmark',
+    secrets: sanitizeSecrets(secrets),
+  });
 }
 
 /**
@@ -95,6 +124,7 @@ export function runBenchmark({
  * @param {string} [opts.instance]   limit to a single instance id
  * @param {string} [opts.mode]       grade backend (sb-cli|local-docker|modal|stub)
  * @param {boolean} [opts.onlyErrors]  re-grade only rows currently marked error
+ * @param {object} [opts.secrets]     grader credentials (allowlisted) merged into the child env
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  * @returns {Promise<{pid: number}>}
  */
@@ -105,6 +135,7 @@ export function runRegrade({
   instance,
   mode,
   onlyErrors,
+  secrets,
   _spawn = spawn,
 } = {}) {
   if (!profile) {
@@ -131,7 +162,11 @@ export function runRegrade({
   if (onlyErrors) {
     args.push('--only-errors');
   }
-  return _launchDetached(args, { _spawn, label: 'regrade' });
+  return _launchDetached(args, {
+    _spawn,
+    label: 'regrade',
+    secrets: sanitizeSecrets(secrets),
+  });
 }
 
 /**
@@ -139,14 +174,18 @@ export function runRegrade({
  * resolve `{pid}` as soon as the child is handed off (do NOT wait for exit), and
  * reject on an early spawn error/exit or the hard-cap timeout.
  */
-function _launchDetached(args, { _spawn = spawn, label = 'process' } = {}) {
+function _launchDetached(
+  args,
+  { _spawn = spawn, label = 'process', secrets } = {},
+) {
   return new Promise((resolve, reject) => {
     let child;
     try {
       child = _spawn('python3', args, {
         detached: true,
         stdio: ['ignore', 'ignore', 'pipe'],
-        env: { ...process.env },
+        // Browser-forwarded grader secrets ride in the env, never argv.
+        env: { ...process.env, ...(secrets || {}) },
       });
     } catch (err) {
       reject(new Error(`Failed to start ${label}: ${err.message}`));

--- a/worca-bench/server/process-manager.js
+++ b/worca-bench/server/process-manager.js
@@ -7,6 +7,8 @@
 // forever. The benchmark run itself is long-lived — this only kicks it off.
 
 import { spawn } from 'node:child_process';
+import { closeSync, mkdirSync, openSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 const HARD_CAP_MS = 180000;
 
@@ -124,6 +126,8 @@ export function runBenchmark({
  * @param {string} [opts.instance]   limit to a single instance id
  * @param {string} [opts.mode]       grade backend (sb-cli|local-docker|modal|stub)
  * @param {boolean} [opts.onlyErrors]  re-grade only rows currently marked error
+ * @param {boolean} [opts.sequential]  grade one rep at a time (whole-profile sweeps)
+ * @param {string} [opts.logPath]     redirect the runner's stdout/stderr to this file
  * @param {object} [opts.secrets]     grader credentials (allowlisted) merged into the child env
  * @param {(args: string[], options: object) => import('node:child_process').ChildProcess} [opts._spawn]
  * @returns {Promise<{pid: number}>}
@@ -135,6 +139,8 @@ export function runRegrade({
   instance,
   mode,
   onlyErrors,
+  sequential,
+  logPath,
   secrets,
   _spawn = spawn,
 } = {}) {
@@ -162,10 +168,14 @@ export function runRegrade({
   if (onlyErrors) {
     args.push('--only-errors');
   }
+  if (sequential) {
+    args.push('--sequential');
+  }
   return _launchDetached(args, {
     _spawn,
     label: 'regrade',
     secrets: sanitizeSecrets(secrets),
+    logPath,
   });
 }
 
@@ -176,21 +186,38 @@ export function runRegrade({
  */
 function _launchDetached(
   args,
-  { _spawn = spawn, label = 'process', secrets } = {},
+  { _spawn = spawn, label = 'process', secrets, logPath } = {},
 ) {
   return new Promise((resolve, reject) => {
+    // When a log file is requested, redirect the child's stdout+stderr into it
+    // so a long detached sweep is diagnosable (otherwise its output is lost).
+    let logFd = null;
+    if (logPath) {
+      try {
+        mkdirSync(dirname(logPath), { recursive: true });
+        logFd = openSync(logPath, 'a');
+      } catch {
+        logFd = null; // best-effort: fall back to discarding output
+      }
+    }
+    const stdio =
+      logFd !== null ? ['ignore', logFd, logFd] : ['ignore', 'ignore', 'pipe'];
+
     let child;
     try {
       child = _spawn('python3', args, {
         detached: true,
-        stdio: ['ignore', 'ignore', 'pipe'],
+        stdio,
         // Browser-forwarded grader secrets ride in the env, never argv.
         env: { ...process.env, ...(secrets || {}) },
       });
     } catch (err) {
+      if (logFd !== null) closeSync(logFd);
       reject(new Error(`Failed to start ${label}: ${err.message}`));
       return;
     }
+    // The child has inherited the fd; the parent can close its copy.
+    if (logFd !== null) closeSync(logFd);
 
     let settled = false;
     let stderr = '';

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -79,12 +79,15 @@ describe('runBenchmark', () => {
       targetDir: '/tmp/out',
       reps: 3,
       maxInstances: 5,
+      maxParallel: 6,
       _spawn,
     });
     expect(capturedArgs).toContain('--reps');
     expect(capturedArgs[capturedArgs.indexOf('--reps') + 1]).toBe('3');
     expect(capturedArgs).toContain('--max-instances');
     expect(capturedArgs[capturedArgs.indexOf('--max-instances') + 1]).toBe('5');
+    expect(capturedArgs).toContain('--max-parallel');
+    expect(capturedArgs[capturedArgs.indexOf('--max-parallel') + 1]).toBe('6');
 
     // Non-positive / non-integer values are dropped entirely.
     await runBenchmark({
@@ -92,10 +95,12 @@ describe('runBenchmark', () => {
       targetDir: '/tmp/out',
       reps: 0,
       maxInstances: undefined,
+      maxParallel: 0,
       _spawn,
     });
     expect(capturedArgs).not.toContain('--reps');
     expect(capturedArgs).not.toContain('--max-instances');
+    expect(capturedArgs).not.toContain('--max-parallel');
   });
 
   it('appends --cache-dir when given', async () => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -129,6 +129,31 @@ describe('runBenchmark', () => {
     expect(capturedArgs).not.toContain('--no-canary');
   });
 
+  it('appends --canary on|off when an explicit boolean is given', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(12);
+    };
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      canary: false,
+      _spawn,
+    });
+    expect(capturedArgs).toContain('--canary');
+    expect(capturedArgs[capturedArgs.indexOf('--canary') + 1]).toBe('off');
+
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      canary: true,
+      _spawn,
+    });
+    expect(capturedArgs[capturedArgs.indexOf('--canary') + 1]).toBe('on');
+    expect(capturedArgs).not.toContain('--no-canary');
+  });
+
   it('appends --cache-dir when given', async () => {
     let capturedArgs = null;
     const _spawn = (_cmd, args) => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'vitest';
-import { runBenchmark } from './process-manager.js';
+import { runBenchmark, runRegrade } from './process-manager.js';
 
 function fakeChild(pid) {
   const child = new EventEmitter();
@@ -185,5 +185,77 @@ describe('runBenchmark', () => {
     await expect(
       runBenchmark({ profile: 'p', targetDir: '/tmp', _spawn }),
     ).rejects.toThrow(/Failed to start benchmark/);
+  });
+});
+
+describe('runRegrade', () => {
+  it('rejects when profile is missing', async () => {
+    await expect(runRegrade({ targetDir: '/tmp' })).rejects.toThrow(
+      /profile is required/,
+    );
+  });
+
+  it('spawns the regrade subcommand with base args and resolves {pid}', async () => {
+    let capturedCmd = null;
+    let capturedArgs = null;
+    const _spawn = (cmd, args) => {
+      capturedCmd = cmd;
+      capturedArgs = args;
+      return fakeChild(4242);
+    };
+    const res = await runRegrade({
+      profile: 'demo',
+      targetDir: '/tmp/out',
+      _spawn,
+    });
+    expect(res).toEqual({ pid: 4242 });
+    expect(capturedCmd).toBe('python3');
+    expect(capturedArgs).toEqual([
+      '-m',
+      'worca_bench.cli',
+      'regrade',
+      '--profile',
+      'demo',
+      '--target-dir',
+      '/tmp/out',
+    ]);
+  });
+
+  it('appends --mode, --instance, --profiles-dir, --only-errors when given', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(7);
+    };
+    await runRegrade({
+      profile: 'demo',
+      targetDir: '/tmp/out',
+      profilesDir: '/authored/profiles',
+      mode: 'sb-cli',
+      instance: 'astropy__astropy-12907',
+      onlyErrors: true,
+      _spawn,
+    });
+    expect(capturedArgs[capturedArgs.indexOf('--mode') + 1]).toBe('sb-cli');
+    expect(capturedArgs[capturedArgs.indexOf('--instance') + 1]).toBe(
+      'astropy__astropy-12907',
+    );
+    expect(capturedArgs[capturedArgs.indexOf('--profiles-dir') + 1]).toBe(
+      '/authored/profiles',
+    );
+    expect(capturedArgs).toContain('--only-errors');
+  });
+
+  it('rejects with a regrade-labelled message on spawn error', async () => {
+    const _spawn = () => {
+      const child = new EventEmitter();
+      child.pid = undefined;
+      child.stderr = new EventEmitter();
+      queueMicrotask(() => child.emit('error', new Error('ENOENT')));
+      return child;
+    };
+    await expect(
+      runRegrade({ profile: 'p', targetDir: '/tmp', _spawn }),
+    ).rejects.toThrow(/Failed to start regrade/);
   });
 });

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -43,6 +43,31 @@ describe('runBenchmark', () => {
     ]);
   });
 
+  it('appends --profiles-dir when given (and omits it otherwise)', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(7);
+    };
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      profilesDir: '/authored/profiles',
+      _spawn,
+    });
+    expect(capturedArgs).toEqual([
+      '-m',
+      'worca_bench.cli',
+      'run',
+      '--profile',
+      'smoke',
+      '--target-dir',
+      '/tmp/out',
+      '--profiles-dir',
+      '/authored/profiles',
+    ]);
+  });
+
   it('detaches and ignores stdin/stdout, pipes stderr', async () => {
     let capturedOpts = null;
     const _spawn = (_cmd, _args, opts) => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -163,6 +163,53 @@ describe('runBenchmark', () => {
     );
   });
 
+  it('merges only allowlisted, non-empty secrets into the child env', async () => {
+    let capturedOpts = null;
+    const _spawn = (_cmd, _args, opts) => {
+      capturedOpts = opts;
+      return fakeChild(55);
+    };
+    await runBenchmark({
+      profile: 'p',
+      targetDir: '/tmp',
+      secrets: {
+        SWEBENCH_API_KEY: 'swb',
+        MODAL_TOKEN_ID: 'mid',
+        MODAL_TOKEN_SECRET: '   ', // blank → dropped
+        EVIL: 'rm -rf', // not allowlisted → dropped
+      },
+      _spawn,
+    });
+    expect(capturedOpts.env.SWEBENCH_API_KEY).toBe('swb');
+    expect(capturedOpts.env.MODAL_TOKEN_ID).toBe('mid');
+    expect(capturedOpts.env.MODAL_TOKEN_SECRET).toBeUndefined();
+    expect(capturedOpts.env.EVIL).toBeUndefined();
+    // Ambient env is still inherited.
+    expect(capturedOpts.env.PATH).toBe(process.env.PATH);
+  });
+
+  it('passes secrets through regrade too (allowlisted, in env not argv)', async () => {
+    let capturedOpts = null;
+    let capturedArgs = null;
+    const _spawn = (_cmd, args, opts) => {
+      capturedArgs = args;
+      capturedOpts = opts;
+      return fakeChild(56);
+    };
+    await runRegrade({
+      profile: 'p',
+      targetDir: '/tmp',
+      mode: 'modal',
+      secrets: { MODAL_TOKEN_ID: 'mid', MODAL_TOKEN_SECRET: 'msec' },
+      _spawn,
+    });
+    expect(capturedOpts.env.MODAL_TOKEN_ID).toBe('mid');
+    expect(capturedOpts.env.MODAL_TOKEN_SECRET).toBe('msec');
+    // Never leaked onto the command line.
+    expect(capturedArgs.join(' ')).not.toContain('mid');
+    expect(capturedArgs.join(' ')).not.toContain('msec');
+  });
+
   it('detaches and ignores stdin/stdout, pipes stderr', async () => {
     let capturedOpts = null;
     const _spawn = (_cmd, _args, opts) => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -116,6 +116,25 @@ describe('runBenchmark', () => {
     );
   });
 
+  it('appends --graphify and --code-review-graph when set', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(11);
+    };
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      graphify: 'full',
+      codeReviewGraph: 'structural',
+      _spawn,
+    });
+    expect(capturedArgs[capturedArgs.indexOf('--graphify') + 1]).toBe('full');
+    expect(capturedArgs[capturedArgs.indexOf('--code-review-graph') + 1]).toBe(
+      'structural',
+    );
+  });
+
   it('detaches and ignores stdin/stdout, pipes stderr', async () => {
     let capturedOpts = null;
     const _spawn = (_cmd, _args, opts) => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -1,0 +1,69 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it } from 'vitest';
+import { runBenchmark } from './process-manager.js';
+
+function fakeChild(pid) {
+  const child = new EventEmitter();
+  child.pid = pid;
+  child.stderr = new EventEmitter();
+  child.unref = () => {};
+  return child;
+}
+
+describe('runBenchmark', () => {
+  it('rejects when profile is missing', async () => {
+    await expect(runBenchmark({ targetDir: '/tmp' })).rejects.toThrow(
+      /profile is required/,
+    );
+  });
+
+  it('spawns the python runner with the right args and resolves {pid}', async () => {
+    let capturedCmd = null;
+    let capturedArgs = null;
+    const _spawn = (cmd, args) => {
+      capturedCmd = cmd;
+      capturedArgs = args;
+      return fakeChild(9999);
+    };
+    const res = await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      _spawn,
+    });
+    expect(res).toEqual({ pid: 9999 });
+    expect(capturedCmd).toBe('python3');
+    expect(capturedArgs).toEqual([
+      '-m',
+      'worca_bench.cli',
+      'run',
+      '--profile',
+      'smoke',
+      '--target-dir',
+      '/tmp/out',
+    ]);
+  });
+
+  it('detaches and ignores stdin/stdout, pipes stderr', async () => {
+    let capturedOpts = null;
+    const _spawn = (_cmd, _args, opts) => {
+      capturedOpts = opts;
+      return fakeChild(123);
+    };
+    await runBenchmark({ profile: 'p', targetDir: '/tmp', _spawn });
+    expect(capturedOpts.detached).toBe(true);
+    expect(capturedOpts.stdio).toEqual(['ignore', 'ignore', 'pipe']);
+  });
+
+  it('rejects if the child errors before producing a pid', async () => {
+    const _spawn = () => {
+      const child = new EventEmitter();
+      child.pid = undefined;
+      child.stderr = new EventEmitter();
+      queueMicrotask(() => child.emit('error', new Error('ENOENT')));
+      return child;
+    };
+    await expect(
+      runBenchmark({ profile: 'p', targetDir: '/tmp', _spawn }),
+    ).rejects.toThrow(/Failed to start benchmark/);
+  });
+});

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -213,6 +213,38 @@ describe('runBenchmark', () => {
     expect(capturedArgs.join(' ')).not.toContain('msec');
   });
 
+  it('appends --preflight on/off and --claude-md-mode', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(31);
+    };
+    await runBenchmark({
+      profile: 'p',
+      targetDir: '/tmp',
+      preflight: true,
+      claudeMdMode: 'project',
+      _spawn,
+    });
+    expect(capturedArgs[capturedArgs.indexOf('--preflight') + 1]).toBe('on');
+    expect(capturedArgs[capturedArgs.indexOf('--claude-md-mode') + 1]).toBe(
+      'project',
+    );
+
+    await runBenchmark({
+      profile: 'p',
+      targetDir: '/tmp',
+      preflight: false,
+      _spawn,
+    });
+    expect(capturedArgs[capturedArgs.indexOf('--preflight') + 1]).toBe('off');
+
+    // Omitted preflight (undefined) => no flag.
+    await runBenchmark({ profile: 'p', targetDir: '/tmp', _spawn });
+    expect(capturedArgs).not.toContain('--preflight');
+    expect(capturedArgs).not.toContain('--claude-md-mode');
+  });
+
   it('detaches and ignores stdin/stdout, pipes stderr', async () => {
     let capturedOpts = null;
     const _spawn = (_cmd, _args, opts) => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -98,6 +98,24 @@ describe('runBenchmark', () => {
     expect(capturedArgs).not.toContain('--max-instances');
   });
 
+  it('appends --cache-dir when given', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(9);
+    };
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      cacheDir: '/Volumes/big/cache',
+      _spawn,
+    });
+    expect(capturedArgs).toContain('--cache-dir');
+    expect(capturedArgs[capturedArgs.indexOf('--cache-dir') + 1]).toBe(
+      '/Volumes/big/cache',
+    );
+  });
+
   it('detaches and ignores stdin/stdout, pipes stderr', async () => {
     let capturedOpts = null;
     const _spawn = (_cmd, _args, opts) => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -68,6 +68,36 @@ describe('runBenchmark', () => {
     ]);
   });
 
+  it('appends --reps and --max-instances when valid (ignores junk)', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(8);
+    };
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      reps: 3,
+      maxInstances: 5,
+      _spawn,
+    });
+    expect(capturedArgs).toContain('--reps');
+    expect(capturedArgs[capturedArgs.indexOf('--reps') + 1]).toBe('3');
+    expect(capturedArgs).toContain('--max-instances');
+    expect(capturedArgs[capturedArgs.indexOf('--max-instances') + 1]).toBe('5');
+
+    // Non-positive / non-integer values are dropped entirely.
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      reps: 0,
+      maxInstances: undefined,
+      _spawn,
+    });
+    expect(capturedArgs).not.toContain('--reps');
+    expect(capturedArgs).not.toContain('--max-instances');
+  });
+
   it('detaches and ignores stdin/stdout, pipes stderr', async () => {
     let capturedOpts = null;
     const _spawn = (_cmd, _args, opts) => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'node:events';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { runBenchmark, runRegrade } from './process-manager.js';
 
@@ -291,6 +294,47 @@ describe('runRegrade', () => {
       '/authored/profiles',
     );
     expect(capturedArgs).toContain('--only-errors');
+  });
+
+  it('appends --sequential and omits --instance for a whole-profile sweep', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(13);
+    };
+    await runRegrade({
+      profile: 'demo',
+      targetDir: '/tmp/out',
+      mode: 'modal',
+      sequential: true,
+      _spawn,
+    });
+    expect(capturedArgs).toContain('--sequential');
+    expect(capturedArgs).not.toContain('--instance');
+    expect(capturedArgs[capturedArgs.indexOf('--mode') + 1]).toBe('modal');
+
+    // No --sequential unless asked.
+    await runRegrade({ profile: 'demo', targetDir: '/tmp/out', _spawn });
+    expect(capturedArgs).not.toContain('--sequential');
+  });
+
+  it('redirects stdout/stderr to a log file when logPath is given', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'bench-pm-'));
+    try {
+      const logPath = join(tmp, 'sub', 'regrade.log'); // dir created on demand
+      let capturedOpts = null;
+      const _spawn = (_cmd, _args, opts) => {
+        capturedOpts = opts;
+        return fakeChild(99);
+      };
+      await runRegrade({ profile: 'p', targetDir: '/tmp', logPath, _spawn });
+      // stdout+stderr both point at the same opened fd (a number, not 'pipe').
+      expect(typeof capturedOpts.stdio[1]).toBe('number');
+      expect(capturedOpts.stdio[2]).toBe(capturedOpts.stdio[1]);
+      expect(existsSync(logPath)).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('rejects with a regrade-labelled message on spawn error', async () => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -103,6 +103,29 @@ describe('runBenchmark', () => {
     expect(capturedArgs).not.toContain('--max-parallel');
   });
 
+  it('appends --no-canary only when noCanary is truthy', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(12);
+    };
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      noCanary: true,
+      _spawn,
+    });
+    expect(capturedArgs).toContain('--no-canary');
+
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      noCanary: false,
+      _spawn,
+    });
+    expect(capturedArgs).not.toContain('--no-canary');
+  });
+
   it('appends --cache-dir when given', async () => {
     let capturedArgs = null;
     const _spawn = (_cmd, args) => {

--- a/worca-bench/server/process-manager.test.js
+++ b/worca-bench/server/process-manager.test.js
@@ -106,6 +106,35 @@ describe('runBenchmark', () => {
     expect(capturedArgs).not.toContain('--max-parallel');
   });
 
+  it('appends --timeout for any non-negative integer (incl. 0 = no limit)', async () => {
+    let capturedArgs = null;
+    const _spawn = (_cmd, args) => {
+      capturedArgs = args;
+      return fakeChild(12);
+    };
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      timeout: 3600,
+      _spawn,
+    });
+    expect(capturedArgs).toContain('--timeout');
+    expect(capturedArgs[capturedArgs.indexOf('--timeout') + 1]).toBe('3600');
+
+    // 0 is a valid explicit override (no limit) and must be passed through.
+    await runBenchmark({
+      profile: 'smoke',
+      targetDir: '/tmp/out',
+      timeout: 0,
+      _spawn,
+    });
+    expect(capturedArgs[capturedArgs.indexOf('--timeout') + 1]).toBe('0');
+
+    // Omitted => no flag (use the profile's value).
+    await runBenchmark({ profile: 'smoke', targetDir: '/tmp/out', _spawn });
+    expect(capturedArgs).not.toContain('--timeout');
+  });
+
   it('appends --no-canary only when noCanary is truthy', async () => {
     let capturedArgs = null;
     const _spawn = (_cmd, args) => {

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -131,6 +131,26 @@ function _mean(values) {
   return sum / values.length;
 }
 
+/**
+ * Collapse re-runs: keep only the most recent row per (instance_id, rep) so a
+ * re-run supersedes an earlier skipped/errored attempt instead of accumulating.
+ * Latest = greatest completed_at (else started_at). Order is otherwise preserved.
+ *
+ * @param {object[]} rows
+ * @returns {object[]}
+ */
+export function dedupeReps(rows) {
+  const byKey = new Map();
+  for (const r of rows) {
+    const key = `${r.instance_id ?? '?'}::${r.rep ?? '?'}`;
+    const ts = r.completed_at || r.started_at || '';
+    const cur = byKey.get(key);
+    const curTs = cur ? cur.completed_at || cur.started_at || '' : '';
+    if (!cur || ts >= curTs) byKey.set(key, r);
+  }
+  return [...byKey.values()];
+}
+
 function _iterations(row) {
   const counters = row.loop_counters;
   if (!counters || typeof counters !== 'object') return 0;
@@ -152,17 +172,21 @@ function _iterations(row) {
  * @param {object[]} rows  rows already filtered to this profile
  * @returns {object} aggregate summary
  */
-export function aggregateProfile(name, rows) {
+export function aggregateProfile(name, allRows) {
+  const rows = dedupeReps(allRows);
   const first = rows[0] || {};
   const graded = rows.filter((r) => typeof r.resolved === 'boolean');
   const resolvedCount = graded.filter((r) => r.resolved === true).length;
-  const costs = rows
+  // Skipped reps (template-incompatible canary, etc.) carry no real cost/time —
+  // exclude them so means/averages reflect reps that actually ran.
+  const measured = rows.filter((r) => r.status !== 'skipped');
+  const costs = measured
     .map((r) => r.cost_usd)
     .filter((c) => typeof c === 'number');
-  const walls = rows
+  const walls = measured
     .map((r) => r.wall_time_s)
     .filter((w) => typeof w === 'number');
-  const iterations = rows.map(_iterations);
+  const iterations = measured.map(_iterations);
 
   const lastRun = rows.reduce((latest, r) => {
     const ts = r.completed_at || r.started_at || null;

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -124,7 +124,7 @@ export function countInstanceIds(text) {
  * configured, non-primary result dir.
  *
  * @param {string} targetDir
- * @returns {Array<{name, benchmark, template, grade_mode, instance_count, canary, _source_dir}>}
+ * @returns {Array<{name, benchmark, template, grade_mode, instance_count, canary, max_parallel, _source_dir}>}
  */
 export function readProfileDefs(targetDir) {
   const dir = join(targetDir, 'profiles');
@@ -148,6 +148,7 @@ export function readProfileDefs(targetDir) {
     let grade_mode = null;
     let instance_count = null;
     let canary = null;
+    let max_parallel = null;
     try {
       const text = readFileSync(join(dir, entry), 'utf8');
       benchmark = scalar(text, 'benchmark');
@@ -160,6 +161,12 @@ export function readProfileDefs(targetDir) {
       // `canary: true|false` — null when unspecified (Python default is true).
       const c = scalar(text, 'canary');
       canary = c === 'true' ? true : c === 'false' ? false : null;
+      // `concurrency.worca` — the pipeline parallelism ("Max parallel"). Matched
+      // as an *indented* numeric `worca:` so the top-level `worca:` block (a
+      // mapping with no inline value) is never picked up. Null when unspecified
+      // (the runner default applies).
+      const mp = text.match(/^\s+worca:\s*(\d+)\s*$/m);
+      max_parallel = mp ? Number(mp[1]) : null;
     } catch {
       // Unreadable profile file — surface the name only.
     }
@@ -170,6 +177,7 @@ export function readProfileDefs(targetDir) {
       grade_mode,
       instance_count,
       canary,
+      max_parallel,
       _source_dir: dir,
     });
   }

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -7,8 +7,18 @@
 // `readResults` is the only function that touches the filesystem, and the
 // aggregation functions operate on a plain rows array.
 
+import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
+
+/**
+ * Stable short id for a result dir, so same-named profiles from different dirs
+ * are distinct and individually navigable (`#/profile?name=X&src=<hash>`).
+ */
+export function srcHash(dir) {
+  if (!dir) return 'na';
+  return createHash('sha256').update(String(dir)).digest('hex').slice(0, 8);
+}
 
 /**
  * Read and parse `<targetDir>/results.jsonl` into an array of row objects.
@@ -199,8 +209,12 @@ export function aggregateProfile(name, allRows) {
     return latest;
   }, null);
 
+  const sourceDir = first._source_dir || null;
   return {
     name,
+    src: srcHash(sourceDir),
+    source_dir: sourceDir,
+    source_label: sourceDir ? basename(sourceDir) : null,
     benchmark: first.benchmark || null,
     worca_ref: first.worca_ref || null,
     worca_version: first.worca_version || null,
@@ -227,35 +241,44 @@ export function aggregateProfile(name, allRows) {
  * @returns {object[]} array of aggregate summaries, one per profile
  */
 export function aggregateByProfile(rows) {
-  const byProfile = new Map();
+  // Group by (source dir, name) so a profile named X in two different result
+  // dirs yields two distinct aggregates rather than silently merging.
+  const byKey = new Map();
   for (const row of rows) {
-    const key = row.profile || '(unknown)';
-    if (!byProfile.has(key)) byProfile.set(key, []);
-    byProfile.get(key).push(row);
+    const name = row.profile || '(unknown)';
+    const key = `${srcHash(row._source_dir)}::${name}`;
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key).push(row);
   }
   const out = [];
-  for (const [name, group] of byProfile) {
-    out.push(aggregateProfile(name, group));
+  for (const group of byKey.values()) {
+    out.push(aggregateProfile(group[0].profile || '(unknown)', group));
   }
-  out.sort((a, b) => a.name.localeCompare(b.name));
+  out.sort(
+    (a, b) => a.name.localeCompare(b.name) || a.src.localeCompare(b.src),
+  );
   return out;
 }
 
 /**
- * Build a side-by-side comparison for the named profiles. Profiles with no
- * matching rows are returned with `reps: 0` so the compare table can still show
- * the requested column (rather than silently dropping it).
+ * Build a side-by-side comparison for the requested profiles. Each ref is
+ * `name` or `name@src` (src scopes to a specific result dir). Refs with no
+ * matching rows return `reps: 0` so the compare column still shows.
  *
  * @param {object[]} rows
- * @param {string[]} names
- * @returns {object[]} aggregates in the same order as `names`
+ * @param {string[]} refs   each "name" or "name@src"
+ * @returns {object[]} aggregates in the same order as `refs`
  */
-export function compareProfiles(rows, names) {
-  const byProfile = new Map();
-  for (const row of rows) {
-    const key = row.profile || '(unknown)';
-    if (!byProfile.has(key)) byProfile.set(key, []);
-    byProfile.get(key).push(row);
-  }
-  return names.map((name) => aggregateProfile(name, byProfile.get(name) || []));
+export function compareProfiles(rows, refs) {
+  return refs.map((ref) => {
+    const at = ref.lastIndexOf('@');
+    const name = at >= 0 ? ref.slice(0, at) : ref;
+    const src = at >= 0 ? ref.slice(at + 1) : null;
+    const group = rows.filter(
+      (r) =>
+        (r.profile || '(unknown)') === name &&
+        (src === null || srcHash(r._source_dir) === src),
+    );
+    return aggregateProfile(name, group);
+  });
 }

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -1,0 +1,168 @@
+// server/results-store.js
+//
+// Pure, side-effect-light helpers for reading and aggregating worca-bench
+// results. The source of truth on disk is `<target-dir>/results.jsonl`, an
+// append-only file with one JSON object per benchmark rep (see the schema in
+// docs / the W-075 plan). Everything here is unit-testable without a server:
+// `readResults` is the only function that touches the filesystem, and the
+// aggregation functions operate on a plain rows array.
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Read and parse `<targetDir>/results.jsonl` into an array of row objects.
+ * Tolerant of blank lines and trailing newlines; malformed lines are skipped
+ * rather than throwing, so one bad append never blanks the whole dashboard.
+ *
+ * @param {string} targetDir
+ * @returns {object[]} parsed rows (empty array if the file is missing)
+ */
+export function readResults(targetDir) {
+  const file = join(targetDir, 'results.jsonl');
+  if (!existsSync(file)) return [];
+  const raw = readFileSync(file, 'utf8');
+  const rows = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      rows.push(JSON.parse(trimmed));
+    } catch {
+      // Skip malformed line — a partial append must not break the read.
+    }
+  }
+  return rows;
+}
+
+/**
+ * Read experiment definitions from `<targetDir>/profiles/*.yaml`. We surface
+ * only the cheap fields (name + benchmark) with a minimal line-oriented YAML
+ * scan — no YAML dependency, and results.jsonl remains the source of truth for
+ * everything else.
+ *
+ * @param {string} targetDir
+ * @returns {Array<{name: string, benchmark: string|null}>}
+ */
+export function readProfileDefs(targetDir) {
+  const dir = join(targetDir, 'profiles');
+  if (!existsSync(dir)) return [];
+  const defs = [];
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith('.yaml') && !entry.endsWith('.yml')) continue;
+    const name = entry.replace(/\.ya?ml$/, '');
+    let benchmark = null;
+    try {
+      const text = readFileSync(join(dir, entry), 'utf8');
+      const m = text.match(/^\s*benchmark\s*:\s*(.+)\s*$/m);
+      if (m) benchmark = m[1].trim().replace(/^["']|["']$/g, '');
+    } catch {
+      // Unreadable profile file — surface the name only.
+    }
+    defs.push({ name, benchmark });
+  }
+  return defs;
+}
+
+function _mean(values) {
+  if (values.length === 0) return null;
+  const sum = values.reduce((a, b) => a + b, 0);
+  return sum / values.length;
+}
+
+function _iterations(row) {
+  const counters = row.loop_counters;
+  if (!counters || typeof counters !== 'object') return 0;
+  return Object.values(counters).reduce(
+    (a, b) => a + (typeof b === 'number' ? b : 0),
+    0,
+  );
+}
+
+/**
+ * Aggregate a single profile's rows into a summary object. Exported so the
+ * profile-detail endpoint and compare endpoint share one code path.
+ *
+ * resolved_rate is computed over rows where `resolved` is a boolean (graded
+ * reps) — `null`/missing reps (not yet graded, errored) are excluded from the
+ * denominator so the rate reflects graded outcomes, not run progress.
+ *
+ * @param {string} name
+ * @param {object[]} rows  rows already filtered to this profile
+ * @returns {object} aggregate summary
+ */
+export function aggregateProfile(name, rows) {
+  const first = rows[0] || {};
+  const graded = rows.filter((r) => typeof r.resolved === 'boolean');
+  const resolvedCount = graded.filter((r) => r.resolved === true).length;
+  const costs = rows
+    .map((r) => r.cost_usd)
+    .filter((c) => typeof c === 'number');
+  const walls = rows
+    .map((r) => r.wall_time_s)
+    .filter((w) => typeof w === 'number');
+  const iterations = rows.map(_iterations);
+
+  const lastRun = rows.reduce((latest, r) => {
+    const ts = r.completed_at || r.started_at || null;
+    if (ts && (!latest || ts > latest)) return ts;
+    return latest;
+  }, null);
+
+  return {
+    name,
+    benchmark: first.benchmark || null,
+    worca_ref: first.worca_ref || null,
+    template: first.template || null,
+    reps: rows.length,
+    graded: graded.length,
+    resolved: resolvedCount,
+    resolved_rate: graded.length > 0 ? resolvedCount / graded.length : 0,
+    mean_cost_usd: _mean(costs),
+    mean_wall_s: _mean(walls),
+    mean_iterations: _mean(iterations),
+    n: rows.length,
+    last_run: lastRun,
+  };
+}
+
+/**
+ * Group all rows by their `profile` field and aggregate each group.
+ * Result is sorted by profile name for deterministic rendering.
+ *
+ * @param {object[]} rows
+ * @returns {object[]} array of aggregate summaries, one per profile
+ */
+export function aggregateByProfile(rows) {
+  const byProfile = new Map();
+  for (const row of rows) {
+    const key = row.profile || '(unknown)';
+    if (!byProfile.has(key)) byProfile.set(key, []);
+    byProfile.get(key).push(row);
+  }
+  const out = [];
+  for (const [name, group] of byProfile) {
+    out.push(aggregateProfile(name, group));
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+/**
+ * Build a side-by-side comparison for the named profiles. Profiles with no
+ * matching rows are returned with `reps: 0` so the compare table can still show
+ * the requested column (rather than silently dropping it).
+ *
+ * @param {object[]} rows
+ * @param {string[]} names
+ * @returns {object[]} aggregates in the same order as `names`
+ */
+export function compareProfiles(rows, names) {
+  const byProfile = new Map();
+  for (const row of rows) {
+    const key = row.profile || '(unknown)';
+    if (!byProfile.has(key)) byProfile.set(key, []);
+    byProfile.get(key).push(row);
+  }
+  return names.map((name) => aggregateProfile(name, byProfile.get(name) || []));
+}

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -124,7 +124,7 @@ export function countInstanceIds(text) {
  * configured, non-primary result dir.
  *
  * @param {string} targetDir
- * @returns {Array<{name, benchmark, template, grade_mode, instance_count, canary, max_parallel, graphify, code_review_graph, preflight, _source_dir}>}
+ * @returns {Array<{name, benchmark, template, grade_mode, instance_count, canary, max_parallel, graphify, code_review_graph, preflight, timeout, _source_dir}>}
  */
 export function readProfileDefs(targetDir) {
   const dir = join(targetDir, 'profiles');
@@ -181,6 +181,7 @@ export function readProfileDefs(targetDir) {
     let graphify = null;
     let code_review_graph = null;
     let preflight = null;
+    let timeout = null;
     try {
       const text = readFileSync(join(dir, entry), 'utf8');
       benchmark = scalar(text, 'benchmark');
@@ -206,6 +207,11 @@ export function readProfileDefs(targetDir) {
       // `skip_preflight: true|false` -> preflight off/on; null when unspecified.
       const sp = scalar(text, 'skip_preflight');
       preflight = sp === 'true' ? 'off' : sp === 'false' ? 'on' : null;
+      // `timeout: <seconds>` — per-instance build cap. Null when unspecified or
+      // <= 0 (no limit), matching the Python _coerce_timeout semantics.
+      const to = scalar(text, 'timeout');
+      timeout =
+        to != null && /^\d+$/.test(to) && Number(to) > 0 ? Number(to) : null;
     } catch {
       // Unreadable profile file — surface the name only.
     }
@@ -220,6 +226,7 @@ export function readProfileDefs(targetDir) {
       graphify,
       code_review_graph,
       preflight,
+      timeout,
       _source_dir: dir,
     });
   }

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -98,7 +98,10 @@ export function readProfileDefs(targetDir) {
     const m = text.match(new RegExp(`^\\s*${key}\\s*:\\s*(.+?)\\s*$`, 'm'));
     if (!m) return null;
     // Strip an inline YAML comment (whitespace + #...) and surrounding quotes.
-    const v = m[1].replace(/\s+#.*$/, '').trim().replace(/^["']|["']$/g, '');
+    const v = m[1]
+      .replace(/\s+#.*$/, '')
+      .trim()
+      .replace(/^["']|["']$/g, '');
     return v || null;
   };
   const defs = [];

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -84,8 +84,12 @@ export function readProfileDefsMulti(dirs) {
  * scan — no YAML dependency, and results.jsonl remains the source of truth for
  * everything else.
  *
+ * Each def is tagged with `_source_dir` (the `profiles/` dir it was read from)
+ * so the launcher can pass `--profiles-dir` and find a YAML authored in a
+ * configured, non-primary result dir.
+ *
  * @param {string} targetDir
- * @returns {Array<{name: string, benchmark: string|null}>}
+ * @returns {Array<{name: string, benchmark: string|null, _source_dir: string}>}
  */
 export function readProfileDefs(targetDir) {
   const dir = join(targetDir, 'profiles');
@@ -102,7 +106,7 @@ export function readProfileDefs(targetDir) {
     } catch {
       // Unreadable profile file — surface the name only.
     }
-    defs.push({ name, benchmark });
+    defs.push({ name, benchmark, _source_dir: dir });
   }
   return defs;
 }

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -124,7 +124,7 @@ export function countInstanceIds(text) {
  * configured, non-primary result dir.
  *
  * @param {string} targetDir
- * @returns {Array<{name, benchmark, template, grade_mode, instance_count, canary, max_parallel, _source_dir}>}
+ * @returns {Array<{name, benchmark, template, grade_mode, instance_count, canary, max_parallel, graphify, code_review_graph, preflight, _source_dir}>}
  */
 export function readProfileDefs(targetDir) {
   const dir = join(targetDir, 'profiles');
@@ -139,6 +139,35 @@ export function readProfileDefs(targetDir) {
       .replace(/^["']|["']$/g, '');
     return v || null;
   };
+  // Parse a top-level graphify / code_review_graph engine block into the UI radio
+  // value ('off' | 'structural' | 'full'), or null when the key is absent. Mirrors
+  // _coerce_engine in config.py: a bare bool, a bare mode string, or an
+  // { enabled, mode } block where `enabled` defaults to FALSE.
+  const engine = (text, key) => {
+    // Shorthand: `key: value` on one line (a non-empty value => not a block header).
+    const inline = text.match(
+      new RegExp(`^${key}[ \\t]*:[ \\t]*([^\\n#]+?)[ \\t]*(?:#.*)?$`, 'm'),
+    );
+    if (inline) {
+      const v = inline[1].trim().replace(/^["']|["']$/g, '');
+      if (v === 'false') return 'off';
+      if (v === 'true') return 'structural';
+      return v;
+    }
+    // Block: `key:` then indented lines. `enabled` defaults false (config.py).
+    const block = text.match(
+      new RegExp(
+        `^${key}[ \\t]*:[ \\t]*(?:#.*)?\\n((?:[ \\t]+\\S[^\\n]*\\n?)+)`,
+        'm',
+      ),
+    );
+    if (!block) return null;
+    const en = block[1].match(/^[ \t]+enabled[ \t]*:[ \t]*(true|false)\b/m);
+    if (!(en && en[1] === 'true')) return 'off';
+    const md = block[1].match(/^[ \t]+mode[ \t]*:[ \t]*([^\s#]+)/m);
+    const mode = md ? md[1].replace(/^["']|["']$/g, '') : null;
+    return mode || 'structural';
+  };
   const defs = [];
   for (const entry of readdirSync(dir)) {
     if (!entry.endsWith('.yaml') && !entry.endsWith('.yml')) continue;
@@ -149,6 +178,9 @@ export function readProfileDefs(targetDir) {
     let instance_count = null;
     let canary = null;
     let max_parallel = null;
+    let graphify = null;
+    let code_review_graph = null;
+    let preflight = null;
     try {
       const text = readFileSync(join(dir, entry), 'utf8');
       benchmark = scalar(text, 'benchmark');
@@ -167,6 +199,13 @@ export function readProfileDefs(targetDir) {
       // (the runner default applies).
       const mp = text.match(/^\s+worca:\s*(\d+)\s*$/m);
       max_parallel = mp ? Number(mp[1]) : null;
+      // Engine modes + preflight — the run-options panel seeds its defaults from
+      // these so the controls mirror the profile (like canary/max_parallel do).
+      graphify = engine(text, 'graphify');
+      code_review_graph = engine(text, 'code_review_graph');
+      // `skip_preflight: true|false` -> preflight off/on; null when unspecified.
+      const sp = scalar(text, 'skip_preflight');
+      preflight = sp === 'true' ? 'off' : sp === 'false' ? 'on' : null;
     } catch {
       // Unreadable profile file — surface the name only.
     }
@@ -178,6 +217,9 @@ export function readProfileDefs(targetDir) {
       instance_count,
       canary,
       max_parallel,
+      graphify,
+      code_review_graph,
+      preflight,
       _source_dir: dir,
     });
   }

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -89,6 +89,31 @@ export function readProfileDefsMulti(dirs) {
 }
 
 /**
+ * Count the entries under a `selection.instance_ids:` YAML block. Returns the
+ * number of `- item` lines indented under that key, or `null` when the key is
+ * absent (no explicit selection → the benchmark runs its full instance set).
+ * A line-oriented scan, consistent with the rest of this dependency-free reader.
+ *
+ * @param {string} text  raw YAML
+ * @returns {number|null}
+ */
+export function countInstanceIds(text) {
+  const lines = text.split('\n');
+  const start = lines.findIndex((l) => /^\s*instance_ids\s*:/.test(l));
+  if (start < 0) return null;
+  const keyIndent = lines[start].match(/^\s*/)[0].length;
+  let count = 0;
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim() || /^\s*#/.test(line)) continue; // blank / comment
+    const indent = line.match(/^\s*/)[0].length;
+    if (indent <= keyIndent) break; // dedented out of the block
+    if (/^\s*-\s*\S/.test(line)) count++;
+  }
+  return count;
+}
+
+/**
  * Read experiment definitions from `<targetDir>/profiles/*.yaml`. We surface
  * only the cheap fields (name + benchmark) with a minimal line-oriented YAML
  * scan — no YAML dependency, and results.jsonl remains the source of truth for
@@ -99,7 +124,7 @@ export function readProfileDefsMulti(dirs) {
  * configured, non-primary result dir.
  *
  * @param {string} targetDir
- * @returns {Array<{name, benchmark, template, grade_mode, _source_dir}>}
+ * @returns {Array<{name, benchmark, template, grade_mode, instance_count, _source_dir}>}
  */
 export function readProfileDefs(targetDir) {
   const dir = join(targetDir, 'profiles');
@@ -121,16 +146,27 @@ export function readProfileDefs(targetDir) {
     let benchmark = null;
     let template = null;
     let grade_mode = null;
+    let instance_count = null;
     try {
       const text = readFileSync(join(dir, entry), 'utf8');
       benchmark = scalar(text, 'benchmark');
       template = scalar(text, 'template');
       // grade: { mode: X } (nested) or `grade: X` (inline shorthand).
       grade_mode = scalar(text, 'mode') || scalar(text, 'grade');
+      // `selection.instance_ids` count — null when the key is absent (the
+      // benchmark runs its full instance set, surfaced as "All" in the UI).
+      instance_count = countInstanceIds(text);
     } catch {
       // Unreadable profile file — surface the name only.
     }
-    defs.push({ name, benchmark, template, grade_mode, _source_dir: dir });
+    defs.push({
+      name,
+      benchmark,
+      template,
+      grade_mode,
+      instance_count,
+      _source_dir: dir,
+    });
   }
   return defs;
 }

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -177,9 +177,11 @@ export function aggregateProfile(name, allRows) {
   const first = rows[0] || {};
   const graded = rows.filter((r) => typeof r.resolved === 'boolean');
   const resolvedCount = graded.filter((r) => r.resolved === true).length;
-  // Skipped reps (template-incompatible canary, etc.) carry no real cost/time —
-  // exclude them so means/averages reflect reps that actually ran.
-  const measured = rows.filter((r) => r.status !== 'skipped');
+  // Skipped + errored reps carry no real measurement (cost/time ~0) — exclude
+  // them so means/averages reflect reps that actually ran to a graded outcome.
+  const measured = rows.filter(
+    (r) => r.status !== 'skipped' && r.status !== 'error',
+  );
   const costs = measured
     .map((r) => r.cost_usd)
     .filter((c) => typeof c === 'number');
@@ -187,6 +189,9 @@ export function aggregateProfile(name, allRows) {
     .map((r) => r.wall_time_s)
     .filter((w) => typeof w === 'number');
   const iterations = measured.map(_iterations);
+  const scores = measured
+    .map((r) => r.score)
+    .filter((s) => typeof s === 'number');
 
   const lastRun = rows.reduce((latest, r) => {
     const ts = r.completed_at || r.started_at || null;
@@ -208,6 +213,7 @@ export function aggregateProfile(name, allRows) {
     mean_cost_usd: _mean(costs),
     mean_wall_s: _mean(walls),
     mean_iterations: _mean(iterations),
+    mean_score: _mean(scores),
     n: rows.length,
     last_run: lastRun,
   };

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -36,6 +36,49 @@ export function readResults(targetDir) {
 }
 
 /**
+ * Read results from several dirs and concatenate, tagging each row with the
+ * `_source_dir` it came from (so artifact drill-down can resolve against the
+ * owning dir). Dirs are deduped.
+ *
+ * @param {string[]} dirs
+ * @returns {object[]} parsed rows across all dirs
+ */
+export function readResultsMulti(dirs) {
+  const out = [];
+  const seen = new Set();
+  for (const dir of dirs) {
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    for (const row of readResults(dir)) {
+      out.push({ ...row, _source_dir: dir });
+    }
+  }
+  return out;
+}
+
+/**
+ * Read profile defs across several dirs, deduped by name (first dir wins).
+ *
+ * @param {string[]} dirs
+ * @returns {Array<{name: string, benchmark: string|null}>}
+ */
+export function readProfileDefsMulti(dirs) {
+  const out = [];
+  const names = new Set();
+  const seen = new Set();
+  for (const dir of dirs) {
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    for (const def of readProfileDefs(dir)) {
+      if (names.has(def.name)) continue;
+      names.add(def.name);
+      out.push(def);
+    }
+  }
+  return out;
+}
+
+/**
  * Read experiment definitions from `<targetDir>/profiles/*.yaml`. We surface
  * only the cheap fields (name + benchmark) with a minimal line-oriented YAML
  * scan — no YAML dependency, and results.jsonl remains the source of truth for

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -89,24 +89,35 @@ export function readProfileDefsMulti(dirs) {
  * configured, non-primary result dir.
  *
  * @param {string} targetDir
- * @returns {Array<{name: string, benchmark: string|null, _source_dir: string}>}
+ * @returns {Array<{name, benchmark, template, grade_mode, _source_dir}>}
  */
 export function readProfileDefs(targetDir) {
   const dir = join(targetDir, 'profiles');
   if (!existsSync(dir)) return [];
+  const scalar = (text, key) => {
+    const m = text.match(new RegExp(`^\\s*${key}\\s*:\\s*(.+?)\\s*$`, 'm'));
+    if (!m) return null;
+    // Strip an inline YAML comment (whitespace + #...) and surrounding quotes.
+    const v = m[1].replace(/\s+#.*$/, '').trim().replace(/^["']|["']$/g, '');
+    return v || null;
+  };
   const defs = [];
   for (const entry of readdirSync(dir)) {
     if (!entry.endsWith('.yaml') && !entry.endsWith('.yml')) continue;
     const name = entry.replace(/\.ya?ml$/, '');
     let benchmark = null;
+    let template = null;
+    let grade_mode = null;
     try {
       const text = readFileSync(join(dir, entry), 'utf8');
-      const m = text.match(/^\s*benchmark\s*:\s*(.+)\s*$/m);
-      if (m) benchmark = m[1].trim().replace(/^["']|["']$/g, '');
+      benchmark = scalar(text, 'benchmark');
+      template = scalar(text, 'template');
+      // grade: { mode: X } (nested) or `grade: X` (inline shorthand).
+      grade_mode = scalar(text, 'mode') || scalar(text, 'grade');
     } catch {
       // Unreadable profile file — surface the name only.
     }
-    defs.push({ name, benchmark, _source_dir: dir });
+    defs.push({ name, benchmark, template, grade_mode, _source_dir: dir });
   }
   return defs;
 }
@@ -160,7 +171,9 @@ export function aggregateProfile(name, rows) {
     name,
     benchmark: first.benchmark || null,
     worca_ref: first.worca_ref || null,
+    worca_version: first.worca_version || null,
     template: first.template || null,
+    grade_mode: first.grade_mode || null,
     reps: rows.length,
     graded: graded.length,
     resolved: resolvedCount,

--- a/worca-bench/server/results-store.js
+++ b/worca-bench/server/results-store.js
@@ -124,7 +124,7 @@ export function countInstanceIds(text) {
  * configured, non-primary result dir.
  *
  * @param {string} targetDir
- * @returns {Array<{name, benchmark, template, grade_mode, instance_count, _source_dir}>}
+ * @returns {Array<{name, benchmark, template, grade_mode, instance_count, canary, _source_dir}>}
  */
 export function readProfileDefs(targetDir) {
   const dir = join(targetDir, 'profiles');
@@ -147,6 +147,7 @@ export function readProfileDefs(targetDir) {
     let template = null;
     let grade_mode = null;
     let instance_count = null;
+    let canary = null;
     try {
       const text = readFileSync(join(dir, entry), 'utf8');
       benchmark = scalar(text, 'benchmark');
@@ -156,6 +157,9 @@ export function readProfileDefs(targetDir) {
       // `selection.instance_ids` count — null when the key is absent (the
       // benchmark runs its full instance set, surfaced as "All" in the UI).
       instance_count = countInstanceIds(text);
+      // `canary: true|false` — null when unspecified (Python default is true).
+      const c = scalar(text, 'canary');
+      canary = c === 'true' ? true : c === 'false' ? false : null;
     } catch {
       // Unreadable profile file — surface the name only.
     }
@@ -165,6 +169,7 @@ export function readProfileDefs(targetDir) {
       template,
       grade_mode,
       instance_count,
+      canary,
       _source_dir: dir,
     });
   }

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -1,0 +1,144 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  aggregateByProfile,
+  aggregateProfile,
+  compareProfiles,
+  readResults,
+} from './results-store.js';
+
+function row(overrides = {}) {
+  return {
+    schema_version: 1,
+    profile: 'p1',
+    benchmark: 'swe-bench-verified',
+    instance_id: 'inst-1',
+    worca_ref: 'local',
+    template: 'builtin:feature',
+    rep: 1,
+    run_id: 'r1',
+    status: 'graded',
+    resolved: true,
+    score: 1.0,
+    cost_usd: 0.4,
+    wall_time_s: 600,
+    loop_counters: { implement_test: 2, pr_changes: 0 },
+    completed_at: '2026-06-16T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('readResults', () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'bench-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns [] when results.jsonl is missing', () => {
+    expect(readResults(dir)).toEqual([]);
+  });
+
+  it('parses one object per line and skips blanks/malformed', () => {
+    const lines = [
+      JSON.stringify(row({ rep: 1 })),
+      '',
+      '   ',
+      '{ not valid json',
+      JSON.stringify(row({ rep: 2, resolved: false })),
+    ].join('\n');
+    writeFileSync(join(dir, 'results.jsonl'), `${lines}\n`);
+    const rows = readResults(dir);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].rep).toBe(1);
+    expect(rows[1].resolved).toBe(false);
+  });
+});
+
+describe('aggregateProfile', () => {
+  it('computes resolved_rate over graded rows only', () => {
+    const rows = [
+      row({ rep: 1, resolved: true }),
+      row({ rep: 2, resolved: false }),
+      row({ rep: 3, resolved: true }),
+      // not-yet-graded reps excluded from the denominator
+      row({ rep: 4, status: 'ran', resolved: null }),
+      row({ rep: 5, status: 'error', resolved: null }),
+    ];
+    const agg = aggregateProfile('p1', rows);
+    expect(agg.reps).toBe(5);
+    expect(agg.graded).toBe(3);
+    expect(agg.resolved).toBe(2);
+    expect(agg.resolved_rate).toBeCloseTo(2 / 3);
+  });
+
+  it('computes mean cost, wall time, and iterations', () => {
+    const rows = [
+      row({ rep: 1, cost_usd: 0.2, wall_time_s: 100, loop_counters: { a: 1 } }),
+      row({ rep: 2, cost_usd: 0.4, wall_time_s: 300, loop_counters: { a: 3 } }),
+    ];
+    const agg = aggregateProfile('p1', rows);
+    expect(agg.mean_cost_usd).toBeCloseTo(0.3);
+    expect(agg.mean_wall_s).toBeCloseTo(200);
+    expect(agg.mean_iterations).toBeCloseTo(2);
+  });
+
+  it('carries benchmark/worca_ref/template from the first row', () => {
+    const agg = aggregateProfile('p1', [row()]);
+    expect(agg.benchmark).toBe('swe-bench-verified');
+    expect(agg.worca_ref).toBe('local');
+    expect(agg.template).toBe('builtin:feature');
+  });
+
+  it('picks last_run as the latest completed_at', () => {
+    const rows = [
+      row({ rep: 1, completed_at: '2026-06-16T10:00:00Z' }),
+      row({ rep: 2, completed_at: '2026-06-16T12:00:00Z' }),
+    ];
+    expect(aggregateProfile('p1', rows).last_run).toBe('2026-06-16T12:00:00Z');
+  });
+
+  it('handles empty input without throwing', () => {
+    const agg = aggregateProfile('p1', []);
+    expect(agg.reps).toBe(0);
+    expect(agg.resolved_rate).toBe(0);
+    expect(agg.mean_cost_usd).toBeNull();
+    expect(agg.mean_iterations).toBeNull();
+  });
+});
+
+describe('aggregateByProfile', () => {
+  it('groups rows by profile and sorts by name', () => {
+    const rows = [
+      row({ profile: 'zeta', resolved: true }),
+      row({ profile: 'alpha', resolved: false }),
+      row({ profile: 'alpha', resolved: true }),
+    ];
+    const out = aggregateByProfile(rows);
+    expect(out.map((a) => a.name)).toEqual(['alpha', 'zeta']);
+    const alpha = out.find((a) => a.name === 'alpha');
+    expect(alpha.reps).toBe(2);
+    expect(alpha.resolved_rate).toBeCloseTo(0.5);
+  });
+
+  it('returns [] for empty input', () => {
+    expect(aggregateByProfile([])).toEqual([]);
+  });
+});
+
+describe('compareProfiles', () => {
+  it('returns aggregates in requested order, zero-filling missing', () => {
+    const rows = [
+      row({ profile: 'a', resolved: true }),
+      row({ profile: 'b', resolved: false }),
+    ];
+    const out = compareProfiles(rows, ['b', 'a', 'missing']);
+    expect(out.map((a) => a.name)).toEqual(['b', 'a', 'missing']);
+    expect(out[2].reps).toBe(0);
+    expect(out[2].resolved_rate).toBe(0);
+  });
+});

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -136,6 +136,42 @@ describe('aggregateProfile', () => {
     expect(agg.resolved_rate).toBe(1);
   });
 
+  it('computes mean_score and excludes skipped + errored reps from means', () => {
+    const agg = aggregateProfile('p1', [
+      row({
+        instance_id: 'a',
+        rep: 1,
+        status: 'graded',
+        resolved: true,
+        score: 1.0,
+        cost_usd: 1.0,
+        wall_time_s: 100,
+      }),
+      row({
+        instance_id: 'b',
+        rep: 1,
+        status: 'graded',
+        resolved: false,
+        score: 0.0,
+        cost_usd: 3.0,
+        wall_time_s: 300,
+      }),
+      // errored rep with 0 cost/time must not drag the means down
+      row({
+        instance_id: 'c',
+        rep: 1,
+        status: 'error',
+        resolved: null,
+        score: null,
+        cost_usd: 0,
+        wall_time_s: 0,
+      }),
+    ]);
+    expect(agg.mean_score).toBe(0.5); // (1 + 0) / 2 graded
+    expect(agg.mean_cost_usd).toBe(2.0); // (1 + 3) / 2, error excluded
+    expect(agg.mean_wall_s).toBe(200);
+  });
+
   it('excludes skipped reps from cost/wall/iteration means', () => {
     const agg = aggregateProfile('p1', [
       row({

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -238,6 +238,25 @@ describe('readProfileDefs', () => {
     expect(readProfileDefs(dir)[0].grade_mode).toBe('local-docker');
   });
 
+  it('parses the canary flag (true/false), null when unspecified', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'off.yaml'),
+      'name: off\nbenchmark: commit0\ncanary: false\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'on.yaml'),
+      'name: on\nbenchmark: commit0\ncanary: true\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'unset.yaml'),
+      'name: unset\nbenchmark: commit0\n',
+    );
+    const defs = readProfileDefs(dir);
+    expect(defs.find((d) => d.name === 'off').canary).toBe(false);
+    expect(defs.find((d) => d.name === 'on').canary).toBe(true);
+    expect(defs.find((d) => d.name === 'unset').canary).toBeNull();
+  });
+
   it('counts selected instance_ids, null when the selection is absent', () => {
     writeFileSync(
       join(dir, 'profiles', 'sel.yaml'),

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -257,6 +257,20 @@ describe('readProfileDefs', () => {
     expect(defs.find((d) => d.name === 'unset').canary).toBeNull();
   });
 
+  it('parses concurrency.worca as max_parallel, ignoring the top-level worca block', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'mp.yaml'),
+      'name: mp\nbenchmark: commit0\nworca:\n  ref: local\nconcurrency:\n  worca: 1\n  grade: 2\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'nomp.yaml'),
+      'name: nomp\nbenchmark: commit0\nworca:\n  ref: local\n',
+    );
+    const defs = readProfileDefs(dir);
+    expect(defs.find((d) => d.name === 'mp').max_parallel).toBe(1);
+    expect(defs.find((d) => d.name === 'nomp').max_parallel).toBeNull();
+  });
+
   it('counts selected instance_ids, null when the selection is absent', () => {
     writeFileSync(
       join(dir, 'profiles', 'sel.yaml'),

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -6,6 +6,7 @@ import {
   aggregateByProfile,
   aggregateProfile,
   compareProfiles,
+  readProfileDefs,
   readResults,
 } from './results-store.js';
 
@@ -94,6 +95,14 @@ describe('aggregateProfile', () => {
     expect(agg.template).toBe('builtin:feature');
   });
 
+  it('carries worca_version + grade_mode config metadata from the first row', () => {
+    const agg = aggregateProfile('p1', [
+      row({ worca_version: '0.58.0', grade_mode: 'local-docker' }),
+    ]);
+    expect(agg.worca_version).toBe('0.58.0');
+    expect(agg.grade_mode).toBe('local-docker');
+  });
+
   it('picks last_run as the latest completed_at', () => {
     const rows = [
       row({ rep: 1, completed_at: '2026-06-16T10:00:00Z' }),
@@ -108,6 +117,43 @@ describe('aggregateProfile', () => {
     expect(agg.resolved_rate).toBe(0);
     expect(agg.mean_cost_usd).toBeNull();
     expect(agg.mean_iterations).toBeNull();
+  });
+});
+
+describe('readProfileDefs', () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'bench-defs-'));
+    mkdirSync(join(dir, 'profiles'));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('parses benchmark, template, and nested grade.mode', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'p.yaml'),
+      'name: p\nbenchmark: swe-bench-verified\ntemplate: builtin:quick-fix\ngrade:\n  mode: local-docker\n',
+    );
+    const [def] = readProfileDefs(dir);
+    expect(def.name).toBe('p');
+    expect(def.benchmark).toBe('swe-bench-verified');
+    expect(def.template).toBe('builtin:quick-fix');
+    expect(def.grade_mode).toBe('local-docker');
+  });
+
+  it('parses the inline grade shorthand (grade: stub)', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'q.yaml'),
+      'name: q\nbenchmark: commit0\ntemplate: builtin:feature\ngrade: stub\n',
+    );
+    expect(readProfileDefs(dir)[0].grade_mode).toBe('stub');
+  });
+
+  it('strips inline YAML comments from scalar values', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'c.yaml'),
+      'name: c\nbenchmark: swe-bench-verified\ngrade:\n  mode: local-docker    # needs Docker\n',
+    );
+    expect(readProfileDefs(dir)[0].grade_mode).toBe('local-docker');
   });
 });
 

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -118,6 +118,50 @@ describe('aggregateProfile', () => {
     expect(agg.mean_cost_usd).toBeNull();
     expect(agg.mean_iterations).toBeNull();
   });
+
+  it('dedupes re-runs by (instance, rep), keeping the latest', () => {
+    const agg = aggregateProfile('p1', [
+      row({
+        status: 'skipped',
+        resolved: null,
+        completed_at: '2026-06-16T09:00:00Z',
+      }),
+      row({
+        status: 'graded',
+        resolved: true,
+        completed_at: '2026-06-16T11:00:00Z',
+      }),
+    ]);
+    expect(agg.reps).toBe(1); // the stale skipped attempt is superseded
+    expect(agg.resolved_rate).toBe(1);
+  });
+
+  it('excludes skipped reps from cost/wall/iteration means', () => {
+    const agg = aggregateProfile('p1', [
+      row({
+        instance_id: 'a',
+        rep: 1,
+        status: 'graded',
+        resolved: true,
+        cost_usd: 1.0,
+        wall_time_s: 100,
+        loop_counters: { implement_test: 2 },
+      }),
+      row({
+        instance_id: 'b',
+        rep: 1,
+        status: 'skipped',
+        resolved: null,
+        cost_usd: 0,
+        wall_time_s: 0,
+        loop_counters: {},
+      }),
+    ]);
+    expect(agg.reps).toBe(2); // both count as reps
+    expect(agg.mean_cost_usd).toBe(1.0); // the skipped 0 is excluded
+    expect(agg.mean_wall_s).toBe(100);
+    expect(agg.mean_iterations).toBe(2);
+  });
 });
 
 describe('readProfileDefs', () => {
@@ -160,9 +204,9 @@ describe('readProfileDefs', () => {
 describe('aggregateByProfile', () => {
   it('groups rows by profile and sorts by name', () => {
     const rows = [
-      row({ profile: 'zeta', resolved: true }),
-      row({ profile: 'alpha', resolved: false }),
-      row({ profile: 'alpha', resolved: true }),
+      row({ profile: 'zeta', rep: 1, resolved: true }),
+      row({ profile: 'alpha', rep: 1, resolved: false }),
+      row({ profile: 'alpha', rep: 2, resolved: true }),
     ];
     const out = aggregateByProfile(rows);
     expect(out.map((a) => a.name)).toEqual(['alpha', 'zeta']);

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -6,6 +6,7 @@ import {
   aggregateByProfile,
   aggregateProfile,
   compareProfiles,
+  countInstanceIds,
   readProfileDefs,
   readResults,
   srcHash,
@@ -235,6 +236,52 @@ describe('readProfileDefs', () => {
       'name: c\nbenchmark: swe-bench-verified\ngrade:\n  mode: local-docker    # needs Docker\n',
     );
     expect(readProfileDefs(dir)[0].grade_mode).toBe('local-docker');
+  });
+
+  it('counts selected instance_ids, null when the selection is absent', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'sel.yaml'),
+      'name: sel\nbenchmark: swe-bench-verified\nselection:\n  instance_ids:\n    - a__a-1\n    - a__a-2\n    - a__a-3\ntemplate: builtin:bugfix\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'all.yaml'),
+      'name: all\nbenchmark: swe-bench-verified\ntemplate: builtin:bugfix\n',
+    );
+    const defs = readProfileDefs(dir);
+    expect(defs.find((d) => d.name === 'sel').instance_count).toBe(3);
+    expect(defs.find((d) => d.name === 'all').instance_count).toBeNull();
+  });
+});
+
+describe('countInstanceIds', () => {
+  it('returns null when there is no instance_ids key (run all)', () => {
+    expect(countInstanceIds('name: p\ntemplate: builtin:bugfix\n')).toBeNull();
+  });
+
+  it('counts the list items under instance_ids', () => {
+    const yaml =
+      'selection:\n  instance_ids:\n    - a__a-1\n    - a__a-2\n    - a__a-3\ntemplate: builtin:bugfix\n';
+    expect(countInstanceIds(yaml)).toBe(3);
+  });
+
+  it('stops at the next dedented key and skips blanks/comments', () => {
+    const yaml = [
+      'selection:',
+      '  instance_ids:',
+      '    - a__a-1',
+      '    # a comment, not an item',
+      '',
+      '    - a__a-2',
+      'template: builtin:bugfix', // dedented out of the block
+      '  - not__counted',
+    ].join('\n');
+    expect(countInstanceIds(yaml)).toBe(2);
+  });
+
+  it('returns 0 for an empty instance_ids block', () => {
+    expect(countInstanceIds('selection:\n  instance_ids:\ntemplate: x\n')).toBe(
+      0,
+    );
   });
 });
 

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -8,6 +8,7 @@ import {
   compareProfiles,
   readProfileDefs,
   readResults,
+  srcHash,
 } from './results-store.js';
 
 function row(overrides = {}) {
@@ -234,6 +235,48 @@ describe('readProfileDefs', () => {
       'name: c\nbenchmark: swe-bench-verified\ngrade:\n  mode: local-docker    # needs Docker\n',
     );
     expect(readProfileDefs(dir)[0].grade_mode).toBe('local-docker');
+  });
+});
+
+describe('src scoping (same name across result dirs)', () => {
+  it('keeps same-named profiles from different dirs distinct', () => {
+    const out = aggregateByProfile([
+      row({ profile: 'x', _source_dir: '/data/a', resolved: true }),
+      row({ profile: 'x', _source_dir: '/data/b', resolved: false }),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.every((o) => o.name === 'x')).toBe(true);
+    expect(out[0].src).not.toBe(out[1].src);
+    expect(new Set(out.map((o) => o.source_dir))).toEqual(
+      new Set(['/data/a', '/data/b']),
+    );
+    expect(new Set(out.map((o) => o.source_label))).toEqual(
+      new Set(['a', 'b']),
+    );
+  });
+
+  it('compareProfiles scopes a ref by name@src', () => {
+    const rows = [
+      row({
+        profile: 'x',
+        instance_id: 'a',
+        _source_dir: '/data/a',
+        resolved: true,
+        cost_usd: 1,
+      }),
+      row({
+        profile: 'x',
+        instance_id: 'b',
+        _source_dir: '/data/b',
+        resolved: false,
+        cost_usd: 5,
+      }),
+    ];
+    const [a] = compareProfiles(rows, [`x@${srcHash('/data/a')}`]);
+    expect(a.resolved_rate).toBe(1); // only the /data/a row
+    expect(a.mean_cost_usd).toBe(1);
+    // a bare name (no @src) still matches across dirs
+    expect(compareProfiles(rows, ['x'])[0].reps).toBe(2);
   });
 });
 

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -271,6 +271,61 @@ describe('readProfileDefs', () => {
     expect(defs.find((d) => d.name === 'nomp').max_parallel).toBeNull();
   });
 
+  it('parses graphify/code_review_graph engine blocks into radio values', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'eng.yaml'),
+      'name: eng\nbenchmark: commit0\n' +
+        'graphify:\n  enabled: true\n  mode: structural\n' +
+        'code_review_graph:\n  enabled: true\n  mode: structural\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'engfull.yaml'),
+      'name: engfull\nbenchmark: commit0\ngraphify:\n  enabled: true\n  mode: full\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'engoff.yaml'),
+      // present-but-disabled (enabled defaults false in block form)
+      'name: engoff\nbenchmark: commit0\ngraphify:\n  mode: structural\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'engshort.yaml'),
+      'name: engshort\nbenchmark: commit0\ngraphify: structural\ncode_review_graph: false\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'engnone.yaml'),
+      'name: engnone\nbenchmark: commit0\n',
+    );
+    const defs = readProfileDefs(dir);
+    const get = (n) => defs.find((d) => d.name === n);
+    expect(get('eng').graphify).toBe('structural');
+    expect(get('eng').code_review_graph).toBe('structural');
+    expect(get('engfull').graphify).toBe('full');
+    expect(get('engoff').graphify).toBe('off'); // enabled defaults false
+    expect(get('engshort').graphify).toBe('structural'); // bare mode shorthand
+    expect(get('engshort').code_review_graph).toBe('off'); // bare false
+    expect(get('engnone').graphify).toBeNull();
+    expect(get('engnone').code_review_graph).toBeNull();
+  });
+
+  it('parses skip_preflight into the preflight radio value', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'pfoff.yaml'),
+      'name: pfoff\nbenchmark: commit0\nskip_preflight: true\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'pfon.yaml'),
+      'name: pfon\nbenchmark: commit0\nskip_preflight: false\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'pfunset.yaml'),
+      'name: pfunset\nbenchmark: commit0\n',
+    );
+    const defs = readProfileDefs(dir);
+    expect(defs.find((d) => d.name === 'pfoff').preflight).toBe('off');
+    expect(defs.find((d) => d.name === 'pfon').preflight).toBe('on');
+    expect(defs.find((d) => d.name === 'pfunset').preflight).toBeNull();
+  });
+
   it('counts selected instance_ids, null when the selection is absent', () => {
     writeFileSync(
       join(dir, 'profiles', 'sel.yaml'),

--- a/worca-bench/server/results-store.test.js
+++ b/worca-bench/server/results-store.test.js
@@ -307,6 +307,25 @@ describe('readProfileDefs', () => {
     expect(get('engnone').code_review_graph).toBeNull();
   });
 
+  it('parses timeout (seconds), null when unset or <= 0', () => {
+    writeFileSync(
+      join(dir, 'profiles', 'to.yaml'),
+      'name: to\nbenchmark: commit0\ntimeout: 3600\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'tozero.yaml'),
+      'name: tozero\nbenchmark: commit0\ntimeout: 0\n',
+    );
+    writeFileSync(
+      join(dir, 'profiles', 'tonone.yaml'),
+      'name: tonone\nbenchmark: commit0\n',
+    );
+    const defs = readProfileDefs(dir);
+    expect(defs.find((d) => d.name === 'to').timeout).toBe(3600);
+    expect(defs.find((d) => d.name === 'tozero').timeout).toBeNull(); // 0 = no limit
+    expect(defs.find((d) => d.name === 'tonone').timeout).toBeNull();
+  });
+
   it('parses skip_preflight into the preflight radio value', () => {
     writeFileSync(
       join(dir, 'profiles', 'pfoff.yaml'),

--- a/worca-bench/server/run-control.js
+++ b/worca-bench/server/run-control.js
@@ -7,7 +7,22 @@
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
+
+// Profile names flow into a pgrep regex and into filesystem paths, so they must
+// be strictly validated to prevent arbitrary process kills / path traversal.
+const NAME_RE = /^[A-Za-z0-9_.-]+$/;
+export function assertValidProfileName(name) {
+  if (
+    typeof name !== 'string' ||
+    name === '.' ||
+    name === '..' ||
+    !NAME_RE.test(name)
+  ) {
+    throw new Error('invalid profile name');
+  }
+  return name;
+}
 
 function pgrep(args) {
   try {
@@ -37,7 +52,11 @@ const _delay = (ms) => new Promise((r) => setTimeout(r, ms));
  * @returns {Promise<number>} number of runner roots stopped
  */
 export async function stopProfileRuns(name) {
-  const roots = pgrep(['-f', `worca_bench.cli run --profile ${name}`]);
+  assertValidProfileName(name);
+  // Escape regex metachars (only `.` is possible in our charset) and anchor the
+  // match so a name can't broaden the pattern or prefix-match another run.
+  const safe = name.replace(/[.]/g, '\\.');
+  const roots = pgrep(['-f', `worca_bench\\.cli run --profile ${safe}( |$)`]);
   if (roots.length === 0) return 0;
   const acc = new Set();
   for (const r of roots) collectTree(r, acc);
@@ -66,6 +85,7 @@ export async function stopProfileRuns(name) {
  * @returns {number} rows removed
  */
 export function clearProfileResults(name, dirs) {
+  assertValidProfileName(name);
   let removed = 0;
   for (const dir of dirs) {
     const file = join(dir, 'results.jsonl');
@@ -87,8 +107,12 @@ export function clearProfileResults(name, dirs) {
       writeFileSync(file, kept.length ? `${kept.join('\n')}\n` : '');
     }
     for (const sub of ['runs', 'work']) {
-      const p = join(dir, sub, name);
-      if (existsSync(p)) rmSync(p, { recursive: true, force: true });
+      const base = resolve(join(dir, sub));
+      const p = resolve(join(base, name));
+      // Defense in depth: never delete outside <dir>/<sub>/.
+      if (p.startsWith(base + sep) && existsSync(p)) {
+        rmSync(p, { recursive: true, force: true });
+      }
     }
   }
   return removed;

--- a/worca-bench/server/run-control.js
+++ b/worca-bench/server/run-control.js
@@ -1,0 +1,95 @@
+// server/run-control.js
+//
+// Stop active runs for a profile, and clear a profile's recorded results.
+// Stopping kills the process TREE rooted at the profile's runner CLI (so the
+// run_pipeline subprocess + agent/git children go too) — POSIX-native via
+// pgrep; a no-op fallback on platforms without pgrep.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function pgrep(args) {
+  try {
+    const r = spawnSync('pgrep', args, { encoding: 'utf8' });
+    if (r.status !== 0 || !r.stdout) return [];
+    return r.stdout
+      .trim()
+      .split('\n')
+      .map((s) => Number.parseInt(s, 10))
+      .filter(Number.isInteger);
+  } catch {
+    return [];
+  }
+}
+
+function collectTree(pid, acc) {
+  acc.add(pid);
+  for (const child of pgrep(['-P', String(pid)])) {
+    if (!acc.has(child)) collectTree(child, acc);
+  }
+}
+
+const _delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Stop active runs for a profile: SIGTERM then SIGKILL the runner CLI tree(s).
+ * @returns {Promise<number>} number of runner roots stopped
+ */
+export async function stopProfileRuns(name) {
+  const roots = pgrep(['-f', `worca_bench.cli run --profile ${name}`]);
+  if (roots.length === 0) return 0;
+  const acc = new Set();
+  for (const r of roots) collectTree(r, acc);
+  const pids = [...acc];
+  for (const p of pids) {
+    try {
+      process.kill(p, 'SIGTERM');
+    } catch {
+      /* already gone / not ours */
+    }
+  }
+  await _delay(1500);
+  for (const p of pids) {
+    try {
+      process.kill(p, 'SIGKILL');
+    } catch {
+      /* gone */
+    }
+  }
+  return roots.length;
+}
+
+/**
+ * Clear a profile's recorded results across the given dirs: drop its rows from
+ * each results.jsonl and remove its runs/<name> + work/<name> trees.
+ * @returns {number} rows removed
+ */
+export function clearProfileResults(name, dirs) {
+  let removed = 0;
+  for (const dir of dirs) {
+    const file = join(dir, 'results.jsonl');
+    if (existsSync(file)) {
+      const kept = [];
+      for (const line of readFileSync(file, 'utf8').split('\n')) {
+        const t = line.trim();
+        if (!t) continue;
+        try {
+          if ((JSON.parse(t).profile || '') === name) {
+            removed++;
+            continue;
+          }
+        } catch {
+          /* keep malformed lines verbatim */
+        }
+        kept.push(t);
+      }
+      writeFileSync(file, kept.length ? `${kept.join('\n')}\n` : '');
+    }
+    for (const sub of ['runs', 'work']) {
+      const p = join(dir, sub, name);
+      if (existsSync(p)) rmSync(p, { recursive: true, force: true });
+    }
+  }
+  return removed;
+}

--- a/worca-bench/server/run-control.js
+++ b/worca-bench/server/run-control.js
@@ -48,6 +48,41 @@ function collectTree(pid, acc) {
 const _delay = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /**
+ * Stop a single action by the pid of its runner CLI: SIGTERM then SIGKILL the
+ * whole process tree (so run_pipeline / regrade children go too). Used by the
+ * Activity dock's per-row Stop. Returns true if a live root was found.
+ * @param {number} pid
+ * @returns {Promise<boolean>}
+ */
+export async function stopPidTree(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0); // alive? (throws if gone)
+  } catch {
+    return false;
+  }
+  const acc = new Set();
+  collectTree(pid, acc);
+  const pids = [...acc];
+  for (const p of pids) {
+    try {
+      process.kill(p, 'SIGTERM');
+    } catch {
+      /* gone / not ours */
+    }
+  }
+  await _delay(1500);
+  for (const p of pids) {
+    try {
+      process.kill(p, 'SIGKILL');
+    } catch {
+      /* gone */
+    }
+  }
+  return true;
+}
+
+/**
  * Stop active runs for a profile: SIGTERM then SIGKILL the runner CLI tree(s).
  * @returns {Promise<number>} number of runner roots stopped
  */

--- a/worca-bench/server/run-control.js
+++ b/worca-bench/server/run-control.js
@@ -4,9 +4,23 @@
 // Stopping kills the process TREE rooted at the profile's runner CLI (so the
 // run_pipeline subprocess + agent/git children go too) — POSIX-native via
 // pgrep; a no-op fallback on platforms without pgrep.
+//
+// The pipeline spawns each agent in its OWN session/process-group
+// (start_new_session=True), so the agent's ppid no longer chains back to the
+// pipeline once that session is created — `pgrep -P` can't reach it, and an
+// agent left running after the pipeline dies is reparented to init (a leak).
+// worca records every spawned agent's pgid under <run_dir>/procs/<pgid>.json
+// for exactly this reason; we read those and SIGTERM→SIGKILL the whole group so
+// no agent (or its MCP/pytest children) survives a Stop.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 
 // Profile names flow into a pgrep regex and into filesystem paths, so they must
@@ -47,6 +61,85 @@ function collectTree(pid, acc) {
 
 const _delay = (ms) => new Promise((r) => setTimeout(r, ms));
 
+function _safeNames(dir) {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Collect worca's tracked agent process groups for a profile by reading every
+ * <dir>/work/<name>/<instance>/rep<N>/.worca/runs/<run_id>/procs/<pgid>.json.
+ * Returns a deduped list of { pgid, pid } leaders.
+ */
+function collectTrackedGroups(dirs, name) {
+  const groups = new Map(); // pgid -> { pgid, pid }
+  for (const dir of dirs || []) {
+    const workProfile = join(dir, 'work', name);
+    if (!existsSync(workProfile)) continue;
+    for (const inst of _safeNames(workProfile)) {
+      const instDir = join(workProfile, inst);
+      for (const rep of _safeNames(instDir)) {
+        const runsDir = join(instDir, rep, '.worca', 'runs');
+        for (const runId of _safeNames(runsDir)) {
+          const procsDir = join(runsDir, runId, 'procs');
+          for (const f of _safeNames(procsDir)) {
+            if (!f.endsWith('.json')) continue;
+            try {
+              const e = JSON.parse(readFileSync(join(procsDir, f), 'utf8'));
+              const pgid = Number(e?.pgid);
+              if (Number.isInteger(pgid) && pgid > 1) {
+                groups.set(pgid, { pgid, pid: Number(e?.pid) || pgid });
+              }
+            } catch {
+              /* skip unreadable/partial entry */
+            }
+          }
+        }
+      }
+    }
+  }
+  return [...groups.values()];
+}
+
+/**
+ * SIGTERM→SIGKILL worca's tracked agent process GROUPS for a profile (the
+ * session-detached agents `pgrep -P` can't reach). Guarded by a liveness check
+ * on the recorded leader pid (cheap PID-reuse guard). POSIX-only — the negative
+ * pid group-signal throws on Windows and is swallowed (degrades to no-op, like
+ * the rest of the control plane). Returns the number of live groups reaped.
+ * @returns {Promise<number>}
+ */
+export async function killTrackedGroups(dirs, name) {
+  assertValidProfileName(name);
+  const live = collectTrackedGroups(dirs, name).filter((g) => {
+    try {
+      process.kill(g.pid, 0); // leader alive? (throws if gone → stale entry)
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  for (const g of live) {
+    try {
+      process.kill(-g.pgid, 'SIGTERM'); // negative pid = whole process group
+    } catch {
+      /* group gone / not ours / Windows */
+    }
+  }
+  if (live.length) await _delay(1500);
+  for (const g of live) {
+    try {
+      process.kill(-g.pgid, 'SIGKILL');
+    } catch {
+      /* gone */
+    }
+  }
+  return live.length;
+}
+
 /**
  * Stop a single action by the pid of its runner CLI: SIGTERM then SIGKILL the
  * whole process tree (so run_pipeline / regrade children go too). Used by the
@@ -83,11 +176,18 @@ export async function stopPidTree(pid) {
 }
 
 /**
- * Stop active runs for a profile: SIGTERM then SIGKILL the runner CLI tree(s).
+ * Stop active runs for a profile: SIGTERM then SIGKILL the runner CLI tree(s)
+ * AND worca's session-detached agent process groups (so no agent leaks as an
+ * orphan when the pipeline dies). `dirs` are the result dirs to scan for the
+ * per-run procs/ registry; omit to skip the group reap (tree-only).
  * @returns {Promise<number>} number of runner roots stopped
  */
-export async function stopProfileRuns(name) {
+export async function stopProfileRuns(name, dirs = []) {
   assertValidProfileName(name);
+  // Reap the tracked agent groups first — while the pipeline is still alive its
+  // procs/ entries are intact; doing it before the tree kill avoids any window
+  // where the pipeline tears the registry down.
+  await killTrackedGroups(dirs, name);
   // Escape regex metachars (only `.` is possible in our charset) and anchor the
   // match so a name can't broaden the pattern or prefix-match another run.
   const safe = name.replace(/[.]/g, '\\.');

--- a/worca-bench/server/run-control.js
+++ b/worca-bench/server/run-control.js
@@ -80,6 +80,47 @@ export async function stopProfileRuns(name) {
 }
 
 /**
+ * Stop an in-flight regrade sweep for a profile: SIGTERM→SIGKILL the regrade CLI
+ * tree (so its swebench/modal child goes too). The runner pid is read from the
+ * profile's regrade heartbeat.
+ * @returns {Promise<number>} number of regrade processes stopped
+ */
+export async function stopRegrade(name, dirs) {
+  assertValidProfileName(name);
+  const roots = new Set();
+  for (const dir of dirs) {
+    const f = join(dir, 'runs', name, 'regrade-status.json');
+    if (!existsSync(f)) continue;
+    try {
+      const s = JSON.parse(readFileSync(f, 'utf8'));
+      if (Number.isInteger(s.pid) && s.status === 'running') roots.add(s.pid);
+    } catch {
+      /* ignore unreadable heartbeat */
+    }
+  }
+  if (roots.size === 0) return 0;
+  const acc = new Set();
+  for (const r of roots) collectTree(r, acc);
+  const pids = [...acc];
+  for (const p of pids) {
+    try {
+      process.kill(p, 'SIGTERM');
+    } catch {
+      /* already gone / not ours */
+    }
+  }
+  await _delay(1500);
+  for (const p of pids) {
+    try {
+      process.kill(p, 'SIGKILL');
+    } catch {
+      /* gone */
+    }
+  }
+  return roots.size;
+}
+
+/**
  * Clear a profile's recorded results across the given dirs: drop its rows from
  * each results.jsonl and remove its runs/<name> + work/<name> trees.
  * @returns {number} rows removed

--- a/worca-bench/server/run-control.test.js
+++ b/worca-bench/server/run-control.test.js
@@ -58,3 +58,29 @@ describe('stopProfileRuns', () => {
     );
   });
 });
+
+describe('input validation (security)', () => {
+  it('rejects path-traversal / unsafe profile names before any fs/proc work', () => {
+    mkdirSync(join(dir, 'work'), { recursive: true });
+    for (const bad of ['../evil', 'a/b', '..', '.', 'a b', 'a;rm', '$(x)']) {
+      expect(() => clearProfileResults(bad, [dir])).toThrow(
+        /invalid profile name/,
+      );
+    }
+  });
+
+  it('rejects unsafe names in stopProfileRuns', async () => {
+    await expect(stopProfileRuns('../../x')).rejects.toThrow(
+      /invalid profile name/,
+    );
+  });
+
+  it('does not delete outside <dir>/<sub> for a crafted dirs arg', () => {
+    // Even a valid name only ever touches <dir>/runs|work/<name>.
+    mkdirSync(join(dir, 'sibling'), { recursive: true });
+    mkdirSync(join(dir, 'work', 'p'), { recursive: true });
+    clearProfileResults('p', [dir]);
+    expect(existsSync(join(dir, 'sibling'))).toBe(true);
+    expect(existsSync(join(dir, 'work', 'p'))).toBe(false);
+  });
+});

--- a/worca-bench/server/run-control.test.js
+++ b/worca-bench/server/run-control.test.js
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -9,7 +10,11 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { clearProfileResults, stopProfileRuns } from './run-control.js';
+import {
+  clearProfileResults,
+  killTrackedGroups,
+  stopProfileRuns,
+} from './run-control.js';
 
 let dir;
 beforeEach(() => {
@@ -55,6 +60,67 @@ describe('stopProfileRuns', () => {
   it('returns 0 when no runner process matches', async () => {
     expect(await stopProfileRuns('definitely-not-a-running-profile-xyz')).toBe(
       0,
+    );
+  });
+});
+
+// Write a worca proc-registry entry: <dir>/work/<name>/<inst>/rep1/.worca/runs/<id>/procs/<pgid>.json
+function seedProcEntry(name, inst, runId, { pgid, pid }) {
+  const procsDir = join(
+    dir,
+    'work',
+    name,
+    inst,
+    'rep1',
+    '.worca',
+    'runs',
+    runId,
+    'procs',
+  );
+  mkdirSync(procsDir, { recursive: true });
+  writeFileSync(
+    join(procsDir, `${pgid}.json`),
+    JSON.stringify({ pgid, pid, stage: 'implement', iteration: 1 }),
+  );
+}
+
+const posix = process.platform !== 'win32';
+
+describe('killTrackedGroups (orphan reap)', () => {
+  it('SIGKILLs a tracked agent process group (detached session leader)', async () => {
+    if (!posix) return; // negative-pid group signal is POSIX-only
+    // A detached child is its own session/group leader: pgid === child.pid —
+    // exactly the shape worca records for a start_new_session agent.
+    const child = spawn('sleep', ['30'], { detached: true, stdio: 'ignore' });
+    child.unref();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(() => process.kill(child.pid, 0)).not.toThrow(); // alive
+
+    seedProcEntry('p1', 'lib', 'p1__lib__rep1', {
+      pgid: child.pid,
+      pid: child.pid,
+    });
+    const reaped = await killTrackedGroups([dir], 'p1');
+    expect(reaped).toBe(1);
+    await new Promise((r) => setTimeout(r, 100));
+    expect(() => process.kill(child.pid, 0)).toThrow(); // gone
+  });
+
+  it('skips stale entries whose leader pid is no longer alive', async () => {
+    seedProcEntry('p1', 'lib', 'p1__lib__rep1', {
+      pgid: 2147483000, // implausible pid → not alive
+      pid: 2147483000,
+    });
+    expect(await killTrackedGroups([dir], 'p1')).toBe(0);
+  });
+
+  it('is a no-op (0) when the profile has no procs registry', async () => {
+    expect(await killTrackedGroups([dir], 'nope')).toBe(0);
+  });
+
+  it('rejects unsafe profile names', async () => {
+    await expect(killTrackedGroups([dir], '../../x')).rejects.toThrow(
+      /invalid profile name/,
     );
   });
 });

--- a/worca-bench/server/run-control.test.js
+++ b/worca-bench/server/run-control.test.js
@@ -1,0 +1,60 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearProfileResults, stopProfileRuns } from './run-control.js';
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'bench-ctl-'));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('clearProfileResults', () => {
+  it('drops the profile rows and removes its runs/work trees', () => {
+    const rows = [
+      { profile: 'keep', instance_id: 'x', rep: 1 },
+      { profile: 'gone', instance_id: 'y', rep: 1 },
+      { profile: 'gone', instance_id: 'y', rep: 2 },
+    ];
+    writeFileSync(
+      join(dir, 'results.jsonl'),
+      `${rows.map((r) => JSON.stringify(r)).join('\n')}\n`,
+    );
+    mkdirSync(join(dir, 'runs', 'gone', 'y', 'rep1'), { recursive: true });
+    mkdirSync(join(dir, 'work', 'gone', 'y', 'rep1'), { recursive: true });
+    mkdirSync(join(dir, 'runs', 'keep'), { recursive: true });
+
+    const removed = clearProfileResults('gone', [dir]);
+
+    expect(removed).toBe(2);
+    const remaining = readFileSync(join(dir, 'results.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l));
+    expect(remaining).toEqual([{ profile: 'keep', instance_id: 'x', rep: 1 }]);
+    expect(existsSync(join(dir, 'runs', 'gone'))).toBe(false);
+    expect(existsSync(join(dir, 'work', 'gone'))).toBe(false);
+    expect(existsSync(join(dir, 'runs', 'keep'))).toBe(true); // untouched
+  });
+
+  it('is a no-op when the profile has no rows or trees', () => {
+    writeFileSync(join(dir, 'results.jsonl'), '');
+    expect(clearProfileResults('nobody', [dir])).toBe(0);
+  });
+});
+
+describe('stopProfileRuns', () => {
+  it('returns 0 when no runner process matches', async () => {
+    expect(await stopProfileRuns('definitely-not-a-running-profile-xyz')).toBe(
+      0,
+    );
+  });
+});

--- a/worca-bench/server/settings-store.js
+++ b/worca-bench/server/settings-store.js
@@ -95,6 +95,49 @@ export function removeResultDir(dir, home) {
 }
 
 /**
+ * Resolve the benchmark cache dir (HuggingFace datasets + repo mirrors — large,
+ * kept off the user's home by default-override). Precedence:
+ *   settings.cache_dir -> WORCA_BENCH_CACHE env -> ~/.worca-bench/cache.
+ *
+ * @returns {{ dir: string, source: 'settings'|'env'|'default' }}
+ */
+export function resolveCacheDir(home) {
+  const fromSettings = loadSettings(home).cache_dir;
+  const fromEnv = process.env.WORCA_BENCH_CACHE;
+  if (fromSettings) {
+    return { dir: resolve(fromSettings), source: 'settings' };
+  }
+  if (fromEnv) {
+    return { dir: resolve(fromEnv), source: 'env' };
+  }
+  return { dir: join(settingsHome(home), 'cache'), source: 'default' };
+}
+
+/**
+ * Set the cache dir (validates an existing directory) or clear it with a
+ * null/empty value (falls back to env/default). Returns updated settings.
+ */
+export function setCacheDir(dir, home) {
+  const settings = loadSettings(home);
+  if (!dir) {
+    settings.cache_dir = undefined;
+    delete settings.cache_dir;
+    saveSettings(settings, home);
+    return settings;
+  }
+  if (typeof dir !== 'string') {
+    throw new Error('dir is required');
+  }
+  const abs = isAbsolute(dir) ? dir : resolve(process.cwd(), dir);
+  if (!isDir(abs)) {
+    throw new Error(`not a directory: ${abs}`);
+  }
+  settings.cache_dir = abs;
+  saveSettings(settings, home);
+  return settings;
+}
+
+/**
  * The effective set of result dirs to read: the always-included primary
  * (launch) dir first, then the configured dirs — absolute, deduped, and only
  * those that currently exist.

--- a/worca-bench/server/settings-store.js
+++ b/worca-bench/server/settings-store.js
@@ -1,0 +1,121 @@
+// server/settings-store.js
+//
+// User-level config for the dashboard, stored at ~/.worca-bench/settings.json:
+//
+//   { "result_dirs": ["/abs/path/a", "/abs/path/b"] }
+//
+// The dashboard reads benchmark results from the UNION of the launch --target-dir
+// (always included — it's where new runs write) and these configured dirs. The
+// Settings page adds/removes entries here. The `home` argument is injectable so
+// tests never touch the real home directory.
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+
+/** Resolve the ~/.worca-bench directory (override via arg or WORCA_BENCH_HOME). */
+export function settingsHome(home) {
+  return (
+    home || process.env.WORCA_BENCH_HOME || join(homedir(), '.worca-bench')
+  );
+}
+
+function settingsFile(home) {
+  return join(settingsHome(home), 'settings.json');
+}
+
+/** Load settings, tolerant of a missing/corrupt file. */
+export function loadSettings(home) {
+  const file = settingsFile(home);
+  if (!existsSync(file)) {
+    return { result_dirs: [] };
+  }
+  try {
+    const data = JSON.parse(readFileSync(file, 'utf8'));
+    return {
+      ...data,
+      result_dirs: Array.isArray(data.result_dirs) ? data.result_dirs : [],
+    };
+  } catch {
+    return { result_dirs: [] };
+  }
+}
+
+/** Persist settings (pretty-printed), creating ~/.worca-bench if needed. */
+export function saveSettings(settings, home) {
+  const file = settingsFile(home);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${JSON.stringify(settings, null, 2)}\n`, 'utf8');
+  return settings;
+}
+
+function isDir(p) {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Add a result dir. Validates it is an existing directory; stores the absolute
+ * path; dedupes. Returns the updated settings. Throws on a non-existent path.
+ */
+export function addResultDir(dir, home) {
+  if (!dir || typeof dir !== 'string') {
+    throw new Error('dir is required');
+  }
+  const abs = isAbsolute(dir) ? dir : resolve(process.cwd(), dir);
+  if (!isDir(abs)) {
+    throw new Error(`not a directory: ${abs}`);
+  }
+  const settings = loadSettings(home);
+  if (!settings.result_dirs.includes(abs)) {
+    settings.result_dirs.push(abs);
+    saveSettings(settings, home);
+  }
+  return settings;
+}
+
+/** Remove a result dir (absolute or relative form). Returns updated settings. */
+export function removeResultDir(dir, home) {
+  const abs = isAbsolute(dir) ? dir : resolve(process.cwd(), dir);
+  const settings = loadSettings(home);
+  settings.result_dirs = settings.result_dirs.filter(
+    (d) => d !== dir && d !== abs,
+  );
+  saveSettings(settings, home);
+  return settings;
+}
+
+/**
+ * The effective set of result dirs to read: the always-included primary
+ * (launch) dir first, then the configured dirs — absolute, deduped, and only
+ * those that currently exist.
+ *
+ * @returns {{ dirs: string[], primary: string, configured: string[] }}
+ */
+export function resolveResultDirs(primaryDir, home) {
+  const settings = loadSettings(home);
+  const primary = primaryDir ? resolve(primaryDir) : null;
+  const seen = new Set();
+  const dirs = [];
+  for (const d of [primary, ...settings.result_dirs]) {
+    if (!d) {
+      continue;
+    }
+    const abs = resolve(d);
+    if (seen.has(abs) || !isDir(abs)) {
+      continue;
+    }
+    seen.add(abs);
+    dirs.push(abs);
+  }
+  return { dirs, primary, configured: settings.result_dirs };
+}

--- a/worca-bench/server/settings-store.js
+++ b/worca-bench/server/settings-store.js
@@ -34,16 +34,17 @@ function settingsFile(home) {
 export function loadSettings(home) {
   const file = settingsFile(home);
   if (!existsSync(file)) {
-    return { result_dirs: [] };
+    return { result_dirs: [], archived: [] };
   }
   try {
     const data = JSON.parse(readFileSync(file, 'utf8'));
     return {
       ...data,
       result_dirs: Array.isArray(data.result_dirs) ? data.result_dirs : [],
+      archived: Array.isArray(data.archived) ? data.archived : [],
     };
   } catch {
-    return { result_dirs: [] };
+    return { result_dirs: [], archived: [] };
   }
 }
 
@@ -61,6 +62,37 @@ function isDir(p) {
   } catch {
     return false;
   }
+}
+
+// ─── Archived profiles ──────────────────────────────────────────────────────
+//
+// Profiles the operator has hidden from the dashboard. Stored as a flat list of
+// stable profile keys (`name@src`, where src is the result-dir source hash), so
+// the same-named profile in two result dirs archives independently. Visibility
+// is a dashboard-wide preference (not per-browser) — kept server-side alongside
+// the result-dir config so it survives reloads and is shared across clients.
+
+/** The set of archived profile keys (`name@src`). */
+export function loadArchived(home) {
+  return new Set(loadSettings(home).archived);
+}
+
+/**
+ * Archive or un-archive a batch of profile keys. `keys` are `name@src` strings;
+ * `archived: true` adds them, `false` removes them. Returns the updated key list.
+ */
+export function setArchived(keys, archived, home) {
+  const list = Array.isArray(keys) ? keys : [keys];
+  const settings = loadSettings(home);
+  const set = new Set(settings.archived);
+  for (const k of list) {
+    if (!k || typeof k !== 'string') continue;
+    if (archived) set.add(k);
+    else set.delete(k);
+  }
+  settings.archived = [...set].sort();
+  saveSettings(settings, home);
+  return settings.archived;
 }
 
 /**

--- a/worca-bench/server/settings-store.test.js
+++ b/worca-bench/server/settings-store.test.js
@@ -4,11 +4,13 @@ import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   addResultDir,
+  loadArchived,
   loadSettings,
   removeResultDir,
   resolveCacheDir,
   resolveResultDirs,
   saveSettings,
+  setArchived,
   setCacheDir,
 } from './settings-store.js';
 
@@ -44,6 +46,44 @@ describe('settings-store', () => {
     addResultDir(dirB, home);
     removeResultDir(dirA, home);
     expect(loadSettings(home).result_dirs).toEqual([resolve(dirB)]);
+  });
+
+  describe('archived profiles', () => {
+    it('defaults to an empty archived set', () => {
+      expect(loadSettings(home).archived).toEqual([]);
+      expect([...loadArchived(home)]).toEqual([]);
+    });
+
+    it('archives keys (deduped, sorted) and reloads them', () => {
+      setArchived(['b@2', 'a@1'], true, home);
+      setArchived(['a@1'], true, home); // dedupe
+      expect(loadSettings(home).archived).toEqual(['a@1', 'b@2']);
+      expect(loadArchived(home).has('a@1')).toBe(true);
+    });
+
+    it('accepts a single key (not just an array)', () => {
+      setArchived('solo@9', true, home);
+      expect([...loadArchived(home)]).toEqual(['solo@9']);
+    });
+
+    it('un-archives keys with archived=false', () => {
+      setArchived(['a@1', 'b@2'], true, home);
+      const remaining = setArchived(['a@1'], false, home);
+      expect(remaining).toEqual(['b@2']);
+      expect(loadArchived(home).has('a@1')).toBe(false);
+    });
+
+    it('ignores empty/non-string keys', () => {
+      setArchived(['', null, 'real@1', undefined], true, home);
+      expect(loadSettings(home).archived).toEqual(['real@1']);
+    });
+
+    it('preserves archived across an unrelated result_dirs write', () => {
+      setArchived(['a@1'], true, home);
+      addResultDir(dirA, home);
+      expect(loadSettings(home).archived).toEqual(['a@1']);
+      expect(loadSettings(home).result_dirs).toEqual([resolve(dirA)]);
+    });
   });
 
   it('resolves the union of primary + configured (existing, deduped)', () => {

--- a/worca-bench/server/settings-store.test.js
+++ b/worca-bench/server/settings-store.test.js
@@ -1,0 +1,68 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  addResultDir,
+  loadSettings,
+  removeResultDir,
+  resolveResultDirs,
+  saveSettings,
+} from './settings-store.js';
+
+let home;
+let dirA;
+let dirB;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'wb-home-'));
+  dirA = mkdtempSync(join(tmpdir(), 'wb-a-'));
+  dirB = mkdtempSync(join(tmpdir(), 'wb-b-'));
+});
+
+describe('settings-store', () => {
+  it('defaults to an empty result_dirs list', () => {
+    expect(loadSettings(home).result_dirs).toEqual([]);
+  });
+
+  it('adds an existing dir, stores absolute, and dedupes', () => {
+    addResultDir(dirA, home);
+    addResultDir(dirA, home);
+    expect(loadSettings(home).result_dirs).toEqual([resolve(dirA)]);
+  });
+
+  it('rejects a non-existent dir', () => {
+    expect(() => addResultDir('/no/such/dir/here', home)).toThrow(
+      /not a directory/,
+    );
+  });
+
+  it('removes a dir', () => {
+    addResultDir(dirA, home);
+    addResultDir(dirB, home);
+    removeResultDir(dirA, home);
+    expect(loadSettings(home).result_dirs).toEqual([resolve(dirB)]);
+  });
+
+  it('resolves the union of primary + configured (existing, deduped)', () => {
+    addResultDir(dirB, home);
+    const { dirs, primary, configured } = resolveResultDirs(dirA, home);
+    expect(primary).toBe(resolve(dirA));
+    expect(dirs).toEqual([resolve(dirA), resolve(dirB)]);
+    expect(configured).toEqual([resolve(dirB)]);
+  });
+
+  it('does not duplicate the primary when it is also configured', () => {
+    addResultDir(dirA, home);
+    const { dirs } = resolveResultDirs(dirA, home);
+    expect(dirs).toEqual([resolve(dirA)]);
+  });
+
+  it('drops configured dirs that no longer exist (but keeps them recorded)', () => {
+    saveSettings({ result_dirs: [resolve(dirB), '/gone/missing'] }, home);
+    const { dirs, configured } = resolveResultDirs(dirA, home);
+    expect(dirs).toContain(resolve(dirB));
+    expect(dirs).not.toContain('/gone/missing');
+    expect(configured).toContain('/gone/missing'); // still recorded in settings.json
+  });
+});

--- a/worca-bench/server/settings-store.test.js
+++ b/worca-bench/server/settings-store.test.js
@@ -1,13 +1,15 @@
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   addResultDir,
   loadSettings,
   removeResultDir,
+  resolveCacheDir,
   resolveResultDirs,
   saveSettings,
+  setCacheDir,
 } from './settings-store.js';
 
 let home;
@@ -64,5 +66,52 @@ describe('settings-store', () => {
     expect(dirs).toContain(resolve(dirB));
     expect(dirs).not.toContain('/gone/missing');
     expect(configured).toContain('/gone/missing'); // still recorded in settings.json
+  });
+
+  describe('cache dir', () => {
+    const ENV = 'WORCA_BENCH_CACHE';
+    let saved;
+    beforeEach(() => {
+      saved = process.env[ENV];
+      delete process.env[ENV];
+    });
+    afterEach(() => {
+      if (saved === undefined) delete process.env[ENV];
+      else process.env[ENV] = saved;
+    });
+
+    it('defaults to <home>/cache when unset', () => {
+      const { dir, source } = resolveCacheDir(home);
+      expect(dir).toBe(join(home, 'cache'));
+      expect(source).toBe('default');
+    });
+
+    it('prefers the env var over the default', () => {
+      process.env[ENV] = dirB;
+      const { dir, source } = resolveCacheDir(home);
+      expect(dir).toBe(resolve(dirB));
+      expect(source).toBe('env');
+    });
+
+    it('prefers settings.cache_dir over the env var', () => {
+      process.env[ENV] = dirB;
+      setCacheDir(dirA, home);
+      const { dir, source } = resolveCacheDir(home);
+      expect(dir).toBe(resolve(dirA));
+      expect(source).toBe('settings');
+    });
+
+    it('rejects a non-existent cache dir', () => {
+      expect(() => setCacheDir('/no/such/cache', home)).toThrow(
+        /not a directory/,
+      );
+    });
+
+    it('clears the cache dir with an empty value (back to default)', () => {
+      setCacheDir(dirA, home);
+      setCacheDir('', home);
+      expect(loadSettings(home).cache_dir).toBeUndefined();
+      expect(resolveCacheDir(home).source).toBe('default');
+    });
   });
 });

--- a/worca-bench/tests/conftest.py
+++ b/worca-bench/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Shared test helpers for worca-bench."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def git(args: list[str], cwd: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def make_git_repo(path: Path, files: dict[str, str] | None = None) -> str:
+    """Create a git repo with initial files. Returns the initial commit sha."""
+    path.mkdir(parents=True, exist_ok=True)
+    files = files or {"README.md": "base\n"}
+    for rel, content in files.items():
+        f = path / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content, encoding="utf-8")
+    git(["init"], path)
+    git(["config", "user.email", "test@test.com"], path)
+    git(["config", "user.name", "Test"], path)
+    git(["add", "-A"], path)
+    git(["commit", "-m", "init"], path)
+    return git(["rev-parse", "HEAD"], path)

--- a/worca-bench/tests/test_actions.py
+++ b/worca-bench/tests/test_actions.py
@@ -1,0 +1,63 @@
+"""CLI-side actions ledger (Activity dock)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from worca_bench import actions
+
+
+def _read(target: Path) -> list[dict]:
+    path = target / "actions.jsonl"
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_start_writes_running_record(tmp_path: Path):
+    aid = actions.start(
+        tmp_path, kind="run", profile="demo", source_dir=tmp_path,
+        params={"reps": 2}, started_at="2026-06-18T10:00:00+00:00",
+    )
+    assert aid.startswith(f"run-demo-{os.getpid()}-")
+    [rec] = _read(tmp_path)
+    assert rec["id"] == aid
+    assert rec["type"] == "run"
+    assert rec["profile"] == "demo"
+    assert rec["status"] == "running"
+    assert rec["pid"] == os.getpid()
+    assert rec["params"]["reps"] == 2
+    # source_dir is recorded (absolute) so the server can backfill src.
+    assert rec["source_dir"] == str(tmp_path.resolve())
+    assert rec["src"] is None
+
+
+def test_progress_then_finish_collapses_to_completed(tmp_path: Path):
+    aid = actions.start(tmp_path, kind="run", profile="p", source_dir=tmp_path)
+    actions.progress(tmp_path, aid, done=3, total=9, errors=1)
+    actions.finish(
+        tmp_path, aid, status="completed",
+        progress={"unit": "instances", "done": 9, "total": 9, "errors": 1},
+    )
+    recs = _read(tmp_path)
+    # one create + one progress + one finish, all sharing the id (latest wins)
+    assert all(r["id"] == aid for r in recs)
+    assert recs[1]["progress"] == {"unit": "instances", "done": 3, "total": 9, "errors": 1}
+    assert recs[-1]["status"] == "completed"
+    assert recs[-1]["ended_at"]
+    assert recs[-1]["progress"]["done"] == 9
+
+
+def test_finish_failed_records_error(tmp_path: Path):
+    aid = actions.start(tmp_path, kind="regrade", profile="p", source_dir=tmp_path)
+    actions.finish(tmp_path, aid, status="failed", error="boom")
+    rec = _read(tmp_path)[-1]
+    assert rec["status"] == "failed"
+    assert rec["error"] == "boom"
+
+
+def test_writes_are_best_effort_no_action_id(tmp_path: Path):
+    # A falsy action_id is a no-op (never raises) for progress/finish.
+    actions.progress(tmp_path, "", done=1)
+    actions.finish(tmp_path, None, status="completed")
+    assert not (tmp_path / "actions.jsonl").exists()

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -53,6 +53,7 @@ def _args(tmp_path, profiles_dir, **over):
         modal_token_secret=None,
         preflight=None,
         claude_md_mode=None,
+        grade_mode=None,
     )
     base.update(over)
     return argparse.Namespace(**base)
@@ -167,6 +168,22 @@ def test_cmd_run_claude_md_mode_override(tmp_path, monkeypatch):
     assert captured["mode"] == "project"
     cli.cmd_run(_args(tmp_path, profiles_dir, claude_md_mode=None))
     assert captured["mode"] == "none"  # profile default
+
+
+def test_cmd_run_grade_mode_override(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["mode"] = profile.grade.mode
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    cli.cmd_run(_args(tmp_path, profiles_dir, grade_mode="modal"))
+    assert captured["mode"] == "modal"
+    # Absent => profile default (stub, from _write_profile).
+    cli.cmd_run(_args(tmp_path, profiles_dir, grade_mode=None))
+    assert captured["mode"] == "stub"
 
 
 def test_cmd_run_threads_cache_dir(tmp_path, monkeypatch):

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -48,6 +48,9 @@ def _args(tmp_path, profiles_dir, **over):
         reps=None,
         cache_dir=None,
         keep_work=False,
+        swebench_api_key=None,
+        modal_token_id=None,
+        modal_token_secret=None,
     )
     base.update(over)
     return argparse.Namespace(**base)
@@ -142,6 +145,40 @@ def test_cmd_run_threads_cache_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "run_profile", fake_run_profile)
     cli.cmd_run(_args(tmp_path, profiles_dir, cache_dir=str(cache)))
     assert str(captured["cache_dir"]) == str(cache)
+
+
+def test_cmd_run_secret_flags_thread_into_secret_env(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    # Clear ambient grader creds so the flag value is unambiguous.
+    for k in ("SWEBENCH_API_KEY", "MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"):
+        monkeypatch.delenv(k, raising=False)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["secret_env"] = kw.get("secret_env")
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir,
+                           swebench_api_key="swb_flag", modal_token_id="mid_flag"))
+    assert rc == 0
+    assert captured["secret_env"]["SWEBENCH_API_KEY"] == "swb_flag"
+    assert captured["secret_env"]["MODAL_TOKEN_ID"] == "mid_flag"
+    assert "MODAL_TOKEN_SECRET" not in captured["secret_env"]
+
+
+def test_cmd_run_secret_flag_overrides_environment(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    monkeypatch.setenv("SWEBENCH_API_KEY", "from_env")
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["secret_env"] = kw.get("secret_env")
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    cli.cmd_run(_args(tmp_path, profiles_dir, swebench_api_key="from_flag"))
+    assert captured["secret_env"]["SWEBENCH_API_KEY"] == "from_flag"
 
 
 def test_cmd_run_cache_dir_falls_back_to_env(tmp_path, monkeypatch):

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -54,6 +54,7 @@ def _args(tmp_path, profiles_dir, **over):
         preflight=None,
         claude_md_mode=None,
         grade_mode=None,
+        timeout=None,
     )
     base.update(over)
     return argparse.Namespace(**base)
@@ -126,6 +127,48 @@ def test_cmd_run_without_max_parallel_keeps_profile_default(tmp_path, monkeypatc
 
     assert rc == 0
     assert captured["workers"] == 4  # the dataclass default
+
+
+def test_cmd_run_timeout_override_reaches_profile(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["timeout"] = profile.timeout
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, timeout=3600))
+    assert rc == 0
+    assert captured["timeout"] == 3600
+
+
+def test_cmd_run_timeout_zero_means_no_limit(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["timeout"] = profile.timeout
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, timeout=0))
+    assert rc == 0
+    assert captured["timeout"] is None  # 0 => unbounded
+
+
+def test_cmd_run_without_timeout_keeps_profile_default(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["timeout"] = profile.timeout
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, timeout=None))
+    assert rc == 0
+    assert captured["timeout"] is None  # profile default (unset)
 
 
 def test_cmd_run_rejects_non_positive_max_parallel(tmp_path, monkeypatch):

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -16,6 +16,8 @@ class _FakeSummary:
         self.profile = profile.name
         self.worca_ref = "local"
         self.reps_total = profile.reps
+        self.results: list = []
+        self.reps_error = 0
         self.incompatible_templates: dict = {}
 
     def as_dict(self):
@@ -169,6 +171,46 @@ def test_cmd_run_without_timeout_keeps_profile_default(tmp_path, monkeypatch):
     rc = cli.cmd_run(_args(tmp_path, profiles_dir, timeout=None))
     assert rc == 0
     assert captured["timeout"] is None  # profile default (unset)
+
+
+def test_cmd_run_records_actions_ledger(tmp_path, monkeypatch):
+    import json
+    profiles_dir = _write_profile(tmp_path)
+    monkeypatch.setattr(
+        cli, "run_profile", lambda profile, target, **kw: _FakeSummary(profile)
+    )
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir))
+    assert rc == 0
+    recs = [
+        json.loads(line)
+        for line in (tmp_path / "actions.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert recs[0]["type"] == "run"
+    assert recs[0]["status"] == "running"
+    assert recs[0]["profile"] == "demo"
+    assert recs[-1]["status"] == "completed"  # CLI wrote its own terminal state
+
+
+def test_cmd_run_records_failed_on_exception(tmp_path, monkeypatch):
+    import json
+
+    def boom(profile, target, **kw):
+        raise RuntimeError("kaboom")
+
+    profiles_dir = _write_profile(tmp_path)
+    monkeypatch.setattr(cli, "run_profile", boom)
+    try:
+        cli.cmd_run(_args(tmp_path, profiles_dir))
+    except RuntimeError:
+        pass
+    recs = [
+        json.loads(line)
+        for line in (tmp_path / "actions.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert recs[-1]["status"] == "failed"
+    assert "kaboom" in (recs[-1].get("error") or "")
 
 
 def test_cmd_run_rejects_non_positive_max_parallel(tmp_path, monkeypatch):

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -186,6 +186,30 @@ def test_cmd_run_grade_mode_override(tmp_path, monkeypatch):
     assert captured["mode"] == "stub"
 
 
+def test_cmd_run_grade_mode_rejected_for_benchmark(tmp_path, monkeypatch):
+    """sb-cli is SWE-bench-only — overriding a commit0 profile to it fails (rc=2)
+    before the runner is ever called."""
+    profiles_dir = tmp_path / "profiles"
+    profiles_dir.mkdir()
+    (profiles_dir / "c0.yaml").write_text(
+        "name: c0\n"
+        "benchmark: commit0\n"
+        "selection:\n  instances_file: x.json\n"
+        "grade:\n  mode: stub\n",
+        encoding="utf-8",
+    )
+    called = {"n": 0}
+
+    def fake_run_profile(profile, target, **kw):
+        called["n"] += 1
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, profile="c0", grade_mode="sb-cli"))
+    assert rc == 2
+    assert called["n"] == 0  # never reached the runner
+
+
 def test_cmd_run_threads_cache_dir(tmp_path, monkeypatch):
     profiles_dir = _write_profile(tmp_path)
     cache = tmp_path / "cache"

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -45,6 +45,7 @@ def _args(tmp_path, profiles_dir, **over):
         no_canary=True,
         max_instances=None,
         reps=None,
+        cache_dir=None,
         keep_work=False,
     )
     base.update(over)
@@ -88,3 +89,34 @@ def test_cmd_run_rejects_non_positive_reps(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "run_profile", lambda *a, **k: None)
     rc = cli.cmd_run(_args(tmp_path, profiles_dir, reps=0))
     assert rc == 2
+
+
+def test_cmd_run_threads_cache_dir(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["cache_dir"] = kw.get("cache_dir")
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    cli.cmd_run(_args(tmp_path, profiles_dir, cache_dir=str(cache)))
+    assert str(captured["cache_dir"]) == str(cache)
+
+
+def test_cmd_run_cache_dir_falls_back_to_env(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    cache = tmp_path / "envcache"
+    cache.mkdir()
+    monkeypatch.setenv("WORCA_BENCH_CACHE", str(cache))
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["cache_dir"] = kw.get("cache_dir")
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    cli.cmd_run(_args(tmp_path, profiles_dir, cache_dir=None))
+    assert str(captured["cache_dir"]) == str(cache)

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -51,6 +51,8 @@ def _args(tmp_path, profiles_dir, **over):
         swebench_api_key=None,
         modal_token_id=None,
         modal_token_secret=None,
+        preflight=None,
+        claude_md_mode=None,
     )
     base.update(over)
     return argparse.Namespace(**base)
@@ -130,6 +132,41 @@ def test_cmd_run_rejects_non_positive_max_parallel(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "run_profile", lambda *a, **k: None)
     rc = cli.cmd_run(_args(tmp_path, profiles_dir, max_parallel=0))
     assert rc == 2
+
+
+def test_cmd_run_preflight_override(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["skip_preflight"] = profile.skip_preflight
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    # --preflight on => run preflight => skip_preflight False.
+    cli.cmd_run(_args(tmp_path, profiles_dir, preflight="on"))
+    assert captured["skip_preflight"] is False
+    # --preflight off => skip it.
+    cli.cmd_run(_args(tmp_path, profiles_dir, preflight="off"))
+    assert captured["skip_preflight"] is True
+    # Absent => profile default (True).
+    cli.cmd_run(_args(tmp_path, profiles_dir, preflight=None))
+    assert captured["skip_preflight"] is True
+
+
+def test_cmd_run_claude_md_mode_override(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["mode"] = profile.claude_md_mode
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    cli.cmd_run(_args(tmp_path, profiles_dir, claude_md_mode="project"))
+    assert captured["mode"] == "project"
+    cli.cmd_run(_args(tmp_path, profiles_dir, claude_md_mode=None))
+    assert captured["mode"] == "none"  # profile default
 
 
 def test_cmd_run_threads_cache_dir(tmp_path, monkeypatch):

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -44,6 +44,7 @@ def _args(tmp_path, profiles_dir, **over):
         dry_run=False,
         no_canary=True,
         max_instances=None,
+        max_parallel=None,
         reps=None,
         cache_dir=None,
         keep_work=False,
@@ -88,6 +89,43 @@ def test_cmd_run_rejects_non_positive_reps(tmp_path, monkeypatch):
     profiles_dir = _write_profile(tmp_path)
     monkeypatch.setattr(cli, "run_profile", lambda *a, **k: None)
     rc = cli.cmd_run(_args(tmp_path, profiles_dir, reps=0))
+    assert rc == 2
+
+
+def test_cmd_run_max_parallel_override_reaches_concurrency(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["workers"] = profile.concurrency.worca
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, max_parallel=8))
+
+    assert rc == 0
+    assert captured["workers"] == 8  # overrode the profile/default concurrency
+
+
+def test_cmd_run_without_max_parallel_keeps_profile_default(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["workers"] = profile.concurrency.worca
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, max_parallel=None))
+
+    assert rc == 0
+    assert captured["workers"] == 4  # the dataclass default
+
+
+def test_cmd_run_rejects_non_positive_max_parallel(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    monkeypatch.setattr(cli, "run_profile", lambda *a, **k: None)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, max_parallel=0))
     assert rc == 2
 
 

--- a/worca-bench/tests/test_cli.py
+++ b/worca-bench/tests/test_cli.py
@@ -1,0 +1,90 @@
+"""CLI plumbing tests — the per-run reps override (and its guard).
+
+These monkeypatch ``run_profile`` so nothing provisions a venv: we only assert
+that ``cmd_run`` threads the override into the resolved profile / runner call.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import worca_bench.cli as cli
+
+
+class _FakeSummary:
+    def __init__(self, profile):
+        self.profile = profile.name
+        self.worca_ref = "local"
+        self.reps_total = profile.reps
+        self.incompatible_templates: dict = {}
+
+    def as_dict(self):
+        return {"profile": self.profile, "reps_total": self.reps_total}
+
+
+def _write_profile(tmp_path):
+    profiles_dir = tmp_path / "profiles"
+    profiles_dir.mkdir()
+    (profiles_dir / "demo.yaml").write_text(
+        "name: demo\n"
+        "benchmark: swe-bench-verified\n"
+        "selection:\n  instance_ids: [x__y-1]\n"
+        "template: builtin:quick-fix\n"
+        "grade:\n  mode: stub\n",
+        encoding="utf-8",
+    )
+    return profiles_dir
+
+
+def _args(tmp_path, profiles_dir, **over):
+    base = dict(
+        target_dir=str(tmp_path),
+        profile="demo",
+        profiles_dir=str(profiles_dir),
+        dry_run=False,
+        no_canary=True,
+        max_instances=None,
+        reps=None,
+        keep_work=False,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def test_cmd_run_reps_override_reaches_the_runner(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["reps"] = profile.reps
+        captured["max_instances"] = kw.get("max_instances")
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, reps=5, max_instances=2))
+
+    assert rc == 0
+    assert captured["reps"] == 5  # overrode the profile default (1)
+    assert captured["max_instances"] == 2
+
+
+def test_cmd_run_without_reps_keeps_profile_default(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    captured = {}
+
+    def fake_run_profile(profile, target, **kw):
+        captured["reps"] = profile.reps
+        return _FakeSummary(profile)
+
+    monkeypatch.setattr(cli, "run_profile", fake_run_profile)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, reps=None))
+
+    assert rc == 0
+    assert captured["reps"] == 1  # the profile's own default
+
+
+def test_cmd_run_rejects_non_positive_reps(tmp_path, monkeypatch):
+    profiles_dir = _write_profile(tmp_path)
+    monkeypatch.setattr(cli, "run_profile", lambda *a, **k: None)
+    rc = cli.cmd_run(_args(tmp_path, profiles_dir, reps=0))
+    assert rc == 2

--- a/worca-bench/tests/test_commit0_gen.py
+++ b/worca-bench/tests/test_commit0_gen.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worca_bench.commit0_gen import (
+    _short_lib,
+    assemble_prompt,
+    build_instance_record,
+    generate_instances,
+)
+
+ROW = {
+    "instance_id": "commit-0/wcwidth",
+    "repo": "commit-0/wcwidth",
+    "base_commit": "0d0054base",
+    "reference_commit": "36a625ref",
+    "setup": {"install": "pip install -e .", "python": "3.10",
+              "specification": "https://wcwidth.example/"},
+    "test": {"test_cmd": "pytest", "test_dir": "tests/"},
+    "src_dir": "wcwidth/",
+}
+
+
+def test_short_lib_takes_last_path_segment():
+    assert _short_lib("commit-0/wcwidth") == "wcwidth"
+    assert _short_lib("tinydb") == "tinydb"
+
+
+def test_assemble_prompt_mentions_src_test_dirs_and_rules():
+    p = assemble_prompt(ROW, "wcwidth", spec_text="SPEC BODY")
+    assert "wcwidth" in p
+    assert "wcwidth/" in p           # src dir
+    assert "tests/" in p             # held-out test dir referenced in the rules
+    assert "https://wcwidth.example/" in p
+    assert "SPEC BODY" in p          # extracted spec text included
+    assert "from scratch" in p.lower()
+
+
+def test_build_instance_record_shape(tmp_path: Path):
+    base = tmp_path / "repos"
+    rec = build_instance_record(
+        ROW, base_dir=base, config_file=tmp_path / ".commit0.yaml",
+        base_branch="commit0", dataset_name="ds", dataset_split="test",
+        spec_text="",
+    )
+    assert rec["instance_id"] == "wcwidth"     # path-safe (dataset id has a '/')
+    assert rec["lib"] == "wcwidth"
+    assert rec["base_commit"] == "0d0054base"
+    assert rec["reference_commit"] == "36a625ref"
+    assert rec["gold_test_paths"] == ["tests/"]
+    assert rec["local_repo"].endswith(f"{Path('repos') / 'wcwidth'}")
+    assert rec["commit0"]["base_branch"] == "commit0"
+    assert rec["commit0"]["dataset_name"] == "ds"
+    assert rec["commit0"]["config_file"].endswith(".commit0.yaml")
+
+
+def test_generate_instances_only_cloned_filters_and_writes(tmp_path: Path):
+    base = tmp_path / "repos"
+    (base / "wcwidth").mkdir(parents=True)   # this one is "cloned"
+    # 'tinydb' row present in the dataset but not cloned -> filtered out.
+    rows = [ROW, {"repo": "commit-0/tinydb", "base_commit": "b", "test": {}}]
+    out = tmp_path / "instances.json"
+
+    recs = generate_instances(
+        "wcwidth", base_dir=base, out_path=out, run_setup=False,
+        only_cloned=True, _rows=rows,
+    )
+    assert [r["lib"] for r in recs] == ["wcwidth"]
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert len(written) == 1
+    assert written[0]["instance_id"] == "wcwidth"
+
+
+def test_generate_instances_without_only_cloned_keeps_all(tmp_path: Path):
+    base = tmp_path / "repos"
+    base.mkdir(parents=True)
+    rows = [ROW, {"repo": "commit-0/tinydb", "base_commit": "b",
+                  "test": {"test_dir": "tests/"}}]
+    out = tmp_path / "instances.json"
+    recs = generate_instances(
+        "lite", base_dir=base, out_path=out, run_setup=False,
+        only_cloned=False, _rows=rows,
+    )
+    assert sorted(r["lib"] for r in recs) == ["tinydb", "wcwidth"]

--- a/worca-bench/tests/test_commit0_gen.py
+++ b/worca-bench/tests/test_commit0_gen.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from worca_bench.commit0_gen import (
+    _sanitize_spec_text,
     _short_lib,
     assemble_prompt,
     build_instance_record,
@@ -20,6 +21,17 @@ ROW = {
     "test": {"test_cmd": "pytest", "test_dir": "tests/"},
     "src_dir": "wcwidth/",
 }
+
+
+def test_sanitize_spec_text_strips_nul_and_c0_controls():
+    # NUL is the one that makes the runner raise "embedded null byte" pre-pipeline.
+    dirty = "Hello\x00 world\x07\x1b keep\ttab\nnewline\rcr"
+    clean = _sanitize_spec_text(dirty)
+    assert "\x00" not in clean
+    assert "\x07" not in clean and "\x1b" not in clean
+    # tab / newline / carriage-return survive.
+    assert "\ttab" in clean and "\nnewline" in clean and "\rcr" in clean
+    assert clean.startswith("Hello world")
 
 
 def test_short_lib_takes_last_path_segment():

--- a/worca-bench/tests/test_config.py
+++ b/worca-bench/tests/test_config.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worca_bench.config import (
+    ProfileError,
+    load_profile,
+    profile_from_dict,
+)
+
+
+def _base(**over):
+    data = {
+        "name": "p1",
+        "benchmark": "swe-bench-verified",
+        "selection": {"instance_ids": ["a__b-1"]},
+    }
+    data.update(over)
+    return data
+
+
+def test_minimal_profile_defaults():
+    prof = profile_from_dict(_base())
+    assert prof.name == "p1"
+    assert prof.worca.ref == "local"
+    assert prof.template == "builtin:feature"
+    assert prof.reps == 1
+    assert prof.grade.mode == "stub"
+    assert prof.claude_md_mode == "none"
+    assert prof.pr_defer is True
+
+
+def test_unknown_benchmark_rejected():
+    with pytest.raises(ProfileError):
+        profile_from_dict(_base(benchmark="nope"))
+
+
+def test_unknown_grade_mode_rejected():
+    with pytest.raises(ProfileError):
+        profile_from_dict(_base(grade={"mode": "wat"}))
+
+
+def test_selection_required():
+    with pytest.raises(ProfileError):
+        profile_from_dict({"name": "x", "benchmark": "commit0", "selection": {}})
+
+
+def test_reps_must_be_positive():
+    with pytest.raises(ProfileError):
+        profile_from_dict(_base(reps=0))
+
+
+def test_template_map_glob_resolution():
+    prof = profile_from_dict(_base(
+        template="builtin:feature",
+        template_map={"django__*": "project:django-tuned"},
+    ))
+    assert prof.template_for("django__django-11099") == "project:django-tuned"
+    assert prof.template_for("astropy__astropy-1") == "builtin:feature"
+
+
+def test_worca_ref_string_form():
+    prof = profile_from_dict(_base(worca="master"))
+    assert prof.worca.ref == "master"
+    assert prof.worca.is_local is False
+
+
+def test_mock_true_enables_default_mock():
+    prof = profile_from_dict(_base(mock=True))
+    assert prof.mock is not None
+    assert prof.mock.scenario is None
+
+
+def test_load_profile_from_json(tmp_path):
+    p = tmp_path / "prof.json"
+    p.write_text(json.dumps(_base(name="jsonprof")), encoding="utf-8")
+    prof = load_profile(p)
+    assert prof.name == "jsonprof"
+
+
+def test_load_profile_from_yaml(tmp_path):
+    p = tmp_path / "prof.yaml"
+    p.write_text(
+        "name: y\nbenchmark: commit0\nselection:\n  instances_file: x.json\n",
+        encoding="utf-8",
+    )
+    prof = load_profile(p)
+    assert prof.benchmark == "commit0"
+    assert prof.selection.instances_file == "x.json"

--- a/worca-bench/tests/test_config.py
+++ b/worca-bench/tests/test_config.py
@@ -31,6 +31,12 @@ def test_minimal_profile_defaults():
     assert prof.grade.mode == "stub"
     assert prof.claude_md_mode == "none"
     assert prof.pr_defer is True
+    assert prof.canary is True  # serial canary on by default
+
+
+def test_canary_flag_parses():
+    assert profile_from_dict(_base(canary=False)).canary is False
+    assert profile_from_dict(_base(canary=True)).canary is True
 
 
 def test_engines_off_by_default():

--- a/worca-bench/tests/test_config.py
+++ b/worca-bench/tests/test_config.py
@@ -8,6 +8,7 @@ from worca_bench.config import (
     ProfileError,
     load_profile,
     profile_from_dict,
+    valid_grade_modes,
 )
 
 
@@ -65,6 +66,32 @@ def test_unknown_benchmark_rejected():
 def test_unknown_grade_mode_rejected():
     with pytest.raises(ProfileError):
         profile_from_dict(_base(grade={"mode": "wat"}))
+
+
+def test_valid_grade_modes_per_benchmark():
+    assert valid_grade_modes("swe-bench-verified") == {
+        "stub", "sb-cli", "local-docker", "modal"}
+    assert valid_grade_modes("commit0") == {"stub", "local-docker", "modal"}
+
+
+def test_commit0_rejects_sb_cli_grade_mode():
+    """sb-cli is SWE-bench-only — a commit0 profile asking for it must fail loud."""
+    with pytest.raises(ProfileError, match="not valid for benchmark 'commit0'"):
+        profile_from_dict({
+            "name": "c0", "benchmark": "commit0",
+            "selection": {"instances_file": "x.json"},
+            "grade": {"mode": "sb-cli"},
+        })
+
+
+def test_commit0_accepts_modal_and_local_docker():
+    for mode in ("modal", "local-docker", "stub"):
+        prof = profile_from_dict({
+            "name": "c0", "benchmark": "commit0",
+            "selection": {"instances_file": "x.json"},
+            "grade": {"mode": mode},
+        })
+        assert prof.grade.mode == mode
 
 
 def test_selection_required():

--- a/worca-bench/tests/test_config.py
+++ b/worca-bench/tests/test_config.py
@@ -32,6 +32,31 @@ def test_minimal_profile_defaults():
     assert prof.pr_defer is True
 
 
+def test_engines_off_by_default():
+    prof = profile_from_dict(_base())
+    assert prof.graphify.enabled is False
+    assert prof.code_review_graph.enabled is False
+    assert prof.engine_settings() == {}  # nothing seeded when off
+
+
+def test_graphify_and_crg_parse_and_seed():
+    prof = profile_from_dict(
+        _base(
+            graphify={"enabled": True, "mode": "full"},
+            code_review_graph="structural",  # bare-string shorthand enables it
+        )
+    )
+    assert prof.graphify.enabled and prof.graphify.mode == "full"
+    assert prof.code_review_graph.enabled
+    assert prof.code_review_graph.mode == "structural"
+    assert prof.engine_settings() == {
+        "graphify": {"enabled": True, "mode": "full"},
+        "code_review_graph": {"enabled": True, "mode": "structural"},
+    }
+    assert prof.graphify.label == "full"
+    assert prof.code_review_graph.label == "structural"
+
+
 def test_unknown_benchmark_rejected():
     with pytest.raises(ProfileError):
         profile_from_dict(_base(benchmark="nope"))

--- a/worca-bench/tests/test_config.py
+++ b/worca-bench/tests/test_config.py
@@ -39,6 +39,20 @@ def test_canary_flag_parses():
     assert profile_from_dict(_base(canary=True)).canary is True
 
 
+def test_timeout_parses():
+    # Unset => no limit (None).
+    assert profile_from_dict(_base()).timeout is None
+    # Positive int => that cap in seconds.
+    assert profile_from_dict(_base(timeout=3600)).timeout == 3600
+    # 0 / negative / null => no limit.
+    assert profile_from_dict(_base(timeout=0)).timeout is None
+    assert profile_from_dict(_base(timeout=-5)).timeout is None
+    assert profile_from_dict(_base(timeout=None)).timeout is None
+    # String-but-numeric coerces; non-numeric => None.
+    assert profile_from_dict(_base(timeout="900")).timeout == 900
+    assert profile_from_dict(_base(timeout="nope")).timeout is None
+
+
 def test_engines_off_by_default():
     prof = profile_from_dict(_base())
     assert prof.graphify.enabled is False

--- a/worca-bench/tests/test_e2e_mock.py
+++ b/worca-bench/tests/test_e2e_mock.py
@@ -1,0 +1,108 @@
+"""End-to-end test of the full runner lifecycle, driven by worca's own mock Claude.
+
+This spawns a REAL worca pipeline (materialize → worca init → run → harvest → grade →
+normalize) but points it at ``tests/mock_claude/mock_claude.py`` via ``WORCA_CLAUDE_BIN``
++ ``MOCK_CLAUDE_SCENARIO`` — so it is free and deterministic. Skipped if the worca-cc
+source repo can't be located (e.g. when worca-bench is installed standalone).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from conftest import make_git_repo
+
+from worca_bench.config import profile_from_dict
+from worca_bench.normalize import read_rows
+from worca_bench.runner import run_profile
+from worca_bench.venvs import find_worca_repo
+
+pytestmark = pytest.mark.live_worca
+
+REPO = find_worca_repo()
+
+
+@pytest.mark.skipif(REPO is None, reason="worca-cc source repo not found")
+def test_full_lifecycle_with_mock_claude(tmp_path: Path):
+    # 1. A tiny "instance" repo to stand in for a benchmark task.
+    src = tmp_path / "instance_src"
+    base = make_git_repo(src, {"src/app.py": "def add(a, b):\n    return 0\n"})
+
+    # 2. A local instances fixture (bypasses HuggingFace).
+    instances = tmp_path / "instances.json"
+    instances.write_text(json.dumps([
+        {"instance_id": "demo__app-1", "problem_statement": "fix add()",
+         "local_repo": str(src), "base_commit": base},
+    ]), encoding="utf-8")
+
+    # 3. Profile: local worca, mock Claude, stub grading.
+    profile = profile_from_dict({
+        "name": "e2e-mock",
+        "benchmark": "swe-bench-verified",
+        "worca": {"ref": "local"},
+        "selection": {"instances_file": str(instances)},
+        "template": "builtin:feature",
+        "reps": 1,
+        "grade": {"mode": "stub"},
+        "mock": True,
+        "claude_md_mode": "none",
+    })
+
+    target = tmp_path / "out"
+    summary = run_profile(profile, target, canary_first=True)
+
+    # Canary passed (template compatible), one rep ran.
+    assert summary.incompatible_templates == {}, summary.incompatible_templates
+    assert summary.reps_run == 1, summary.as_dict()
+
+    rows = read_rows(target)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["instance_id"] == "demo__app-1"
+    assert row["status"] == "graded"
+    assert row["resolved"] is True            # stub resolves on a non-empty diff
+    assert row["diff_lines"] >= 1             # mock implementer created a file
+    assert row["leaked"] is False
+    assert row["pipeline_status"] is not None
+    assert row["cost_usd"] >= 0.0
+    assert "by_stage" in row["tokens"]
+
+    # Artifacts were archived for drill-down.
+    artifacts = target / row["artifacts_dir"]
+    assert (artifacts / "diff.patch").exists()
+    assert (artifacts / "status.json").exists()
+
+
+@pytest.mark.skipif(REPO is None, reason="worca-cc source repo not found")
+def test_incompatible_template_is_skipped(tmp_path: Path):
+    """A template no worca version can resolve must be flagged + its reps skipped,
+    not run — the canary guard (W-075 §5)."""
+    src = tmp_path / "instance_src"
+    base = make_git_repo(src, {"a.py": "x = 1\n"})
+    instances = tmp_path / "instances.json"
+    instances.write_text(json.dumps([
+        {"instance_id": "demo__a-1", "problem_statement": "p",
+         "local_repo": str(src), "base_commit": base},
+    ]), encoding="utf-8")
+
+    profile = profile_from_dict({
+        "name": "e2e-bad-template",
+        "benchmark": "swe-bench-verified",
+        "worca": {"ref": "local"},
+        "selection": {"instances_file": str(instances)},
+        "template": "builtin:this-template-does-not-exist",
+        "reps": 2,
+        "grade": {"mode": "stub"},
+        "mock": True,
+    })
+
+    target = tmp_path / "out"
+    summary = run_profile(profile, target, canary_first=True)
+
+    assert "builtin:this-template-does-not-exist" in summary.incompatible_templates
+    assert summary.reps_run == 0
+    assert summary.reps_skipped == 2
+    rows = read_rows(target)
+    assert all(r["status"] == "skipped" for r in rows)

--- a/worca-bench/tests/test_harvest.py
+++ b/worca-bench/tests/test_harvest.py
@@ -38,6 +38,26 @@ def test_extract_diff_excludes_worca_scaffolding(tmp_path):
         assert ex not in diff
 
 
+def test_extract_diff_excludes_beads_agents_and_git_meta(tmp_path):
+    """Regression: bead/agent scaffolding and worca's .gitignore/.gitattributes
+    rewrites must not leak into the graded patch (they break apply on a pristine
+    SWE-bench eval container)."""
+    repo = tmp_path / "r"
+    base = make_git_repo(repo, {"astropy/separable.py": "x = 1\n"})
+    (repo / ".beads").mkdir()
+    (repo / ".beads" / "issues.jsonl").write_text("{}\n", encoding="utf-8")
+    (repo / "AGENTS.md").write_text("# agents", encoding="utf-8")
+    (repo / ".gitattributes").write_text("* text=auto\n", encoding="utf-8")
+    (repo / ".gitignore").write_text(".worca/\nlogs/\n", encoding="utf-8")
+    (repo / "astropy" / "separable.py").write_text("x = 2\n", encoding="utf-8")
+    diff = extract_diff(repo, base)
+    assert "astropy/separable.py" in diff
+    assert ".beads" not in diff
+    assert "AGENTS.md" not in diff
+    assert ".gitattributes" not in diff
+    assert ".gitignore" not in diff
+
+
 def test_extract_diff_includes_untracked_new_file(tmp_path):
     repo = tmp_path / "r"
     base = make_git_repo(repo, {"README.md": "hi\n"})

--- a/worca-bench/tests/test_harvest.py
+++ b/worca-bench/tests/test_harvest.py
@@ -77,6 +77,22 @@ def test_extra_excludes_drops_gold_tests(tmp_path):
     assert "test_lib.py" not in diff
 
 
+def test_extra_excludes_drops_binary_spec_pdf(tmp_path):
+    """Regression (Commit0): a binary spec.pdf materializing in the tree otherwise
+    lands in the prediction patch as an incomplete binary diff
+    (``Binary files ... differ`` with no full index), which `git apply` rejects at
+    grade time. Excluding it keeps the patch clean and applyable."""
+    repo = tmp_path / "r"
+    base = make_git_repo(repo, {"lib.py": "def f(): pass\n"})
+    (repo / "lib.py").write_text("def f(): return 1\n", encoding="utf-8")
+    # a NEW binary file appears in the repo root (as Commit0's spec.pdf does)
+    (repo / "spec.pdf").write_bytes(b"%PDF-1.4\x00\x01\x02 binary payload \xff\xfe")
+    diff = extract_diff(repo, base, extra_excludes=("spec.pdf", "spec.pdf.bz2"))
+    assert "lib.py" in diff
+    assert "spec.pdf" not in diff
+    assert "Binary files" not in diff
+
+
 def test_diff_line_count_ignores_headers():
     diff = (
         "diff --git a/x b/x\n"

--- a/worca-bench/tests/test_harvest.py
+++ b/worca-bench/tests/test_harvest.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+
+from conftest import make_git_repo
+
+from worca_bench.harvest import (
+    DEFAULT_EXCLUDES,
+    Telemetry,
+    diff_line_count,
+    extract_diff,
+    parse_telemetry,
+    touches_paths,
+)
+
+
+def test_extract_diff_captures_source_change(tmp_path):
+    repo = tmp_path / "r"
+    base = make_git_repo(repo, {"src/main.py": "x = 1\n"})
+    (repo / "src" / "main.py").write_text("x = 2\n", encoding="utf-8")
+    diff = extract_diff(repo, base)
+    assert "src/main.py" in diff
+    assert "x = 2" in diff
+
+
+def test_extract_diff_excludes_worca_scaffolding(tmp_path):
+    repo = tmp_path / "r"
+    base = make_git_repo(repo, {"src/main.py": "x = 1\n"})
+    # simulate worca writing scaffolding + a plan file
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / "settings.json").write_text("{}", encoding="utf-8")
+    (repo / ".worca").mkdir()
+    (repo / ".worca" / "x").write_text("junk", encoding="utf-8")
+    (repo / "MASTER_PLAN.md").write_text("# plan", encoding="utf-8")
+    (repo / "src" / "main.py").write_text("x = 2\n", encoding="utf-8")
+    diff = extract_diff(repo, base)
+    assert "src/main.py" in diff
+    for ex in DEFAULT_EXCLUDES:
+        assert ex not in diff
+
+
+def test_extract_diff_includes_untracked_new_file(tmp_path):
+    repo = tmp_path / "r"
+    base = make_git_repo(repo, {"README.md": "hi\n"})
+    (repo / "NEW.py").write_text("print('new')\n", encoding="utf-8")
+    diff = extract_diff(repo, base)
+    assert "NEW.py" in diff
+
+
+def test_extra_excludes_drops_gold_tests(tmp_path):
+    repo = tmp_path / "r"
+    base = make_git_repo(repo, {"lib.py": "def f(): pass\n"})
+    (repo / "lib.py").write_text("def f(): return 1\n", encoding="utf-8")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_lib.py").write_text("def test_f(): assert f()\n", encoding="utf-8")
+    diff = extract_diff(repo, base, extra_excludes=("tests",))
+    assert "lib.py" in diff
+    assert "test_lib.py" not in diff
+
+
+def test_diff_line_count_ignores_headers():
+    diff = (
+        "diff --git a/x b/x\n"
+        "--- a/x\n+++ b/x\n"
+        "@@ -1 +1 @@\n-old\n+new\n+another\n"
+    )
+    assert diff_line_count(diff) == 3  # -old, +new, +another
+
+
+def test_touches_paths_detects_gold_test_edit():
+    diff = "diff --git a/tests/test_lib.py b/tests/test_lib.py\n+evil\n"
+    assert touches_paths(diff, ("tests/test_lib.py",)) == ["tests/test_lib.py"]
+    assert touches_paths(diff, ("src/other.py",)) == []
+
+
+def test_parse_telemetry_from_status():
+    status = {
+        "pipeline_status": "completed",
+        "loop_counters": {"implement_test": 2},
+        "token_usage": {
+            "input_tokens": 100, "output_tokens": 50, "total_cost_usd": 0.01,
+            "by_stage": {"plan": {}}, "by_model": {"opus": {}},
+        },
+        "stages": {
+            "plan": {"iterations": [
+                {"cost_usd": 0.004, "duration_ms": 500, "duration_api_ms": 400,
+                 "outcome": "success", "api_retries": 1},
+            ]},
+            "review": {"iterations": [
+                {"cost_usd": 0.006, "duration_ms": 700, "duration_api_ms": 600,
+                 "outcome": "approve"},
+            ]},
+        },
+    }
+    t = parse_telemetry(status)
+    assert isinstance(t, Telemetry)
+    assert t.pipeline_status == "completed"
+    assert t.cost_usd == 0.01            # top-level wins when present
+    assert t.tokens["total"] == 150
+    assert t.wall_time_s == 1.2          # (500+700)/1000
+    assert t.api_time_s == 1.0
+    assert t.loop_counters == {"implement_test": 2}
+    assert t.stage_outcomes == {"plan": "success", "review": "approve"}
+    assert t.api_retries == 1
+
+
+def test_parse_telemetry_falls_back_to_stage_cost_sum():
+    status = {
+        "pipeline_status": "completed",
+        "token_usage": {"input_tokens": 0, "output_tokens": 0},
+        "stages": {
+            "plan": {"iterations": [{"cost_usd": 0.5}]},
+            "pr": {"iterations": [{"cost_usd": 0.25}]},
+        },
+    }
+    t = parse_telemetry(status)
+    assert t.cost_usd == 0.75

--- a/worca-bench/tests/test_launcher.py
+++ b/worca-bench/tests/test_launcher.py
@@ -1,0 +1,31 @@
+"""Launcher env assembly — focus on the PR-defer signal.
+
+PR defer must ride the WORCA_DEFER_PR env var, not the settings.json seed:
+worca.stages is template-driven, so a settings-only seed is stripped when a
+template enables the PR stage. The env var is read directly by the guardian
+and composes monotonically, so it holds regardless of the template.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from worca_bench.config import Profile
+from worca_bench.launcher import build_launch_env
+from worca_bench.venvs import WorcaEnv
+
+
+def _wenv() -> WorcaEnv:
+    return WorcaEnv(ref="local", python="python3")
+
+
+def test_pr_defer_sets_env_signal(tmp_path: Path):
+    profile = Profile(name="p", benchmark="swe-bench-verified", pr_defer=True)
+    env = build_launch_env(profile, _wenv(), run_scratch=tmp_path / "s")
+    assert env["WORCA_DEFER_PR"] == "1"
+
+
+def test_pr_defer_disabled_omits_env_signal(tmp_path: Path):
+    profile = Profile(name="p", benchmark="swe-bench-verified", pr_defer=False)
+    env = build_launch_env(profile, _wenv(), run_scratch=tmp_path / "s")
+    assert "WORCA_DEFER_PR" not in env

--- a/worca-bench/tests/test_launcher.py
+++ b/worca-bench/tests/test_launcher.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from worca_bench.config import Profile
-from worca_bench.launcher import build_launch_env
+from worca_bench.launcher import _as_text, build_launch_env
 from worca_bench.venvs import WorcaEnv
 
 
@@ -29,3 +29,11 @@ def test_pr_defer_disabled_omits_env_signal(tmp_path: Path):
     profile = Profile(name="p", benchmark="swe-bench-verified", pr_defer=False)
     env = build_launch_env(profile, _wenv(), run_scratch=tmp_path / "s")
     assert "WORCA_DEFER_PR" not in env
+
+
+def test_as_text_coerces_bytes_str_none():
+    # The timeout path can yield bytes even under text=True — must not crash.
+    assert _as_text(b"hello") == "hello"
+    assert _as_text("hello") == "hello"
+    assert _as_text(None) == ""
+    assert _as_text(b"\xff\xfe") == "��"  # invalid bytes -> replacement

--- a/worca-bench/tests/test_launcher.py
+++ b/worca-bench/tests/test_launcher.py
@@ -10,13 +10,49 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import worca_bench.launcher as launcher_mod
 from worca_bench.config import Profile
-from worca_bench.launcher import _as_text, build_launch_env
+from worca_bench.launcher import _as_text, build_launch_env, launch
 from worca_bench.venvs import WorcaEnv
 
 
 def _wenv() -> WorcaEnv:
     return WorcaEnv(ref="local", python="python3")
+
+
+class _FakeProc:
+    returncode = 0
+    stdout = ""
+    stderr = ""
+
+
+def test_launch_default_timeout_is_unbounded(tmp_path: Path, monkeypatch):
+    # The hardcoded 1800s cap is gone — default timeout is None (no limit).
+    captured = {}
+
+    def fake_run(args, **kw):
+        captured["timeout"] = kw.get("timeout", "MISSING")
+        return _FakeProc()
+
+    monkeypatch.setattr(launcher_mod.subprocess, "run", fake_run)
+    profile = Profile(name="p", benchmark="swe-bench-verified")
+    launch(profile, _wenv(), tmp_path, prompt="x", template="builtin:feature",
+           run_id="r1", run_scratch=tmp_path / "s")
+    assert captured["timeout"] is None
+
+
+def test_launch_forwards_explicit_timeout(tmp_path: Path, monkeypatch):
+    captured = {}
+
+    def fake_run(args, **kw):
+        captured["timeout"] = kw.get("timeout")
+        return _FakeProc()
+
+    monkeypatch.setattr(launcher_mod.subprocess, "run", fake_run)
+    profile = Profile(name="p", benchmark="swe-bench-verified")
+    launch(profile, _wenv(), tmp_path, prompt="x", template="builtin:feature",
+           run_id="r2", run_scratch=tmp_path / "s", timeout=42)
+    assert captured["timeout"] == 42
 
 
 def test_pr_defer_sets_env_signal(tmp_path: Path):

--- a/worca-bench/tests/test_normalize_stats.py
+++ b/worca-bench/tests/test_normalize_stats.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from worca_bench import RESULTS_SCHEMA_VERSION
+from worca_bench.harvest import Telemetry
+from worca_bench.normalize import append_row, build_row, read_rows
+from worca_bench.stats import aggregate, aggregate_by_profile
+
+
+def _row(**over):
+    t = Telemetry(pipeline_status="completed", cost_usd=0.1, wall_time_s=10.0,
+                  loop_counters={"implement_test": 1})
+    kw = dict(
+        profile_name="p", benchmark="swe-bench-verified", instance_id="a__b-1",
+        worca_ref="local", template="builtin:feature", rep=1, run_id="rid",
+        status="graded", resolved=True, score=1.0, telemetry=t, diff="+x\n",
+        leaked=False, error=None, started_at="t0", completed_at="t1",
+        artifacts_dir="runs/p/a__b-1/rep1",
+    )
+    kw.update(over)
+    return build_row(**kw)
+
+
+def test_build_row_schema_keys():
+    row = _row()
+    assert row["schema_version"] == RESULTS_SCHEMA_VERSION
+    for key in ("profile", "benchmark", "instance_id", "worca_ref", "template", "rep",
+                "run_id", "status", "resolved", "score", "cost_usd", "tokens",
+                "wall_time_s", "api_time_s", "pipeline_status", "loop_counters",
+                "stage_outcomes", "api_retries", "diff_lines", "leaked", "error",
+                "artifacts_dir"):
+        assert key in row, key
+    assert row["diff_lines"] == 1
+
+
+def test_append_and_read_roundtrip(tmp_path: Path):
+    append_row(tmp_path, _row(rep=1))
+    append_row(tmp_path, _row(rep=2, resolved=False, score=0.0))
+    rows = read_rows(tmp_path)
+    assert len(rows) == 2
+    assert {r["rep"] for r in rows} == {1, 2}
+
+
+def test_aggregate_resolved_rate_and_cost():
+    rows = [
+        _row(rep=1, resolved=True, score=1.0),
+        _row(rep=2, resolved=False, score=0.0, telemetry=Telemetry(cost_usd=0.3, wall_time_s=20.0)),
+        _row(rep=3, status="error", resolved=None, score=None),
+    ]
+    agg = aggregate(rows)
+    assert agg["n"] == 3
+    assert agg["graded"] == 2
+    assert agg["errors"] == 1
+    assert agg["resolved_rate"] == 0.5     # 1 of 2 graded
+    assert abs(agg["mean_cost_usd"] - (0.1 + 0.3 + 0.1) / 3) < 1e-9
+
+
+def test_aggregate_by_profile_groups():
+    rows = [_row(profile_name="A"), _row(profile_name="B"), _row(profile_name="A")]
+    by = aggregate_by_profile(rows)
+    assert set(by) == {"A", "B"}
+    assert by["A"]["n"] == 2
+
+
+def test_aggregate_empty():
+    agg = aggregate([])
+    assert agg["n"] == 0
+    assert agg["resolved_rate"] is None

--- a/worca-bench/tests/test_normalize_stats.py
+++ b/worca-bench/tests/test_normalize_stats.py
@@ -25,13 +25,23 @@ def _row(**over):
 def test_build_row_schema_keys():
     row = _row()
     assert row["schema_version"] == RESULTS_SCHEMA_VERSION
-    for key in ("profile", "benchmark", "instance_id", "worca_ref", "template", "rep",
+    for key in ("profile", "benchmark", "instance_id", "worca_ref", "worca_version",
+                "template", "grade_mode", "rep",
                 "run_id", "status", "resolved", "score", "cost_usd", "tokens",
                 "wall_time_s", "api_time_s", "pipeline_status", "loop_counters",
                 "stage_outcomes", "api_retries", "diff_lines", "leaked", "error",
                 "artifacts_dir"):
         assert key in row, key
     assert row["diff_lines"] == 1
+
+
+def test_build_row_carries_config_metadata():
+    row = _row(worca_version="0.58.0", grade_mode="local-docker")
+    assert row["worca_version"] == "0.58.0"
+    assert row["grade_mode"] == "local-docker"
+    # Defaults are None when not supplied (back-compat for older rows).
+    assert _row()["worca_version"] is None
+    assert _row()["grade_mode"] is None
 
 
 def test_append_and_read_roundtrip(tmp_path: Path):

--- a/worca-bench/tests/test_normalize_stats.py
+++ b/worca-bench/tests/test_normalize_stats.py
@@ -50,6 +50,17 @@ def test_build_row_carries_config_metadata():
         assert base[k] is None
 
 
+def test_build_row_carries_test_counts():
+    # Commit0-style fine-grained counts ride alongside the numeric score.
+    row = _row(tests_passed=38, tests_total=38)
+    assert row["tests_passed"] == 38
+    assert row["tests_total"] == 38
+    # None for pass/fail-only graders (SWE-bench / stub).
+    base = _row()
+    assert base["tests_passed"] is None
+    assert base["tests_total"] is None
+
+
 def test_append_and_read_roundtrip(tmp_path: Path):
     append_row(tmp_path, _row(rep=1))
     append_row(tmp_path, _row(rep=2, resolved=False, score=0.0))

--- a/worca-bench/tests/test_normalize_stats.py
+++ b/worca-bench/tests/test_normalize_stats.py
@@ -36,12 +36,18 @@ def test_build_row_schema_keys():
 
 
 def test_build_row_carries_config_metadata():
-    row = _row(worca_version="0.58.0", grade_mode="local-docker")
+    row = _row(
+        worca_version="0.58.0", grade_mode="local-docker",
+        graphify="full", code_review_graph="structural",
+    )
     assert row["worca_version"] == "0.58.0"
     assert row["grade_mode"] == "local-docker"
+    assert row["graphify"] == "full"
+    assert row["code_review_graph"] == "structural"
     # Defaults are None when not supplied (back-compat for older rows).
-    assert _row()["worca_version"] is None
-    assert _row()["grade_mode"] is None
+    base = _row()
+    for k in ("worca_version", "grade_mode", "graphify", "code_review_graph"):
+        assert base[k] is None
 
 
 def test_append_and_read_roundtrip(tmp_path: Path):

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -7,7 +7,13 @@ from conftest import make_git_repo
 
 from worca_bench.config import GradeConfig, profile_from_dict
 from worca_bench.plugins import get_plugin
-from worca_bench.plugins.base import Instance, Prepared, grade_env, stub_grade
+from worca_bench.plugins.base import (
+    GradeResult,
+    Instance,
+    Prepared,
+    grade_env,
+    stub_grade,
+)
 from worca_bench.plugins.commit0 import Commit0Plugin
 import pytest
 
@@ -320,3 +326,71 @@ def test_commit0_grade_stub(tmp_path: Path):
                               prepared=Prepared(base_commit="x"))
     assert r.status == "graded"
     assert r.resolved is True
+
+
+def test_commit0_load_instances_sets_lib(tmp_path: Path):
+    """The library name `commit0 test` needs is carried in extra['lib'] — defaulting
+    to the instance id but honoring an explicit per-record override."""
+    f = tmp_path / "instances.json"
+    f.write_text(json.dumps([
+        {"instance_id": "tinydb", "spec": "build it", "local_repo": "/x",
+         "gold_test_paths": ["tests/"]},
+        {"instance_id": "foo__1", "lib": "foolib", "prompt": "p"},
+    ]), encoding="utf-8")
+    profile = profile_from_dict(
+        {"name": "p", "benchmark": "commit0", "selection": {"instances_file": str(f)}})
+    insts = Commit0Plugin().load_instances(profile)
+    assert insts[0].extra["lib"] == "tinydb"          # defaults to instance id
+    assert insts[0].extra["gold_test_paths"] == ("tests/",)
+    assert insts[1].extra["lib"] == "foolib"          # explicit override wins
+
+
+def test_commit0_grade_unsupported_mode_errors(tmp_path: Path):
+    """sb-cli is SWE-bench-only; commit0 must reject it with an actionable error."""
+    r = Commit0Plugin().grade(Instance(id="tinydb", prompt=""), "+x\n", tmp_path,
+                              tmp_path, GradeConfig(mode="sb-cli"),
+                              prepared=Prepared(base_commit=""))
+    assert r.status == "error"
+    assert "unsupported grade mode" in r.detail
+
+
+def test_commit0_grade_modal_without_tokens_errors(tmp_path: Path):
+    """Modal grading fails fast (before any shell-out) when tokens are absent."""
+    r = Commit0Plugin().grade(Instance(id="tinydb", prompt=""), "+x\n", tmp_path,
+                              tmp_path, GradeConfig(mode="modal"),
+                              prepared=Prepared(base_commit=""), secret_env={})
+    assert r.status == "error"
+    assert "MODAL_TOKEN_ID" in r.detail and "MODAL_TOKEN_SECRET" in r.detail
+
+
+def test_commit0_grade_modal_with_tokens_dispatches_backend(monkeypatch, tmp_path: Path):
+    """With tokens present, modal dispatches to the pristine grader with backend=modal."""
+    captured = {}
+    plugin = Commit0Plugin()
+
+    def fake_pristine(instance, diff, target_dir, prepared, secret_env, backend):
+        captured["backend"] = backend
+        return GradeResult(status="graded", resolved=True, score=1.0)
+
+    monkeypatch.setattr(plugin, "_grade_on_pristine", fake_pristine)
+    r = plugin.grade(Instance(id="tinydb", prompt=""), "+x\n", tmp_path, tmp_path,
+                     GradeConfig(mode="modal"), prepared=Prepared(base_commit=""),
+                     secret_env={"MODAL_TOKEN_ID": "i", "MODAL_TOKEN_SECRET": "s"})
+    assert captured["backend"] == "modal"
+    assert r.status == "graded" and r.resolved is True
+
+
+def test_commit0_grade_local_docker_dispatches_backend(monkeypatch, tmp_path: Path):
+    """local-docker dispatches to the pristine grader with backend=local (no token check)."""
+    captured = {}
+    plugin = Commit0Plugin()
+
+    def fake_pristine(instance, diff, target_dir, prepared, secret_env, backend):
+        captured["backend"] = backend
+        return GradeResult(status="graded", resolved=False, score=0.0)
+
+    monkeypatch.setattr(plugin, "_grade_on_pristine", fake_pristine)
+    r = plugin.grade(Instance(id="tinydb", prompt=""), "+x\n", tmp_path, tmp_path,
+                     GradeConfig(mode="local-docker"), prepared=Prepared(base_commit=""))
+    assert captured["backend"] == "local"
+    assert r.status == "graded"

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -342,6 +342,40 @@ def test_commit0_grade_stub(tmp_path: Path):
     assert r.resolved is True
 
 
+def test_commit0_grade_threads_timeout_from_options(tmp_path: Path, monkeypatch):
+    """grade.options.timeout flows to _grade_on_pristine (→ `commit0 test --timeout`,
+    which is the Modal sandbox timeout). Raising it unblocks slow suites that
+    otherwise SandboxTimeout."""
+    captured = {}
+
+    def fake_pristine(self, instance, diff, target_dir, prepared, secret_env,
+                      backend, grade_timeout=None):
+        captured["timeout"] = grade_timeout
+        captured["backend"] = backend
+        return GradeResult(status="graded", resolved=True, score=1.0)
+
+    monkeypatch.setattr(Commit0Plugin, "_grade_on_pristine", fake_pristine)
+    inst = Instance(id="lib", prompt="",
+                    extra={"commit0": {"base_dir": "b", "config_file": "c"}})
+    tokens = {"MODAL_TOKEN_ID": "a", "MODAL_TOKEN_SECRET": "b"}
+
+    Commit0Plugin().grade(
+        inst, "+d\n", tmp_path, tmp_path,
+        GradeConfig(mode="modal", options={"timeout": 5400}),
+        prepared=Prepared(base_commit=""), secret_env=tokens,
+    )
+    assert captured["timeout"] == 5400
+    assert captured["backend"] == "modal"
+
+    # No timeout in options => None (commit0's own default applies).
+    Commit0Plugin().grade(
+        inst, "+d\n", tmp_path, tmp_path,
+        GradeConfig(mode="modal", options={}),
+        prepared=Prepared(base_commit=""), secret_env=tokens,
+    )
+    assert captured["timeout"] is None
+
+
 def test_commit0_load_instances_sets_lib(tmp_path: Path):
     """The library name `commit0 test` needs is carried in extra['lib'] — defaulting
     to the instance id but honoring an explicit per-record override."""
@@ -382,7 +416,8 @@ def test_commit0_grade_modal_with_tokens_dispatches_backend(monkeypatch, tmp_pat
     captured = {}
     plugin = Commit0Plugin()
 
-    def fake_pristine(instance, diff, target_dir, prepared, secret_env, backend):
+    def fake_pristine(instance, diff, target_dir, prepared, secret_env, backend,
+                      grade_timeout=None):
         captured["backend"] = backend
         return GradeResult(status="graded", resolved=True, score=1.0)
 
@@ -399,7 +434,8 @@ def test_commit0_grade_local_docker_dispatches_backend(monkeypatch, tmp_path: Pa
     captured = {}
     plugin = Commit0Plugin()
 
-    def fake_pristine(instance, diff, target_dir, prepared, secret_env, backend):
+    def fake_pristine(instance, diff, target_dir, prepared, secret_env, backend,
+                      grade_timeout=None):
         captured["backend"] = backend
         return GradeResult(status="graded", resolved=False, score=0.0)
 

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -13,6 +13,7 @@ import pytest
 
 from worca_bench.plugins.swebench import (
     SwebenchPlugin,
+    _classify_sb_report,
     _load_dataset_with_retry,
     _resolved_from_instance_report,
     harness_report_path,
@@ -132,6 +133,53 @@ def test_harness_report_path_layout(monkeypatch, tmp_path: Path):
     )
 
 
+def _write_sb_report(path: Path, **buckets):
+    """Write an sb-cli-shaped summary report with the given id buckets."""
+    data = {
+        "resolved_ids": [], "unresolved_ids": [], "failed_ids": [],
+        "error_ids": [], "pending_ids": [], "completed_ids": [],
+    }
+    data.update(buckets)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_classify_sb_report_buckets(tmp_path: Path):
+    iid = "astropy__astropy-12907"
+    rep = tmp_path / "r.json"
+
+    _write_sb_report(rep, resolved_ids=[iid])
+    v = _classify_sb_report(rep, iid)
+    assert v.status == "graded" and v.resolved is True and v.score == 1.0
+
+    _write_sb_report(rep, unresolved_ids=[iid])
+    v = _classify_sb_report(rep, iid)
+    assert v.status == "graded" and v.resolved is False and v.score == 0.0
+
+    # A remote failure is an ERROR, not a graded-as-unresolved verdict.
+    _write_sb_report(rep, failed_ids=[iid])
+    v = _classify_sb_report(rep, iid)
+    assert v.status == "error" and v.resolved is None
+    assert "failed to evaluate" in v.detail
+
+    _write_sb_report(rep, error_ids=[iid])
+    assert _classify_sb_report(rep, iid).status == "error"
+
+    _write_sb_report(rep, pending_ids=[iid])
+    assert _classify_sb_report(rep, iid).status == "error"
+
+
+def test_classify_sb_report_absent_and_missing(tmp_path: Path):
+    assert _classify_sb_report(None, "x") is None
+    assert _classify_sb_report(tmp_path / "nope.json", "x") is None
+    rep = tmp_path / "r.json"
+    # Report exists but the instance is in no bucket → no result.
+    _write_sb_report(rep, resolved_ids=["some__other-1"])
+    assert _classify_sb_report(rep, "astropy__astropy-12907") is None
+    # Corrupt report → no result.
+    rep.write_text("{not json", encoding="utf-8")
+    assert _classify_sb_report(rep, "x") is None
+
+
 def test_grade_env_merges_secrets_over_os_environ(monkeypatch):
     monkeypatch.setenv("PATH", "/usr/bin")
     env = grade_env({"SWEBENCH_API_KEY": "swb_test"})
@@ -158,8 +206,10 @@ def test_sb_cli_reads_report_and_threads_secret(monkeypatch, tmp_path: Path):
         if cmd[:2] == ["sb-cli", "get-report"]:
             out = Path(cmd[cmd.index("-o") + 1])
             out.mkdir(parents=True, exist_ok=True)
+            # sb-cli summary report format: disjoint id buckets.
             (out / "report.json").write_text(
-                json.dumps({iid: {"resolved": True}}), encoding="utf-8")
+                json.dumps({"resolved_ids": [iid], "unresolved_ids": [],
+                            "failed_ids": []}), encoding="utf-8")
         # Non-zero exit must NOT discard the written report.
         return _Proc(returncode=1, stderr="benign warning")
 

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from conftest import make_git_repo
+from conftest import git, make_git_repo
 
 from worca_bench.config import GradeConfig, profile_from_dict
 from worca_bench.plugins import get_plugin
@@ -12,6 +12,7 @@ from worca_bench.plugins.base import (
     Instance,
     Prepared,
     grade_env,
+    neutralize_remotes,
     stub_grade,
 )
 from worca_bench.plugins.commit0 import Commit0Plugin
@@ -86,6 +87,35 @@ def test_swebench_materialize_from_local_repo(tmp_path: Path):
     got_base = SwebenchPlugin().materialize(inst, dest)
     assert got_base == base
     assert (dest / "main.py").exists()
+
+
+def test_neutralize_remotes_strips_all_remotes(tmp_path: Path):
+    repo = tmp_path / "repo"
+    make_git_repo(repo, {"main.py": "x = 1\n"})
+    git(["remote", "add", "origin", "https://github.com/astropy/astropy.git"], repo)
+    git(["remote", "add", "upstream", "https://github.com/other/other.git"], repo)
+    removed = neutralize_remotes(repo)
+    assert set(removed) == {"origin", "upstream"}
+    assert git(["remote"], repo) == ""
+
+
+def test_neutralize_remotes_no_remotes_is_noop(tmp_path: Path):
+    repo = tmp_path / "repo"
+    make_git_repo(repo)
+    assert neutralize_remotes(repo) == []
+
+
+def test_materialize_from_local_strips_carried_origin(tmp_path: Path):
+    # A copied source tree can carry a real origin in .git/config; materialize
+    # must strip it so no pipeline stage (e.g. a misbehaving guardian) can
+    # `gh repo fork` / `gh pr create` against the real upstream.
+    src = tmp_path / "src"
+    base = make_git_repo(src, {"main.py": "x = 1\n"})
+    git(["remote", "add", "origin", "https://github.com/astropy/astropy.git"], src)
+    dest = tmp_path / "work"
+    inst = Instance(id="a__b-1", prompt="p", local_repo=str(src), base_commit=base)
+    SwebenchPlugin().materialize(inst, dest)
+    assert git(["remote"], dest) == ""
 
 
 def test_stub_grade_resolves_on_nonempty_diff():

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -7,11 +7,16 @@ from conftest import make_git_repo
 
 from worca_bench.config import GradeConfig, profile_from_dict
 from worca_bench.plugins import get_plugin
-from worca_bench.plugins.base import Instance, stub_grade
+from worca_bench.plugins.base import Instance, Prepared, grade_env, stub_grade
 from worca_bench.plugins.commit0 import Commit0Plugin
 import pytest
 
-from worca_bench.plugins.swebench import SwebenchPlugin, _load_dataset_with_retry
+from worca_bench.plugins.swebench import (
+    SwebenchPlugin,
+    _load_dataset_with_retry,
+    _resolved_from_instance_report,
+    harness_report_path,
+)
 
 
 def test_load_dataset_with_retry_recovers(monkeypatch):
@@ -87,6 +92,100 @@ def test_stub_grade_respects_expect_override():
     r = stub_grade("+lots of changes\n", inst)
     assert r.resolved is False
     assert r.score == 0.0
+
+
+def _write_instance_report(path: Path, instance_id: str, *, resolved: bool):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({instance_id: {"resolved": resolved, "patch_exists": True}}),
+        encoding="utf-8",
+    )
+
+
+def test_resolved_from_instance_report_reads_resolved(tmp_path: Path):
+    rep = tmp_path / "report.json"
+    _write_instance_report(rep, "astropy__astropy-12907", resolved=True)
+    assert _resolved_from_instance_report(rep, "astropy__astropy-12907") is True
+
+    _write_instance_report(rep, "astropy__astropy-13033", resolved=False)
+    assert _resolved_from_instance_report(rep, "astropy__astropy-13033") is False
+
+
+def test_resolved_from_instance_report_handles_missing_and_corrupt(tmp_path: Path):
+    assert _resolved_from_instance_report(None, "x") is None
+    assert _resolved_from_instance_report(tmp_path / "nope.json", "x") is None
+    corrupt = tmp_path / "bad.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    assert _resolved_from_instance_report(corrupt, "x") is None
+    # Present file but the instance isn't in it → no result.
+    other = tmp_path / "other.json"
+    _write_instance_report(other, "some__other-1", resolved=True)
+    assert _resolved_from_instance_report(other, "astropy__astropy-1") is None
+
+
+def test_harness_report_path_layout(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    p = harness_report_path("wb-astropy__astropy-12907", "astropy__astropy-12907")
+    assert p == (
+        tmp_path / "logs" / "run_evaluation" / "wb-astropy__astropy-12907"
+        / "worca-bench" / "astropy__astropy-12907" / "report.json"
+    )
+
+
+def test_grade_env_merges_secrets_over_os_environ(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = grade_env({"SWEBENCH_API_KEY": "swb_test"})
+    assert env["SWEBENCH_API_KEY"] == "swb_test"
+    assert env["PATH"] == "/usr/bin"  # ambient env preserved
+    assert grade_env(None).get("SWEBENCH_API_KEY") is None
+
+
+class _Proc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_sb_cli_reads_report_and_threads_secret(monkeypatch, tmp_path: Path):
+    """sb-cli grading: report is authoritative even when the CLI exits non-zero,
+    and the SWEBENCH_API_KEY secret reaches the subprocess env."""
+    iid = "astropy__astropy-12907"
+    captured_envs = []
+
+    def fake_run(cmd, *a, **kw):
+        captured_envs.append(kw.get("env") or {})
+        if cmd[:2] == ["sb-cli", "get-report"]:
+            out = Path(cmd[cmd.index("-o") + 1])
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "report.json").write_text(
+                json.dumps({iid: {"resolved": True}}), encoding="utf-8")
+        # Non-zero exit must NOT discard the written report.
+        return _Proc(returncode=1, stderr="benign warning")
+
+    monkeypatch.setattr("worca_bench.plugins.swebench.subprocess.run", fake_run)
+    plugin = SwebenchPlugin()
+    grade = GradeConfig(mode="sb-cli", options={})
+    res = plugin.grade(Instance(id=iid, prompt=""), "+patch\n", tmp_path, tmp_path,
+                       grade, prepared=Prepared(base_commit=""),
+                       secret_env={"SWEBENCH_API_KEY": "swb_test"})
+    assert res.status == "graded"
+    assert res.resolved is True
+    assert res.score == 1.0
+    assert all(e.get("SWEBENCH_API_KEY") == "swb_test" for e in captured_envs)
+
+
+def test_sb_cli_errors_when_no_report(monkeypatch, tmp_path: Path):
+    def fake_run(cmd, *a, **kw):
+        return _Proc(returncode=2, stderr="auth failed")
+
+    monkeypatch.setattr("worca_bench.plugins.swebench.subprocess.run", fake_run)
+    plugin = SwebenchPlugin()
+    grade = GradeConfig(mode="sb-cli", options={})
+    res = plugin.grade(Instance(id="x__y-1", prompt=""), "+p\n", tmp_path, tmp_path,
+                       grade, prepared=Prepared(base_commit=""))
+    assert res.status == "error"
+    assert "auth failed" in res.detail
 
 
 def test_commit0_prepare_stashes_and_restores_gold_tests(tmp_path: Path):

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -379,6 +379,42 @@ def test_commit0_grade_threads_timeout_from_options(tmp_path: Path, monkeypatch)
     assert captured["rebuild"] is False
 
 
+def test_commit0_grade_preflight(monkeypatch):
+    import worca_bench.plugins.commit0 as c0
+    plugin = Commit0Plugin()
+    inst = Instance(id="simpy", prompt="", extra={"lib": "simpy"})
+
+    assert plugin._grade_image_name(inst) == "wentingzhao/simpy:v0"
+
+    # stub never blocks.
+    assert plugin.grade_preflight(inst, GradeConfig(mode="stub"))[0] is True
+
+    # modal without creds -> definitively not gradeable.
+    ok, reason = plugin.grade_preflight(inst, GradeConfig(mode="modal"), secret_env={})
+    assert ok is False and "MODAL_TOKEN" in reason
+
+    tokens = {"MODAL_TOKEN_ID": "a", "MODAL_TOKEN_SECRET": "b"}
+    # modal + creds + published image -> ok.
+    monkeypatch.setattr(c0, "_image_published", lambda img: True)
+    assert plugin.grade_preflight(inst, GradeConfig(mode="modal"), secret_env=tokens)[0] is True
+
+    # image the registry says is genuinely missing -> not gradeable.
+    monkeypatch.setattr(c0, "_image_published", lambda img: False)
+    ok, reason = plugin.grade_preflight(inst, GradeConfig(mode="modal"), secret_env=tokens)
+    assert ok is False and "not published" in reason
+
+    # local-docker with the daemon down -> not gradeable.
+    monkeypatch.setattr(c0, "_docker_running", lambda: False)
+    monkeypatch.setattr(c0, "_image_published", lambda img: True)
+    ok, reason = plugin.grade_preflight(inst, GradeConfig(mode="local-docker"))
+    assert ok is False and "docker daemon" in reason
+
+    # inconclusive image check (None) must NOT block.
+    monkeypatch.setattr(c0, "_docker_running", lambda: True)
+    monkeypatch.setattr(c0, "_image_published", lambda img: None)
+    assert plugin.grade_preflight(inst, GradeConfig(mode="local-docker"))[0] is True
+
+
 def test_commit0_load_instances_sets_lib(tmp_path: Path):
     """The library name `commit0 test` needs is carried in extra['lib'] — defaulting
     to the instance id but honoring an explicit per-record override."""

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -238,6 +238,61 @@ def test_sb_cli_errors_when_no_report(monkeypatch, tmp_path: Path):
     assert "auth failed" in res.detail
 
 
+def test_grade_unsupported_mode_errors(tmp_path: Path):
+    plugin = SwebenchPlugin()
+    grade = GradeConfig(mode="bogus", options={})
+    res = plugin.grade(Instance(id="x__y-1", prompt=""), "+p\n", tmp_path, tmp_path,
+                       grade, prepared=Prepared(base_commit=""))
+    assert res.status == "error"
+    assert "unsupported grade mode bogus" in res.detail
+
+
+def test_grade_modal_requires_tokens(monkeypatch, tmp_path: Path):
+    """Modal grading fails fast (no subprocess) when its tokens are absent."""
+    for k in ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"):
+        monkeypatch.delenv(k, raising=False)
+    called = {"n": 0}
+
+    def fake_run(*a, **kw):
+        called["n"] += 1
+        return _Proc(returncode=0)
+
+    monkeypatch.setattr("worca_bench.plugins.swebench.subprocess.run", fake_run)
+    plugin = SwebenchPlugin()
+    grade = GradeConfig(mode="modal", options={})
+    res = plugin.grade(Instance(id="x__y-1", prompt=""), "+p\n", tmp_path, tmp_path,
+                       grade, prepared=Prepared(base_commit=""))
+    assert res.status == "error"
+    assert "MODAL_TOKEN_ID" in res.detail and "MODAL_TOKEN_SECRET" in res.detail
+    assert called["n"] == 0  # never reached the harness
+
+
+def test_grade_modal_dispatches_to_harness_with_tokens(monkeypatch, tmp_path: Path):
+    """With tokens present, modal routes through the harness grader (registry),
+    passes --modal true, threads the tokens into the env, and reads the report."""
+    monkeypatch.chdir(tmp_path)
+    iid = "astropy__astropy-12907"
+    captured = {}
+
+    def fake_run(cmd, *a, **kw):
+        captured["cmd"] = cmd
+        captured["env"] = kw.get("env") or {}
+        rep = harness_report_path(f"wb-{iid}", iid)
+        _write_instance_report(rep, iid, resolved=True)
+        return _Proc(returncode=0)
+
+    monkeypatch.setattr("worca_bench.plugins.swebench.subprocess.run", fake_run)
+    plugin = SwebenchPlugin()
+    grade = GradeConfig(mode="modal", options={})
+    res = plugin.grade(Instance(id=iid, prompt=""), "+patch\n", tmp_path, tmp_path,
+                       grade, prepared=Prepared(base_commit=""),
+                       secret_env={"MODAL_TOKEN_ID": "mid", "MODAL_TOKEN_SECRET": "msec"})
+    assert res.status == "graded" and res.resolved is True
+    assert "--modal" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--modal") + 1] == "true"
+    assert captured["env"]["MODAL_TOKEN_ID"] == "mid"
+
+
 def test_commit0_prepare_stashes_and_restores_gold_tests(tmp_path: Path):
     repo = tmp_path / "lib"
     make_git_repo(repo, {

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -349,9 +349,10 @@ def test_commit0_grade_threads_timeout_from_options(tmp_path: Path, monkeypatch)
     captured = {}
 
     def fake_pristine(self, instance, diff, target_dir, prepared, secret_env,
-                      backend, grade_timeout=None):
+                      backend, grade_timeout=None, rebuild=False):
         captured["timeout"] = grade_timeout
         captured["backend"] = backend
+        captured["rebuild"] = rebuild
         return GradeResult(status="graded", resolved=True, score=1.0)
 
     monkeypatch.setattr(Commit0Plugin, "_grade_on_pristine", fake_pristine)
@@ -361,19 +362,21 @@ def test_commit0_grade_threads_timeout_from_options(tmp_path: Path, monkeypatch)
 
     Commit0Plugin().grade(
         inst, "+d\n", tmp_path, tmp_path,
-        GradeConfig(mode="modal", options={"timeout": 5400}),
+        GradeConfig(mode="modal", options={"timeout": 5400, "rebuild": True}),
         prepared=Prepared(base_commit=""), secret_env=tokens,
     )
     assert captured["timeout"] == 5400
     assert captured["backend"] == "modal"
+    assert captured["rebuild"] is True
 
-    # No timeout in options => None (commit0's own default applies).
+    # No timeout/rebuild in options => defaults (None / False).
     Commit0Plugin().grade(
         inst, "+d\n", tmp_path, tmp_path,
         GradeConfig(mode="modal", options={}),
         prepared=Prepared(base_commit=""), secret_env=tokens,
     )
     assert captured["timeout"] is None
+    assert captured["rebuild"] is False
 
 
 def test_commit0_load_instances_sets_lib(tmp_path: Path):
@@ -417,7 +420,7 @@ def test_commit0_grade_modal_with_tokens_dispatches_backend(monkeypatch, tmp_pat
     plugin = Commit0Plugin()
 
     def fake_pristine(instance, diff, target_dir, prepared, secret_env, backend,
-                      grade_timeout=None):
+                      grade_timeout=None, rebuild=False):
         captured["backend"] = backend
         return GradeResult(status="graded", resolved=True, score=1.0)
 
@@ -435,7 +438,7 @@ def test_commit0_grade_local_docker_dispatches_backend(monkeypatch, tmp_path: Pa
     plugin = Commit0Plugin()
 
     def fake_pristine(instance, diff, target_dir, prepared, secret_env, backend,
-                      grade_timeout=None):
+                      grade_timeout=None, rebuild=False):
         captured["backend"] = backend
         return GradeResult(status="graded", resolved=False, score=0.0)
 

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -9,7 +9,33 @@ from worca_bench.config import GradeConfig, profile_from_dict
 from worca_bench.plugins import get_plugin
 from worca_bench.plugins.base import Instance, stub_grade
 from worca_bench.plugins.commit0 import Commit0Plugin
-from worca_bench.plugins.swebench import SwebenchPlugin
+import pytest
+
+from worca_bench.plugins.swebench import SwebenchPlugin, _load_dataset_with_retry
+
+
+def test_load_dataset_with_retry_recovers(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)  # no real backoff
+    calls = {"n": 0}
+
+    def flaky(name, split="test"):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise TimeoutError("CDN read timed out")
+        return f"DS({name},{split})"
+
+    assert _load_dataset_with_retry(flaky, "ds", attempts=4) == "DS(ds,test)"
+    assert calls["n"] == 3
+
+
+def test_load_dataset_with_retry_exhausts(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+
+    def always_fail(name, split="test"):
+        raise TimeoutError("nope")
+
+    with pytest.raises(RuntimeError, match="after 3 attempts"):
+        _load_dataset_with_retry(always_fail, "ds", attempts=3)
 
 
 def test_get_plugin_dispatch():

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import make_git_repo
+
+from worca_bench.config import GradeConfig, profile_from_dict
+from worca_bench.plugins import get_plugin
+from worca_bench.plugins.base import Instance, stub_grade
+from worca_bench.plugins.commit0 import Commit0Plugin
+from worca_bench.plugins.swebench import SwebenchPlugin
+
+
+def test_get_plugin_dispatch():
+    sp = get_plugin(profile_from_dict(
+        {"name": "p", "benchmark": "swe-bench-verified",
+         "selection": {"instance_ids": ["x"]}}))
+    assert isinstance(sp, SwebenchPlugin)
+    cp = get_plugin(profile_from_dict(
+        {"name": "p", "benchmark": "commit0",
+         "selection": {"instances_file": "x.json"}}))
+    assert isinstance(cp, Commit0Plugin)
+
+
+def test_swebench_load_from_file_filters_ids(tmp_path: Path):
+    f = tmp_path / "inst.json"
+    f.write_text(json.dumps([
+        {"instance_id": "a__b-1", "problem_statement": "fix a", "repo": "a/b",
+         "base_commit": "abc"},
+        {"instance_id": "c__d-2", "problem_statement": "fix c", "repo": "c/d",
+         "base_commit": "def"},
+    ]), encoding="utf-8")
+    prof = profile_from_dict({
+        "name": "p", "benchmark": "swe-bench-verified",
+        "selection": {"instances_file": str(f), "instance_ids": ["a__b-1"]},
+    })
+    insts = SwebenchPlugin().load_instances(prof)
+    assert [i.id for i in insts] == ["a__b-1"]
+    assert insts[0].prompt == "fix a"
+
+
+def test_swebench_materialize_from_local_repo(tmp_path: Path):
+    src = tmp_path / "src"
+    base = make_git_repo(src, {"main.py": "x = 1\n"})
+    dest = tmp_path / "work"
+    inst = Instance(id="a__b-1", prompt="p", local_repo=str(src), base_commit=base)
+    got_base = SwebenchPlugin().materialize(inst, dest)
+    assert got_base == base
+    assert (dest / "main.py").exists()
+
+
+def test_stub_grade_resolves_on_nonempty_diff():
+    inst = Instance(id="x", prompt="p")
+    assert stub_grade("+new line\n", inst).resolved is True
+    assert stub_grade("", inst).resolved is False
+
+
+def test_stub_grade_respects_expect_override():
+    inst = Instance(id="x", prompt="p", extra={"expect_resolved": False})
+    r = stub_grade("+lots of changes\n", inst)
+    assert r.resolved is False
+    assert r.score == 0.0
+
+
+def test_commit0_prepare_stashes_and_restores_gold_tests(tmp_path: Path):
+    repo = tmp_path / "lib"
+    make_git_repo(repo, {
+        "lib.py": "def f(): pass\n",
+        "tests/test_lib.py": "def test_f(): assert f()\n",
+    })
+    inst = Instance(id="lib", prompt="spec", local_repo=str(repo),
+                    extra={"gold_test_paths": ("tests/test_lib.py",)})
+    prepared = Commit0Plugin().prepare(inst, repo)
+    # gold test hidden during the run
+    assert not (repo / "tests" / "test_lib.py").exists()
+    assert prepared.gold_test_paths == ("tests/test_lib.py",)
+    assert prepared.extra_excludes == ("tests/test_lib.py",)
+    # restore brings it back
+    prepared.restore()
+    assert (repo / "tests" / "test_lib.py").exists()
+
+
+def test_commit0_grade_stub(tmp_path: Path):
+    inst = Instance(id="lib", prompt="spec")
+    from worca_bench.plugins.base import Prepared
+
+    r = Commit0Plugin().grade(inst, "+impl\n", tmp_path, tmp_path,
+                              GradeConfig(mode="stub"),
+                              prepared=Prepared(base_commit="x"))
+    assert r.status == "graded"
+    assert r.resolved is True

--- a/worca-bench/tests/test_plugins.py
+++ b/worca-bench/tests/test_plugins.py
@@ -311,10 +311,24 @@ def test_commit0_prepare_stashes_and_restores_gold_tests(tmp_path: Path):
     # gold test hidden during the run
     assert not (repo / "tests" / "test_lib.py").exists()
     assert prepared.gold_test_paths == ("tests/test_lib.py",)
-    assert prepared.extra_excludes == ("tests/test_lib.py",)
+    # gold tests + the Commit0 spec artifacts are all excluded from the graded diff
+    assert prepared.extra_excludes == (
+        "tests/test_lib.py", "spec.pdf", "spec.pdf.bz2",
+    )
     # restore brings it back
     prepared.restore()
     assert (repo / "tests" / "test_lib.py").exists()
+
+
+def test_commit0_prepare_excludes_spec_artifacts_without_gold(tmp_path: Path):
+    # Even with no gold tests, the spec.pdf / spec.pdf.bz2 that ship in every Commit0
+    # repo root must be excluded — they materialize in the tree and otherwise leak into
+    # the prediction patch as a binary diff that breaks `git apply` at grade time.
+    repo = tmp_path / "lib"
+    make_git_repo(repo, {"lib.py": "def f(): pass\n"})
+    inst = Instance(id="lib", prompt="spec", local_repo=str(repo), extra={})
+    prepared = Commit0Plugin().prepare(inst, repo)
+    assert prepared.extra_excludes == ("spec.pdf", "spec.pdf.bz2")
 
 
 def test_commit0_grade_stub(tmp_path: Path):

--- a/worca-bench/tests/test_regrade.py
+++ b/worca-bench/tests/test_regrade.py
@@ -43,7 +43,7 @@ def _seed(tmp_path, *, diff_text="+added line\n"):
 def _args(tmp_path, profiles, **over):
     base = dict(
         target_dir=str(tmp_path), profile="demo", profiles_dir=str(profiles),
-        mode="stub", only_errors=False, instance=None,
+        mode="stub", only_errors=False, instance=None, sequential=False,
     )
     base.update(over)
     return argparse.Namespace(**base)
@@ -109,3 +109,45 @@ def test_regrade_no_matches_returns_1(tmp_path: Path):
     profiles = _seed(tmp_path)
     rc = cli.cmd_regrade(_args(tmp_path, profiles, instance=["nonexistent__x-1"]))
     assert rc == 1
+
+
+def test_regrade_sequential_skips_the_thread_pool(tmp_path: Path, monkeypatch):
+    profiles = _seed(tmp_path)
+    import concurrent.futures as cf
+
+    used = {"pool": False}
+    real = cf.ThreadPoolExecutor
+
+    def spy(*a, **k):
+        used["pool"] = True
+        return real(*a, **k)
+
+    monkeypatch.setattr(cf, "ThreadPoolExecutor", spy)
+    # --sequential grades in a plain in-order loop, no executor at all.
+    rc = cli.cmd_regrade(_args(tmp_path, profiles, sequential=True))
+    assert rc == 0
+    assert used["pool"] is False
+    assert read_rows(tmp_path)[0]["status"] == "graded"
+
+
+def test_regrade_writes_heartbeat_and_increments(tmp_path: Path):
+    profiles = _seed(tmp_path)
+    rc = cli.cmd_regrade(_args(tmp_path, profiles, sequential=True))
+    assert rc == 0
+    import json as _json
+
+    hb = _json.loads(
+        (tmp_path / "runs" / "demo" / "regrade-status.json").read_text()
+    )
+    assert hb["status"] == "done"
+    assert hb["total"] == 1 and hb["done"] == 1
+    assert hb["counts"]["graded"] == 1 and hb["counts"]["resolved"] == 1
+    assert hb["mode"] == "stub" and isinstance(hb["pid"], int)
+
+
+def test_regrade_persists_grade_provenance(tmp_path: Path):
+    profiles = _seed(tmp_path)
+    cli.cmd_regrade(_args(tmp_path, profiles, sequential=True))
+    row = read_rows(tmp_path)[0]
+    assert row["grade_detail"]  # stub grade carries a detail string
+    assert row["graded_at"] and row["regraded_at"]

--- a/worca-bench/tests/test_regrade.py
+++ b/worca-bench/tests/test_regrade.py
@@ -1,0 +1,111 @@
+"""Regrade subcommand + the in-place row rewrite it depends on.
+
+Uses ``grade.mode == stub`` so nothing shells out to sb-cli / Docker / network:
+stub grading resolves on a non-empty diff, which is enough to prove the regrade
+reads the saved ``diff.patch``, grades it, and rewrites the matching rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import worca_bench.cli as cli
+from worca_bench.normalize import append_row, read_rows, rewrite_rows
+
+
+def _row(instance_id, *, status, profile="demo", rep=1):
+    return {
+        "schema_version": 1, "profile": profile, "benchmark": "swe-bench-verified",
+        "instance_id": instance_id, "rep": rep,
+        "run_id": f"{profile}__{instance_id}__rep{rep}",
+        "status": status, "resolved": None, "score": None, "error": "harness failed",
+        "artifacts_dir": f"runs/{profile}/{instance_id}/rep{rep}",
+    }
+
+
+def _seed(tmp_path, *, diff_text="+added line\n"):
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    (profiles / "demo.yaml").write_text(
+        "name: demo\nbenchmark: swe-bench-verified\n"
+        "selection:\n  instance_ids: [astropy__astropy-12907]\n"
+        "template: builtin:quick-fix\ngrade:\n  mode: stub\n",
+        encoding="utf-8",
+    )
+    append_row(tmp_path, _row("astropy__astropy-12907", status="error"))
+    art = tmp_path / "runs" / "demo" / "astropy__astropy-12907" / "rep1"
+    art.mkdir(parents=True)
+    (art / "diff.patch").write_text(diff_text, encoding="utf-8")
+    return profiles
+
+
+def _args(tmp_path, profiles, **over):
+    base = dict(
+        target_dir=str(tmp_path), profile="demo", profiles_dir=str(profiles),
+        mode="stub", only_errors=False, instance=None,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def test_rewrite_rows_mutates_in_place_atomically(tmp_path: Path):
+    append_row(tmp_path, _row("a__b-1", status="error"))
+    append_row(tmp_path, _row("a__b-2", status="error", rep=2))
+
+    def mutate(row):
+        if row["instance_id"] == "a__b-1":
+            row["status"] = "graded"
+            return True
+        return False
+
+    changed = rewrite_rows(tmp_path, mutate)
+    assert changed == 1
+    rows = {r["instance_id"]: r for r in read_rows(tmp_path)}
+    assert rows["a__b-1"]["status"] == "graded"
+    assert rows["a__b-2"]["status"] == "error"  # untouched
+    assert len(read_rows(tmp_path)) == 2  # no dupes / drops
+
+
+def test_regrade_stub_updates_error_row_to_graded(tmp_path: Path):
+    profiles = _seed(tmp_path)
+    rc = cli.cmd_regrade(_args(tmp_path, profiles, only_errors=True))
+    assert rc == 0
+    row = read_rows(tmp_path)[0]
+    assert row["status"] == "graded"
+    assert row["resolved"] is True  # stub resolves on a non-empty diff
+    assert row["score"] == 1.0
+    assert row["error"] is None
+    assert row["grade_mode"] == "stub"
+    assert "regraded_at" in row
+
+
+def test_regrade_missing_diff_marks_error(tmp_path: Path):
+    profiles = _seed(tmp_path)
+    # Remove the saved diff so regrade can't find a patch to grade.
+    (tmp_path / "runs" / "demo" / "astropy__astropy-12907" / "rep1" / "diff.patch").unlink()
+    rc = cli.cmd_regrade(_args(tmp_path, profiles))
+    assert rc == 0
+    row = read_rows(tmp_path)[0]
+    assert row["status"] == "error"
+    assert "no diff.patch" in row["error"]
+
+
+def test_regrade_instance_filter_limits_scope(tmp_path: Path):
+    profiles = _seed(tmp_path)
+    append_row(tmp_path, _row("astropy__astropy-99999", status="error"))
+    art = tmp_path / "runs" / "demo" / "astropy__astropy-99999" / "rep1"
+    art.mkdir(parents=True)
+    (art / "diff.patch").write_text("+x\n", encoding="utf-8")
+
+    rc = cli.cmd_regrade(_args(tmp_path, profiles, instance=["astropy__astropy-12907"]))
+    assert rc == 0
+    rows = {r["instance_id"]: r for r in read_rows(tmp_path)}
+    assert rows["astropy__astropy-12907"]["status"] == "graded"
+    assert rows["astropy__astropy-99999"]["status"] == "error"  # filtered out
+
+
+def test_regrade_no_matches_returns_1(tmp_path: Path):
+    profiles = _seed(tmp_path)
+    rc = cli.cmd_regrade(_args(tmp_path, profiles, instance=["nonexistent__x-1"]))
+    assert rc == 1

--- a/worca-bench/tests/test_regrade.py
+++ b/worca-bench/tests/test_regrade.py
@@ -130,6 +130,60 @@ def test_regrade_sequential_skips_the_thread_pool(tmp_path: Path, monkeypatch):
     assert read_rows(tmp_path)[0]["status"] == "graded"
 
 
+def test_regrade_commit0_enriches_instance_with_config_block(tmp_path: Path, monkeypatch):
+    """Regression: a commit0 regrade must rebuild the FULL instance from the
+    instances_file so the grader gets the `commit0` config block + local_repo.
+    A bare Instance(id=) made the grader error: "needs the 'commit0' config block"."""
+    import json
+
+    import worca_bench.plugins.commit0 as c0mod
+    from worca_bench.plugins.base import GradeResult
+
+    inst_file = tmp_path / "instances.json"
+    inst_file.write_text(
+        json.dumps([{
+            "instance_id": "tinydb", "lib": "tinydb",
+            "local_repo": str(tmp_path / "repos" / "tinydb"),
+            "base_commit": "abc", "reference_commit": "def",
+            "gold_test_paths": ["tests/"], "spec": "build it",
+            "commit0": {
+                "base_dir": str(tmp_path / "repos"),
+                "config_file": str(tmp_path / ".commit0.yaml"),
+                "base_branch": "commit0", "dataset_name": "ds", "dataset_split": "test",
+            },
+        }]),
+        encoding="utf-8",
+    )
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    (profiles / "c0.yaml").write_text(
+        "name: c0\nbenchmark: commit0\n"
+        f"selection:\n  instances_file: {inst_file}\n  instance_ids: [tinydb]\n"
+        "template: builtin:feature\ngrade:\n  mode: modal\n",
+        encoding="utf-8",
+    )
+    append_row(tmp_path, _row("tinydb", status="error", profile="c0"))
+    art = tmp_path / "runs" / "c0" / "tinydb" / "rep1"
+    art.mkdir(parents=True)
+    (art / "diff.patch").write_text("+x\n", encoding="utf-8")
+
+    captured = {}
+
+    def fake_grade(self, instance, diff, work, target_dir, grade, *, prepared, secret_env=None):
+        captured["inst"] = instance
+        return GradeResult(status="graded", resolved=True, score=1.0, detail="ok")
+
+    monkeypatch.setattr(c0mod.Commit0Plugin, "grade", fake_grade)
+    rc = cli.cmd_regrade(_args(tmp_path, profiles, profile="c0", mode="modal"))
+    assert rc == 0
+    inst = captured["inst"]
+    # The enriched instance carries everything the commit0 grader needs.
+    assert inst.extra.get("commit0", {}).get("base_dir")  # config block reached grade()
+    assert inst.extra.get("commit0", {}).get("config_file")
+    assert inst.local_repo  # skeleton path present
+    assert inst.extra.get("gold_test_paths") == ("tests/",)
+
+
 def test_regrade_writes_heartbeat_and_increments(tmp_path: Path):
     profiles = _seed(tmp_path)
     rc = cli.cmd_regrade(_args(tmp_path, profiles, sequential=True))

--- a/worca-bench/tests/test_runner.py
+++ b/worca-bench/tests/test_runner.py
@@ -1,0 +1,24 @@
+"""Runner-level cache wiring: HF dataset cache redirect."""
+
+from __future__ import annotations
+
+import os
+
+from worca_bench.runner import _apply_cache_env
+
+_CACHE_ENV = ("HF_HOME", "HF_DATASETS_CACHE", "WORCA_BENCH_CACHE")
+
+
+def test_apply_cache_env_redirects_hf_and_creates_dir(tmp_path, monkeypatch):
+    for k in _CACHE_ENV:
+        monkeypatch.delenv(k, raising=False)
+    cache = tmp_path / "cache"
+    try:
+        _apply_cache_env(cache)
+        assert os.environ["HF_DATASETS_CACHE"] == str(cache / "hf" / "datasets")
+        assert os.environ["HF_HOME"] == str(cache / "hf")
+        assert os.environ["WORCA_BENCH_CACHE"] == str(cache)
+        assert (cache / "hf").is_dir()  # created eagerly
+    finally:
+        for k in _CACHE_ENV:
+            os.environ.pop(k, None)

--- a/worca-bench/tests/test_runner.py
+++ b/worca-bench/tests/test_runner.py
@@ -3,10 +3,89 @@
 from __future__ import annotations
 
 import os
+import types
 
+import worca_bench.runner as R
+from worca_bench.config import GradeConfig, Profile, Selection
+from worca_bench.plugins.base import Instance
 from worca_bench.runner import _apply_cache_env
 
 _CACHE_ENV = ("HF_HOME", "HF_DATASETS_CACHE", "WORCA_BENCH_CACHE")
+
+
+def test_run_profile_skips_ungradeable_before_building(tmp_path, monkeypatch):
+    """The grade preflight skips un-gradeable instances *without* building them
+    (no venv provision, no _run_one_rep) — so no tokens are spent."""
+    insts = [Instance(id="a", prompt=""), Instance(id="b", prompt="")]
+
+    class FakePlugin:
+        def load_instances(self, profile):
+            return insts
+
+        def grade_preflight(self, inst, grade, *, secret_env=None):
+            return False, f"{inst.id} image not published"
+
+        def materialize(self, *a, **k):  # would be the build path
+            raise AssertionError("must not build an un-gradeable instance")
+
+    monkeypatch.setattr(R, "get_plugin", lambda p: FakePlugin())
+    monkeypatch.setattr(
+        R, "resolve_worca_env",
+        lambda *a, **k: types.SimpleNamespace(
+            describe=lambda: "local", resolved_sha="sha", version="0.0",
+        ),
+    )
+    monkeypatch.setattr(R, "load_overlay", lambda sha: {})
+
+    profile = Profile(
+        name="p", benchmark="commit0",
+        selection=Selection(instance_ids=["a", "b"]),
+        grade=GradeConfig(mode="modal"),
+    )
+    summary = R.run_profile(profile, tmp_path, canary_first=False, secret_env={})
+
+    assert summary.reps_skipped == 2
+    assert summary.reps_run == 0
+    assert set(summary.ungradeable) == {"a", "b"}
+    assert "not published" in summary.ungradeable["a"]
+
+
+def test_run_profile_preflight_opt_out(tmp_path, monkeypatch):
+    """`grade.options.preflight: false` disables the preflight (no skips from it)."""
+    calls = {"preflight": 0}
+
+    class FakePlugin:
+        def load_instances(self, profile):
+            return [Instance(id="a", prompt="")]
+
+        def grade_preflight(self, inst, grade, *, secret_env=None):
+            calls["preflight"] += 1
+            return False, "would skip"
+
+        def materialize(self, *a, **k):
+            raise RuntimeError("stop before build")
+
+    monkeypatch.setattr(R, "get_plugin", lambda p: FakePlugin())
+    monkeypatch.setattr(
+        R, "resolve_worca_env",
+        lambda *a, **k: types.SimpleNamespace(
+            describe=lambda: "local", resolved_sha="sha", version="0.0",
+        ),
+    )
+    monkeypatch.setattr(R, "load_overlay", lambda sha: {})
+
+    profile = Profile(
+        name="p", benchmark="commit0",
+        selection=Selection(instance_ids=["a"]),
+        grade=GradeConfig(mode="modal", options={"preflight": False}),
+    )
+    # Preflight disabled => grade_preflight never consulted; the instance proceeds
+    # to build (our fake raises, proving we got past the skip).
+    try:
+        R.run_profile(profile, tmp_path, canary_first=False, secret_env={})
+    except Exception:
+        pass
+    assert calls["preflight"] == 0
 
 
 def test_apply_cache_env_redirects_hf_and_creates_dir(tmp_path, monkeypatch):

--- a/worca-bench/tests/test_templates.py
+++ b/worca-bench/tests/test_templates.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from worca_bench.templates import (
+    TemplateRefError,
+    parse_ref,
+    resolve_for_launch,
+)
+
+
+def test_parse_ref_forms():
+    assert parse_ref("builtin:feature") == ("builtin", "feature")
+    assert parse_ref("project:tuned") == ("project", "tuned")
+    assert parse_ref("feature") == (None, "feature")
+
+
+def test_parse_ref_unknown_tier():
+    with pytest.raises(TemplateRefError):
+        parse_ref("weird:x")
+
+
+def test_builtin_and_bare_passthrough(tmp_path: Path):
+    assert resolve_for_launch("builtin:feature", tree=tmp_path, templates={}) == "feature"
+    assert resolve_for_launch("feature", tree=tmp_path, templates={}) == "feature"
+    # no project template seeded for builtin
+    assert not (tmp_path / ".claude" / "templates").exists()
+
+
+def test_project_template_is_seeded(tmp_path: Path):
+    defn = {"id": "tuned", "name": "Tuned", "config": {"agents": {"implementer": {"model": "opus"}}}}
+    bare = resolve_for_launch("project:tuned", tree=tmp_path, templates={"tuned": defn})
+    assert bare == "tuned"
+    seeded = tmp_path / ".claude" / "templates" / "tuned" / "template.json"
+    assert seeded.exists()
+    data = json.loads(seeded.read_text())
+    assert data["id"] == "tuned"
+    assert data["config"]["agents"]["implementer"]["model"] == "opus"
+
+
+def test_user_template_seeded_to_isolated_dir(tmp_path: Path):
+    user_dir = tmp_path / "user_templates"
+    bare = resolve_for_launch(
+        "user:foo", tree=tmp_path, templates={"foo": {"config": {}}},
+        user_templates_dir=user_dir,
+    )
+    assert bare == "foo"
+    assert (user_dir / "foo" / "template.json").exists()
+
+
+def test_missing_definition_raises(tmp_path: Path):
+    with pytest.raises(TemplateRefError):
+        resolve_for_launch("project:absent", tree=tmp_path, templates={})

--- a/worca-bench/tests/test_templates.py
+++ b/worca-bench/tests/test_templates.py
@@ -51,6 +51,57 @@ def test_user_template_seeded_to_isolated_dir(tmp_path: Path):
     assert (user_dir / "foo" / "template.json").exists()
 
 
-def test_missing_definition_raises(tmp_path: Path):
+def test_user_template_passthrough_when_present_on_host(tmp_path: Path):
+    # A `user:` ref with no profile.templates definition resolves seamlessly against
+    # an existing host template — worca's own project>user>builtin resolution finds it.
+    # worca-bench must NOT require an embedded copy, and must NOT overwrite the host one.
+    user_dir = tmp_path / "user_templates"
+    host = user_dir / "foo" / "template.json"
+    host.parent.mkdir(parents=True)
+    host.write_text(json.dumps({"id": "foo", "name": "Host Foo", "config": {"x": 1}}))
+
+    bare = resolve_for_launch(
+        "user:foo", tree=tmp_path, templates={}, user_templates_dir=user_dir
+    )
+    assert bare == "foo"
+    # untouched — no copy / overwrite from the (empty) profile templates
+    data = json.loads(host.read_text())
+    assert data["name"] == "Host Foo"
+    assert data["config"] == {"x": 1}
+
+
+def test_project_template_passthrough_when_present_in_tree(tmp_path: Path):
+    # Same seamless fallback for the project tier: an on-disk template in the work
+    # tree is used as-is when the profile carries no definition.
+    existing = tmp_path / ".claude" / "templates" / "tuned" / "template.json"
+    existing.parent.mkdir(parents=True)
+    existing.write_text(json.dumps({"id": "tuned", "config": {"agents": {}}}))
+
+    bare = resolve_for_launch("project:tuned", tree=tmp_path, templates={})
+    assert bare == "tuned"
+    assert json.loads(existing.read_text())["id"] == "tuned"  # untouched
+
+
+def test_explicit_definition_overrides_on_disk_template(tmp_path: Path):
+    # When a profile DOES carry a definition, it materializes (overrides) the host copy
+    # — preserving the self-contained / CI path for isolated hosts.
+    user_dir = tmp_path / "user_templates"
+    host = user_dir / "foo" / "template.json"
+    host.parent.mkdir(parents=True)
+    host.write_text(json.dumps({"id": "foo", "name": "Stale Host", "config": {}}))
+
+    bare = resolve_for_launch(
+        "user:foo", tree=tmp_path,
+        templates={"foo": {"name": "Profile Foo", "config": {"y": 2}}},
+        user_templates_dir=user_dir,
+    )
+    assert bare == "foo"
+    data = json.loads(host.read_text())
+    assert data["name"] == "Profile Foo"
+    assert data["config"] == {"y": 2}
+
+
+def test_missing_definition_and_no_on_disk_raises(tmp_path: Path):
+    # Neither an embedded definition nor an existing on-disk template -> hard error.
     with pytest.raises(TemplateRefError):
         resolve_for_launch("project:absent", tree=tmp_path, templates={})

--- a/worca-bench/tests/test_venvs.py
+++ b/worca-bench/tests/test_venvs.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from worca_bench.config import WorcaRef
+from worca_bench.venvs import _pip_target, _ref_hash, resolve_worca_env
+
+
+def test_ref_hash_stable_and_distinct():
+    a = _ref_hash(WorcaRef(ref="master"))
+    b = _ref_hash(WorcaRef(ref="master"))
+    c = _ref_hash(WorcaRef(ref="v0.58.0"))
+    assert a == b
+    assert a != c
+
+
+def test_pip_target_version_pin():
+    assert _pip_target(WorcaRef(ref="0.58.0")) == "worca-cc==0.58.0"
+
+
+def test_pip_target_git_ref():
+    target = _pip_target(WorcaRef(ref="my-branch"))
+    assert target.startswith("git+https://github.com/SinishaDjukic/worca-cc@")
+    assert target.endswith("my-branch")
+
+
+def test_pip_target_path_source():
+    target = _pip_target(WorcaRef(ref="x", source="path:/tmp/worca"))
+    assert target == "/tmp/worca"
+
+
+def test_resolve_local_without_build(tmp_path: Path):
+    # build=False must never create a venv or hit the network.
+    env = resolve_worca_env(WorcaRef(ref="local"), tmp_path, build=False)
+    assert env.ref == "local"
+    assert "PYTHONPATH" in env.env_overrides
+    assert not (tmp_path / "cache" / "venvs").exists()
+
+
+def test_resolve_non_local_no_build_describes(tmp_path: Path):
+    env = resolve_worca_env(WorcaRef(ref="master"), tmp_path, build=False)
+    assert env.ref == "master"
+    # no venv built
+    assert not (tmp_path / "cache" / "venvs" / "master").exists()

--- a/worca-bench/tests/test_worca_install.py
+++ b/worca-bench/tests/test_worca_install.py
@@ -63,3 +63,11 @@ def test_collect_secret_env_picks_known_keys():
     env = {"ANTHROPIC_API_KEY": "k", "RANDOM": "v", "ANTHROPIC_BASE_URL": "u"}
     got = collect_secret_env(env)
     assert got == {"ANTHROPIC_API_KEY": "k", "ANTHROPIC_BASE_URL": "u"}
+
+
+def test_collect_secret_env_includes_grader_credentials():
+    env = {"SWEBENCH_API_KEY": "swb", "MODAL_TOKEN_ID": "mid",
+           "MODAL_TOKEN_SECRET": "msec", "RANDOM": "v"}
+    got = collect_secret_env(env)
+    assert got == {"SWEBENCH_API_KEY": "swb", "MODAL_TOKEN_ID": "mid",
+                   "MODAL_TOKEN_SECRET": "msec"}

--- a/worca-bench/tests/test_worca_install.py
+++ b/worca-bench/tests/test_worca_install.py
@@ -71,3 +71,21 @@ def test_collect_secret_env_includes_grader_credentials():
     got = collect_secret_env(env)
     assert got == {"SWEBENCH_API_KEY": "swb", "MODAL_TOKEN_ID": "mid",
                    "MODAL_TOKEN_SECRET": "msec"}
+
+
+def test_collect_secret_env_extra_overlays_environment():
+    env = {"SWEBENCH_API_KEY": "from-env"}
+    # An explicit extra (CLI flag / browser-forwarded) wins over the environment.
+    got = collect_secret_env(env, extra={"SWEBENCH_API_KEY": "from-flag",
+                                         "MODAL_TOKEN_ID": "mid"})
+    assert got == {"SWEBENCH_API_KEY": "from-flag", "MODAL_TOKEN_ID": "mid"}
+
+
+def test_collect_secret_env_extra_is_allowlisted_and_ignores_blanks():
+    env = {"SWEBENCH_API_KEY": "real"}
+    got = collect_secret_env(
+        env,
+        # Unknown key dropped; blank value must not shadow the env value.
+        extra={"NOT_A_SECRET": "x", "SWEBENCH_API_KEY": ""},
+    )
+    assert got == {"SWEBENCH_API_KEY": "real"}

--- a/worca-bench/tests/test_worca_install.py
+++ b/worca-bench/tests/test_worca_install.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from worca_bench.worca_install import (
+    collect_secret_env,
+    deep_merge,
+    load_overlay,
+    seed_settings,
+)
+
+
+def test_deep_merge_nested():
+    base = {"worca": {"models": {"opus": "x"}, "stages": {"plan": {"enabled": True}}}}
+    overlay = {"worca": {"models": {"sonnet": "y"}, "stages": {"pr": {"defer": True}}}}
+    merged = deep_merge(base, overlay)
+    assert merged["worca"]["models"] == {"opus": "x", "sonnet": "y"}
+    assert merged["worca"]["stages"]["plan"]["enabled"] is True
+    assert merged["worca"]["stages"]["pr"]["defer"] is True
+
+
+def test_deep_merge_skips_underscore_keys():
+    merged = deep_merge({"a": 1}, {"_comment": "ignore", "b": 2})
+    assert merged == {"a": 1, "b": 2}
+
+
+def test_load_overlay_default_minimal():
+    overlay = load_overlay(None)
+    assert isinstance(overlay, dict)  # default ships empty worca overlay
+
+
+def test_seed_settings_minimal_surface(tmp_path: Path):
+    tree = tmp_path / "repo"
+    (tree / ".claude").mkdir(parents=True)
+    # version self-seeded a base settings.json
+    (tree / ".claude" / "settings.json").write_text(
+        json.dumps({"worca": {"stages": {"plan": {"enabled": True}}}}),
+        encoding="utf-8",
+    )
+    seed_settings(
+        tree,
+        overlay={"models": {"opus": "claude-opus-4-8"}},
+        extra_settings={"models": {"sonnet": "claude-sonnet-4-6"}},
+        pr_defer=True,
+        secret_env={"ANTHROPIC_API_KEY": "sk-test"},
+    )
+    settings = json.loads((tree / ".claude" / "settings.json").read_text())
+    # base preserved
+    assert settings["worca"]["stages"]["plan"]["enabled"] is True
+    # overlay + extra merged
+    assert settings["worca"]["models"] == {"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-4-6"}
+    # pr.defer injected
+    assert settings["worca"]["stages"]["pr"]["defer"] is True
+    # secret NOT in settings.json
+    assert "ANTHROPIC_API_KEY" not in json.dumps(settings)
+    # secret IS in settings.local.json
+    local = json.loads((tree / ".claude" / "settings.local.json").read_text())
+    assert local["worca"]["_bench_secret_env"]["ANTHROPIC_API_KEY"] == "sk-test"
+
+
+def test_collect_secret_env_picks_known_keys():
+    env = {"ANTHROPIC_API_KEY": "k", "RANDOM": "v", "ANTHROPIC_BASE_URL": "u"}
+    got = collect_secret_env(env)
+    assert got == {"ANTHROPIC_API_KEY": "k", "ANTHROPIC_BASE_URL": "u"}

--- a/worca-bench/vitest.config.js
+++ b/worca-bench/vitest.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Exclude Playwright e2e tests from Vitest runs.
+    exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**'],
+    environmentMatchGlobs: [['app/**/*.test.js', 'jsdom']],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      reportsDirectory: './coverage-out',
+      include: ['app/**/*.js', 'server/**/*.js', 'bin/**/*.js'],
+      exclude: [
+        '**/*.test.js',
+        'app/main.bundle.js',
+        'app/main.bundle.js.map',
+        'app/vendor/**',
+        'scripts/**',
+        'e2e/**',
+      ],
+    },
+  },
+});

--- a/worca-bench/worca_bench/__init__.py
+++ b/worca-bench/worca_bench/__init__.py
@@ -1,0 +1,11 @@
+"""worca-bench — config-evaluation harness for worca pipelines (W-075).
+
+A version-agnostic orchestrator that evaluates any worca version/branch/commit
+against external coding benchmarks (SWE-bench Verified, Commit0). It NEVER imports
+worca — it provisions an isolated venv per ref and shells out to that venv's
+``run_pipeline``. See docs/plans/W-075-worca-bench.md.
+"""
+
+__version__ = "0.1.0"
+
+RESULTS_SCHEMA_VERSION = 1

--- a/worca-bench/worca_bench/actions.py
+++ b/worca-bench/worca_bench/actions.py
@@ -1,0 +1,125 @@
+"""Actions ledger — CLI-first lifecycle recording for the Activity dock.
+
+Every Run/Regrade launch records its OWN lifecycle to an append-only
+``<target>/actions.jsonl`` — the same ledger the dashboard reads. Because the CLI
+owns this (start → progress → terminal status in a ``finally``), a run/regrade
+launched from the CLI, cron, or CI shows up in the dock exactly like a UI-launched
+one — and the terminal state is the *real* outcome (completed vs failed), not the
+server guessing from pid liveness.
+
+The on-disk format matches ``server/actions-store.js``: one JSON object per line,
+latest-record-per-``id`` wins, so a lifecycle transition is just another append.
+The server reads/reconciles/stops; it no longer writes the ledger. ``source_dir``
+(the result dir) is recorded so the server can backfill ``src`` with its own
+``srcHash`` — avoiding a JS/Python hash-string mismatch.
+
+All writes are best-effort: a ledger failure must never crash or fail a run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _file(target_dir: Path) -> Path:
+    return Path(target_dir) / "actions.jsonl"
+
+
+def _append(target_dir: Path, rec: dict[str, Any]) -> None:
+    try:
+        path = _file(target_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(rec) + "\n")
+    except OSError:
+        # A ledger write must never break the run it's describing.
+        pass
+
+
+def start(
+    target_dir: Path,
+    *,
+    kind: str,
+    profile: str,
+    source_dir: Path | str | None = None,
+    params: dict[str, Any] | None = None,
+    started_at: str | None = None,
+) -> str:
+    """Record a launch as ``running`` and return its action id.
+
+    ``kind`` is ``"run"`` or ``"regrade"``. The id embeds the pid so the server's
+    in-memory spawn overlay can match this record by pid and drop its synthetic
+    placeholder once the CLI takes over.
+    """
+    started = started_at or _now()
+    pid = os.getpid()
+    try:
+        ms = int(datetime.fromisoformat(started).timestamp() * 1000)
+    except ValueError:
+        ms = 0
+    aid = f"{kind}-{profile}-{pid}-{ms}"
+    _append(target_dir, {
+        "id": aid,
+        "type": kind,
+        "profile": profile,
+        "source_dir": str(Path(source_dir).resolve()) if source_dir else None,
+        "src": None,  # server backfills via srcHash(source_dir)
+        "pid": pid,
+        "params": params or {},
+        "status": "running",
+        "started_at": started,
+        "updated_at": started,
+    })
+    return aid
+
+
+def progress(
+    target_dir: Path,
+    action_id: str,
+    *,
+    done: int,
+    total: int | None = None,
+    errors: int = 0,
+    unit: str = "instances",
+) -> None:
+    """Patch live progress for a running action."""
+    if not action_id:
+        return
+    _append(target_dir, {
+        "id": action_id,
+        "progress": {"unit": unit, "done": done, "total": total, "errors": errors},
+        "updated_at": _now(),
+    })
+
+
+def finish(
+    target_dir: Path,
+    action_id: str,
+    *,
+    status: str,
+    error: str | None = None,
+    progress: dict[str, Any] | None = None,
+) -> None:
+    """Write the terminal record (``completed`` | ``failed``) for an action."""
+    if not action_id:
+        return
+    ended = _now()
+    rec: dict[str, Any] = {
+        "id": action_id,
+        "status": status,
+        "ended_at": ended,
+        "updated_at": ended,
+    }
+    if error:
+        rec["error"] = error[:400]
+    if progress is not None:
+        rec["progress"] = progress
+    _append(target_dir, rec)

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -109,8 +109,16 @@ def cmd_run(args: argparse.Namespace) -> int:
     if cmm is not None:
         profile.claude_md_mode = cmm
     # Grade backend override (UI Run options dropdown). Absent => profile default.
+    # Validated against the benchmark's supported set (commit0 has no sb-cli).
     gm = getattr(args, "grade_mode", None)
     if gm is not None:
+        from .config import valid_grade_modes
+        allowed = valid_grade_modes(profile.benchmark)
+        if gm not in allowed:
+            print(f"--grade-mode {gm!r} is not valid for benchmark "
+                  f"{profile.benchmark!r}; use one of {sorted(allowed)}",
+                  file=sys.stderr)
+            return 2
         profile.grade.mode = gm
     # Benchmark cache (HF datasets / repo mirrors): flag wins, else env, else None.
     cache_dir = getattr(args, "cache_dir", None) or os.environ.get("WORCA_BENCH_CACHE")
@@ -297,6 +305,28 @@ def cmd_regrade(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_commit0_gen(args: argparse.Namespace) -> int:
+    """Set up a Commit0 split and write its instances file (the input a commit0
+    profile's ``selection.instances_file`` points at)."""
+    from .commit0_gen import generate_instances
+
+    base_dir = Path(args.base_dir)
+    out_path = Path(args.out)
+    records = generate_instances(
+        args.split,
+        base_dir=base_dir,
+        out_path=out_path,
+        config_file=Path(args.config_file) if args.config_file else None,
+        dataset_name=args.dataset_name,
+        dataset_split=args.dataset_split,
+        base_branch=args.base_branch,
+        run_setup=not args.skip_setup,
+    )
+    print(json.dumps({"instances": len(records), "out": str(out_path),
+                      "libs": [r["lib"] for r in records]}, indent=2))
+    return 0
+
+
 def cmd_stats(args: argparse.Namespace) -> int:
     rows = read_rows(Path(args.target_dir))
     if args.profile:
@@ -369,6 +399,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="grade one rep at a time (ignore concurrency.grade) — e.g. a whole-profile Modal sweep")
     _add_secret_flags(p_regrade)
     p_regrade.set_defaults(func=cmd_regrade)
+
+    p_c0 = sub.add_parser(
+        "commit0-gen",
+        help="set up a Commit0 split and write its instances file (for a commit0 profile)")
+    p_c0.add_argument("split", help="Commit0 split or single library name (e.g. wcwidth, lite, all)")
+    p_c0.add_argument("--base-dir", required=True, help="dir to clone Commit0 repos into")
+    p_c0.add_argument("--out", required=True, help="path to write the instances JSON")
+    p_c0.add_argument("--config-file", help="commit0 dot-file path (default: <base-dir>/../.commit0.yaml)")
+    p_c0.add_argument("--dataset-name", default="wentingzhao/commit0_combined",
+                      help="HuggingFace dataset name")
+    p_c0.add_argument("--dataset-split", default="test", help="HuggingFace dataset split")
+    p_c0.add_argument("--base-branch", default="commit0",
+                      help="skeleton branch commit0 setup checks out (default: commit0)")
+    p_c0.add_argument("--skip-setup", action="store_true",
+                      help="skip `commit0 setup` (repos already cloned under --base-dir)")
+    p_c0.set_defaults(func=cmd_commit0_gen)
 
     p_stats = sub.add_parser("stats", help="aggregate results.jsonl")
     p_stats.add_argument("--target-dir", required=True)

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -13,7 +13,7 @@ import os
 import sys
 from pathlib import Path
 
-from .config import Profile, find_profile, load_profile
+from .config import EngineConfig, Profile, find_profile, load_profile
 from .normalize import read_rows
 from .runner import run_profile
 from .stats import aggregate, aggregate_by_profile
@@ -51,6 +51,18 @@ def cmd_run(args: argparse.Namespace) -> int:
             print("--reps must be >= 1", file=sys.stderr)
             return 2
         profile.reps = reps_override
+    # Code-graph engines: a CLI flag enables the engine (and sets its mode),
+    # overriding the profile. Absent flag => leave the profile's setting (off by
+    # default). graphify mode is validated; CRG mode passes through.
+    gfx = getattr(args, "graphify", None)
+    if gfx is not None:
+        if gfx not in ("structural", "full"):
+            print("--graphify mode must be 'structural' or 'full'", file=sys.stderr)
+            return 2
+        profile.graphify = EngineConfig(enabled=True, mode=gfx)
+    crg = getattr(args, "code_review_graph", None)
+    if crg is not None:
+        profile.code_review_graph = EngineConfig(enabled=True, mode=crg)
     # Benchmark cache (HF datasets / repo mirrors): flag wins, else env, else None.
     cache_dir = getattr(args, "cache_dir", None) or os.environ.get("WORCA_BENCH_CACHE")
     summary = run_profile(
@@ -119,6 +131,15 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--max-instances", type=int, help="cap instances (smoke runs)")
     p_run.add_argument("--reps", type=int, help="override the profile's reps for this run")
     p_run.add_argument("--cache-dir", help="benchmark cache dir (HF datasets / repo mirrors)")
+    p_run.add_argument(
+        "--graphify", nargs="?", const="structural", metavar="MODE",
+        help="enable graphify (mode: structural|full; default structural)",
+    )
+    p_run.add_argument(
+        "--code-review-graph", "--crg", nargs="?", const="structural", metavar="MODE",
+        dest="code_review_graph",
+        help="enable code-review-graph (mode passthrough; default structural)",
+    )
     p_run.add_argument("--keep-work", action="store_true", help="keep per-rep worktrees")
     p_run.set_defaults(func=cmd_run)
 

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -99,6 +99,15 @@ def cmd_run(args: argparse.Namespace) -> int:
     crg = getattr(args, "code_review_graph", None)
     if crg is not None:
         profile.code_review_graph = EngineConfig(enabled=True, mode=crg)
+    # Preflight on/off override (UI Run option). Preflight is where graphify/CRG
+    # graphs build, so an engine sweep needs it ON; the hermetic default is OFF.
+    pf = getattr(args, "preflight", None)
+    if pf is not None:
+        profile.skip_preflight = (pf == "off")
+    # CLAUDE.md load mode override (UI dropdown; default hermetic 'none').
+    cmm = getattr(args, "claude_md_mode", None)
+    if cmm is not None:
+        profile.claude_md_mode = cmm
     # Benchmark cache (HF datasets / repo mirrors): flag wins, else env, else None.
     cache_dir = getattr(args, "cache_dir", None) or os.environ.get("WORCA_BENCH_CACHE")
     # Grader credentials: environment + CLI-flag overlay (allowlist-enforced).
@@ -319,6 +328,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="enable code-review-graph (mode passthrough; default structural)",
     )
     p_run.add_argument("--keep-work", action="store_true", help="keep per-rep worktrees")
+    p_run.add_argument(
+        "--preflight", choices=["on", "off"],
+        help="run preflight (builds graphify/CRG graphs) or skip it; overrides the profile")
+    p_run.add_argument(
+        "--claude-md-mode", dest="claude_md_mode",
+        choices=["none", "project", "project+local", "all"],
+        help="CLAUDE.md load mode for the run; overrides the profile")
     _add_secret_flags(p_run)
     p_run.set_defaults(func=cmd_run)
 

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -108,6 +108,15 @@ def cmd_run(args: argparse.Namespace) -> int:
     cmm = getattr(args, "claude_md_mode", None)
     if cmm is not None:
         profile.claude_md_mode = cmm
+    # Canary on/off override (UI Run option). The profile's `canary` flag is the
+    # default; an explicit `--canary on|off` overrides it, and `--no-canary` is a
+    # back-compat alias for off. This is resolved into `canary_first` below.
+    canary = profile.canary
+    cf = getattr(args, "canary", None)
+    if cf is not None:
+        canary = (cf == "on")
+    if getattr(args, "no_canary", False):
+        canary = False
     # Grade backend override (UI Run options dropdown). Absent => profile default.
     # Validated against the benchmark's supported set (commit0 has no sb-cli).
     gm = getattr(args, "grade_mode", None)
@@ -128,7 +137,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     summary = run_profile(
         profile, target,
         dry_run=args.dry_run,
-        canary_first=not args.no_canary,
+        canary_first=canary,
         max_instances=args.max_instances,
         keep_work=args.keep_work,
         cache_dir=Path(cache_dir) if cache_dir else None,
@@ -346,7 +355,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--target-dir", required=True, help="dir for clones/results/artifacts")
     p_run.add_argument("--profiles-dir", help="extra dir to search for profiles")
     p_run.add_argument("--dry-run", action="store_true", help="resolve + plan, do not run")
-    p_run.add_argument("--no-canary", action="store_true", help="skip the per-template canary")
+    p_run.add_argument(
+        "--canary", choices=["on", "off"],
+        help="run the per-template canary or skip it; overrides the profile's canary flag")
+    p_run.add_argument("--no-canary", action="store_true",
+                       help="back-compat alias for --canary off")
     p_run.add_argument("--max-instances", type=int, help="cap instances (smoke runs)")
     p_run.add_argument("--max-parallel", type=int,
                        help="override pipeline parallelism for this run (concurrency.worca)")

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -108,6 +108,10 @@ def cmd_run(args: argparse.Namespace) -> int:
     cmm = getattr(args, "claude_md_mode", None)
     if cmm is not None:
         profile.claude_md_mode = cmm
+    # Grade backend override (UI Run options dropdown). Absent => profile default.
+    gm = getattr(args, "grade_mode", None)
+    if gm is not None:
+        profile.grade.mode = gm
     # Benchmark cache (HF datasets / repo mirrors): flag wins, else env, else None.
     cache_dir = getattr(args, "cache_dir", None) or os.environ.get("WORCA_BENCH_CACHE")
     # Grader credentials: environment + CLI-flag overlay (allowlist-enforced).
@@ -335,6 +339,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--claude-md-mode", dest="claude_md_mode",
         choices=["none", "project", "project+local", "all"],
         help="CLAUDE.md load mode for the run; overrides the profile")
+    p_run.add_argument(
+        "--grade-mode", dest="grade_mode",
+        choices=["stub", "sb-cli", "local-docker", "modal"],
+        help="grade backend for the run; overrides the profile's grade.mode")
     _add_secret_flags(p_run)
     p_run.set_defaults(func=cmd_run)
 

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -43,6 +43,13 @@ def _resolve_profile(name_or_path: str, target_dir: Path | None,
 def cmd_run(args: argparse.Namespace) -> int:
     target = Path(args.target_dir)
     profile = _resolve_profile(args.profile, target, args.profiles_dir)
+    # Per-run override of the profile's reps (e.g. from the UI launch controls).
+    reps_override = getattr(args, "reps", None)
+    if reps_override is not None:
+        if reps_override < 1:
+            print("--reps must be >= 1", file=sys.stderr)
+            return 2
+        profile.reps = reps_override
     summary = run_profile(
         profile, target,
         dry_run=args.dry_run,
@@ -106,6 +113,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--dry-run", action="store_true", help="resolve + plan, do not run")
     p_run.add_argument("--no-canary", action="store_true", help="skip the per-template canary")
     p_run.add_argument("--max-instances", type=int, help="cap instances (smoke runs)")
+    p_run.add_argument("--reps", type=int, help="override the profile's reps for this run")
     p_run.add_argument("--keep-work", action="store_true", help="keep per-rep worktrees")
     p_run.set_defaults(func=cmd_run)
 

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -1,0 +1,131 @@
+"""worca-bench CLI (W-075).
+
+    worca-bench run    --profile NAME --target-dir DIR [--dry-run] [--no-canary]
+    worca-bench list   [--profiles-dir DIR]
+    worca-bench stats  --target-dir DIR [--profile NAME]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .config import Profile, find_profile, load_profile
+from .normalize import read_rows
+from .runner import run_profile
+from .stats import aggregate, aggregate_by_profile
+
+
+def _default_profile_dirs(target_dir: Path | None) -> list[Path]:
+    dirs: list[Path] = []
+    if target_dir:
+        dirs.append(Path(target_dir) / "profiles")
+    dirs.append(Path.cwd() / "profiles")
+    # in-tree profiles shipped with worca-bench
+    dirs.append(Path(__file__).resolve().parents[1] / "profiles")
+    return [d for d in dirs if d.exists()]
+
+
+def _resolve_profile(name_or_path: str, target_dir: Path | None,
+                     profiles_dir: str | None) -> Profile:
+    p = Path(name_or_path)
+    if p.exists():
+        return load_profile(p)
+    search = []
+    if profiles_dir:
+        search.append(Path(profiles_dir))
+    search.extend(_default_profile_dirs(target_dir))
+    return find_profile(name_or_path, search)
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    target = Path(args.target_dir)
+    profile = _resolve_profile(args.profile, target, args.profiles_dir)
+    summary = run_profile(
+        profile, target,
+        dry_run=args.dry_run,
+        canary_first=not args.no_canary,
+        max_instances=args.max_instances,
+        keep_work=args.keep_work,
+    )
+    if args.dry_run:
+        print(f"[dry-run] profile={summary.profile} worca={summary.worca_ref} "
+              f"reps={summary.reps_total}")
+    else:
+        print(json.dumps(summary.as_dict(), indent=2))
+        if summary.incompatible_templates:
+            print("\nincompatible templates (skipped):", file=sys.stderr)
+            for t, why in summary.incompatible_templates.items():
+                print(f"  {t}: {why}", file=sys.stderr)
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    dirs = []
+    if args.profiles_dir:
+        dirs.append(Path(args.profiles_dir))
+    dirs.extend(_default_profile_dirs(None))
+    seen: set[str] = set()
+    for d in dirs:
+        for f in sorted(d.glob("*.y*ml")):
+            try:
+                prof = load_profile(f)
+            except Exception as e:  # noqa: BLE001
+                print(f"  ! {f.name}: {e}", file=sys.stderr)
+                continue
+            if prof.name in seen:
+                continue
+            seen.add(prof.name)
+            print(f"  {prof.name:30s} {prof.benchmark:20s} reps={prof.reps} "
+                  f"worca={prof.worca.ref} template={prof.template}")
+    if not seen:
+        print("(no profiles found)")
+    return 0
+
+
+def cmd_stats(args: argparse.Namespace) -> int:
+    rows = read_rows(Path(args.target_dir))
+    if args.profile:
+        rows = [r for r in rows if r.get("profile") == args.profile]
+        print(json.dumps({args.profile: aggregate(rows)}, indent=2))
+    else:
+        print(json.dumps(aggregate_by_profile(rows), indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="worca-bench", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_run = sub.add_parser("run", help="run a profile")
+    p_run.add_argument("--profile", required=True, help="profile name or path")
+    p_run.add_argument("--target-dir", required=True, help="dir for clones/results/artifacts")
+    p_run.add_argument("--profiles-dir", help="extra dir to search for profiles")
+    p_run.add_argument("--dry-run", action="store_true", help="resolve + plan, do not run")
+    p_run.add_argument("--no-canary", action="store_true", help="skip the per-template canary")
+    p_run.add_argument("--max-instances", type=int, help="cap instances (smoke runs)")
+    p_run.add_argument("--keep-work", action="store_true", help="keep per-rep worktrees")
+    p_run.set_defaults(func=cmd_run)
+
+    p_list = sub.add_parser("list", help="list available profiles")
+    p_list.add_argument("--profiles-dir", help="extra dir to search for profiles")
+    p_list.set_defaults(func=cmd_list)
+
+    p_stats = sub.add_parser("stats", help="aggregate results.jsonl")
+    p_stats.add_argument("--target-dir", required=True)
+    p_stats.add_argument("--profile", help="limit to one profile")
+    p_stats.set_defaults(func=cmd_stats)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -217,6 +217,19 @@ def cmd_regrade(args: argparse.Namespace) -> int:
         print("no matching rows to regrade", file=sys.stderr)
         return 1
 
+    # Full instances carry the per-benchmark grading metadata a bare Instance(id=)
+    # lacks — notably the commit0 config block (base_dir/config_file), local_repo, and
+    # gold_test_paths, without which commit0 grading errors ("needs the 'commit0'
+    # config block"). Enrich from the instances_file when the profile has one (commit0
+    # always does; SWE-bench may). No file => bare instance, since id-keyed graders
+    # (SWE-bench sb-cli/docker) need only the id.
+    instances_by_id: dict[str, Instance] = {}
+    if profile.selection.instances_file:
+        try:
+            instances_by_id = {i.id: i for i in plugin.load_instances(profile)}
+        except Exception:  # noqa: BLE001 - never let instance-load failure abort regrade
+            instances_by_id = {}
+
     def _regrade_one(row: dict):
         iid = row["instance_id"]
         rep = row.get("rep")
@@ -226,7 +239,7 @@ def cmd_regrade(args: argparse.Namespace) -> int:
             return iid, rep, GradeResult(status="error",
                                          detail=f"no diff.patch at {diff_path}")
         diff = diff_path.read_text(encoding="utf-8")
-        inst = Instance(id=iid, prompt="")
+        inst = instances_by_id.get(iid) or Instance(id=iid, prompt="")
         try:
             gr = plugin.grade(inst, diff, target, target, grade_cfg,
                               prepared=Prepared(base_commit=""), secret_env=secret_env)

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -50,12 +51,15 @@ def cmd_run(args: argparse.Namespace) -> int:
             print("--reps must be >= 1", file=sys.stderr)
             return 2
         profile.reps = reps_override
+    # Benchmark cache (HF datasets / repo mirrors): flag wins, else env, else None.
+    cache_dir = getattr(args, "cache_dir", None) or os.environ.get("WORCA_BENCH_CACHE")
     summary = run_profile(
         profile, target,
         dry_run=args.dry_run,
         canary_first=not args.no_canary,
         max_instances=args.max_instances,
         keep_work=args.keep_work,
+        cache_dir=Path(cache_dir) if cache_dir else None,
     )
     if args.dry_run:
         print(f"[dry-run] profile={summary.profile} worca={summary.worca_ref} "
@@ -114,6 +118,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--no-canary", action="store_true", help="skip the per-template canary")
     p_run.add_argument("--max-instances", type=int, help="cap instances (smoke runs)")
     p_run.add_argument("--reps", type=int, help="override the profile's reps for this run")
+    p_run.add_argument("--cache-dir", help="benchmark cache dir (HF datasets / repo mirrors)")
     p_run.add_argument("--keep-work", action="store_true", help="keep per-rep worktrees")
     p_run.set_defaults(func=cmd_run)
 

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -161,6 +161,7 @@ def cmd_regrade(args: argparse.Namespace) -> int:
 
     from .plugins import get_plugin
     from .plugins.base import GradeResult, Instance, Prepared
+    from .regrade_status import write_status
     from .worca_install import collect_secret_env
 
     target = Path(args.target_dir)
@@ -198,40 +199,88 @@ def cmd_regrade(args: argparse.Namespace) -> int:
             gr = GradeResult(status="error", detail=f"regrade error: {e}")
         return iid, rep, gr
 
-    workers = max(1, profile.concurrency.grade)
-    verdicts: dict[tuple, GradeResult] = {}
-    with ThreadPoolExecutor(max_workers=workers) as ex:
-        futs = [ex.submit(_regrade_one, r) for r in sel]
-        for fut in as_completed(futs):
-            iid, rep, gr = fut.result()
-            verdicts[(iid, rep)] = gr
-    for (iid, rep), gr in sorted(verdicts.items(), key=lambda kv: str(kv[0])):
+    # Sequential mode grades one rep at a time — used by the dashboard "Regrade
+    # All" so a 20-instance Modal sweep doesn't fire 20 harness builds at once.
+    workers = 1 if getattr(args, "sequential", False) else max(1, profile.concurrency.grade)
+    total = len(sel)
+    counts = {"graded": 0, "resolved": 0, "error": 0}
+    started = _now()
+
+    def _hb(done: int, current: str | None, status: str = "running") -> None:
+        # Best-effort progress heartbeat — never let a status-write failure abort
+        # an in-flight (expensive) grade.
+        try:
+            write_status(target, profile.name, mode=mode, total=total, done=done,
+                         current=current, counts=counts, status=status,
+                         started_at=started, updated_at=_now())
+        except OSError:
+            pass
+
+    def _record(gr: GradeResult) -> None:
         if gr.status == "graded":
-            print(f"  {iid} rep{rep}: graded resolved={gr.resolved}")
+            counts["graded"] += 1
+            if gr.resolved:
+                counts["resolved"] += 1
         else:
-            print(f"  {iid} rep{rep}: {gr.status} ({gr.detail[:80]})")
+            counts["error"] += 1
 
-    now = _now()
+    def _print_one(iid: str, rep, gr: GradeResult) -> None:
+        if gr.status == "graded":
+            print(f"  {iid} rep{rep}: graded resolved={gr.resolved}", flush=True)
+        else:
+            print(f"  {iid} rep{rep}: {gr.status} ({(gr.detail or '')[:80]})", flush=True)
 
-    def _mutate(row: dict) -> bool:
-        if row.get("profile") != profile.name:
-            return False
-        gr = verdicts.get((row.get("instance_id"), row.get("rep")))
-        if gr is None:
-            return False
-        row["status"] = gr.status
-        row["resolved"] = gr.resolved
-        row["score"] = gr.score
-        row["error"] = gr.detail if gr.status == "error" else None
-        row["grade_mode"] = mode
-        row["regraded_at"] = now
-        return True
+    def _apply(iid: str, rep, gr: GradeResult) -> None:
+        # Write THIS row immediately so the dashboard reflects progress as it
+        # happens (and a mid-sweep crash never loses completed verdicts).
+        when = _now()
 
-    n = rewrite_rows(target, _mutate)
-    graded = sum(1 for gr in verdicts.values() if gr.status == "graded")
-    resolved = sum(1 for gr in verdicts.values() if gr.resolved)
-    print(f"\nregraded {n} rows via {mode}: {graded} graded "
-          f"({resolved} resolved), {len(verdicts) - graded} error")
+        def _m(row: dict) -> bool:
+            if (row.get("profile") != profile.name
+                    or row.get("instance_id") != iid or row.get("rep") != rep):
+                return False
+            row["status"] = gr.status
+            row["resolved"] = gr.resolved
+            row["score"] = gr.score
+            row["error"] = gr.detail if gr.status == "error" else None
+            row["grade_mode"] = mode
+            row["grade_detail"] = gr.detail
+            row["report_path"] = gr.report_path
+            row["regraded_at"] = when
+            row["graded_at"] = when
+            return True
+
+        rewrite_rows(target, _m)
+
+    try:
+        if workers == 1:
+            _hb(0, sel[0]["instance_id"])
+            for i, row in enumerate(sel):
+                iid, rep = row["instance_id"], row.get("rep")
+                _hb(i, iid)  # i completed; now grading iid
+                _iid, _rep, gr = _regrade_one(row)
+                _record(gr)
+                _apply(iid, rep, gr)
+                _print_one(iid, rep, gr)
+        else:
+            _hb(0, None)
+            done = 0
+            with ThreadPoolExecutor(max_workers=workers) as ex:
+                futs = [ex.submit(_regrade_one, r) for r in sel]
+                for fut in as_completed(futs):
+                    iid, rep, gr = fut.result()
+                    _record(gr)
+                    _apply(iid, rep, gr)
+                    done += 1
+                    _hb(done, None)
+                    _print_one(iid, rep, gr)
+        _hb(total, None, status="done")
+    except BaseException:
+        _hb(counts["graded"] + counts["error"], None, status="error")
+        raise
+
+    print(f"\nregraded {total} rows via {mode}: {counts['graded']} graded "
+          f"({counts['resolved']} resolved), {counts['error']} error")
     return 0
 
 
@@ -291,6 +340,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_regrade.add_argument(
         "--instance", action="append", metavar="ID",
         help="limit to specific instance id(s); repeatable")
+    p_regrade.add_argument(
+        "--sequential", action="store_true",
+        help="grade one rep at a time (ignore concurrency.grade) — e.g. a whole-profile Modal sweep")
     _add_secret_flags(p_regrade)
     p_regrade.set_defaults(func=cmd_regrade)
 

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -29,6 +29,34 @@ def _default_profile_dirs(target_dir: Path | None) -> list[Path]:
     return [d for d in dirs if d.exists()]
 
 
+# CLI flag → secret env-var name. These let an operator pass grader credentials
+# at launch instead of exporting them; the dashboard server forwards the same
+# values (held only in the browser) via the subprocess env, never argv.
+_SECRET_FLAGS = {
+    "swebench_api_key": "SWEBENCH_API_KEY",
+    "modal_token_id": "MODAL_TOKEN_ID",
+    "modal_token_secret": "MODAL_TOKEN_SECRET",
+}
+
+
+def _add_secret_flags(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--swebench-api-key", metavar="KEY",
+                   help="sb-cli (hosted SWE-bench) API key; overrides $SWEBENCH_API_KEY")
+    p.add_argument("--modal-token-id", metavar="ID",
+                   help="Modal token id; overrides $MODAL_TOKEN_ID")
+    p.add_argument("--modal-token-secret", metavar="SECRET",
+                   help="Modal token secret; overrides $MODAL_TOKEN_SECRET")
+
+
+def _cli_secret_env(args: argparse.Namespace) -> dict[str, str]:
+    """Secrets supplied as CLI flags (None when absent), keyed by env-var name."""
+    return {
+        env: getattr(args, attr)
+        for attr, env in _SECRET_FLAGS.items()
+        if getattr(args, attr, None)
+    }
+
+
 def _resolve_profile(name_or_path: str, target_dir: Path | None,
                      profiles_dir: str | None) -> Profile:
     p = Path(name_or_path)
@@ -73,6 +101,9 @@ def cmd_run(args: argparse.Namespace) -> int:
         profile.code_review_graph = EngineConfig(enabled=True, mode=crg)
     # Benchmark cache (HF datasets / repo mirrors): flag wins, else env, else None.
     cache_dir = getattr(args, "cache_dir", None) or os.environ.get("WORCA_BENCH_CACHE")
+    # Grader credentials: environment + CLI-flag overlay (allowlist-enforced).
+    from .worca_install import collect_secret_env
+    secret_env = collect_secret_env(extra=_cli_secret_env(args))
     summary = run_profile(
         profile, target,
         dry_run=args.dry_run,
@@ -80,6 +111,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         max_instances=args.max_instances,
         keep_work=args.keep_work,
         cache_dir=Path(cache_dir) if cache_dir else None,
+        secret_env=secret_env,
     )
     if args.dry_run:
         print(f"[dry-run] profile={summary.profile} worca={summary.worca_ref} "
@@ -136,7 +168,7 @@ def cmd_regrade(args: argparse.Namespace) -> int:
     mode = args.mode or profile.grade.mode
     grade_cfg = GradeConfig(mode=mode, options=dict(profile.grade.options))
     plugin = get_plugin(profile)
-    secret_env = collect_secret_env()
+    secret_env = collect_secret_env(extra=_cli_secret_env(args))
 
     rows = read_rows(target)
     sel = [r for r in rows if r.get("profile") == profile.name]
@@ -238,6 +270,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="enable code-review-graph (mode passthrough; default structural)",
     )
     p_run.add_argument("--keep-work", action="store_true", help="keep per-rep worktrees")
+    _add_secret_flags(p_run)
     p_run.set_defaults(func=cmd_run)
 
     p_list = sub.add_parser("list", help="list available profiles")
@@ -258,6 +291,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_regrade.add_argument(
         "--instance", action="append", metavar="ID",
         help="limit to specific instance id(s); repeatable")
+    _add_secret_flags(p_regrade)
     p_regrade.set_defaults(func=cmd_regrade)
 
     p_stats = sub.add_parser("stats", help="aggregate results.jsonl")

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -13,9 +13,9 @@ import os
 import sys
 from pathlib import Path
 
-from .config import EngineConfig, Profile, find_profile, load_profile
-from .normalize import read_rows
-from .runner import run_profile
+from .config import EngineConfig, GradeConfig, Profile, find_profile, load_profile
+from .normalize import read_rows, rewrite_rows
+from .runner import _artifacts_rel, _now, run_profile
 from .stats import aggregate, aggregate_by_profile
 
 
@@ -116,6 +116,93 @@ def cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_regrade(args: argparse.Namespace) -> int:
+    """Re-grade saved diffs for a profile without re-running the pipeline.
+
+    Reads each rep's persisted ``diff.patch`` from its artifacts dir, grades it
+    with the chosen backend (``--mode``, default = the profile's grade mode), and
+    rewrites the matching ``results.jsonl`` rows in place. Decouples grading from
+    the expensive agent run so a grading-env failure (or a backend switch, e.g.
+    local-docker → sb-cli) never costs another pipeline.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from .plugins import get_plugin
+    from .plugins.base import GradeResult, Instance, Prepared
+    from .worca_install import collect_secret_env
+
+    target = Path(args.target_dir)
+    profile = _resolve_profile(args.profile, target, args.profiles_dir)
+    mode = args.mode or profile.grade.mode
+    grade_cfg = GradeConfig(mode=mode, options=dict(profile.grade.options))
+    plugin = get_plugin(profile)
+    secret_env = collect_secret_env()
+
+    rows = read_rows(target)
+    sel = [r for r in rows if r.get("profile") == profile.name]
+    if args.only_errors:
+        sel = [r for r in sel if r.get("status") == "error"]
+    if args.instance:
+        want = set(args.instance)
+        sel = [r for r in sel if r.get("instance_id") in want]
+    if not sel:
+        print("no matching rows to regrade", file=sys.stderr)
+        return 1
+
+    def _regrade_one(row: dict):
+        iid = row["instance_id"]
+        rep = row.get("rep")
+        art = row.get("artifacts_dir") or _artifacts_rel(profile.name, iid, rep)
+        diff_path = target / art / "diff.patch"
+        if not diff_path.exists():
+            return iid, rep, GradeResult(status="error",
+                                         detail=f"no diff.patch at {diff_path}")
+        diff = diff_path.read_text(encoding="utf-8")
+        inst = Instance(id=iid, prompt="")
+        try:
+            gr = plugin.grade(inst, diff, target, target, grade_cfg,
+                              prepared=Prepared(base_commit=""), secret_env=secret_env)
+        except Exception as e:  # noqa: BLE001 - one rep failing must not kill regrade
+            gr = GradeResult(status="error", detail=f"regrade error: {e}")
+        return iid, rep, gr
+
+    workers = max(1, profile.concurrency.grade)
+    verdicts: dict[tuple, GradeResult] = {}
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futs = [ex.submit(_regrade_one, r) for r in sel]
+        for fut in as_completed(futs):
+            iid, rep, gr = fut.result()
+            verdicts[(iid, rep)] = gr
+    for (iid, rep), gr in sorted(verdicts.items(), key=lambda kv: str(kv[0])):
+        if gr.status == "graded":
+            print(f"  {iid} rep{rep}: graded resolved={gr.resolved}")
+        else:
+            print(f"  {iid} rep{rep}: {gr.status} ({gr.detail[:80]})")
+
+    now = _now()
+
+    def _mutate(row: dict) -> bool:
+        if row.get("profile") != profile.name:
+            return False
+        gr = verdicts.get((row.get("instance_id"), row.get("rep")))
+        if gr is None:
+            return False
+        row["status"] = gr.status
+        row["resolved"] = gr.resolved
+        row["score"] = gr.score
+        row["error"] = gr.detail if gr.status == "error" else None
+        row["grade_mode"] = mode
+        row["regraded_at"] = now
+        return True
+
+    n = rewrite_rows(target, _mutate)
+    graded = sum(1 for gr in verdicts.values() if gr.status == "graded")
+    resolved = sum(1 for gr in verdicts.values() if gr.resolved)
+    print(f"\nregraded {n} rows via {mode}: {graded} graded "
+          f"({resolved} resolved), {len(verdicts) - graded} error")
+    return 0
+
+
 def cmd_stats(args: argparse.Namespace) -> int:
     rows = read_rows(Path(args.target_dir))
     if args.profile:
@@ -156,6 +243,22 @@ def build_parser() -> argparse.ArgumentParser:
     p_list = sub.add_parser("list", help="list available profiles")
     p_list.add_argument("--profiles-dir", help="extra dir to search for profiles")
     p_list.set_defaults(func=cmd_list)
+
+    p_regrade = sub.add_parser(
+        "regrade", help="re-grade saved diffs for a profile (no pipeline re-run)")
+    p_regrade.add_argument("--profile", required=True, help="profile name or path")
+    p_regrade.add_argument("--target-dir", required=True, help="dir holding results/runs")
+    p_regrade.add_argument("--profiles-dir", help="extra dir to search for profiles")
+    p_regrade.add_argument(
+        "--mode", choices=["sb-cli", "local-docker", "modal", "stub"],
+        help="grade backend (default: the profile's grade mode)")
+    p_regrade.add_argument(
+        "--only-errors", action="store_true",
+        help="re-grade only rows currently marked error (e.g. stranded by a grading-env failure)")
+    p_regrade.add_argument(
+        "--instance", action="append", metavar="ID",
+        help="limit to specific instance id(s); repeatable")
+    p_regrade.set_defaults(func=cmd_regrade)
 
     p_stats = sub.add_parser("stats", help="aggregate results.jsonl")
     p_stats.add_argument("--target-dir", required=True)

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -51,6 +51,14 @@ def cmd_run(args: argparse.Namespace) -> int:
             print("--reps must be >= 1", file=sys.stderr)
             return 2
         profile.reps = reps_override
+    # Per-run override of worca-pipeline parallelism (UI "Max parallel" control,
+    # maps to concurrency.worca — the ThreadPoolExecutor width in the runner).
+    parallel_override = getattr(args, "max_parallel", None)
+    if parallel_override is not None:
+        if parallel_override < 1:
+            print("--max-parallel must be >= 1", file=sys.stderr)
+            return 2
+        profile.concurrency.worca = parallel_override
     # Code-graph engines: a CLI flag enables the engine (and sets its mode),
     # overriding the profile. Absent flag => leave the profile's setting (off by
     # default). graphify mode is validated; CRG mode passes through.
@@ -129,6 +137,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--dry-run", action="store_true", help="resolve + plan, do not run")
     p_run.add_argument("--no-canary", action="store_true", help="skip the per-template canary")
     p_run.add_argument("--max-instances", type=int, help="cap instances (smoke runs)")
+    p_run.add_argument("--max-parallel", type=int,
+                       help="override pipeline parallelism for this run (concurrency.worca)")
     p_run.add_argument("--reps", type=int, help="override the profile's reps for this run")
     p_run.add_argument("--cache-dir", help="benchmark cache dir (HF datasets / repo mirrors)")
     p_run.add_argument(

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -139,15 +139,49 @@ def cmd_run(args: argparse.Namespace) -> int:
     # Grader credentials: environment + CLI-flag overlay (allowlist-enforced).
     from .worca_install import collect_secret_env
     secret_env = collect_secret_env(extra=_cli_secret_env(args))
-    summary = run_profile(
-        profile, target,
-        dry_run=args.dry_run,
-        canary_first=canary,
-        max_instances=args.max_instances,
-        keep_work=args.keep_work,
-        cache_dir=Path(cache_dir) if cache_dir else None,
-        secret_env=secret_env,
-    )
+
+    # Activity-dock ledger: the CLI owns its own lifecycle so a run launched from
+    # the CLI / cron / CI shows up in the dock just like a UI-launched one. The
+    # source dir (= the result dir) lets the server backfill `src`. Skipped for
+    # dry-run (nothing actually executes).
+    from . import actions
+    action_id = None
+    if not args.dry_run:
+        action_id = actions.start(
+            target, kind="run", profile=profile.name, source_dir=target,
+            params={
+                "reps": profile.reps,
+                "max_instances": args.max_instances,
+                "timeout": profile.timeout,
+            },
+        )
+
+    def _progress(*, done, total, errors):
+        actions.progress(target, action_id, done=done, total=total, errors=errors)
+
+    try:
+        summary = run_profile(
+            profile, target,
+            dry_run=args.dry_run,
+            canary_first=canary,
+            max_instances=args.max_instances,
+            keep_work=args.keep_work,
+            cache_dir=Path(cache_dir) if cache_dir else None,
+            secret_env=secret_env,
+            progress_cb=(_progress if action_id else None),
+        )
+    except BaseException as e:  # noqa: BLE001 - record terminal state then re-raise
+        if action_id:
+            actions.finish(target, action_id, status="failed", error=str(e))
+        raise
+    if action_id:
+        actions.finish(
+            target, action_id, status="completed",
+            progress={
+                "unit": "instances", "done": len(summary.results),
+                "total": summary.reps_total, "errors": summary.reps_error,
+            },
+        )
     if args.dry_run:
         print(f"[dry-run] profile={summary.profile} worca={summary.worca_ref} "
               f"reps={summary.reps_total}")
@@ -254,6 +288,16 @@ def cmd_regrade(args: argparse.Namespace) -> int:
     counts = {"graded": 0, "resolved": 0, "error": 0}
     started = _now()
 
+    # Activity-dock ledger (CLI-first): the regrade records its own lifecycle so a
+    # CLI/cron-launched sweep shows up in the dock too. The regrade-status.json
+    # heartbeat below still powers the per-profile detail block.
+    from . import actions
+    action_id = actions.start(
+        target, kind="regrade", profile=profile.name, source_dir=target,
+        params={"mode": mode, "instance": getattr(args, "instance", None),
+                "only_errors": bool(getattr(args, "only_errors", False))},
+    )
+
     def _hb(done: int, current: str | None, status: str = "running") -> None:
         # Best-effort progress heartbeat — never let a status-write failure abort
         # an in-flight (expensive) grade.
@@ -263,6 +307,9 @@ def cmd_regrade(args: argparse.Namespace) -> int:
                          started_at=started, updated_at=_now())
         except OSError:
             pass
+        if status == "running":
+            actions.progress(target, action_id, done=done, total=total,
+                             errors=counts["error"], unit="regraded")
 
     def _record(gr: GradeResult) -> None:
         if gr.status == "graded":
@@ -323,9 +370,15 @@ def cmd_regrade(args: argparse.Namespace) -> int:
                     _hb(done, None)
                     _print_one(iid, rep, gr)
         _hb(total, None, status="done")
-    except BaseException:
+    except BaseException as e:  # noqa: BLE001 - record terminal state then re-raise
         _hb(counts["graded"] + counts["error"], None, status="error")
+        actions.finish(target, action_id, status="failed", error=str(e))
         raise
+    actions.finish(
+        target, action_id, status="completed",
+        progress={"unit": "regraded", "done": total, "total": total,
+                  "errors": counts["error"]},
+    )
 
     print(f"\nregraded {total} rows via {mode}: {counts['graded']} graded "
           f"({counts['resolved']} resolved), {counts['error']} error")

--- a/worca-bench/worca_bench/cli.py
+++ b/worca-bench/worca_bench/cli.py
@@ -129,6 +129,11 @@ def cmd_run(args: argparse.Namespace) -> int:
                   file=sys.stderr)
             return 2
         profile.grade.mode = gm
+    # Per-build timeout override (UI Run option / CLI). A non-negative int wins over
+    # the profile; 0 (or any non-positive) means no limit (unbounded build).
+    to = getattr(args, "timeout", None)
+    if to is not None:
+        profile.timeout = to if to > 0 else None
     # Benchmark cache (HF datasets / repo mirrors): flag wins, else env, else None.
     cache_dir = getattr(args, "cache_dir", None) or os.environ.get("WORCA_BENCH_CACHE")
     # Grader credentials: environment + CLI-flag overlay (allowlist-enforced).
@@ -364,6 +369,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--max-parallel", type=int,
                        help="override pipeline parallelism for this run (concurrency.worca)")
     p_run.add_argument("--reps", type=int, help="override the profile's reps for this run")
+    p_run.add_argument(
+        "--timeout", type=int, metavar="SECONDS",
+        help="per-instance build timeout in seconds (0 = no limit); overrides the profile")
     p_run.add_argument("--cache-dir", help="benchmark cache dir (HF datasets / repo mirrors)")
     p_run.add_argument(
         "--graphify", nargs="?", const="structural", metavar="MODE",

--- a/worca-bench/worca_bench/commit0_gen.py
+++ b/worca-bench/worca_bench/commit0_gen.py
@@ -1,0 +1,210 @@
+"""Generate a Commit0 instances file from a `commit0 setup` checkout (W-075 §3 / G1).
+
+Commit0 has no HuggingFace-style "just load it" path for worca-bench: each instance
+is a *local skeleton* (a cloned repo at its base commit, implementation stripped) plus
+the metadata the runner + grader need. This module turns a `commit0 setup <split>`
+checkout into the `selection.instances_file` JSON a commit0 profile consumes:
+
+    [
+      {
+        "instance_id": "wcwidth",          # worca-bench id (path-safe; the lib name)
+        "lib": "wcwidth",                  # what `commit0 test` expects
+        "local_repo": "/abs/repos/wcwidth",# skeleton to materialize from
+        "base_commit": "0d0054…",          # skeleton commit (impl stripped)
+        "reference_commit": "36a625…",     # gold impl (for reference grading)
+        "gold_test_paths": ["tests/"],     # hidden during the run, graded on pristine
+        "spec": "…",                       # the agent prompt (spec text + how-to)
+        "commit0": { … }                   # config the grader reconstructs from
+      },
+      …
+    ]
+
+The grader (`Commit0Plugin._grade_on_pristine`) reads the ``commit0`` block to drive
+``commit0 test`` against the live setup checkout on a scratch branch.
+"""
+
+from __future__ import annotations
+
+import bz2
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Keep the assembled prompt bounded — a full spec PDF can be hundreds of KB of text.
+_SPEC_TEXT_LIMIT = 16000
+
+
+def _short_lib(repo: str) -> str:
+    """The Commit0 library name `commit0 test` expects (repo path's last segment)."""
+    return str(repo).rsplit("/", 1)[-1]
+
+
+def extract_spec_text(repo_dir: Path) -> str:
+    """Best-effort plain text of a repo's ``spec.pdf.bz2`` (empty string on failure).
+
+    Commit0 ships the per-library specification as a bz2-compressed PDF in the repo
+    root. We decompress + extract text so the agent prompt carries the real spec;
+    any failure (missing file, no PDF reader, parse error) degrades to "" — the
+    caller falls back to the spec URL + structural metadata.
+    """
+    pdf_bz2 = Path(repo_dir) / "spec.pdf.bz2"
+    if not pdf_bz2.exists():
+        return ""
+    try:
+        import io
+
+        from pypdf import PdfReader
+
+        raw = bz2.decompress(pdf_bz2.read_bytes())
+        reader = PdfReader(io.BytesIO(raw))
+        parts = []
+        for page in reader.pages:
+            parts.append(page.extract_text() or "")
+            if sum(len(p) for p in parts) > _SPEC_TEXT_LIMIT:
+                break
+        return "\n".join(parts).strip()[:_SPEC_TEXT_LIMIT]
+    except Exception:  # noqa: BLE001 - spec text is best-effort; never fail the gen
+        return ""
+
+
+def assemble_prompt(row: dict[str, Any], lib: str, spec_text: str) -> str:
+    """Build the agent work-request for one Commit0 library from dataset metadata.
+
+    Commit0 is greenfield: the package modules exist but their implementations are
+    stripped (docstrings/signatures remain). The agent must implement the public API
+    so the held-out test suite passes — without seeing those tests (worca-bench hides
+    them; worca's own tester writes throwaway tests).
+    """
+    setup = row.get("setup") or {}
+    test = row.get("test") or {}
+    src_dir = row.get("src_dir") or "the package directory"
+    test_dir = test.get("test_dir") or "tests/"
+    spec_url = setup.get("specification") or ""
+    install = setup.get("install") or "pip install -e ."
+    python = setup.get("python") or ""
+
+    lines = [
+        f"# Implement the `{lib}` Python library from scratch (Commit0)",
+        "",
+        f"This is a greenfield build. The package under `{src_dir}` has its module "
+        "structure in place, but the implementations have been removed — function and "
+        "class bodies are stubbed while docstrings and signatures remain. Your task is "
+        "to implement the full public API so the library behaves per its specification.",
+        "",
+        "## Rules",
+        f"- Implement only library source under `{src_dir}` (and supporting modules it needs).",
+        f"- Do NOT add, modify, or depend on anything under `{test_dir}` — the grading "
+        "test suite is held out and supplied at evaluation time. Write your own throwaway "
+        "tests if you practice TDD, but they will not be graded and must live elsewhere.",
+        f"- Environment: install with `{install}`"
+        + (f" (Python {python})." if python else "."),
+        "",
+        "## Specification",
+    ]
+    if spec_url:
+        lines.append(f"- Reference: {spec_url}")
+    lines.append("- The full specification also ships as `spec.pdf` in the repo root.")
+    if spec_text:
+        lines += ["", "### Specification text (extracted from spec.pdf)", "", spec_text]
+    return "\n".join(lines)
+
+
+def build_instance_record(
+    row: dict[str, Any],
+    *,
+    base_dir: Path,
+    config_file: Path,
+    base_branch: str,
+    dataset_name: str,
+    dataset_split: str,
+    spec_text: str,
+) -> dict[str, Any]:
+    """Assemble one instances-file record (pure — no I/O beyond the passed spec_text)."""
+    repo = row.get("repo") or row.get("instance_id") or ""
+    lib = _short_lib(repo)
+    test = row.get("test") or {}
+    test_dir = test.get("test_dir") or "tests/"
+    local_repo = (Path(base_dir) / lib).resolve()
+    return {
+        "instance_id": lib,  # path-safe worca-bench id (dataset id has a '/')
+        "lib": lib,
+        "local_repo": str(local_repo),
+        "base_commit": row.get("base_commit"),
+        "reference_commit": row.get("reference_commit"),
+        "gold_test_paths": [test_dir],
+        "spec": assemble_prompt(row, lib, spec_text),
+        # Everything the grader needs to drive `commit0 test` against the live setup.
+        "commit0": {
+            "base_dir": str(Path(base_dir).resolve()),
+            "config_file": str(Path(config_file).resolve()),
+            "base_branch": base_branch,
+            "dataset_name": dataset_name,
+            "dataset_split": dataset_split,
+        },
+    }
+
+
+def _run_setup(split: str, base_dir: Path, config_file: Path,
+               dataset_name: str, dataset_split: str) -> None:  # pragma: no cover - shells out
+    cmd = [
+        "commit0", "setup", split,
+        "--base-dir", str(base_dir),
+        "--commit0-config-file", str(config_file),
+        "--dataset-name", dataset_name,
+        "--dataset-split", dataset_split,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def _load_rows(dataset_name: str, dataset_split: str):  # pragma: no cover - network/HF
+    from datasets import load_dataset
+
+    return list(load_dataset(dataset_name, split=dataset_split))
+
+
+def generate_instances(
+    split: str,
+    *,
+    base_dir: Path,
+    out_path: Path,
+    config_file: Path | None = None,
+    dataset_name: str = "wentingzhao/commit0_combined",
+    dataset_split: str = "test",
+    base_branch: str = "commit0",
+    run_setup: bool = True,
+    only_cloned: bool = True,
+    _rows: list[dict] | None = None,  # injectable for tests
+) -> list[dict[str, Any]]:
+    """Set up a Commit0 split (optionally) and write its instances file.
+
+    Returns the records written. ``split`` is a Commit0 split or a single library
+    name (e.g. ``wcwidth``). With ``only_cloned`` (default) only repos present under
+    ``base_dir`` are emitted — so a single-library setup yields a single instance.
+    """
+    base_dir = Path(base_dir)
+    config_file = Path(config_file) if config_file else (base_dir.parent / ".commit0.yaml")
+    if run_setup:
+        _run_setup(split, base_dir, config_file, dataset_name, dataset_split)  # pragma: no cover
+
+    rows = _rows if _rows is not None else _load_rows(dataset_name, dataset_split)
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        lib = _short_lib(row.get("repo") or row.get("instance_id") or "")
+        if not lib:
+            continue
+        repo_dir = base_dir / lib
+        if only_cloned and not repo_dir.exists():
+            continue
+        spec_text = extract_spec_text(repo_dir)
+        records.append(build_instance_record(
+            row, base_dir=base_dir, config_file=config_file, base_branch=base_branch,
+            dataset_name=dataset_name, dataset_split=dataset_split, spec_text=spec_text,
+        ))
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(records, indent=2), encoding="utf-8")
+    print(f"wrote {len(records)} commit0 instance(s) to {out_path}", file=sys.stderr)
+    return records

--- a/worca-bench/worca_bench/commit0_gen.py
+++ b/worca-bench/worca_bench/commit0_gen.py
@@ -64,9 +64,22 @@ def extract_spec_text(repo_dir: Path) -> str:
             parts.append(page.extract_text() or "")
             if sum(len(p) for p in parts) > _SPEC_TEXT_LIMIT:
                 break
-        return "\n".join(parts).strip()[:_SPEC_TEXT_LIMIT]
+        return _sanitize_spec_text("\n".join(parts))[:_SPEC_TEXT_LIMIT]
     except Exception:  # noqa: BLE001 - spec text is best-effort; never fail the gen
         return ""
+
+
+def _sanitize_spec_text(text: str) -> str:
+    """Strip control characters PDF extraction can emit (notably NUL).
+
+    pypdf occasionally yields embedded NUL (``\\x00``) and other C0 control bytes.
+    A NUL in the agent prompt makes the runner raise ``ValueError: embedded null
+    byte`` the moment it touches a path/syscall — failing the instance before the
+    pipeline even starts. Drop all C0 controls except tab/newline/carriage-return.
+    """
+    return "".join(
+        ch for ch in text if ch in "\t\n\r" or ord(ch) >= 0x20
+    ).strip()
 
 
 def assemble_prompt(row: dict[str, Any], lib: str, spec_text: str) -> str:

--- a/worca-bench/worca_bench/config.py
+++ b/worca-bench/worca_bench/config.py
@@ -82,6 +82,32 @@ class MockConfig:
 
 
 @dataclass
+class EngineConfig:
+    """Optional code-graph engine (graphify / code-review-graph). Both are
+    cross-template settings keys, off by default. ``mode`` is engine-specific
+    (graphify: structural|full) and only seeded when enabled + provided; extra
+    keys (e.g. CRG freshness) pass through ``options``."""
+
+    enabled: bool = False
+    mode: str | None = None
+    options: dict[str, Any] = field(default_factory=dict)
+
+    def to_settings(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"enabled": True}
+        if self.mode:
+            out["mode"] = self.mode
+        out.update(self.options)
+        return out
+
+    @property
+    def label(self) -> str | None:
+        """Compact value for results rows: mode (or 'on') when enabled, else None."""
+        if not self.enabled:
+            return None
+        return self.mode or "on"
+
+
+@dataclass
 class Profile:
     name: str
     benchmark: str
@@ -103,6 +129,18 @@ class Profile:
     claude_md_mode: str = "none"
     skip_preflight: bool = True
     pr_defer: bool = True
+    # Optional code-graph engines (off by default).
+    graphify: EngineConfig = field(default_factory=EngineConfig)
+    code_review_graph: EngineConfig = field(default_factory=EngineConfig)
+
+    def engine_settings(self) -> dict[str, Any]:
+        """worca.* overlay for any enabled code-graph engine (empty when off)."""
+        out: dict[str, Any] = {}
+        if self.graphify.enabled:
+            out["graphify"] = self.graphify.to_settings()
+        if self.code_review_graph.enabled:
+            out["code_review_graph"] = self.code_review_graph.to_settings()
+        return out
 
     def template_for(self, instance_id: str) -> str:
         """Resolve the template for an instance via ``template_map`` globs, else
@@ -138,6 +176,19 @@ def _coerce_worca(raw: Any) -> WorcaRef:
     if isinstance(raw, str):
         return WorcaRef(ref=raw)
     return WorcaRef(ref=raw.get("ref", "local"), source=raw.get("source"))
+
+
+def _coerce_engine(raw: Any) -> EngineConfig:
+    if raw is None:
+        return EngineConfig()
+    if isinstance(raw, bool):
+        return EngineConfig(enabled=raw)
+    if isinstance(raw, str):  # shorthand: a bare mode string enables it
+        return EngineConfig(enabled=True, mode=raw)
+    enabled = bool(raw.get("enabled", False))
+    mode = raw.get("mode")
+    options = {k: v for k, v in raw.items() if k not in ("enabled", "mode")}
+    return EngineConfig(enabled=enabled, mode=mode, options=options)
 
 
 def _coerce_selection(raw: Any) -> Selection:
@@ -192,6 +243,8 @@ def profile_from_dict(data: dict[str, Any]) -> Profile:
         claude_md_mode=data.get("claude_md_mode", "none"),
         skip_preflight=bool(data.get("skip_preflight", True)),
         pr_defer=bool(data.get("pr_defer", True)),
+        graphify=_coerce_engine(data.get("graphify")),
+        code_review_graph=_coerce_engine(data.get("code_review_graph")),
     )
     profile.validate()
     return profile

--- a/worca-bench/worca_bench/config.py
+++ b/worca-bench/worca_bench/config.py
@@ -144,6 +144,11 @@ class Profile:
     claude_md_mode: str = "none"
     skip_preflight: bool = True
     pr_defer: bool = True
+    # Run a serial canary (one instance per template) before fanning out the
+    # full sweep. Default True (fail fast on a broken config); set False to
+    # launch every instance immediately. A `--no-canary` launch flag still
+    # forces it off regardless of this default.
+    canary: bool = True
     # Optional code-graph engines (off by default).
     graphify: EngineConfig = field(default_factory=EngineConfig)
     code_review_graph: EngineConfig = field(default_factory=EngineConfig)
@@ -259,6 +264,7 @@ def profile_from_dict(data: dict[str, Any]) -> Profile:
         claude_md_mode=data.get("claude_md_mode", "none"),
         skip_preflight=bool(data.get("skip_preflight", True)),
         pr_defer=bool(data.get("pr_defer", True)),
+        canary=bool(data.get("canary", True)),
         graphify=_coerce_engine(data.get("graphify")),
         code_review_graph=_coerce_engine(data.get("code_review_graph")),
     )

--- a/worca-bench/worca_bench/config.py
+++ b/worca-bench/worca_bench/config.py
@@ -152,6 +152,9 @@ class Profile:
     # Optional code-graph engines (off by default).
     graphify: EngineConfig = field(default_factory=EngineConfig)
     code_review_graph: EngineConfig = field(default_factory=EngineConfig)
+    # Optional per-instance build timeout in seconds. None = no limit (default).
+    # Absent / null / 0 all mean unbounded; a positive int caps each pipeline build.
+    timeout: int | None = None
 
     def engine_settings(self) -> dict[str, Any]:
         """worca.* overlay for any enabled code-graph engine (empty when off)."""
@@ -212,6 +215,18 @@ def _coerce_engine(raw: Any) -> EngineConfig:
     return EngineConfig(enabled=enabled, mode=mode, options=options)
 
 
+def _coerce_timeout(raw: Any) -> int | None:
+    """Per-instance build timeout in seconds. Absent/None/0/non-positive => None
+    (no limit); a positive int caps the build."""
+    if raw is None:
+        return None
+    try:
+        v = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return v if v > 0 else None
+
+
 def _coerce_selection(raw: Any) -> Selection:
     raw = raw or {}
     sample = None
@@ -267,6 +282,7 @@ def profile_from_dict(data: dict[str, Any]) -> Profile:
         canary=bool(data.get("canary", True)),
         graphify=_coerce_engine(data.get("graphify")),
         code_review_graph=_coerce_engine(data.get("code_review_graph")),
+        timeout=_coerce_timeout(data.get("timeout")),
     )
     profile.validate()
     return profile

--- a/worca-bench/worca_bench/config.py
+++ b/worca-bench/worca_bench/config.py
@@ -21,6 +21,21 @@ except ImportError:  # pragma: no cover - PyYAML is a hard dep, guard for clarit
 VALID_BENCHMARKS = {"swe-bench-verified", "commit0"}
 VALID_GRADE_MODES = {"stub", "sb-cli", "modal", "local-docker"}
 
+# Which grade backends each benchmark actually supports. SWE-bench can grade via
+# the hosted sb-cli API, a local Docker harness, or Modal serverless. Commit0 has
+# no hosted equivalent — it runs its own tests via ``commit0 test`` on a local
+# Docker (``local-docker``) or Modal (``modal``) backend. ``stub`` (plumbing-only,
+# no real grade) is valid everywhere.
+BENCHMARK_GRADE_MODES = {
+    "swe-bench-verified": {"stub", "sb-cli", "local-docker", "modal"},
+    "commit0": {"stub", "local-docker", "modal"},
+}
+
+
+def valid_grade_modes(benchmark: str) -> set[str]:
+    """Grade modes valid for a benchmark (falls back to the full set if unknown)."""
+    return BENCHMARK_GRADE_MODES.get(benchmark, VALID_GRADE_MODES)
+
 
 class ProfileError(ValueError):
     """Raised when a profile is malformed or references unknown values."""
@@ -156,10 +171,11 @@ class Profile:
                 f"unknown benchmark {self.benchmark!r}; expected one of "
                 f"{sorted(VALID_BENCHMARKS)}"
             )
-        if self.grade.mode not in VALID_GRADE_MODES:
+        allowed = valid_grade_modes(self.benchmark)
+        if self.grade.mode not in allowed:
             raise ProfileError(
-                f"unknown grade.mode {self.grade.mode!r}; expected one of "
-                f"{sorted(VALID_GRADE_MODES)}"
+                f"grade.mode {self.grade.mode!r} is not valid for benchmark "
+                f"{self.benchmark!r}; expected one of {sorted(allowed)}"
             )
         if self.reps < 1:
             raise ProfileError(f"reps must be >= 1, got {self.reps}")

--- a/worca-bench/worca_bench/config.py
+++ b/worca-bench/worca_bench/config.py
@@ -1,0 +1,226 @@
+"""Profile config model + YAML loader (requirement 5).
+
+A *profile* is the full reproducible experiment spec: which benchmark, which
+instances, which worca ref, which template(s), how many reps, and how to grade.
+Profiles live in ``worca-bench/profiles/*.yaml`` (in-repo) or under a target dir.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML is a hard dep, guard for clarity
+    yaml = None
+
+VALID_BENCHMARKS = {"swe-bench-verified", "commit0"}
+VALID_GRADE_MODES = {"stub", "sb-cli", "modal", "local-docker"}
+
+
+class ProfileError(ValueError):
+    """Raised when a profile is malformed or references unknown values."""
+
+
+@dataclass
+class WorcaRef:
+    """Which worca to install. ``local`` uses the current environment (for tests
+    and dev); anything else is a pip-installable ref (branch | tag | commit | version)."""
+
+    ref: str = "local"
+    # Explicit source override. When None, ``local`` => current env, otherwise a
+    # git ref against the worca-cc repo. Set ``source`` to pin a different origin.
+    source: str | None = None
+
+    @property
+    def is_local(self) -> bool:
+        return self.ref == "local" or (self.source or "").startswith("path:")
+
+
+@dataclass
+class Sample:
+    n: int
+    stratify_by: str | None = None
+    seed: int = 0
+
+
+@dataclass
+class Selection:
+    instance_ids: list[str] = field(default_factory=list)
+    sample: Sample | None = None
+    # Local fixture of instances (bypasses HuggingFace). Used by tests and offline runs.
+    instances_file: str | None = None
+
+
+@dataclass
+class GradeConfig:
+    mode: str = "stub"
+    # sb-cli/local-docker knobs (passed through to the plugin)
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Concurrency:
+    worca: int = 4
+    grade: int = 4
+
+
+@dataclass
+class MockConfig:
+    """When present, the runner drives the spawned worca pipeline with the repo's
+    mock Claude (``tests/mock_claude/mock_claude.py``) — free + deterministic.
+    This powers both e2e tests and a user-facing ``--mock`` dry-run."""
+
+    # Path to a scenario JSON. When None, a built-in all-succeed scenario is used.
+    scenario: str | None = None
+    # Path to the mock_claude.py to use. When None, resolved from the worca-cc repo.
+    mock_bin: str | None = None
+
+
+@dataclass
+class Profile:
+    name: str
+    benchmark: str
+    worca: WorcaRef = field(default_factory=WorcaRef)
+    selection: Selection = field(default_factory=Selection)
+    template: str = "builtin:feature"
+    template_map: dict[str, str] = field(default_factory=dict)
+    # Definitions for non-builtin (project:/user:) templates, keyed by bare name.
+    # Each value is a template.json-shaped dict ({id, name, config, ...}).
+    templates: dict[str, dict[str, Any]] = field(default_factory=dict)
+    reps: int = 1
+    grade: GradeConfig = field(default_factory=GradeConfig)
+    concurrency: Concurrency = field(default_factory=Concurrency)
+    # Minimal cross-template settings overlay (model aliases). Secrets go to
+    # settings.local.json via the environment, never here. See worca_install.py.
+    settings: dict[str, Any] = field(default_factory=dict)
+    settings_ref: str | None = None
+    mock: MockConfig | None = None
+    claude_md_mode: str = "none"
+    skip_preflight: bool = True
+    pr_defer: bool = True
+
+    def template_for(self, instance_id: str) -> str:
+        """Resolve the template for an instance via ``template_map`` globs, else
+        the profile default (requirement 2)."""
+        for glob, tmpl in self.template_map.items():
+            if fnmatch.fnmatch(instance_id, glob):
+                return tmpl
+        return self.template
+
+    def validate(self) -> None:
+        if self.benchmark not in VALID_BENCHMARKS:
+            raise ProfileError(
+                f"unknown benchmark {self.benchmark!r}; expected one of "
+                f"{sorted(VALID_BENCHMARKS)}"
+            )
+        if self.grade.mode not in VALID_GRADE_MODES:
+            raise ProfileError(
+                f"unknown grade.mode {self.grade.mode!r}; expected one of "
+                f"{sorted(VALID_GRADE_MODES)}"
+            )
+        if self.reps < 1:
+            raise ProfileError(f"reps must be >= 1, got {self.reps}")
+        if not self.selection.instance_ids and not self.selection.sample \
+                and not self.selection.instances_file:
+            raise ProfileError(
+                "selection must set one of: instance_ids, sample, instances_file"
+            )
+
+
+def _coerce_worca(raw: Any) -> WorcaRef:
+    if raw is None:
+        return WorcaRef()
+    if isinstance(raw, str):
+        return WorcaRef(ref=raw)
+    return WorcaRef(ref=raw.get("ref", "local"), source=raw.get("source"))
+
+
+def _coerce_selection(raw: Any) -> Selection:
+    raw = raw or {}
+    sample = None
+    if raw.get("sample"):
+        s = raw["sample"]
+        sample = Sample(n=int(s["n"]), stratify_by=s.get("stratify_by"), seed=int(s.get("seed", 0)))
+    return Selection(
+        instance_ids=list(raw.get("instance_ids", []) or []),
+        sample=sample,
+        instances_file=raw.get("instances_file"),
+    )
+
+
+def profile_from_dict(data: dict[str, Any]) -> Profile:
+    """Build a validated Profile from a parsed dict."""
+    if "name" not in data:
+        raise ProfileError("profile is missing required key 'name'")
+    if "benchmark" not in data:
+        raise ProfileError("profile is missing required key 'benchmark'")
+
+    grade_raw = data.get("grade") or {}
+    if isinstance(grade_raw, str):
+        grade_raw = {"mode": grade_raw}
+    conc_raw = data.get("concurrency") or {}
+    mock_raw = data.get("mock")
+    mock = None
+    if mock_raw is not None:
+        if mock_raw is True:
+            mock = MockConfig()
+        elif isinstance(mock_raw, dict):
+            mock = MockConfig(scenario=mock_raw.get("scenario"), mock_bin=mock_raw.get("mock_bin"))
+
+    profile = Profile(
+        name=data["name"],
+        benchmark=data["benchmark"],
+        worca=_coerce_worca(data.get("worca")),
+        selection=_coerce_selection(data.get("selection")),
+        template=data.get("template", "builtin:feature"),
+        template_map=dict(data.get("template_map", {}) or {}),
+        templates=dict(data.get("templates", {}) or {}),
+        reps=int(data.get("reps", 1)),
+        grade=GradeConfig(mode=grade_raw.get("mode", "stub"), options=grade_raw.get("options", {}) or {}),
+        concurrency=Concurrency(
+            worca=int(conc_raw.get("worca", 4)),
+            grade=int(conc_raw.get("grade", 4)),
+        ),
+        settings=dict(data.get("settings", {}) or {}),
+        settings_ref=data.get("settings_ref"),
+        mock=mock,
+        claude_md_mode=data.get("claude_md_mode", "none"),
+        skip_preflight=bool(data.get("skip_preflight", True)),
+        pr_defer=bool(data.get("pr_defer", True)),
+    )
+    profile.validate()
+    return profile
+
+
+def load_profile(path: str | Path) -> Profile:
+    """Load and validate a profile from a YAML (or JSON) file."""
+    p = Path(path)
+    if not p.exists():
+        raise ProfileError(f"profile file not found: {p}")
+    text = p.read_text(encoding="utf-8")
+    if p.suffix in (".json",):
+        data = json.loads(text)
+    else:
+        if yaml is None:  # pragma: no cover
+            raise ProfileError("PyYAML is required to load .yaml profiles")
+        data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ProfileError(f"profile {p} did not parse to a mapping")
+    return profile_from_dict(data)
+
+
+def find_profile(name: str, search_dirs: list[Path]) -> Profile:
+    """Find ``<name>.yaml`` / ``<name>.json`` across the given dirs (first match wins)."""
+    for d in search_dirs:
+        for ext in (".yaml", ".yml", ".json"):
+            candidate = d / f"{name}{ext}"
+            if candidate.exists():
+                return load_profile(candidate)
+    raise ProfileError(
+        f"profile {name!r} not found in: {', '.join(str(d) for d in search_dirs)}"
+    )

--- a/worca-bench/worca_bench/harvest.py
+++ b/worca-bench/worca_bench/harvest.py
@@ -20,7 +20,7 @@ from typing import Any
 # `.gitignore`/`.gitattributes` are scaffolding — leaving them in pollutes the
 # diff and makes `git apply` fail on a pristine SWE-bench eval container.
 DEFAULT_EXCLUDES = (
-    ".claude", ".worca", ".worktrees", ".beads",
+    ".claude", ".worca", ".worktrees", ".beads", ".wb_scratch",
     "MASTER_PLAN.md", "AGENTS.md", ".gitignore", ".gitattributes",
 )
 

--- a/worca-bench/worca_bench/harvest.py
+++ b/worca-bench/worca_bench/harvest.py
@@ -1,9 +1,10 @@
 """Extract a source-only diff + parse worca telemetry from a completed run (W-075 §2 step 5, §6).
 
 The agent's patch is *source-only*: worca's own scaffolding (``.claude/``, ``.worca/``,
+``.beads/``, ``AGENTS.md``, the ``.gitignore``/``.gitattributes`` worca rewrites,
 ``MASTER_PLAN.md``) and any benchmark test paths are excluded, so the diff matches what
-the grader expects (the harness supplies the tests). Telemetry is read from the run's
-``status.json``.
+the grader expects (the harness supplies the tests) and applies cleanly on a pristine
+eval container. Telemetry is read from the run's ``status.json``.
 """
 
 from __future__ import annotations
@@ -14,8 +15,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# worca writes these into the target tree; they must never leak into the patch.
-DEFAULT_EXCLUDES = (".claude", ".worca", ".worktrees", "MASTER_PLAN.md")
+# worca / its tooling write these into the target tree during a run; they must
+# never leak into the graded patch. `.beads`, `AGENTS.md`, and the rewritten
+# `.gitignore`/`.gitattributes` are scaffolding — leaving them in pollutes the
+# diff and makes `git apply` fail on a pristine SWE-bench eval container.
+DEFAULT_EXCLUDES = (
+    ".claude", ".worca", ".worktrees", ".beads",
+    "MASTER_PLAN.md", "AGENTS.md", ".gitignore", ".gitattributes",
+)
 
 
 def extract_diff(

--- a/worca-bench/worca_bench/harvest.py
+++ b/worca-bench/worca_bench/harvest.py
@@ -1,0 +1,128 @@
+"""Extract a source-only diff + parse worca telemetry from a completed run (W-075 §2 step 5, §6).
+
+The agent's patch is *source-only*: worca's own scaffolding (``.claude/``, ``.worca/``,
+``MASTER_PLAN.md``) and any benchmark test paths are excluded, so the diff matches what
+the grader expects (the harness supplies the tests). Telemetry is read from the run's
+``status.json``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# worca writes these into the target tree; they must never leak into the patch.
+DEFAULT_EXCLUDES = (".claude", ".worca", ".worktrees", "MASTER_PLAN.md")
+
+
+def extract_diff(
+    tree: Path,
+    base: str,
+    *,
+    extra_excludes: tuple[str, ...] = (),
+) -> str:
+    """Return a unified diff of the working tree vs ``base``, source-only.
+
+    Untracked files are surfaced via intent-to-add so newly created source files
+    appear in the diff regardless of whether the pipeline committed them.
+    """
+    subprocess.run(["git", "-C", str(tree), "add", "-A", "-N"],
+                   capture_output=True, text=True)
+    pathspec = ["--", "."]
+    for ex in DEFAULT_EXCLUDES + tuple(extra_excludes):
+        pathspec.append(f":(exclude){ex}")
+    proc = subprocess.run(
+        ["git", "-C", str(tree), "diff", base, *pathspec],
+        capture_output=True, text=True,
+    )
+    return proc.stdout
+
+
+def diff_line_count(diff: str) -> int:
+    """Count added/removed content lines (excludes diff headers)."""
+    n = 0
+    for line in diff.splitlines():
+        if line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
+            n += 1
+    return n
+
+
+def touches_paths(diff: str, paths: tuple[str, ...]) -> list[str]:
+    """Return which of ``paths`` the diff touches (used by the Commit0 leakage guard)."""
+    hit: list[str] = []
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            for p in paths:
+                if p and p in line and p not in hit:
+                    hit.append(p)
+    return hit
+
+
+@dataclass
+class Telemetry:
+    pipeline_status: str | None = None
+    cost_usd: float = 0.0
+    tokens: dict[str, Any] = field(default_factory=dict)
+    wall_time_s: float = 0.0
+    api_time_s: float = 0.0
+    loop_counters: dict[str, int] = field(default_factory=dict)
+    stage_outcomes: dict[str, str] = field(default_factory=dict)
+    api_retries: int = 0
+
+
+def _sum_stage_field(status: dict[str, Any], field_name: str) -> float:
+    total = 0.0
+    for stage in (status.get("stages") or {}).values():
+        for it in stage.get("iterations", []) or []:
+            v = it.get(field_name)
+            if isinstance(v, (int, float)):
+                total += v
+    return total
+
+
+def parse_telemetry(status: dict[str, Any]) -> Telemetry:
+    """Flatten worca's status.json into the fields the results row needs (§6)."""
+    top_tokens = status.get("token_usage") or {}
+    tokens = {
+        "input": top_tokens.get("input_tokens", 0),
+        "output": top_tokens.get("output_tokens", 0),
+        "total": (top_tokens.get("input_tokens", 0) or 0) + (top_tokens.get("output_tokens", 0) or 0),
+        "by_stage": top_tokens.get("by_stage", {}) or {},
+        "by_model": top_tokens.get("by_model", {}) or {},
+    }
+    cost = top_tokens.get("total_cost_usd")
+    if not isinstance(cost, (int, float)) or cost == 0:
+        cost = _sum_stage_field(status, "cost_usd")
+
+    stage_outcomes: dict[str, str] = {}
+    for name, stage in (status.get("stages") or {}).items():
+        iters = stage.get("iterations") or []
+        if iters and iters[-1].get("outcome") is not None:
+            stage_outcomes[name] = iters[-1]["outcome"]
+        elif stage.get("status"):
+            stage_outcomes[name] = stage["status"]
+
+    return Telemetry(
+        pipeline_status=status.get("pipeline_status"),
+        cost_usd=float(cost or 0.0),
+        tokens=tokens,
+        wall_time_s=_sum_stage_field(status, "duration_ms") / 1000.0,
+        api_time_s=_sum_stage_field(status, "duration_api_ms") / 1000.0,
+        loop_counters=dict(status.get("loop_counters") or {}),
+        stage_outcomes=stage_outcomes,
+        api_retries=int(_sum_stage_field(status, "api_retries")),
+    )
+
+
+def archive_artifacts(run_dir: Path | None, diff: str, dest: Path) -> None:
+    """Copy status.json / events.jsonl + write diff.patch into the per-rep artifact dir."""
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "diff.patch").write_text(diff, encoding="utf-8")
+    if run_dir and run_dir.exists():
+        for name in ("status.json", "events.jsonl"):
+            src = run_dir / name
+            if src.exists():
+                shutil.copy2(src, dest / name)

--- a/worca-bench/worca_bench/launcher.py
+++ b/worca-bench/worca_bench/launcher.py
@@ -93,6 +93,16 @@ def build_launch_env(
         env.pop(k, None)
     env["WORCA_SKIP_BEADS"] = "1"
 
+    # Defer PR creation via the ENV signal, not just the settings.json seed.
+    # worca.stages is a *template-driven* key: when a template is in play (always,
+    # in worca-bench) the project's stages.pr.defer seed is stripped and the
+    # template's own stages win — so a template with the PR stage enabled (feature,
+    # bugfix, ...) would create a PR despite the seed. WORCA_DEFER_PR=1 is read
+    # directly by the guardian (compute_defer_pr) and composes monotonically, so it
+    # holds regardless of what the template sets. See docs: PR defer is monotonic.
+    if profile.pr_defer:
+        env["WORCA_DEFER_PR"] = "1"
+
     if profile.mock is not None:
         mock = profile.mock
         scenario: dict[str, Any]

--- a/worca-bench/worca_bench/launcher.py
+++ b/worca-bench/worca_bench/launcher.py
@@ -122,6 +122,15 @@ def build_launch_env(
     return env
 
 
+def _as_text(s) -> str:
+    """Coerce subprocess output (str | bytes | None) to str."""
+    if s is None:
+        return ""
+    if isinstance(s, bytes):
+        return s.decode("utf-8", "replace")
+    return s
+
+
 def launch(
     profile: Profile,
     wenv: WorcaEnv,
@@ -154,7 +163,11 @@ def launch(
         )
         rc, out, err = proc.returncode, proc.stdout, proc.stderr
     except subprocess.TimeoutExpired as e:
-        rc, out, err = 124, e.stdout or "", (e.stderr or "") + "\n[worca-bench] run timed out"
+        # On timeout the partial stdout/stderr can come back as bytes even under
+        # text=True — decode defensively so the timeout path never crashes.
+        out = _as_text(e.stdout)
+        err = _as_text(e.stderr) + "\n[worca-bench] run timed out"
+        rc = 124
 
     run_dir = tree / ".worca" / "runs" / run_id
     status_path = run_dir / "status.json"

--- a/worca-bench/worca_bench/launcher.py
+++ b/worca-bench/worca_bench/launcher.py
@@ -1,0 +1,177 @@
+"""Spawn a worca pipeline run in a prepared tree (W-075 §2 step 4).
+
+Two launch modes share one code path:
+  * **real**  — uses the host ``claude`` CLI (costs money). Secrets flow via env.
+  * **mock**  — points ``WORCA_CLAUDE_BIN`` at the worca-cc repo's
+    ``tests/mock_claude/mock_claude.py`` and ``MOCK_CLAUDE_SCENARIO`` at a scripted
+    scenario. This is free + deterministic — it powers the e2e tests and the
+    user-facing ``--mock`` dry-run.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .config import MockConfig, Profile
+from .worca_install import LEAKY_ENV, collect_secret_env
+from .venvs import WorcaEnv
+
+# A minimal all-succeed scenario that drives planner→coordinator→implementer→tester
+# →reviewer→guardian to completion AND produces a real (non-empty) diff via the
+# implementer's run_command. Mirrors the shape worca's integration suite uses.
+DEFAULT_MOCK_SCENARIO: dict[str, Any] = {
+    "agents": {
+        "planner": {
+            "action": "succeed", "delay_s": 0.02, "result_text": "Plan ready",
+            "structured_output": {"summary": "mock plan", "files": ["WORCA_BENCH_MOCK.txt"]},
+        },
+        "coordinator": {
+            "action": "succeed", "delay_s": 0.02, "result_text": "Beads assigned",
+            "structured_output": {"beads": [{"id": "bead-1", "title": "mock fix", "effort": "low"}]},
+        },
+        "implementer": {
+            "action": "succeed", "delay_s": 0.02,
+            "run_command": "printf 'worca-bench mock change\\n' >> WORCA_BENCH_MOCK.txt",
+            "result_text": "Applied change",
+            "structured_output": {"changes": "added WORCA_BENCH_MOCK.txt"},
+        },
+        "tester": {
+            "action": "succeed", "delay_s": 0.02, "result_text": "Tests pass",
+            "structured_output": {"passed": True, "test_summary": "mock tests passed"},
+        },
+        "reviewer": {
+            "action": "succeed", "delay_s": 0.02, "result_text": "Approved",
+            "structured_output": {"outcome": "approve", "feedback": "lgtm"},
+        },
+        "guardian": {
+            "action": "succeed", "delay_s": 0.02, "result_text": "Ready",
+            "structured_output": {"pr_number": 1, "pr_url": "https://example.invalid/pr/1"},
+        },
+    },
+    "default": {"action": "succeed", "delay_s": 0.02, "result_text": "ok"},
+}
+
+
+@dataclass
+class RunOutcome:
+    run_id: str
+    returncode: int
+    run_dir: Path | None
+    status: dict[str, Any] | None
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0 and self.status is not None
+
+
+def _mock_bin_path(mock: MockConfig, wenv: WorcaEnv) -> Path:
+    if mock.mock_bin:
+        return Path(mock.mock_bin)
+    if wenv.repo is None:
+        raise FileNotFoundError(
+            "mock mode needs the worca-cc repo to locate mock_claude.py; "
+            "set mock.mock_bin or WORCA_BENCH_WORCA_REPO"
+        )
+    return wenv.repo / "tests" / "mock_claude" / "mock_claude.py"
+
+
+def build_launch_env(
+    profile: Profile,
+    wenv: WorcaEnv,
+    *,
+    run_scratch: Path,
+) -> dict[str, str]:
+    """Assemble the subprocess environment for ``run_pipeline``."""
+    env = wenv.base_env()
+    for k in LEAKY_ENV:
+        env.pop(k, None)
+    env["WORCA_SKIP_BEADS"] = "1"
+
+    if profile.mock is not None:
+        mock = profile.mock
+        scenario: dict[str, Any]
+        if mock.scenario:
+            scenario = json.loads(Path(mock.scenario).read_text(encoding="utf-8"))
+        else:
+            scenario = DEFAULT_MOCK_SCENARIO
+        scenario_path = run_scratch / "mock_scenario.json"
+        scenario_path.write_text(json.dumps(scenario), encoding="utf-8")
+        mock_bin = _mock_bin_path(mock, wenv)
+        env["WORCA_CLAUDE_BIN"] = f"{wenv.python} {mock_bin}"
+        env["MOCK_CLAUDE_SCENARIO"] = str(scenario_path)
+    else:
+        # Real mode: ensure secrets reach the subprocess (also seeded to
+        # settings.local.json, but env is the primary path for the claude CLI).
+        env.update(collect_secret_env())
+    return env
+
+
+def launch(
+    profile: Profile,
+    wenv: WorcaEnv,
+    tree: Path,
+    *,
+    prompt: str,
+    template: str,
+    run_id: str,
+    run_scratch: Path,
+    timeout: int = 1800,
+) -> RunOutcome:
+    """Run the pipeline in ``tree`` and return its outcome + parsed status.json."""
+    run_scratch.mkdir(parents=True, exist_ok=True)
+    env = build_launch_env(profile, wenv, run_scratch=run_scratch)
+
+    args = [
+        wenv.python, "-m", "worca.scripts.run_pipeline",
+        "--prompt", prompt,
+        "--template", template,
+        "--claude-md-mode", profile.claude_md_mode,
+        "--run-id", run_id,
+    ]
+    if profile.skip_preflight:
+        args.append("--skip-preflight")
+
+    try:
+        proc = subprocess.run(
+            args, cwd=str(tree), env=env,
+            capture_output=True, text=True, timeout=timeout,
+        )
+        rc, out, err = proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired as e:
+        rc, out, err = 124, e.stdout or "", (e.stderr or "") + "\n[worca-bench] run timed out"
+
+    run_dir = tree / ".worca" / "runs" / run_id
+    status_path = run_dir / "status.json"
+    status: dict[str, Any] | None = None
+    if status_path.exists():
+        try:
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            status = None
+    return RunOutcome(run_id=run_id, returncode=rc, run_dir=run_dir, status=status,
+                      stdout=out, stderr=err)
+
+
+def canary(profile: Profile, wenv: WorcaEnv, tree: Path, *, template: str,
+           run_scratch: Path, timeout: int = 300) -> tuple[bool, str]:
+    """Cheap pre-sweep check that ``(version, template)`` produces a valid status.json.
+
+    Returns ``(ok, reason)``. A canary that never reaches a valid status.json means
+    the config is rejected by this worca version — skip/flag the combo (W-075 §5).
+    """
+    outcome = launch(
+        profile, wenv, tree,
+        prompt="worca-bench canary: validate config loads",
+        template=template, run_id=f"canary-{template.replace(':', '_')}",
+        run_scratch=run_scratch, timeout=timeout,
+    )
+    if outcome.status is None:
+        tail = (outcome.stderr or outcome.stdout or "").strip()[-400:]
+        return False, f"no valid status.json (rc={outcome.returncode}): {tail}"
+    return True, "ok"

--- a/worca-bench/worca_bench/launcher.py
+++ b/worca-bench/worca_bench/launcher.py
@@ -140,9 +140,15 @@ def launch(
     template: str,
     run_id: str,
     run_scratch: Path,
-    timeout: int = 1800,
+    timeout: int | None = None,
 ) -> RunOutcome:
-    """Run the pipeline in ``tree`` and return its outcome + parsed status.json."""
+    """Run the pipeline in ``tree`` and return its outcome + parsed status.json.
+
+    ``timeout`` is the per-build wall-clock cap in seconds; ``None`` (the default)
+    means no limit — ``subprocess.run`` waits for the pipeline to finish. A positive
+    value caps the build and, on expiry, returns rc=124 with the partial tree intact
+    (the caller still harvests + grades whatever was built).
+    """
     run_scratch.mkdir(parents=True, exist_ok=True)
     env = build_launch_env(profile, wenv, run_scratch=run_scratch)
 

--- a/worca-bench/worca_bench/normalize.py
+++ b/worca-bench/worca_bench/normalize.py
@@ -40,6 +40,9 @@ def build_row(
     grade_mode: str | None = None,
     graphify: str | None = None,
     code_review_graph: str | None = None,
+    report_path: str | None = None,
+    grade_detail: str | None = None,
+    graded_at: str | None = None,
 ) -> dict[str, Any]:
     return {
         "schema_version": RESULTS_SCHEMA_VERSION,
@@ -57,6 +60,10 @@ def build_row(
         "status": status,
         "resolved": resolved,
         "score": score,
+        # Grading provenance (which backend, when, where the report landed).
+        "grade_detail": grade_detail,
+        "graded_at": graded_at,
+        "report_path": report_path,
         "cost_usd": round(telemetry.cost_usd, 6),
         "tokens": telemetry.tokens,
         "wall_time_s": round(telemetry.wall_time_s, 3),

--- a/worca-bench/worca_bench/normalize.py
+++ b/worca-bench/worca_bench/normalize.py
@@ -38,6 +38,8 @@ def build_row(
     artifacts_dir: str,
     worca_version: str | None = None,
     grade_mode: str | None = None,
+    graphify: str | None = None,
+    code_review_graph: str | None = None,
 ) -> dict[str, Any]:
     return {
         "schema_version": RESULTS_SCHEMA_VERSION,
@@ -48,6 +50,8 @@ def build_row(
         "worca_version": worca_version,
         "template": template,
         "grade_mode": grade_mode,
+        "graphify": graphify,
+        "code_review_graph": code_review_graph,
         "rep": rep,
         "run_id": run_id,
         "status": status,

--- a/worca-bench/worca_bench/normalize.py
+++ b/worca-bench/worca_bench/normalize.py
@@ -1,0 +1,93 @@
+"""Normalize a completed rep into a single ``results.jsonl`` row (W-075 §6).
+
+``results.jsonl`` is append-only and is the dashboard's source of truth. One row
+per (profile, instance, rep), joining worca telemetry with the grader verdict.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+from . import RESULTS_SCHEMA_VERSION
+from .harvest import Telemetry, diff_line_count
+
+_WRITE_LOCK = threading.Lock()
+
+
+def build_row(
+    *,
+    profile_name: str,
+    benchmark: str,
+    instance_id: str,
+    worca_ref: str,
+    template: str,
+    rep: int,
+    run_id: str,
+    status: str,
+    resolved: bool | None,
+    score: float | None,
+    telemetry: Telemetry,
+    diff: str,
+    leaked: bool,
+    error: str | None,
+    started_at: str | None,
+    completed_at: str | None,
+    artifacts_dir: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": RESULTS_SCHEMA_VERSION,
+        "profile": profile_name,
+        "benchmark": benchmark,
+        "instance_id": instance_id,
+        "worca_ref": worca_ref,
+        "template": template,
+        "rep": rep,
+        "run_id": run_id,
+        "status": status,
+        "resolved": resolved,
+        "score": score,
+        "cost_usd": round(telemetry.cost_usd, 6),
+        "tokens": telemetry.tokens,
+        "wall_time_s": round(telemetry.wall_time_s, 3),
+        "api_time_s": round(telemetry.api_time_s, 3),
+        "pipeline_status": telemetry.pipeline_status,
+        "loop_counters": telemetry.loop_counters,
+        "stage_outcomes": telemetry.stage_outcomes,
+        "api_retries": telemetry.api_retries,
+        "diff_lines": diff_line_count(diff),
+        "leaked": leaked,
+        "error": error,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "artifacts_dir": artifacts_dir,
+    }
+
+
+def append_row(target_dir: Path, row: dict[str, Any]) -> None:
+    """Append one row to ``<target_dir>/results.jsonl`` (thread-safe)."""
+    path = target_dir / "results.jsonl"
+    line = json.dumps(row) + "\n"
+    with _WRITE_LOCK:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+
+
+def read_rows(target_dir: Path) -> list[dict[str, Any]]:
+    """Read all rows from ``results.jsonl`` (tolerant of partial last lines)."""
+    path = target_dir / "results.jsonl"
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows

--- a/worca-bench/worca_bench/normalize.py
+++ b/worca-bench/worca_bench/normalize.py
@@ -84,6 +84,31 @@ def append_row(target_dir: Path, row: dict[str, Any]) -> None:
             fh.write(line)
 
 
+def rewrite_rows(target_dir: Path, mutate) -> int:
+    """Rewrite ``results.jsonl`` in place, applying ``mutate(row)`` to each row.
+
+    ``mutate`` may edit the row dict in place and returns truthy when it changed
+    it. Returns the number of rows changed. The file is rewritten atomically
+    (temp + replace) under the same lock as :func:`append_row`. This is the only
+    sanctioned way to mutate the otherwise append-only log — used by regrade.
+    """
+    path = target_dir / "results.jsonl"
+    if not path.exists():
+        return 0
+    changed = 0
+    with _WRITE_LOCK:
+        rows = read_rows(target_dir)
+        for row in rows:
+            if mutate(row):
+                changed += 1
+        tmp = path.with_suffix(".jsonl.tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row) + "\n")
+        tmp.replace(path)
+    return changed
+
+
 def read_rows(target_dir: Path) -> list[dict[str, Any]]:
     """Read all rows from ``results.jsonl`` (tolerant of partial last lines)."""
     path = target_dir / "results.jsonl"

--- a/worca-bench/worca_bench/normalize.py
+++ b/worca-bench/worca_bench/normalize.py
@@ -29,6 +29,8 @@ def build_row(
     status: str,
     resolved: bool | None,
     score: float | None,
+    tests_passed: int | None = None,
+    tests_total: int | None = None,
     telemetry: Telemetry,
     diff: str,
     leaked: bool,
@@ -60,6 +62,10 @@ def build_row(
         "status": status,
         "resolved": resolved,
         "score": score,
+        # Fine-grained suite counts (Commit0 held-out tests). None for
+        # pass/fail-only graders; score == tests_passed / tests_total.
+        "tests_passed": tests_passed,
+        "tests_total": tests_total,
         # Grading provenance (which backend, when, where the report landed).
         "grade_detail": grade_detail,
         "graded_at": graded_at,

--- a/worca-bench/worca_bench/normalize.py
+++ b/worca-bench/worca_bench/normalize.py
@@ -36,6 +36,8 @@ def build_row(
     started_at: str | None,
     completed_at: str | None,
     artifacts_dir: str,
+    worca_version: str | None = None,
+    grade_mode: str | None = None,
 ) -> dict[str, Any]:
     return {
         "schema_version": RESULTS_SCHEMA_VERSION,
@@ -43,7 +45,9 @@ def build_row(
         "benchmark": benchmark,
         "instance_id": instance_id,
         "worca_ref": worca_ref,
+        "worca_version": worca_version,
         "template": template,
+        "grade_mode": grade_mode,
         "rep": rep,
         "run_id": run_id,
         "status": status,

--- a/worca-bench/worca_bench/overlays/default.json
+++ b/worca-bench/worca_bench/overlays/default.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Version-keyed settings overlay (W-075 §5). Keys here are deep-merged into the version-self-seeded .claude/settings.json under the 'worca' namespace. Keep this MINIMAL — only cross-template keys that survive the template strip (models, pricing). Secrets never go here; they land in settings.local.json via the environment. Add a <version-range>.json sibling only when a real schema break (e.g. pre-W-051 model alias format) needs an override.",
+  "applies_to": "*",
+  "worca": {}
+}

--- a/worca-bench/worca_bench/plugins/__init__.py
+++ b/worca-bench/worca_bench/plugins/__init__.py
@@ -1,0 +1,19 @@
+"""Benchmark plugins. Each adapts one benchmark to the shared runner contract."""
+
+from __future__ import annotations
+
+from ..config import Profile
+from .base import BenchmarkPlugin
+
+
+def get_plugin(profile: Profile) -> BenchmarkPlugin:
+    """Return the plugin for a profile's benchmark."""
+    if profile.benchmark == "swe-bench-verified":
+        from .swebench import SwebenchPlugin
+
+        return SwebenchPlugin()
+    if profile.benchmark == "commit0":
+        from .commit0 import Commit0Plugin
+
+        return Commit0Plugin()
+    raise ValueError(f"no plugin for benchmark {profile.benchmark!r}")

--- a/worca-bench/worca_bench/plugins/base.py
+++ b/worca-bench/worca_bench/plugins/base.py
@@ -123,6 +123,32 @@ def _git_head(tree: Path) -> str:
     return _git(["rev-parse", "HEAD"], tree)
 
 
+def neutralize_remotes(dest: Path) -> list[str]:
+    """Strip every git remote from a materialized bench tree.
+
+    The bench never legitimately pushes (PR creation is always deferred) and
+    grades from the local working tree, so a real ``origin`` is pure liability:
+    a misbehaving guardian that discovers the upstream there can ``gh repo
+    fork`` + ``gh pr create`` against it — real PRs were opened against
+    astropy/astropy this way despite ``pr_defer``. Removing all remotes makes
+    push / fork / pr-create fail to resolve a repo, a defense-in-depth backstop
+    under the guardian prompt's defer-mode "no remote contact" rule. Best-effort:
+    never raises (a tree with no remotes is a no-op). Returns the names removed.
+    """
+    try:
+        names = _git(["remote"], dest).split()
+    except subprocess.CalledProcessError:
+        return []
+    removed: list[str] = []
+    for name in names:
+        try:
+            _git(["remote", "remove", name], dest)
+            removed.append(name)
+        except subprocess.CalledProcessError:
+            pass
+    return removed
+
+
 def init_repo_from_local(src: str | Path, dest: Path, base_commit: str | None) -> str:
     """Copy a local source repo into ``dest`` as a git repo at ``base_commit`` (or HEAD).
 
@@ -141,6 +167,9 @@ def init_repo_from_local(src: str | Path, dest: Path, base_commit: str | None) -
               "commit", "-m", "base"], dest)
     if base_commit:
         _git(["checkout", base_commit], dest)
+    # Defense-in-depth: a copied source tree can carry a real origin in its
+    # .git/config. Strip every remote so no pipeline stage can reach upstream.
+    neutralize_remotes(dest)
     return _git_head(dest)
 
 

--- a/worca-bench/worca_bench/plugins/base.py
+++ b/worca-bench/worca_bench/plugins/base.py
@@ -83,6 +83,22 @@ class BenchmarkPlugin:
     ) -> GradeResult:
         raise NotImplementedError
 
+    def grade_preflight(
+        self,
+        instance: Instance,
+        grade: GradeConfig,
+        *,
+        secret_env: dict[str, str] | None = None,
+    ) -> tuple[bool, str]:
+        """Cheap, pre-build check that grading this instance is *possible* later, so
+        a token-burning build isn't wasted on something we can't grade.
+
+        Returns ``(ok, reason)``. Default: assume gradeable (no cheap signal). It is
+        best-effort — a check that can't run (missing tooling) must NOT block the
+        run; only a *definitive* "cannot grade" should return ``False``.
+        """
+        return True, ""
+
 
 # ----------------------------- shared helpers ------------------------------ #
 

--- a/worca-bench/worca_bench/plugins/base.py
+++ b/worca-bench/worca_bench/plugins/base.py
@@ -46,6 +46,11 @@ class GradeResult:
     score: float | None = None
     report_path: str | None = None
     detail: str = ""
+    # Fine-grained test counts when the grader runs a real suite (Commit0:
+    # held-out tests passed / total). ``None`` for pass/fail-only graders
+    # (SWE-bench resolved boolean, stub). ``score`` == passed / total.
+    tests_passed: int | None = None
+    tests_total: int | None = None
 
 
 class BenchmarkPlugin:

--- a/worca-bench/worca_bench/plugins/base.py
+++ b/worca-bench/worca_bench/plugins/base.py
@@ -74,11 +74,24 @@ class BenchmarkPlugin:
         grade: GradeConfig,
         *,
         prepared: Prepared,
+        secret_env: dict[str, str] | None = None,
     ) -> GradeResult:
         raise NotImplementedError
 
 
 # ----------------------------- shared helpers ------------------------------ #
+
+def grade_env(secret_env: dict[str, str] | None) -> dict[str, str]:
+    """Subprocess environment for grader shell-outs: os.environ + grader secrets.
+
+    sb-cli (``SWEBENCH_API_KEY``) and Modal (``MODAL_TOKEN_*``) credentials live
+    in worca-bench's secret env, not the ambient shell — merge them in so the
+    grader subprocess can authenticate.
+    """
+    import os
+
+    return {**os.environ, **(secret_env or {})}
+
 
 def _git(cmd: list[str], cwd: Path) -> str:
     return subprocess.run(["git", "-C", str(cwd), *cmd],

--- a/worca-bench/worca_bench/plugins/base.py
+++ b/worca-bench/worca_bench/plugins/base.py
@@ -1,0 +1,130 @@
+"""Benchmark plugin interface (W-075 §3).
+
+Unifying principle: the agent's patch is **source-only**; the harness supplies the
+tests. Each plugin: loads instances, gives a prompt, materializes the base tree,
+optionally hides benchmark tests during the run (Commit0), and grades the diff.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from ..config import GradeConfig, Profile
+
+
+@dataclass
+class Instance:
+    """One benchmark task."""
+
+    id: str
+    prompt: str
+    repo: str | None = None
+    base_commit: str | None = None
+    # Local source repo (a path). When set, materialize copies from here instead of
+    # cloning over the network — used by tests and offline runs.
+    local_repo: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Prepared:
+    """Result of pre-run preparation: paths to exclude from the diff + a restore hook."""
+
+    base_commit: str
+    extra_excludes: tuple[str, ...] = ()
+    restore: Callable[[], None] | None = None
+    gold_test_paths: tuple[str, ...] = ()
+
+
+@dataclass
+class GradeResult:
+    status: str  # graded | ran | error
+    resolved: bool | None = None
+    score: float | None = None
+    report_path: str | None = None
+    detail: str = ""
+
+
+class BenchmarkPlugin:
+    name: str = "base"
+
+    def load_instances(self, profile: Profile) -> list[Instance]:
+        raise NotImplementedError
+
+    def prompt_for(self, instance: Instance) -> str:
+        return instance.prompt
+
+    def materialize(self, instance: Instance, dest: Path) -> str:  # returns base_commit
+        raise NotImplementedError
+
+    def prepare(self, instance: Instance, tree: Path) -> Prepared:
+        """Default: nothing to hide; diff against the materialized base_commit."""
+        base = _git_head(tree)
+        return Prepared(base_commit=base)
+
+    def grade(
+        self,
+        instance: Instance,
+        diff: str,
+        tree: Path,
+        target_dir: Path,
+        grade: GradeConfig,
+        *,
+        prepared: Prepared,
+    ) -> GradeResult:
+        raise NotImplementedError
+
+
+# ----------------------------- shared helpers ------------------------------ #
+
+def _git(cmd: list[str], cwd: Path) -> str:
+    return subprocess.run(["git", "-C", str(cwd), *cmd],
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+def _git_head(tree: Path) -> str:
+    return _git(["rev-parse", "HEAD"], tree)
+
+
+def init_repo_from_local(src: str | Path, dest: Path, base_commit: str | None) -> str:
+    """Copy a local source repo into ``dest`` as a git repo at ``base_commit`` (or HEAD).
+
+    Used for offline/test materialization. Returns the base commit sha.
+    """
+    import shutil
+
+    src = Path(src)
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest)
+    if not (dest / ".git").exists():
+        _git(["init"], dest)
+        _git(["add", "-A"], dest)
+        _git(["-c", "user.email=bench@worca.dev", "-c", "user.name=bench",
+              "commit", "-m", "base"], dest)
+    if base_commit:
+        _git(["checkout", base_commit], dest)
+    return _git_head(dest)
+
+
+def stub_grade(diff: str, instance: Instance) -> GradeResult:
+    """Plumbing-only grader: no real test execution.
+
+    Resolves on the instance's ``expect_resolved`` override if present, else on
+    whether the agent produced a non-empty diff. Powers free e2e tests and a
+    user dry-run before paying for real grading.
+    """
+    expect = instance.extra.get("expect_resolved")
+    if expect is not None:
+        resolved = bool(expect)
+    else:
+        resolved = bool(diff.strip())
+    return GradeResult(
+        status="graded",
+        resolved=resolved,
+        score=1.0 if resolved else 0.0,
+        detail="stub grade (no test execution)",
+    )

--- a/worca-bench/worca_bench/plugins/commit0.py
+++ b/worca-bench/worca_bench/plugins/commit0.py
@@ -180,7 +180,8 @@ class Commit0Plugin(BenchmarkPlugin):
                     detail=f"commit0 {backend}: no test results parsed (rc={proc.returncode}): {tail}")
             score = passed / total
             return GradeResult(status="graded", resolved=(passed == total),
-                               score=score, detail=f"commit0 {backend} {passed}/{total}")
+                               score=score, detail=f"commit0 {backend} {passed}/{total}",
+                               tests_passed=passed, tests_total=total)
         except (subprocess.CalledProcessError, OSError) as e:
             tail = getattr(e, "stderr", "") or ""
             return GradeResult(status="error", detail=f"commit0 grade failed: {e} {tail}".strip())

--- a/worca-bench/worca_bench/plugins/commit0.py
+++ b/worca-bench/worca_bench/plugins/commit0.py
@@ -1,0 +1,135 @@
+"""Commit0 plugin (W-075 §3) — greenfield library build with contamination handling.
+
+Decision: **hide the gold tests during the run, grade on a pristine tree.** Before
+launch we stash the held-out test paths out of the agent's worktree (its TDD tester
+writes its own throwaway tests). We extract a source-only diff (gold tests excluded),
+then grade by applying it onto a fresh skeleton that carries the gold tests. A leakage
+guard (in the runner, using ``Prepared.gold_test_paths``) fails any rep whose diff
+touches a gold-test path.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..config import Profile
+from .base import (
+    BenchmarkPlugin,
+    GradeResult,
+    Instance,
+    Prepared,
+    _git,
+    _git_head,
+    init_repo_from_local,
+    stub_grade,
+)
+
+
+class Commit0Plugin(BenchmarkPlugin):
+    name = "commit0"
+
+    def load_instances(self, profile: Profile) -> list[Instance]:
+        sel = profile.selection
+        if not sel.instances_file:
+            raise RuntimeError(
+                "commit0 currently requires selection.instances_file (a list of "
+                "libraries with skeleton path + gold_test_paths). Run `commit0 setup "
+                "lite` and generate the file, or use the offline fixture form."
+            )
+        raw = Path(sel.instances_file).read_text(encoding="utf-8")
+        records = json.loads(raw)
+        want = set(sel.instance_ids)
+        out: list[Instance] = []
+        for r in records:
+            if want and r["instance_id"] not in want:
+                continue
+            out.append(Instance(
+                id=r["instance_id"],
+                prompt=r.get("spec", r.get("prompt", "")),
+                local_repo=r.get("local_repo"),
+                base_commit=r.get("base_commit"),
+                extra={"gold_test_paths": tuple(r.get("gold_test_paths", []))},
+            ))
+        return out
+
+    def materialize(self, instance: Instance, dest: Path) -> str:
+        if not instance.local_repo:
+            raise ValueError(f"commit0 instance {instance.id} needs a local_repo skeleton")
+        return init_repo_from_local(instance.local_repo, dest, instance.base_commit)
+
+    def prepare(self, instance: Instance, tree: Path) -> Prepared:
+        """Stash the gold tests out of the tree so the agent can't see them."""
+        base = _git_head(tree)
+        gold = tuple(instance.extra.get("gold_test_paths", ()))
+        stash_dir = tree.parent / f"{tree.name}__gold_tests"
+        stash_dir.mkdir(parents=True, exist_ok=True)
+        moved: list[tuple[Path, Path]] = []
+        for rel in gold:
+            src = tree / rel
+            if src.exists():
+                dst = stash_dir / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(dst))
+                moved.append((src, dst))
+
+        def restore() -> None:
+            for src, dst in moved:
+                src.parent.mkdir(parents=True, exist_ok=True)
+                if dst.exists():
+                    shutil.move(str(dst), str(src))
+            if stash_dir.exists():
+                shutil.rmtree(stash_dir, ignore_errors=True)
+
+        return Prepared(
+            base_commit=base,
+            extra_excludes=gold,
+            restore=restore,
+            gold_test_paths=gold,
+        )
+
+    def grade(self, instance, diff, tree, target_dir, grade, *, prepared) -> GradeResult:
+        if grade.mode == "stub":
+            return stub_grade(diff, instance)
+        # Real grading: apply the source-only diff onto a pristine skeleton that has
+        # the gold tests, then run commit0 test. Best-effort (needs commit0 + Docker).
+        return self._grade_on_pristine(instance, diff, target_dir, grade, prepared)  # pragma: no cover
+
+    def _grade_on_pristine(self, instance, diff, target_dir, grade, prepared) -> GradeResult:  # pragma: no cover
+        pristine = target_dir / "cache" / "commit0" / "pristine" / instance.id
+        try:
+            init_repo_from_local(instance.local_repo, pristine, instance.base_commit)
+            patch = target_dir / "predictions" / f"{instance.id}.patch"
+            patch.parent.mkdir(parents=True, exist_ok=True)
+            patch.write_text(diff, encoding="utf-8")
+            subprocess.run(["git", "-C", str(pristine), "apply", "--whitespace=nowarn",
+                            str(patch)], check=True, capture_output=True, text=True)
+            _git(["add", "-A"], pristine)
+            _git(["-c", "user.email=bench@worca.dev", "-c", "user.name=bench",
+                  "commit", "-m", "worca-bench candidate"], pristine)
+            lib = instance.extra.get("lib", instance.id)
+            proc = subprocess.run(
+                ["commit0", "test", lib, "--branch", "HEAD"],
+                cwd=str(pristine), capture_output=True, text=True,
+            )
+            passed, total = _parse_pytest_counts(proc.stdout + proc.stderr)
+            score = (passed / total) if total else 0.0
+            return GradeResult(status="graded", resolved=(total > 0 and passed == total),
+                               score=score, detail=f"commit0 {passed}/{total}")
+        except (subprocess.CalledProcessError, OSError) as e:
+            return GradeResult(status="error", detail=f"commit0 grade failed: {e}")
+
+
+def _parse_pytest_counts(text: str) -> tuple[int, int]:  # pragma: no cover
+    import re
+
+    passed = failed = 0
+    m = re.search(r"(\d+) passed", text)
+    if m:
+        passed = int(m.group(1))
+    m = re.search(r"(\d+) failed", text)
+    if m:
+        failed = int(m.group(1))
+    return passed, passed + failed

--- a/worca-bench/worca_bench/plugins/commit0.py
+++ b/worca-bench/worca_bench/plugins/commit0.py
@@ -28,6 +28,10 @@ from .base import (
     stub_grade,
 )
 
+# Per-library spec files Commit0 ships in every repo root. They are not source and
+# (notably spec.pdf, which is binary) must never leak into the graded prediction diff.
+_SPEC_ARTIFACTS = ("spec.pdf", "spec.pdf.bz2")
+
 
 class Commit0Plugin(BenchmarkPlugin):
     name = "commit0"
@@ -96,7 +100,11 @@ class Commit0Plugin(BenchmarkPlugin):
 
         return Prepared(
             base_commit=base,
-            extra_excludes=gold,
+            # Exclude the gold tests AND the spec artifacts every Commit0 repo ships in
+            # its root: spec.pdf is binary, so if it materializes in the tree it lands in
+            # the prediction patch as an incomplete binary diff that `git apply` rejects
+            # at grade time ("cannot apply binary patch ... without full index line").
+            extra_excludes=gold + _SPEC_ARTIFACTS,
             restore=restore,
             gold_test_paths=gold,
         )

--- a/worca-bench/worca_bench/plugins/commit0.py
+++ b/worca-bench/worca_bench/plugins/commit0.py
@@ -150,6 +150,12 @@ class Commit0Plugin(BenchmarkPlugin):
         # SandboxTimeout surfaces as "no test results parsed"). Raise it via the
         # profile's `grade.options.timeout`.
         grade_timeout = _coerce_pos_int((grade.options or {}).get("timeout"))
+        # Optional `grade.options.rebuild` → `commit0 test --rebuild`. commit0 pulls a
+        # prebuilt per-library image (`wentingzhao/<lib>:v0`); some libraries have no
+        # published image (404 on Docker Hub, or the Modal pull hangs). --rebuild
+        # builds the image locally from the repo instead — the only way to grade a
+        # library whose prebuilt image is missing.
+        rebuild = bool((grade.options or {}).get("rebuild"))
         # Real grading: apply the source-only diff onto the live Commit0 setup
         # checkout (which carries the held-out tests + the .commit0.yaml config that
         # `commit0 test` resolves repo/dataset/image state from) on a throwaway
@@ -157,10 +163,11 @@ class Commit0Plugin(BenchmarkPlugin):
         # commit0 + Docker for local; Modal credentials for modal).
         return self._grade_on_pristine(
             instance, diff, target_dir, prepared, secret_env, backend, grade_timeout,
+            rebuild,
         )  # pragma: no cover
 
-    def _grade_on_pristine(self, instance, diff, target_dir, prepared,
-                           secret_env, backend, grade_timeout=None) -> GradeResult:  # pragma: no cover
+    def _grade_on_pristine(self, instance, diff, target_dir, prepared, secret_env,
+                           backend, grade_timeout=None, rebuild=False) -> GradeResult:  # pragma: no cover
         lib = instance.extra.get("lib", instance.id)
         cfg = instance.extra.get("commit0") or {}
         base_dir = cfg.get("base_dir")
@@ -195,6 +202,8 @@ class Commit0Plugin(BenchmarkPlugin):
                    "--backend", backend, "--commit0-config-file", str(config_file)]
             if grade_timeout:
                 cmd += ["--timeout", str(grade_timeout)]
+            if rebuild:
+                cmd += ["--rebuild"]
             proc = subprocess.run(
                 cmd, cwd=str(Path(config_file).parent), capture_output=True, text=True,
                 env=grade_env(secret_env),

--- a/worca-bench/worca_bench/plugins/commit0.py
+++ b/worca-bench/worca_bench/plugins/commit0.py
@@ -52,7 +52,17 @@ class Commit0Plugin(BenchmarkPlugin):
                 prompt=r.get("spec", r.get("prompt", "")),
                 local_repo=r.get("local_repo"),
                 base_commit=r.get("base_commit"),
-                extra={"gold_test_paths": tuple(r.get("gold_test_paths", []))},
+                extra={
+                    "gold_test_paths": tuple(r.get("gold_test_paths", [])),
+                    # The Commit0 library name `commit0 test` expects (e.g. "tinydb").
+                    # Defaults to the instance id, but real Commit0 instance ids and
+                    # library names can differ, so the generator sets it explicitly.
+                    "lib": r.get("lib", r["instance_id"]),
+                    "reference_commit": r.get("reference_commit"),
+                    # Config the grader reconstructs `commit0 test` from (base_dir,
+                    # dot-file path, skeleton branch). Written by `commit0-gen`.
+                    "commit0": r.get("commit0") or {},
+                },
             ))
         return out
 
@@ -91,39 +101,96 @@ class Commit0Plugin(BenchmarkPlugin):
             gold_test_paths=gold,
         )
 
+    # worca-bench grade.mode → Commit0's ``commit0 test --backend`` value. Commit0
+    # runs its own tests in Docker (``local``) or on Modal serverless x86 (``modal``,
+    # which is actually Commit0's default backend). ``sb-cli`` is SWE-bench-only and
+    # has no Commit0 equivalent. ``stub`` is handled before this map (no real run).
+    BACKENDS = {"local-docker": "local", "modal": "modal"}
+
     def grade(self, instance, diff, tree, target_dir, grade, *, prepared,
               secret_env=None) -> GradeResult:
         if grade.mode == "stub":
             return stub_grade(diff, instance)
-        # Real grading: apply the source-only diff onto a pristine skeleton that has
-        # the gold tests, then run commit0 test. Best-effort (needs commit0 + Docker).
-        return self._grade_on_pristine(instance, diff, target_dir, grade, prepared, secret_env)  # pragma: no cover
+        backend = self.BACKENDS.get(grade.mode)
+        if backend is None:
+            return GradeResult(
+                status="error",
+                detail=f"unsupported grade mode {grade.mode!r} for commit0; "
+                       "use 'stub', 'local-docker', or 'modal'")
+        # Modal authenticates from MODAL_TOKEN_ID/SECRET — fail fast with an
+        # actionable message rather than dying deep in the commit0/modal client.
+        if backend == "modal":
+            env = grade_env(secret_env)
+            if not (env.get("MODAL_TOKEN_ID") and env.get("MODAL_TOKEN_SECRET")):
+                return GradeResult(
+                    status="error",
+                    detail="modal grading needs MODAL_TOKEN_ID + MODAL_TOKEN_SECRET "
+                           "(set them in the dashboard Settings, pass "
+                           "--modal-token-id/--modal-token-secret, or export them)")
+        # Real grading: apply the source-only diff onto the live Commit0 setup
+        # checkout (which carries the held-out tests + the .commit0.yaml config that
+        # `commit0 test` resolves repo/dataset/image state from) on a throwaway
+        # branch, then `commit0 test <lib> --branch <scratch>`. Best-effort (needs
+        # commit0 + Docker for local; Modal credentials for modal).
+        return self._grade_on_pristine(instance, diff, target_dir, prepared, secret_env, backend)  # pragma: no cover
 
-    def _grade_on_pristine(self, instance, diff, target_dir, grade, prepared,
-                           secret_env=None) -> GradeResult:  # pragma: no cover
-        pristine = target_dir / "cache" / "commit0" / "pristine" / instance.id
+    def _grade_on_pristine(self, instance, diff, target_dir, prepared,
+                           secret_env, backend) -> GradeResult:  # pragma: no cover
+        lib = instance.extra.get("lib", instance.id)
+        cfg = instance.extra.get("commit0") or {}
+        base_dir = cfg.get("base_dir")
+        config_file = cfg.get("config_file")
+        base_branch = cfg.get("base_branch", "commit0")
+        if not base_dir or not config_file:
+            return GradeResult(
+                status="error",
+                detail="commit0 grading needs the 'commit0' config block (base_dir + "
+                       "config_file) in the instances file — regenerate it with "
+                       "`worca-bench commit0-gen`")
+        repo_dir = Path(base_dir) / lib
+        # Unique, path-safe scratch branch so concurrent grades of distinct libs in
+        # the same setup never collide.
+        scratch = f"wb-grade-{instance.id}".replace("/", "_")
         try:
-            init_repo_from_local(instance.local_repo, pristine, instance.base_commit)
-            patch = target_dir / "predictions" / f"{instance.id}.patch"
+            # Apply the candidate source diff onto a fresh checkout of the skeleton.
+            _git(["checkout", "-f", "-B", scratch, base_branch], repo_dir)
+            patch = Path(target_dir) / "predictions" / f"{instance.id}.patch"
             patch.parent.mkdir(parents=True, exist_ok=True)
             patch.write_text(diff, encoding="utf-8")
-            subprocess.run(["git", "-C", str(pristine), "apply", "--whitespace=nowarn",
+            subprocess.run(["git", "-C", str(repo_dir), "apply", "--whitespace=nowarn",
                             str(patch)], check=True, capture_output=True, text=True)
-            _git(["add", "-A"], pristine)
+            _git(["add", "-A"], repo_dir)
             _git(["-c", "user.email=bench@worca.dev", "-c", "user.name=bench",
-                  "commit", "-m", "worca-bench candidate"], pristine)
-            lib = instance.extra.get("lib", instance.id)
+                  "commit", "-m", "worca-bench candidate"], repo_dir)
+            # `commit0 test` requires TEST_IDS (a pytest selection string). The
+            # held-out suite is the gold test dir(s) — exactly what the harness hides
+            # during the run and grades against here.
+            test_ids = " ".join(instance.extra.get("gold_test_paths", ())) or "tests/"
             proc = subprocess.run(
-                ["commit0", "test", lib, "--branch", "HEAD"],
-                cwd=str(pristine), capture_output=True, text=True,
+                ["commit0", "test", lib, test_ids, "--branch", scratch,
+                 "--backend", backend, "--commit0-config-file", str(config_file)],
+                cwd=str(Path(config_file).parent), capture_output=True, text=True,
                 env=grade_env(secret_env),
             )
             passed, total = _parse_pytest_counts(proc.stdout + proc.stderr)
-            score = (passed / total) if total else 0.0
-            return GradeResult(status="graded", resolved=(total > 0 and passed == total),
-                               score=score, detail=f"commit0 {passed}/{total}")
+            if total == 0:
+                tail = (proc.stderr or proc.stdout or "").strip()[-600:]
+                return GradeResult(
+                    status="error",
+                    detail=f"commit0 {backend}: no test results parsed (rc={proc.returncode}): {tail}")
+            score = passed / total
+            return GradeResult(status="graded", resolved=(passed == total),
+                               score=score, detail=f"commit0 {backend} {passed}/{total}")
         except (subprocess.CalledProcessError, OSError) as e:
-            return GradeResult(status="error", detail=f"commit0 grade failed: {e}")
+            tail = getattr(e, "stderr", "") or ""
+            return GradeResult(status="error", detail=f"commit0 grade failed: {e} {tail}".strip())
+        finally:
+            # Leave the setup back on its skeleton branch and drop the scratch branch.
+            try:
+                _git(["checkout", "-f", base_branch], repo_dir)
+                _git(["branch", "-D", scratch], repo_dir)
+            except subprocess.CalledProcessError:
+                pass
 
 
 def _parse_pytest_counts(text: str) -> tuple[int, int]:  # pragma: no cover

--- a/worca-bench/worca_bench/plugins/commit0.py
+++ b/worca-bench/worca_bench/plugins/commit0.py
@@ -42,6 +42,41 @@ def _coerce_pos_int(raw):
     return v if v > 0 else None
 
 
+def _docker_running() -> bool:
+    """True if the local Docker daemon answers — needed for local-docker grading."""
+    try:
+        return subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=15,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _image_published(image: str) -> bool | None:
+    """Registry existence of a grade image without pulling it.
+
+    ``True`` if the manifest exists, ``False`` only when the registry *definitively*
+    reports it missing, ``None`` when the check can't run (docker absent) or is
+    inconclusive (auth/network) — a preflight must never block on an inconclusive
+    signal.
+    """
+    try:
+        p = subprocess.run(
+            ["docker", "manifest", "inspect", image],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if p.returncode == 0:
+        return True
+    err = (p.stderr or "").lower()
+    if any(s in err for s in (
+        "no such manifest", "not found", "manifest unknown", "manifest for",
+    )):
+        return False
+    return None  # auth / network / unknown — inconclusive, don't block
+
+
 class Commit0Plugin(BenchmarkPlugin):
     name = "commit0"
 
@@ -165,6 +200,44 @@ class Commit0Plugin(BenchmarkPlugin):
             instance, diff, target_dir, prepared, secret_env, backend, grade_timeout,
             rebuild,
         )  # pragma: no cover
+
+    def _grade_image_name(self, instance) -> str:
+        """The Docker Hub image `commit0 test` pulls for this library (see commit0
+        harness/spec.py: ``wentingzhao/<repo>:v0``)."""
+        lib = instance.extra.get("lib", instance.id)
+        return f"wentingzhao/{lib}:v0".lower()
+
+    def grade_preflight(self, instance, grade, *, secret_env=None) -> tuple[bool, str]:
+        """Pre-build check that this library can be graded later — so a real (token-
+        burning) pipeline build isn't wasted on something commit0 can't grade.
+
+        Catches the deterministic blockers: missing Modal creds, an unreachable
+        Docker daemon (local-docker), and a grade image that the registry reports as
+        genuinely unpublished. Environmental/transient failures (disk space mid-run,
+        a test suite that hangs the sandbox) are NOT predictable here and fall back
+        to the build/grade timeouts.
+        """
+        if grade.mode == "stub":
+            return True, ""
+        backend = self.BACKENDS.get(grade.mode)
+        if backend is None:
+            return True, ""  # unknown mode — grade() reports it
+        if backend == "modal":
+            env = grade_env(secret_env)
+            if not (env.get("MODAL_TOKEN_ID") and env.get("MODAL_TOKEN_SECRET")):
+                return False, (
+                    "modal grading needs MODAL_TOKEN_ID + MODAL_TOKEN_SECRET — set "
+                    "them before launching, or the build can't be graded"
+                )
+        if backend == "local" and not _docker_running():
+            return False, "docker daemon not reachable (needed for local-docker grading)"
+        img = self._grade_image_name(instance)
+        if _image_published(img) is False:
+            return False, (
+                f"commit0 grade image {img} is not published — this library cannot "
+                "be graded by this commit0 release"
+            )
+        return True, ""
 
     def _grade_on_pristine(self, instance, diff, target_dir, prepared, secret_env,
                            backend, grade_timeout=None, rebuild=False) -> GradeResult:  # pragma: no cover

--- a/worca-bench/worca_bench/plugins/commit0.py
+++ b/worca-bench/worca_bench/plugins/commit0.py
@@ -33,6 +33,15 @@ from .base import (
 _SPEC_ARTIFACTS = ("spec.pdf", "spec.pdf.bz2")
 
 
+def _coerce_pos_int(raw):
+    """A positive int (seconds), else None. Mirrors the build-timeout coercion."""
+    try:
+        v = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return v if v > 0 else None
+
+
 class Commit0Plugin(BenchmarkPlugin):
     name = "commit0"
 
@@ -135,15 +144,23 @@ class Commit0Plugin(BenchmarkPlugin):
                     detail="modal grading needs MODAL_TOKEN_ID + MODAL_TOKEN_SECRET "
                            "(set them in the dashboard Settings, pass "
                            "--modal-token-id/--modal-token-secret, or export them)")
+        # Optional per-grade timeout (seconds) → `commit0 test --timeout`. This is
+        # the test-run cap AND the Modal sandbox timeout (modal.Sandbox.create
+        # timeout=); commit0's default is 1800s, which large suites exceed (a
+        # SandboxTimeout surfaces as "no test results parsed"). Raise it via the
+        # profile's `grade.options.timeout`.
+        grade_timeout = _coerce_pos_int((grade.options or {}).get("timeout"))
         # Real grading: apply the source-only diff onto the live Commit0 setup
         # checkout (which carries the held-out tests + the .commit0.yaml config that
         # `commit0 test` resolves repo/dataset/image state from) on a throwaway
         # branch, then `commit0 test <lib> --branch <scratch>`. Best-effort (needs
         # commit0 + Docker for local; Modal credentials for modal).
-        return self._grade_on_pristine(instance, diff, target_dir, prepared, secret_env, backend)  # pragma: no cover
+        return self._grade_on_pristine(
+            instance, diff, target_dir, prepared, secret_env, backend, grade_timeout,
+        )  # pragma: no cover
 
     def _grade_on_pristine(self, instance, diff, target_dir, prepared,
-                           secret_env, backend) -> GradeResult:  # pragma: no cover
+                           secret_env, backend, grade_timeout=None) -> GradeResult:  # pragma: no cover
         lib = instance.extra.get("lib", instance.id)
         cfg = instance.extra.get("commit0") or {}
         base_dir = cfg.get("base_dir")
@@ -174,10 +191,12 @@ class Commit0Plugin(BenchmarkPlugin):
             # held-out suite is the gold test dir(s) — exactly what the harness hides
             # during the run and grades against here.
             test_ids = " ".join(instance.extra.get("gold_test_paths", ())) or "tests/"
+            cmd = ["commit0", "test", lib, test_ids, "--branch", scratch,
+                   "--backend", backend, "--commit0-config-file", str(config_file)]
+            if grade_timeout:
+                cmd += ["--timeout", str(grade_timeout)]
             proc = subprocess.run(
-                ["commit0", "test", lib, test_ids, "--branch", scratch,
-                 "--backend", backend, "--commit0-config-file", str(config_file)],
-                cwd=str(Path(config_file).parent), capture_output=True, text=True,
+                cmd, cwd=str(Path(config_file).parent), capture_output=True, text=True,
                 env=grade_env(secret_env),
             )
             passed, total = _parse_pytest_counts(proc.stdout + proc.stderr)

--- a/worca-bench/worca_bench/plugins/commit0.py
+++ b/worca-bench/worca_bench/plugins/commit0.py
@@ -23,6 +23,7 @@ from .base import (
     Prepared,
     _git,
     _git_head,
+    grade_env,
     init_repo_from_local,
     stub_grade,
 )
@@ -90,14 +91,16 @@ class Commit0Plugin(BenchmarkPlugin):
             gold_test_paths=gold,
         )
 
-    def grade(self, instance, diff, tree, target_dir, grade, *, prepared) -> GradeResult:
+    def grade(self, instance, diff, tree, target_dir, grade, *, prepared,
+              secret_env=None) -> GradeResult:
         if grade.mode == "stub":
             return stub_grade(diff, instance)
         # Real grading: apply the source-only diff onto a pristine skeleton that has
         # the gold tests, then run commit0 test. Best-effort (needs commit0 + Docker).
-        return self._grade_on_pristine(instance, diff, target_dir, grade, prepared)  # pragma: no cover
+        return self._grade_on_pristine(instance, diff, target_dir, grade, prepared, secret_env)  # pragma: no cover
 
-    def _grade_on_pristine(self, instance, diff, target_dir, grade, prepared) -> GradeResult:  # pragma: no cover
+    def _grade_on_pristine(self, instance, diff, target_dir, grade, prepared,
+                           secret_env=None) -> GradeResult:  # pragma: no cover
         pristine = target_dir / "cache" / "commit0" / "pristine" / instance.id
         try:
             init_repo_from_local(instance.local_repo, pristine, instance.base_commit)
@@ -113,6 +116,7 @@ class Commit0Plugin(BenchmarkPlugin):
             proc = subprocess.run(
                 ["commit0", "test", lib, "--branch", "HEAD"],
                 cwd=str(pristine), capture_output=True, text=True,
+                env=grade_env(secret_env),
             )
             passed, total = _parse_pytest_counts(proc.stdout + proc.stderr)
             score = (passed / total) if total else 0.0

--- a/worca-bench/worca_bench/plugins/swebench.py
+++ b/worca-bench/worca_bench/plugins/swebench.py
@@ -22,6 +22,7 @@ from .base import (
     _git,
     grade_env,
     init_repo_from_local,
+    neutralize_remotes,
     stub_grade,
 )
 
@@ -113,6 +114,10 @@ class SwebenchPlugin(BenchmarkPlugin):
         subprocess.run(["git", "clone", url, str(dest)], check=True,
                        capture_output=True, text=True)
         _git(["checkout", instance.base_commit], dest)
+        # A fresh clone leaves origin = the real upstream (e.g. astropy/astropy).
+        # The bench never pushes and grades locally, so strip it — otherwise a
+        # misbehaving guardian can fork + open a PR against upstream.
+        neutralize_remotes(dest)
         return _git(["rev-parse", "HEAD"], dest)
 
     # ---- grade ----------------------------------------------------------- #

--- a/worca-bench/worca_bench/plugins/swebench.py
+++ b/worca-bench/worca_bench/plugins/swebench.py
@@ -1,0 +1,192 @@
+"""SWE-bench Verified plugin (W-075 §3).
+
+Clean by construction: the gold ``FAIL_TO_PASS`` tests arrive via ``test_patch`` only
+at grade time, never in the agent's tree — so no test-hiding is needed. The prompt is
+the issue ``problem_statement`` (``hints_text`` is intentionally excluded).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from ..config import Profile
+from .base import (
+    BenchmarkPlugin,
+    GradeResult,
+    Instance,
+    _git,
+    init_repo_from_local,
+    stub_grade,
+)
+
+HF_DATASET = "princeton-nlp/SWE-bench_Verified"
+MODEL_NAME = "worca-bench"
+
+
+class SwebenchPlugin(BenchmarkPlugin):
+    name = "swe-bench-verified"
+
+    # ---- instance loading ----------------------------------------------- #
+    def load_instances(self, profile: Profile) -> list[Instance]:
+        sel = profile.selection
+        if sel.instances_file:
+            return self._load_from_file(Path(sel.instances_file), sel.instance_ids)
+        return self._load_from_hf(profile)
+
+    def _load_from_file(self, path: Path, ids: list[str]) -> list[Instance]:
+        raw = path.read_text(encoding="utf-8")
+        records = (
+            [json.loads(line) for line in raw.splitlines() if line.strip()]
+            if path.suffix == ".jsonl"
+            else json.loads(raw)
+        )
+        want = set(ids)
+        out: list[Instance] = []
+        for r in records:
+            iid = r["instance_id"]
+            if want and iid not in want:
+                continue
+            out.append(self._to_instance(r))
+        return out
+
+    def _load_from_hf(self, profile: Profile) -> list[Instance]:
+        try:
+            from datasets import load_dataset
+        except ImportError as e:  # pragma: no cover - optional dep
+            raise RuntimeError(
+                "SWE-bench needs the 'datasets' package (pip install worca-bench[swebench]) "
+                "or a local selection.instances_file"
+            ) from e
+        ds = load_dataset(HF_DATASET, split="test")
+        ids = set(profile.selection.instance_ids)
+        records = [r for r in ds if not ids or r["instance_id"] in ids]
+        if profile.selection.sample:  # pragma: no cover - exercised via integration
+            records = _sample(records, profile.selection.sample)
+        return [self._to_instance(r) for r in records]
+
+    @staticmethod
+    def _to_instance(r: dict) -> Instance:
+        return Instance(
+            id=r["instance_id"],
+            prompt=r.get("problem_statement", ""),
+            repo=r.get("repo"),
+            base_commit=r.get("base_commit"),
+            local_repo=r.get("local_repo"),
+            extra={k: r[k] for k in ("expect_resolved", "version", "environment_setup_commit")
+                   if k in r},
+        )
+
+    # ---- materialize ----------------------------------------------------- #
+    def materialize(self, instance: Instance, dest: Path) -> str:
+        if instance.local_repo:
+            return init_repo_from_local(instance.local_repo, dest, instance.base_commit)
+        if not instance.repo or not instance.base_commit:
+            raise ValueError(f"instance {instance.id} lacks repo/base_commit for cloning")
+        dest.mkdir(parents=True, exist_ok=True)
+        url = f"https://github.com/{instance.repo}.git"
+        subprocess.run(["git", "clone", url, str(dest)], check=True,
+                       capture_output=True, text=True)
+        _git(["checkout", instance.base_commit], dest)
+        return _git(["rev-parse", "HEAD"], dest)
+
+    # ---- grade ----------------------------------------------------------- #
+    def grade(self, instance, diff, tree, target_dir, grade, *, prepared) -> GradeResult:
+        if grade.mode == "stub":
+            return stub_grade(diff, instance)
+        prediction = {
+            "instance_id": instance.id,
+            "model_name_or_path": MODEL_NAME,
+            "model_patch": diff,
+        }
+        if grade.mode == "sb-cli":
+            return self._grade_sb_cli(prediction, target_dir, grade)
+        if grade.mode in ("local-docker", "modal"):
+            return self._grade_harness(prediction, grade)
+        return GradeResult(status="error", detail=f"unsupported grade mode {grade.mode}")
+
+    # Real graders below are best-effort shell-outs (require sb-cli / Docker / network);
+    # they are not exercised by unit tests, which use grade.mode == 'stub'.
+    def _grade_sb_cli(self, prediction, target_dir, grade) -> GradeResult:  # pragma: no cover
+        preds_dir = target_dir / "predictions"
+        preds_dir.mkdir(parents=True, exist_ok=True)
+        preds = preds_dir / f"{prediction['instance_id']}.jsonl"
+        preds.write_text(json.dumps(prediction) + "\n", encoding="utf-8")
+        run_id = grade.options.get("run_id", f"wb-{prediction['instance_id']}")
+        subset = grade.options.get("subset", "swe-bench_verified")
+        try:
+            subprocess.run(
+                ["sb-cli", "submit", subset, "test",
+                 "--predictions_path", str(preds), "--run_id", run_id],
+                check=True, capture_output=True, text=True,
+            )
+            out_dir = target_dir / "sb-reports" / run_id
+            out_dir.mkdir(parents=True, exist_ok=True)
+            subprocess.run(
+                ["sb-cli", "get-report", subset, "test", run_id, "-o", str(out_dir)],
+                check=True, capture_output=True, text=True,
+            )
+            report = next(out_dir.glob("*.json"), None)
+            resolved = _resolved_from_report(report, prediction["instance_id"]) if report else None
+            return GradeResult(status="graded", resolved=resolved,
+                               score=1.0 if resolved else 0.0,
+                               report_path=str(report) if report else None,
+                               detail="sb-cli")
+        except (subprocess.CalledProcessError, OSError) as e:
+            return GradeResult(status="error", detail=f"sb-cli failed: {e}")
+
+    def _grade_harness(self, prediction, grade) -> GradeResult:  # pragma: no cover
+        with tempfile.TemporaryDirectory() as td:
+            preds = Path(td) / "predictions.jsonl"
+            preds.write_text(json.dumps(prediction) + "\n", encoding="utf-8")
+            run_id = grade.options.get("run_id", f"wb-{prediction['instance_id']}")
+            cmd = ["python", "-m", "swebench.harness.run_evaluation",
+                   "--dataset_name", HF_DATASET,
+                   "--predictions_path", str(preds),
+                   "--run_id", run_id, "--max_workers", "1",
+                   "--instance_ids", prediction["instance_id"]]
+            if grade.mode == "modal":
+                cmd += ["--modal", "true"]
+            try:
+                subprocess.run(cmd, check=True, capture_output=True, text=True)
+                report = Path.cwd() / f"{MODEL_NAME}.{run_id}.json"
+                resolved = _resolved_from_report(report, prediction["instance_id"])
+                return GradeResult(status="graded", resolved=resolved,
+                                   score=1.0 if resolved else 0.0,
+                                   report_path=str(report), detail=grade.mode)
+            except (subprocess.CalledProcessError, OSError) as e:
+                return GradeResult(status="error", detail=f"harness failed: {e}")
+
+
+def _sample(records, sample):  # pragma: no cover - integration-only
+    import random
+
+    rng = random.Random(sample.seed)
+    if sample.stratify_by:
+        buckets: dict = {}
+        for r in records:
+            buckets.setdefault(r.get(sample.stratify_by), []).append(r)
+        out = []
+        per = max(1, sample.n // max(1, len(buckets)))
+        for items in buckets.values():
+            rng.shuffle(items)
+            out.extend(items[:per])
+        return out[: sample.n]
+    pool = list(records)
+    rng.shuffle(pool)
+    return pool[: sample.n]
+
+
+def _resolved_from_report(report: Path | None, instance_id: str) -> bool | None:  # pragma: no cover
+    if not report or not report.exists():
+        return None
+    try:
+        data = json.loads(report.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    resolved_ids = data.get("resolved_ids") or data.get("resolved_instances") or []
+    if isinstance(resolved_ids, list):
+        return instance_id in resolved_ids
+    return None

--- a/worca-bench/worca_bench/plugins/swebench.py
+++ b/worca-bench/worca_bench/plugins/swebench.py
@@ -8,8 +8,10 @@ the issue ``problem_statement`` (``hints_text`` is intentionally excluded).
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 from ..config import Profile
@@ -24,6 +26,21 @@ from .base import (
 
 HF_DATASET = "princeton-nlp/SWE-bench_Verified"
 MODEL_NAME = "worca-bench"
+
+
+def _load_dataset_with_retry(load_dataset, name, *, split="test", attempts=4):
+    """Load an HF dataset, retrying transient network failures with backoff."""
+    last: Exception | None = None
+    for i in range(attempts):
+        try:
+            return load_dataset(name, split=split)
+        except Exception as e:  # noqa: BLE001 - retry any transient fetch failure
+            last = e
+            if i < attempts - 1:
+                time.sleep(3 * (i + 1))
+    raise RuntimeError(
+        f"failed to load HF dataset {name!r} after {attempts} attempts: {last}"
+    ) from last
 
 
 class SwebenchPlugin(BenchmarkPlugin):
@@ -53,6 +70,11 @@ class SwebenchPlugin(BenchmarkPlugin):
         return out
 
     def _load_from_hf(self, profile: Profile) -> list[Instance]:
+        # The Verified dataset is hundreds of MB over a CDN that can be slow/flaky.
+        # HF's default 10s download timeout is too aggressive — bump it before the
+        # (lazy) datasets import so huggingface_hub reads the larger value, then
+        # retry transient network failures with backoff.
+        os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "60")
         try:
             from datasets import load_dataset
         except ImportError as e:  # pragma: no cover - optional dep
@@ -60,7 +82,7 @@ class SwebenchPlugin(BenchmarkPlugin):
                 "SWE-bench needs the 'datasets' package (pip install worca-bench[swebench]) "
                 "or a local selection.instances_file"
             ) from e
-        ds = load_dataset(HF_DATASET, split="test")
+        ds = _load_dataset_with_retry(load_dataset, HF_DATASET)
         ids = set(profile.selection.instance_ids)
         records = [r for r in ds if not ids or r["instance_id"] in ids]
         if profile.selection.sample:  # pragma: no cover - exercised via integration

--- a/worca-bench/worca_bench/plugins/swebench.py
+++ b/worca-bench/worca_bench/plugins/swebench.py
@@ -20,6 +20,7 @@ from .base import (
     GradeResult,
     Instance,
     _git,
+    grade_env,
     init_repo_from_local,
     stub_grade,
 )
@@ -115,7 +116,8 @@ class SwebenchPlugin(BenchmarkPlugin):
         return _git(["rev-parse", "HEAD"], dest)
 
     # ---- grade ----------------------------------------------------------- #
-    def grade(self, instance, diff, tree, target_dir, grade, *, prepared) -> GradeResult:
+    def grade(self, instance, diff, tree, target_dir, grade, *, prepared,
+              secret_env=None) -> GradeResult:
         if grade.mode == "stub":
             return stub_grade(diff, instance)
         prediction = {
@@ -124,42 +126,58 @@ class SwebenchPlugin(BenchmarkPlugin):
             "model_patch": diff,
         }
         if grade.mode == "sb-cli":
-            return self._grade_sb_cli(prediction, target_dir, grade)
+            return self._grade_sb_cli(prediction, target_dir, grade, secret_env)
         if grade.mode in ("local-docker", "modal"):
-            return self._grade_harness(prediction, grade)
+            return self._grade_harness(prediction, grade, secret_env)
         return GradeResult(status="error", detail=f"unsupported grade mode {grade.mode}")
 
     # Real graders below are best-effort shell-outs (require sb-cli / Docker / network);
     # they are not exercised by unit tests, which use grade.mode == 'stub'.
-    def _grade_sb_cli(self, prediction, target_dir, grade) -> GradeResult:  # pragma: no cover
+    def _grade_sb_cli(self, prediction, target_dir, grade, secret_env=None) -> GradeResult:  # pragma: no cover
+        iid = prediction["instance_id"]
+        env = grade_env(secret_env)
         preds_dir = target_dir / "predictions"
         preds_dir.mkdir(parents=True, exist_ok=True)
-        preds = preds_dir / f"{prediction['instance_id']}.jsonl"
+        preds = preds_dir / f"{iid}.jsonl"
         preds.write_text(json.dumps(prediction) + "\n", encoding="utf-8")
-        run_id = grade.options.get("run_id", f"wb-{prediction['instance_id']}")
+        run_id = grade.options.get("run_id", f"wb-{iid}")
         subset = grade.options.get("subset", "swe-bench_verified")
+        out_dir = target_dir / "sb-reports" / run_id
+        out_dir.mkdir(parents=True, exist_ok=True)
         try:
-            subprocess.run(
+            submit = subprocess.run(
                 ["sb-cli", "submit", subset, "test",
                  "--predictions_path", str(preds), "--run_id", run_id],
-                check=True, capture_output=True, text=True,
+                capture_output=True, text=True, env=env,
             )
-            out_dir = target_dir / "sb-reports" / run_id
-            out_dir.mkdir(parents=True, exist_ok=True)
-            subprocess.run(
+            get = subprocess.run(
                 ["sb-cli", "get-report", subset, "test", run_id, "-o", str(out_dir)],
-                check=True, capture_output=True, text=True,
+                capture_output=True, text=True, env=env,
             )
-            report = next(out_dir.glob("*.json"), None)
-            resolved = _resolved_from_report(report, prediction["instance_id"]) if report else None
+        except OSError as e:
+            return GradeResult(status="error", detail=f"sb-cli not available: {e}")
+        # The report is authoritative; read it regardless of the CLI exit codes
+        # (sb-cli can exit non-zero on benign warnings). Only hard-error when no
+        # report came back at all.
+        report = next(out_dir.glob("*.json"), None)
+        resolved = _resolved_from_instance_report(report, iid)
+        if resolved is None:
+            resolved = _resolved_from_report(report, iid)
+        if resolved is not None:
+            detail = "sb-cli"
+            if submit.returncode or get.returncode:
+                detail = f"sb-cli (submit rc={submit.returncode}, get rc={get.returncode})"
             return GradeResult(status="graded", resolved=resolved,
                                score=1.0 if resolved else 0.0,
-                               report_path=str(report) if report else None,
-                               detail="sb-cli")
-        except (subprocess.CalledProcessError, OSError) as e:
-            return GradeResult(status="error", detail=f"sb-cli failed: {e}")
+                               report_path=str(report), detail=detail)
+        tail = (get.stderr or get.stdout or submit.stderr or submit.stdout or "").strip()[-1000:]
+        return GradeResult(
+            status="error",
+            detail=f"sb-cli failed (submit rc={submit.returncode}, "
+                   f"get rc={get.returncode}): {tail}")
 
-    def _grade_harness(self, prediction, grade) -> GradeResult:  # pragma: no cover
+    def _grade_harness(self, prediction, grade, secret_env=None) -> GradeResult:  # pragma: no cover
+        env = grade_env(secret_env)
         with tempfile.TemporaryDirectory() as td:
             preds = Path(td) / "predictions.jsonl"
             preds.write_text(json.dumps(prediction) + "\n", encoding="utf-8")
@@ -172,14 +190,32 @@ class SwebenchPlugin(BenchmarkPlugin):
             if grade.mode == "modal":
                 cmd += ["--modal", "true"]
             try:
-                subprocess.run(cmd, check=True, capture_output=True, text=True)
-                report = Path.cwd() / f"{MODEL_NAME}.{run_id}.json"
-                resolved = _resolved_from_report(report, prediction["instance_id"])
+                proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+            except OSError as e:
+                return GradeResult(status="error", detail=f"harness failed: {e}")
+            # The harness's per-instance report.json is authoritative and is
+            # written even when the process exits non-zero (e.g. image cleanup
+            # noise, or other instances in a batch erroring). Read it regardless
+            # of the return code; only fall back to a hard error when no report
+            # was produced at all (genuine grading failure — image build, etc.).
+            inst_report = harness_report_path(run_id, prediction["instance_id"])
+            resolved = _resolved_from_instance_report(
+                inst_report, prediction["instance_id"])
+            if resolved is None:
+                summary = Path.cwd() / f"{MODEL_NAME}.{run_id}.json"
+                resolved = _resolved_from_report(summary, prediction["instance_id"])
+                inst_report = summary if resolved is not None else inst_report
+            if resolved is not None:
+                detail = grade.mode if proc.returncode == 0 else (
+                    f"{grade.mode} (harness rc={proc.returncode})")
                 return GradeResult(status="graded", resolved=resolved,
                                    score=1.0 if resolved else 0.0,
-                                   report_path=str(report), detail=grade.mode)
-            except (subprocess.CalledProcessError, OSError) as e:
-                return GradeResult(status="error", detail=f"harness failed: {e}")
+                                   report_path=str(inst_report), detail=detail)
+            tail = (proc.stderr or proc.stdout or "").strip()[-1000:]
+            return GradeResult(
+                status="error",
+                detail=f"harness failed (rc={proc.returncode}); "
+                       f"no report at {inst_report}: {tail}")
 
 
 def _sample(records, sample):  # pragma: no cover - integration-only
@@ -199,6 +235,30 @@ def _sample(records, sample):  # pragma: no cover - integration-only
     pool = list(records)
     rng.shuffle(pool)
     return pool[: sample.n]
+
+
+def harness_report_path(run_id: str, instance_id: str) -> Path:
+    """Where ``run_evaluation`` writes the per-instance report (cwd-relative)."""
+    return (Path.cwd() / "logs" / "run_evaluation" / run_id / MODEL_NAME
+            / instance_id / "report.json")
+
+
+def _resolved_from_instance_report(report: Path | None, instance_id: str) -> bool | None:
+    """Read ``resolved`` from a per-instance ``report.json``.
+
+    The harness writes ``{<instance_id>: {"resolved": bool, ...}}``. Returns
+    None when the report is absent or unparseable (treated as "no result").
+    """
+    if not report or not report.exists():
+        return None
+    try:
+        data = json.loads(report.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    entry = data.get(instance_id)
+    if isinstance(entry, dict) and "resolved" in entry:
+        return bool(entry["resolved"])
+    return None
 
 
 def _resolved_from_report(report: Path | None, instance_id: str) -> bool | None:  # pragma: no cover

--- a/worca-bench/worca_bench/plugins/swebench.py
+++ b/worca-bench/worca_bench/plugins/swebench.py
@@ -116,6 +116,17 @@ class SwebenchPlugin(BenchmarkPlugin):
         return _git(["rev-parse", "HEAD"], dest)
 
     # ---- grade ----------------------------------------------------------- #
+    # Grade-backend registry: ``grade.mode`` → bound-method name. Adding a backend
+    # is a one-liner here plus a ``_grade_<x>(prediction, target_dir, grade,
+    # secret_env)`` method — the dispatch in ``grade()`` stays closed. ``stub`` is
+    # handled before the registry (it needs no prediction); ``local-docker`` and
+    # ``modal`` share the harness grader (``modal`` only flips ``--modal true``).
+    GRADERS = {
+        "sb-cli": "_grade_sb_cli",
+        "local-docker": "_grade_harness",
+        "modal": "_grade_harness",
+    }
+
     def grade(self, instance, diff, tree, target_dir, grade, *, prepared,
               secret_env=None) -> GradeResult:
         if grade.mode == "stub":
@@ -125,11 +136,11 @@ class SwebenchPlugin(BenchmarkPlugin):
             "model_name_or_path": MODEL_NAME,
             "model_patch": diff,
         }
-        if grade.mode == "sb-cli":
-            return self._grade_sb_cli(prediction, target_dir, grade, secret_env)
-        if grade.mode in ("local-docker", "modal"):
-            return self._grade_harness(prediction, grade, secret_env)
-        return GradeResult(status="error", detail=f"unsupported grade mode {grade.mode}")
+        method = self.GRADERS.get(grade.mode)
+        if method is None:
+            return GradeResult(status="error",
+                               detail=f"unsupported grade mode {grade.mode}")
+        return getattr(self, method)(prediction, target_dir, grade, secret_env)
 
     # Real graders below are best-effort shell-outs (require sb-cli / Docker / network);
     # they are not exercised by unit tests, which use grade.mode == 'stub'.
@@ -172,9 +183,21 @@ class SwebenchPlugin(BenchmarkPlugin):
             detail=f"sb-cli failed (submit rc={submit.returncode}, "
                    f"get rc={get.returncode}): {tail}")
 
-    def _grade_harness(self, prediction, grade, secret_env=None) -> GradeResult:  # pragma: no cover
+    def _grade_harness(self, prediction, _target_dir, grade, secret_env=None) -> GradeResult:
         env = grade_env(secret_env)
-        with tempfile.TemporaryDirectory() as td:
+        # Modal runs the harness on hosted x86 workers (the way to grade SWE-bench
+        # from an Apple-Silicon host). It authenticates from MODAL_TOKEN_ID/SECRET
+        # in the env — fail fast with an actionable message if they're absent
+        # rather than letting the harness die deep inside the modal client.
+        if grade.mode == "modal" and not (
+            env.get("MODAL_TOKEN_ID") and env.get("MODAL_TOKEN_SECRET")
+        ):
+            return GradeResult(
+                status="error",
+                detail="modal grading needs MODAL_TOKEN_ID + MODAL_TOKEN_SECRET "
+                       "(set them in the dashboard Settings, pass "
+                       "--modal-token-id/--modal-token-secret, or export them)")
+        with tempfile.TemporaryDirectory() as td:  # pragma: no cover - needs the real harness
             preds = Path(td) / "predictions.jsonl"
             preds.write_text(json.dumps(prediction) + "\n", encoding="utf-8")
             run_id = grade.options.get("run_id", f"wb-{prediction['instance_id']}")

--- a/worca-bench/worca_bench/plugins/swebench.py
+++ b/worca-bench/worca_bench/plugins/swebench.py
@@ -147,7 +147,8 @@ class SwebenchPlugin(BenchmarkPlugin):
         try:
             submit = subprocess.run(
                 ["sb-cli", "submit", subset, "test",
-                 "--predictions_path", str(preds), "--run_id", run_id],
+                 "--predictions_path", str(preds), "--run_id", run_id,
+                 "-o", str(out_dir)],  # keep sb-cli's report out of the cwd
                 capture_output=True, text=True, env=env,
             )
             get = subprocess.run(
@@ -157,19 +158,14 @@ class SwebenchPlugin(BenchmarkPlugin):
         except OSError as e:
             return GradeResult(status="error", detail=f"sb-cli not available: {e}")
         # The report is authoritative; read it regardless of the CLI exit codes
-        # (sb-cli can exit non-zero on benign warnings). Only hard-error when no
-        # report came back at all.
+        # (sb-cli can exit non-zero on benign warnings). Classify by the report's
+        # explicit id buckets — a remote eval *failure* (failed_ids/error_ids) is
+        # an error, NOT a graded-as-unresolved verdict. Only hard-error when no
+        # usable report came back at all.
         report = next(out_dir.glob("*.json"), None)
-        resolved = _resolved_from_instance_report(report, iid)
-        if resolved is None:
-            resolved = _resolved_from_report(report, iid)
-        if resolved is not None:
-            detail = "sb-cli"
-            if submit.returncode or get.returncode:
-                detail = f"sb-cli (submit rc={submit.returncode}, get rc={get.returncode})"
-            return GradeResult(status="graded", resolved=resolved,
-                               score=1.0 if resolved else 0.0,
-                               report_path=str(report), detail=detail)
+        verdict = _classify_sb_report(report, iid)
+        if verdict is not None:
+            return verdict
         tail = (get.stderr or get.stdout or submit.stderr or submit.stdout or "").strip()[-1000:]
         return GradeResult(
             status="error",
@@ -235,6 +231,47 @@ def _sample(records, sample):  # pragma: no cover - integration-only
     pool = list(records)
     rng.shuffle(pool)
     return pool[: sample.n]
+
+
+def _classify_sb_report(report: Path | None, instance_id: str) -> GradeResult | None:
+    """Map an sb-cli summary report's id buckets to a GradeResult for one instance.
+
+    sb-cli reports carry disjoint id lists (``resolved_ids``, ``unresolved_ids``,
+    ``failed_ids``, ``error_ids``, ``pending_ids``). A *resolved/unresolved* verdict
+    is a real grade; ``failed``/``error`` mean the hosted harness could not
+    evaluate the instance (e.g. the patch failed to apply) — that is an error, not
+    a "graded as unresolved". Returns None when the report is missing/unparseable
+    or the instance appears in no bucket (caller treats as no result).
+    """
+    if not report or not report.exists():
+        return None
+    try:
+        data = json.loads(report.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    def _in(bucket: str) -> bool:
+        v = data.get(bucket)
+        return isinstance(v, list) and instance_id in v
+
+    rp = str(report)
+    if _in("resolved_ids"):
+        return GradeResult(status="graded", resolved=True, score=1.0,
+                           report_path=rp, detail="sb-cli")
+    if _in("unresolved_ids"):
+        return GradeResult(status="graded", resolved=False, score=0.0,
+                           report_path=rp, detail="sb-cli")
+    if _in("failed_ids"):
+        return GradeResult(status="error", report_path=rp,
+                           detail="sb-cli: instance failed to evaluate "
+                                  "(patch did not apply / harness error)")
+    if _in("error_ids"):
+        return GradeResult(status="error", report_path=rp,
+                           detail="sb-cli: evaluation error")
+    if _in("pending_ids"):
+        return GradeResult(status="error", report_path=rp,
+                           detail="sb-cli: evaluation still pending")
+    return None
 
 
 def harness_report_path(run_id: str, instance_id: str) -> Path:

--- a/worca-bench/worca_bench/regrade_status.py
+++ b/worca-bench/worca_bench/regrade_status.py
@@ -1,0 +1,58 @@
+"""Regrade progress heartbeat (W-075 usability).
+
+A regrade sweep is a long, detached process whose only previous side effect was a
+single ``results.jsonl`` rewrite at the very end — so the dashboard had no way to
+show that a sweep was running, how far along it was, or whether it finished.
+
+This writes a tiny, atomically-updated status file per profile that the server
+reads to surface live progress (X/N, current instance, counts) and completion:
+
+    <target>/runs/<profile>/regrade-status.json
+
+The file carries the runner ``pid`` so the server can tell a genuinely-running
+sweep (``status: running`` + live pid) from a crashed one (running + dead pid).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def status_path(target_dir: Path, profile: str) -> Path:
+    return Path(target_dir) / "runs" / profile / "regrade-status.json"
+
+
+def write_status(
+    target_dir: Path,
+    profile: str,
+    *,
+    mode: str,
+    total: int,
+    done: int,
+    current: str | None,
+    counts: dict[str, int],
+    status: str,
+    started_at: str,
+    updated_at: str,
+) -> None:
+    """Atomically (temp + replace) write the heartbeat for one profile."""
+    path = status_path(target_dir, profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "profile": profile,
+        "mode": mode,
+        "pid": os.getpid(),
+        "total": total,
+        "done": done,
+        "current": current,
+        "counts": dict(counts),
+        "status": status,  # running | done | error
+        "started_at": started_at,
+        "updated_at": updated_at,
+    }
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    tmp.replace(path)

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -239,6 +239,7 @@ def _run_one_rep(
             )
 
         archive_artifacts(outcome.run_dir, diff, artifacts)
+        completed = _now()
         row = build_row(
             profile_name=profile.name, benchmark=profile.benchmark,
             instance_id=inst.id, worca_ref=wenv.describe(), template=template,
@@ -246,8 +247,11 @@ def _run_one_rep(
         graphify=profile.graphify.label, code_review_graph=profile.code_review_graph.label,
             rep=rep, run_id=run_id, status=status, resolved=resolved, score=score,
             telemetry=telemetry, diff=diff, leaked=leaked, error=error,
-            started_at=started, completed_at=_now(),
+            started_at=started, completed_at=completed,
             artifacts_dir=_artifacts_rel(profile.name, inst.id, rep),
+            report_path=(grade.report_path if grade else None),
+            grade_detail=(grade.detail if grade else None),
+            graded_at=(completed if grade else None),
         )
         append_row(target_dir, row)
         return RepResult(inst.id, rep, status, resolved, score, error)

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -8,6 +8,7 @@ fails fast on configs a worca version rejects, before the parallel sweep.
 
 from __future__ import annotations
 
+import os
 import shutil
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -77,6 +78,19 @@ def plan_reps(profile: Profile, instances: list[Instance]) -> list[tuple[Instanc
     return [(inst, rep) for inst in instances for rep in range(1, profile.reps + 1)]
 
 
+def _apply_cache_env(cache_dir: Path) -> None:
+    """Point HuggingFace's dataset cache at the benchmark cache dir so the large
+    SWE-bench/Commit0 dataset downloads land there (not the user's ~/.cache). Set
+    before any ``datasets.load_dataset`` call (plugin.load_instances). Also flows
+    to the run_pipeline subprocess, which inherits os.environ."""
+    cache_dir = Path(cache_dir)
+    hf = cache_dir / "hf"
+    hf.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("HF_HOME", str(hf))
+    os.environ["HF_DATASETS_CACHE"] = str(hf / "datasets")
+    os.environ["WORCA_BENCH_CACHE"] = str(cache_dir)
+
+
 def run_profile(
     profile: Profile,
     target_dir: Path,
@@ -85,9 +99,12 @@ def run_profile(
     canary_first: bool = True,
     max_instances: int | None = None,
     keep_work: bool = False,
+    cache_dir: Path | None = None,
 ) -> RunSummary:
     target_dir = Path(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
+    if cache_dir is not None:
+        _apply_cache_env(cache_dir)
     plugin = get_plugin(profile)
     instances = plugin.load_instances(profile)
     if max_instances is not None:

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -211,6 +211,7 @@ def _run_one_rep(
             profile, wenv, work,
             prompt=plugin.prompt_for(inst), template=bare_template,
             run_id=run_id, run_scratch=work / ".wb_scratch",
+            timeout=profile.timeout,
         )
         diff = extract_diff(work, prepared.base_commit,
                             extra_excludes=prepared.extra_excludes)

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -52,6 +52,9 @@ class RunSummary:
     reps_skipped: int = 0
     reps_error: int = 0
     incompatible_templates: dict[str, str] = field(default_factory=dict)
+    # instance_id -> reason for instances skipped by the grade preflight (we can't
+    # grade them later, so they were never built — no tokens spent).
+    ungradeable: dict[str, str] = field(default_factory=dict)
     results: list[RepResult] = field(default_factory=list)
 
     def as_dict(self) -> dict[str, Any]:
@@ -63,6 +66,7 @@ class RunSummary:
             "reps_skipped": self.reps_skipped,
             "reps_error": self.reps_error,
             "incompatible_templates": self.incompatible_templates,
+            "ungradeable": self.ungradeable,
         }
 
 
@@ -129,10 +133,26 @@ def run_profile(
         secret_env = collect_secret_env()
     templates = {profile.template_for(i.id) for i in instances}
 
-    if canary_first and instances:
+    # Grade preflight: definitively un-gradeable instances (missing image / docker
+    # down / no modal creds) are skipped BEFORE any token-burning build. On by
+    # default for real grading; opt out with `grade.options.preflight: false`.
+    if profile.grade.mode != "stub" and bool(
+        (profile.grade.options or {}).get("preflight", True)
+    ):
+        for inst in instances:
+            ok, reason = plugin.grade_preflight(
+                inst, profile.grade, secret_env=secret_env
+            )
+            if not ok:
+                summary.ungradeable[inst.id] = reason
+
+    # The canary validates each template by building one instance — use the first
+    # *gradeable* one so the canary build isn't itself wasted on a skipped instance.
+    canary_pool = [i for i in instances if i.id not in summary.ungradeable]
+    if canary_first and canary_pool:
         for tmpl in sorted(templates):
             ok, reason = _canary_template(
-                profile, wenv, plugin, instances[0], tmpl, target_dir, overlay, secret_env,
+                profile, wenv, plugin, canary_pool[0], tmpl, target_dir, overlay, secret_env,
             )
             if not ok:
                 summary.incompatible_templates[tmpl] = reason
@@ -140,6 +160,11 @@ def run_profile(
     def _task(item: tuple[Instance, int]) -> RepResult:
         inst, rep = item
         tmpl = profile.template_for(inst.id)
+        if inst.id in summary.ungradeable:
+            row = _skip_row(profile, inst, rep, wenv, tmpl,
+                            f"grade preflight: {summary.ungradeable[inst.id]}")
+            append_row(target_dir, row)
+            return RepResult(inst.id, rep, "skipped", error=row["error"])
         if tmpl in summary.incompatible_templates:
             row = _skip_row(profile, inst, rep, wenv, tmpl,
                             summary.incompatible_templates[tmpl])

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -168,7 +168,7 @@ def _canary_template(
     try:
         plugin.materialize(inst, work)
         worca_init(work, wenv)
-        seed_settings(work, overlay=overlay, extra_settings=profile.settings,
+        seed_settings(work, overlay=overlay, extra_settings={**profile.settings, **profile.engine_settings()},
                       pr_defer=profile.pr_defer, secret_env=secret_env)
         bare = resolve_for_launch(template, tree=work, templates=profile.templates)
         ok, reason = run_canary(
@@ -197,7 +197,7 @@ def _run_one_rep(
             shutil.rmtree(work, ignore_errors=True)
         plugin.materialize(inst, work)
         worca_init(work, wenv)
-        seed_settings(work, overlay=overlay, extra_settings=profile.settings,
+        seed_settings(work, overlay=overlay, extra_settings={**profile.settings, **profile.engine_settings()},
                       pr_defer=profile.pr_defer, secret_env=secret_env)
         prepared = plugin.prepare(inst, work)
 
@@ -238,6 +238,7 @@ def _run_one_rep(
             profile_name=profile.name, benchmark=profile.benchmark,
             instance_id=inst.id, worca_ref=wenv.describe(), template=template,
             worca_version=wenv.version, grade_mode=profile.grade.mode,
+        graphify=profile.graphify.label, code_review_graph=profile.code_review_graph.label,
             rep=rep, run_id=run_id, status=status, resolved=resolved, score=score,
             telemetry=telemetry, diff=diff, leaked=leaked, error=error,
             started_at=started, completed_at=_now(),
@@ -263,7 +264,8 @@ def _skip_row(profile, inst, rep, wenv, template, reason) -> dict[str, Any]:
     return build_row(
         profile_name=profile.name, benchmark=profile.benchmark, instance_id=inst.id,
         worca_ref=wenv.describe(), template=template,
-        worca_version=wenv.version, grade_mode=profile.grade.mode, rep=rep,
+        worca_version=wenv.version, grade_mode=profile.grade.mode,
+        graphify=profile.graphify.label, code_review_graph=profile.code_review_graph.label, rep=rep,
         run_id=f"{profile.name}__{inst.id}__rep{rep}", status="skipped",
         resolved=None, score=None, telemetry=Telemetry(), diff="", leaked=False,
         error=f"template incompatible: {reason}", started_at=_now(), completed_at=_now(),
@@ -275,7 +277,8 @@ def _error_row(profile, inst, rep, wenv, template, err, started) -> dict[str, An
     return build_row(
         profile_name=profile.name, benchmark=profile.benchmark, instance_id=inst.id,
         worca_ref=wenv.describe(), template=template,
-        worca_version=wenv.version, grade_mode=profile.grade.mode, rep=rep,
+        worca_version=wenv.version, grade_mode=profile.grade.mode,
+        graphify=profile.graphify.label, code_review_graph=profile.code_review_graph.label, rep=rep,
         run_id=f"{profile.name}__{inst.id}__rep{rep}", status="error",
         resolved=None, score=None, telemetry=Telemetry(), diff="", leaked=False,
         error=err, started_at=started, completed_at=_now(),

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -246,6 +246,8 @@ def _run_one_rep(
             worca_version=wenv.version, grade_mode=profile.grade.mode,
         graphify=profile.graphify.label, code_review_graph=profile.code_review_graph.label,
             rep=rep, run_id=run_id, status=status, resolved=resolved, score=score,
+            tests_passed=(grade.tests_passed if grade else None),
+            tests_total=(grade.tests_total if grade else None),
             telemetry=telemetry, diff=diff, leaked=leaked, error=error,
             started_at=started, completed_at=completed,
             artifacts_dir=_artifacts_rel(profile.name, inst.id, rep),

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -237,6 +237,7 @@ def _run_one_rep(
         row = build_row(
             profile_name=profile.name, benchmark=profile.benchmark,
             instance_id=inst.id, worca_ref=wenv.describe(), template=template,
+            worca_version=wenv.version, grade_mode=profile.grade.mode,
             rep=rep, run_id=run_id, status=status, resolved=resolved, score=score,
             telemetry=telemetry, diff=diff, leaked=leaked, error=error,
             started_at=started, completed_at=_now(),
@@ -261,7 +262,8 @@ def _run_one_rep(
 def _skip_row(profile, inst, rep, wenv, template, reason) -> dict[str, Any]:
     return build_row(
         profile_name=profile.name, benchmark=profile.benchmark, instance_id=inst.id,
-        worca_ref=wenv.describe(), template=template, rep=rep,
+        worca_ref=wenv.describe(), template=template,
+        worca_version=wenv.version, grade_mode=profile.grade.mode, rep=rep,
         run_id=f"{profile.name}__{inst.id}__rep{rep}", status="skipped",
         resolved=None, score=None, telemetry=Telemetry(), diff="", leaked=False,
         error=f"template incompatible: {reason}", started_at=_now(), completed_at=_now(),
@@ -272,7 +274,8 @@ def _skip_row(profile, inst, rep, wenv, template, reason) -> dict[str, Any]:
 def _error_row(profile, inst, rep, wenv, template, err, started) -> dict[str, Any]:
     return build_row(
         profile_name=profile.name, benchmark=profile.benchmark, instance_id=inst.id,
-        worca_ref=wenv.describe(), template=template, rep=rep,
+        worca_ref=wenv.describe(), template=template,
+        worca_version=wenv.version, grade_mode=profile.grade.mode, rep=rep,
         run_id=f"{profile.name}__{inst.id}__rep{rep}", status="error",
         resolved=None, score=None, telemetry=Telemetry(), diff="", leaked=False,
         error=err, started_at=started, completed_at=_now(),

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -101,6 +101,7 @@ def run_profile(
     keep_work: bool = False,
     cache_dir: Path | None = None,
     secret_env: dict[str, str] | None = None,
+    progress_cb=None,
 ) -> RunSummary:
     target_dir = Path(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -160,6 +161,17 @@ def run_profile(
                 summary.reps_error += 1
             else:
                 summary.reps_run += 1
+            if progress_cb is not None:
+                # Best-effort live progress for the Activity dock — never let a
+                # ledger write abort the sweep.
+                try:
+                    progress_cb(
+                        done=len(summary.results),
+                        total=summary.reps_total,
+                        errors=summary.reps_error,
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
     return summary
 
 

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -100,6 +100,7 @@ def run_profile(
     max_instances: int | None = None,
     keep_work: bool = False,
     cache_dir: Path | None = None,
+    secret_env: dict[str, str] | None = None,
 ) -> RunSummary:
     target_dir = Path(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -120,7 +121,11 @@ def run_profile(
         return summary
 
     overlay = load_overlay(wenv.resolved_sha)
-    secret_env = collect_secret_env()
+    # Secrets reach grading two ways: the ambient environment (collected here) or
+    # explicitly threaded in by the caller (CLI flags / browser-supplied values
+    # forwarded by the dashboard server). An explicit set wins outright.
+    if secret_env is None:
+        secret_env = collect_secret_env()
     templates = {profile.template_for(i.id) for i in instances}
 
     if canary_first and instances:

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -1,0 +1,263 @@
+"""Per-rep lifecycle orchestrator + sweep driver (W-075 §2, §9).
+
+For each (instance, rep): materialize the base tree → install worca → stash benchmark
+tests (Commit0) → launch the pipeline → harvest a source-only diff + telemetry →
+leakage guard → grade → normalize into ``results.jsonl``. A serial canary per template
+fails fast on configs a worca version rejects, before the parallel sweep.
+"""
+
+from __future__ import annotations
+
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import Profile
+from .harvest import archive_artifacts, extract_diff, parse_telemetry, touches_paths
+from .harvest import Telemetry
+from .launcher import canary as run_canary
+from .launcher import launch
+from .normalize import append_row, build_row
+from .plugins import get_plugin
+from .plugins.base import BenchmarkPlugin, Instance
+from .templates import resolve_for_launch
+from .venvs import WorcaEnv, resolve_worca_env
+from .worca_install import collect_secret_env, load_overlay, seed_settings, worca_init
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class RepResult:
+    instance_id: str
+    rep: int
+    status: str
+    resolved: bool | None = None
+    score: float | None = None
+    error: str | None = None
+
+
+@dataclass
+class RunSummary:
+    profile: str
+    worca_ref: str
+    reps_total: int
+    reps_run: int = 0
+    reps_skipped: int = 0
+    reps_error: int = 0
+    incompatible_templates: dict[str, str] = field(default_factory=dict)
+    results: list[RepResult] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "profile": self.profile,
+            "worca_ref": self.worca_ref,
+            "reps_total": self.reps_total,
+            "reps_run": self.reps_run,
+            "reps_skipped": self.reps_skipped,
+            "reps_error": self.reps_error,
+            "incompatible_templates": self.incompatible_templates,
+        }
+
+
+def _work_dir(target: Path, profile: str, inst_id: str, rep: int) -> Path:
+    return target / "work" / profile / inst_id / f"rep{rep}"
+
+
+def _artifacts_rel(profile: str, inst_id: str, rep: int) -> str:
+    return f"runs/{profile}/{inst_id}/rep{rep}"
+
+
+def plan_reps(profile: Profile, instances: list[Instance]) -> list[tuple[Instance, int]]:
+    return [(inst, rep) for inst in instances for rep in range(1, profile.reps + 1)]
+
+
+def run_profile(
+    profile: Profile,
+    target_dir: Path,
+    *,
+    dry_run: bool = False,
+    canary_first: bool = True,
+    max_instances: int | None = None,
+    keep_work: bool = False,
+) -> RunSummary:
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    plugin = get_plugin(profile)
+    instances = plugin.load_instances(profile)
+    if max_instances is not None:
+        instances = instances[:max_instances]
+    tasks = plan_reps(profile, instances)
+
+    wenv = resolve_worca_env(profile.worca, target_dir, build=not dry_run)
+    summary = RunSummary(
+        profile=profile.name, worca_ref=wenv.describe(), reps_total=len(tasks),
+    )
+
+    if dry_run:
+        return summary
+
+    overlay = load_overlay(wenv.resolved_sha)
+    secret_env = collect_secret_env()
+    templates = {profile.template_for(i.id) for i in instances}
+
+    if canary_first and instances:
+        for tmpl in sorted(templates):
+            ok, reason = _canary_template(
+                profile, wenv, plugin, instances[0], tmpl, target_dir, overlay, secret_env,
+            )
+            if not ok:
+                summary.incompatible_templates[tmpl] = reason
+
+    def _task(item: tuple[Instance, int]) -> RepResult:
+        inst, rep = item
+        tmpl = profile.template_for(inst.id)
+        if tmpl in summary.incompatible_templates:
+            row = _skip_row(profile, inst, rep, wenv, tmpl,
+                            summary.incompatible_templates[tmpl])
+            append_row(target_dir, row)
+            return RepResult(inst.id, rep, "skipped", error=row["error"])
+        return _run_one_rep(
+            profile, wenv, plugin, inst, rep, target_dir, overlay, secret_env, keep_work,
+        )
+
+    workers = max(1, profile.concurrency.worca)
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futs = {ex.submit(_task, t): t for t in tasks}
+        for fut in as_completed(futs):
+            res = fut.result()
+            summary.results.append(res)
+            if res.status == "skipped":
+                summary.reps_skipped += 1
+            elif res.status == "error":
+                summary.reps_error += 1
+            else:
+                summary.reps_run += 1
+    return summary
+
+
+def _canary_template(
+    profile, wenv: WorcaEnv, plugin: BenchmarkPlugin, inst: Instance, template: str,
+    target_dir: Path, overlay, secret_env,
+) -> tuple[bool, str]:
+    work = _work_dir(target_dir, profile.name, "__canary__", 0) / template.replace(":", "_")
+    if work.exists():
+        shutil.rmtree(work, ignore_errors=True)
+    try:
+        plugin.materialize(inst, work)
+        worca_init(work, wenv)
+        seed_settings(work, overlay=overlay, extra_settings=profile.settings,
+                      pr_defer=profile.pr_defer, secret_env=secret_env)
+        bare = resolve_for_launch(template, tree=work, templates=profile.templates)
+        ok, reason = run_canary(
+            profile, wenv, work, template=bare,
+            run_scratch=work / ".wb_scratch",
+        )
+        return ok, reason
+    except Exception as e:  # noqa: BLE001 - canary must never crash the sweep
+        return False, f"canary error: {e}"
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def _run_one_rep(
+    profile, wenv: WorcaEnv, plugin: BenchmarkPlugin, inst: Instance, rep: int,
+    target_dir: Path, overlay, secret_env, keep_work: bool,
+) -> RepResult:
+    run_id = f"{profile.name}__{inst.id}__rep{rep}"
+    template = profile.template_for(inst.id)
+    work = _work_dir(target_dir, profile.name, inst.id, rep)
+    artifacts = target_dir / _artifacts_rel(profile.name, inst.id, rep)
+    started = _now()
+    prepared = None
+    try:
+        if work.exists():
+            shutil.rmtree(work, ignore_errors=True)
+        plugin.materialize(inst, work)
+        worca_init(work, wenv)
+        seed_settings(work, overlay=overlay, extra_settings=profile.settings,
+                      pr_defer=profile.pr_defer, secret_env=secret_env)
+        prepared = plugin.prepare(inst, work)
+
+        bare_template = resolve_for_launch(template, tree=work, templates=profile.templates)
+        outcome = launch(
+            profile, wenv, work,
+            prompt=plugin.prompt_for(inst), template=bare_template,
+            run_id=run_id, run_scratch=work / ".wb_scratch",
+        )
+        diff = extract_diff(work, prepared.base_commit,
+                            extra_excludes=prepared.extra_excludes)
+        telemetry = parse_telemetry(outcome.status) if outcome.status else Telemetry()
+
+        # Leakage guard: a diff touching gold-test paths is contamination (Commit0).
+        leaked_paths = touches_paths(diff, prepared.gold_test_paths)
+        leaked = bool(leaked_paths)
+
+        if outcome.status is None:
+            status, resolved, score, error = "error", None, None, (
+                outcome.stderr or outcome.stdout or "no status.json"
+            ).strip()[-400:]
+            grade = None
+        elif leaked:
+            status, resolved, score, error = "error", False, 0.0, (
+                f"leakage guard: diff touched gold-test paths {leaked_paths}"
+            )
+            grade = None
+        else:
+            grade = plugin.grade(inst, diff, work, target_dir, profile.grade,
+                                 prepared=prepared)
+            status = grade.status
+            resolved, score, error = grade.resolved, grade.score, (
+                grade.detail if grade.status == "error" else None
+            )
+
+        archive_artifacts(outcome.run_dir, diff, artifacts)
+        row = build_row(
+            profile_name=profile.name, benchmark=profile.benchmark,
+            instance_id=inst.id, worca_ref=wenv.describe(), template=template,
+            rep=rep, run_id=run_id, status=status, resolved=resolved, score=score,
+            telemetry=telemetry, diff=diff, leaked=leaked, error=error,
+            started_at=started, completed_at=_now(),
+            artifacts_dir=_artifacts_rel(profile.name, inst.id, rep),
+        )
+        append_row(target_dir, row)
+        return RepResult(inst.id, rep, status, resolved, score, error)
+    except Exception as e:  # noqa: BLE001 - one rep failing must not kill the sweep
+        row = _error_row(profile, inst, rep, wenv, template, str(e), started)
+        append_row(target_dir, row)
+        return RepResult(inst.id, rep, "error", error=str(e))
+    finally:
+        if prepared and prepared.restore:
+            try:
+                prepared.restore()
+            except Exception:  # noqa: BLE001
+                pass
+        if not keep_work:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+def _skip_row(profile, inst, rep, wenv, template, reason) -> dict[str, Any]:
+    return build_row(
+        profile_name=profile.name, benchmark=profile.benchmark, instance_id=inst.id,
+        worca_ref=wenv.describe(), template=template, rep=rep,
+        run_id=f"{profile.name}__{inst.id}__rep{rep}", status="skipped",
+        resolved=None, score=None, telemetry=Telemetry(), diff="", leaked=False,
+        error=f"template incompatible: {reason}", started_at=_now(), completed_at=_now(),
+        artifacts_dir=_artifacts_rel(profile.name, inst.id, rep),
+    )
+
+
+def _error_row(profile, inst, rep, wenv, template, err, started) -> dict[str, Any]:
+    return build_row(
+        profile_name=profile.name, benchmark=profile.benchmark, instance_id=inst.id,
+        worca_ref=wenv.describe(), template=template, rep=rep,
+        run_id=f"{profile.name}__{inst.id}__rep{rep}", status="error",
+        resolved=None, score=None, telemetry=Telemetry(), diff="", leaked=False,
+        error=err, started_at=started, completed_at=_now(),
+        artifacts_dir=_artifacts_rel(profile.name, inst.id, rep),
+    )

--- a/worca-bench/worca_bench/runner.py
+++ b/worca-bench/worca_bench/runner.py
@@ -227,7 +227,7 @@ def _run_one_rep(
             grade = None
         else:
             grade = plugin.grade(inst, diff, work, target_dir, profile.grade,
-                                 prepared=prepared)
+                                 prepared=prepared, secret_env=secret_env)
             status = grade.status
             resolved, score, error = grade.resolved, grade.score, (
                 grade.detail if grade.status == "error" else None

--- a/worca-bench/worca_bench/stats.py
+++ b/worca-bench/worca_bench/stats.py
@@ -1,0 +1,48 @@
+"""Aggregate ``results.jsonl`` rows into per-profile statistics.
+
+Pure functions so both the CLI (`worca-bench stats`) and any external consumer can
+reuse them. The dashboard computes the equivalent in JS from the same rows.
+"""
+
+from __future__ import annotations
+
+from statistics import mean, median
+from typing import Any, Iterable
+
+
+def _graded(rows: Iterable[dict]) -> list[dict]:
+    return [r for r in rows if r.get("status") == "graded"]
+
+
+def aggregate(rows: list[dict]) -> dict[str, Any]:
+    """Aggregate a set of rows (assumed one profile/config) into headline stats."""
+    graded = _graded(rows)
+    resolved = [r for r in graded if r.get("resolved") is True]
+    scores = [r["score"] for r in graded if isinstance(r.get("score"), (int, float))]
+    costs = [r["cost_usd"] for r in rows if isinstance(r.get("cost_usd"), (int, float))]
+    walls = [r["wall_time_s"] for r in rows if isinstance(r.get("wall_time_s"), (int, float))]
+    iters = [_total_iterations(r) for r in rows]
+    return {
+        "n": len(rows),
+        "graded": len(graded),
+        "errors": sum(1 for r in rows if r.get("status") == "error"),
+        "skipped": sum(1 for r in rows if r.get("status") == "skipped"),
+        "leaked": sum(1 for r in rows if r.get("leaked")),
+        "resolved_rate": (len(resolved) / len(graded)) if graded else None,
+        "mean_score": mean(scores) if scores else None,
+        "mean_cost_usd": mean(costs) if costs else None,
+        "median_cost_usd": median(costs) if costs else None,
+        "mean_wall_s": mean(walls) if walls else None,
+        "mean_iterations": mean(iters) if iters else None,
+    }
+
+
+def _total_iterations(row: dict) -> int:
+    return sum(v for v in (row.get("loop_counters") or {}).values() if isinstance(v, int))
+
+
+def aggregate_by_profile(rows: list[dict]) -> dict[str, dict[str, Any]]:
+    groups: dict[str, list[dict]] = {}
+    for r in rows:
+        groups.setdefault(r.get("profile", "?"), []).append(r)
+    return {name: aggregate(rs) for name, rs in groups.items()}

--- a/worca-bench/worca_bench/templates.py
+++ b/worca-bench/worca_bench/templates.py
@@ -5,8 +5,13 @@ It does not parse a ``tier:name`` prefix. worca-bench owns that syntax: it parse
 ``builtin:`` / ``project:`` / ``user:``, seeds project/user template definitions into
 the right tier dir, and hands worca the bare id.
 
-Template definitions for non-builtin tiers come from ``profile.templates[name]`` — a
-``template.json``-shaped dict ({id, name, config, ...}).
+Template definitions for non-builtin tiers may come from ``profile.templates[name]`` — a
+``template.json``-shaped dict ({id, name, config, ...}) — which makes a profile
+self-contained for isolated/CI hosts. When the profile carries no such definition but
+the template already exists on disk in the right tier dir (e.g. a user template under
+``~/.worca/templates/<name>``), the ref resolves seamlessly against it with no copy —
+the same template worca's own resolution would pick. Only a ref with neither an embedded
+definition nor an on-disk template is an error.
 """
 
 from __future__ import annotations
@@ -34,11 +39,12 @@ def parse_ref(ref: str) -> tuple[str | None, str]:
     return None, ref
 
 
-def _seed_template(dir_: Path, defn: dict[str, Any] | None, name: str) -> None:
-    if defn is None:
-        raise TemplateRefError(
-            f"profile.templates is missing a definition for non-builtin template {name!r}"
-        )
+def _seed_template(dir_: Path, defn: dict[str, Any], name: str) -> None:
+    """Materialize a ``template.json`` for ``name`` from an explicit profile definition.
+
+    Only writes ``template.json`` — any sibling ``agents/`` override dir already on disk
+    is preserved (``mkdir(exist_ok=True)`` never deletes).
+    """
     dir_.mkdir(parents=True, exist_ok=True)
     payload = dict(defn)
     payload.setdefault("id", name)
@@ -55,20 +61,40 @@ def resolve_for_launch(
     templates: dict[str, dict[str, Any]],
     user_templates_dir: Path | None = None,
 ) -> str:
-    """Return the bare id to pass to ``--template``, seeding project/user tiers.
+    """Return the bare id to pass to ``--template``, seeding project/user tiers as needed.
 
-    ``builtin:`` and bare refs pass through (a fresh clone has no shadow, so a bare
-    id resolves to the builtin). ``project:`` seeds ``<tree>/.claude/templates/<name>``.
-    ``user:`` seeds ``~/.worca/templates/<name>`` (host-global; isolate per CI user).
+    ``builtin:`` and bare refs pass through untouched — worca's own
+    project > user > builtin resolution handles them (a bare id finds an existing
+    user/project template, or falls back to the builtin).
+
+    For an explicit ``project:`` / ``user:`` ref, the tier dir is
+    ``<tree>/.claude/templates/<name>`` (project) or ``~/.worca/templates/<name>``
+    (user, host-global; isolate per CI user). Resolution there is:
+
+    1. ``profile.templates[name]`` present → materialize it (self-contained / CI path;
+       overrides any on-disk copy so the run host need not already have the template).
+    2. no definition, but ``template.json`` already exists on disk → use it as-is,
+       **no copy/overwrite** (the seamless host path — what worca would resolve anyway).
+    3. neither → hard error.
     """
     tier, name = parse_ref(ref)
     if tier in (None, "builtin"):
         return name
     if tier == "project":
-        _seed_template(tree / ".claude" / "templates" / name, templates.get(name), name)
-        return name
-    if tier == "user":
+        dir_ = tree / ".claude" / "templates" / name
+    elif tier == "user":
         base = user_templates_dir or (Path.home() / ".worca" / "templates")
-        _seed_template(base / name, templates.get(name), name)
-        return name
-    raise TemplateRefError(f"unhandled tier in {ref!r}")  # pragma: no cover
+        dir_ = base / name
+    else:  # pragma: no cover - parse_ref already rejects unknown tiers
+        raise TemplateRefError(f"unhandled tier in {ref!r}")
+
+    defn = templates.get(name)
+    if defn is not None:
+        _seed_template(dir_, defn, name)
+    elif not (dir_ / "template.json").exists():
+        raise TemplateRefError(
+            f"template {name!r} ({tier} tier) has no definition in profile.templates "
+            f"and no existing template at {dir_}"
+        )
+    # else: template already present on disk — resolve seamlessly, leave it untouched.
+    return name

--- a/worca-bench/worca_bench/templates.py
+++ b/worca-bench/worca_bench/templates.py
@@ -1,0 +1,74 @@
+"""tier:name template resolution (requirement 2).
+
+worca's ``--template`` takes a *bare* id and resolves project > user > builtin.
+It does not parse a ``tier:name`` prefix. worca-bench owns that syntax: it parses
+``builtin:`` / ``project:`` / ``user:``, seeds project/user template definitions into
+the right tier dir, and hands worca the bare id.
+
+Template definitions for non-builtin tiers come from ``profile.templates[name]`` — a
+``template.json``-shaped dict ({id, name, config, ...}).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+VALID_TIERS = {"builtin", "project", "user"}
+
+
+class TemplateRefError(ValueError):
+    pass
+
+
+def parse_ref(ref: str) -> tuple[str | None, str]:
+    """Split ``tier:name`` → (tier, name). A bare ``name`` returns (None, name)."""
+    if ":" in ref:
+        tier, name = ref.split(":", 1)
+        if tier not in VALID_TIERS:
+            raise TemplateRefError(
+                f"unknown template tier {tier!r} in {ref!r}; expected {sorted(VALID_TIERS)}"
+            )
+        return tier, name
+    return None, ref
+
+
+def _seed_template(dir_: Path, defn: dict[str, Any] | None, name: str) -> None:
+    if defn is None:
+        raise TemplateRefError(
+            f"profile.templates is missing a definition for non-builtin template {name!r}"
+        )
+    dir_.mkdir(parents=True, exist_ok=True)
+    payload = dict(defn)
+    payload.setdefault("id", name)
+    payload.setdefault("name", name)
+    payload.setdefault("builtin", False)
+    payload.setdefault("config", {})
+    (dir_ / "template.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def resolve_for_launch(
+    ref: str,
+    *,
+    tree: Path,
+    templates: dict[str, dict[str, Any]],
+    user_templates_dir: Path | None = None,
+) -> str:
+    """Return the bare id to pass to ``--template``, seeding project/user tiers.
+
+    ``builtin:`` and bare refs pass through (a fresh clone has no shadow, so a bare
+    id resolves to the builtin). ``project:`` seeds ``<tree>/.claude/templates/<name>``.
+    ``user:`` seeds ``~/.worca/templates/<name>`` (host-global; isolate per CI user).
+    """
+    tier, name = parse_ref(ref)
+    if tier in (None, "builtin"):
+        return name
+    if tier == "project":
+        _seed_template(tree / ".claude" / "templates" / name, templates.get(name), name)
+        return name
+    if tier == "user":
+        base = user_templates_dir or (Path.home() / ".worca" / "templates")
+        _seed_template(base / name, templates.get(name), name)
+        return name
+    raise TemplateRefError(f"unhandled tier in {ref!r}")  # pragma: no cover

--- a/worca-bench/worca_bench/venvs.py
+++ b/worca-bench/worca_bench/venvs.py
@@ -1,0 +1,182 @@
+"""worca version/ref provisioning (requirement 1).
+
+The runner is version-agnostic: it never imports worca. For each requested ref it
+resolves a ``WorcaEnv`` describing how to invoke that worca — either the current
+environment (``local``, for tests/dev) or an isolated venv with a pinned install.
+Venvs are cached by ref-hash under ``<target>/cache/venvs/`` and reused across reps.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .config import WorcaRef
+
+WORCA_REPO_SLUG = "SinishaDjukic/worca-cc"
+GIT_BASE = f"git+https://github.com/{WORCA_REPO_SLUG}"
+
+
+class VenvError(RuntimeError):
+    pass
+
+
+def find_worca_repo() -> Path | None:
+    """Locate the worca-cc source repo (needed for ``local`` ref + the mock Claude).
+
+    Order: ``WORCA_BENCH_WORCA_REPO`` env → the repo this package lives in →
+    ``None`` (caller must then require a non-local ref)."""
+    env = os.environ.get("WORCA_BENCH_WORCA_REPO")
+    if env:
+        p = Path(env).expanduser().resolve()
+        if (p / "src" / "worca").is_dir():
+            return p
+    # worca-bench/worca_bench/venvs.py -> parents[2] == repo root (in-tree layout)
+    here = Path(__file__).resolve()
+    for cand in here.parents:
+        if (cand / "src" / "worca").is_dir() and (cand / "worca-bench").is_dir():
+            return cand
+    return None
+
+
+@dataclass
+class WorcaEnv:
+    """How to invoke a resolved worca install."""
+
+    ref: str
+    python: str  # interpreter that has worca importable
+    env_overrides: dict[str, str] = field(default_factory=dict)
+    repo: Path | None = None  # worca-cc source repo, when known
+    resolved_sha: str | None = None
+
+    def base_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        env.update(self.env_overrides)
+        return env
+
+    def describe(self) -> str:
+        if self.resolved_sha:
+            return f"{self.ref}@{self.resolved_sha[:12]}"
+        return self.ref
+
+
+def _ref_hash(ref: WorcaRef) -> str:
+    key = f"{ref.source or ''}::{ref.ref}"
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def _pip_target(ref: WorcaRef) -> str:
+    """Map a ref to a pip install target."""
+    source = ref.source
+    if source and source.startswith("path:"):
+        return source[len("path:"):]
+    if source and (source.startswith("git+") or source.startswith("http")):
+        # explicit source with the ref as the @<ref> suffix
+        base = source.rstrip("@")
+        return f"{base}@{ref.ref}"
+    # Released version like "0.58.0" => PyPI pin; otherwise treat as a git ref.
+    if ref.ref and ref.ref[0].isdigit():
+        return f"worca-cc=={ref.ref}"
+    return f"{GIT_BASE}@{ref.ref}"
+
+
+def _git_sha(repo: Path, ref: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", ref],
+            cwd=repo, capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+
+
+def resolve_worca_env(
+    ref: WorcaRef,
+    target_dir: Path,
+    *,
+    build: bool = True,
+) -> WorcaEnv:
+    """Resolve (and, for non-local refs, build+cache) a venv for ``ref``.
+
+    ``build=False`` returns the env description without creating the venv — used by
+    tests and ``--dry-run`` to avoid network/pip.
+    """
+    repo = find_worca_repo()
+
+    if ref.is_local:
+        if repo is None:
+            raise VenvError(
+                "worca ref 'local' requires the worca-cc source repo; set "
+                "WORCA_BENCH_WORCA_REPO or use a pip-installable ref"
+            )
+        # Use the current interpreter; make worca importable from source.
+        return WorcaEnv(
+            ref="local",
+            python=sys.executable,
+            env_overrides={"PYTHONPATH": _prepend_pythonpath(str(repo / "src"))},
+            repo=repo,
+            resolved_sha=_git_sha(repo, "HEAD"),
+        )
+
+    venv_dir = target_dir / "cache" / "venvs" / _ref_hash(ref)
+    py = venv_dir / ("Scripts" if os.name == "nt" else "bin") / (
+        "python.exe" if os.name == "nt" else "python"
+    )
+    resolved_sha = _git_sha(repo, ref.ref) if repo else None
+
+    if not build:
+        return WorcaEnv(ref=ref.ref, python=str(py), repo=repo, resolved_sha=resolved_sha)
+
+    if not py.exists():
+        _build_venv(venv_dir, _pip_target(ref))
+    elif not _worca_importable(py):
+        # Stale/broken cache — rebuild.
+        _build_venv(venv_dir, _pip_target(ref))
+
+    return WorcaEnv(ref=ref.ref, python=str(py), repo=repo, resolved_sha=resolved_sha)
+
+
+def _prepend_pythonpath(path: str) -> str:
+    existing = os.environ.get("PYTHONPATH", "")
+    return f"{path}{os.pathsep}{existing}" if existing else path
+
+
+def _worca_importable(py: Path) -> bool:
+    try:
+        r = subprocess.run(
+            [str(py), "-c", "import worca"],
+            capture_output=True, timeout=60,
+        )
+        return r.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _build_venv(venv_dir: Path, pip_target: str) -> None:
+    venv_dir.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "venv", str(venv_dir)],
+            check=True, capture_output=True, text=True,
+        )
+        py = venv_dir / ("Scripts" if os.name == "nt" else "bin") / (
+            "python.exe" if os.name == "nt" else "python"
+        )
+        subprocess.run(
+            [str(py), "-m", "pip", "install", "--upgrade", "pip"],
+            check=True, capture_output=True, text=True,
+        )
+        subprocess.run(
+            [str(py), "-m", "pip", "install", pip_target],
+            check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as e:  # pragma: no cover - network path
+        raise VenvError(
+            f"failed to provision worca venv for {pip_target!r}: "
+            f"{(e.stderr or '').strip()[:500]}"
+        ) from e

--- a/worca-bench/worca_bench/venvs.py
+++ b/worca-bench/worca_bench/venvs.py
@@ -52,6 +52,7 @@ class WorcaEnv:
     env_overrides: dict[str, str] = field(default_factory=dict)
     repo: Path | None = None  # worca-cc source repo, when known
     resolved_sha: str | None = None
+    version: str | None = None  # resolved worca package version (e.g. "0.58.0")
 
     def base_env(self) -> dict[str, str]:
         env = dict(os.environ)
@@ -95,6 +96,22 @@ def _git_sha(repo: Path, ref: str) -> str | None:
         return None
 
 
+def _worca_version(python: str, env_overrides: dict[str, str] | None = None) -> str | None:
+    """Query the resolved worca package version (best-effort; None on failure)."""
+    try:
+        env = dict(os.environ)
+        if env_overrides:
+            env.update(env_overrides)
+        out = subprocess.run(
+            [python, "-c",
+             "import worca,sys; sys.stdout.write(getattr(worca,'__version__','') or '')"],
+            capture_output=True, text=True, env=env, timeout=30, check=False,
+        )
+        return out.stdout.strip() or None
+    except Exception:  # noqa: BLE001 - version is advisory metadata
+        return None
+
+
 def resolve_worca_env(
     ref: WorcaRef,
     target_dir: Path,
@@ -115,12 +132,14 @@ def resolve_worca_env(
                 "WORCA_BENCH_WORCA_REPO or use a pip-installable ref"
             )
         # Use the current interpreter; make worca importable from source.
+        overrides = {"PYTHONPATH": _prepend_pythonpath(str(repo / "src"))}
         return WorcaEnv(
             ref="local",
             python=sys.executable,
-            env_overrides={"PYTHONPATH": _prepend_pythonpath(str(repo / "src"))},
+            env_overrides=overrides,
             repo=repo,
             resolved_sha=_git_sha(repo, "HEAD"),
+            version=_worca_version(sys.executable, overrides) if build else None,
         )
 
     venv_dir = target_dir / "cache" / "venvs" / _ref_hash(ref)
@@ -138,7 +157,10 @@ def resolve_worca_env(
         # Stale/broken cache — rebuild.
         _build_venv(venv_dir, _pip_target(ref))
 
-    return WorcaEnv(ref=ref.ref, python=str(py), repo=repo, resolved_sha=resolved_sha)
+    return WorcaEnv(
+        ref=ref.ref, python=str(py), repo=repo, resolved_sha=resolved_sha,
+        version=_worca_version(str(py)),
+    )
 
 
 def _prepend_pythonpath(path: str) -> str:

--- a/worca-bench/worca_bench/worca_install.py
+++ b/worca-bench/worca_bench/worca_install.py
@@ -28,7 +28,13 @@ LEAKY_ENV = (
     "GRAPHIFY_OUT",
 )
 # Secrets to materialize into settings.local.json env when present in the environment.
-SECRET_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")
+SECRET_ENV_KEYS = (
+    # Pipeline (worca / Claude) credentials.
+    "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN",
+    # Grader credentials: sb-cli (hosted SWE-bench eval) and Modal (serverless
+    # x86 harness). Collected so they reach plugin.grade() via secret_env.
+    "SWEBENCH_API_KEY", "MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET",
+)
 
 
 class InstallError(RuntimeError):

--- a/worca-bench/worca_bench/worca_install.py
+++ b/worca-bench/worca_bench/worca_install.py
@@ -113,10 +113,24 @@ def seed_settings(
         )
 
 
-def collect_secret_env(environ: dict[str, str] | None = None) -> dict[str, str]:
-    """Pull known secret keys from the environment for settings.local.json."""
+def collect_secret_env(
+    environ: dict[str, str] | None = None,
+    *,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Pull known secret keys from the environment for settings.local.json.
+
+    ``extra`` overlays explicitly-supplied secrets (e.g. CLI flags or values
+    passed down from the browser) *on top of* the environment-collected set.
+    Both are filtered through ``SECRET_ENV_KEYS`` so an unknown key can never be
+    injected into the subprocess env, and empty values never shadow a real one.
+    """
     environ = environ if environ is not None else dict(os.environ)
-    return {k: environ[k] for k in SECRET_ENV_KEYS if environ.get(k)}
+    out = {k: environ[k] for k in SECRET_ENV_KEYS if environ.get(k)}
+    for k, v in (extra or {}).items():
+        if k in SECRET_ENV_KEYS and v:
+            out[k] = v
+    return out
 
 
 def _merge_json_file(path: Path, patch: dict[str, Any]) -> None:

--- a/worca-bench/worca_bench/worca_install.py
+++ b/worca-bench/worca_bench/worca_install.py
@@ -1,0 +1,124 @@
+"""Install worca into a cloned benchmark repo + seed a minimal, version-portable config.
+
+This is the "install into the cloned git repo" step (W-075 §2 step 3, §5). The design
+goal is to inject the *least* version-specific surface:
+
+  1. Base   — the pinned worca version self-seeds via ``worca init`` (schema-correct).
+  2. Overlay — only cross-template keys (model aliases) + a version-keyed overlay.
+  3. Template — carries the experiment (passed as ``--template`` at launch, not here).
+
+Secrets (ANTHROPIC_API_KEY / per-model env) go to ``settings.local.json`` (gitignored),
+never into ``settings.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .venvs import WorcaEnv
+
+OVERLAY_DIR = Path(__file__).parent / "overlays"
+# Env vars worca's own integration suite strips to avoid leaking parent run state.
+LEAKY_ENV = (
+    "WORCA_PLAN_FILE", "WORCA_PROJECT_ROOT", "WORCA_RUN_ID", "WORCA_RUN_DIR",
+    "GRAPHIFY_OUT",
+)
+# Secrets to materialize into settings.local.json env when present in the environment.
+SECRET_ENV_KEYS = ("ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN")
+
+
+class InstallError(RuntimeError):
+    pass
+
+
+def deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``overlay`` into ``base`` (overlay wins on scalars)."""
+    out = dict(base)
+    for k, v in overlay.items():
+        if k.startswith("_"):
+            continue
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def load_overlay(resolved_sha: str | None) -> dict[str, Any]:
+    """Pick the version-keyed overlay. Today only ``default.json`` exists; add
+    ``<range>.json`` siblings when a schema break needs a targeted override."""
+    default = OVERLAY_DIR / "default.json"
+    data = json.loads(default.read_text(encoding="utf-8")) if default.exists() else {}
+    return data.get("worca", {}) or {}
+
+
+def worca_init(tree: Path, wenv: WorcaEnv, *, timeout: int = 300) -> None:
+    """Run ``worca init`` in the tree using the pinned worca (self-seeds settings)."""
+    env = wenv.base_env()
+    for k in LEAKY_ENV:
+        env.pop(k, None)
+    try:
+        subprocess.run(
+            [wenv.python, "-m", "worca.cli.main", "init"],
+            cwd=str(tree), env=env, check=True, capture_output=True, text=True,
+            timeout=timeout,
+        )
+    except subprocess.CalledProcessError as e:
+        raise InstallError(
+            f"worca init failed in {tree}: {(e.stderr or e.stdout or '').strip()[:800]}"
+        ) from e
+
+
+def seed_settings(
+    tree: Path,
+    *,
+    overlay: dict[str, Any],
+    extra_settings: dict[str, Any] | None = None,
+    pr_defer: bool = True,
+    secret_env: dict[str, str] | None = None,
+) -> None:
+    """Apply the minimal cross-template overlay + secrets to the version-seeded config.
+
+    ``settings.json`` gets only model aliases / pricing-style keys + ``pr.defer``;
+    ``settings.local.json`` gets secret env. Both are deep-merged over whatever
+    ``worca init`` already wrote so we never clobber the version's own defaults.
+    """
+    claude = tree / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+
+    worca_overlay = deep_merge(overlay, extra_settings or {})
+    if pr_defer:
+        worca_overlay = deep_merge(worca_overlay, {"stages": {"pr": {"defer": True}}})
+
+    if worca_overlay:
+        _merge_json_file(claude / "settings.json", {"worca": worca_overlay})
+
+    secret_env = secret_env or {}
+    if secret_env:
+        # Stored under worca.models._bench_env so it merges into the subprocess env
+        # without inlining secrets into the shared settings.json.
+        _merge_json_file(
+            claude / "settings.local.json",
+            {"worca": {"_bench_secret_env": secret_env}},
+        )
+
+
+def collect_secret_env(environ: dict[str, str] | None = None) -> dict[str, str]:
+    """Pull known secret keys from the environment for settings.local.json."""
+    environ = environ if environ is not None else dict(os.environ)
+    return {k: environ[k] for k in SECRET_ENV_KEYS if environ.get(k)}
+
+
+def _merge_json_file(path: Path, patch: dict[str, Any]) -> None:
+    existing: dict[str, Any] = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            existing = {}
+    merged = deep_merge(existing, patch)
+    path.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Introduces **worca-bench** (W-075) — a standalone harness for measuring whether one pipeline config (per-agent model/effort, template, worca version) beats another on **SWE-bench Verified** and **Commit0**. It is version-agnostic (never imports worca): it provisions an isolated venv per ref, `pip install`s the requested branch/tag/commit/version, and shells out to that venv's `run_pipeline`. The dashboard half mirrors the worca-ui stack (lit-html + Shoelace + esbuild + Express) and reads results from a `--target-dir`.

## What's included

- **Python engine** (`worca-bench/worca_bench/`): runner, launcher, per-ref venv provisioning, SWE-bench + Commit0 plugins, harvest (source-only diff on a pristine tree), grading (modal / sb-cli / docker / stub), normalize → `results.jsonl`, regrade CLI.
- **Dashboard** (`worca-bench/app/` + `server/`): profile/run/activity views over the target dir, port 3500.
- **Tests**: `worca-bench/tests/` (pytest) + vitest, plus a free deterministic e2e via the repo's `mock_claude`.
- Safety: grading is source-only on a pristine tree; Commit0 stashes gold tests with a leakage guard; remotes are neutralized at materialize.

## Testing / CI caveat

⚠️ **worca-bench is not yet wired into CI.** `test.yml` runs `ruff check .` (covers worca-bench lint) and `pytest tests/` (main repo only — it does **not** run `worca-bench/tests/` or the worca-bench vitest suite). So a green check on this PR validates lint + main-repo tests, **not** worca-bench behavior. Run the subsystem suites locally before relying on it:

```bash
cd worca-bench && pytest tests/ && npx vitest run
```

A follow-up to add a worca-bench CI job is worth filing.

## Plan

- [docs/plans/W-075-worca-bench.md](https://github.com/SinishaDjukic/worca-cc/blob/master/docs/plans/W-075-worca-bench.md)

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)
