### PR TITLE
fix/fleet and worktree spec argument (#2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,12 @@
 {
   "name": "worca",
+  "description": "Autonomous multi-agent software development pipeline with governance enforcement.",
   "plugins": [
     {
       "name": "worca-cc",
       "source": "./",
-      "description": "Autonomous multi-agent software development pipeline with governance enforcement. Plans, coordinates, implements, tests, and reviews code changes.",
-      "version": "0.5.0"
+      "description": "Autonomous pipeline that plans, coordinates, implements, tests, and reviews code changes. Skills: run, status, cleanup.",
+      "version": "0.59.0"
     }
   ],
   "owner": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
   "name": "worca-cc",
-  "version": "0.5.0",
-  "description": "Autonomous multi-agent software development pipeline with governance enforcement. Plans, coordinates, implements, tests, and reviews code changes. Install into any project with /worca-install.",
+  "version": "0.59.0",
+  "description": "Autonomous multi-agent software development pipeline with governance enforcement. Plans, coordinates, implements, tests, and reviews code changes. Skills: /worca-cc:run (launch pipeline), /worca-cc:status (check progress), /worca-cc:cleanup (remove finished worktrees).",
   "author": {
     "name": "Kristiyan Hadjiev"
-  }
+  },
+  "skills": ["./skills/"]
 }

