### PR TITLE
fix(worca-ui): resolve prompt by stage prefix for agent-swapped stages (#347)

### DIFF
--- a/worca-ui/app/views/run-detail.js
+++ b/worca-ui/app/views/run-detail.js
@@ -1633,7 +1633,12 @@ function _iterationDetailView(
   const iterPrompt = iterPrompts.find((ip) => ip.iteration === iterNum);
   const userPrompt = iterPrompt?.prompt || promptData?.userPrompt || null;
   const iterPromptData = userPrompt
-    ? { agentInstructions: promptData?.agentInstructions, userPrompt }
+    ? {
+        agentInstructions: promptData?.agentInstructions,
+        agentInstructionsIsRawTemplate:
+          promptData?.agentInstructionsIsRawTemplate,
+        userPrompt,
+      }
     : promptData;
   const iterDur = iter.started_at
     ? formatDuration(elapsed(iter.started_at, iter.completed_at || null))
@@ -1689,8 +1694,12 @@ function _copyToClipboard(text, btn) {
 
 function _agentPromptSection(_stageKey, promptData) {
   if (!promptData) return nothing;
-  const { agentInstructions, userPrompt } = promptData;
+  const { agentInstructions, agentInstructionsIsRawTemplate, userPrompt } =
+    promptData;
   if (!agentInstructions && !userPrompt) return nothing;
+  const promptLabel = agentInstructionsIsRawTemplate
+    ? 'Agent Prompt (unresolved template — not the delivered prompt)'
+    : 'Agent Prompt (resolved)';
   return html`
     <sl-details class="agent-prompt-section" @sl-after-show=${scrollOnExpand}>
       <div slot="summary" class="agent-prompt-header">
@@ -1703,7 +1712,7 @@ function _agentPromptSection(_stageKey, promptData) {
           ? html`
         <div class="agent-prompt-block">
           <div class="agent-prompt-label-row">
-            <span class="agent-prompt-label">Agent Prompt (resolved)</span>
+            <span class="agent-prompt-label">${promptLabel}</span>
             <button class="copy-btn" @click=${(e) => _copyToClipboard(agentInstructions, e.currentTarget)}>
               ${unsafeHTML(iconSvg(ClipboardCopy, 11))} Copy
             </button>

--- a/worca-ui/server/test/ws-message-router-agent-prompt-stage-prefix.test.js
+++ b/worca-ui/server/test/ws-message-router-agent-prompt-stage-prefix.test.js
@@ -1,0 +1,197 @@
+/**
+ * #347: get-agent-prompt must not leak the raw, unresolved agent template when
+ * a stage runs with a runtime agent swap (e.g. plan_review edit mode swaps
+ * plan_reviewer -> plan_editor). status.json records the original agent, but the
+ * resolved file on disk is named for the executed agent, so the exact-match
+ * lookup misses. The handler must fall back to a stage-prefix scan of resolved/
+ * before falling through to the raw template — and when it does render the raw
+ * template, flag it as such.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMessageRouter } from '../ws-message-router.js';
+
+function makeTmpDir() {
+  const d = join(
+    tmpdir(),
+    `worca-agentprompt-prefix-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+function mockWatcherSet(worcaDir) {
+  return {
+    get worcaDir() {
+      return worcaDir;
+    },
+    get settingsPath() {
+      return join(worcaDir, 'settings.json');
+    },
+    get projectRoot() {
+      return worcaDir;
+    },
+    statusWatcher: {
+      scheduleRefresh: vi.fn(),
+      lastPipelineStatus: new Map(),
+      resolveLatestRunDir: vi.fn(() => worcaDir),
+      currentActiveRunId: vi.fn(() => null),
+    },
+    logWatcher: {
+      watchLogFile: vi.fn(),
+      watchAllLogFiles: vi.fn(),
+      sendArchivedLogs: vi.fn(),
+      resolveLogsBaseDir: vi.fn(() => worcaDir),
+      clearLogWatchers: vi.fn(),
+    },
+    beadsWatcher: {
+      getBeadsDbPath: vi.fn(() => join(worcaDir, 'beads.db')),
+    },
+    eventWatcher: {
+      readEventsFromFile: vi.fn(() => []),
+      subscribeEvents: vi.fn(),
+      maybeCloseEventWatcher: vi.fn(),
+    },
+  };
+}
+
+function mockClientManager() {
+  const subsMap = new Map();
+  return {
+    ensureSubs(ws) {
+      if (!subsMap.has(ws)) subsMap.set(ws, {});
+      return subsMap.get(ws);
+    },
+    getSubs(ws) {
+      return subsMap.get(ws) || null;
+    },
+    setProtocol(ws, protocol, projectId) {
+      const s = this.ensureSubs(ws);
+      s.protocolVersion = protocol;
+      s.projectId = projectId;
+    },
+  };
+}
+
+function makeRouter(projDir) {
+  const ws0 = mockWatcherSet(projDir);
+  return createMessageRouter({
+    watcherSets: new Map([['default', ws0]]),
+    getDefaultWs: () => ws0,
+    prefsPath: join(projDir, 'prefs.json'),
+    webhookInbox: null,
+    clientManager: mockClientManager(),
+    broadcaster: { broadcast: vi.fn(), broadcastToSubscribers: vi.fn() },
+  });
+}
+
+async function fetchPrompt(router, runId, stage) {
+  const mockWs = { send: vi.fn(), isAlive: true };
+  await router.handleMessage(
+    mockWs,
+    JSON.stringify({
+      id: 'req',
+      type: 'get-agent-prompt',
+      payload: { runId, stage },
+    }),
+  );
+  expect(mockWs.send).toHaveBeenCalled();
+  return JSON.parse(mockWs.send.mock.calls[0][0]);
+}
+
+describe('get-agent-prompt stage-prefix fallback (#347)', () => {
+  let projDir;
+  const RUN_ID = 'run-prefix-001';
+
+  beforeEach(() => {
+    projDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(projDir, { recursive: true, force: true });
+  });
+
+  it('resolves the executed-agent file when status.json records a different (swapped) agent', async () => {
+    const runDir = join(projDir, 'runs', RUN_ID);
+    mkdirSync(join(runDir, 'agents', 'resolved'), { recursive: true });
+
+    // status.json records the ORIGINAL agent (plan_reviewer)...
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: RUN_ID,
+        pipeline_status: 'running',
+        stages: {
+          plan_review: {
+            agent: 'plan_reviewer',
+            iterations: [{ number: 1, prompt: 'Review the plan' }],
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    // ...but the resolved file on disk is named for the EXECUTED agent (plan_editor).
+    writeFileSync(
+      join(runDir, 'agents', 'resolved', 'plan_review-plan_editor-iter-1.md'),
+      'RESOLVED EDIT-MODE PROMPT (no raw braces)',
+      'utf8',
+    );
+
+    const response = await fetchPrompt(
+      makeRouter(projDir),
+      RUN_ID,
+      'plan_review',
+    );
+
+    expect(response.ok).toBe(true);
+    expect(response.payload.agentInstructions).toBe(
+      'RESOLVED EDIT-MODE PROMPT (no raw braces)',
+    );
+    // The resolved file was found, so this is NOT the raw-template fallback.
+    expect(response.payload.agentInstructionsIsRawTemplate).toBe(false);
+  });
+
+  it('flags the raw, unresolved template when only the source template exists', async () => {
+    const runDir = join(projDir, 'runs', RUN_ID);
+    mkdirSync(join(runDir, 'agents'), { recursive: true });
+
+    writeFileSync(
+      join(runDir, 'status.json'),
+      JSON.stringify({
+        run_id: RUN_ID,
+        pipeline_status: 'running',
+        stages: {
+          plan_review: {
+            agent: 'plan_reviewer',
+            iterations: [{ number: 1, prompt: 'Review the plan' }],
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    // No resolved/ file — only the unresolved source template with raw syntax.
+    writeFileSync(
+      join(runDir, 'agents', 'plan_reviewer.md'),
+      '# Plan Reviewer\n\n{{block:graphify-orientation}}\n',
+      'utf8',
+    );
+
+    const response = await fetchPrompt(
+      makeRouter(projDir),
+      RUN_ID,
+      'plan_review',
+    );
+
+    expect(response.ok).toBe(true);
+    expect(response.payload.agentInstructions).toContain(
+      '{{block:graphify-orientation}}',
+    );
+    expect(response.payload.agentInstructionsIsRawTemplate).toBe(true);
+  });
+});

--- a/worca-ui/server/ws-message-router.js
+++ b/worca-ui/server/ws-message-router.js
@@ -6,7 +6,7 @@
  * via resolveProject() before accessing watchers or filesystem paths.
  */
 
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { isRequest, makeError, makeOk } from '../app/protocol.js';
 import {
@@ -37,6 +37,47 @@ import { resolveRunDir } from './run-dir-resolver.js';
 import { readSettings } from './settings-reader.js';
 import { discoverRunsAsync, findRun } from './watcher.js';
 import { resolveBeadsCounts } from './ws-beads-watcher.js';
+
+/**
+ * Read a resolved agent prompt by stage prefix (#347).
+ *
+ * The pipeline writes resolved prompts as `{stage}-{executed_agent}-iter-{N}.md`.
+ * When a stage runs with a runtime agent swap (e.g. plan_review edit mode swaps
+ * plan_reviewer -> plan_editor), status.json records the original agent but the
+ * file on disk is named for the executed one, so an exact `{stage}-{agent}` match
+ * misses. Scan the resolved/ dir for any `{stage}-*-iter-{N}.md` and return its
+ * content. Returns null when no match (or the dir is absent/unreadable).
+ *
+ * @param {string} worcaDir
+ * @param {string} runId
+ * @param {string} stage
+ * @param {number} iterNum
+ * @returns {string|null}
+ */
+function _readResolvedByStagePrefix(worcaDir, runId, stage, iterNum) {
+  const suffix = `-iter-${iterNum}.md`;
+  const prefix = `${stage}-`;
+  for (const base of ['runs', 'results']) {
+    const dir = join(worcaDir, base, runId, 'agents', 'resolved');
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    const match = entries.find(
+      (name) => name.startsWith(prefix) && name.endsWith(suffix),
+    );
+    if (match) {
+      try {
+        return readFileSync(join(dir, match), 'utf8');
+      } catch {
+        /* ignore and keep scanning other bases */
+      }
+    }
+  }
+  return null;
+}
 
 /**
  * @param {{
@@ -253,11 +294,29 @@ export function createMessageRouter({
             break;
           }
         }
+        // Stage-prefix fallback (#347): when a stage runs with a runtime agent
+        // swap (e.g. plan_review edit mode swaps plan_reviewer -> plan_editor),
+        // status.json records the original agent but the resolved file on disk
+        // is named for the executed agent. The exact-match candidates above all
+        // miss, so scan resolved/ for any {stage}-*-iter-{N}.md and use it
+        // before falling through to the raw, unresolved template.
+        if (content == null) {
+          content = _readResolvedByStagePrefix(
+            effectiveWorcaDir,
+            effectiveRunId,
+            stage,
+            iterNum,
+          );
+        }
         resolvedIterationPrompts.push({ iteration: iterNum, prompt: content });
         if (!resolvedPrompt && content) resolvedPrompt = content;
       }
 
-      // Fall back to unresolved agent template (pre-W-037 runs)
+      // Fall back to unresolved agent template (pre-W-037 runs). This renders
+      // the raw template — literal {{block:...}} / {{#if ...}} / {{placeholder}}
+      // syntax survives — so flag it (#347) and let the UI label it as such
+      // rather than letting it pass for the actual delivered system prompt.
+      let agentInstructionsIsRawTemplate = false;
       if (!resolvedPrompt) {
         const templateCandidates = [
           join(
@@ -279,6 +338,7 @@ export function createMessageRouter({
           if (existsSync(p)) {
             try {
               resolvedPrompt = readFileSync(p, 'utf8');
+              agentInstructionsIsRawTemplate = true;
             } catch {
               /* ignore */
             }
@@ -291,6 +351,7 @@ export function createMessageRouter({
         JSON.stringify(
           makeOk(req, {
             agentInstructions: resolvedPrompt,
+            agentInstructionsIsRawTemplate,
             userPrompt,
             iterationPrompts,
             resolvedIterationPrompts,


### PR DESCRIPTION
Fixes #347.

## Problem

The worca-ui prompt view rendered the **raw, unresolved agent template** — leaking literal `{{block:...}}` / `{{#if ...}}` / `{{placeholder}}` syntax — for any stage whose executing agent differs from the agent recorded in `status.json`. Observed as a verbatim `{{block:graphify-orientation}}` in the plan-review agent's prompt view.

The model always received the correctly-resolved prompt; this was a **display artifact** surfaced by #343/#344 (which made the resolved file the thing the UI shows).

## Root cause

`get-agent-prompt` resolved the on-disk file as `{stage}-{agentName}-iter-N.md`, where `agentName` comes from `status.json`. When a stage runs with a runtime agent swap (`plan_review` edit mode swaps `plan_reviewer → plan_editor`), the recorded agent and the executed agent diverge, the exact-match candidates all miss, and the handler fell through to reading the unresolved source template.

## Fixes

1. **Stage-prefix fallback (primary).** When the exact-match candidates miss, `_readResolvedByStagePrefix` scans `resolved/` for any `{stage}-*-iter-N.md` and uses it before the raw-template fallback. Eliminates the symptom for the known case and any future agent swap.
2. **Harden the raw-template fallback.** When the raw template *is* rendered (pre-W-037 runs with no resolved file), the response now carries `agentInstructionsIsRawTemplate: true` and the UI labels the block **"Agent Prompt (unresolved template — not the delivered prompt)"** so it is never mistaken for the delivered system prompt.

Issue fix #2 (record the executed agent in `status.json`) was intentionally **not** taken — it touches the status.json schema and its consumers; the stage-prefix scan resolves the symptom without that surface.

## Tests

- `server/test/ws-message-router-agent-prompt-stage-prefix.test.js` — two cases: swapped-agent resolves the executed-agent file (`isRawTemplate=false`); template-only run flags `isRawTemplate=true` and still contains the raw `{{block:...}}`.
- Full UI vitest suite green (5218 passed). Playwright `run-detail-agent-prompt` + `markdown-rendering` specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
