### PR TITLE
fix(agents): deliver agent role via --append-system-prompt-file, not --agent (#343)

### DIFF
--- a/src/worca/orchestrator/overlay.py
+++ b/src/worca/orchestrator/overlay.py
@@ -490,4 +490,23 @@ def resolve_agent(
     result = resolve_blocks(content, context, resolver, core_dir, template_agents_dir)
     result = resolve_placeholders(result, context)
     result = re.sub(r"\n{3,}", "\n\n", result)
-    return result
+    return _strip_frontmatter(result)
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Drop a leading YAML frontmatter block, if present.
+
+    Shipped core agent templates carry no frontmatter (they begin at
+    ``# <Agent> Agent``), so this is a no-op for them. It only fires when a
+    project/user overlay (``.claude/agents/<agent>.md``) was authored in
+    Claude-native agent format (``---\\nname: …\\n---``). The resolved file is
+    delivered to the CLI via ``--append-system-prompt-file``, which injects the
+    file verbatim as system-prompt text — leaking a raw ``--- name: … ---``
+    header into the prompt. Stripping a single leading block keeps the system
+    prompt clean. See GH #343.
+    """
+    if not text.startswith("---"):
+        return text
+    # Match an opening fence on its own line through the next closing fence.
+    m = re.match(r"^---[ \t]*\n.*?\n---[ \t]*\n?", text, re.DOTALL)
+    return text[m.end():].lstrip("\n") if m else text

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -1752,9 +1752,10 @@ def run_stage(
         msize: Multiplier for max_turns (1-10). E.g. msize=2 doubles turns.
         iteration: Current iteration number (1-indexed). Controls log file path.
         prompt_override: When provided, used instead of context["prompt"].
-        agent_override: When provided, used as the --agent path instead of the
-            default _agent_path(). Allows per-stage resolved templates to be
-            passed directly to the claude CLI.
+        agent_override: When provided, used as the resolved agent .md path
+            instead of the default _agent_path(). Delivered to the claude CLI as
+            the system prompt via --append-system-prompt-file (GH #343). Allows
+            per-stage resolved templates to be passed directly.
         env_overrides: Extra env vars merged into model_env before passing to
             run_agent(). Used for CLAUDE_CODE_EFFORT_LEVEL injection.
         graphify_out: When set, exported as GRAPHIFY_OUT in the agent

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -253,7 +253,10 @@ def build_command(
 
     Args:
         prompt: The prompt to send to the agent.
-        agent: Path to the agent .md file (e.g. ".claude/agents/core/planner.md").
+        agent: Path to the rendered agent .md file (e.g.
+            ".claude/agents/core/planner.md"). Delivered to the CLI as the
+            system prompt via --append-system-prompt-file (GH #343), and its
+            filename stem is used to resolve per-agent tool grants.
         output_format: Output format ("text", "json", "stream-json").
         json_schema: Inline JSON schema string for structured output, or path
                      to a .json file (will be read and inlined).
@@ -287,7 +290,17 @@ def build_command(
         *_claude_bin,
         "-p",
         cli_prompt,
-        "--agent",
+        # The rendered agent .md is the agent's system prompt. We deliver it via
+        # --append-system-prompt-file (a path-taking flag), NOT --agent: as of
+        # Claude Code 2.1.190/2.1.191 the --agent flag resolves a *registered
+        # agent name* only (from .claude/agents/, plugins, builtins) and rejects
+        # a filesystem path with "not found", exiting without a result event.
+        # Older versions silently ignored the path and ran the DEFAULT agent, so
+        # --agent <path> never actually loaded these prompts on any tested CLI.
+        # See GH #343. The role is appended on top of Claude Code's base harness
+        # prompt; --model/--tools/--disallowedTools/effort are passed explicitly
+        # below, so no agent-frontmatter capabilities are lost by dropping --agent.
+        "--append-system-prompt-file",
         agent,
         "--output-format",
         output_format,

--- a/tests/mock_claude/mock_claude.py
+++ b/tests/mock_claude/mock_claude.py
@@ -2,7 +2,8 @@
 """Mock Claude CLI for integration testing.
 
 Reads MOCK_CLAUDE_SCENARIO env var for a path to a JSON scenario file.
-Parses --agent from argv to select a per-agent directive.
+Parses --append-system-prompt-file (or legacy --agent) from argv to select a
+per-agent directive.
 Emits stream-JSON events matching Claude CLI output format, then exits.
 
 Directive resolution order (per scenario):
@@ -136,9 +137,12 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
+    # worca delivers the agent's rendered .md via --append-system-prompt-file
+    # (GH #343); the path basename still identifies the agent/iteration. We also
+    # accept the legacy --agent flag so this mock's own unit tests keep working.
     agent_raw = None
     for i, arg in enumerate(sys.argv):
-        if arg == "--agent" and i + 1 < len(sys.argv):
+        if arg in ("--append-system-prompt-file", "--agent") and i + 1 < len(sys.argv):
             agent_raw = sys.argv[i + 1]
             break
 

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -71,8 +71,24 @@ def test_build_command_basic():
     assert cmd[0] == "claude"
     assert "-p" in cmd
     assert "do stuff" in cmd
-    assert "--agent" in cmd
-    assert "planner" in cmd
+    # GH #343: the rendered agent .md is delivered as the system prompt via
+    # --append-system-prompt-file, NOT --agent (which now resolves a registered
+    # agent *name* and rejects a path).
+    assert "--append-system-prompt-file" in cmd
+    assert "--agent" not in cmd
+    idx = cmd.index("--append-system-prompt-file")
+    assert cmd[idx + 1] == "planner"
+
+
+def test_build_command_does_not_use_agent_flag():
+    """Regression for GH #343: --agent <path> is rejected by Claude Code
+    >=2.1.190 (name-only resolution). worca must use --append-system-prompt-file
+    so the agent role is actually loaded as a system prompt."""
+    cmd, _ = build_command("prompt", agent=".worca/runs/x/agents/resolved/plan-planner-iter-1.md")
+    assert "--agent" not in cmd
+    assert "--append-system-prompt-file" in cmd
+    idx = cmd.index("--append-system-prompt-file")
+    assert cmd[idx + 1] == ".worca/runs/x/agents/resolved/plan-planner-iter-1.md"
 
 
 def test_build_command_default_output_format():
@@ -203,7 +219,8 @@ def test_run_agent_passes_correct_command():
         run_agent("my prompt", agent="implementer", max_turns=20, json_schema='{"type":"object"}', settings={})
     args = mock_popen.call_args[0][0]
     assert args[0] == "claude"
-    assert "--agent" in args
+    assert "--append-system-prompt-file" in args
+    assert "--agent" not in args
     assert "implementer" in args
     assert "--json-schema" in args
 

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -14,7 +14,30 @@ from worca.orchestrator.overlay import (
     _parse_sections,
     _parse_overrides,
     _heading_matches,
+    _strip_frontmatter,
 )
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter stripping (GH #343 — defensive, for Claude-native overlays)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_frontmatter_noop_for_shipped_agents():
+    """Shipped core templates have no frontmatter — must pass through verbatim."""
+    body = "# Planner Agent\n\n## Role\n\nYou are the Planner.\n"
+    assert _strip_frontmatter(body) == body
+
+
+def test_strip_frontmatter_removes_leading_yaml_block():
+    text = "---\nname: planner\ndescription: x\n---\n# Planner Agent\n\nBody.\n"
+    assert _strip_frontmatter(text) == "# Planner Agent\n\nBody.\n"
+
+
+def test_strip_frontmatter_only_strips_leading_block():
+    """A --- horizontal rule later in the doc must be preserved."""
+    text = "# Title\n\nIntro.\n\n---\n\n## Next\n"
+    assert _strip_frontmatter(text) == text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Fixes #343 (P0). Every pipeline run fails at the **first agent dispatch** (plan stage) on Claude Code **≥ 2.1.190/2.1.191** with:

```
stop_reason = AgentSubprocessError
plan -> error: claude agent stream failed: No result event found in stream-json output (returncode=1)
--agent '.worca/runs/<id>/agents/resolved/plan-planner-iter-1.md' not found. Available agents: …
```

worca delivered each agent's system prompt by passing the rendered role `.md` **path** to Claude Code's `--agent` flag. Claude Code changed `--agent` to resolve a **registered agent name** only (from `.claude/agents/`, plugins, builtins) and now rejects a filesystem path.

### Behavioral-canary finding

Tested across cached CLIs (2.1.178–2.1.195) with a system prompt that forces a distinctive token: **`--agent <path>` never loaded the role on any tested version.** Pre-2.1.190 silently ran the **default** agent (canary ignored); 2.1.190+ hard-errors. So the role `.md` files (`planner.md`, etc.) have been **dormant the whole time** — the `-p` block prompt + `--json-schema` carried the pipeline. The regression bisects to 2.1.190/2.1.191 (undocumented).

## Fix (option B2 from the issue)

Deliver the rendered role via **`--append-system-prompt-file <path>`** — a path-taking flag verified functional on 2.1.195 — which loads the role as a system prompt **for the first time**. `--model` / `--tools` / `--disallowedTools` / effort are already passed explicitly, so dropping `--agent` loses no capabilities.

- **`claude_cli.build_command`** — `--agent <path>` → `--append-system-prompt-file <path>` (agent filename stem still drives per-agent tool grants).
- **`overlay.resolve_agent`** — added `_strip_frontmatter()`: defensively drops a leading `--- … ---` block for project/user overlays authored in Claude-native agent format. **No-op for shipped agents** (they have no frontmatter).
- **`mock_claude`** — now parses `--append-system-prompt-file` (keeps legacy `--agent` so its own unit tests pass).
- Docstrings in `runner.py` / `claude_cli.py` updated.

## Tests

- New regression test: `build_command` emits `--append-system-prompt-file` and **not** `--agent`.
- Updated `test_claude_cli.py` / `test_run_agent_passes_correct_command` assertions.
- 3 new `_strip_frontmatter` tests (shipped-agent no-op, leading-block strip, mid-doc `---` preserved).

## Validation (local)

- Unit suite: green except 3 `test_crg_validation_spike.py` failures **confirmed pre-existing on master** (require an external CRG binary), unrelated to this change.
- **Full integration suite (`tests/integration/`): green** — the full pipeline runs end-to-end through `mock_claude` with the new flag.
- ruff + biome clean; worca-ui build clean.

## Notes / follow-up

Because the role prompts now actually load, agent behavior changes (for the better — this is the intended design). Block templates already restate some role + guide-precedence content; a follow-up dedup pass and a worca-bench A/B of the activated roles would be worthwhile, but are out of scope for this P0 unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