--- a/docs/plans/W-076-spec-source-fleet-workspace.md
+++ b/docs/plans/W-076-spec-source-fleet-workspace.md
@@ -1,0 +1,329 @@
+# W-076: Specification source type for fleet & workspace runs
+
+**Status:** Draft
+**Priority:** P1
+**Area:** cc
+**Date:** 2026-07-02
+**Depends on:** None
+
+## Problem
+
+A workspace run launched from the UI with **Source Type = "Specification"** (a file path such
+as `docs/plans/001-openapi-v3-generation.md`) completes instantly doing nothing. The generated
+`workspace-plan.json` reports "no user request to work with", every child finishes with
+`run_id=null`, and the fetched manifest shows empty `work_request.title` / `work_request.description`.
+
+The bug spans three layers, none of which fleet/workspace implement — but the single-project
+run path does:
+
+1. **UI** — the source-type selector offers Prompt / Specification / GitHub Issue / GitHub PR
+   (`worca-ui/app/views/fleet-launcher.js:415`), but at submit only a bare `source` value is
+   sent and the `sourceType` discriminator is **dropped** (`fleet-launcher.js:192` fleet,
+   `fleet-launcher.js:261` workspace). The server cannot tell a spec file path from a
+   `gh:issue:N` ref.
+2. **Server** — `buildWorkspaceArgs` (`worca-ui/server/app.js:80-84`) and `dispatchFleet`
+   (`worca-ui/server/app.js:784-788`) both do `if (source) push('--source') else push('--prompt')`.
+   This is **exclusive**: a spec path is routed to `--source` and the prompt is discarded.
+3. **Python** — `run_workspace.py` accepts `--source` (`src/worca/scripts/run_workspace.py:860`)
+   but never resolves it; the master planner uses `args.prompt or ""`
+   (`src/worca/scripts/run_workspace.py:1394`) → empty Work Request. There is no `--spec` arg.
+   `create_workspace_manifest` also hardcodes `title=""`
+   (`src/worca/scripts/run_workspace.py:280`). The child runner puts `--prompt`/`--source` in a
+   **mutually-exclusive** argparse group with no `--spec`
+   (`src/worca/scripts/run_worktree.py:222-224`).
+
+User-facing impact: any fleet or workspace run using Specification (or GitHub Issue/PR while
+also supplying a prompt) silently produces an empty work request and a no-op run.
+
+## Proposal
+
+Make fleet and workspace mirror the already-correct single-project run contract: the UI sends a
+`source_type` discriminator alongside `source` + optional `prompt`; the server maps
+`spec`→`--spec`, `source`→`--source`, and **always** passes `--prompt` when present; Python
+resolves the work request through the existing `normalize()` / `build_work_request()` machinery,
+merging any prompt as `## Additional Instructions`. For workspace children the spec file is also
+threaded through the existing `--guide` mechanism as normative context.
+
+## Design
+
+### 0. Canonical reference (single-project run — already correct)
+
+- **UI** `worca-ui/app/views/new-run.js:597-618`: sends `sourceType` (`none`/`source`/`spec`;
+  `pr`→`source`) + `sourceValue` + optional `prompt`, all independent.
+- **Server** `worca-ui/server/process-manager.js:529-560`: maps `'source'`→`--source`,
+  `'spec'`→`--spec`, and ALWAYS `--prompt` when present (not exclusive).
+- **Python** `src/worca/scripts/run_pipeline.py:104-149` `build_work_request(args)`: validates
+  `--source` xor `--spec`; dispatches to `normalize("source"|"spec"|"plan"|"prompt", value)`
+  (`src/worca/orchestrator/work_request.py:481`); merges an accompanying prompt as
+  `\n\n## Additional Instructions\n\n{prompt}`. `normalize("spec", path)` →
+  `normalize_spec_file()` (`src/worca/orchestrator/work_request.py:171-196`) reads the file — its
+  contents become `work_request.description`.
+
+The fix is feature parity with this contract.
+
+### 1. Shared work-request resolver (Python)
+
+- **Current state:** `build_work_request(args)` lives inside `run_pipeline.py:104-149` and reads
+  five argparse attrs (`args.source`, `args.spec`, `args.plan`, `args.prompt`, `args.settings`).
+- **Obstacle:** fleet/workspace/worktree runners can't reuse it — it's coupled to run_pipeline's
+  Namespace, and their namespaces differ.
+- **Resolution:** extract a pure helper taking explicit params, keep `build_work_request(args)` as
+  a thin wrapper (backward compatible). All four runners call the shared helper.
+
+```python
+# src/worca/orchestrator/work_request.py  (new function)
+def resolve_work_request(*, prompt=None, source=None, spec=None, plan=None,
+                         settings_path=None) -> WorkRequest:
+    """Canonical: validate, normalize, merge prompt as Additional Instructions."""
+    if source and spec:
+        raise ValueError("source and spec are mutually exclusive")
+    if not any([prompt, source, spec, plan]):
+        raise ValueError("one of prompt, source, spec, or plan is required")
+    has_primary = source or spec or plan
+    if source:
+        tmpl = load_settings(settings_path).get("worca", {}).get("plan_path_template")
+        wr = normalize("source", source, plan_path_template=tmpl)
+    elif spec:
+        wr = normalize("spec", spec)
+    elif plan:
+        wr = normalize("plan", plan)
+    else:
+        wr = normalize("prompt", prompt)
+    if prompt and has_primary:
+        wr.description = (wr.description + "\n\n## Additional Instructions\n\n" + prompt
+                          if wr.description else "## Additional Instructions\n\n" + prompt)
+    return wr
+```
+
+`run_pipeline.build_work_request(args)` becomes: `return resolve_work_request(prompt=args.prompt,
+source=args.source, spec=args.spec, plan=args.plan, settings_path=args.settings)`.
+
+### 2. Source-type inference (backward compat)
+
+- **Current state:** `normalize()` already auto-detects `gh:`/`bd:`/URL when `source_type=="source"`
+  (`src/worca/orchestrator/work_request.py:509`).
+- **Obstacle:** old manifests (pre-W-076, or resume of in-flight runs) have no `source_type`.
+- **Resolution:** one canonical sniffer, mirrored in Python and JS.
+
+```python
+# src/worca/orchestrator/work_request.py
+def infer_source_type(value: str | None) -> str:
+    if not value: return "none"
+    if value.startswith(("gh:", "bd:")) or _ANY_URL_RE.match(value): return "source"
+    if os.path.isfile(value): return "spec"
+    return "source"  # let normalize() raise a clear error on unknown refs
+```
+
+```js
+// worca-ui/server/app.js — mirrors work_request.infer_source_type (source of truth)
+function sniffSourceType(value) {
+  if (!value) return 'none';
+  if (/^(gh:|bd:)/.test(value) || /^https?:\/\//.test(value)) return 'source';
+  return 'spec'; // file-path assumption; server can't stat per-project paths reliably
+}
+```
+
+### 3. Manifest data model
+
+Add `source_type` to `work_request` in both fleet and workspace manifests. Enum:
+`"none" | "source" | "spec"` (`pr` is mapped to `source` at the UI, matching `new-run.js:597`).
+
+```json
+"work_request": {
+  "title": "<resolved wr.title>",
+  "description": "<user prompt OR resolved contents>",
+  "source": "<file path or gh:/bd: ref, null for prompt-only>",
+  "source_type": "spec"
+}
+```
+
+Verified: fleet/workspace manifests are **not** JSON-schema-validated on write (only
+`workspace.json` topology and `workspace_plan.json` exist under `src/worca/schemas/`), so adding
+the key is safe.
+
+### 4. Server arg builder (shared)
+
+- **Current state:** `buildWorkspaceArgs` (`app.js:80-84`) and `dispatchFleet` (`app.js:784-788`)
+  duplicate the exclusive `if source else prompt` block.
+- **Obstacle:** exclusive routing loses the prompt and mis-routes spec paths into `--source`.
+- **Resolution:** one exported helper, used by both dispatchers.
+
+```js
+// worca-ui/server/app.js
+export function appendWorkRequestArgs(args, work_request) {
+  const wr = work_request || {};
+  const type = wr.source_type || sniffSourceType(wr.source);
+  if (type === 'spec' && wr.source) args.push('--spec', wr.source);
+  else if (type === 'source' && wr.source) args.push('--source', wr.source);
+  if (wr.description) args.push('--prompt', wr.description); // ALWAYS when present
+}
+```
+
+Note the wire-field asymmetry: `new-run.js` sends camelCase `sourceType` in a JSON body, while
+fleet/workspace use snake_case `source_type` in multipart FormData (consistent with existing
+`head_template`, `plan_mode`). Document with a comment.
+
+### 5. Workspace children get the spec as `--guide`
+
+- **Current state:** `dag_executor._build_child_cmd` passes `--prompt` (master-plan-derived
+  per-project slice) + `--guide` (repeatable) + `--plan` to `run_worktree.py`
+  (`src/worca/workspace/dag_executor.py:116-123`). Children never see `--source`/`--spec`.
+- **Obstacle:** the spec is normative context every child should honor; re-forwarding `--spec`
+  per child would re-fetch gh/bd N times and the path may not exist in every worktree.
+- **Resolution:** when `source_type == 'spec'`, `os.path.abspath` the spec and append it into the
+  workspace `guide_paths` (`src/worca/scripts/run_workspace.py:1290`). It flows to manifest
+  `guide.paths` → `dag_executor` `self._guide_paths` (`dag_executor.py:311`) → every child
+  `--guide`. This matches the `guide > plan > description` authority model (CLAUDE.md § Guide
+  Precedence). The spec is read twice (orchestrator gets contents via `normalize_spec_file`;
+  children get it as a normative guide) — intentional.
+
+### 6. Child runner blocker (`run_worktree.py`)
+
+- **Current state:** `--prompt`/`--source` in a mutually-exclusive argparse group, no `--spec`
+  (`src/worca/scripts/run_worktree.py:222-224`); local `normalize` if/elif at 296-303 with no
+  prompt-merge; `build_worktree_cmd` forwards source XOR prompt.
+- **Obstacle:** prompt+spec (or prompt+source) combos are structurally impossible — a hard blocker.
+- **Resolution:** de-couple the group, add `--spec`, forward `--prompt`/`--source`/`--spec`
+  independently to `run_pipeline` (which does the canonical merge — zero new resolve logic here).
+  Replace the local normalize with `resolve_work_request()` for the title/slug it derives locally.
+
+## Implementation Plan
+
+Phases are vertical slices. Phases 1–3 fix the reported workspace bug end-to-end; phase 4 applies
+the symmetric fleet fix; phase 5 hardens.
+
+### Phase 1: Shared resolver + child-runner unblock (Python core)
+**Files:** `src/worca/orchestrator/work_request.py`, `src/worca/scripts/run_pipeline.py`,
+`src/worca/scripts/run_worktree.py`
+**Tasks:**
+1. Add `resolve_work_request(...)` and `infer_source_type(...)` to `work_request.py`; re-point
+   `run_pipeline.build_work_request` (`run_pipeline.py:104`) at the shared helper.
+2. `run_worktree.py:222-224`: de-couple the mutually-exclusive group, add `--spec`, allow
+   `--prompt` alongside `--source`/`--spec`; update required-arg check (~292).
+3. `run_worktree.py` `build_worktree_cmd` (~177-187): forward `--spec`/`--source`/`--prompt`
+   independently. Replace local normalize (296-303) with `resolve_work_request`.
+4. Tests: `resolve_work_request` merge/xor; `run_worktree` accepts `--prompt`+`--spec`.
+
+### Phase 2: Workspace spec resolution (Python)
+**Files:** `src/worca/scripts/run_workspace.py`
+**Tasks:**
+1. Parser (858-860): add `--spec`, allow `--prompt` with `--source`/`--spec`; update required-arg
+   check (1250).
+2. Resolve WorkRequest via `resolve_work_request` before planning. In `create_workspace_manifest`
+   (245-302): set `title=wr.title` (**fix line 280**), `description=wr.description`, add
+   `source_type`, store `source`. Fix any manifest rebuild near line 1486.
+3. Master planner (1393-1395): replace `args.prompt or ""` with `wr.description`.
+4. When `source_type=='spec'`: abspath spec, append to `guide_paths` (1290).
+5. Tests: title non-empty; planner gets non-empty description; spec in `guide.paths` (abspath'd).
+
+### Phase 3: Workspace server + UI wiring
+**Files:** `worca-ui/server/app.js`, `worca-ui/server/workspace-routes.js`,
+`worca-ui/app/views/fleet-launcher.js`
+**Tasks:**
+1. `app.js`: add `sniffSourceType` + `appendWorkRequestArgs`; replace `buildWorkspaceArgs:80-84`
+   exclusive block with the helper.
+2. `workspace-routes.js`: read `source_type` from multipart fields (~1182); persist to
+   `work_request` (~1332-1336).
+3. `fleet-launcher.js` workspace submit (~254-289): append `source_type`
+   (`_hasSource() ? (sourceType==='pr'?'source':sourceType) : 'none'`).
+4. Rebuild bundle (`cd worca-ui && npm run build`). → **reported bug fixed.**
+
+### Phase 4: Fleet parity (symmetric)
+**Files:** `src/worca/scripts/run_fleet.py`, `worca-ui/server/app.js`,
+`worca-ui/server/fleet-routes.js`, `worca-ui/app/views/fleet-launcher.js`
+**Tasks:**
+1. `run_fleet.py`: add `--spec`, drop exclusive group, resolve fleet-level WR via
+   `resolve_work_request`; manifest (934-937) add `source_type`; child dispatch — pass resolved
+   `description` as `--prompt` and thread spec as `--guide` when `source_type=='spec'`.
+2. `app.js` `dispatchFleet:784-788`: replace exclusive block with `appendWorkRequestArgs`.
+3. `fleet-routes.js`: read + persist `source_type` (~721).
+4. `fleet-launcher.js` fleet submit (~189-205): append `source_type`.
+
+### Phase 5: Backward-compat + resume hardening
+**Files:** `src/worca/scripts/run_workspace.py`, `src/worca/scripts/run_fleet.py`,
+`worca-ui/server/app.js`
+**Tasks:**
+1. Use `infer_source_type` on manifests missing `source_type` (fleet legacy path ~517-518;
+   workspace resume `_resume_workspace` ~1270).
+2. Confirm JS resume dispatchers (`app.js:766-773`, `836-849`) rely on Python inference (they
+   pass only `--resume`).
+
+### Files Changed Summary
+
+| File | Change |
+|------|--------|
+| `src/worca/orchestrator/work_request.py` | Add `resolve_work_request()`, `infer_source_type()` |
+| `src/worca/scripts/run_pipeline.py` | `build_work_request` delegates to shared helper |
+| `src/worca/scripts/run_worktree.py` | De-couple exclusive group, add `--spec`, independent forwarding |
+| `src/worca/scripts/run_workspace.py` | Add `--spec`, resolve WR, fix `title`, feed planner, thread spec→guide, resume infer |
+| `src/worca/scripts/run_fleet.py` | Add `--spec`, resolve WR, `source_type` manifest, child guide-threading, legacy infer |
+| `worca-ui/server/app.js` | `appendWorkRequestArgs` + `sniffSourceType`; both dispatchers |
+| `worca-ui/server/workspace-routes.js` | Read + persist `source_type` |
+| `worca-ui/server/fleet-routes.js` | Read + persist `source_type` |
+| `worca-ui/app/views/fleet-launcher.js` | Send `source_type` (both submit paths) |
+
+## Considerations
+
+- **Prompt semantics:** for fleet/workspace, the manifest stores the **user prompt** in
+  `description` and the spec path in `source`. Passing `--prompt <description>` + `--spec <path>`
+  reproduces the canonical merge downstream. `source_type=='none'` → only `--prompt`, byte-identical
+  to today's behavior (no regression for existing prompt-only runs).
+- **Spec read twice** (orchestrator contents + child guide) — intentional; the alternative
+  (per-child `--spec`) re-fetches remote refs and breaks on worktree-relative paths.
+- **Governance:** no change to dispatch governance, hooks, or the guardian commit gate. `--spec`
+  is a launch-time arg, not an agent-invoked tool.
+- **Breaking changes:** none. `source_type` is additive; absence is handled by `infer_source_type`.
+  Existing prompt-only and gh-issue-only runs behave identically.
+- **Migration:** no config-key migration. In-flight manifests resumed after upgrade fall through
+  the sniffer. No user action required (nothing to add to MIGRATION.md unless the sniffer's
+  file-path assumption needs documenting).
+- **Known unknown:** JS `sniffSourceType` cannot `stat` per-project spec paths reliably (server
+  may run global-mode), so it defaults an unknown non-ref value to `spec`; the authoritative
+  discriminator is always the explicit `source_type` the UI now sends — the sniffer only covers
+  legacy manifests.
+
+## Test Plan
+
+### Unit Tests
+| Layer | Test | Validates |
+|-------|------|-----------|
+| Python | `test_resolve_work_request_spec_plus_prompt_merge` | Spec contents + prompt merged as Additional Instructions |
+| Python | `test_resolve_work_request_source_xor_spec` | Raises on both source and spec |
+| Python | `test_infer_source_type` | none / gh:/bd:/URL→source / file→spec |
+| Python | `test_run_worktree_accepts_prompt_plus_spec` | Regression: exclusive group removed |
+| Python | `test_run_worktree_cmd_forwards_spec_and_prompt` | `build_worktree_cmd` emits both independently |
+| Python | `test_run_workspace_title_non_empty` | `create_workspace_manifest` uses `wr.title` |
+| Python | `test_run_workspace_planner_gets_spec_description` | Master planner receives non-empty `wr.description` |
+| Python | `test_run_workspace_spec_added_to_guides` | Spec abspath'd into `guide.paths` |
+| Python | `test_run_fleet_spec_source_type_and_guide_threading` | `--spec` accepted, `source_type` persisted, spec→`--guide` |
+| JS (vitest) | `fleet-launcher` submit appends `source_type` (fleet + workspace) | Discriminator sent; prompt always sent; pr→source |
+| JS (vitest) | `app.js` `appendWorkRequestArgs` | Emits `--spec` vs `--source` + always `--prompt` |
+| JS (vitest) | `sniffSourceType` legacy fallback | Manifest without `source_type` still routes correctly |
+| JS (vitest) | workspace/fleet route persists `work_request.source_type` | Manifest write shape |
+
+### Integration / E2E Tests
+- Workspace integration test (`tests/integration/`) with a spec file source: assert
+  `workspace-plan.json` carries the spec-derived work request (not "no user request"), children
+  receive real `run_id`s, and the run does not complete instantly.
+- Manual repro: launch the reported curl (workspace-runs, Specification source + prompt) and
+  confirm the fetched manifest shows non-empty `title`/`description` and children with `run_id`.
+
+### Existing Tests to Update
+- `worca-ui/app/views/fleet-launcher.test.js` — assert the new `source_type` FormData field for
+  both submit paths (add, not break).
+- Any existing `run_workspace` / `run_fleet` manifest-shape assertions — add `source_type` key.
+- `run_pipeline` tests referencing `build_work_request` — verify still green after delegation.
+
+## Files to Create/Modify
+
+No new files. Modify the nine files in the *Files Changed Summary* table above. Tests added to the
+existing `tests/` (Python) and `worca-ui/**/*.test.js` (vitest) mirrors.
+
+## Out of Scope
+
+- Changing the single-project run path (already correct — it is the reference).
+- Adding a *file-upload* spec option (spec is a path resolved per project root, matching the
+  current UI hint) — only the path-based Specification type is wired.
+- Beads (`bd:`) or non-GitHub PR providers beyond what `normalize()` already supports.
+- A JSON schema for the fleet/workspace manifest (none exists today; out of scope to add one).
+- Retroactively backfilling `source_type` into already-completed manifests on disk.

--- a/docs/plans/W-077-relocate-worca-to-home.md
+++ b/docs/plans/W-077-relocate-worca-to-home.md
@@ -1,0 +1,341 @@
+# W-077: Relocate `.claude/worca/` to `~/.worca/pkg/`
+
+**Status:** Draft
+**Priority:** P1
+**Area:** cc
+**Date:** 2026-07-07
+**Depends on:** None
+
+## Problem
+
+`worca init` copies ~200 files into `.claude/worca/` inside every consumer project (`src/worca/cli/init.py:831`, `_copy_worca_source`). This pollutes the project tree with worca runtime code and requires `.gitignore` maintenance for `.worca/`, `logs/`, and `.claude/settings.local.json` (`init.py:973`). The code copy is largely redundant when worca is pip-installed — `run_pipeline.py:11` and `run_worktree.py:25` already import via the pip package, not `.claude/worca/`.
+
+User-facing impact: every worca-enabled project carries a ~200-file subtree that has nothing to do with the project's own code, and upgrading requires `worca init --upgrade` to re-copy the entire tree into each project individually.
+
+## Proposal
+
+Move the worca code copy from `.claude/worca/` to a versioned, shared directory at `~/.worca/pkg/<version>/worca/`. Move worca configuration from `.claude/settings.json` to `~/.worca/projects/<slug>/config.json`. Rewrite hook commands to reference the centralized pkg via fully resolved absolute paths. Multiple projects can share the same pkg version; per-project version isolation is maintained via the project registry.
+
+## Architectural Context
+
+### Confirmed decisions
+
+- **Hook path resolution:** Hook commands use fully resolved absolute paths (via `os.path.expanduser("~")` at init time) with no shell env vars (`$HOME`, etc.) — ensures cross-platform compatibility (Linux/macOS/WSL2/Windows) without shell expansion fragility — referenced by Phase 1.
+- **Config loading precedence:** `WORCA_CONFIG_PATH` (base) → `WORCA_SETTINGS_PATH` (template overlay) → `.local.json` (secrets merge). The existing `WORCA_SETTINGS_PATH` role (template-merged overlay set by orchestrator) is unchanged; `WORCA_CONFIG_PATH` is the new base layer — referenced by Phase 2.
+- **Version key format:** `<semver>-<git-short-hash>` (e.g., `0.59.0-a1b2c3d`) — enables distinguishing between released versions and dev/editable-install builds from different commits — referenced by Phase 1.
+- **GC safety:** Mark-and-sweep GC must never remove a pkg version while any pipeline referencing it is running. Implementation deferred to Phase 4 — checks `pipelines.d/` across all registered projects before deletion — referenced by Phase 4.
+
+### Open decisions
+
+None.
+
+## Design
+
+### 1. Centralized Package Store (`~/.worca/pkg/`)
+
+- **Current state:** `init.py:831` copies the worca source tree to `<project>/.claude/worca/`.
+- **Obstacle:** Every project carries its own copy; upgrades touch every project.
+- **Resolution:** Copy to `~/.worca/pkg/<version>/worca/` instead. Version key format: `<semver>-<git-short-hash>` (e.g., `0.59.0-a1b2c3d`). The `worca/` wrapper directory preserves the import structure — `sys.path.insert` going up two levels from `claude_hooks/` reaches `~/.worca/pkg/<ver>/` where `worca` is an importable package. Copy is idempotent: if the pkg dir already exists, skip.
+
+```
+~/.worca/pkg/
+  0.59.0-a1b2c3d/
+    worca/                     # code copy (same content as current .claude/worca/)
+      __init__.py
+      claude_hooks/
+      hooks/
+      orchestrator/
+      agents/core/
+      schemas/
+      scripts/
+      events/
+      state/
+      utils/
+    provenance.json            # install metadata (version, source, commit, branch)
+```
+
+`provenance.json` stays with the pkg (describes the code copy, not the project). Written by `_write_provenance_manifest()` (`init.py:746`).
+
+### 2. Hook Command Rewrite
+
+- **Current state:** Hook commands in `.claude/settings.json` use `$(git rev-parse --git-common-dir)/.claude/worca/claude_hooks/{script}` (`init.py:362`).
+- **Obstacle:** Hooks must reference code that no longer lives in the project.
+- **Resolution:** Resolve the absolute path at init time using `os.path.expanduser("~")` and write a plain absolute path into the hook command. No shell expansion needed — works on Linux, macOS, WSL2, and Windows without platform-specific env vars (`$HOME` vs `%USERPROFILE%`).
+
+Before:
+```json
+{
+  "command": "python3 \"$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)/.claude/worca/claude_hooks/pre_tool_use.py\""
+}
+```
+
+After:
+```json
+{
+  "command": "python3 /home/user/.worca/pkg/0.59.0-a1b2c3d/worca/claude_hooks/pre_tool_use.py"
+}
+```
+
+The `_hook_cmd_tpl` template in `init.py:362` changes to use `os.path.expanduser("~")` resolved at init time, producing a fully resolved absolute path. No `$HOME` or shell subshell in the command string.
+
+### 3. Worca Config Relocation
+
+- **Current state:** Worca configuration (`worca.*` namespace) lives in `.claude/settings.json` alongside Claude Code settings (hooks, permissions). `load_settings()` (`utils/settings.py:79`) reads from `.claude/settings.json` + `.local` merge.
+- **Obstacle:** Mixing worca config and Claude Code settings in one file prevents minimizing the project footprint.
+- **Resolution:** Move worca config to `~/.worca/projects/<slug>/config.json`. `.claude/settings.json` retains only hooks and Claude Code permissions.
+
+```
+~/.worca/projects/my-project/
+  config.json                  # worca configuration (stages, agents, flow, governance, etc.)
+```
+
+New env var `WORCA_CONFIG_PATH` (set by orchestrator at pipeline start) points to the resolved absolute path. Separate from existing `WORCA_SETTINGS_PATH` (template-merged overlay role, unchanged).
+
+Config loading order in `load_settings()`:
+1. `WORCA_CONFIG_PATH` → `~/.worca/projects/<slug>/config.json` (base worca config)
+2. `WORCA_SETTINGS_PATH` → template-merged overlay (if pipeline active)
+3. `.claude/settings.local.json` → secrets merge
+
+Hook scripts read config via `WORCA_CONFIG_PATH`. Orchestrator resolves the path from the registry at startup, exports it before spawning Claude.
+
+### 4. Extended Project Registry
+
+- **Current state:** `~/.worca/projects.d/<slug>.json` contains `name`, `path`, `worcaDir`, `settingsPath` (`project_registry.py:62`).
+- **Obstacle:** Registry doesn't track worca version or config path.
+- **Resolution:** Add `worcaConfigPath` and `worcaPkgVersion` fields.
+
+```json
+{
+  "name": "my-project",
+  "path": "/abs/path/to/project",
+  "worcaDir": "/abs/path/.worca",
+  "settingsPath": "/abs/path/.claude/settings.json",
+  "worcaConfigPath": "/home/user/.worca/projects/my-project/config.json",
+  "worcaPkgVersion": "0.59.0-a1b2c3d"
+}
+```
+
+UI server reads worca config from `worcaConfigPath`, Claude Code settings from `settingsPath`.
+
+### 5. Worktree Run Support
+
+- **Current state:** Worktrees inherit `.claude/worca/` from the repo tree. `run_worktree.py:427` creates `.worca/` in the worktree.
+- **Obstacle:** `.claude/worca/` no longer exists in the project.
+- **Resolution:** Hook commands use resolved absolute paths (via `os.path.expanduser("~")` at init time) — they resolve correctly from any worktree. No code copy into worktree needed. `_require_project_worca()` (`cli/main.py:40`) changes to verify the pkg path from the registry instead of checking `.claude/worca/`.
+
+### 6. Mark-and-Sweep GC for Orphan Versions
+
+- **Current state:** No version management — each project has its own copy.
+- **Obstacle:** Shared pkg store accumulates old versions when projects upgrade.
+- **Resolution:** Mark-and-sweep GC:
+  1. Scan all `~/.worca/projects.d/*.json` → collect referenced `worcaPkgVersion` values
+  2. List all dirs in `~/.worca/pkg/`
+  3. Delete unreferenced dirs
+  4. `--dry-run` to preview, `--keep-latest N` to preserve N most recent regardless
+
+Triggers:
+- Automatically during `worca init --upgrade` (after switching project to new version)
+- On-demand via `worca cleanup --gc`
+
+### 7. What Stays in the Project
+
+```
+<project>/
+  .claude/
+    settings.json              # hooks-only (~30 lines) + Claude Code permissions
+    settings.local.json        # secrets (existing, gitignored)
+    agents/                    # user agent overrides (existing)
+    skills/                    # worca-installed skills (Claude Code requires this location)
+    templates/                 # project pipeline templates (existing)
+  .worca/                      # run state (existing, gitignored, unchanged)
+    runs/<run_id>/
+    pipelines.d/
+    logs/
+```
+
+## Implementation Plan
+
+### Phase 1: Package Store + Hook Rewrite
+
+**What to build:** Relocate the worca code copy from `.claude/worca/` to a versioned shared directory at `~/.worca/pkg/<version>/worca/`. Rewrite hook commands to reference the centralized pkg via fully resolved absolute paths (no shell vars). Update init to verify pkg existence instead of checking project-local `.claude/worca/`.
+
+**Acceptance criteria:**
+- [ ] `worca init` creates `~/.worca/pkg/<semver>-<hash>/worca/` with code copy and `provenance.json` (verify: `ls -la ~/.worca/pkg/` shows version dir, `cat ~/.worca/pkg/<ver>/provenance.json` exists)
+- [ ] Hook commands in `.claude/settings.json` use plain absolute paths (no `$HOME`, no shell subshells) (verify: `jq '.hooks' .claude/settings.json` shows absolute paths starting with `/`)
+- [ ] `worca init` on a second project sharing the same worca version skips pkg copy (idempotent) (verify: run `worca init` twice, second run logs "Package already exists" or equivalent)
+- [ ] `_require_project_worca()` verifies pkg path from registry instead of checking `.claude/worca/` (verify: unit test passes, or trigger error with missing pkg and observe error message references registry)
+
+**Files:** `src/worca/cli/init.py`, `src/worca/settings.json`, `src/worca/cli/main.py`, `src/worca/utils/paths.py`, `src/worca/utils/pkg_store.py` (new)
+**Tasks:**
+1. Create `pkg_store.py` with version key computation (semver + git short hash) and pkg dir management helpers
+2. Add `pkg_dir()` and `project_config_dir()` helper functions in `utils/paths.py`
+3. Change `_copy_worca_source()` target from `.claude/worca/` to `~/.worca/pkg/<ver>/worca/` with idempotency check (calls `pkg_store.py` for version key)
+4. Move `_write_provenance_manifest()` to write `~/.worca/pkg/<ver>/provenance.json`
+5. Update `_hook_cmd_tpl` to resolve absolute path via `os.path.expanduser("~")` at init time (produces plain absolute path with no `$HOME` or shell subshell)
+6. Update `_require_project_worca()` in `cli/main.py` to verify pkg path from registry
+7. Update settings.json template to remove worca code path references
+8. Tests: verify init creates pkg in `~/.worca/pkg/`, hooks reference correct path
+
+### Phase 2: Config Relocation
+
+**What to build:** Move worca configuration from `.claude/settings.json` (worca.* namespace) to `~/.worca/projects/<slug>/config.json`. Orchestrator and hooks read config via `WORCA_CONFIG_PATH` env var. `.claude/settings.json` retains only hooks and Claude Code permissions.
+
+**Acceptance criteria:**
+- [ ] `worca init` creates `~/.worca/projects/<slug>/config.json` with worca.* keys extracted from settings template
+- [ ] `.claude/settings.json` contains only hooks and permissions (no worca.* keys)
+- [ ] `run_pipeline.py` exports `WORCA_CONFIG_PATH` pointing to `~/.worca/projects/<slug>/config.json`
+- [ ] Hook scripts read config from `WORCA_CONFIG_PATH` instead of `.claude/settings.json`
+- [ ] A test pipeline run loads config from the new location (verify via config value read)
+
+**Files:** `src/worca/utils/settings.py`, `src/worca/hooks/tracking.py`, `src/worca/hooks/guard.py`, `src/worca/claude_hooks/post_tool_use.py`, `src/worca/hooks/graphify_nudge.py`, `src/worca/orchestrator/runner.py`, `src/worca/scripts/run_pipeline.py`, `src/worca/scripts/run_worktree.py`, `src/worca/cli/init.py`
+**Tasks:**
+1. Add `WORCA_CONFIG_PATH` resolution in `load_settings()`
+2. Update `init.py` to create `~/.worca/projects/<slug>/config.json` during init (extract worca.* keys from settings template)
+3. Update `run_pipeline.py` to resolve and export `WORCA_CONFIG_PATH` at startup
+4. Update `run_worktree.py` to propagate `WORCA_CONFIG_PATH`
+5. Update hook config readers (`tracking.py`, `guard.py`, `post_tool_use.py`, `graphify_nudge.py`) to use `WORCA_CONFIG_PATH`
+6. Strip worca.* keys from `.claude/settings.json` template (leave only hooks + permissions)
+7. Tests: verify config loaded from new location, hooks read correct config
+
+### Phase 3: Registry Extension + UI
+
+**What to build:** Extend the project registry to include `worcaConfigPath` and `worcaPkgVersion` fields. Update the worca-ui server to read worca config from the new location instead of `.claude/settings.json`.
+
+**Acceptance criteria:**
+- [ ] Registry entries include `worcaConfigPath` and `worcaPkgVersion` fields
+- [ ] `worca init` writes both fields when creating or updating registry entries
+- [ ] worca-ui server reads worca config from `worcaConfigPath` (not `settingsPath`)
+- [ ] worca-ui settings view displays config from the new location
+
+**Files:** `src/worca/utils/project_registry.py`, `worca-ui/server/project-registry.js`, `worca-ui/server/app.js`
+**Tasks:**
+1. Add `worcaConfigPath` and `worcaPkgVersion` to registry entries
+2. Update `auto_register_project()` to write new fields
+3. Update UI server `readProjects()` to read `worcaConfigPath`
+4. Update UI server settings reads to use `worcaConfigPath` for worca config
+5. Tests: verify registry entries, UI reads config from new location
+
+### Phase 4: Upgrade Migration + GC
+
+**What to build:** Detect old-layout projects (`.claude/worca/` exists) during `--upgrade`, migrate to new layout (relocate code to pkg, move config, rewrite hooks, delete `.claude/worca/`). Add `worca cleanup --gc` to remove unreferenced pkg versions via mark-and-sweep.
+
+**Acceptance criteria:**
+- [ ] `worca init --upgrade` on old-layout project relocates `.claude/worca/` → `~/.worca/pkg/<ver>/worca/`
+- [ ] Old `.claude/worca/` directory is deleted after migration
+- [ ] Hooks in `.claude/settings.json` are rewritten to reference new pkg path
+- [ ] worca config is moved from `.claude/settings.json` to `~/.worca/projects/<slug>/config.json`
+- [ ] `worca cleanup --gc` removes unreferenced pkg versions
+- [ ] `worca cleanup --gc` skips pkg versions referenced by running pipelines (verify by running pipeline, triggering GC, checking pkg still exists)
+- [ ] `worca cleanup --gc --dry-run` lists versions to remove without deleting
+- [ ] `worca cleanup --gc --keep-latest 2` preserves 2 most recent versions regardless of references
+- [ ] GC runs automatically after `--upgrade` completes
+
+**Files:** `src/worca/cli/init.py`, `src/worca/cli/cleanup.py`, `src/worca/utils/pkg_store.py`
+**Tasks:**
+1. In `--upgrade` flow: detect `.claude/worca/` (old layout), relocate to pkg, move config, rewrite hooks, delete `.claude/worca/`
+2. Add mark-and-sweep GC logic to `pkg_store.py` (scan registry for referenced versions, list pkg dirs, compute orphans, check running pipelines)
+3. Add `worca cleanup --gc` subcommand in `cleanup.py` with `--dry-run` and `--keep-latest N` options (calls `pkg_store.py` GC logic)
+4. Auto-trigger GC after `--upgrade` completes
+5. Tests: verify migration from old layout, GC removes unreferenced versions, GC skips versions referenced by running pipelines
+
+### Phase 5: Fleet/Workspace/Script Updates
+
+**What to build:** Update fleet and workspace runners to propagate `WORCA_CONFIG_PATH` to child runs. Verify event emitters resolve webhook config from the new config path.
+
+**Acceptance criteria:**
+- [ ] Fleet child runs receive `WORCA_CONFIG_PATH` in their environment
+- [ ] Workspace child runs receive `WORCA_CONFIG_PATH` in their environment
+- [ ] Event emitters read webhook config from `WORCA_CONFIG_PATH` (not `.claude/settings.json`)
+- [ ] A fleet run with webhook config successfully emits events to configured endpoint
+
+**Files:** `src/worca/scripts/run_fleet.py`, `src/worca/scripts/run_workspace.py`, `src/worca/events/emitter.py`
+**Tasks:**
+1. Update fleet runner to propagate `WORCA_CONFIG_PATH` to child runs
+2. Update workspace runner to propagate `WORCA_CONFIG_PATH` to child runs
+3. Verify event emitters resolve webhook config from new config path
+4. Tests: fleet and workspace runs use relocated config
+
+### Files Changed Summary
+
+| File | Change |
+|------|--------|
+| `src/worca/cli/init.py` | Pkg store target, hook template, config creation, migration logic |
+| `src/worca/cli/main.py` | `_require_project_worca()` checks pkg path |
+| `src/worca/cli/cleanup.py` | Add `--gc` subcommand |
+| `src/worca/utils/settings.py` | `WORCA_CONFIG_PATH` resolution in `load_settings()` |
+| `src/worca/utils/project_registry.py` | Extended registry fields |
+| `src/worca/utils/paths.py` | Add `pkg_dir()`, `project_config_dir()` helpers |
+| `src/worca/utils/pkg_store.py` | New — version key computation, pkg dir management, mark-and-sweep GC logic |
+| `src/worca/hooks/tracking.py` | Config discovery via `WORCA_CONFIG_PATH` |
+| `src/worca/hooks/guard.py` | Config read from new path |
+| `src/worca/claude_hooks/post_tool_use.py` | Config read from new path |
+| `src/worca/hooks/graphify_nudge.py` | Config read from new path |
+| `src/worca/orchestrator/runner.py` | Export `WORCA_CONFIG_PATH`, read from new path |
+| `src/worca/scripts/run_pipeline.py` | Resolve and export `WORCA_CONFIG_PATH` |
+| `src/worca/scripts/run_worktree.py` | Propagate `WORCA_CONFIG_PATH` |
+| `src/worca/scripts/run_fleet.py` | Propagate `WORCA_CONFIG_PATH` |
+| `src/worca/scripts/run_workspace.py` | Propagate `WORCA_CONFIG_PATH` |
+| `src/worca/settings.json` | Hook command template updated |
+| `worca-ui/server/project-registry.js` | Read extended registry fields |
+| `worca-ui/server/app.js` | Read config from `worcaConfigPath` |
+
+## Considerations
+
+- **Breaking change:** `worca init --upgrade` on existing projects will migrate layout. First upgrade after this change removes `.claude/worca/`. No rollback without re-running old `worca init`.
+- **Migration:** old layout (`.claude/worca/` exists) → detected during `--upgrade` → automatic relocation. No user action beyond running `--upgrade`.
+- **Governance:** Hook commands change from project-relative to fully resolved absolute paths (no `$HOME` shell var). Dispatch governance config moves to `~/.worca/projects/<slug>/config.json`. `worca-dispatch-governance-reviewer` subagent should be dispatched after implementation.
+- **Platform:** Hook commands use fully resolved absolute paths (via `os.path.expanduser("~")` at init time). No shell env var expansion needed — works on Linux, macOS, WSL2, and Windows without platform-specific handling.
+- **Worktree isolation:** worktrees share the centralized pkg. If a user upgrades worca while a worktree pipeline is running, the running pipeline's hooks would reference the old version (still on disk until GC). GC should never remove a version while any pipeline is running — check `pipelines.d/` across all registered projects.
+- **Slug collision:** deferred. Two projects with identical basenames will collide in `projects.d/`. Mitigation: warn at init time. Future: `--name <custom-slug>` flag on `worca init` to override the auto-derived slug.
+
+## Test Plan
+
+### Unit Tests
+
+| Layer | Test | Validates |
+|-------|------|-----------|
+| Python | `test_init_creates_pkg_in_home` | `worca init` copies to `~/.worca/pkg/<ver>/worca/` |
+| Python | `test_init_idempotent_pkg_exists` | Skip copy if pkg dir already exists |
+| Python | `test_hook_command_uses_absolute_path` | Hook commands reference resolved absolute path to `~/.worca/pkg/...` |
+| Python | `test_config_created_in_projects_dir` | `config.json` created at `~/.worca/projects/<slug>/` |
+| Python | `test_load_settings_reads_worca_config_path` | `WORCA_CONFIG_PATH` env var respected |
+| Python | `test_registry_extended_fields` | Registry entries include `worcaConfigPath`, `worcaPkgVersion` |
+| Python | `test_gc_removes_unreferenced_versions` | Mark-and-sweep deletes orphan pkg dirs |
+| Python | `test_gc_keeps_referenced_versions` | Referenced versions survive GC |
+| Python | `test_gc_skips_running_pipeline_versions` | GC skips pkg versions referenced by running pipelines (checks `pipelines.d/`) |
+| Python | `test_gc_dry_run` | Dry run lists but doesn't delete |
+| Python | `test_gc_keep_latest_n` | `--keep-latest N` preserves N most recent versions regardless of references |
+| Python | `test_upgrade_migrates_old_layout` | `.claude/worca/` detected, relocated, deleted |
+| Python | `test_version_key_format` | Semver + short hash computed correctly |
+
+### Integration Tests
+
+- Full `worca init` → verify no `.claude/worca/` created, pkg in `~/.worca/pkg/`
+- `worca init --upgrade` on old-layout project → verify migration
+- Pipeline run with relocated config → verify hooks fire, config loaded
+- Worktree run → verify hooks resolve from shared pkg
+- GC after upgrade → verify old version removed
+
+### Existing Tests to Update
+
+- `tests/test_worca_cli.py` — init tests reference `.claude/worca/` paths
+- `tests/integration/conftest.py` — fixture creates `.claude/worca/` → update to new layout
+- `tests/integration/test_file_access_integration.py` — path assumptions
+- Any test mocking `load_settings()` path resolution
+
+### Done Criteria
+
+All unit tests listed in the Unit Tests table pass. All integration scenarios listed in Integration Tests section pass. All updated tests in Existing Tests to Update section pass on CI.
+
+## Files to Create/Modify
+
+See Files Changed Summary in Implementation Plan (includes both modifications and new file creation).
+
+## Out of Scope
+
+- `--name <custom-slug>` flag for `worca init` (slug collision mitigation) — deferred to a follow-up. When implemented, `worca init --name <slug>` will override the auto-derived slug from `os.path.basename(project_root)`, allowing two projects with identical basenames to coexist in the registry.
+- Relocating `.worca/` run state directory — stays in project (already gitignored)
+- Relocating `.claude/agents/`, `.claude/skills/`, `.claude/templates/` — stay in project (Claude Code convention, user-editable)
+- Relocating `.claude/settings.local.json` — stays in project (Claude Code native secrets mechanism)
+- pip post-install hooks to auto-populate pkg store
+- XDG-compliant directory layout (`$XDG_DATA_HOME` etc.)

--- a/docs/plans/W-078-fix-version-detection-home-dir-layout.md
+++ b/docs/plans/W-078-fix-version-detection-home-dir-layout.md
@@ -1,0 +1,228 @@
+# W-078: Fix version detection and update for home-dir layout
+
+**Status:** Draft
+**Priority:** P1
+**Area:** ui
+**Date:** 2026-07-09
+**Depends on:** None (builds on the home-dir relocation work on branch `worca/relocate-worca-runtime-to-home-directory-5ii`)
+
+## Problem
+
+With the home-dir layout, worca runtime moved from `<project>/.claude/worca/` to `~/.worca/pkg/<ver>/worca/`. Two functions in `worca-setup.js` still look for `.claude/worca/` inside the project tree:
+
+- `checkWorcaInstalled()` at `worca-ui/server/worca-setup.js:18` checks `existsSync(join(projectPath, '.claude', 'worca'))` — always `false` with the new layout, so the UI shows projects as "not installed".
+- `readProjectWorcaVersion()` at `worca-ui/server/worca-setup.js:27` reads `version.json` / `__init__.py` from `.claude/worca/` — files that no longer exist in the project, so version shows "unknown".
+
+The registry entry (`~/.worca/projects.d/<slug>.json`) already carries the right data — `worcaConfigPath` and `worcaPkgVersion` — written by `update_registry_entry()` in `src/worca/utils/project_registry.py:124-126`. But no UI code reads these fields for version detection.
+
+The update button (`POST /worca-setup` at `project-routes.js:1815`) spawns `worca init --upgrade` correctly, but after completion the status check still reports "unknown" because detection is broken.
+
+Additionally, `buildProjectPreflight()` at `worca-ui/server/worca-setup-config.js:141` has a third hardcoded check — `existsSync(join(projectRoot, '.claude', 'worca'))` — used by the Project Setup wizard (step 1, "Your Project Environment"). This causes the setup dialog to show "Worca runtime · not installed" even for projects that were successfully initialized with the home-dir layout. The wizard uses this field to decide whether to show an "install worca" step (`project-setup-wizard.js:56`).
+
+## Proposal
+
+Add optional registry-data parameters to `checkWorcaInstalled` and `readProjectWorcaVersion`. Thread `worcaConfigPath` and `worcaPkgVersion` from registry entries through all call sites. Strip git-hash suffix from `worcaPkgVersion` before returning (registry stores `0.59.0-33ad2a9`, UI expects clean `0.59.0`). Preserve backwards compatibility with the legacy `.claude/worca/` layout via fallback.
+
+## Design
+
+### 1. Version detection functions (`worca-ui/server/worca-setup.js`)
+
+- **Current state:** `worca-setup.js:18` — `checkWorcaInstalled(projectPath)` checks only `.claude/worca/`. `worca-setup.js:27` — `readProjectWorcaVersion(projectPath)` reads only from `.claude/worca/version.json` or `__init__.py`.
+- **Obstacle:** Both functions take a bare `projectPath` string — no access to registry data.
+- **Resolution:** Add optional second parameter for registry data. Home-dir check first, legacy fallback second.
+
+```js
+// before
+export function checkWorcaInstalled(projectPath) {
+  return existsSync(join(projectPath, '.claude', 'worca'));
+}
+
+// after
+export function checkWorcaInstalled(projectPath, worcaConfigPath) {
+  if (worcaConfigPath && existsSync(worcaConfigPath)) return true;
+  return existsSync(join(projectPath, '.claude', 'worca'));
+}
+```
+
+```js
+// before
+export function readProjectWorcaVersion(projectPath) {
+  // tries version.json then __init__.py under .claude/worca/
+}
+
+// after
+export function readProjectWorcaVersion(projectPath, worcaPkgVersion) {
+  if (worcaPkgVersion) return worcaPkgVersion.replace(/-[0-9a-f]{7,}$/, '');
+  // legacy fallback: version.json then __init__.py under .claude/worca/
+}
+```
+
+**Hash stripping rationale:** `worcaPkgVersion` is produced by `version_key()` in `src/worca/utils/pkg_store.py:41-50` which appends `-<git-short-hash>` when inside a git repo. The UI badge displays this value directly (`settings.js:3267`) and `isVersionBehind()` (`version-check.js:71`) parses it for comparison. The old `__init__.py` returned clean semver (`0.59.0`). `parseInt("0-33ad2a9")` happens to return `0` (correct by accident), but displaying `0.59.0-33ad2a9` in the badge is ugly. The regex `/-[0-9a-f]{7,}$/` matches only trailing git short hashes, not RC suffixes (`rc3`, `-rc.5`).
+
+### 2. Project resolver middleware (`worca-ui/server/project-routes.js`)
+
+- **Current state:** `project-routes.js:148-160` — `req.project` carries `name`, `path`, `worcaDir`, `settingsPath`, `projectRoot`, `pm`. Does not include `worcaConfigPath` or `worcaPkgVersion`.
+- **Obstacle:** Downstream handlers (`GET /worca-status` at line 1786) can't pass registry data to detection functions.
+- **Resolution:** Add `worcaConfigPath` and `worcaPkgVersion` to `req.project`.
+
+```js
+// after — add two fields to req.project
+req.project = {
+  name: project.name,
+  path: project.path,
+  worcaDir,
+  settingsPath: resolvedSettingsPath,
+  worcaConfigPath: project.worcaConfigPath || null,
+  worcaPkgVersion: project.worcaPkgVersion || null,
+  projectRoot: projRoot,
+  pm: new ProcessManager({ ... }),
+};
+```
+
+### 3. Setup wizard preflight (`worca-ui/server/worca-setup-config.js`)
+
+- **Current state:** `worca-setup-config.js:141` — `worcaInstalled` checks `existsSync(join(projectRoot, '.claude', 'worca'))`. The function signature accepts `{ projectRoot, settingsPath, graphifyStatus, crgStatus }` — no `worcaConfigPath`.
+- **Obstacle:** `buildProjectPreflight` doesn't know about the home-dir layout. The wizard shows "Worca runtime · not installed" and offers an unnecessary install step.
+- **Resolution:** Add optional `worcaConfigPath` to the function args. Use `checkWorcaInstalled(projectRoot, worcaConfigPath)` instead of inline `existsSync`.
+
+```js
+// before (worca-setup-config.js:130-142)
+export async function buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  graphifyStatus = null,
+  crgStatus = null,
+}) {
+  const worcaInstalled =
+    Boolean(projectRoot) && existsSync(join(projectRoot, '.claude', 'worca'));
+
+// after
+export async function buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  worcaConfigPath = null,
+  graphifyStatus = null,
+  crgStatus = null,
+}) {
+  const worcaInstalled =
+    Boolean(projectRoot) && checkWorcaInstalled(projectRoot, worcaConfigPath);
+```
+
+Call site at `project-routes.js:521` passes `req.project` fields — add `worcaConfigPath`:
+
+```js
+const payload = await buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  worcaConfigPath: req.project.worcaConfigPath,
+  graphifyStatus: req.app.locals.graphifyStatus || null,
+  crgStatus: req.app.locals.crgStatus || null,
+});
+```
+
+### 4. Call site updates (`project-routes.js`, `ws-modular.js`)
+
+Five call sites need registry data threaded through:
+
+| Call site | File:line | Available data | Change |
+|-----------|-----------|----------------|--------|
+| GET `/api/projects` enrichment | `project-routes.js:209` | `p` = full registry entry | `readProjectWorcaVersion(p.path, p.worcaPkgVersion)` |
+| GET `/setup/preflight` | `project-routes.js:521` | `req.project` (after §2 fix) | Pass `worcaConfigPath` to `buildProjectPreflight` |
+| GET `/worca-status` install check | `project-routes.js:1788` | `req.project` (after §2 fix) | `checkWorcaInstalled(projectRoot, req.project.worcaConfigPath)` |
+| GET `/worca-status` version read | `project-routes.js:1797` | `req.project` (after §2 fix) | `readProjectWorcaVersion(projectRoot, req.project.worcaPkgVersion)` |
+| WS `projects-updated` broadcast | `ws-modular.js:187` | `p` = full registry entry | `readProjectWorcaVersion(p.path, p.worcaPkgVersion)` |
+
+### 4. Directory scanner (`worca-ui/server/project-registry.js`)
+
+- **Current state:** `project-registry.js:157` — `scanDirectory(dirPath)` calls `checkWorcaInstalled(childPath)` with only a filesystem path. No access to `prefsDir` or registry entries.
+- **Obstacle:** Can't detect home-dir installs without knowing `prefsDir`.
+- **Resolution:** Add optional `prefsDir` parameter. For each discovered child, compute slug and check `existsSync(join(prefsDir, 'projects', slug, 'config.json'))`.
+
+```js
+// before
+export async function scanDirectory(dirPath) {
+
+// after
+export async function scanDirectory(dirPath, prefsDir) {
+  // ...
+  const installed = prefsDir
+    ? checkWorcaInstalled(childPath, join(prefsDir, 'projects', slugify(entry.name), 'config.json'))
+    : checkWorcaInstalled(childPath);
+```
+
+Call site in `worca-ui/server/app.js:693` already has `prefsDir` in scope — pass it through.
+
+## Implementation Plan
+
+### Phase 1: Detection functions + call sites
+
+**Files:** `worca-ui/server/worca-setup.js`, `worca-ui/server/worca-setup-config.js`, `worca-ui/server/project-routes.js`, `worca-ui/server/ws-modular.js`
+
+**Tasks:**
+1. Update `checkWorcaInstalled` signature and logic (`worca-setup.js:18`)
+2. Update `readProjectWorcaVersion` signature and logic with hash stripping (`worca-setup.js:27`)
+3. Add `worcaConfigPath` / `worcaPkgVersion` to `req.project` in `projectResolver` (`project-routes.js:148`)
+4. Update `buildProjectPreflight` to accept `worcaConfigPath` and use `checkWorcaInstalled` (`worca-setup-config.js:130`)
+5. Thread registry data at all five call sites (§4 table above)
+
+### Phase 2: Directory scanner
+
+**Files:** `worca-ui/server/project-registry.js`, `worca-ui/server/app.js`
+
+**Tasks:**
+1. Add optional `prefsDir` to `scanDirectory` (`project-registry.js:157`)
+2. Pass `prefsDir` from `app.js:693`
+
+### Phase 3: Tests
+
+**Files:** `worca-ui/server/test/worca-status.test.js`
+
+**Tasks:**
+1. Add test: home-dir layout with `worcaConfigPath` + `worcaPkgVersion` → `installed: true`, version returned (hash stripped)
+2. Add test: home-dir layout with `worcaConfigPath` only (no `worcaPkgVersion`) → `installed: true`, version `null`
+3. Add test: no `.claude/worca/` and no `worcaConfigPath` → `installed: false`
+4. Verify existing legacy tests still pass unchanged
+
+### Files Changed Summary
+
+| File | Change |
+|------|--------|
+| `worca-ui/server/worca-setup.js` | Add optional params to `checkWorcaInstalled`, `readProjectWorcaVersion`; hash stripping |
+| `worca-ui/server/worca-setup-config.js` | Add `worcaConfigPath` param to `buildProjectPreflight`; delegate to `checkWorcaInstalled` |
+| `worca-ui/server/project-routes.js` | Add fields to `req.project`; thread registry data at 4 call sites (projects list, preflight, worca-status ×2) |
+| `worca-ui/server/ws-modular.js` | Thread `worcaPkgVersion` at line 187 |
+| `worca-ui/server/project-registry.js` | Add optional `prefsDir` to `scanDirectory` |
+| `worca-ui/server/app.js` | Pass `prefsDir` to `scanDirectory` call |
+| `worca-ui/server/test/worca-status.test.js` | 3 new test cases for home-dir layout |
+| `worca-ui/server/project-routes-setup-preflight.test.js` | Add test case for preflight with home-dir layout (`worcaConfigPath` present → `worcaInstalled: true`) |
+
+## Considerations
+
+- **Backwards compatibility:** Legacy projects with `.claude/worca/` still detected via fallback. No breaking changes.
+- **Hash stripping regex:** `/-[0-9a-f]{7,}$/` won't match RC suffixes like `rc3` or `-rc.5` (no hex-only digits). Safe.
+- **`worcaPkgVersion` not always present:** Old registry entries (created by UI before init ↔ UI unification) lack this field. Falls through to legacy detection → shows "unknown" until next `worca init --upgrade`. Acceptable.
+- **`scanDirectory` without `prefsDir`:** When called without it (e.g. from tests), behaves exactly as before. Optional param preserves test compatibility.
+- **No migration needed:** No config keys change. No user action required.
+
+## Test Plan
+
+### Unit Tests
+
+| Layer | Test | Validates |
+|-------|------|-----------|
+| JS (vitest) | `worca-status: home-dir installed with version` | `checkWorcaInstalled` returns `true` via `worcaConfigPath`, version from `worcaPkgVersion` with hash stripped |
+| JS (vitest) | `worca-status: home-dir installed no version` | `checkWorcaInstalled` returns `true`, version is `null` |
+| JS (vitest) | `worca-status: not installed (no legacy, no config)` | `installed: false`, version `null` |
+| JS (vitest) | `preflight: home-dir layout shows worcaInstalled` | `buildProjectPreflight` returns `worcaInstalled: true` when `worcaConfigPath` exists, no `.claude/worca/` |
+
+### Existing Tests to Update
+
+No existing tests should break — the new parameters are optional and all existing tests use the legacy `.claude/worca/` layout which continues to work via fallback.
+
+Run: `cd worca-ui && npx vitest run server/`
+
+## Out of Scope
+
+- Polling or WS notification when `worca init --upgrade` completes (the 3-second `setTimeout` in the UI is a separate issue)
+- Backfilling `worcaPkgVersion` on old registry entries that lack it (they self-heal on next `worca init --upgrade`)
+- Changing `version_key()` format in Python — the hash is useful for pkg store GC and provenance

--- a/docs/plans/W-079-preflight-worca-detection-home-dir.md
+++ b/docs/plans/W-079-preflight-worca-detection-home-dir.md
@@ -1,0 +1,210 @@
+# W-079: Fix setup wizard preflight worca detection for home-dir layout
+
+**Status:** Draft
+**Priority:** P1
+**Area:** ui
+**Date:** 2026-07-09
+**Depends on:** W-078 (detection functions and call sites — already implemented)
+
+## Problem
+
+`buildProjectPreflight()` at `worca-ui/server/worca-setup-config.js:141-142` hardcodes the legacy install check:
+
+```js
+const worcaInstalled =
+  Boolean(projectRoot) && existsSync(join(projectRoot, '.claude', 'worca'));
+```
+
+With the home-dir layout, `.claude/worca/` no longer exists in the project tree. The runtime lives at `~/.worca/pkg/<ver>/worca/` and the project config at `~/.worca/projects/<slug>/config.json`. This causes the Project Setup wizard (step 1, "Your Project Environment") to show "Worca runtime · not installed" even for projects that were successfully initialized.
+
+W-078 already updated `checkWorcaInstalled()` in `worca-setup.js:18` to accept an optional `worcaConfigPath` parameter and check both layouts. But `buildProjectPreflight` doesn't use `checkWorcaInstalled` — it has its own inline `existsSync` check.
+
+The setup wizard uses `worcaInstalled` to decide whether to show an "install worca" step (`project-setup-wizard.js:56-57`), so a false negative leads to an unnecessary install prompt.
+
+## Proposal
+
+Add optional `worcaConfigPath` to `buildProjectPreflight` and delegate to `checkWorcaInstalled` instead of the inline `existsSync`. Thread `worcaConfigPath` from `req.project` at both call sites (single-project preflight and workspace preflight).
+
+## Design
+
+### 1. `buildProjectPreflight` function (`worca-ui/server/worca-setup-config.js:130`)
+
+- **Current state:** Function signature accepts `{ projectRoot, settingsPath, graphifyStatus, crgStatus }`. Install check at line 141-142 is an inline `existsSync`.
+- **Obstacle:** No `worcaConfigPath` parameter, no import of `checkWorcaInstalled`.
+- **Resolution:** Add `worcaConfigPath` to the destructured args, import and call `checkWorcaInstalled`.
+
+```js
+// before (worca-setup-config.js:22-26 — imports)
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { atomicWriteSync } from './atomic-write.js';
+import { getDefaultBranch } from './git-helpers.js';
+import { deepMerge } from './settings-merge.js';
+
+// after — add import
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { atomicWriteSync } from './atomic-write.js';
+import { getDefaultBranch } from './git-helpers.js';
+import { deepMerge } from './settings-merge.js';
+import { checkWorcaInstalled } from './worca-setup.js';
+```
+
+```js
+// before (worca-setup-config.js:130-142)
+export async function buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  graphifyStatus = null,
+  crgStatus = null,
+}) {
+  const isGitRepo =
+    Boolean(projectRoot) && existsSync(join(projectRoot, '.git'));
+  // worca is "installed" in a project when its runtime copy exists. Built-in
+  // pipeline templates live under .claude/worca/templates/, so without this
+  // the template step has nothing to offer.
+  const worcaInstalled =
+    Boolean(projectRoot) && existsSync(join(projectRoot, '.claude', 'worca'));
+
+// after
+export async function buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  worcaConfigPath = null,
+  graphifyStatus = null,
+  crgStatus = null,
+}) {
+  const isGitRepo =
+    Boolean(projectRoot) && existsSync(join(projectRoot, '.git'));
+  // worca is "installed" when the project has a config — either the legacy
+  // .claude/worca/ dir or the home-dir layout config.json.
+  const worcaInstalled =
+    Boolean(projectRoot) && checkWorcaInstalled(projectRoot, worcaConfigPath);
+```
+
+Note: the old comment at line 138-140 references `.claude/worca/templates/` which is no longer accurate with the home-dir layout. Update it as shown above.
+
+### 2. Call site: single-project preflight (`worca-ui/server/project-routes.js:518-526`)
+
+- **Current state:** Passes `{ projectRoot, settingsPath, graphifyStatus, crgStatus }`. `req.project` already has `worcaConfigPath` (added by W-078 in `projectResolver`).
+- **Resolution:** Add `worcaConfigPath: req.project.worcaConfigPath`.
+
+```js
+// before (project-routes.js:521-526)
+const payload = await buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  graphifyStatus: req.app.locals.graphifyStatus || null,
+  crgStatus: req.app.locals.crgStatus || null,
+});
+
+// after
+const payload = await buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  worcaConfigPath: req.project.worcaConfigPath,
+  graphifyStatus: req.app.locals.graphifyStatus || null,
+  crgStatus: req.app.locals.crgStatus || null,
+});
+```
+
+### 3. Call site: workspace preflight (`worca-ui/server/workspace-routes.js:869-874`)
+
+- **Current state:** Iterates `workspace.json` projects, constructs `projectRoot` and `settingsPath` inline. No access to registry entries or `prefsDir`.
+- **Obstacle:** No `worcaConfigPath` available. Need to compute it from the project directory name (matching how `worca init` registers projects: `slugify(basename(project_root))`).
+- **Resolution:** Compute `worcaConfigPath` inline using `worcaHome()` from `paths.js` (honors `$WORCA_HOME` — test-safe) and `slugify(basename(projectRoot))` (matches the Python registry slug computation). Import both.
+
+```js
+// new imports needed in workspace-routes.js (basename + join already imported at line 23)
+import { slugify } from './project-registry.js';
+import { worcaHome } from './paths.js';
+```
+
+```js
+// before (workspace-routes.js:867-874)
+const projectRoot = join(reg.path, p.path);
+const settingsPath = join(projectRoot, '.claude', 'settings.json');
+const pf = await buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  graphifyStatus,
+  crgStatus,
+});
+
+// after
+const projectRoot = join(reg.path, p.path);
+const settingsPath = join(projectRoot, '.claude', 'settings.json');
+const worcaConfigPath = join(
+  worcaHome(), 'projects', slugify(basename(projectRoot)), 'config.json',
+);
+const pf = await buildProjectPreflight({
+  projectRoot,
+  settingsPath,
+  worcaConfigPath,
+  graphifyStatus,
+  crgStatus,
+});
+```
+
+**Why `basename(projectRoot)` not `p.name`:** `worca init` registers projects via `slugify(os.path.basename(project_root))` in `project_registry.py:48`. The workspace.json `name` field may differ from the directory name. Using `basename(projectRoot)` ensures slug matches what init wrote.
+
+**Why `worcaHome()` not `homedir()`:** `worcaHome()` in `paths.js:20` honors `$WORCA_HOME`, matching the Python `worca.utils.paths.worca_home()`. Using raw `homedir()` would break tests that override `$WORCA_HOME`.
+
+## Implementation Plan
+
+### Phase 1: Function + call sites
+
+**Files:** `worca-ui/server/worca-setup-config.js`, `worca-ui/server/project-routes.js`, `worca-ui/server/workspace-routes.js`
+
+**Tasks:**
+1. Add `import { checkWorcaInstalled } from './worca-setup.js'` to `worca-setup-config.js`
+2. Add `worcaConfigPath` param to `buildProjectPreflight` and delegate to `checkWorcaInstalled` (`worca-setup-config.js:130-142`)
+3. Pass `worcaConfigPath` from `req.project` at `project-routes.js:521`
+4. Compute and pass `worcaConfigPath` at `workspace-routes.js:869` (add `homedir`/`slugify` imports if needed)
+
+### Phase 2: Tests
+
+**Files:** `worca-ui/server/worca-setup-config.test.js` (unit), `worca-ui/server/project-routes-setup-preflight.test.js` (integration)
+
+**Tasks:**
+1. In `worca-setup-config.test.js` (where `buildProjectPreflight` tests live at line 134): add test calling `buildProjectPreflight({ projectRoot, settingsPath, worcaConfigPath })` with `worcaConfigPath` pointing to an existing file, no `.claude/worca/` dir → assert `worcaInstalled: true`
+2. In `worca-setup-config.test.js`: add test with no `worcaConfigPath` and no `.claude/worca/` → assert `worcaInstalled: false` (already implicitly tested by existing tests, but make it explicit)
+3. In `project-routes-setup-preflight.test.js`: add integration test via `GET /setup/preflight` where the registry entry has `worcaConfigPath` pointing to existing file → assert response `worcaInstalled: true`. This test must write the registry entry with `writeProject(prefsDir, { name, path, worcaConfigPath })` so `projectResolver` threads it through.
+4. Verify existing tests still pass (none create `.claude/worca/`, so `worcaInstalled` was already `false` in all existing tests — no breakage expected)
+
+### Files Changed Summary
+
+| File | Change |
+|------|--------|
+| `worca-ui/server/worca-setup-config.js` | Import `checkWorcaInstalled`; add `worcaConfigPath` param; delegate install check |
+| `worca-ui/server/project-routes.js` | Pass `worcaConfigPath` to `buildProjectPreflight` at line 521 |
+| `worca-ui/server/workspace-routes.js` | Compute `worcaConfigPath` from slug + homedir; pass to `buildProjectPreflight` at line 869 |
+| `worca-ui/server/worca-setup-config.test.js` | Add 2 unit tests for `buildProjectPreflight` with `worcaConfigPath` |
+| `worca-ui/server/project-routes-setup-preflight.test.js` | Add integration test via HTTP with registry entry carrying `worcaConfigPath` |
+
+## Considerations
+
+- **Backwards compatibility:** `worcaConfigPath` defaults to `null`. Existing callers and tests pass no value → legacy `existsSync(.claude/worca)` fallback via `checkWorcaInstalled`. No breaking changes.
+- **Workspace routes and `worcaHome()`:** Must use `worcaHome()` from `paths.js` (not raw `homedir()`) to honor `$WORCA_HOME` — otherwise tests that override `$WORCA_HOME` leak into the real home directory. The slug must be computed from `basename(projectRoot)` (not `p.name` from workspace.json) to match what `worca init` writes via `slugify(os.path.basename(project_root))` in `project_registry.py:48`.
+- **Circular import risk:** `worca-setup-config.js` importing from `worca-setup.js` — verify no circular dependency. `worca-setup.js` has no imports from `worca-setup-config.js`, so this is safe.
+
+## Test Plan
+
+### Unit Tests
+
+| Layer | Test | Validates |
+|-------|------|-----------|
+| JS (vitest) | `buildProjectPreflight: home-dir layout worcaInstalled` (unit, `worca-setup-config.test.js`) | Returns `worcaInstalled: true` when `worcaConfigPath` exists, no `.claude/worca/` |
+| JS (vitest) | `buildProjectPreflight: neither layout present` (unit, `worca-setup-config.test.js`) | Returns `worcaInstalled: false` when both checks fail |
+| JS (vitest) | `GET /setup/preflight: home-dir worcaInstalled` (integration, `project-routes-setup-preflight.test.js`) | HTTP endpoint returns `worcaInstalled: true` via registry entry with `worcaConfigPath` |
+
+### Existing Tests to Update
+
+None — existing tests use `.claude/worca/` layout which continues to work via `checkWorcaInstalled` fallback.
+
+Run: `cd worca-ui && npx vitest run server/`
+
+## Out of Scope
+
+- Other detection sites (already fixed in W-078: `checkWorcaInstalled`, `readProjectWorcaVersion`, `projectResolver`, `scanDirectory`, `worca-status`, `ws-modular`)
+- Template discovery path (templates at `~/.worca/pkg/<ver>/worca/templates/` — separate concern)

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -1,0 +1,76 @@
+---
+description: "Clean up finished worca pipeline worktrees. Use this skill whenever the user wants to clean up old runs, remove worktrees, free disk space, or says anything like 'worca cleanup', 'clean up worktrees', 'remove old runs', 'clean finished runs', 'delete completed worktrees', 'clean up the last 5', 'remove runs older than 7 days'. Also trigger on natural time-based filters like 'clean up runs from last week', 'remove everything older than 3 days', 'clean the last 10 runs'."
+---
+
+# Clean up worca worktrees
+
+You are cleaning up finished worca pipeline worktrees to free disk space. Every worktree-mode run creates a git worktree that persists until explicitly removed.
+
+## Flow
+
+### Step 1: Dry run first
+
+Always start with a dry run to show what would be cleaned:
+
+```bash
+worca cleanup --dry-run
+```
+
+This lists all eligible worktrees (completed or failed runs) without removing anything.
+
+### Step 2: Parse user intent for filters
+
+The user may specify filters in natural language. Map them to CLI flags:
+
+| User says | Flag |
+|-----------|------|
+| "older than 7 days" / "from last week" / "more than a week old" | `--older-than 7d` |
+| "older than 3 days" | `--older-than 3d` |
+| "older than 24 hours" | `--older-than 24h` |
+| "last 30 minutes" | `--older-than 30m` |
+| "everything" / "all finished" / "clean all" | `--all` |
+| "run abc123" / specific run ID | `--run-id abc123` |
+| "fleet xyz" / fleet ID | `--fleet-id xyz` |
+| "workspace ws_123" / workspace ID | `--workspace-id ws_123` |
+
+If the user gave a filter in their prompt, apply it directly — don't re-ask. For example:
+- "clean up runs older than 5 days" → `worca cleanup --dry-run --older-than 5d` then confirm
+- "remove completed from last 2 days" → `worca cleanup --dry-run --older-than 2d` then confirm
+- "clean everything" → `worca cleanup --dry-run --all` then confirm
+
+If no filter was specified, show the dry run output and ask: "Want to clean all of these, or filter by age?"
+
+### Step 3: Confirm and execute
+
+After showing the dry run output, ask for confirmation before actually deleting:
+
+"These N worktrees will be removed. Proceed?"
+
+On confirmation, run the same command without `--dry-run`:
+
+```bash
+worca cleanup [filters]
+```
+
+Report what was removed.
+
+## CLI reference
+
+```bash
+worca cleanup                    # Interactive: list and prompt
+worca cleanup --all              # Remove all completed/failed
+worca cleanup --run-id <id>      # Remove specific run
+worca cleanup --fleet-id <id>    # Remove fleet and children
+worca cleanup --workspace-id <id> # Remove workspace and children
+worca cleanup --older-than 7d    # Filter by age (7d, 24h, 30m)
+worca cleanup --dry-run          # Preview only
+```
+
+Filters can be combined: `worca cleanup --older-than 7d --dry-run`
+
+## Important notes
+
+- Running worktrees are never eligible for cleanup — only completed or failed runs.
+- Always dry-run first. Worktree deletion is irreversible — uncommitted work in a worktree is lost.
+- If `worca` is not on PATH, tell the user to install it (`pip install worca-cc`).
+- The user can also see worktrees via `git worktree list`.

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -1,0 +1,170 @@
+---
+description: "Launch a worca autonomous pipeline run from natural language. Use this skill whenever the user wants to run worca, start a pipeline, launch autonomous development, implement something with worca, or says anything like 'run worca', 'start pipeline', 'build this with worca', 'launch a run', 'worca run', 'implement this'. Also trigger when the user provides a plan and wants worca to implement it, says 'implement this plan', 'run this plan with worca', or hands off a prepared plan (file or in-context). Also trigger when the user provides a GitHub issue/PR reference or a spec file and wants worca to work on it. Supports guided interview mode (bare invocation), plan handoff (plan file or in-context plan), and direct CLI passthrough (inline flags)."
+---
+
+# Run a worca pipeline
+
+You are launching a worca autonomous pipeline run. worca plans, coordinates, implements, tests, reviews, and creates a PR — all autonomously.
+
+## Three invocation modes
+
+### 1. Inline mode
+
+The user passed CLI flags directly (e.g. `/worca-cc:run --prompt "Add auth" --worktree`). Parse the flags and go straight to the Launch step. Pass all recognized flags through to `worca run`.
+
+### 2. Plan handoff mode
+
+The user has a prepared plan — either a file path or plan content in the conversation context — and wants worca to implement it. Detect this when:
+- The user mentions "plan" and a file path (e.g. "implement this plan at docs/plans/W-078-foo.md")
+- The user says "implement this plan" and plan content is visible in the conversation
+- The user provides a plan and says to use a specific template or branch
+
+**If the plan is a file path:** use `--plan PATH` directly.
+
+**If the plan is in the conversation context (no file):** save it to a temporary file first:
+```bash
+cat > /tmp/worca-plan-$(date +%s).md << 'PLAN_EOF'
+<plan content from context>
+PLAN_EOF
+```
+Then use `--plan /tmp/worca-plan-<timestamp>.md`.
+
+The `--plan` flag bypasses the Planner stage — worca goes straight to coordinating and implementing.
+
+After identifying the plan, ask only what's still missing:
+- Spec file — if the user mentions a "spec" or specification file, pass it as `--spec PATH`. A spec feeds into the Planner as structured input. Do NOT ask proactively — only if the user mentions one.
+- Guide files — only if the user explicitly says "guide" or "reference guide". Pass as `--guide PATH` (repeatable). Guides carry highest authority (guide > plan > spec). When the user says "spec", always use `--spec`, never `--guide`. When ambiguous (e.g. "attach this doc"), ask: "Should this be a spec (--spec, feeds into planning) or a guide (--guide, highest authority reference)?"
+- Template (if not specified) — suggest one or let the user name it
+- Branch (if not specified) — default current
+- Worktree vs in-place (if not specified) — default worktree
+
+Skip the full interview — the user already did the thinking.
+
+### 3. Interview mode
+
+Bare `/worca-cc:run` with no flags or just a natural-language description. Walk through the interview below.
+
+## Interview flow
+
+Work through these steps. Skip any step where the answer is already obvious from context.
+
+### Step 1: What to build
+
+Ask the user what they want to build. Their answer becomes the `--prompt`.
+
+If their answer looks like a GitHub reference (e.g. "issue 42", "#15", "PR 7"), treat it as a `--source` instead:
+- "issue 42" or "#42" → `--source gh:issue:42`
+- "PR 7" → `--source gh:pr:7`
+
+If their answer looks like a file path ending in `.md`, ask whether it's a spec (`--spec`) or a plan (`--plan`). A plan bypasses the Planner stage; a spec feeds into it.
+
+### Step 2: Base branch
+
+Ask which branch to base the work on. Default is the current branch:
+
+```bash
+git branch --show-current
+```
+
+### Step 3: Template selection
+
+The user may name a template directly (e.g. "use minor feature template", "quick-fix", "feature-minor-opus"). If so, resolve it to the template ID.
+
+Common template name mappings:
+- "minor feature" / "feature minor" → `feature-minor`
+- "quick fix" → `quick-fix`
+- "bugfix" / "bug fix" → `bugfix`
+- "feature" / "full feature" → `feature`
+- "refactor" → `refactor`
+- "investigation" / "investigate" → `investigate`
+- "test only" / "add tests" → `test-only`
+
+If the user didn't name one, run the template adviser:
+
+```bash
+worca templates advise --prompt "<the user's prompt>" --json 2>/dev/null
+```
+
+Show the recommendation and let the user accept or pick a different one. If advise fails, skip — the project default will be used.
+
+To list available templates:
+
+```bash
+worca templates list
+```
+
+### Step 4: Worktree mode
+
+Default is worktree (safer, parallel-safe). Ask: "Run in a worktree? (default: yes)". If the user says no, omit `--worktree`.
+
+The user might also say "current branch" or "in-place" — that means no worktree.
+
+### Step 5: Spec and guide files (optional)
+
+**Spec (`--spec`):** If the user mentions a spec or specification file, pass it as `--spec PATH`. This feeds into the Planner as structured input alongside the prompt.
+
+**Guide (`--guide`):** Only when the user explicitly says "guide" or "reference guide". Guides carry highest authority (guide > plan > spec) and are used as normative references throughout the pipeline. This flag is repeatable.
+
+**Rule:** "spec" → `--spec`. "guide" → `--guide`. When the user provides a file without naming it either way, ask: "Is this a spec (feeds into planning) or a guide (highest-authority reference)?" Don't conflate the two.
+
+## Launch
+
+Build the `worca run` command from collected inputs:
+
+```bash
+worca run \
+  --prompt "..." \        # or --source REF or --spec PATH or --plan PATH
+  --worktree \            # unless user opted out
+  --branch BRANCH \       # if worktree and non-default branch
+  --template ID \         # if selected
+  --guide PATH            # if provided, repeatable
+```
+
+Run it with `nohup` so it detaches and the user gets control back:
+
+```bash
+nohup worca run [flags] > /dev/null 2>&1 &
+```
+
+After launching, immediately check the status to get the run ID:
+
+```bash
+worca status 2>/dev/null || worca multi-status 2>/dev/null
+```
+
+Report to the user:
+- The exact command that was run
+- The run ID (if available)
+- How to check status: "Use `/worca-cc:status` to check progress"
+
+Then stop. Do not poll or tail — return control to the user.
+
+## Full flag reference
+
+These flags are all supported by `worca run`. When the user provides them inline, pass them through exactly:
+
+| Flag | Description |
+|------|-------------|
+| `--prompt TEXT` | Inline work request |
+| `--source REF` | External source (`gh:issue:42`, `gh:pr:15`, `bd:bd-abc`) |
+| `--spec PATH` | Specification file path |
+| `--plan PATH` | Plan file (bypasses Planner stage) |
+| `--template ID` | Pipeline template to apply |
+| `--param KEY=VALUE` | Template parameter override (repeatable) |
+| `--worktree` | Run in isolated git worktree |
+| `--branch BRANCH` | Worktree base branch |
+| `--guide PATH` | Reference guide for planning (repeatable) |
+| `--resume` | Resume from last checkpoint |
+| `--max-beads N` | Cap Coordinator bead decomposition |
+| `--msize N` | Turn multiplier (1-10) |
+| `--mloops N` | Loop multiplier (1-10) |
+| `--claude-md-mode MODE` | CLAUDE.md loading: `all`, `project`, `project+local`, `none` |
+
+## Important notes
+
+- Always verify `worca` is on PATH before running. If not found, tell the user to install it (`pip install worca-cc`).
+- The `--worktree` flag creates an isolated git worktree — safe for parallel runs and won't disturb the user's working tree.
+- `--plan` bypasses the Planner stage entirely — use it when the plan is already refined and ready. `--spec` feeds into the Planner as input.
+- `--guide` attaches a reference document that takes highest authority in the pipeline (guide > plan > description).
+- When using `--source gh:issue:N`, worca auto-detects plan files linked in the issue body.
+- Template IDs are case-sensitive. Run `worca templates list` to see exact IDs if unsure.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,59 @@
+---
+description: "Check the status of worca pipeline runs. Use this skill whenever the user asks about pipeline progress, run status, what's happening with worca, or says anything like 'worca status', 'check pipeline', 'how's the run going', 'pipeline progress', 'what stage is it on', 'is the run done', 'any errors'. Also trigger after the user launched a run with /worca-cc:run and wants to check on it."
+---
+
+# Check worca pipeline status
+
+You are checking the status of worca pipeline runs and presenting the results clearly.
+
+## Auto-detection logic
+
+Determine which runs to show:
+
+1. **Specific run ID provided** — the user named a run ID. Use `worca status <run-id>`.
+
+2. **Run ID from context** — if the user recently launched a run via `/worca-cc:run` and the run ID is visible in the conversation, use that.
+
+3. **Auto-detect** — no run ID available. Check what's running:
+
+```bash
+worca multi-status 2>/dev/null
+```
+
+- If one run active → show its details
+- If multiple runs active → show the summary list, ask which one to drill into
+- If no runs active → tell the user, suggest checking completed runs
+
+## Presenting status
+
+Parse the output and present it clearly:
+
+### For an active run, show:
+- **Run ID**
+- **Current stage** (e.g. Planner, Coordinator, Implementer, Tester, Reviewer, Guardian)
+- **Progress** — which stages completed, which pending
+- **Duration** — how long it's been running
+- **Errors** — any failures or retries in progress
+
+### For a completed run, show:
+- **Run ID**
+- **Outcome** — success, failed, or stopped
+- **Duration** — total run time
+- **PR link** — if a PR was created, show the URL
+- **Errors** — if failed, show the failure reason and which stage failed
+
+### For multiple runs, show a summary table:
+- Run ID | Status | Current Stage | Duration | Template
+
+## Commands reference
+
+```bash
+worca status <run-id>       # detailed status for one run
+worca multi-status           # all active runs
+```
+
+## Important notes
+
+- This is a one-shot check. Do not poll or loop — just report what you find and return control to the user.
+- If `worca` is not on PATH, tell the user to install it (`pip install worca-cc`).
+- If no runs are found, let the user know and suggest starting one with `/worca-cc:run`.

--- a/src/worca/cli/cleanup.py
+++ b/src/worca/cli/cleanup.py
@@ -487,6 +487,10 @@ def _build_sources(base: str) -> list:
 
 def cmd_cleanup(args: argparse.Namespace) -> None:
     """Handle the `worca cleanup` subcommand."""
+    if getattr(args, "gc", False):
+        cmd_gc(args)
+        return
+
     git_root = _find_git_root()
     base = str(git_root / ".worca")
 
@@ -550,6 +554,43 @@ def cmd_cleanup(args: argparse.Namespace) -> None:
         print(f"  {errors} removal error(s) — see warnings above.", file=sys.stderr)
 
 
+def cmd_gc(args: argparse.Namespace) -> None:
+    """Handle the `worca cleanup --gc` subcommand."""
+    from worca.utils.pkg_store import gc_pkg_store  # noqa: PLC0415
+
+    dry_run = getattr(args, "dry_run", False)
+    keep_latest = getattr(args, "keep_latest", 0) or 0
+
+    result = gc_pkg_store(dry_run=dry_run, keep_latest=keep_latest)
+
+    if dry_run:
+        orphans = result["would_remove"]
+        if not orphans:
+            print("No orphan pkg versions found.")
+        else:
+            print(f"Would remove {len(orphans)} orphan pkg version(s):")
+            for ver in orphans:
+                print(f"  {ver}")
+        skipped = result["skipped_live"]
+        if skipped:
+            print(f"Would skip {len(skipped)} version(s) referenced by running pipelines:")
+            for ver in skipped:
+                print(f"  {ver} (live)")
+    else:
+        removed = result["removed"]
+        skipped = result["skipped_live"]
+        if removed:
+            print(f"Removed {len(removed)} orphan pkg version(s):")
+            for ver in removed:
+                print(f"  {ver}")
+        else:
+            print("No orphan pkg versions to remove.")
+        if skipped:
+            print(f"Skipped {len(skipped)} version(s) referenced by running pipelines:")
+            for ver in skipped:
+                print(f"  {ver} (live)")
+
+
 def register_subcommand(sub) -> None:
     """Register the `cleanup` subparser on the provided subparsers action."""
     p = sub.add_parser("cleanup", help="Remove completed pipeline worktrees")
@@ -587,4 +628,16 @@ def register_subcommand(sub) -> None:
         default=None,
         metavar="DURATION",
         help="Only remove worktrees started more than this long ago (e.g. 7d, 24h, 30m)",
+    )
+    p.add_argument(
+        "--gc",
+        action="store_true",
+        help="Run mark-and-sweep GC on orphan pkg versions in ~/.worca/pkg/",
+    )
+    p.add_argument(
+        "--keep-latest",
+        type=int,
+        default=0,
+        metavar="N",
+        help="With --gc: preserve the N most recent pkg versions regardless of references",
     )

