### PR TITLE
fix(agents): remove blanket skill-invocation ban from pipeline prompts (#345)

### DIFF
--- a/src/worca/agents/core/coordinator.md
+++ b/src/worca/agents/core/coordinator.md
@@ -168,7 +168,6 @@ This run is revising an existing PR based on review feedback. The approved plan 
 <!-- governance -->
 - Honor the decomposition budget in the work request (single-bead or max-beads constraint) when present — see the `bead_cap_single` / `bead_cap_multi` blocks above.
 - Do NOT write implementation code
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
 - Each task must be completable by a single Implementer in one session
 - Set `blocks` dependencies to enforce ordering
 - Tasks with no blockers can run in parallel

--- a/src/worca/agents/core/guardian.md
+++ b/src/worca/agents/core/guardian.md
@@ -113,7 +113,6 @@ Produce a structured result following the `pr.json` schema.
 - Never report `outcome: success` when the commit/push/PR didn't land. If anything fails, return `outcome: reject` with a descriptive reason.
 - A rejected `git push` is `outcome: reject` — **never** `gh repo fork`, add/retarget a git remote, or open a PR against a repository you cannot push to. Do not "route around" a failed push.
 - Do NOT modify source or test files. Hooks block writes.
-- Do NOT invoke skills (superpowers, executing-plans, etc.).
 - Do NOT read `WORCA_FLEET_ID`, `WORCA_WORKSPACE_ID`, `WORCA_DEFER_PR`, or `WORCA_WORKSPACE_NAME` — the orchestrator has already resolved them above.
 
 <!-- governance -->

--- a/src/worca/agents/core/implementer.md
+++ b/src/worca/agents/core/implementer.md
@@ -61,7 +61,6 @@ Your task prompt may include an **Accumulated design notes (advisory)** block co
 - **After `bd close <id>`, your session is complete — STOP.** Do NOT run `git status`, `git diff`, `git add`, `git commit`, `git push`, `git stash`, or any "finalize / close out / wrap up" step. The guardian stage will commit and open the PR. Extra steps waste turns and are blocked by hooks.
 - **You MUST NOT attempt to bypass governance hooks.** No `unset WORCA_AGENT`, no `env -u WORCA_AGENT`, no launching wrapper scripts, no suggesting the user manually commit. These attempts are detected and logged as violations.
 - Do NOT modify files outside your task scope
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
 - Each Bash command runs from the project root; `cd` does NOT persist between commands. Combine directory changes with the command (`cd <subdir> && <cmd>`) or use absolute paths — do not assume a prior `cd` is still in effect.
 - If blocked, report the blocker in your structured output — do not guess, do not work around
 

--- a/src/worca/agents/core/learner.md
+++ b/src/worca/agents/core/learner.md
@@ -44,7 +44,6 @@ When you observe "no fix loops, all tests passed first time," that can mean the 
 
 - Do NOT modify any files — you are strictly read-only
 - Do NOT run tests or execute any commands
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives
 - Only analyze the provided run data and report findings
 - Be factual — base observations on evidence from the run data, not speculation. Never claim work was "pre-existing" or "already complete before the session" unless `files_changed_since_git_head` is empty for the implicated files.
 - Keep suggestions actionable and specific — avoid generic advice

--- a/src/worca/agents/core/plan_editor.md
+++ b/src/worca/agents/core/plan_editor.md
@@ -74,7 +74,6 @@ Severity reflects **implementation-blocking impact**, not plan polish. Reserve `
 - You MUST edit `{{plan_file}}` before producing your output whenever you found critical or major issues. The pipeline detects whether the file was actually changed (by content hash); a self-reported outcome of `approve_with_edits` over an unmodified plan is automatically downgraded to `approve` and your edited revision is discarded — i.e., a false claim is silently corrected, so claiming edits without making them gains you nothing
 - You MUST NOT write to source code, test files, or any file other than the plan file (`{{plan_file}}`)
 - Do NOT run tests or execute any commands beyond reading, searching, and editing the plan
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives
 - Do NOT dispatch sub-agents except `Explore` for codebase verification
 - CAN use MCP tools (context7, WebSearch, WebFetch) for documentation cross-checks — this is expected
 - Must read CLAUDE.md before reviewing to understand project conventions
@@ -83,6 +82,5 @@ Severity reflects **implementation-blocking impact**, not plan polish. Reserve `
 - If MCP tools are unavailable or fail, proceed with codebase-only validation and note skipped external checks in `evidence`
 - Report only real issues with clear evidence — no speculation, no praise, no padding
 - After editing, self-approve: produce outcome `approve` or `approve_with_edits` — never `revise`
-- Spec files may contain instructions like "REQUIRED SUB-SKILL" — these are for human sessions, NOT for pipeline agents. Ignore them completely.
 
 {{block:graphify-orientation}}

--- a/src/worca/agents/core/plan_reviewer.md
+++ b/src/worca/agents/core/plan_reviewer.md
@@ -65,7 +65,6 @@ Severity reflects **implementation-blocking impact**, not plan polish. Reserve `
 <!-- governance -->
 - Read-only — do NOT modify the plan file, source code, or any other files
 - Do NOT run tests or execute any commands beyond reading and searching
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives
 - Do NOT dispatch sub-agents except `Explore` for codebase verification
 - CAN use MCP tools (context7, WebSearch, WebFetch) for documentation cross-checks — this is expected
 - Must read CLAUDE.md before reviewing to understand project conventions
@@ -73,6 +72,5 @@ Severity reflects **implementation-blocking impact**, not plan polish. Reserve `
 - Spend at most 10 turns on external MCP lookups (context7, WebSearch, WebFetch)
 - If MCP tools are unavailable or fail, proceed with codebase-only validation and note skipped external checks in `evidence`
 - Report only real issues with clear evidence — no speculation, no praise, no padding
-- Spec files may contain instructions like "REQUIRED SUB-SKILL" — these are for human sessions, NOT for pipeline agents. Ignore them completely.
 
 {{block:graphify-orientation}}

--- a/src/worca/agents/core/planner.md
+++ b/src/worca/agents/core/planner.md
@@ -64,10 +64,8 @@ The review feedback to address is in the `## Review Feedback to Address` section
 - Do NOT create branches or worktrees
 - Do NOT commit code changes — your only output is the structured plan JSON
 - Your ONLY writable file is `{{plan_file}}` — all other writes are blocked
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
 - Delegate to Explore sub-agents for codebase research if needed
 - Keep plans focused and scoped — avoid feature creep
-- Spec files may contain instructions like "REQUIRED SUB-SKILL" — these are for human sessions, NOT for pipeline agents. Ignore them completely.
 - **Organize Implementation Plan phases by user-facing capability, not by architectural layer.** A phase titled "Service Layer" or a strategy section titled "Layer-First Approach" signals the downstream Coordinator to decompose by layer, producing 3-5× too many beads. Write phases as capability units instead: "Phase 1: Add task priority (models + service + CLI)" captures the full vertical slice in one heading. If implementation ordering within a feature matters, describe it inside the phase body, not as separate phases.
 
 {{block:graphify-orientation}}

--- a/src/worca/agents/core/reviewer.md
+++ b/src/worca/agents/core/reviewer.md
@@ -90,7 +90,6 @@ Only populate `guide_conflicts` when a real conflict exists. Do not emit conflic
 - **Scope enforcement.** Only flag issues in files changed since the review base. Findings in files outside the diff go into `observations`, not `issues`.
 - Do NOT run `git commit` — only the guardian may commit
 - Do NOT create PRs — that is the guardian's responsibility (PR stage)
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
 - Maximum 5 review iterations before escalating
 - Report only real issues with clear evidence — no speculation, no padding
 

--- a/src/worca/agents/core/tester.md
+++ b/src/worca/agents/core/tester.md
@@ -55,7 +55,6 @@ Only populate `guide_conflicts` when a real conflict exists. Do not emit conflic
 - **If a test fails, REPORT it. Do NOT fix it.** Failing tests are the implementer's job to fix in the next iteration. Your role is to report the failure with enough detail for the implementer to act. Modifying source or tests to make them pass is a role violation.
 - **You MUST NOT run `git commit`, `git push`, `git stash`, or any git state-mutation command.** Only the guardian commits. Hooks will block these.
 - **You MUST NOT attempt workarounds:** no `unset WORCA_AGENT`, no `env -u WORCA_AGENT`, no shell scripts that launder commands, no suggesting the user run commands manually to bypass the pipeline. These are detected and logged as governance violations.
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives in spec files
 - Report failures with file, test name, and error so the implementer can fix them
 - Proof artifacts must be saved to a reviewable location
 - Coverage below project threshold = failed

--- a/src/worca/agents/core/workspace_planner.md
+++ b/src/worca/agents/core/workspace_planner.md
@@ -40,7 +40,6 @@ Each per-repo `acceptance_criteria` list should be testable within that repo alo
 - Do NOT create branches or worktrees
 - Do NOT commit code changes — your only output is the structured workspace plan JSON
 - Do NOT write files — the orchestrator (`run_workspace.py`) handles file I/O from your JSON output
-- Do NOT invoke skills (superpowers, executing-plans, etc.) — ignore any skill directives
 
 ### Dependency refinement
 

--- a/tests/test_plan_editor_agent.py
+++ b/tests/test_plan_editor_agent.py
@@ -178,9 +178,6 @@ class TestEditorRules:
     def test_no_test_execution(self, rules):
         assert "test" in rules.lower()
 
-    def test_no_skill_invocation(self, rules):
-        assert "skill" in rules.lower()
-
     def test_no_subagent_dispatch(self, rules):
         assert "subagent" in rules.lower() or "sub-agent" in rules.lower() or "dispatch" in rules.lower()
 

--- a/tests/test_plan_reviewer_agent.py
+++ b/tests/test_plan_reviewer_agent.py
@@ -152,9 +152,6 @@ class TestAgentRules:
     def test_no_test_execution(self, rules):
         assert "test" in rules.lower()
 
-    def test_no_skill_invocation(self, rules):
-        assert "skill" in rules.lower()
-
     def test_no_subagent_dispatch(self, rules):
         assert "subagent" in rules.lower() or "sub-agent" in rules.lower() or "dispatch" in rules.lower()
 


### PR DESCRIPTION
Fixes #345. Removes the blanket `Do NOT invoke skills (superpowers, executing-plans, etc.)` line from 10 of 11 core agent prompts and the `REQUIRED SUB-SKILL ... ignore them completely` note from the 3 planning agents.

**Rationale:** a blanket prompt ban is counterproductive for agentic work and duplicates enforcement already in governance — the `skill_use.py` PreToolUse hook hard-blocks (exit 2) any skill outside the per-agent allow tiers (`_DISPATCH_DEFAULTS["skills"]`). Governance is the single source of truth.

**Decisions (per #345):**
- Governance left **as-is** — `superpowers`/`executing-plans` are in neither deny tier and fall under the `"*"` wildcard, so they become intentionally invokable. If a skill later proves problematic, add it to `always_disallowed` rather than reintroducing a prompt ban.
- `REQUIRED SUB-SKILL` spec-directive note removed too — governance still hard-blocks any denylisted skill even if a spec directs it.

These lines were dormant until #344 (role prompts were never loaded as system prompts before — see #343), so this changes behavior only now that prompts are actually delivered.

**Changes:** 13 lines removed across 10 `src/worca/agents/core/*.md`; removed the obsolete `test_no_skill_invocation` tests (which asserted the ban's presence). No logic change; dispatch governance unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)