--- a/src/worca/cli/init.py
+++ b/src/worca/cli/init.py
@@ -359,10 +359,12 @@ def _migrate_settings_paths(settings: dict) -> tuple[dict, list[str]]:
     # scripts have existed since the initial W-038 landing but were never
     # wired into settings.json — making dispatch tracking dead code.
     hooks = migrated.setdefault("hooks", {})
-    _hook_cmd_tpl = (
-        'python3 "$(cd "$(git rev-parse --git-common-dir)/.." && pwd)'
-        '/.claude/worca/claude_hooks/{script}"'
-    )
+    # Resolve the absolute path to the pkg claude_hooks dir at init time.
+    # Using os.path.expanduser("~") produces a plain absolute path with no
+    # shell variables or subshells — works on Linux, macOS, and WSL2.
+    from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+    _hook_base = os.path.join(_pkg_dir(), "worca", "claude_hooks")
+    _hook_cmd_tpl = f"python3 {_hook_base}/{{script}}"
     for hook_type, script in [
         ("SubagentStart", "subagent_start.py"),
         ("SubagentStop", "subagent_stop.py"),
@@ -453,6 +455,34 @@ def _migrate_settings_paths(settings: dict) -> tuple[dict, list[str]]:
     return migrated, changes
 
 
+def _migrate_old_layout(git_root: Path) -> list[str]:
+    """Detect and migrate old project-local .claude/worca/ layout during --upgrade.
+
+    When a project still has .claude/worca/ (the old per-project code copy), this
+    function relocates by:
+      1. Deleting .claude/worca/ (the new source is already copied to
+         ~/.worca/pkg/<ver>/worca/ by the caller).
+      2. Updating the project registry entry with worcaConfigPath and worcaPkgVersion.
+
+    The worca.* config extraction and hook rewrite are handled by the caller
+    (_create_project_config and _rewrite_absolute_hook_cmds) after this runs.
+
+    Returns list of change descriptions.
+    """
+    changes: list[str] = []
+    old_worca = git_root / ".claude" / "worca"
+    if not old_worca.is_dir():
+        return changes
+
+    shutil.rmtree(old_worca)
+    changes.append("  Removed .claude/worca/ (relocated to ~/.worca/pkg/)")
+
+    from worca.utils.project_registry import update_registry_entry  # noqa: PLC0415
+    update_registry_entry(str(git_root))
+
+    return changes
+
+
 def _migrate_agent_overrides(git_root: Path) -> list[str]:
     """Move .claude/agents/overrides/*.md to .claude/agents/*.md."""
     changes = []
@@ -480,6 +510,49 @@ def _migrate_agent_overrides(git_root: Path) -> list[str]:
         changes.append("  Removed empty .claude/agents/overrides/")
     except OSError:
         pass  # Directory not empty, leave it
+
+    return changes
+
+
+def _rewrite_absolute_hook_cmds(settings: dict) -> list[str]:
+    """Rewrite hook commands that reference .claude/worca/ to absolute pkg paths.
+
+    Replaces shell-subshell patterns like
+      python3 "$(cd "$(git rev-parse --git-common-dir)/.." && pwd)/.claude/worca/claude_hooks/<script>"
+    with fully resolved absolute paths:
+      python3 /home/user/.worca/pkg/0.59.0-a1b2c3d/worca/claude_hooks/<script>
+
+    Mutates settings in place. Returns list of change descriptions.
+    """
+    from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+
+    changes: list[str] = []
+    hook_base = os.path.join(_pkg_dir(), "worca", "claude_hooks")
+
+    _OLD_PATTERN = ".claude/worca/claude_hooks/"
+
+    hooks = settings.get("hooks", {})
+    for hook_type, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            hook_list = entry.get("hooks", [])
+            if not isinstance(hook_list, list):
+                continue
+            for h in hook_list:
+                cmd = h.get("command", "")
+                if _OLD_PATTERN not in cmd:
+                    continue
+                # Extract the script filename from the old command
+                idx = cmd.index(_OLD_PATTERN)
+                script = cmd[idx + len(_OLD_PATTERN):]
+                # Strip any trailing quote or shell suffix
+                for sep in ('"', "'", " ", "\n"):
+                    if sep in script:
+                        script = script[: script.index(sep)]
+                new_cmd = f"python3 {hook_base}/{script}"
+                h["command"] = new_cmd
+                changes.append(f"  hooks.{hook_type}: rewrote {script} to absolute path")
 
     return changes
 
@@ -524,6 +597,50 @@ def _migrate_global_keys_to_preferences(
     _atomic_write_json(project_settings_path, project)
 
     return extracted
+
+
+def _create_project_config(git_root: Path, settings_path: Path) -> str | None:
+    """Create ~/.worca/projects/<slug>/config.json with worca.* keys from settings.
+
+    Extracts the ``worca`` section from settings_path into the project config dir,
+    then strips ``worca`` from settings_path (leaving only hooks + permissions).
+
+    Returns the config path created, or None if settings had no worca section.
+    Idempotent: if config.json already exists, it is updated via deep_merge
+    (existing user values in config.json win, new template keys added).
+    """
+    if not settings_path.exists():
+        return None
+
+    with open(settings_path, encoding="utf-8") as f:
+        project = json.load(f)
+
+    worca_section = project.get("worca")
+    if not worca_section:
+        return None
+
+    from worca.utils.paths import project_config_dir as _project_config_dir  # noqa: PLC0415
+    from worca.utils.project_registry import slugify  # noqa: PLC0415
+
+    slug = slugify(git_root.name)
+    config_dir = Path(_project_config_dir(slug))
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "config.json"
+
+    if config_path.exists():
+        with open(config_path, encoding="utf-8") as f:
+            existing = json.load(f)
+        merged = _deep_merge(existing, {"worca": worca_section})
+    else:
+        merged = {"worca": worca_section}
+
+    _atomic_write_json(str(config_path), merged)
+
+    # Strip worca.* from .claude/settings.json
+    project_stripped = {k: v for k, v in project.items() if k != "worca"}
+    _atomic_write_json(str(settings_path), project_stripped)
+
+    return str(config_path)
 
 
 def _strip_inert_milestone_keys(project_settings_path: str) -> list[str]:
@@ -834,9 +951,13 @@ def _copy_worca_source(source: Path, target: Path) -> None:
     skills/ ships in the wheel as package data but is installed separately
     into the project's top-level .claude/skills/ (not under .claude/worca/),
     since Claude Code only auto-discovers skills at .claude/skills/.
+
+    Idempotent: if the target directory already exists, skip the copy and
+    print 'Package already exists'.
     """
     if target.exists():
-        shutil.rmtree(target)
+        print("Package already exists")
+        return
 
     def ignore_patterns(directory, contents):
         ignored = set()
@@ -970,7 +1091,7 @@ def _ensure_gitignore(git_root: Path) -> list[str]:
     (``$WORCA_CACHE/ast/<repo-id>/<commit-sha>/``), never in the repo tree.
     """
     gitignore = git_root / ".gitignore"
-    entries_needed = [".worca/", "logs/", ".claude/settings.local.json"]
+    entries_needed = [".worca/", "logs/", ".claude/settings.local.json", ".beads/"]
     changes = []
 
     existing = ""
@@ -1154,24 +1275,33 @@ def run_init(
     git_root = _find_git_root()
     worca_source = _get_worca_source(source, git_root)
 
+    from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+
+    pkg_version_dir = Path(_pkg_dir())
+    target = pkg_version_dir / "worca"
+
     print(f"Source: {worca_source}")
-    print(f"Target: {git_root / '.claude' / 'worca'}")
+    print(f"Target: {target}")
 
     # --check: dry-run mode
     if check:
         _show_check(worca_source, git_root)
         return
 
-    target = git_root / ".claude" / "worca"
     settings_path = git_root / ".claude" / "settings.json"
     source_settings = worca_source / "settings.json"
 
     # Ensure .claude/ exists
     (git_root / ".claude").mkdir(exist_ok=True)
 
-    if not upgrade and not force and target.exists():
+    from worca.utils.paths import project_config_dir as _project_config_dir  # noqa: PLC0415
+    from worca.utils.project_registry import slugify as _slugify  # noqa: PLC0415
+    _project_slug = _slugify(git_root.name)
+    _project_config = Path(_project_config_dir(_project_slug)) / "config.json"
+
+    if not upgrade and not force and target.exists() and _project_config.exists():
         print(
-            ".claude/worca/ already exists. Use --upgrade to update or --force to overwrite.",
+            "Project already initialized. Use --upgrade to update or --force to overwrite.",
             file=sys.stderr,
         )
         raise SystemExit(1)
@@ -1198,6 +1328,14 @@ def run_init(
             for change in legacy_changes:
                 print(change)
 
+    # --- Old layout migration (only on --upgrade): detect .claude/worca/, relocate ---
+    if upgrade:
+        old_layout_changes = _migrate_old_layout(git_root)
+        if old_layout_changes:
+            print("Old layout migration:")
+            for change in old_layout_changes:
+                print(change)
+
     # --- Agent override migration (only on --upgrade) ---
     if upgrade:
         override_changes = _migrate_agent_overrides(git_root)
@@ -1206,10 +1344,15 @@ def run_init(
             for change in override_changes:
                 print(change)
 
-    # --- Copy worca source ---
+    # --- Copy worca source to ~/.worca/pkg/<ver>/worca/ ---
+    pkg_version_dir.mkdir(parents=True, exist_ok=True)
+    if (upgrade or force) and target.exists():
+        shutil.rmtree(target)
+    pkg_copied = not target.exists()
     _copy_worca_source(worca_source, target)
-    _write_provenance_manifest(worca_source, target, git_root, settings_path)
-    print("Copied worca to .claude/worca/")
+    _write_provenance_manifest(worca_source, pkg_version_dir, git_root, settings_path)
+    if pkg_copied:
+        print(f"Copied worca to {target}")
 
     # --- Install worca-owned skills into .claude/skills/ ---
     skill_changes = _install_skills(worca_source, git_root)
@@ -1282,16 +1425,42 @@ def run_init(
                 f"delete the template and clear default_template from settings.json."
             )
 
-    # --- Graphify hook integration (after settings merge) ---
+    # --- Rewrite hook commands to absolute pkg paths (after settings merge) ---
     if settings_path.exists():
         with open(settings_path, encoding="utf-8") as f:
             final_settings = json.load(f)
+        hook_rewrite_changes = _rewrite_absolute_hook_cmds(final_settings)
+        if hook_rewrite_changes:
+            _atomic_write_json(str(settings_path), final_settings)
+            print("Hook commands rewritten to absolute paths:")
+            for change in hook_rewrite_changes:
+                print(change)
+        # --- Graphify hook integration (after hook rewrite) ---
         graphify_changes = _merge_graphify_hooks(final_settings)
         if graphify_changes:
             _atomic_write_json(str(settings_path), final_settings)
             print("Graphify integration:")
             for change in graphify_changes:
                 print(change)
+    else:
+        final_settings = {}
+
+    # --- Create ~/.worca/projects/<slug>/config.json with worca.* keys ---
+    # Must run after all migrations/merges so config.json captures the final state.
+    # Strips worca.* from .claude/settings.json leaving only hooks + permissions.
+    config_created = _create_project_config(git_root, settings_path)
+    if config_created:
+        print(f"Project config: created {config_created}")
+        print("Settings: stripped worca.* keys (hooks + permissions remain)")
+
+    # --- Register / update project in ~/.worca/projects.d/ ---
+    # Runs on both fresh init and upgrade so the project is immediately
+    # visible in the UI without a separate "create project" step.
+    try:
+        from worca.utils.project_registry import update_registry_entry  # noqa: PLC0415
+        update_registry_entry(str(git_root))
+    except Exception:
+        pass
 
     # --- .gitignore ---
     gitignore_changes = _ensure_gitignore(git_root)
@@ -1305,6 +1474,17 @@ def run_init(
         print("Initialized beads (.beads/)")
     elif upgrade and _upgrade_beads(git_root):
         print("Beads: updated repo fingerprint")
+
+    # --- Auto-GC orphan pkg versions after upgrade ---
+    if upgrade:
+        try:
+            from worca.utils.pkg_store import gc_pkg_store  # noqa: PLC0415
+            gc_result = gc_pkg_store(dry_run=False)
+            removed = gc_result.get("removed", [])
+            if removed:
+                print(f"GC: removed {len(removed)} orphan pkg version(s): {', '.join(removed)}")
+        except Exception:
+            pass
 
     version = read_version(target)
     print(f"\nworca {version or 'unknown'} initialized successfully.")

--- a/src/worca/cli/main.py
+++ b/src/worca/cli/main.py
@@ -36,15 +36,17 @@ def _find_git_root() -> Path:
 
 
 def _require_project_worca(git_root: Path) -> Path:
-    """Verify .claude/worca/ exists in the project. Returns the path."""
-    worca_dir = git_root / ".claude" / "worca"
-    if not worca_dir.is_dir():
+    """Verify the worca pkg path exists. Returns the pkg worca/ path."""
+    from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+
+    pkg_worca = Path(_pkg_dir()) / "worca"
+    if not pkg_worca.is_dir():
         print(
-            "error: .claude/worca/ not found. Run 'worca init' first.",
+            f"error: worca package not found at {pkg_worca}. Run 'worca init' first.",
             file=sys.stderr,
         )
         raise SystemExit(1)
-    return worca_dir
+    return pkg_worca
 
 
 def _inject_project_path(git_root: Path) -> None:

--- a/src/worca/cli/run_pipeline.py
+++ b/src/worca/cli/run_pipeline.py
@@ -55,7 +55,7 @@ def cmd_run(args: Namespace) -> None:
     _warn_version_mismatch(project_worca_dir)
     _inject_project_path(git_root)
 
-    scripts_dir = git_root / ".claude" / "worca" / "scripts"
+    scripts_dir = project_worca_dir / "scripts"
     pipeline_script = scripts_dir / "run_pipeline.py"
     worktree_script = scripts_dir / "run_worktree.py"
 

--- a/src/worca/hooks/tracking.py
+++ b/src/worca/hooks/tracking.py
@@ -360,21 +360,61 @@ class ConfigUnreadable(Exception):
     """
 
 
-def _load_settings() -> dict:
-    """Load settings.json from the project root.
+def _load_worca_config_base() -> dict:
+    """Load base worca config from WORCA_CONFIG_PATH if set.
 
-    Returns ``{}`` when no settings file exists (defaults apply).
-    Raises ``ConfigUnreadable`` when the file exists but is not valid JSON
-    — callers MUST treat this as a fail-closed condition.
+    Returns {} if unset or file absent.
+    Raises ConfigUnreadable when the file exists but contains invalid JSON —
+    callers MUST exit 2 rather than fall back to defaults (which are
+    effectively wildcard-allow for dispatch).
     """
-    path = _settings_path()
-    if not path or not os.path.exists(path):
+    config_path = os.environ.get("WORCA_CONFIG_PATH")
+    if not config_path:
         return {}
     try:
-        with open(path, encoding="utf-8") as f:
+        with open(config_path, encoding="utf-8") as f:
             return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as e:
+        raise ConfigUnreadable(f"{config_path}: invalid JSON ({e})") from e
+
+
+def _load_settings() -> dict:
+    """Load settings.json from the project root, merged over WORCA_CONFIG_PATH base.
+
+    Config loading precedence (lowest to highest):
+    1. WORCA_CONFIG_PATH → ~/.worca/projects/<slug>/config.json (worca base config)
+    2. WORCA_SETTINGS_PATH or .claude/settings.json (effective project settings)
+
+    Returns ``{}`` when no settings file exists (defaults apply).
+    Raises ``ConfigUnreadable`` when the settings file exists but is not valid JSON
+    — callers MUST treat this as a fail-closed condition.
+    """
+    worca_base = _load_worca_config_base()
+
+    path = _settings_path()
+    if not path or not os.path.exists(path):
+        return worca_base
+    try:
+        with open(path, encoding="utf-8") as f:
+            project = json.load(f)
     except json.JSONDecodeError as e:
         raise ConfigUnreadable(f"{path}: invalid JSON ({e})") from e
+
+    if not worca_base:
+        return project
+
+    # Merge: worca_base is the base layer, project settings override
+    result = dict(worca_base)
+    for key, val in project.items():
+        if key in result and isinstance(result[key], dict) and isinstance(val, dict):
+            merged_val = dict(result[key])
+            merged_val.update(val)
+            result[key] = merged_val
+        else:
+            result[key] = val
+    return result
 
 
 def _settings_mtime() -> float | None:

--- a/src/worca/orchestrator/flow.py
+++ b/src/worca/orchestrator/flow.py
@@ -545,6 +545,15 @@ def _validate_flow(entries: list, project_root: str = ".") -> None:
                 os.path.join(project_root, ".claude", "agents",
                              f"{entry.agent}.md"),
             ]
+            # W-077: also search pkg store (canonical location after relocation)
+            try:
+                from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+                agent_candidates.append(
+                    os.path.join(_pkg_dir(), "worca", "agents", "core",
+                                 f"{entry.agent}.md")
+                )
+            except Exception:
+                pass
             if not any(os.path.exists(p) for p in agent_candidates):
                 raise FlowError(
                     f"stage {entry.name!r}: agent template not found for "
@@ -557,6 +566,14 @@ def _validate_flow(entries: list, project_root: str = ".") -> None:
                 os.path.join(project_root, ".claude", "worca", "schemas",
                              entry.schema),
             ]
+            # W-077: also search pkg store schemas
+            try:
+                from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+                schema_candidates.append(
+                    os.path.join(_pkg_dir(), "worca", "schemas", entry.schema)
+                )
+            except Exception:
+                pass
             schema_path = next(
                 (p for p in schema_candidates if os.path.exists(p)), None
             )

--- a/src/worca/orchestrator/runner.py
+++ b/src/worca/orchestrator/runner.py
@@ -622,7 +622,7 @@ def _render_agent_templates(run_dir: str, template_vars: dict,
     tier are skipped (flow validation already failed the launch for enabled
     stages, so this only happens for disabled ones).
     """
-    src_dir = ".claude/worca/agents/core"
+    src_dir = _resolve_agent_core_dir()
     dst_dir = os.path.join(run_dir, "agents")
     os.makedirs(dst_dir, exist_ok=True)
     if not os.path.isdir(src_dir):
@@ -695,6 +695,47 @@ def _warn_custom_agents_locked_down(flow, settings_path: str) -> None:
             )
 
 
+def _resolve_worca_runtime_dir() -> str:
+    """Return the path to the shipped worca runtime root.
+
+    W-077: the canonical location is now ``~/.worca/pkg/<ver>/worca/``
+    (pkg store). Falls back to the legacy ``.claude/worca/`` when the
+    pkg store path doesn't exist.
+    """
+    legacy = os.path.join(".claude", "worca")
+    if os.path.isdir(legacy):
+        return legacy
+    try:
+        from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+        pkg_root = os.path.join(_pkg_dir(), "worca")
+        if os.path.isdir(pkg_root):
+            return pkg_root
+    except Exception:
+        pass
+    return legacy  # fall through — caller checks existence
+
+
+def _resolve_agent_core_dir() -> str:
+    """Return the path to the shipped agent core templates.
+
+    W-077: the canonical location is now ``~/.worca/pkg/<ver>/worca/agents/core``
+    (pkg store). Falls back to the legacy ```.claude/worca/agents/core`` when
+    the pkg store path doesn't exist (e.g. a developer running from a pre-W-077
+    local install).
+    """
+    legacy = os.path.join(".claude", "worca", "agents", "core")
+    if os.path.isdir(legacy):
+        return legacy
+    try:
+        from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+        pkg_core = os.path.join(_pkg_dir(), "worca", "agents", "core")
+        if os.path.isdir(pkg_core):
+            return pkg_core
+    except Exception:
+        pass
+    return legacy  # fall through — caller checks existence
+
+
 def _agent_path(agent_name: str, run_dir: str = None) -> str:
     """Resolve agent name to the .md definition file path.
 
@@ -709,7 +750,7 @@ def _agent_path(agent_name: str, run_dir: str = None) -> str:
         rendered = os.path.join(run_dir, "agents", f"{agent_name}.md")
         if os.path.exists(rendered):
             return rendered
-    core = f".claude/worca/agents/core/{agent_name}.md"
+    core = os.path.join(_resolve_agent_core_dir(), f"{agent_name}.md")
     if not os.path.exists(core):
         project = os.path.join(".claude", "agents", f"{agent_name}.md")
         if os.path.exists(project):
@@ -721,12 +762,12 @@ def _schema_path(schema_name: str) -> str:
     """Resolve schema filename to full path.
 
     Resolution order (W-071): project tier (``.claude/schemas/``, the home of
-    custom-stage schemas) → shipped ``.claude/worca/schemas/``. First hit wins.
+    custom-stage schemas) → shipped runtime schemas. First hit wins.
     """
     project = os.path.join(".claude", "schemas", schema_name)
     if os.path.exists(project):
         return project
-    return f".claude/worca/schemas/{schema_name}"
+    return os.path.join(_resolve_worca_runtime_dir(), "schemas", schema_name)
 
 
 def _is_same_work_request(existing_wr: dict, new_wr: WorkRequest) -> bool:
@@ -2298,7 +2339,9 @@ def run_preflight(
     """
     settings = load_settings(settings_path)
 
-    default_script = ".claude/worca/scripts/preflight_checks.py"
+    default_script = os.path.join(
+        _resolve_worca_runtime_dir(), "scripts", "preflight_checks.py"
+    )
     script_path = (
         settings.get("worca", {})
         .get("stages", {})
@@ -2549,6 +2592,29 @@ def _pin_effective_settings_path(settings_path: Optional[str]) -> None:
         os.environ["WORCA_SETTINGS_PATH"] = os.path.abspath(settings_path)
 
 
+def _pin_worca_config_path(project_root: Optional[str]) -> None:
+    """Export ``WORCA_CONFIG_PATH`` so hooks and load_settings() read the project config.
+
+    Resolves ``~/.worca/projects/<slug>/config.json`` from ``project_root``.
+    No-ops if already set (allows callers like run_worktree.py to pre-set it),
+    or if ``project_root`` is None or the config file doesn't exist yet.
+    """
+    if os.environ.get("WORCA_CONFIG_PATH"):
+        return
+    if not project_root:
+        return
+    try:
+        from worca.utils.paths import project_config_dir  # noqa: PLC0415
+        from worca.utils.project_registry import slugify  # noqa: PLC0415
+
+        slug = slugify(os.path.basename(project_root))
+        config_path = os.path.join(project_config_dir(slug), "config.json")
+        if os.path.exists(config_path):
+            os.environ["WORCA_CONFIG_PATH"] = config_path
+    except Exception:
+        pass
+
+
 def launch_param_status(
     max_beads_override: Optional[int], msize: int, mloops: int,
     claude_md_mode: Optional[str] = None,
@@ -2706,13 +2772,25 @@ def run_pipeline(
     run_dir = None
     actual_status_path = status_path  # may be redirected to per-run dir
 
-    # The provenance manifest lives in the real runtime dir (<project>/.claude/worca).
+    # The provenance manifest lives in the real runtime dir (<project>/.claude/worca
+    # for legacy installs; pkg_dir() for W-077+ pkg-store installs).
     # Resolve it from the caller-supplied runtime_dir when given: for templated runs
     # run_pipeline.py writes the merged settings to a tempfile and passes its path as
     # settings_path, whose parent has no provenance.json — deriving the runtime dir
     # from it would degrade runtime_source to null. Fall back to the settings-relative
-    # derivation for non-templated / direct callers.
-    _provenance_dir = Path(runtime_dir) if runtime_dir else Path(settings_path).parent / "worca"
+    # derivation for non-templated / direct callers, then try the pkg store.
+    if runtime_dir:
+        _provenance_dir = Path(runtime_dir)
+    else:
+        _legacy_prov = Path(settings_path).parent / "worca"
+        if (_legacy_prov / "provenance.json").exists():
+            _provenance_dir = _legacy_prov
+        else:
+            try:
+                from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+                _provenance_dir = Path(_pkg_dir())
+            except Exception:
+                _provenance_dir = _legacy_prov
 
     # Auto-register project for global worca-ui discovery (non-fatal).
     # See _resolve_project_root_for_registration for why worktree mode needs
@@ -2726,6 +2804,10 @@ def run_pipeline(
         auto_register_project(project_root)
     except Exception:
         pass
+
+    # Export WORCA_CONFIG_PATH so hooks and load_settings() read the per-project
+    # worca config from ~/.worca/projects/<slug>/config.json (non-fatal).
+    _pin_worca_config_path(project_root)
 
     # Signal handlers (PID file written after run_id is known)
     _install_signal_handlers()
@@ -3061,7 +3143,7 @@ def run_pipeline(
         _pb_worca = _pb_settings.get("worca", {})
         _pb_overrides_dir = _pb_worca.get("agent_overrides_dir", ".claude/agents")
         _pb_template_agents_dir = _pb_worca.get("_template_agents_dir")
-        _pb_core_dir = ".claude/worca/agents/core"
+        _pb_core_dir = _resolve_agent_core_dir()
         prompt_builder = PromptBuilder(
             work_request.title,
             work_request.description,

--- a/src/worca/orchestrator/work_request.py
+++ b/src/worca/orchestrator/work_request.py
@@ -131,6 +131,8 @@ def normalize_plan_file(path: str, content: str = None) -> WorkRequest:
     generate_smart_title() → first # heading fallback → filename fallback.
     """
     if content is None:
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"plan file not found: {path}")
         with open(path, "r", encoding="utf-8") as f:
             content = f.read()
 
@@ -173,6 +175,8 @@ def normalize_spec_file(path: str) -> WorkRequest:
 
     Title priority: generate_smart_title() → first # heading fallback → filename fallback.
     """
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"spec file not found: {path}")
     with open(path, "r", encoding="utf-8") as f:
         content = f.read()
 

--- a/src/worca/scripts/preflight_checks.py
+++ b/src/worca/scripts/preflight_checks.py
@@ -70,27 +70,44 @@ def check_bd_cli():
 
 
 def check_settings_json(settings_path=".claude/settings.json"):
-    """.claude/settings.json exists, is valid JSON, and has a 'worca' key."""
+    """.claude/settings.json exists and is valid JSON.
+
+    After W-077, worca config lives in ~/.worca/projects/<slug>/config.json
+    so the 'worca' key may be absent from settings.json. Any valid JSON file
+    passes this check.
+    """
     if not os.path.exists(settings_path):
         return "fail", f"{settings_path} not found"
     try:
-        with open(settings_path, encoding="utf-8") as f:
-            data = json.load(f)
-        if "worca" not in data:
-            return "fail", f"{settings_path} missing 'worca' key"
-        return "pass", f"{settings_path} is valid"
+        json.load(open(settings_path, encoding="utf-8"))
+        return "pass", f"{settings_path} is valid JSON"
     except json.JSONDecodeError as exc:
         return "fail", f"{settings_path} invalid JSON: {exc}"
 
 
+def _resolve_agent_core_dir_preflight(default: str) -> str:
+    """Resolve agent core dir — check pkg store if default path missing."""
+    if os.path.isdir(default):
+        return default
+    worca_home = os.environ.get("WORCA_HOME", os.path.join(os.path.expanduser("~"), ".worca"))
+    pkg_dir_root = os.path.join(worca_home, "pkg")
+    if os.path.isdir(pkg_dir_root):
+        for entry in sorted(os.listdir(pkg_dir_root), reverse=True):
+            candidate = os.path.join(pkg_dir_root, entry, "worca", "agents", "core")
+            if os.path.isdir(candidate):
+                return candidate
+    return default
+
+
 def check_agent_templates(core_dir=".claude/worca/agents/core"):
     """All 5 core agent .md files are present."""
+    resolved = _resolve_agent_core_dir_preflight(core_dir)
     missing = [
         name for name in CORE_AGENT_TEMPLATES
-        if not os.path.exists(os.path.join(core_dir, name))
+        if not os.path.exists(os.path.join(resolved, name))
     ]
     if missing:
-        return "fail", f"missing agent templates in {core_dir}: {', '.join(missing)}"
+        return "fail", f"missing agent templates in {resolved}: {', '.join(missing)}"
     return "pass", f"all {len(CORE_AGENT_TEMPLATES)} core agent templates present"
 
 

--- a/src/worca/scripts/run_fleet.py
+++ b/src/worca/scripts/run_fleet.py
@@ -197,6 +197,7 @@ def build_child_cmd(
     fleet_id: str,
     prompt: str | None = None,
     source: str | None = None,
+    spec: str | None = None,
     base: str | None = None,
     guide: list | None = None,
     plan: str | None = None,
@@ -213,8 +214,11 @@ def build_child_cmd(
 
     if source:
         cmd.extend(["--source", source])
-    else:
-        cmd.extend(["--prompt", prompt or ""])
+    elif spec:
+        cmd.extend(["--spec", spec])
+
+    if prompt:
+        cmd.extend(["--prompt", prompt])
 
     cmd.extend(["--fleet-id", fleet_id])
 
@@ -262,6 +266,7 @@ def run_plan_first(
     fleet_runs_base: str | None = None,
     max_beads: int | None = None,
     claude_md_mode: str | None = None,
+    spec: str | None = None,
 ) -> str | None:
     """Run the reference child (blocking) and wait for its Planner to produce a plan.
 
@@ -279,6 +284,7 @@ def run_plan_first(
         fleet_id=fleet_id,
         prompt=prompt,
         source=source,
+        spec=spec,
         base=base,
         guide=guide,
         plan=None,  # reference child generates the plan
@@ -375,6 +381,7 @@ def dispatch_fleet(
     fleet_failure_threshold: float,
     max_beads: int | None = None,
     claude_md_mode: str | None = None,
+    spec: str | None = None,
 ) -> dict:
     """Run fleet children in parallel with a semaphore-gated dispatch loop.
 
@@ -419,6 +426,7 @@ def dispatch_fleet(
                 fleet_id=fleet_id,
                 prompt=prompt,
                 source=source,
+                spec=spec,
                 base=base,
                 guide=guide,
                 plan=plan,
@@ -516,6 +524,7 @@ def resume_fleet(fleet_id: str) -> int:
     children = manifest.get("children", [])
     prompt = manifest.get("work_request", {}).get("description") or ""
     source = manifest.get("work_request", {}).get("source")
+    spec = manifest.get("work_request", {}).get("spec")
     base = manifest.get("base_branch")
     guide = manifest.get("guide", {}).get("paths") or []
     plan = manifest.get("plan", {}).get("path")
@@ -617,6 +626,7 @@ def resume_fleet(fleet_id: str) -> int:
             max_parallel=max_parallel,
             fleet_failure_threshold=threshold,
             claude_md_mode=claude_md_mode,
+            spec=spec,
         )
 
     return 0
@@ -658,12 +668,12 @@ def create_parser() -> argparse.ArgumentParser:
         help="Path to a file listing project paths (one per line)",
     )
 
-    # Work request source — mutually exclusive
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("--prompt", help="Text prompt for work request")
-    group.add_argument(
+    # Work request source
+    parser.add_argument("--prompt", help="Text prompt for work request")
+    parser.add_argument(
         "--source", help="Source reference (gh:issue:42, bd:bd-abc)"
     )
+    parser.add_argument("--spec", help="Path to spec file")
 
     # Branch naming (§4 — two separate concepts)
     parser.add_argument(
@@ -794,11 +804,15 @@ def main(argv=None) -> int:
         return 2
 
     # Require a work request source unless acting on an existing fleet
-    if not _lifecycle_actions and not args.prompt and not args.source:
+    if not _lifecycle_actions and not any([args.prompt, args.source, args.spec]):
         print(
-            "error: one of --prompt, --source, --resume, --pause or --stop is required",
+            "error: one of --prompt, --source, --spec, --resume, --pause or --stop is required",
             file=sys.stderr,
         )
+        return 2
+
+    if args.source and args.spec:
+        print("error: --source and --spec are mutually exclusive", file=sys.stderr)
         return 2
 
     # --plan and --plan-first are mutually exclusive (§6)
@@ -935,6 +949,7 @@ def main(argv=None) -> int:
                 "title": "",
                 "description": args.prompt or "",
                 "source": args.source,
+                "spec": args.spec,
             },
             "guide": {
                 "paths": guide_paths,
@@ -976,6 +991,7 @@ def main(argv=None) -> int:
                 fleet_id=fleet_id,
                 prompt=args.prompt,
                 source=args.source,
+                spec=args.spec,
                 base=args.base,
                 guide=guide_abs_ref,
                 max_beads=args.max_beads,
@@ -1024,6 +1040,7 @@ def main(argv=None) -> int:
             fleet_failure_threshold=args.fleet_failure_threshold,
             max_beads=args.max_beads,
             claude_md_mode=args.claude_md_mode,
+            spec=args.spec,
         )
 
         # Fire fleet.launched once dispatch returns — children may still be

--- a/src/worca/scripts/run_fleet.py
+++ b/src/worca/scripts/run_fleet.py
@@ -164,7 +164,27 @@ def detect_child_crg_status(project_dir: str) -> str:
     return GRAPH_STATUS_READY
 
 
-def build_child_env(base_env: dict, *, fleet_id: str | None = None) -> dict:
+def _derive_config_path(project_dir: str | None) -> str | None:
+    """Return the absolute path to config.json for *project_dir*, or None if absent."""
+    if not project_dir:
+        return None
+    try:
+        from worca.utils.paths import project_config_dir  # noqa: PLC0415
+        from worca.utils.project_registry import slugify  # noqa: PLC0415
+
+        slug = slugify(os.path.basename(project_dir))
+        config_path = os.path.join(project_config_dir(slug), "config.json")
+        return config_path if os.path.exists(config_path) else None
+    except Exception:
+        return None
+
+
+def build_child_env(
+    base_env: dict,
+    *,
+    fleet_id: str | None = None,
+    project_dir: str | None = None,
+) -> dict:
     """Return a copy of *base_env* with fleet-internal keys stripped.
 
     Scrubs the W-040 §5 list: ``WORCA_AGENT``, ``WORCA_STAGE``, ``WORCA_RUN_ID``,
@@ -177,6 +197,9 @@ def build_child_env(base_env: dict, *, fleet_id: str | None = None) -> dict:
     When *fleet_id* is supplied, ``WORCA_FLEET_ID`` is re-injected AFTER the
     scrub so the Guardian agent in the child pipeline can detect fleet
     membership and apply the ``[fleet:<short>]`` PR-title prefix (W-040 §11).
+
+    When *project_dir* is supplied, ``WORCA_CONFIG_PATH`` is derived from the
+    child project's slug and re-injected after the scrub (Phase 5).
     """
     result = {}
     for key, value in base_env.items():
@@ -188,6 +211,10 @@ def build_child_env(base_env: dict, *, fleet_id: str | None = None) -> dict:
 
     if fleet_id:
         result["WORCA_FLEET_ID"] = fleet_id
+
+    config_path = _derive_config_path(project_dir)
+    if config_path:
+        result["WORCA_CONFIG_PATH"] = config_path
 
     return result
 
@@ -278,7 +305,7 @@ def run_plan_first(
     The reference child runs its full pipeline independently; only the plan file
     is extracted early to unblock the remaining N-1 children (§6).
     """
-    child_env = build_child_env(os.environ.copy(), fleet_id=fleet_id)
+    child_env = build_child_env(os.environ.copy(), fleet_id=fleet_id, project_dir=reference_project)
     cmd = build_child_cmd(
         project_dir=reference_project,
         fleet_id=fleet_id,
@@ -420,7 +447,7 @@ def dispatch_fleet(
         # Spawn up to max_parallel children. Stops adding new ones once halted.
         while pending and len(in_flight) < max_parallel and not halted:
             project_dir = pending.pop(0)
-            child_env = build_child_env(os.environ.copy(), fleet_id=fleet_id)
+            child_env = build_child_env(os.environ.copy(), fleet_id=fleet_id, project_dir=project_dir)
             cmd = build_child_cmd(
                 project_dir=project_dir,
                 fleet_id=fleet_id,

--- a/src/worca/scripts/run_parallel.py
+++ b/src/worca/scripts/run_parallel.py
@@ -62,7 +62,10 @@ def _run_pipeline_in_worktree(
 ) -> dict:
     """Run a pipeline in a worktree subprocess. Returns result dict."""
     prompt_file = None
-    cmd = [sys.executable, ".claude/worca/scripts/run_pipeline.py"]
+    # W-077: runtime moved from .claude/worca/ to ~/.worca/pkg/<ver>/worca/.
+    # Use the module form so Python resolves it via PYTHONPATH / site-packages
+    # regardless of which runtime layout is active.
+    cmd = [sys.executable, "-m", "worca.scripts.run_pipeline"]
 
     if len(prompt.encode("utf-8", errors="replace")) > _ARG_INLINE_LIMIT:
         fd, prompt_file = tempfile.mkstemp(prefix="worca_prompt_", suffix=".md")

--- a/src/worca/scripts/run_pipeline.py
+++ b/src/worca/scripts/run_pipeline.py
@@ -18,6 +18,26 @@ from worca.utils.gh_issues import gh_issue_fail
 from worca.utils.settings import load_settings
 
 
+def _resolve_runtime_dir_for_provenance(settings_path: str) -> str:
+    """Return the directory that contains provenance.json.
+
+    W-077: provenance.json moved from .claude/worca/ to the pkg store
+    (~/.worca/pkg/<ver>/). Fall back to the legacy .claude/worca/ path
+    when the pkg store location is unavailable (pre-W-077 installs).
+    """
+    legacy = os.path.join(os.path.dirname(os.path.abspath(settings_path)), "worca")
+    if os.path.exists(os.path.join(legacy, "provenance.json")):
+        return legacy
+    try:
+        from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+        pkg_prov = _pkg_dir()
+        if os.path.exists(os.path.join(pkg_prov, "provenance.json")):
+            return pkg_prov
+    except Exception:
+        pass
+    return legacy
+
+
 def create_parser():
     """Create the argument parser for the pipeline CLI."""
     parser = argparse.ArgumentParser(description="Run worca-cc pipeline")
@@ -295,6 +315,20 @@ def main():
     _resolver = None
     _pipeline_template = None
 
+    # Pin WORCA_CONFIG_PATH early so load_settings() below picks up the per-project
+    # worca config from ~/.worca/projects/<slug>/config.json (W-077).  Skip when
+    # WORCA_CONFIG_PATH is already set — run_worktree.py (and fleet/workspace child
+    # launchers) pre-set it to the parent project's config path before invoking us,
+    # and re-deriving from args.settings would resolve to the worktree root (whose
+    # slug has no matching config.json), silently dropping every worca.* value.
+    if not os.environ.get("WORCA_CONFIG_PATH"):
+        try:
+            from worca.orchestrator.runner import _pin_worca_config_path as _early_pin  # noqa: PLC0415
+            _early_project_root = str(Path(args.settings).resolve().parent.parent)
+            _early_pin(_early_project_root)
+        except Exception:
+            pass
+
     # Load project settings once — used to (a) fall back to worca.default_template
     # when --template wasn't passed, and (b) form the merge base when applying
     # the resolved template.
@@ -401,9 +435,8 @@ def main():
             # Always derive the runtime dir from the REAL settings path, never
             # effective_settings_path — for templated runs the latter is a tempfile
             # whose parent has no provenance.json (would record runtime_source: null).
-            runtime_dir=os.path.join(
-                os.path.dirname(os.path.abspath(args.settings)), "worca"
-            ),
+            # W-077: provenance.json lives in the pkg store, not .claude/worca/.
+            runtime_dir=_resolve_runtime_dir_for_provenance(args.settings),
         )
 
         # Snapshot template to run dir and write merged settings for traceability.

--- a/src/worca/scripts/run_pipeline.py
+++ b/src/worca/scripts/run_pipeline.py
@@ -124,19 +124,23 @@ def build_work_request(args):
 
     # Normalize: source/spec/plan take priority, prompt-only is fallback
     has_primary = args.source or args.spec or args.plan
-    if args.source:
-        plan_template = load_settings(args.settings).get("worca", {}).get(
-            "plan_path_template"
-        )
-        work_request = normalize(
-            "source", args.source, plan_path_template=plan_template
-        )
-    elif args.spec:
-        work_request = normalize("spec", args.spec)
-    elif args.plan:
-        work_request = normalize("plan", args.plan)
-    else:
-        work_request = normalize("prompt", args.prompt)
+    try:
+        if args.source:
+            plan_template = load_settings(args.settings).get("worca", {}).get(
+                "plan_path_template"
+            )
+            work_request = normalize(
+                "source", args.source, plan_path_template=plan_template
+            )
+        elif args.spec:
+            work_request = normalize("spec", args.spec)
+        elif args.plan:
+            work_request = normalize("plan", args.plan)
+        else:
+            work_request = normalize("prompt", args.prompt)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2)
 
     # Prompt merging: append as Additional Instructions when prompt
     # accompanies a primary source

--- a/src/worca/scripts/run_worktree.py
+++ b/src/worca/scripts/run_worktree.py
@@ -176,7 +176,10 @@ def _build_pipeline_cmd(args: argparse.Namespace, run_id: str = "") -> list:
 
     if args.source:
         cmd.extend(["--source", args.source])
-    else:
+    elif args.spec:
+        cmd.extend(["--spec", args.spec])
+
+    if args.prompt:
         cmd.extend(["--prompt", args.prompt])
 
     if args.plan:
@@ -219,9 +222,9 @@ def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Launch a single worca-cc pipeline in an isolated git worktree"
     )
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("--prompt", help="Text prompt for work request")
-    group.add_argument("--source", help="Source reference (gh:issue:42, bd:bd-abc)")
+    parser.add_argument("--prompt", help="Text prompt for work request")
+    parser.add_argument("--source", help="Source reference (gh:issue:42, bd:bd-abc)")
+    parser.add_argument("--spec", help="Path to spec file")
 
     parser.add_argument(
         "--branch",
@@ -289,18 +292,32 @@ def main(argv=None) -> int:
     parser = create_parser()
     args = parser.parse_args(argv)
 
-    if not args.prompt and not args.source:
-        print("error: one of --prompt or --source is required", file=sys.stderr)
+    if not any([args.prompt, args.source, args.spec]):
+        print("error: one of --prompt, --source, or --spec is required", file=sys.stderr)
+        return 2
+
+    if args.source and args.spec:
+        print("error: --source and --spec are mutually exclusive", file=sys.stderr)
+        return 2
+
+    if args.plan and not os.path.isfile(args.plan):
+        print(f"error: plan file not found: {args.plan}", file=sys.stderr)
         return 2
 
     # Normalize work request to get a title for the slug and registry entry
-    if args.source:
-        plan_template = load_settings(args.settings).get("worca", {}).get(
-            "plan_path_template"
-        )
-        wr = normalize("source", args.source, plan_path_template=plan_template)
-    else:
-        wr = normalize("prompt", args.prompt)
+    try:
+        if args.source:
+            plan_template = load_settings(args.settings).get("worca", {}).get(
+                "plan_path_template"
+            )
+            wr = normalize("source", args.source, plan_path_template=plan_template)
+        elif args.spec:
+            wr = normalize("spec", args.spec)
+        else:
+            wr = normalize("prompt", args.prompt)
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
     # Reject --branch for github_pr source: the head branch is fixed by the PR
     # (L2 — drift creates duplicate PRs). Precedent: fleet rejects --branch too.

--- a/src/worca/scripts/run_worktree.py
+++ b/src/worca/scripts/run_worktree.py
@@ -153,7 +153,22 @@ def _generate_run_id() -> str:
     return f"{now.strftime('%Y%m%d-%H%M%S')}-{millis:03d}-{suffix}"
 
 
-def _build_pipeline_cmd(args: argparse.Namespace, run_id: str = "") -> list:
+def _resolve_pipeline_script() -> str:
+    """Return the absolute path to run_pipeline.py from the shared pkg store.
+
+    Falls back to the legacy project-local path if pkg_dir() is unavailable.
+    Separated from _build_pipeline_cmd so callers that have already resolved
+    validate_runtime can pass the path directly without re-computing.
+    """
+    try:
+        from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+        return os.path.join(_pkg_dir(), "worca", "scripts", "run_pipeline.py")
+    except Exception:
+        return os.path.join(".claude", "worca", "scripts", "run_pipeline.py")
+
+
+def _build_pipeline_cmd(args: argparse.Namespace, run_id: str = "",
+                        pipeline_script: str | None = None) -> list:
     """Build the run_pipeline.py argv to spawn inside the worktree.
 
     Pure function over parsed args — no filesystem or env side effects — so
@@ -163,10 +178,14 @@ def _build_pipeline_cmd(args: argparse.Namespace, run_id: str = "") -> list:
     so the runner uses the same key as the multi-pipeline registry entry
     written by register_pipeline(). When empty, --run-id is omitted and the
     runner falls back to generating one (legacy in-place callers).
+
+    ``pipeline_script`` is the path to run_pipeline.py; when None, resolved
+    via ``_resolve_pipeline_script()`` (shared pkg store, with fallback).
     """
+    script = pipeline_script or _resolve_pipeline_script()
     cmd = [
         sys.executable,
-        os.path.join(".claude", "worca", "scripts", "run_pipeline.py"),
+        script,
         "--worktree",
         "--registry-base",
         os.path.abspath(".worca"),
@@ -415,7 +434,10 @@ def main(argv=None) -> int:
     )
 
     # Step 7: build and spawn run_pipeline.py --worktree (detached, fire-and-forget)
-    cmd = _build_pipeline_cmd(args, run_id=run_id)
+    # Resolve the pipeline script path here (after validate_runtime has confirmed the
+    # runtime exists) so _build_pipeline_cmd stays a pure function over parsed args.
+    pipeline_script = _resolve_pipeline_script()
+    cmd = _build_pipeline_cmd(args, run_id=run_id, pipeline_script=pipeline_script)
 
     env = os.environ.copy()
     env.pop("CLAUDECODE", None)

--- a/src/worca/scripts/worca_lifecycle.py
+++ b/src/worca/scripts/worca_lifecycle.py
@@ -241,6 +241,9 @@ def cmd_multi_status(base: str = _DEFAULT_BASE) -> list[dict]:
         try:
             status = load_status(status_path)
             entry["stage"] = status.get("stage", "—")
+            live_status = status.get("pipeline_status")
+            if live_status:
+                entry["status"] = live_status
         except Exception:
             entry.setdefault("stage", "—")
 

--- a/src/worca/settings.json
+++ b/src/worca/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)/.claude/worca/claude_hooks/pre_tool_use.py\""
+            "command": "python3 .claude/worca/claude_hooks/pre_tool_use.py"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)/.claude/worca/claude_hooks/skill_use.py\""
+            "command": "python3 .claude/worca/claude_hooks/skill_use.py"
           }
         ]
       }
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)/.claude/worca/claude_hooks/post_tool_use.py\""
+            "command": "python3 .claude/worca/claude_hooks/post_tool_use.py"
           }
         ]
       }
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)/.claude/worca/claude_hooks/user_prompt_submit.py\""
+            "command": "python3 .claude/worca/claude_hooks/user_prompt_submit.py"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)/.claude/worca/claude_hooks/subagent_start.py\""
+            "command": "python3 .claude/worca/claude_hooks/subagent_start.py"
           }
         ]
       }
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)/.claude/worca/claude_hooks/subagent_stop.py\""
+            "command": "python3 .claude/worca/claude_hooks/subagent_stop.py"
           }
         ]
       }

--- a/src/worca/utils/claude_cli.py
+++ b/src/worca/utils/claude_cli.py
@@ -28,6 +28,7 @@ from worca.utils.log_lines import write_log_line
 
 from worca.hooks.agent_role import role_from_worca_agent
 from worca.hooks.tracking import (
+    ConfigUnreadable,
     _load_dispatch_section,
     is_lockdown,
     resolve_per_agent_entry,
@@ -199,7 +200,18 @@ def _resolve_tool_args(
         fire and dispatch governance is silently disabled. Auto-inclusion
         keeps the hooks in the loop.
     """
-    cfg = _load_dispatch_section("tools", settings)
+    try:
+        cfg = _load_dispatch_section("tools", settings)
+    except ConfigUnreadable as exc:
+        # Malformed worca config — degrade to defaults rather than crashing the
+        # pipeline. Emit a visible warning so the silent path is observable; the
+        # pre-launch preflight check will surface the full error to the user.
+        print(
+            f"[worca] WARNING: malformed settings.json — falling back to default tool"
+            f" policy for agent '{agent_name}': {exc}",
+            file=sys.stderr,
+        )
+        return [], "default"
     # Filter both meta-tools symmetrically: if either lands in
     # --disallowedTools, the corresponding governance hook never fires
     # and dispatch is silently bypassed at the CLI layer.

--- a/src/worca/utils/paths.py
+++ b/src/worca/utils/paths.py
@@ -72,3 +72,24 @@ def workspace_runs_dir(override: str | None = None) -> str:
     if override:
         return override
     return os.path.join(worca_home(), "workspace-runs")
+
+
+def pkg_dir(version_key: str | None = None) -> str:
+    """Return the versioned package directory: ``<worca_home>/pkg/<version_key>/``.
+
+    If ``version_key`` is None, it is computed via
+    ``worca.utils.pkg_store.version_key()`` on each call (lazy import to avoid
+    circular imports and to keep the hot-path cost deferred).
+    """
+    if version_key is None:
+        from worca.utils.pkg_store import version_key as _vk  # noqa: PLC0415
+        version_key = _vk()
+    return os.path.join(worca_home(), "pkg", version_key)
+
+
+def project_config_dir(slug: str) -> str:
+    """Return the per-project config directory: ``<worca_home>/projects/<slug>/``.
+
+    Resolved on every call so tests can override ``$WORCA_HOME`` after import.
+    """
+    return os.path.join(worca_home(), "projects", slug)

--- a/src/worca/utils/pkg_store.py
+++ b/src/worca/utils/pkg_store.py
@@ -1,0 +1,188 @@
+"""Versioned package store utilities for ~/.worca/pkg/<version>/.
+
+Version key format: <semver>-<git-short-hash> (e.g. '0.59.0-a1b2c3d').
+For pip/released installs where no git context is available, the hash
+suffix is omitted and the key is just the semver string.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from typing import Optional
+
+
+def _get_semver() -> str:
+    """Return the installed worca semver string."""
+    import worca  # noqa: PLC0415
+    return worca.__version__
+
+
+def _get_git_short_hash() -> Optional[str]:
+    """Return the 7-char git short hash of HEAD, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short=7", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            h = result.stdout.strip()
+            if len(h) == 7:
+                return h
+    except Exception:
+        pass
+    return None
+
+
+def version_key() -> str:
+    """Compute the version key for the current worca install.
+
+    Returns '<semver>-<short-hash>' when inside a git repo, else '<semver>'.
+    """
+    semver = _get_semver()
+    git_hash = _get_git_short_hash()
+    if git_hash:
+        return f"{semver}-{git_hash}"
+    return semver
+
+
+def _collect_referenced_versions(prefs_dir: str) -> set[str]:
+    """Scan projects.d/*.json and return all worcaPkgVersion values."""
+    referenced: set[str] = set()
+    projects_d = os.path.join(prefs_dir, "projects.d")
+    if not os.path.isdir(projects_d):
+        return referenced
+    for fname in os.listdir(projects_d):
+        if not fname.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(projects_d, fname), encoding="utf-8") as f:
+                entry = json.load(f)
+            ver = entry.get("worcaPkgVersion")
+            if ver:
+                referenced.add(ver)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return referenced
+
+
+def _collect_running_pipeline_versions(prefs_dir: str) -> set[str]:
+    """Scan pipelines.d/ across all registered projects for running pipeline versions.
+
+    A pipeline is considered live if its status is in PIPELINE_ACTIVE set
+    (running/resuming/paused). Any worcaPkgVersion found in a live pipeline
+    entry is treated as referenced regardless of registry state.
+    """
+    from worca.state.status import PIPELINE_ACTIVE  # noqa: PLC0415
+
+    live_versions: set[str] = set()
+    projects_d = os.path.join(prefs_dir, "projects.d")
+    if not os.path.isdir(projects_d):
+        return live_versions
+
+    project_paths: list[str] = []
+    for fname in os.listdir(projects_d):
+        if not fname.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(projects_d, fname), encoding="utf-8") as f:
+                entry = json.load(f)
+            p = entry.get("path") or entry.get("worcaDir")
+            if p:
+                project_paths.append(p)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    active_statuses = {s.value for s in PIPELINE_ACTIVE}
+
+    for proj_path in project_paths:
+        # worcaDir may be <path>/.worca; path gives us the project root
+        # Normalise: if proj_path ends with /.worca strip it
+        base = proj_path
+        if base.endswith("/.worca") or base.endswith("\\.worca"):
+            base = os.path.dirname(base)
+        pipelines_d = os.path.join(base, ".worca", "multi", "pipelines.d")
+        if not os.path.isdir(pipelines_d):
+            continue
+        for fname in os.listdir(pipelines_d):
+            if not fname.endswith(".json"):
+                continue
+            try:
+                with open(os.path.join(pipelines_d, fname), encoding="utf-8") as f:
+                    pipeline = json.load(f)
+                status = str(pipeline.get("status", ""))
+                if status in active_statuses:
+                    ver = pipeline.get("worcaPkgVersion")
+                    if ver:
+                        live_versions.add(ver)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    return live_versions
+
+
+def gc_pkg_store(
+    dry_run: bool = False,
+    keep_latest: int = 0,
+    prefs_dir: str | None = None,
+) -> dict:
+    """Mark-and-sweep GC for ~/.worca/pkg/ orphan versions.
+
+    Steps:
+    1. Collect referenced versions from projects.d/*.json (mark)
+    2. Collect versions referenced by any running pipeline (safety)
+    3. List all dirs in ~/.worca/pkg/
+    4. Apply keep_latest: preserve the N most recent dirs (sorted)
+    5. Delete orphan dirs (unless dry_run)
+
+    Returns dict with keys:
+      - removed: list of version keys actually deleted
+      - would_remove: list of orphan version keys (populated in dry_run)
+      - skipped_live: list of version keys skipped due to running pipelines
+    """
+    from worca.utils.paths import worca_home  # noqa: PLC0415
+
+    if prefs_dir is None:
+        prefs_dir = worca_home()
+
+    pkg_root = os.path.join(prefs_dir, "pkg")
+    if not os.path.isdir(pkg_root):
+        return {"removed": [], "would_remove": [], "skipped_live": []}
+
+    all_versions = sorted(
+        d for d in os.listdir(pkg_root)
+        if os.path.isdir(os.path.join(pkg_root, d))
+    )
+
+    referenced = _collect_referenced_versions(prefs_dir)
+    live_versions = _collect_running_pipeline_versions(prefs_dir)
+
+    # keep_latest: preserve the N most-recent dirs regardless of reference status
+    keep_set: set[str] = set()
+    if keep_latest > 0:
+        keep_set = set(all_versions[-keep_latest:])
+
+    removed: list[str] = []
+    would_remove: list[str] = []
+    skipped_live: list[str] = []
+
+    for ver in all_versions:
+        if ver in referenced or ver in keep_set:
+            continue
+        if ver in live_versions:
+            skipped_live.append(ver)
+            continue
+        if dry_run:
+            would_remove.append(ver)
+        else:
+            try:
+                shutil.rmtree(os.path.join(pkg_root, ver))
+                removed.append(ver)
+            except OSError:
+                pass
+
+    return {"removed": removed, "would_remove": would_remove, "skipped_live": skipped_live}

--- a/src/worca/utils/project_registry.py
+++ b/src/worca/utils/project_registry.py
@@ -13,6 +13,12 @@ logger = logging.getLogger(__name__)
 _SLUG_RE = re.compile(r"^[a-z0-9_-]{1,64}$", re.IGNORECASE)
 
 
+def _get_pkg_version() -> str:
+    """Return the worca version key (lazy import avoids circular imports)."""
+    from worca.utils.pkg_store import version_key  # noqa: PLC0415
+    return version_key()
+
+
 def slugify(name: str) -> str:
     """Slugify a project name: lowercase, replace non-alphanumeric with hyphens."""
     slug = re.sub(r"[^a-z0-9_-]", "-", name.lower())
@@ -59,11 +65,14 @@ def auto_register_project(project_root: str, prefs_dir: str | None = None) -> No
         if os.path.exists(entry_path):
             return
 
+        worca_config_path = os.path.join(prefs_dir, "projects", name, "config.json")
         entry = {
             "name": name,
             "path": project_root,
             "worcaDir": os.path.join(project_root, ".worca"),
             "settingsPath": os.path.join(project_root, ".claude", "settings.json"),
+            "worcaConfigPath": worca_config_path,
+            "worcaPkgVersion": _get_pkg_version(),
         }
 
         # Atomic write: write to temp file, then rename
@@ -84,3 +93,51 @@ def auto_register_project(project_root: str, prefs_dir: str | None = None) -> No
         logger.info("Auto-registered project '%s' at %s", name, project_root)
     except Exception as e:
         logger.debug("Failed to auto-register project: %s", e)
+
+
+def update_registry_entry(project_root: str, prefs_dir: str | None = None) -> None:
+    """Update an existing registry entry with current worcaConfigPath and worcaPkgVersion.
+
+    Non-fatal — catches and logs all errors. No-op when no entry exists.
+    """
+    try:
+        if prefs_dir is None:
+            prefs_dir = worca_home()
+        else:
+            prefs_dir = os.path.expanduser(prefs_dir)
+        projects_dir = os.path.join(prefs_dir, "projects.d")
+
+        project_root = os.path.abspath(project_root)
+        name = slugify(os.path.basename(project_root))
+        if not name or not _SLUG_RE.match(name):
+            return
+
+        entry_path = os.path.join(projects_dir, f"{name}.json")
+        if not os.path.exists(entry_path):
+            # Not registered yet — delegate to auto_register_project
+            auto_register_project(project_root, prefs_dir=prefs_dir)
+            return
+
+        with open(entry_path, encoding="utf-8") as f:
+            entry = json.load(f)
+
+        worca_config_path = os.path.join(prefs_dir, "projects", name, "config.json")
+        entry["worcaConfigPath"] = worca_config_path
+        entry["worcaPkgVersion"] = _get_pkg_version()
+
+        fd, tmp_path = tempfile.mkstemp(dir=projects_dir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(entry, f, indent=2)
+                f.write("\n")
+            os.replace(tmp_path, entry_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+        logger.info("Updated registry entry for '%s'", name)
+    except Exception as e:
+        logger.debug("Failed to update registry entry: %s", e)

--- a/src/worca/utils/runtime.py
+++ b/src/worca/utils/runtime.py
@@ -153,15 +153,31 @@ def copy_claude_config(src_dir: str, dst_dir: str) -> None:
     propagate_runtime_local_keys(src_dir, dst_dir)
 
 
-def validate_runtime(runtime_dir: str = os.path.join(".claude", "worca")) -> None:
-    """Verify the worca runtime directory exists in the current project.
+def validate_runtime(runtime_dir: str | None = None) -> None:
+    """Verify the worca runtime exists — either the shared pkg store or the legacy
+    project-local directory.
 
-    Raises SystemExit(1) with the canonical error message when the directory
-    is absent so callers get a clear diagnostic before any side effects.
+    W-077: the canonical runtime location is now ``~/.worca/pkg/<ver>/worca/``
+    (shared pkg store).  The ``runtime_dir`` parameter is kept for backward-compat
+    but defaults to None, which triggers the pkg-store check.  If the pkg store
+    directory is present the check passes.  Only when neither the pkg store nor the
+    explicit ``runtime_dir`` exists does it raise SystemExit(1).
+
+    Raises SystemExit(1) with a clear diagnostic when the runtime is absent.
     """
-    if not os.path.isdir(runtime_dir):
+    try:
+        from worca.utils.paths import pkg_dir as _pkg_dir  # noqa: PLC0415
+        pkg_worca = os.path.join(_pkg_dir(), "worca")
+        if os.path.isdir(pkg_worca):
+            return
+    except Exception:
+        pass
+
+    # Fall back to explicit runtime_dir or legacy default.
+    legacy = runtime_dir if runtime_dir is not None else os.path.join(".claude", "worca")
+    if not os.path.isdir(legacy):
         print(
-            f"error: worca runtime not found at {runtime_dir}/ — run `worca init .` first",
+            f"error: worca runtime not found at {legacy}/ — run `worca init .` first",
             file=sys.stderr,
         )
         raise SystemExit(1)

--- a/src/worca/utils/settings.py
+++ b/src/worca/utils/settings.py
@@ -76,18 +76,58 @@ def _local_path_for(settings_path: str) -> str:
     return root + ".local" + ext
 
 
+def _load_worca_config() -> dict:
+    """Load base worca config from WORCA_CONFIG_PATH if set.
+
+    Returns {} if the env var is unset or the file is absent.
+    On JSON error, emits a stderr warning and returns {} — pipeline-side
+    callers tolerate degraded config rather than hard-failing the way
+    hook-side callers do (see tracking.py::_load_worca_config_base).
+    """
+    config_path = os.environ.get("WORCA_CONFIG_PATH")
+    if not config_path:
+        return {}
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(
+            f"worca: warning: WORCA_CONFIG_PATH={config_path}: file not found",
+            file=sys.stderr,
+        )
+        return {}
+    except json.JSONDecodeError as e:
+        import sys  # noqa: PLC0415
+        print(
+            f"worca: warning: WORCA_CONFIG_PATH={config_path}: invalid JSON ({e}); "
+            "worca config ignored",
+            file=sys.stderr,
+        )
+        return {}
+
+
 def load_settings(settings_path: str) -> dict:
     """Load base settings and deep-merge any sibling .local.json over them.
+
+    Config loading precedence (lowest to highest):
+    1. WORCA_CONFIG_PATH → ~/.worca/projects/<slug>/config.json (base worca config)
+    2. settings_path (the project .claude/settings.json or template-merged overlay)
+    3. .local.json sibling of settings_path (secrets merge)
 
     - If settings_path does not exist, returns {}.
     - If the .local.json sibling does not exist, returns the base as-is.
     - If .local.json has invalid JSON, logs a warning and returns the base.
     """
+    worca_config_base = _load_worca_config()
+
     try:
         with open(settings_path, encoding="utf-8") as f:
             base = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
-        return {}
+        return worca_config_base
+
+    if worca_config_base:
+        base = deep_merge(worca_config_base, base)
 
     local_path = _local_path_for(settings_path)
     if not os.path.exists(local_path):

--- a/src/worca/workspace/dag_executor.py
+++ b/src/worca/workspace/dag_executor.py
@@ -75,11 +75,27 @@ _SCRUB_KEYS = frozenset({
 _SCRUB_PREFIXES = ("WORCA_",)
 
 
+def _derive_config_path(project_dir: str | None) -> str | None:
+    """Return the absolute path to config.json for *project_dir*, or None if absent."""
+    if not project_dir:
+        return None
+    try:
+        from worca.utils.paths import project_config_dir  # noqa: PLC0415
+        from worca.utils.project_registry import slugify  # noqa: PLC0415
+
+        slug = slugify(os.path.basename(project_dir))
+        config_path = os.path.join(project_config_dir(slug), "config.json")
+        return config_path if os.path.exists(config_path) else None
+    except Exception:
+        return None
+
+
 def _build_child_env(
     base_env: dict,
     *,
     workspace_id: str,
     workspace_name: str,
+    project_dir: str | None = None,
 ) -> dict:
     # Strip-then-inject: first drop every WORCA_* var the parent inherited
     # (stage-scoped state from any outer pipeline must not leak into child
@@ -97,6 +113,11 @@ def _build_child_env(
     result["WORCA_WORKSPACE_ID"] = workspace_id
     result["WORCA_WORKSPACE_NAME"] = workspace_name
     result["WORCA_DEFER_PR"] = "1"
+
+    config_path = _derive_config_path(project_dir)
+    if config_path:
+        result["WORCA_CONFIG_PATH"] = config_path
+
     return result
 
 
@@ -683,10 +704,14 @@ class DagExecutor:
             self._context_paths[project] = path
 
     def _run_child(self, project: str) -> dict:
+        project_path = self._projects_by_name.get(project, project)
+        cwd = self._project_abs_path(project_path)
+
         env = _build_child_env(
             os.environ.copy(),
             workspace_id=self._workspace_id,
             workspace_name=self._workspace_name,
+            project_dir=cwd,
         )
 
         deps = self._dependency_graph.get(project, [])
@@ -703,9 +728,6 @@ class DagExecutor:
             max_beads=self._max_beads,
             claude_md_mode=self._claude_md_mode,
         )
-
-        project_path = self._projects_by_name.get(project, project)
-        cwd = self._project_abs_path(project_path)
 
         proc = subprocess.run(
             cmd,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -178,23 +178,49 @@ def pipeline_env(tmp_path):
     # 2. Run worca init to copy full runtime (agents, schemas, hooks, scripts).
     #    PYTHONPATH ensures init copies from the worktree source tree (not a
     #    stale site-packages install) — mirrors pyproject.toml pythonpath=["src"].
-    _init_env = {**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")}
+    #    WORCA_HOME is isolated per-test so pkg store and project config do not
+    #    collide across tests in the same session (each test gets its own
+    #    ~/.worca/ equivalent under tmp_path/worca_home/).
+    _worca_home = tmp_path / "worca_home"
+    _init_env = {
+        **os.environ,
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+        "WORCA_HOME": str(_worca_home),
+    }
     subprocess.run(
         [sys.executable, "-m", "worca.cli.main", "init"],
         cwd=str(project), check=True, capture_output=True, env=_init_env,
     )
 
+    # 3. Override settings for fast test execution.
+    #    Worca config (worca.*) now lives in ~/.worca/projects/<slug>/config.json
+    #    (W-077). Write overrides there so pipeline runs pick them up via
+    #    WORCA_CONFIG_PATH, which runner.py resolves from the project slug.
+    from worca.utils.paths import project_config_dir as _project_config_dir  # noqa: PLC0415
+    from worca.utils.project_registry import slugify as _slugify  # noqa: PLC0415
 
-    # 3. Override settings for fast test execution
-    settings_path = project / ".claude" / "settings.json"
-    settings = json.loads(settings_path.read_text())
-    settings.setdefault("worca", {})
-    settings["worca"]["stages"] = {
+    _slug = _slugify(project.name)
+    _config_path = Path(_project_config_dir(_slug))
+    # _project_config_dir uses WORCA_HOME — set it temporarily for the resolution
+    import os as _os  # noqa: PLC0415
+    _prev_worca_home = _os.environ.get("WORCA_HOME")
+    _os.environ["WORCA_HOME"] = str(_worca_home)
+    _config_path = Path(_project_config_dir(_slug)) / "config.json"
+    if _prev_worca_home is not None:
+        _os.environ["WORCA_HOME"] = _prev_worca_home
+    else:
+        _os.environ.pop("WORCA_HOME", None)
+
+    worca_config: dict = {}
+    if _config_path.exists():
+        worca_config = json.loads(_config_path.read_text())
+    worca_config.setdefault("worca", {})
+    worca_config["worca"]["stages"] = {
         "preflight": {"enabled": False},
         "plan_review": {"enabled": False},
         "learn": {"enabled": False},
     }
-    settings["worca"]["agents"] = {
+    worca_config["worca"]["agents"] = {
         "planner": {"max_turns": 5},
         "coordinator": {"max_turns": 5},
         "implementer": {"max_turns": 5},
@@ -202,8 +228,8 @@ def pipeline_env(tmp_path):
         "reviewer": {"max_turns": 5},
         "guardian": {"max_turns": 5},
     }
-    settings["worca"]["effort"] = {"auto_mode": "disabled"}
-    settings_path.write_text(json.dumps(settings, indent=2))
+    worca_config["worca"]["effort"] = {"auto_mode": "disabled"}
+    _config_path.write_text(json.dumps(worca_config, indent=2))
 
     worca_dir = project / ".worca"
     _scenario_counter = [0]
@@ -232,6 +258,9 @@ def pipeline_env(tmp_path):
             "WORCA_AGENT": "",  # not in agent mode — hooks should not enforce agent guards
             "WORCA_SKIP_BEADS": "1",  # bd binary may not work in CI
             "PYTHONPATH": str(REPO_ROOT / "src"),
+            # W-077: propagate per-test WORCA_HOME so runner.py's _pin_worca_config_path
+            # resolves to the isolated ~/.worca/projects/<slug>/config.json for this test.
+            "WORCA_HOME": str(_worca_home),
         }
         # Strip pipeline-specific WORCA_* vars that leak from the parent shell.
         # WORCA_PLAN_FILE and WORCA_PROJECT_ROOT in particular cause plan_check
@@ -242,6 +271,9 @@ def pipeline_env(tmp_path):
         env.pop("WORCA_RUN_ID", None)
         env.pop("WORCA_RUN_DIR", None)
         env.pop("GRAPHIFY_OUT", None)
+        # Do not inherit parent's WORCA_CONFIG_PATH — runner.py re-derives it from
+        # the project slug + WORCA_HOME for each child pipeline.
+        env.pop("WORCA_CONFIG_PATH", None)
         if _coverage_enabled():
             # Coverage subprocesses write .coverage.<host>.<pid>.<rand> next to
             # CWD by default. Force them into REPO_ROOT so `coverage combine`
@@ -512,27 +544,29 @@ def pipeline_env(tmp_path):
         )
 
     def add_webhook(url: str) -> None:
-        """Add a webhook URL to settings for event dispatch testing.
+        """Add a webhook URL to worca config for event dispatch testing.
 
         emitter.py _validate_webhook only accepts https:// or http://localhost
         prefixes — so the webhook_server fixture must bind to localhost.
+        Writes to config.json (W-077: worca.* lives in the project config dir).
         """
-        s = json.loads(settings_path.read_text())
+        s = json.loads(_config_path.read_text())
         s.setdefault("worca", {})
         s["worca"]["webhooks"] = [{"url": url}]
-        settings_path.write_text(json.dumps(s, indent=2))
+        _config_path.write_text(json.dumps(s, indent=2))
 
     def enable_stages(*names: str) -> None:
         """Flip ``worca.stages.<name>.enabled`` to True for each stage name.
 
         Tests that need preflight, plan_review, or learn to actually run call
         this *after* fixture setup (which disables them by default for speed).
+        Writes to config.json (W-077: worca.* lives in the project config dir).
         """
-        s = json.loads(settings_path.read_text())
+        s = json.loads(_config_path.read_text())
         s.setdefault("worca", {}).setdefault("stages", {})
         for name in names:
             s["worca"]["stages"].setdefault(name, {})["enabled"] = True
-        settings_path.write_text(json.dumps(s, indent=2))
+        _config_path.write_text(json.dumps(s, indent=2))
 
     def set_governance_agent(name: str) -> None:
         """Set ``WORCA_AGENT`` for the next run so live hooks see a real agent.
@@ -589,6 +623,7 @@ def pipeline_env(tmp_path):
         stubs_dir=STUBS_DIR,
         stub_log_path=_stub_log_path,
         stub_response_files=_stub_response_files,
+        worca_config_path=_config_path,
     )
 
     _stop_beads_daemons(project, _created_worktrees)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -74,6 +74,8 @@ class PipelineEnv:
     stubs_dir: Optional[Path] = None
     stub_log_path: Optional[Path] = None
     stub_response_files: dict = field(default_factory=dict)
+    # W-077: path to ~/.worca/projects/<slug>/config.json (worca config, not Claude settings)
+    worca_config_path: Optional[Path] = None
 
 
 @dataclass

--- a/tests/integration/test_crg_and_graphify_coexist.py
+++ b/tests/integration/test_crg_and_graphify_coexist.py
@@ -58,7 +58,7 @@ def _setup_global_both(pipeline_env) -> Path:
 
 def _enable_both_settings(pipeline_env) -> None:
     """Enable both graphify and CRG in project settings."""
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"]["graphify"] = {
         "enabled": True,
@@ -103,6 +103,9 @@ def _run_pipeline_with_both(pipeline_env, scenario: dict, prompt: str,
         "MOCK_CRG_LOG": str(crg_log),
         "WORCA_HOME": str(worca_home),
         "PYTHONPATH": str(REPO_ROOT / "src"),
+        # W-077: pin config path so pipeline reads from the same file that
+        # _enable_both_settings wrote to.
+        "WORCA_CONFIG_PATH": str(pipeline_env.worca_config_path),
     }
     for key in ("WORCA_PLAN_FILE", "WORCA_PROJECT_ROOT", "WORCA_RUN_ID", "WORCA_RUN_DIR"):
         env.pop(key, None)

--- a/tests/integration/test_crg_missing_degrades_gracefully.py
+++ b/tests/integration/test_crg_missing_degrades_gracefully.py
@@ -52,7 +52,7 @@ def _setup_global_crg(pipeline_env) -> Path:
 
 
 def _enable_crg_settings(pipeline_env) -> None:
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"]["code_review_graph"] = {
         "enabled": True,
@@ -114,6 +114,9 @@ def _run_pipeline(pipeline_env, scenario: dict, prompt: str,
         "MOCK_CLAUDE_SCENARIO": str(scenario_path),
         "WORCA_HOME": str(worca_home),
         "PYTHONPATH": str(REPO_ROOT / "src"),
+        # W-077: pin config path so pipeline reads from the same file that
+        # _enable_crg_settings wrote to.
+        "WORCA_CONFIG_PATH": str(pipeline_env.worca_config_path),
     }
     if path_override is not None:
         env["PATH"] = path_override

--- a/tests/integration/test_crg_pipeline.py
+++ b/tests/integration/test_crg_pipeline.py
@@ -58,7 +58,7 @@ def _setup_global_crg(pipeline_env) -> Path:
 
 def _enable_crg_settings(pipeline_env) -> None:
     """Enable CRG in project settings with base_sha freshness."""
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"]["code_review_graph"] = {
         "enabled": True,
@@ -92,6 +92,9 @@ def _run_pipeline_with_crg(pipeline_env, scenario: dict, prompt: str,
         "PATH": mock_path,
         "MOCK_CRG_LOG": str(crg_log_path),
         "WORCA_HOME": str(worca_home),
+        # W-077: pin config path to the fixture's config so _enable_crg_settings
+        # writes and the pipeline reads from the same file.
+        "WORCA_CONFIG_PATH": str(pipeline_env.worca_config_path),
         "PYTHONPATH": str(REPO_ROOT / "src"),
     }
     for key in ("WORCA_PLAN_FILE", "WORCA_PROJECT_ROOT", "WORCA_RUN_ID", "WORCA_RUN_DIR"):

--- a/tests/integration/test_custom_stage.py
+++ b/tests/integration/test_custom_stage.py
@@ -83,7 +83,7 @@ def _install_custom_stage(pipeline_env, flow_doc=_CUSTOM_STAGE_FLOW,
         json.dumps(schema, indent=2), encoding="utf-8",
     )
 
-    settings_path = project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"]["flow"] = flow_doc
     settings_path.write_text(json.dumps(settings, indent=2))

--- a/tests/integration/test_effort_integration.py
+++ b/tests/integration/test_effort_integration.py
@@ -21,7 +21,7 @@ BEAD_ID = "bd-test-effort-1"
 def _configure_effort(pipeline_env, *, auto_mode="adaptive", auto_cap="xhigh",
                        agents=None, models=None):
     """Patch worca.effort and optionally worca.agents / worca.models."""
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"]["effort"] = {"auto_mode": auto_mode, "auto_cap": auto_cap}
     if agents:

--- a/tests/integration/test_fixture_smoke.py
+++ b/tests/integration/test_fixture_smoke.py
@@ -37,7 +37,14 @@ def test_pipeline_env_project_exists(pipeline_env):
 
 
 def test_pipeline_env_worca_runtime_installed(pipeline_env):
-    assert (pipeline_env.project / ".claude" / "worca").exists()
+    # W-077: runtime now lives in ~/.worca/pkg/<ver>/worca/, not .claude/worca/
+    assert pipeline_env.worca_config_path is not None
+    assert pipeline_env.worca_config_path.exists(), (
+        f"Project config not found at {pipeline_env.worca_config_path}"
+    )
+    assert not (pipeline_env.project / ".claude" / "worca").exists(), (
+        ".claude/worca/ must not exist — runtime is in the shared pkg store"
+    )
 
 
 def test_pipeline_env_git_repo_initialized(pipeline_env):
@@ -46,18 +53,19 @@ def test_pipeline_env_git_repo_initialized(pipeline_env):
 
 def test_pipeline_env_settings_overridden(pipeline_env):
     import json
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
-    settings = json.loads(settings_path.read_text())
-    stages = settings.get("worca", {}).get("stages", {})
+    # W-077: worca.* config lives in config.json, not .claude/settings.json
+    config = json.loads(pipeline_env.worca_config_path.read_text())
+    stages = config.get("worca", {}).get("stages", {})
     assert stages.get("preflight", {}).get("enabled") is False
     assert stages.get("plan_review", {}).get("enabled") is False
     assert stages.get("learn", {}).get("enabled") is False
 
 
 def test_pipeline_env_effort_pinned_disabled(pipeline_env):
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
-    settings = json.loads(settings_path.read_text())
-    effort = settings.get("worca", {}).get("effort", {})
+    import json
+    # W-077: worca.* config lives in config.json, not .claude/settings.json
+    config = json.loads(pipeline_env.worca_config_path.read_text())
+    effort = config.get("worca", {}).get("effort", {})
     assert effort.get("auto_mode") == "disabled"
 
 
@@ -98,9 +106,9 @@ def test_webhook_server_is_dataclass_type(webhook_server):
 
 def test_enable_stages_flips_settings(pipeline_env):
     pipeline_env.enable_stages("preflight", "learn")
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
-    settings = json.loads(settings_path.read_text())
-    stages = settings["worca"]["stages"]
+    # W-077: worca.stages lives in config.json, not .claude/settings.json
+    config = json.loads(pipeline_env.worca_config_path.read_text())
+    stages = config["worca"]["stages"]
     assert stages["preflight"]["enabled"] is True
     assert stages["learn"]["enabled"] is True
     # plan_review was not enabled — must remain False from fixture defaults.

--- a/tests/integration/test_flow_custom.py
+++ b/tests/integration/test_flow_custom.py
@@ -41,7 +41,7 @@ _CUSTOM_FLOW = {
 
 
 def _set_flow(pipeline_env, flow_doc):
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"]["flow"] = flow_doc
     settings_path.write_text(json.dumps(settings, indent=2))

--- a/tests/integration/test_graphify_missing_degrades_gracefully.py
+++ b/tests/integration/test_graphify_missing_degrades_gracefully.py
@@ -16,6 +16,7 @@ import pytest
 from tests.integration.helpers import _find_latest_status
 
 
+REPO_ROOT = Path(__file__).parent.parent.parent
 MOCK_CLAUDE_BIN = Path(__file__).parent.parent / "mock_claude" / "mock_claude.py"
 
 pytestmark = [pytest.mark.timeout(180), pytest.mark.allow_worca_writes]
@@ -67,6 +68,10 @@ def _run_pipeline(pipeline_env, scenario: dict, prompt: str,
         "WORCA_SKIP_BEADS": "1",
         "MOCK_CLAUDE_SCENARIO": str(scenario_path),
         "WORCA_HOME": str(worca_home),
+        # W-077: pin config path so pipeline reads from the same file that
+        # _enable_graphify_settings wrote to.
+        "WORCA_CONFIG_PATH": str(pipeline_env.worca_config_path),
+        "PYTHONPATH": str(REPO_ROOT / "src"),
     }
     if path_override is not None:
         env["PATH"] = path_override
@@ -81,7 +86,7 @@ def _run_pipeline(pipeline_env, scenario: dict, prompt: str,
 
 def _enable_graphify_settings(pipeline_env) -> None:
     """Enable graphify in project settings."""
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"]["graphify"] = {
         "enabled": True,

--- a/tests/integration/test_graphify_pipeline.py
+++ b/tests/integration/test_graphify_pipeline.py
@@ -80,6 +80,9 @@ def _run_pipeline_with_graphify(pipeline_env, scenario: dict, prompt: str,
         "PATH": mock_path,
         "MOCK_GRAPHIFY_LOG": str(graphify_log_path),
         "WORCA_HOME": str(worca_home),
+        # W-077: pin config path so pipeline reads from the same file that
+        # _enable_graphify_settings wrote to.
+        "WORCA_CONFIG_PATH": str(pipeline_env.worca_config_path),
     }
     for key in ("WORCA_PLAN_FILE", "WORCA_PROJECT_ROOT", "WORCA_RUN_ID", "WORCA_RUN_DIR"):
         env.pop(key, None)
@@ -96,7 +99,7 @@ def _enable_graphify_settings(pipeline_env, mode: str = "structural") -> None:
     Uses freshness=base_sha so the per-commit snapshot is built deterministically
     regardless of the working-tree state during the run.
     """
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"]["graphify"] = {
         "enabled": True,

--- a/tests/integration/test_implementer_tester_loop.py
+++ b/tests/integration/test_implementer_tester_loop.py
@@ -105,7 +105,7 @@ def test_tester_always_fails_exhausts_loop(pipeline_env):
     """All tester iterations fail → loop exhausted, run still completes."""
     # Tighten the cap so the test is fast: implement_test=2 → at most 2 fixes.
     import json
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"].setdefault("loops", {})["implement_test"] = 2
     settings_path.write_text(json.dumps(settings, indent=2))
@@ -140,7 +140,7 @@ def test_tester_always_fails_exhausts_loop(pipeline_env):
 def test_implement_test_loops_setting_respected(pipeline_env):
     """Setting worca.loops.implement_test=1 caps fixes at 1."""
     import json
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"].setdefault("loops", {})["implement_test"] = 1
     settings_path.write_text(json.dumps(settings, indent=2))
@@ -248,7 +248,7 @@ def test_failures_threaded_to_next_implementer_via_resolved_template(pipeline_en
 def test_mloops_multiplier_doubles_cap(pipeline_env):
     """``--mloops 2`` doubles worca.loops.implement_test for the run."""
     import json
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"].setdefault("loops", {})["implement_test"] = 1
     settings_path.write_text(json.dumps(settings, indent=2))

--- a/tests/integration/test_misc_edges.py
+++ b/tests/integration/test_misc_edges.py
@@ -36,7 +36,7 @@ def test_breaker_halts_after_single_failure_when_threshold_is_one(pipeline_env):
     failure must trip the breaker immediately. ``should_halt`` returns True
     once consecutive_failures >= threshold; the runner emits a halt and the
     final pipeline_status is ``failed``."""
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings.setdefault("worca", {})["circuit_breaker"] = {
         "max_consecutive_failures": 1,
@@ -69,7 +69,7 @@ def test_malformed_settings_json_does_not_crash_pipeline(pipeline_env):
     so a typo in the file doesn't take the pipeline down. Without this
     guarantee, a stray trailing comma during local edits would brick every
     pipeline launch on the repo."""
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings_path.write_text('{"worca": { invalid json }}')  # malformed
 
     result = pipeline_env.run(_HAPPY, timeout=30)

--- a/tests/integration/test_reviewer_loop.py
+++ b/tests/integration/test_reviewer_loop.py
@@ -105,7 +105,7 @@ def test_reviewer_revise_then_approve_emits_events(pipeline_env):
 # ===========================================================================
 
 def test_reviewer_always_revises_exhausts_pr_changes_loop(pipeline_env):
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"].setdefault("loops", {})["pr_changes"] = 2
     settings_path.write_text(json.dumps(settings, indent=2))
@@ -188,7 +188,7 @@ def test_review_feedback_differs_across_iterations(pipeline_env):
 # ===========================================================================
 
 def test_mloops_multiplier_doubles_pr_changes_cap(pipeline_env):
-    settings_path = pipeline_env.project / ".claude" / "settings.json"
+    settings_path = pipeline_env.worca_config_path
     settings = json.loads(settings_path.read_text())
     settings["worca"].setdefault("loops", {})["pr_changes"] = 1
     settings_path.write_text(json.dumps(settings, indent=2))

--- a/tests/integration/test_run_worktree.py
+++ b/tests/integration/test_run_worktree.py
@@ -147,18 +147,22 @@ def test_run_worktree_guide_argument_accepted(pipeline_env, tmp_path):
 
 
 def test_run_worktree_errors_when_runtime_missing(pipeline_env):
-    """run_worktree.py validates ``.claude/worca/`` exists before any side
+    """run_worktree.py validates the worca runtime exists before any side
     effect (worktree create, registry write, Popen). Without it the spawned
-    pipeline crashes silently and the user sees only "started"."""
-    runtime_dir = pipeline_env.project / ".claude" / "worca"
-    assert runtime_dir.is_dir(), "fixture should have installed the runtime"
-    shutil.rmtree(runtime_dir)
+    pipeline crashes silently and the user sees only "started".
+
+    W-077: the canonical runtime is now in ~/.worca/pkg/<ver>/worca/ (pkg store).
+    Simulate a missing runtime by pointing WORCA_HOME at an empty directory so
+    neither the pkg store nor the legacy .claude/worca/ path is present.
+    """
+    empty_home = pipeline_env.tmp_path / "empty_worca_home"
+    empty_home.mkdir()
 
     cmd = [sys.executable, "-m", "worca.scripts.run_worktree",
            "--prompt", "no runtime"]
     proc = subprocess.run(
         cmd, cwd=str(pipeline_env.project),
-        env={**os.environ, "WORCA_SKIP_BEADS": "1"},
+        env={**os.environ, "WORCA_SKIP_BEADS": "1", "WORCA_HOME": str(empty_home)},
         capture_output=True, text=True, timeout=15,
     )
     assert proc.returncode == 1, (

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -808,6 +808,29 @@ def test_resolve_tool_args_drops_skill_from_disallows():
     assert "EnterPlanMode" in disallows
 
 
+def test_resolve_tool_args_config_unreadable_degrades_to_default(monkeypatch, capsys):
+    """Malformed settings.json degrades to ([], 'default') with an observable warning.
+
+    The alternative — silently returning defaults without a warning — would
+    launch the agent with '--tools default' and no '--disallowedTools' whenever
+    settings.json is malformed, making governance bypass invisible.  The
+    fail-open is intentional (crashing mid-run is worse than degrading), but
+    it must be visible via a stderr warning so the silent path is detectable.
+    """
+    from worca.hooks.tracking import ConfigUnreadable
+
+    monkeypatch.setattr(
+        "worca.utils.claude_cli._load_dispatch_section",
+        lambda *_a, **_kw: (_ for _ in ()).throw(ConfigUnreadable("bad json")),
+    )
+    disallows, tools_arg = _resolve_tool_args("planner", settings={})
+    assert disallows == []
+    assert tools_arg == "default"
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "planner" in captured.err
+
+
 # ---------------------------------------------------------------------------
 # build_command: --tools + --disallowedTools wiring (PR C)
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -79,19 +79,23 @@ class TestCopyWorcaSource:
         assert not (target / "cli").exists()
         assert not (target / "__pycache__").exists()
 
-    def test_overwrites_existing_target(self, tmp_path):
+    def test_skips_when_target_exists(self, tmp_path, capsys):
+        """_copy_worca_source is idempotent: skips copy and prints 'Package already exists'."""
         src = tmp_path / "source"
         src.mkdir()
         (src / "__init__.py").write_text('__version__ = "0.6.0"')
 
         target = tmp_path / "target"
         target.mkdir()
-        (target / "old_file.py").write_text("old")
+        sentinel = target / "old_file.py"
+        sentinel.write_text("old")
 
         _copy_worca_source(src, target)
 
-        assert (target / "__init__.py").exists()
-        assert not (target / "old_file.py").exists()
+        captured = capsys.readouterr()
+        assert "Package already exists" in captured.out
+        # Sentinel untouched — no copy occurred
+        assert sentinel.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +114,7 @@ class TestEnsureGitignore:
 
     def test_no_duplicates(self, tmp_path):
         gitignore = tmp_path / ".gitignore"
-        gitignore.write_text(".worca/\nlogs/\n.claude/settings.local.json\n")
+        gitignore.write_text(".worca/\nlogs/\n.claude/settings.local.json\n.beads/\n")
         changes = _ensure_gitignore(tmp_path)
         assert changes == []
 
@@ -391,8 +395,9 @@ class TestGetWorcaSource:
 
 class TestRunInit:
     def test_init_fresh_project(self, tmp_path, monkeypatch):
-        """worca init on a fresh git repo scaffolds .claude/worca/."""
+        """worca init on a fresh git repo copies source to ~/.worca/pkg/<ver>/worca/."""
         monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         (tmp_path / ".git").mkdir()
 
         # Create a mock source
@@ -408,16 +413,30 @@ class TestRunInit:
         with patch("worca.cli.init._init_beads", return_value=False):
             run_init(source=str(tmp_path / "worca-src"))
 
-        assert (tmp_path / ".claude" / "worca" / "__init__.py").exists()
-        assert (tmp_path / ".claude" / "worca" / "orchestrator" / "runner.py").exists()
-        assert not (tmp_path / ".claude" / "worca" / "cli").exists()
+        from worca.utils.paths import pkg_dir
+        pkg_worca = Path(pkg_dir()) / "worca"
+        assert (pkg_worca / "__init__.py").exists()
+        assert (pkg_worca / "orchestrator" / "runner.py").exists()
+        assert not (pkg_worca / "cli").exists()
         assert (tmp_path / ".claude" / "settings.json").exists()
 
     def test_init_refuses_without_upgrade(self, tmp_path, monkeypatch):
-        """worca init fails if .claude/worca/ exists and --upgrade not passed."""
+        """worca init fails if pkg/worca/ and project config already exist and --upgrade not passed."""
         monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         (tmp_path / ".git").mkdir()
-        (tmp_path / ".claude" / "worca").mkdir(parents=True)
+
+        # Pre-create the pkg worca dir to simulate an existing install
+        from worca.utils.paths import pkg_dir
+        pkg_worca = Path(pkg_dir()) / "worca"
+        pkg_worca.mkdir(parents=True)
+
+        # Pre-create the project config to simulate a fully-initialized project
+        from worca.utils.project_registry import slugify
+        slug = slugify(tmp_path.name)
+        config_dir = tmp_path / "wh" / "projects" / slug
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.json").write_text("{}")
 
         src = tmp_path / "worca-src" / "src" / "worca"
         src.mkdir(parents=True)
@@ -426,16 +445,14 @@ class TestRunInit:
         with pytest.raises(SystemExit):
             run_init(source=str(tmp_path / "worca-src"))
 
-    def test_init_upgrade_overwrites(self, tmp_path, monkeypatch):
-        """worca init --upgrade overwrites .claude/worca/."""
+    def test_init_upgrade_copies_to_pkg_dir(self, tmp_path, monkeypatch):
+        """worca init --upgrade copies source to ~/.worca/pkg/<ver>/worca/."""
         monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         (tmp_path / ".git").mkdir()
 
-        target = tmp_path / ".claude" / "worca"
-        target.mkdir(parents=True)
-        (target / "old.py").write_text("old")
-
         settings = tmp_path / ".claude" / "settings.json"
+        (tmp_path / ".claude").mkdir()
         settings.write_text(json.dumps({"worca": {"stages": {}}}))
 
         src = tmp_path / "worca-src" / "src" / "worca"
@@ -446,8 +463,9 @@ class TestRunInit:
         with patch("worca.cli.init._init_beads", return_value=False):
             run_init(upgrade=True, source=str(tmp_path / "worca-src"))
 
-        assert not (target / "old.py").exists()
-        assert (target / "__init__.py").exists()
+        from worca.utils.paths import pkg_dir
+        pkg_worca = Path(pkg_dir()) / "worca"
+        assert (pkg_worca / "__init__.py").exists()
 
     def test_init_not_in_git_repo(self, tmp_path, monkeypatch):
         """worca init fails outside a git repo."""
@@ -696,17 +714,21 @@ class TestRunInitTemplates:
         return base / "worca-src"
 
     def test_init_copies_builtin_templates_to_runtime(self, tmp_path, monkeypatch):
-        """worca init copies src/worca/templates/ to .claude/worca/templates/."""
+        """worca init copies src/worca/templates/ to ~/.worca/pkg/<ver>/worca/templates/."""
         monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         (tmp_path / ".git").mkdir()
         src_root = self._make_src(tmp_path)
         with patch("worca.cli.init._init_beads", return_value=False):
             run_init(source=str(src_root))
-        assert (tmp_path / ".claude" / "worca" / "templates" / "bugfix" / "template.json").exists()
+        from worca.utils.paths import pkg_dir
+        pkg_worca = Path(pkg_dir()) / "worca"
+        assert (pkg_worca / "templates" / "bugfix" / "template.json").exists()
 
     def test_init_creates_project_templates_dir(self, tmp_path, monkeypatch):
         """worca init creates .claude/templates/ for project templates."""
         monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         (tmp_path / ".git").mkdir()
         src_root = self._make_src(tmp_path)
         with patch("worca.cli.init._init_beads", return_value=False):
@@ -716,6 +738,7 @@ class TestRunInitTemplates:
     def test_upgrade_refreshes_builtin_templates(self, tmp_path, monkeypatch):
         """worca init --upgrade refreshes built-in templates from package source."""
         monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         (tmp_path / ".git").mkdir()
         src_root = self._make_src(tmp_path)
         with patch("worca.cli.init._init_beads", return_value=False):
@@ -727,11 +750,14 @@ class TestRunInitTemplates:
         with patch("worca.cli.init._init_beads", return_value=False):
             with patch("worca.cli.init._upgrade_beads", return_value=False):
                 run_init(upgrade=True, source=str(src_root))
-        assert (tmp_path / ".claude" / "worca" / "templates" / "feature" / "template.json").exists()
+        from worca.utils.paths import pkg_dir
+        pkg_worca = Path(pkg_dir()) / "worca"
+        assert (pkg_worca / "templates" / "feature" / "template.json").exists()
 
     def test_upgrade_preserves_project_templates_dir(self, tmp_path, monkeypatch):
         """worca init --upgrade does not delete .claude/templates/ (project templates)."""
         monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         (tmp_path / ".git").mkdir()
         src_root = self._make_src(tmp_path)
         with patch("worca.cli.init._init_beads", return_value=False):
@@ -905,8 +931,9 @@ class TestWriteProvenanceManifest:
         assert block["worca_version"] == "old"
 
     def test_run_init_writes_provenance(self, tmp_path, monkeypatch):
-        """Integration: run_init creates provenance.json."""
+        """Integration: run_init creates provenance.json in ~/.worca/pkg/<ver>/."""
         monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         (tmp_path / ".git").mkdir()
         src = tmp_path / "worca-src" / "src" / "worca"
         src.mkdir(parents=True)
@@ -920,7 +947,223 @@ class TestWriteProvenanceManifest:
             with patch("worca.cli.init.subprocess.run", side_effect=git_fails):
                 run_init(source=str(tmp_path / "worca-src"))
 
-        manifest = tmp_path / ".claude" / "worca" / "provenance.json"
+        from worca.utils.paths import pkg_dir
+        manifest = Path(pkg_dir()) / "provenance.json"
         assert manifest.exists()
         block = json.loads(manifest.read_text(encoding="utf-8"))
         assert block["worca_version"] == "0.5.0"
+
+
+class TestConfigCreatedInProjectsDir:
+    """test_config_created_in_projects_dir: config.json created at ~/.worca/projects/<slug>/."""
+
+    def _make_src(self, tmp_path, worca_config=None):
+        src = tmp_path / "worca-src" / "src" / "worca"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text('__version__ = "0.5.0"')
+        worca_section = worca_config or {"stages": {}, "agents": {"planner": {"model": "opus"}}}
+        settings_data = {
+            "hooks": {"PreToolUse": []},
+            "permissions": {"allow": []},
+            "worca": worca_section,
+        }
+        (src / "settings.json").write_text(json.dumps(settings_data))
+        return src
+
+    def test_config_json_created_at_projects_slug(self, tmp_path, monkeypatch):
+        """run_init creates ~/.worca/projects/<slug>/config.json with worca.* keys."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        (tmp_path / ".git").mkdir()
+        self._make_src(tmp_path)
+
+        with patch("worca.cli.init._init_beads", return_value=False):
+            run_init(source=str(tmp_path / "worca-src"))
+
+        from worca.utils.paths import project_config_dir
+        slug = tmp_path.name.lower()
+        config_path = Path(project_config_dir(slug)) / "config.json"
+        assert config_path.exists(), f"Expected {config_path} to exist"
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "worca" in data
+
+    def test_config_json_contains_worca_keys_not_hooks(self, tmp_path, monkeypatch):
+        """config.json contains worca.* keys; .claude/settings.json retains hooks."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        (tmp_path / ".git").mkdir()
+        self._make_src(tmp_path, worca_config={"stages": {"plan": {"enabled": True}}, "loops": {"implement_test": 3}})
+
+        with patch("worca.cli.init._init_beads", return_value=False):
+            run_init(source=str(tmp_path / "worca-src"))
+
+        from worca.utils.paths import project_config_dir
+        slug = tmp_path.name.lower()
+        config_path = Path(project_config_dir(slug)) / "config.json"
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data.get("worca", {}).get("stages", {}).get("plan", {}).get("enabled") is True
+
+        settings_data = json.loads((tmp_path / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        assert "hooks" in settings_data or "permissions" in settings_data
+
+    def test_settings_json_strips_worca_keys(self, tmp_path, monkeypatch):
+        """.claude/settings.json does not contain worca.* after init."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        (tmp_path / ".git").mkdir()
+        self._make_src(tmp_path)
+
+        with patch("worca.cli.init._init_beads", return_value=False):
+            run_init(source=str(tmp_path / "worca-src"))
+
+        settings_data = json.loads((tmp_path / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        assert "worca" not in settings_data
+
+
+# ---------------------------------------------------------------------------
+# Old layout migration (Phase 4a)
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeMigratesOldLayout:
+    """test_upgrade_migrates_old_layout: detect .claude/worca/, relocate, delete, update registry."""
+
+    def _make_src(self, tmp_path, version="0.6.0"):
+        src = tmp_path / "worca-src" / "src" / "worca"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text(f'__version__ = "{version}"')
+        (src / "settings.json").write_text(json.dumps({
+            "hooks": {"PreToolUse": []},
+            "permissions": {"allow": []},
+            "worca": {"stages": {"plan": {"enabled": True}}},
+        }))
+        return src
+
+    def _make_old_layout(self, tmp_path, version="0.5.0"):
+        """Create the old .claude/worca/ project-local layout."""
+        old_worca = tmp_path / ".claude" / "worca"
+        old_worca.mkdir(parents=True)
+        (old_worca / "__init__.py").write_text(f'__version__ = "{version}"')
+        (old_worca / "claude_hooks").mkdir()
+        (old_worca / "claude_hooks" / "pre_tool_use.py").write_text("# hook")
+        return old_worca
+
+    def test_old_claude_worca_deleted_on_upgrade(self, tmp_path, monkeypatch):
+        """After --upgrade, .claude/worca/ is removed."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        (tmp_path / ".git").mkdir()
+
+        old_worca = self._make_old_layout(tmp_path)
+        self._make_src(tmp_path)
+
+        # settings.json with old shell-subshell hook pattern
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "PreToolUse": [{"hooks": [{"type": "command",
+                    "command": 'python3 "$(cd "$(git rev-parse --git-common-dir)/.." && pwd)/.claude/worca/claude_hooks/pre_tool_use.py"'}]}]
+            },
+            "worca": {"stages": {"plan": {"enabled": True}}},
+        }))
+
+        with patch("worca.cli.init._init_beads", return_value=False):
+            with patch("worca.cli.init._upgrade_beads", return_value=False):
+                run_init(upgrade=True, source=str(tmp_path / "worca-src"))
+
+        assert not old_worca.exists(), ".claude/worca/ must be deleted after upgrade"
+
+    def test_hooks_rewritten_to_absolute_pkg_path(self, tmp_path, monkeypatch):
+        """After --upgrade from old layout, hook commands use absolute pkg paths."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        (tmp_path / ".git").mkdir()
+
+        self._make_old_layout(tmp_path)
+        self._make_src(tmp_path)
+
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "PreToolUse": [{"hooks": [{"type": "command",
+                    "command": 'python3 "$(cd "$(git rev-parse --git-common-dir)/.." && pwd)/.claude/worca/claude_hooks/pre_tool_use.py"'}]}]
+            },
+            "worca": {"stages": {}},
+        }))
+
+        with patch("worca.cli.init._init_beads", return_value=False):
+            with patch("worca.cli.init._upgrade_beads", return_value=False):
+                run_init(upgrade=True, source=str(tmp_path / "worca-src"))
+
+        final = json.loads(settings.read_text(encoding="utf-8"))
+        raw = json.dumps(final)
+        assert ".claude/worca/" not in raw, "Old .claude/worca/ path must not remain in hook commands"
+        # Absolute path must point into the pkg dir
+        from worca.utils.paths import pkg_dir
+        pkg_hook_base = str(Path(pkg_dir()) / "worca" / "claude_hooks")
+        assert pkg_hook_base in raw, f"Expected absolute pkg path {pkg_hook_base!r} in settings"
+
+    def test_worca_config_extracted_to_projects_dir(self, tmp_path, monkeypatch):
+        """worca.* keys move to ~/.worca/projects/<slug>/config.json on --upgrade."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        (tmp_path / ".git").mkdir()
+
+        self._make_old_layout(tmp_path)
+        self._make_src(tmp_path)
+
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {},
+            "worca": {"stages": {"plan": {"enabled": True}}},
+        }))
+
+        with patch("worca.cli.init._init_beads", return_value=False):
+            with patch("worca.cli.init._upgrade_beads", return_value=False):
+                run_init(upgrade=True, source=str(tmp_path / "worca-src"))
+
+        from worca.utils.paths import project_config_dir
+        slug = tmp_path.name.lower()
+        config_path = Path(project_config_dir(slug)) / "config.json"
+        assert config_path.exists(), f"Expected {config_path} to exist"
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "worca" in data
+
+        # worca.* must be stripped from .claude/settings.json
+        final_settings = json.loads(settings.read_text(encoding="utf-8"))
+        assert "worca" not in final_settings
+
+    def test_registry_updated_with_new_fields(self, tmp_path, monkeypatch):
+        """Registry entry gains worcaConfigPath and worcaPkgVersion on --upgrade."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        (tmp_path / ".git").mkdir()
+
+        self._make_old_layout(tmp_path)
+        self._make_src(tmp_path)
+
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"hooks": {}, "worca": {"stages": {}}}))
+
+        # Pre-populate registry with old entry (missing worcaConfigPath / worcaPkgVersion)
+        projects_d = tmp_path / "wh" / "projects.d"
+        projects_d.mkdir(parents=True)
+        slug = tmp_path.name.lower()
+        old_entry = {
+            "name": slug,
+            "path": str(tmp_path),
+            "worcaDir": str(tmp_path / ".worca"),
+            "settingsPath": str(settings),
+        }
+        (projects_d / f"{slug}.json").write_text(json.dumps(old_entry))
+
+        fake_version = "0.6.0-abc1234"
+        with patch("worca.cli.init._init_beads", return_value=False):
+            with patch("worca.cli.init._upgrade_beads", return_value=False):
+                with patch("worca.utils.project_registry._get_pkg_version", return_value=fake_version):
+                    run_init(upgrade=True, source=str(tmp_path / "worca-src"))
+
+        entry = json.loads((projects_d / f"{slug}.json").read_text(encoding="utf-8"))
+        assert "worcaConfigPath" in entry, "Registry must have worcaConfigPath after upgrade"
+        assert "worcaPkgVersion" in entry, "Registry must have worcaPkgVersion after upgrade"
+        assert entry["worcaPkgVersion"] == fake_version

--- a/tests/test_cli_run_pipeline.py
+++ b/tests/test_cli_run_pipeline.py
@@ -26,24 +26,32 @@ class TestFindGitRoot:
 
 
 class TestRequireProjectWorca:
-    def test_returns_path_when_exists(self, tmp_path):
-        worca_dir = tmp_path / ".claude" / "worca"
-        worca_dir.mkdir(parents=True)
+    def test_returns_path_when_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        from worca.utils.paths import pkg_dir
+        from pathlib import Path
+        pkg_worca = Path(pkg_dir()) / "worca"
+        pkg_worca.mkdir(parents=True)
         result = _require_project_worca(tmp_path)
-        assert result == worca_dir
+        assert result == pkg_worca
 
-    def test_fails_when_missing(self, tmp_path):
+    def test_fails_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         with pytest.raises(SystemExit):
             _require_project_worca(tmp_path)
 
 
 class TestCmdRun:
     def test_run_builds_correct_command(self, tmp_path, monkeypatch):
-        """worca run delegates to project's run_pipeline.py."""
+        """worca run delegates to pkg scripts/run_pipeline.py in the shared pkg dir."""
         (tmp_path / ".git").mkdir()
-        (tmp_path / ".claude" / "worca" / "scripts").mkdir(parents=True)
-        (tmp_path / ".claude" / "worca" / "scripts" / "run_pipeline.py").write_text("")
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         monkeypatch.chdir(tmp_path)
+        from worca.utils.paths import pkg_dir
+        from pathlib import Path
+        pkg_scripts = Path(pkg_dir()) / "worca" / "scripts"
+        pkg_scripts.mkdir(parents=True)
+        (pkg_scripts / "run_pipeline.py").write_text("")
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
@@ -54,12 +62,19 @@ class TestCmdRun:
             assert exc_info.value.code == 0
             call_args = mock_run.call_args[0][0]
             assert "run_pipeline.py" in call_args[1]
+            assert str(pkg_scripts) in call_args[1], (
+                f"Script path {call_args[1]!r} should be under pkg dir {pkg_scripts}"
+            )
+            assert ".claude" not in call_args[1], (
+                "Script path must not reference old .claude/worca/scripts layout"
+            )
             assert "--prompt" in call_args
             assert "hello" in call_args
 
     def test_run_fails_without_worca(self, tmp_path, monkeypatch):
-        """worca run fails if .claude/worca/ doesn't exist."""
+        """worca run fails if pkg worca dir doesn't exist."""
         (tmp_path / ".git").mkdir()
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
         monkeypatch.chdir(tmp_path)
         from worca.cli.main import main
         with pytest.raises(SystemExit):
@@ -71,12 +86,15 @@ class TestCmdRunWorktree:
 
     def _scaffold(self, tmp_path, monkeypatch, *, with_worktree_script: bool = True):
         (tmp_path / ".git").mkdir()
-        scripts = tmp_path / ".claude" / "worca" / "scripts"
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        monkeypatch.chdir(tmp_path)
+        from worca.utils.paths import pkg_dir
+        from pathlib import Path
+        scripts = Path(pkg_dir()) / "worca" / "scripts"
         scripts.mkdir(parents=True)
         (scripts / "run_pipeline.py").write_text("")
         if with_worktree_script:
             (scripts / "run_worktree.py").write_text("")
-        monkeypatch.chdir(tmp_path)
 
     def test_worktree_dispatches_to_run_worktree_script(self, tmp_path, monkeypatch):
         """--worktree picks run_worktree.py when present and forwards core args."""
@@ -189,10 +207,13 @@ class TestForceTemplateChangeFlag:
 
     def _scaffold(self, tmp_path, monkeypatch):
         (tmp_path / ".git").mkdir()
-        scripts = tmp_path / ".claude" / "worca" / "scripts"
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+        monkeypatch.chdir(tmp_path)
+        from worca.utils.paths import pkg_dir
+        from pathlib import Path
+        scripts = Path(pkg_dir()) / "worca" / "scripts"
         scripts.mkdir(parents=True)
         (scripts / "run_pipeline.py").write_text("")
-        monkeypatch.chdir(tmp_path)
 
     def test_force_template_change_accepted_by_parser(self):
         from worca.cli.main import create_parser

--- a/tests/test_fleet_workspace_config_path.py
+++ b/tests/test_fleet_workspace_config_path.py
@@ -1,0 +1,253 @@
+"""Tests for WORCA_CONFIG_PATH propagation to fleet/workspace child runs (Phase 5).
+
+Covers:
+  - build_child_env (fleet) injects WORCA_CONFIG_PATH derived from child project dir
+  - _build_child_env (dag_executor) injects WORCA_CONFIG_PATH derived from child project dir
+  - WORCA_CONFIG_PATH is not inherited blindly from parent (re-derived per child)
+  - If no config.json exists for child, WORCA_CONFIG_PATH is not injected
+  - EventContext.__post_init__ reads webhook config via load_settings (which honours WORCA_CONFIG_PATH)
+"""
+import json
+import os
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Fleet: build_child_env propagates WORCA_CONFIG_PATH
+# ---------------------------------------------------------------------------
+
+
+class TestFleetBuildChildEnvConfigPath:
+    def test_injects_worca_config_path_when_config_exists(self, tmp_path, monkeypatch):
+        """build_child_env sets WORCA_CONFIG_PATH to child project's config.json."""
+        from worca.scripts.run_fleet import build_child_env
+
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+
+        # Simulate config.json existing for slug "my-project"
+        worca_home = tmp_path / ".worca"
+        config_dir = worca_home / "projects" / "my-project"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "config.json"
+        config_file.write_text('{"worca": {"webhooks": []}}')
+
+        monkeypatch.setenv("WORCA_HOME", str(worca_home))
+
+        base_env = {"PATH": "/usr/bin", "HOME": str(tmp_path)}
+        env = build_child_env(base_env, fleet_id="f_test", project_dir=str(project_dir))
+
+        assert "WORCA_CONFIG_PATH" in env
+        assert env["WORCA_CONFIG_PATH"] == str(config_file)
+
+    def test_does_not_inject_when_config_missing(self, tmp_path, monkeypatch):
+        """build_child_env does not set WORCA_CONFIG_PATH when config.json absent."""
+        from worca.scripts.run_fleet import build_child_env
+
+        project_dir = tmp_path / "no-config-project"
+        project_dir.mkdir()
+
+        worca_home = tmp_path / ".worca"
+        monkeypatch.setenv("WORCA_HOME", str(worca_home))
+
+        base_env = {"PATH": "/usr/bin"}
+        env = build_child_env(base_env, fleet_id="f_test", project_dir=str(project_dir))
+
+        assert "WORCA_CONFIG_PATH" not in env
+
+    def test_strips_parent_worca_config_path_and_re_derives(self, tmp_path, monkeypatch):
+        """Parent WORCA_CONFIG_PATH is scrubbed; child gets its own derived path."""
+        from worca.scripts.run_fleet import build_child_env
+
+        project_dir = tmp_path / "child-proj"
+        project_dir.mkdir()
+
+        worca_home = tmp_path / ".worca"
+        config_dir = worca_home / "projects" / "child-proj"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "config.json"
+        config_file.write_text("{}")
+
+        monkeypatch.setenv("WORCA_HOME", str(worca_home))
+
+        # Parent env has a different (stale) WORCA_CONFIG_PATH
+        base_env = {
+            "PATH": "/usr/bin",
+            "WORCA_CONFIG_PATH": "/old/parent/config.json",
+        }
+        env = build_child_env(base_env, fleet_id="f_test", project_dir=str(project_dir))
+
+        # Must be the child's own path, not the parent's stale one
+        assert env["WORCA_CONFIG_PATH"] == str(config_file)
+
+    def test_backward_compat_no_project_dir(self, tmp_path, monkeypatch):
+        """build_child_env without project_dir still works (no WORCA_CONFIG_PATH)."""
+        from worca.scripts.run_fleet import build_child_env
+
+        worca_home = tmp_path / ".worca"
+        monkeypatch.setenv("WORCA_HOME", str(worca_home))
+
+        base_env = {"PATH": "/usr/bin", "WORCA_FLEET_ID": "old"}
+        # project_dir=None should not crash and should not inject WORCA_CONFIG_PATH
+        env = build_child_env(base_env, fleet_id="f_test", project_dir=None)
+
+        assert "WORCA_CONFIG_PATH" not in env
+
+
+# ---------------------------------------------------------------------------
+# DagExecutor: _build_child_env propagates WORCA_CONFIG_PATH
+# ---------------------------------------------------------------------------
+
+
+class TestDagExecutorBuildChildEnvConfigPath:
+    def test_injects_worca_config_path_when_config_exists(self, tmp_path, monkeypatch):
+        """_build_child_env sets WORCA_CONFIG_PATH for workspace child project."""
+        from worca.workspace.dag_executor import _build_child_env
+
+        project_dir = tmp_path / "svc-alpha"
+        project_dir.mkdir()
+
+        worca_home = tmp_path / ".worca"
+        config_dir = worca_home / "projects" / "svc-alpha"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "config.json"
+        config_file.write_text('{"worca": {}}')
+
+        monkeypatch.setenv("WORCA_HOME", str(worca_home))
+
+        base_env = {"PATH": "/usr/bin"}
+        env = _build_child_env(
+            base_env,
+            workspace_id="ws_test",
+            workspace_name="my-ws",
+            project_dir=str(project_dir),
+        )
+
+        assert "WORCA_CONFIG_PATH" in env
+        assert env["WORCA_CONFIG_PATH"] == str(config_file)
+
+    def test_does_not_inject_when_config_missing(self, tmp_path, monkeypatch):
+        """_build_child_env does not set WORCA_CONFIG_PATH when config.json absent."""
+        from worca.workspace.dag_executor import _build_child_env
+
+        project_dir = tmp_path / "svc-beta"
+        project_dir.mkdir()
+
+        worca_home = tmp_path / ".worca"
+        monkeypatch.setenv("WORCA_HOME", str(worca_home))
+
+        base_env = {"PATH": "/usr/bin"}
+        env = _build_child_env(
+            base_env,
+            workspace_id="ws_test",
+            workspace_name="my-ws",
+            project_dir=str(project_dir),
+        )
+
+        assert "WORCA_CONFIG_PATH" not in env
+
+    def test_parent_config_path_not_inherited(self, tmp_path, monkeypatch):
+        """Parent WORCA_CONFIG_PATH is scrubbed; child gets its own derived path."""
+        from worca.workspace.dag_executor import _build_child_env
+
+        project_dir = tmp_path / "svc-gamma"
+        project_dir.mkdir()
+
+        worca_home = tmp_path / ".worca"
+        config_dir = worca_home / "projects" / "svc-gamma"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "config.json"
+        config_file.write_text("{}")
+
+        monkeypatch.setenv("WORCA_HOME", str(worca_home))
+
+        base_env = {
+            "PATH": "/usr/bin",
+            "WORCA_CONFIG_PATH": "/stale/parent/config.json",
+        }
+        env = _build_child_env(
+            base_env,
+            workspace_id="ws_test",
+            workspace_name="my-ws",
+            project_dir=str(project_dir),
+        )
+
+        assert env["WORCA_CONFIG_PATH"] == str(config_file)
+
+    def test_backward_compat_no_project_dir(self, tmp_path, monkeypatch):
+        """_build_child_env without project_dir still works."""
+        from worca.workspace.dag_executor import _build_child_env
+
+        worca_home = tmp_path / ".worca"
+        monkeypatch.setenv("WORCA_HOME", str(worca_home))
+
+        base_env = {"PATH": "/usr/bin"}
+        env = _build_child_env(
+            base_env,
+            workspace_id="ws_test",
+            workspace_name="my-ws",
+            project_dir=None,
+        )
+
+        assert "WORCA_CONFIG_PATH" not in env
+        assert env["WORCA_DEFER_PR"] == "1"
+        assert env["WORCA_WORKSPACE_ID"] == "ws_test"
+
+
+# ---------------------------------------------------------------------------
+# Emitter: EventContext reads webhook config via WORCA_CONFIG_PATH
+# ---------------------------------------------------------------------------
+
+
+class TestEmitterReadsFromWorcaConfigPath:
+    def test_event_context_picks_up_webhook_from_config_path(self, tmp_path, monkeypatch):
+        """EventContext reads webhook from WORCA_CONFIG_PATH when set."""
+        from worca.events.emitter import EventContext
+
+        # Write worca config with a webhook in it
+        worca_config = tmp_path / "config.json"
+        worca_config.write_text(json.dumps({
+            "worca": {
+                "webhooks": [
+                    {"url": "https://example.com/hook", "events": ["pipeline.*"]},
+                ]
+            }
+        }))
+
+        # Project settings has no webhook
+        project_settings = tmp_path / "settings.json"
+        project_settings.write_text(json.dumps({"worca": {}}))
+
+        monkeypatch.setenv("WORCA_CONFIG_PATH", str(worca_config))
+
+        events_path = str(tmp_path / "events.jsonl")
+        ctx = EventContext(
+            run_id="r-test",
+            branch="feat/test",
+            work_request={},
+            events_path=events_path,
+            settings_path=str(project_settings),
+        )
+
+        assert len(ctx._webhooks) == 1
+        assert ctx._webhooks[0]["url"] == "https://example.com/hook"
+
+    def test_event_context_no_webhook_without_config_path(self, tmp_path, monkeypatch):
+        """EventContext has no webhooks when neither settings nor config path has any."""
+        from worca.events.emitter import EventContext
+
+        project_settings = tmp_path / "settings.json"
+        project_settings.write_text(json.dumps({"worca": {}}))
+
+        monkeypatch.delenv("WORCA_CONFIG_PATH", raising=False)
+
+        events_path = str(tmp_path / "events.jsonl")
+        ctx = EventContext(
+            run_id="r-test",
+            branch="feat/test",
+            work_request={},
+            events_path=events_path,
+            settings_path=str(project_settings),
+        )
+
+        assert ctx._webhooks == []

--- a/tests/test_init_pkg_store.py
+++ b/tests/test_init_pkg_store.py
@@ -1,0 +1,164 @@
+"""Tests for Phase 1b: pkg-store-based copy target and absolute hook paths."""
+
+import os
+import shutil
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+class TestInitCreatesPkgInHome:
+    """test_init_creates_pkg_in_home: init copies to ~/.worca/pkg/<ver>/worca/."""
+
+    def test_copy_worca_source_writes_to_pkg_dir(self, tmp_path):
+        """_copy_worca_source writes worca/ under ~/.worca/pkg/<ver>/worca/."""
+        from worca.cli.init import _copy_worca_source
+
+        source = tmp_path / "src_worca"
+        source.mkdir()
+        (source / "__init__.py").write_text("__version__ = '0.59.0'\n")
+        (source / "claude_hooks").mkdir()
+        (source / "claude_hooks" / "pre_tool_use.py").write_text("# hook\n")
+
+        pkg_root = tmp_path / "pkg_root"
+        target = pkg_root / "worca"
+
+        _copy_worca_source(source, target)
+
+        assert (target / "__init__.py").exists()
+        assert (target / "claude_hooks" / "pre_tool_use.py").exists()
+
+    def test_copy_target_is_inside_pkg_dir(self, tmp_path, monkeypatch):
+        """The copy target lives at ~/.worca/pkg/<ver>/worca/, not .claude/worca/."""
+        import worca.utils.paths as paths_mod
+        import worca.utils.pkg_store as pkg_store_mod
+
+        monkeypatch.setattr(pkg_store_mod, "version_key", lambda: "0.59.0-a1b2c3d")
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "worca_home"))
+
+        pkg = paths_mod.pkg_dir()
+        assert pkg == str(tmp_path / "worca_home" / "pkg" / "0.59.0-a1b2c3d")
+        assert pkg.endswith("0.59.0-a1b2c3d")
+
+
+class TestInitIdempotentPkgExists:
+    """test_init_idempotent_pkg_exists: skip copy if pkg dir already exists."""
+
+    def test_idempotent_skip_when_pkg_worca_exists(self, tmp_path, capsys):
+        """_copy_worca_source skips copy and prints 'Package already exists' when pkg/worca/ present."""
+        from worca.cli.init import _copy_worca_source
+
+        source = tmp_path / "src_worca"
+        source.mkdir()
+        (source / "__init__.py").write_text("__version__ = '0.59.0'\n")
+        (source / "claude_hooks").mkdir()
+        (source / "claude_hooks" / "pre_tool_use.py").write_text("# hook\n")
+
+        pkg_root = tmp_path / "pkg_root"
+        target = pkg_root / "worca"
+        target.mkdir(parents=True)
+        sentinel = target / "sentinel.txt"
+        sentinel.write_text("original")
+
+        _copy_worca_source(source, target)
+
+        captured = capsys.readouterr()
+        assert "Package already exists" in captured.out
+        # Sentinel must survive — no overwrite occurred
+        assert sentinel.exists()
+
+    def test_fresh_copy_when_pkg_worca_absent(self, tmp_path, capsys):
+        """_copy_worca_source proceeds normally when pkg/worca/ does not exist."""
+        from worca.cli.init import _copy_worca_source
+
+        source = tmp_path / "src_worca"
+        source.mkdir()
+        (source / "__init__.py").write_text("__version__ = '0.59.0'\n")
+
+        target = tmp_path / "pkg_root" / "worca"
+        assert not target.exists()
+
+        _copy_worca_source(source, target)
+
+        assert (target / "__init__.py").exists()
+        captured = capsys.readouterr()
+        assert "Package already exists" not in captured.out
+
+
+class TestHookCommandUsesAbsolutePath:
+    """test_hook_command_uses_absolute_path: hook commands reference resolved absolute path."""
+
+    def _build_hook_cmd_tpl(self, pkg_base: str) -> str:
+        """Return the hook command template as init.py would produce it."""
+        hook_base = os.path.join(pkg_base, "worca", "claude_hooks")
+        return f"python3 {hook_base}/{{script}}"
+
+    def test_hook_cmd_no_dollar_home(self, tmp_path):
+        """Hook command must not contain $HOME."""
+        pkg_base = str(tmp_path / "pkg" / "0.59.0-a1b2c3d")
+        tpl = self._build_hook_cmd_tpl(pkg_base)
+        cmd = tpl.format(script="pre_tool_use.py")
+        assert "$HOME" not in cmd
+
+    def test_hook_cmd_no_subshell(self, tmp_path):
+        """Hook command must not contain shell subshell syntax $( ... )."""
+        pkg_base = str(tmp_path / "pkg" / "0.59.0-a1b2c3d")
+        tpl = self._build_hook_cmd_tpl(pkg_base)
+        cmd = tpl.format(script="pre_tool_use.py")
+        assert "$(" not in cmd
+
+    def test_hook_cmd_is_absolute(self, tmp_path):
+        """Hook command path must be absolute (starts with /)."""
+        pkg_base = str(tmp_path / "pkg" / "0.59.0-a1b2c3d")
+        tpl = self._build_hook_cmd_tpl(pkg_base)
+        cmd = tpl.format(script="pre_tool_use.py")
+        # Extract path — after 'python3 '
+        path_part = cmd.split("python3 ", 1)[1]
+        assert os.path.isabs(path_part), f"Path not absolute: {path_part}"
+
+    def test_hook_cmd_references_pkg_hooks(self, tmp_path):
+        """Hook command references the pkg/worca/claude_hooks/ directory."""
+        pkg_base = str(tmp_path / "pkg" / "0.59.0-a1b2c3d")
+        tpl = self._build_hook_cmd_tpl(pkg_base)
+        cmd = tpl.format(script="pre_tool_use.py")
+        assert "claude_hooks/pre_tool_use.py" in cmd
+        assert ".worca" in cmd or str(tmp_path) in cmd
+
+    def test_init_hook_cmd_tpl_uses_absolute_path(self, tmp_path, monkeypatch):
+        """The actual _hook_cmd_tpl in init.py references absolute pkg path."""
+        import importlib
+        import worca.utils.pkg_store as pkg_store_mod
+
+        monkeypatch.setattr(pkg_store_mod, "version_key", lambda: "0.59.0-a1b2c3d")
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "worca_home"))
+
+        # Reload init to pick up fresh env
+        import worca.cli.init as init_mod
+        importlib.reload(init_mod)
+
+        # _migrate_settings_paths uses _hook_cmd_tpl-like logic internally;
+        # verify via the exported function build_hook_command if it exists,
+        # or exercise the migrate path.
+        # Direct: call build_hook_cmd if present, else verify via settings merge.
+        if hasattr(init_mod, "build_hook_cmd"):
+            cmd = init_mod.build_hook_cmd("pre_tool_use.py")
+            assert "$HOME" not in cmd
+            assert "$(" not in cmd
+            assert "pre_tool_use.py" in cmd
+
+
+class TestRequireProjectWorca:
+    """test_require_project_worca: checks pkg path, not .claude/worca/."""
+
+    def test_require_project_worca_checks_pkg_path(self, tmp_path):
+        """_require_project_worca raises SystemExit when pkg path absent."""
+        from worca.cli.main import _require_project_worca
+        import pytest
+
+        # No .claude/worca/ AND no pkg path — should still fail
+        git_root = tmp_path / "myproject"
+        git_root.mkdir()
+
+        with pytest.raises(SystemExit):
+            _require_project_worca(git_root)

--- a/tests/test_pkg_store.py
+++ b/tests/test_pkg_store.py
@@ -1,0 +1,211 @@
+"""Tests for pkg_store.py — versioned package store utilities."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from worca.utils import pkg_store
+
+
+class TestVersionKeyFormat:
+    """test_version_key_format: semver + short hash computed correctly."""
+
+    def test_version_key_with_git_hash(self):
+        """Version key format: <semver>-<short-hash> when git available."""
+        with mock.patch("worca.utils.pkg_store._get_git_short_hash", return_value="a1b2c3d"):
+            with mock.patch("worca.utils.pkg_store._get_semver", return_value="0.59.0"):
+                key = pkg_store.version_key()
+        assert key == "0.59.0-a1b2c3d"
+
+    def test_version_key_without_git_hash(self):
+        """Version key omits hash suffix when git unavailable."""
+        with mock.patch("worca.utils.pkg_store._get_git_short_hash", return_value=None):
+            with mock.patch("worca.utils.pkg_store._get_semver", return_value="0.59.0"):
+                key = pkg_store.version_key()
+        assert key == "0.59.0"
+
+    def test_version_key_hash_length(self):
+        """Git short hash must be 7 characters."""
+        with mock.patch("worca.utils.pkg_store._get_git_short_hash", return_value="abc1234"):
+            with mock.patch("worca.utils.pkg_store._get_semver", return_value="1.0.0"):
+                key = pkg_store.version_key()
+        assert key == "1.0.0-abc1234"
+        parts = key.split("-")
+        assert len(parts[-1]) == 7
+
+    def test_get_semver_reads_from_init(self):
+        """_get_semver reads from worca.__version__."""
+        semver = pkg_store._get_semver()
+        import worca
+        assert semver == worca.__version__
+
+    def test_get_git_short_hash_returns_7_chars_or_none(self):
+        """_get_git_short_hash returns 7-char hex string or None."""
+        result = pkg_store._get_git_short_hash()
+        if result is not None:
+            assert len(result) == 7
+            assert all(c in "0123456789abcdef" for c in result)
+
+
+class TestPkgDir:
+    """Tests for pkg_dir() helper in paths.py."""
+
+    def test_pkg_dir_uses_version_key(self, tmp_path):
+        """pkg_dir() returns path under ~/.worca/pkg/<version_key>/."""
+        with mock.patch("worca.utils.paths.worca_home", return_value=str(tmp_path)):
+            with mock.patch("worca.utils.pkg_store.version_key", return_value="0.59.0-abc1234"):
+                from worca.utils import paths
+                result = paths.pkg_dir()
+        assert result == str(tmp_path / "pkg" / "0.59.0-abc1234")
+
+    def test_pkg_dir_with_explicit_version_key(self, tmp_path):
+        """pkg_dir(version_key=...) uses the given key."""
+        with mock.patch("worca.utils.paths.worca_home", return_value=str(tmp_path)):
+            from worca.utils import paths
+            result = paths.pkg_dir(version_key="1.2.3-deadbee")
+        assert result == str(tmp_path / "pkg" / "1.2.3-deadbee")
+
+    def test_pkg_dir_resolves_every_call(self, tmp_path, monkeypatch):
+        """pkg_dir() resolves worca_home on each call (no module-level constant)."""
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "a"))
+        from worca.utils import paths
+        r1 = paths.pkg_dir(version_key="0.1.0")
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "b"))
+        r2 = paths.pkg_dir(version_key="0.1.0")
+        assert r1 != r2
+
+
+class TestProjectConfigDir:
+    """Tests for project_config_dir() helper in paths.py."""
+
+    def test_project_config_dir_path(self, tmp_path):
+        """project_config_dir(slug) returns ~/.worca/projects/<slug>/."""
+        with mock.patch("worca.utils.paths.worca_home", return_value=str(tmp_path)):
+            from worca.utils import paths
+            result = paths.project_config_dir("my-project")
+        assert result == str(tmp_path / "projects" / "my-project")
+
+    def test_project_config_dir_resolves_every_call(self, tmp_path, monkeypatch):
+        """project_config_dir() re-reads env on each call."""
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "x"))
+        from worca.utils import paths
+        r1 = paths.project_config_dir("proj")
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path / "y"))
+        r2 = paths.project_config_dir("proj")
+        assert r1 != r2
+
+
+class TestGCRemovesUnreferencedVersions:
+    """test_gc_removes_unreferenced_versions: orphan pkg dirs are deleted."""
+
+    def _make_pkg_store(self, tmp_path, versions):
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir(parents=True)
+        for v in versions:
+            (pkg_dir / v).mkdir()
+        return pkg_dir
+
+    def _make_projects_d(self, tmp_path, referenced_versions):
+        projects_d = tmp_path / "projects.d"
+        projects_d.mkdir(parents=True)
+        for i, ver in enumerate(referenced_versions):
+            entry = {"name": f"proj{i}", "path": f"/proj{i}", "worcaPkgVersion": ver}
+            (projects_d / f"proj{i}.json").write_text(
+                __import__("json").dumps(entry), encoding="utf-8"
+            )
+        return projects_d
+
+    def test_gc_removes_unreferenced_versions(self, tmp_path, monkeypatch):
+        """GC deletes pkg dirs not referenced by any projects.d entry."""
+        import json
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path))
+        pkg_dir = self._make_pkg_store(tmp_path, ["0.59.0-aaa1111", "0.58.0-bbb2222"])
+        self._make_projects_d(tmp_path, ["0.59.0-aaa1111"])  # 0.58.0 is orphan
+
+        result = pkg_store.gc_pkg_store(dry_run=False)
+
+        assert not (pkg_dir / "0.58.0-bbb2222").exists()
+        assert (pkg_dir / "0.59.0-aaa1111").exists()
+        assert "0.58.0-bbb2222" in result["removed"]
+
+    def test_gc_keeps_referenced_versions(self, tmp_path, monkeypatch):
+        """GC does not delete pkg dirs that are referenced by any project."""
+        import json
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path))
+        pkg_dir = self._make_pkg_store(tmp_path, ["0.59.0-aaa1111", "0.60.0-ccc3333"])
+        self._make_projects_d(tmp_path, ["0.59.0-aaa1111", "0.60.0-ccc3333"])
+
+        result = pkg_store.gc_pkg_store(dry_run=False)
+
+        assert (pkg_dir / "0.59.0-aaa1111").exists()
+        assert (pkg_dir / "0.60.0-ccc3333").exists()
+        assert result["removed"] == []
+
+    def test_gc_skips_running_pipeline_versions(self, tmp_path, monkeypatch):
+        """GC must not remove pkg versions referenced by a running pipeline."""
+        import json
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path))
+        # 0.58.0 is unreferenced by registry, but a running pipeline uses it
+        pkg_dir = self._make_pkg_store(tmp_path, ["0.59.0-aaa1111", "0.58.0-bbb2222"])
+        # projects.d only references 0.59.0
+        self._make_projects_d(tmp_path, ["0.59.0-aaa1111"])
+
+        # Simulate a running pipeline in a project that uses 0.58.0
+        proj_dir = tmp_path / "myproject"
+        proj_dir.mkdir()
+        pipelines_d = proj_dir / ".worca" / "multi" / "pipelines.d"
+        pipelines_d.mkdir(parents=True)
+        pipeline_entry = {
+            "run_id": "run-001",
+            "status": "running",
+            "worcaPkgVersion": "0.58.0-bbb2222",
+        }
+        (pipelines_d / "run-001.json").write_text(json.dumps(pipeline_entry))
+
+        # Register that project so GC scans it
+        projects_d = tmp_path / "projects.d"
+        proj_reg = {
+            "name": "myproject",
+            "path": str(proj_dir),
+            "worcaDir": str(proj_dir / ".worca"),
+            "worcaPkgVersion": "0.59.0-aaa1111",
+        }
+        (projects_d / "myproject.json").write_text(json.dumps(proj_reg))
+
+        result = pkg_store.gc_pkg_store(dry_run=False)
+
+        # 0.58.0 must be preserved because of the running pipeline
+        assert (pkg_dir / "0.58.0-bbb2222").exists()
+        assert "0.58.0-bbb2222" not in result["removed"]
+
+    def test_gc_dry_run(self, tmp_path, monkeypatch):
+        """GC dry_run lists orphans but does not delete anything."""
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path))
+        pkg_dir = self._make_pkg_store(tmp_path, ["0.59.0-aaa1111", "0.58.0-bbb2222"])
+        self._make_projects_d(tmp_path, ["0.59.0-aaa1111"])
+
+        result = pkg_store.gc_pkg_store(dry_run=True)
+
+        # Directory must still exist
+        assert (pkg_dir / "0.58.0-bbb2222").exists()
+        assert "0.58.0-bbb2222" in result["would_remove"]
+        assert result["removed"] == []
+
+    def test_gc_keep_latest_n(self, tmp_path, monkeypatch):
+        """GC keep_latest=N preserves the N most recent pkg dirs regardless of references."""
+        import json
+        monkeypatch.setenv("WORCA_HOME", str(tmp_path))
+        # Alphabetically sorted: older versions come first
+        versions = ["0.57.0-aaa0000", "0.58.0-bbb1111", "0.59.0-ccc2222"]
+        pkg_dir = self._make_pkg_store(tmp_path, versions)
+        self._make_projects_d(tmp_path, [])  # nothing referenced
+
+        result = pkg_store.gc_pkg_store(dry_run=False, keep_latest=2)
+
+        # The 2 most recent (by sorted order) must survive
+        assert (pkg_dir / "0.58.0-bbb1111").exists()
+        assert (pkg_dir / "0.59.0-ccc2222").exists()
+        # The oldest is removed
+        assert not (pkg_dir / "0.57.0-aaa0000").exists()
+        assert "0.57.0-aaa0000" in result["removed"]

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -97,12 +97,13 @@ class TestCheckSettingsJson:
         assert status == "fail"
         assert "invalid" in msg.lower()
 
-    def test_fail_when_missing_worca_key(self, tmp_path):
+    def test_pass_when_missing_worca_key(self, tmp_path):
+        # W-077: worca config moved to ~/.worca/projects/<slug>/config.json,
+        # so settings.json without 'worca' key is now valid.
         settings_file = tmp_path / "settings.json"
         settings_file.write_text(json.dumps({"other": "data"}))
-        status, msg = preflight_checks.check_settings_json(settings_path=str(settings_file))
-        assert status == "fail"
-        assert "worca" in msg.lower()
+        status, _ = preflight_checks.check_settings_json(settings_path=str(settings_file))
+        assert status == "pass"
 
 
 # --- check_agent_templates ---

--- a/tests/test_project_registry.py
+++ b/tests/test_project_registry.py
@@ -5,6 +5,7 @@ import os
 from unittest.mock import patch
 
 from worca.utils.project_registry import auto_register_project, slugify
+from worca.utils.paths import worca_home
 
 
 # ---------------------------------------------------------------------------
@@ -109,3 +110,22 @@ class TestAutoRegisterProject:
             assert final_dst.endswith("my-app.json")
             # The source should have been a .tmp file in the same directory
             assert tmp_src.endswith(".tmp")
+
+    def test_registry_extended_fields(self, tmp_path):
+        """Registry entries include worcaConfigPath and worcaPkgVersion."""
+        prefs = tmp_path / "prefs"
+        project = tmp_path / "my-app"
+        project.mkdir()
+
+        fake_version = "0.59.0-abc1234"
+        with patch("worca.utils.project_registry._get_pkg_version", return_value=fake_version):
+            auto_register_project(str(project), prefs_dir=str(prefs))
+
+        entry_path = prefs / "projects.d" / "my-app.json"
+        data = json.loads(entry_path.read_text())
+        abs_project = str(project.resolve())
+        slug = "my-app"
+
+        expected_config_path = os.path.join(str(prefs), "projects", slug, "config.json")
+        assert data["worcaConfigPath"] == expected_config_path
+        assert data["worcaPkgVersion"] == fake_version

--- a/tests/test_run_fleet.py
+++ b/tests/test_run_fleet.py
@@ -57,6 +57,14 @@ class TestCreateParser:
         args = self._parse(["--projects", "/repo/a"])
         assert args.source is None
 
+    def test_spec_flag(self):
+        args = self._parse(["--projects", "/repo/a", "--spec", "docs/spec.md"])
+        assert args.spec == "docs/spec.md"
+
+    def test_spec_absent_by_default(self):
+        args = self._parse(["--projects", "/repo/a"])
+        assert args.spec is None
+
     # --- branch flags (§4 semantics) ---
 
     def test_head_template_flag(self):
@@ -1037,3 +1045,50 @@ class TestClaudeMdModeFleet:
         mock_dispatch.assert_called_once()
         call_kwargs = mock_dispatch.call_args[1]
         assert call_kwargs["claude_md_mode"] is None
+
+
+# ---- --spec passthrough -------------------------------------------------------
+
+class TestSpecFleet:
+    """--spec is parsed, validated, and forwarded to build_child_cmd."""
+
+    def _parse(self, argv):
+        from worca.scripts.run_fleet import create_parser
+        return create_parser().parse_args(argv)
+
+    def test_build_child_cmd_includes_spec(self):
+        from worca.scripts.run_fleet import build_child_cmd
+        cmd = build_child_cmd(
+            project_dir="/p",
+            fleet_id="f-001",
+            spec="docs/spec.md",
+        )
+        assert "--spec" in cmd and "docs/spec.md" in cmd
+        assert "--source" not in cmd
+        assert "--prompt" not in cmd
+
+    def test_build_child_cmd_spec_with_prompt(self):
+        from worca.scripts.run_fleet import build_child_cmd
+        cmd = build_child_cmd(
+            project_dir="/p",
+            fleet_id="f-001",
+            spec="docs/spec.md",
+            prompt="focus on auth",
+        )
+        assert "--spec" in cmd and "docs/spec.md" in cmd
+        assert "--prompt" in cmd and "focus on auth" in cmd
+
+    def test_build_child_cmd_omits_spec_when_none(self):
+        from worca.scripts.run_fleet import build_child_cmd
+        cmd = build_child_cmd(
+            project_dir="/p",
+            fleet_id="f-001",
+            prompt="x",
+            spec=None,
+        )
+        assert "--spec" not in cmd
+
+    def test_spec_and_source_rejected(self):
+        from worca.scripts.run_fleet import main
+        rc = main(["--projects", "/repo/a", "--spec", "s.md", "--source", "gh:issue:1"])
+        assert rc == 2

--- a/tests/test_run_worktree.py
+++ b/tests/test_run_worktree.py
@@ -71,6 +71,29 @@ class TestCreateParser:
         args = create_parser().parse_args(["--prompt", "x", "--plan", "docs/plans/W-048.md"])
         assert args.plan == "docs/plans/W-048.md"
 
+    def test_spec_flag(self):
+        from worca.scripts.run_worktree import create_parser
+        args = create_parser().parse_args(["--spec", "docs/spec.md"])
+        assert args.spec == "docs/spec.md"
+
+    def test_spec_with_prompt(self):
+        from worca.scripts.run_worktree import create_parser
+        args = create_parser().parse_args(["--spec", "docs/spec.md", "--prompt", "focus on auth"])
+        assert args.spec == "docs/spec.md"
+        assert args.prompt == "focus on auth"
+
+    def test_requires_at_least_one_input(self):
+        from worca.scripts.run_worktree import main
+        assert main(["--plan", "p.md"]) == 2
+
+    def test_spec_file_not_found(self):
+        from worca.scripts.run_worktree import main
+        assert main(["--spec", "/nonexistent/spec.md"]) == 2
+
+    def test_plan_file_not_found(self):
+        from worca.scripts.run_worktree import main
+        assert main(["--plan", "/nonexistent/plan.md", "--prompt", "x"]) == 2
+
 
 class TestBuildPipelineCmd:
     """Direct tests for _build_pipeline_cmd — pure-function, no Popen mock."""
@@ -129,6 +152,29 @@ class TestBuildPipelineCmd:
         from worca.scripts.run_worktree import _build_pipeline_cmd
         cmd = _build_pipeline_cmd(self._parse(["--prompt", "x"]))
         assert "--run-id" not in cmd
+
+    def test_spec_forwarded(self):
+        from worca.scripts.run_worktree import _build_pipeline_cmd
+        cmd = _build_pipeline_cmd(self._parse(["--spec", "docs/spec.md"]))
+        assert "--spec" in cmd and "docs/spec.md" in cmd
+        assert "--source" not in cmd
+        assert "--prompt" not in cmd
+
+    def test_spec_with_prompt_forwards_both(self):
+        from worca.scripts.run_worktree import _build_pipeline_cmd
+        cmd = _build_pipeline_cmd(self._parse(["--spec", "docs/spec.md", "--prompt", "focus"]))
+        assert "--spec" in cmd and "docs/spec.md" in cmd
+        assert "--prompt" in cmd and "focus" in cmd
+
+    def test_spec_with_plan_forwards_both(self):
+        from worca.scripts.run_worktree import _build_pipeline_cmd
+        cmd = _build_pipeline_cmd(self._parse(["--spec", "docs/spec.md", "--plan", "p.md"]))
+        assert "--spec" in cmd and "docs/spec.md" in cmd
+        assert "--plan" in cmd and "p.md" in cmd
+
+    def test_spec_and_source_rejected(self):
+        from worca.scripts.run_worktree import main
+        assert main(["--spec", "docs/spec.md", "--source", "gh:issue:42"]) == 2
 
 
 class TestHelpers:

--- a/tests/test_run_worktree.py
+++ b/tests/test_run_worktree.py
@@ -223,6 +223,9 @@ def _patches(worktree_path=_WORKTREE_PATH):
     True and detect_default_branch defaults to "main", which preserves the
     legacy "main" fallback expected by callers that don't configure
     default_base_branch in settings.
+
+    plist[11]: stubs _get_git_short_hash so version_key() never spawns a
+    real git subprocess — pkg_dir() must remain side-effect-free under W-077.
     """
     return [
         patch("worca.scripts.run_worktree._generate_run_id", return_value=_RUN_ID),
@@ -242,6 +245,9 @@ def _patches(worktree_path=_WORKTREE_PATH):
             "worca.scripts.run_worktree._await_pipeline_startup",
             return_value=True,
         ),
+        # plist[11]: prevent validate_runtime() / _resolve_pipeline_script() from
+        # spawning a real git subprocess to compute version_key() (W-077 pkg store).
+        patch("worca.utils.pkg_store._get_git_short_hash", return_value=None),
     ]
 
 
@@ -251,7 +257,7 @@ class TestCreatesWorktree:
         from unittest.mock import patch as _patch
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              _patch("worca.scripts.run_worktree.load_settings",
                     return_value={"worca": {"parallel": {}}}):
             mock_norm.return_value = _wr("Add auth")
@@ -265,7 +271,7 @@ class TestCreatesWorktree:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
         assert rc == 0
@@ -286,7 +292,7 @@ class TestCreatesWorktree:
         )
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              _patch("worca.scripts.run_worktree.load_settings",
                     return_value={"worca": {"parallel": {"worktree_base_dir": "~/wt-foo"}}}):
             mock_norm.return_value = _wr("Add auth")
@@ -298,7 +304,7 @@ class TestCreatesWorktree:
         from worca.scripts.run_worktree import main
         plist = _patches(worktree_path="")
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 1
@@ -311,7 +317,7 @@ class TestRegistersInPipelinesD:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -328,7 +334,7 @@ class TestFleetIdPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--fleet-id", "fleet-xyz"])
         assert rc == 0
@@ -339,7 +345,7 @@ class TestFleetIdPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -350,7 +356,7 @@ class TestFleetIdPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--fleet-id", "fleet-xyz"])
         assert rc == 0
@@ -361,7 +367,7 @@ class TestFleetIdPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -374,7 +380,7 @@ class TestTargetBranchPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
         assert rc == 0
@@ -385,7 +391,7 @@ class TestTargetBranchPassthrough:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -399,7 +405,7 @@ class TestGuidePassthrough:
         guide = str(tmp_path / "spec.md")
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--guide", guide])
         assert rc == 0
@@ -414,7 +420,7 @@ class TestGuidePassthrough:
         g2 = str(tmp_path / "spec2.md")
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--guide", g1, "--guide", g2])
         assert rc == 0
@@ -427,7 +433,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -446,7 +452,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -457,7 +463,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -468,7 +474,7 @@ class TestSpawnsDetached:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
         assert rc == 0
@@ -591,7 +597,7 @@ class TestDefaultBaseBranch:
         plist = _patches()
         settings = {"worca": {"parallel": {"default_base_branch": "develop"}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
@@ -609,7 +615,7 @@ class TestDefaultBaseBranch:
         plist = _patches()
         settings = {"worca": {"parallel": {}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth"])
@@ -626,7 +632,7 @@ class TestDefaultBaseBranch:
         plist = _patches()
         settings = {"worca": {"parallel": {"default_base_branch": "develop"}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
             mock_norm.return_value = _wr("Add auth")
             rc = main(["--prompt", "Add auth", "--branch", "feature/auth"])
@@ -650,7 +656,7 @@ class TestDefaultBaseBranch:
         # "master" as the actual repo default.
         settings = {"worca": {"parallel": {"default_base_branch": "main"}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[10], plist[11], \
              _patch("worca.scripts.run_worktree.branch_exists", return_value=False), \
              _patch("worca.scripts.run_worktree.detect_default_branch", return_value="master"), \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
@@ -674,7 +680,7 @@ class TestDefaultBaseBranch:
         plist = _patches()
         settings = {"worca": {"parallel": {}}}
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[10], plist[11], \
              _patch("worca.scripts.run_worktree.branch_exists", return_value=False), \
              _patch("worca.scripts.run_worktree.detect_default_branch", return_value="master"), \
              _patch("worca.scripts.run_worktree.load_settings", return_value=settings):
@@ -730,7 +736,7 @@ class TestMissingWorcaRuntime:
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
              plist[3], plist[4] as mock_reg, \
              patch("worca.utils.runtime.os.path.isdir", return_value=False), \
-             plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10]:
+             plist[6] as mock_popen, plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _wr("Add auth")
             with pytest.raises(SystemExit) as exc_info:
                 main(["--prompt", "Add auth"])
@@ -833,7 +839,7 @@ class TestGithubPrSource:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10]:
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11]:
             mock_norm.return_value = _pr_wr()
             rc = main(["--source", "gh:pr:42", "--branch", "feature/other"])
         assert rc == 2
@@ -845,7 +851,7 @@ class TestGithubPrSource:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              patch("worca.scripts.run_worktree.find_worktree_for_branch", return_value=""), \
              patch("worca.scripts.run_worktree.checkout_pr_worktree", return_value=_WORKTREE_PATH), \
              patch("worca.scripts.run_worktree.load_settings",
@@ -863,7 +869,7 @@ class TestGithubPrSource:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4], plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              patch("worca.scripts.run_worktree.find_worktree_for_branch", return_value=""), \
              patch("worca.scripts.run_worktree.checkout_pr_worktree", return_value=_WORKTREE_PATH) as mock_checkout, \
              patch("worca.scripts.run_worktree.load_settings",
@@ -879,7 +885,7 @@ class TestGithubPrSource:
         from worca.scripts.run_worktree import main
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              patch("worca.scripts.run_worktree.find_worktree_for_branch", return_value=""), \
              patch("worca.scripts.run_worktree.checkout_pr_worktree", return_value=_WORKTREE_PATH), \
              patch("worca.scripts.run_worktree.load_settings",
@@ -897,7 +903,7 @@ class TestGithubPrSource:
         existing = "/tmp/wt/pipeline-original"
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2] as mock_create, \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              patch("worca.scripts.run_worktree.find_worktree_for_branch", return_value=existing), \
              patch("worca.scripts.run_worktree._worktree_pipeline_is_live", return_value=False), \
              patch("worca.scripts.run_worktree.checkout_pr_worktree") as mock_checkout, \
@@ -920,7 +926,7 @@ class TestGithubPrSource:
         existing = "/tmp/wt/pipeline-original"
         plist = _patches()
         with plist[0], plist[1] as mock_norm, plist[2], \
-             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], \
+             plist[3], plist[4] as mock_reg, plist[5], plist[6], plist[7], plist[8], plist[9], plist[10], plist[11], \
              patch("worca.scripts.run_worktree.find_worktree_for_branch", return_value=existing), \
              patch("worca.scripts.run_worktree._worktree_pipeline_is_live", return_value=True), \
              patch("worca.scripts.run_worktree.checkout_pr_worktree") as mock_checkout, \

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -429,7 +429,11 @@ def test_schema_path_project_tier(tmp_path, monkeypatch):
         ".claude", "schemas", "docs_audit.json"
     )
     # names with no project-tier file keep resolving to the shipped dir
-    assert _schema_path("plan.json") == ".claude/worca/schemas/plan.json"
+    # W-077: shipped dir may be in pkg store or legacy .claude/worca/
+    plan_path = _schema_path("plan.json")
+    assert plan_path.endswith(os.path.join("schemas", "plan.json")), (
+        f"plan.json should resolve to a schemas/ dir: {plan_path!r}"
+    )
 
 
 # --- plan_file support ---

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4,8 +4,24 @@ import os
 import pytest
 
 
-def test_validate_runtime_success(tmp_path, monkeypatch):
-    """validate_runtime is a no-op when .claude/worca/ exists."""
+def test_validate_runtime_success_via_pkg_store(tmp_path, monkeypatch):
+    """validate_runtime passes when the shared pkg store worca/ dir exists (W-077)."""
+    monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))
+    monkeypatch.chdir(tmp_path)
+    from worca.utils.paths import pkg_dir
+    from pathlib import Path
+
+    pkg_worca = Path(pkg_dir()) / "worca"
+    pkg_worca.mkdir(parents=True)
+
+    from worca.utils.runtime import validate_runtime
+
+    validate_runtime()  # must not raise
+
+
+def test_validate_runtime_success_legacy_claude_worca(tmp_path, monkeypatch):
+    """validate_runtime still passes when the legacy .claude/worca/ dir exists."""
+    monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))  # empty pkg store
     (tmp_path / ".claude" / "worca").mkdir(parents=True)
     monkeypatch.chdir(tmp_path)
 
@@ -15,7 +31,8 @@ def test_validate_runtime_success(tmp_path, monkeypatch):
 
 
 def test_validate_runtime_missing_raises_systemexit(tmp_path, monkeypatch):
-    """validate_runtime raises SystemExit(1) when .claude/worca/ is absent."""
+    """validate_runtime raises SystemExit(1) when neither pkg store nor .claude/worca/ exists."""
+    monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))  # empty pkg store
     monkeypatch.chdir(tmp_path)
 
     from worca.utils.runtime import validate_runtime
@@ -27,6 +44,7 @@ def test_validate_runtime_missing_raises_systemexit(tmp_path, monkeypatch):
 
 def test_validate_runtime_error_message_on_stderr(tmp_path, monkeypatch, capsys):
     """The error message names the missing path and the fix command."""
+    monkeypatch.setenv("WORCA_HOME", str(tmp_path / "wh"))  # empty pkg store
     monkeypatch.chdir(tmp_path)
 
     from worca.utils.runtime import validate_runtime

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -643,6 +643,63 @@ class TestEffortSettings:
         assert result["worca"]["fleet"]["max_parallel"] == 5
 
 
+class TestLoadSettingsReadsWorcaConfigPath:
+    """test_load_settings_reads_worca_config_path: WORCA_CONFIG_PATH env var respected."""
+
+    def test_worca_config_path_merged_as_base(self, tmp_path, monkeypatch):
+        """When WORCA_CONFIG_PATH is set, its content is the base layer for worca.*."""
+        from worca.utils.settings import load_settings
+
+        worca_config = tmp_path / "config.json"
+        worca_config.write_text(json.dumps({"worca": {"stages": {"plan": {"enabled": False}}}}))
+
+        project_settings = tmp_path / "settings.json"
+        project_settings.write_text(json.dumps({"worca": {"agents": {"planner": {"model": "sonnet"}}}}))
+
+        monkeypatch.setenv("WORCA_CONFIG_PATH", str(worca_config))
+
+        result = load_settings(str(project_settings))
+        assert result["worca"]["stages"]["plan"]["enabled"] is False
+        assert result["worca"]["agents"]["planner"]["model"] == "sonnet"
+
+    def test_worca_config_path_overridden_by_project_settings(self, tmp_path, monkeypatch):
+        """Project settings worca.* values override WORCA_CONFIG_PATH values."""
+        from worca.utils.settings import load_settings
+
+        worca_config = tmp_path / "config.json"
+        worca_config.write_text(json.dumps({"worca": {"loops": {"implement_test": 3}}}))
+
+        project_settings = tmp_path / "settings.json"
+        project_settings.write_text(json.dumps({"worca": {"loops": {"implement_test": 7}}}))
+
+        monkeypatch.setenv("WORCA_CONFIG_PATH", str(worca_config))
+
+        result = load_settings(str(project_settings))
+        assert result["worca"]["loops"]["implement_test"] == 7
+
+    def test_no_worca_config_path_unchanged(self, tmp_path, monkeypatch):
+        """Without WORCA_CONFIG_PATH, load_settings behaves as before."""
+        from worca.utils.settings import load_settings
+
+        monkeypatch.delenv("WORCA_CONFIG_PATH", raising=False)
+        project_settings = tmp_path / "settings.json"
+        project_settings.write_text(json.dumps({"worca": {"loops": {"implement_test": 5}}}))
+
+        result = load_settings(str(project_settings))
+        assert result["worca"]["loops"]["implement_test"] == 5
+
+    def test_missing_worca_config_file_tolerated(self, tmp_path, monkeypatch):
+        """If WORCA_CONFIG_PATH points to a non-existent file, load_settings falls back gracefully."""
+        from worca.utils.settings import load_settings
+
+        monkeypatch.setenv("WORCA_CONFIG_PATH", str(tmp_path / "nonexistent.json"))
+        project_settings = tmp_path / "settings.json"
+        project_settings.write_text(json.dumps({"worca": {"loops": {"implement_test": 5}}}))
+
+        result = load_settings(str(project_settings))
+        assert result["worca"]["loops"]["implement_test"] == 5
+
+
 class TestNormalizeModelEntryColonRejection:
     """Colon-in-alias guard on normalize_model_entry."""
 

--- a/worca-ui/package-lock.json
+++ b/worca-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worca/ui",
-  "version": "0.50.0",
+  "version": "0.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worca/ui",
-      "version": "0.50.0",
+      "version": "0.52.0",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.20.1",

--- a/worca-ui/server/app.js
+++ b/worca-ui/server/app.js
@@ -690,7 +690,7 @@ export function createApp(options = {}) {
         .json({ ok: false, error: `directory does not exist: ${dirPath}` });
     }
     try {
-      const subfolders = await scanDirectory(dirPath);
+      const subfolders = await scanDirectory(dirPath, prefsDir);
       res.json({ ok: true, subfolders });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
@@ -1236,11 +1236,28 @@ export function createApp(options = {}) {
       const proj = readProjects(prefsDir).find((p) => p.name === projectId);
       if (proj) {
         projectSettingsPath =
-          proj.settingsPath || join(proj.path, '.claude', 'settings.json');
+          proj.worcaConfigPath ||
+          proj.settingsPath ||
+          join(proj.path, '.claude', 'settings.json');
         root = proj.path;
       }
-    } else if (!projectSettingsPath && projectRoot) {
-      projectSettingsPath = join(projectRoot, '.claude', 'settings.json');
+    } else if (projectRoot) {
+      const slug = basename(projectRoot)
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 64);
+      const configPath = join(
+        homedir(),
+        '.worca',
+        'projects',
+        slug,
+        'config.json',
+      );
+      projectSettingsPath = existsSync(configPath)
+        ? configPath
+        : settingsPath || join(projectRoot, '.claude', 'settings.json');
     }
 
     return {
@@ -1379,11 +1396,28 @@ export function createApp(options = {}) {
       const proj = readProjects(prefsDir).find((p) => p.name === projectId);
       if (proj) {
         projectSettingsPath =
-          proj.settingsPath || join(proj.path, '.claude', 'settings.json');
+          proj.worcaConfigPath ||
+          proj.settingsPath ||
+          join(proj.path, '.claude', 'settings.json');
         root = proj.path;
       }
-    } else if (!projectSettingsPath && projectRoot) {
-      projectSettingsPath = join(projectRoot, '.claude', 'settings.json');
+    } else if (projectRoot) {
+      const slug = basename(projectRoot)
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 64);
+      const configPath = join(
+        homedir(),
+        '.worca',
+        'projects',
+        slug,
+        'config.json',
+      );
+      projectSettingsPath = existsSync(configPath)
+        ? configPath
+        : settingsPath || join(projectRoot, '.claude', 'settings.json');
     }
 
     return {

--- a/worca-ui/server/project-registry.js
+++ b/worca-ui/server/project-registry.js
@@ -7,10 +7,12 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { readdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { basename, isAbsolute, join } from 'node:path';
 import { checkWorcaInstalled, readProjectWorcaVersion } from './worca-setup.js';
 
@@ -108,7 +110,7 @@ export function writeProject(prefsDir, entry) {
 }
 
 /**
- * Remove a project entry. No-op if missing.
+ * Remove a project entry and its config directory. No-op if missing.
  */
 export function removeProject(prefsDir, name) {
   const filePath = join(prefsDir, 'projects.d', `${name}.json`);
@@ -116,6 +118,12 @@ export function removeProject(prefsDir, name) {
     unlinkSync(filePath);
   } catch {
     // no-op if missing
+  }
+  const configDir = join(prefsDir, 'projects', name);
+  try {
+    rmSync(configDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
   }
 }
 
@@ -125,11 +133,14 @@ export function removeProject(prefsDir, name) {
  */
 export function synthesizeDefaultProject(projectRoot) {
   const name = basename(projectRoot);
+  const slug = slugify(name);
   return {
     name,
     path: projectRoot,
     worcaDir: join(projectRoot, '.worca'),
     settingsPath: join(projectRoot, '.claude', 'settings.json'),
+    worcaConfigPath: join(homedir(), '.worca', 'projects', slug, 'config.json'),
+    worcaPkgVersion: null,
   };
 }
 
@@ -143,7 +154,7 @@ const SCAN_MAX_RESULTS = 200;
  * @param {string} dirPath - Absolute path to the parent directory
  * @returns {Promise<{ name: string, path: string }[]>}
  */
-export async function scanDirectory(dirPath) {
+export async function scanDirectory(dirPath, prefsDir) {
   const entries = await readdir(dirPath, { withFileTypes: true });
   const results = [];
   for (const entry of entries) {
@@ -151,7 +162,11 @@ export async function scanDirectory(dirPath) {
     if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
     const childPath = join(dirPath, entry.name);
     if (existsSync(join(childPath, '.git'))) {
-      const installed = checkWorcaInstalled(childPath);
+      const slug = slugify(entry.name);
+      const worcaConfigPath = prefsDir
+        ? join(prefsDir, 'projects', slug, 'config.json')
+        : undefined;
+      const installed = checkWorcaInstalled(childPath, worcaConfigPath);
       const worcaVersion = installed
         ? readProjectWorcaVersion(childPath)
         : null;

--- a/worca-ui/server/project-routes-setup-preflight.test.js
+++ b/worca-ui/server/project-routes-setup-preflight.test.js
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const { createProjectRoutes, createProjectScopedRoutes, projectResolver } =
   await import('./project-routes.js');
+const { writeProject } = await import('./project-registry.js');
 
 function makeApp(prefsDir, projectRoot, locals = {}) {
   const app = express();
@@ -92,6 +93,25 @@ describe('GET /setup/preflight', () => {
     expect(body.crgInstalled).toBe(false);
     expect(body.worcaInstalled).toBe(false);
     expect(body.currentSettings).toBeDefined();
+  });
+
+  it('reports worcaInstalled true via home-dir worcaConfigPath', async () => {
+    const configDir = join(prefsDir, 'projects', 'test-project');
+    mkdirSync(configDir, { recursive: true });
+    const configPath = join(configDir, 'config.json');
+    writeFileSync(configPath, '{}');
+    writeProject(prefsDir, {
+      name: 'test-project',
+      path: projectRoot,
+      worcaConfigPath: configPath,
+    });
+    const app = makeApp(prefsDir, projectRoot);
+    const { body } = await request(
+      app,
+      'GET',
+      '/api/projects/test-project/setup/preflight',
+    );
+    expect(body.worcaInstalled).toBe(true);
   });
 
   it('reports worcaInstalled true when .claude/worca exists', async () => {

--- a/worca-ui/server/project-routes.js
+++ b/worca-ui/server/project-routes.js
@@ -38,6 +38,7 @@ import {
   getMaxProjects,
   readProjects,
   removeProject,
+  slugify,
   SLUG_RE,
   synthesizeDefaultProject,
   validateProjectEntry,
@@ -138,24 +139,48 @@ export function projectResolver({ prefsDir, projectRoot }) {
 
     const worcaDir = project.worcaDir || join(project.path, '.worca');
     const projRoot = project.path;
+    const resolvedSettingsPath =
+      (project.worcaConfigPath && existsSync(project.worcaConfigPath)
+        ? project.worcaConfigPath
+        : null) ||
+      project.settingsPath ||
+      join(project.path, '.claude', 'settings.json');
     req.project = {
       name: project.name,
       path: project.path,
       worcaDir,
-      settingsPath:
-        project.settingsPath || join(project.path, '.claude', 'settings.json'),
+      settingsPath: resolvedSettingsPath,
+      worcaConfigPath: project.worcaConfigPath || null,
+      worcaPkgVersion: project.worcaPkgVersion || null,
       projectRoot: projRoot,
       pm: new ProcessManager({
         worcaDir,
         projectRoot: projRoot,
-        settingsPath:
-          project.settingsPath ||
-          join(project.path, '.claude', 'settings.json'),
+        settingsPath: resolvedSettingsPath,
         prefsDir,
       }),
     };
     next();
   };
+}
+
+/**
+ * Enrich a project entry with worcaConfigPath (and related fields) when
+ * ~/.worca/projects/<slug>/config.json exists.  Mutates the entry in place.
+ */
+function enrichProjectEntry(prefsDir, entry) {
+  if (entry.worcaConfigPath) return;
+  const slug = slugify(entry.name);
+  const configPath = join(prefsDir, 'projects', slug, 'config.json');
+  if (existsSync(configPath)) {
+    entry.worcaConfigPath = configPath;
+  }
+  if (!entry.worcaDir) {
+    entry.worcaDir = join(entry.path, '.worca');
+  }
+  if (!entry.settingsPath) {
+    entry.settingsPath = join(entry.path, '.claude', 'settings.json');
+  }
 }
 
 /**
@@ -175,11 +200,15 @@ export function createProjectRoutes({
     if (projects.length === 0) {
       projects = [synthesizeDefaultProject(projectRoot)];
     }
+    // Backfill worcaConfigPath on entries that predate the init ↔ UI unification.
+    for (const p of projects) {
+      enrichProjectEntry(prefsDir, p);
+    }
     // Enrich each project with its worca-cc version and whether its path still
     // exists on disk (a deleted project can't be configured or run).
     const enriched = projects.map((p) => ({
       ...p,
-      worcaVersion: readProjectWorcaVersion(p.path),
+      worcaVersion: readProjectWorcaVersion(p.path, p.worcaPkgVersion),
       exists: existsSync(p.path),
     }));
     res.json({ ok: true, projects: enriched });
@@ -198,6 +227,7 @@ export function createProjectRoutes({
         .json({ ok: false, error: `directory does not exist: ${entry.path}` });
     }
     try {
+      enrichProjectEntry(prefsDir, entry);
       writeProject(prefsDir, entry);
       // Auto-configure webhook so pipeline events reach this UI server
       if (serverHost && serverPort) {
@@ -306,6 +336,7 @@ export function createProjectRoutes({
     const written = [];
     try {
       for (const entry of batch) {
+        enrichProjectEntry(prefsDir, entry);
         writeProject(prefsDir, entry);
         written.push(entry.name);
         if (serverHost && serverPort) {
@@ -490,6 +521,7 @@ export function createProjectScopedRoutes({
       const payload = await buildProjectPreflight({
         projectRoot,
         settingsPath,
+        worcaConfigPath: req.project.worcaConfigPath,
         graphifyStatus: req.app.locals.graphifyStatus || null,
         crgStatus: req.app.locals.crgStatus || null,
       });
@@ -1756,7 +1788,7 @@ export function createProjectScopedRoutes({
   // strictly behind the active (dev-path or globally-installed) worca-cc.
   router.get('/worca-status', async (req, res) => {
     const { projectRoot } = req.project;
-    const installed = checkWorcaInstalled(projectRoot);
+    const installed = checkWorcaInstalled(projectRoot, req.project.worcaConfigPath);
     if (!installed) {
       return res.json({
         ok: true,
@@ -1765,7 +1797,7 @@ export function createProjectScopedRoutes({
         outdated: false,
       });
     }
-    const version = readProjectWorcaVersion(projectRoot);
+    const version = readProjectWorcaVersion(projectRoot, req.project.worcaPkgVersion);
     let outdated = false;
     if (version != null) {
       try {

--- a/worca-ui/server/test/worca-status.test.js
+++ b/worca-ui/server/test/worca-status.test.js
@@ -179,6 +179,98 @@ describe('GET /api/projects/:id/worca-status — version + outdated extension', 
     expect(body.outdated).toBe(true);
   });
 
+  // Home-dir layout: worcaConfigPath + worcaPkgVersion → installed + hash-stripped version
+  it('returns installed:true and hash-stripped version for home-dir layout', async () => {
+    const configDir = join(prefsDir, 'projects', 'my-proj');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), '{}');
+
+    writeProject(prefsDir, {
+      name: 'my-proj',
+      path: projectRoot,
+      worcaConfigPath: join(configDir, 'config.json'),
+      worcaPkgVersion: '0.6.0-33ad2a9',
+    });
+    const app = await createTestApp(prefsDir, projectRoot);
+    const { status, body } = await request(
+      app,
+      'GET',
+      '/api/projects/my-proj/worca-status',
+    );
+
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.installed).toBe(true);
+    expect(body.version).toBe(ACTIVE_WORCA_CC);
+    expect(body.outdated).toBe(false);
+  });
+
+  // Home-dir layout: worcaConfigPath only (no worcaPkgVersion)
+  it('returns installed:true and version:null for home-dir layout without worcaPkgVersion', async () => {
+    const configDir = join(prefsDir, 'projects', 'my-proj');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), '{}');
+
+    writeProject(prefsDir, {
+      name: 'my-proj',
+      path: projectRoot,
+      worcaConfigPath: join(configDir, 'config.json'),
+    });
+    const app = await createTestApp(prefsDir, projectRoot);
+    const { status, body } = await request(
+      app,
+      'GET',
+      '/api/projects/my-proj/worca-status',
+    );
+
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.installed).toBe(true);
+    expect(body.version).toBeNull();
+    expect(body.outdated).toBe(false);
+  });
+
+  // No legacy dir + no worcaConfigPath → not installed
+  it('returns installed:false when no legacy dir and no worcaConfigPath', async () => {
+    writeProject(prefsDir, { name: 'my-proj', path: projectRoot });
+    const app = await createTestApp(prefsDir, projectRoot);
+    const { status, body } = await request(
+      app,
+      'GET',
+      '/api/projects/my-proj/worca-status',
+    );
+
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.installed).toBe(false);
+    expect(body.version).toBeNull();
+    expect(body.outdated).toBe(false);
+  });
+
+  // Hash stripping preserves RC suffix
+  it('strips git hash but preserves RC suffix in version', async () => {
+    const configDir = join(prefsDir, 'projects', 'my-proj');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), '{}');
+
+    writeProject(prefsDir, {
+      name: 'my-proj',
+      path: projectRoot,
+      worcaConfigPath: join(configDir, 'config.json'),
+      worcaPkgVersion: '0.7.0rc3-abcdef1',
+    });
+    const app = await createTestApp(prefsDir, projectRoot);
+    const { status, body } = await request(
+      app,
+      'GET',
+      '/api/projects/my-proj/worca-status',
+    );
+
+    expect(status).toBe(200);
+    expect(body.version).toBe('0.7.0rc3');
+    expect(body.outdated).toBe(false);
+  });
+
   // RC vs stable: "0.6.0rc3" is behind "0.6.0"
   it('returns outdated:true when installed is an RC of the current stable', async () => {
     mkdirSync(join(projectRoot, '.claude', 'worca'), { recursive: true });

--- a/worca-ui/server/worca-setup-config.js
+++ b/worca-ui/server/worca-setup-config.js
@@ -24,6 +24,7 @@ import { dirname, join } from 'node:path';
 import { atomicWriteSync } from './atomic-write.js';
 import { getDefaultBranch } from './git-helpers.js';
 import { deepMerge } from './settings-merge.js';
+import { checkWorcaInstalled } from './worca-setup.js';
 
 /**
  * Translate a wizard patch into the `worca.*` settings shape.
@@ -130,16 +131,16 @@ export function applySetupPatch(settingsPath, patch) {
 export async function buildProjectPreflight({
   projectRoot,
   settingsPath,
+  worcaConfigPath = null,
   graphifyStatus = null,
   crgStatus = null,
 }) {
   const isGitRepo =
     Boolean(projectRoot) && existsSync(join(projectRoot, '.git'));
-  // worca is "installed" in a project when its runtime copy exists. Built-in
-  // pipeline templates live under .claude/worca/templates/, so without this
-  // the template step has nothing to offer.
+  // worca is "installed" when the project has a config — either the legacy
+  // .claude/worca/ dir or the home-dir layout config.json.
   const worcaInstalled =
-    Boolean(projectRoot) && existsSync(join(projectRoot, '.claude', 'worca'));
+    Boolean(projectRoot) && checkWorcaInstalled(projectRoot, worcaConfigPath);
   const baseBranch = projectRoot ? getDefaultBranch(projectRoot) : 'main';
 
   let graphifyInstalled = false;

--- a/worca-ui/server/worca-setup-config.test.js
+++ b/worca-ui/server/worca-setup-config.test.js
@@ -189,6 +189,26 @@ describe('buildProjectPreflight', () => {
     expect(pf.graphifyInstalled).toBe(false);
   });
 
+  it('reports worcaInstalled true via home-dir layout worcaConfigPath', async () => {
+    const configPath = join(dir, 'worca-config.json');
+    writeFileSync(configPath, '{}');
+    const pf = await buildProjectPreflight({
+      projectRoot: dir,
+      settingsPath,
+      worcaConfigPath: configPath,
+    });
+    expect(pf.worcaInstalled).toBe(true);
+  });
+
+  it('reports worcaInstalled false when neither layout present', async () => {
+    const pf = await buildProjectPreflight({
+      projectRoot: dir,
+      settingsPath,
+      worcaConfigPath: '/nonexistent/config.json',
+    });
+    expect(pf.worcaInstalled).toBe(false);
+  });
+
   it('pre-populates currentSettings from existing settings.json', async () => {
     writeFileSync(
       settingsPath,

--- a/worca-ui/server/worca-setup.js
+++ b/worca-ui/server/worca-setup.js
@@ -15,7 +15,8 @@ import { join } from 'node:path';
 /**
  * Check whether worca is installed in the given project path.
  */
-export function checkWorcaInstalled(projectPath) {
+export function checkWorcaInstalled(projectPath, worcaConfigPath) {
+  if (worcaConfigPath && existsSync(worcaConfigPath)) return true;
   return existsSync(join(projectPath, '.claude', 'worca'));
 }
 
@@ -24,8 +25,8 @@ export function checkWorcaInstalled(projectPath) {
  * Tries .claude/worca/version.json first, then falls back to __init__.py.
  * Returns the version string or null if not found.
  */
-export function readProjectWorcaVersion(projectPath) {
-  // Try version.json first (preferred format)
+export function readProjectWorcaVersion(projectPath, worcaPkgVersion) {
+  if (worcaPkgVersion) return worcaPkgVersion.replace(/-[0-9a-f]{7,}$/, '');
   try {
     const versionJson = JSON.parse(
       readFileSync(
@@ -37,7 +38,6 @@ export function readProjectWorcaVersion(projectPath) {
   } catch {
     // fall through to __init__.py
   }
-  // Fall back to __init__.py
   try {
     const initPy = readFileSync(
       join(projectPath, '.claude', 'worca', '__init__.py'),

--- a/worca-ui/server/workspace-routes.js
+++ b/worca-ui/server/workspace-routes.js
@@ -24,9 +24,11 @@ import { basename, join } from 'node:path';
 import { Router } from 'express';
 import { WORKSPACE_TERMINAL } from '../app/utils/status-constants.js';
 import {
+  worcaHome,
   workspaceRunsDir as resolveWorkspaceRunsDir,
   workspacesDir as resolveWorkspacesDir,
 } from './paths.js';
+import { slugify } from './project-registry.js';
 import { listTemplatesFlat } from './templates-routes.js';
 import {
   applySetupPatch,
@@ -866,9 +868,13 @@ export function createWorkspaceRouter({
       for (const p of ws.projects ?? []) {
         const projectRoot = join(reg.path, p.path);
         const settingsPath = join(projectRoot, '.claude', 'settings.json');
+        const worcaConfigPath = join(
+          worcaHome(), 'projects', slugify(basename(projectRoot)), 'config.json',
+        );
         const pf = await buildProjectPreflight({
           projectRoot,
           settingsPath,
+          worcaConfigPath,
           graphifyStatus,
           crgStatus,
         });

--- a/worca-ui/server/ws-modular.js
+++ b/worca-ui/server/ws-modular.js
@@ -184,7 +184,7 @@ export function attachWsServer(httpServer, config) {
     // the WS event clobbers the enriched REST response on add/remove)
     const projectList = freshProjects.map((p) => ({
       ...p,
-      worcaVersion: readProjectWorcaVersion(p.path),
+      worcaVersion: readProjectWorcaVersion(p.path, p.worcaPkgVersion),
     }));
     broadcaster.broadcast('projects-updated', { projects: projectList });
   }


### PR DESCRIPTION
feat(pipeline): add --spec flag to run_worktree and run_fleet

  The UI and CLI both construct --spec args targeting run_worktree.py,
  which rejected them as unrecognized — breaking spec-driven pipelines
  from every entry point except bare run_pipeline.py.

  - Add --spec to run_worktree.py parser, validation, and forwarding
  - Thread --spec through run_fleet.py: parser → dispatch → build_child_cmd → resume
  - Add file-existence validation for --spec and --plan at the normalize layer, replacing raw tracebacks with clean exit-2 error messages