### PR TITLE
feat: per-profile task-source config and project/workspace bindings

### DIFF
--- a/.claude/skills/creating-worca-cc-plugins/SKILL.md
+++ b/.claude/skills/creating-worca-cc-plugins/SKILL.md
@@ -154,7 +154,10 @@ backend, keep a single subprocess seam with error-kind mapping, detach anything 
 env var so nothing depends on the server's cwd. For **per-run write-back**, add a
 `writeBack` select to `inputs` (default `no`); the host pins the run's inputs on the row and
 passes them to `capabilities({inputs})` / `reportResult`, so only runs that opted in are
-reported.
+reported. The key name `writeBack` is the host's reserved opt-out channel: when the
+`capabilities` probe errors, the host fails CLOSED (no report until retry) only for runs
+that pinned a `writeBack` input — every other run keeps the fail-open default rather than
+silently dropping the tracker comment on a transient blip.
 
 ## Where the host logic lives
 

--- a/.claude/skills/creating-worca-cc-plugins/SKILL.md
+++ b/.claude/skills/creating-worca-cc-plugins/SKILL.md
@@ -54,6 +54,7 @@ Only `name` is required. Unknown fields are warnings (errors under `--strict`).
 | `taskSources[].id` | kebab-case |
 | `taskSources[].module` | must start `./`, no `..`, no backslashes |
 | `taskSources[].configSchema[]` | persistent config — `text` \| `select`, plus `secret`/`required`/`default`/`help`/`options` |
+| `taskSources[].multiProfile` | `true` → one install holds several independent configurations (two Jira servers, two orgs), each with its own config/secrets/state. Users create profiles in the UI and bind each project/workspace to one. Omit it and the source uses a single implicit `default` profile — identical to before profiles existed |
 | `taskSources[].inputs[]` | per-run UI — see next table. **Exactly one `task-browser` required** |
 
 ## Marketplace manifest (repo-level, optional)
@@ -102,14 +103,15 @@ export default function createTaskSource(ctx) {
 | `validateConfig` | `()` | `{ok:true, identity?}` \| `{ok:false, errors:[{field,message}]}` — gates the whole pane |
 | `listTasks` | `({inputs, search, cursor})` | `{tasks:[{id,title,url,state,labels,updatedAt}], cursor?}` |
 | `getTask` | `(id)` — **positional** | `{...summary, body /* markdown */, meta}` |
-| `reportResult` | `(id, {status, summary, links})` — **positional** | anything |
-| `capabilities` | `()` — optional | `{writeBack, incrementalSync}`; missing → `writeBack: true` |
+| `reportResult` | `(id, {status, summary, links, inputs})` — **positional** | anything |
+| `capabilities` | `({inputs})` — optional | `{writeBack, incrementalSync}`; missing → `writeBack: true` |
 | custom | `(args)` | whatever the widget needs |
 
-`ctx` = `{ apiVersion, config, state: {get, set}, log }`.
+`ctx` = `{ apiVersion, profile, config, state: {get, set}, log }`.
 
 - `ctx.config` — `configSchema` values, defaults applied, `{"$env":"VAR"}` already resolved
 - `ctx.state.get/set` — a KV bag; `set` only *records*, the **host** persists it after a successful frame
+- `ctx.profile` — which profile this op runs against (`'default'` unless `multiProfile`). `config` and `state` are *already* that profile's bucket; the id is here so a connector that keeps its own on-disk storage can key it the same way
 - `ctx.log(level, msg)` — the only legal output channel
 
 Throw `Object.assign(new Error(msg), { kind })` to pick the error kind:
@@ -134,15 +136,25 @@ Payload arrives on stdin, one JSON frame leaves on stdout, process exits. 30s ti
 | Agent `.md` with no `.meta.json` sidecar | Registry silently ignores it (warn only) |
 | Workflow template referencing an agent key you don't ship | Template skipped at import |
 | Non-opaque task ids | `getTask(id)` receives exactly what `listTasks` emitted — keep them round-trippable |
+| Self-managed storage not keyed by `ctx.profile` | Two profiles share one cache/cookie jar/CLI config dir → one instance silently answers with the other's data. Hang every path you own off the profile id |
 | `getTask().body` not markdown | It becomes the pipeline prompt verbatim |
 | Symlinks pointing outside the plugin dir | Deleted during export, reported as a warning |
 
-## The one example worth reading
+## The example worth reading
 
 `plugins/github-source/` — a complete, zero-dependency GitHub Issues source:
 ETag revalidation via `ctx.state`, `remote-select` repo picker, a filter micro-syntax,
 `{"$env":"GH_TOKEN"}` token config, and write-back that comments and optionally closes the issue.
-Copy its shape.
+Copy its shape for a plain HTTP-API source.
+
+Patterns it doesn't show, for connectors that need them: with `multiProfile`, key any
+self-managed on-disk storage by `ctx.profile`. When wrapping an **external CLI** as the
+backend, keep a single subprocess seam with error-kind mapping, detach anything interactive
+(e.g. a browser login) so it outlives the 30s op timeout, and pin the CLI's config via an
+env var so nothing depends on the server's cwd. For **per-run write-back**, add a
+`writeBack` select to `inputs` (default `no`); the host pins the run's inputs on the row and
+passes them to `capabilities({inputs})` / `reportResult`, so only runs that opted in are
+reported.
 
 ## Where the host logic lives
 
@@ -151,7 +163,8 @@ Copy its shape.
 | Manifest schema + validation | `src/core/plugin-manifest.mjs` |
 | Install / update / uninstall lifecycle | `src/core/plugin-store.mjs` |
 | Child-process protocol | `src/core/plugin-shim.mjs`, `plugin-shim-child.mjs` |
-| Config / secrets / state | `src/core/plugin-config.mjs` |
+| Config / secrets / state (per-profile buckets) | `src/core/plugin-config.mjs` |
+| Profile → project/workspace binding resolution | `src/core/source-bindings.mjs` |
 | Widget rendering | `ui/public/source-pane.mjs`, `ui/public/plugins-view.mjs` |
 | CLI | `src/cli/worca-cc.mjs` (`worca plugin help`) |
 

--- a/src/cli/worca-cc.mjs
+++ b/src/cli/worca-cc.mjs
@@ -810,7 +810,7 @@ Usage:
   worca plugin link <dir>                         Dev mode: use a local dir as "current"
   worca plugin init <name> [--dir <D>] [--with task-source,agents,skills,workflows]
   worca plugin validate <dir> [--strict]          Lint a plugin dir (--strict: unknown fields error)
-  worca plugin exec <name> <sourceId> <op> [--args '<json>'] [--inspect]   Debug one connector op
+  worca plugin exec <name> <sourceId> <op> [--args '<json>'] [--profile <id>] [--inspect]   Debug one connector op
   worca plugin channel <name> <channelId> [--check] [--inspect]            Run a chat channel worker in the
                                                   foreground (typed lines = simulated inbound); --check runs
                                                   the module's validateConfig once and exits
@@ -1286,9 +1286,9 @@ async function cmdPlugin(argv) {
       }
 
       case 'exec': {
-        const a = pluginArgs(rest, ['--args'], ['--inspect']);
+        const a = pluginArgs(rest, ['--args', '--profile'], ['--inspect']);
         const [name, sourceId, op] = a._;
-        if (!name || !sourceId || !op) fail("Usage: worca plugin exec <name> <sourceId> <op> [--args '<json>'] [--inspect]");
+        if (!name || !sourceId || !op) fail("Usage: worca plugin exec <name> <sourceId> <op> [--args '<json>'] [--profile <id>] [--inspect]");
         if (a.inspect) process.env.WORCA_PLUGIN_INSPECT = '1'; // shim spawns the child with --inspect-brk
         let args = {};
         if (a.args) {
@@ -1299,7 +1299,9 @@ async function cmdPlugin(argv) {
           }
         }
         const { callSource } = await import('../core/plugin-shim.mjs');
-        const result = await callSource({ plugin: name, sourceId, op, args });
+        // --profile targets one instance of a multi-profile source; absent, the
+        // shim falls back to the implicit default bucket (single-profile case).
+        const result = await callSource({ plugin: name, sourceId, op, args, profile: a.profile || undefined });
         process.stdout.write(JSON.stringify(result, null, 2) + '\n'); // stdout = result ONLY
         return 0;
       }

--- a/src/core/db.mjs
+++ b/src/core/db.mjs
@@ -50,8 +50,10 @@ const BUSY_TIMEOUT_MS = 5000;
 const OPEN_RETRY_LIMIT = 100;
 const OPEN_BACKOFF_MS = 15;
 
-/** Latest schema version. Bump + append a new migration step when the DDL grows. */
-const SCHEMA_VERSION = 17;
+/** Latest schema version. Bump + append a new migration step when the DDL grows.
+ *  Exported so migration tests assert "reached the module's current version"
+ *  instead of hardcoding the number — a schema bump then touches no test file. */
+export const SCHEMA_VERSION = 18;
 
 /** Absolute path to the database file: <worcaHome>/worca-cc.db. */
 export function dbPath() {
@@ -513,6 +515,29 @@ CREATE TABLE IF NOT EXISTS step_questions (
 );
 `;
 
+/**
+ * v18 (task-source profiles): which PROFILE of a plugin task source a project or
+ * workspace uses. One row per (scope, plugin, source) — a project that pulls from
+ * two different sources binds each independently.
+ *
+ * scope_type is 'project' | 'workspace'; scope_key is projects.key or
+ * workspaces.id respectively. Deliberately NOT a foreign key: a binding must
+ * survive a project being removed and re-added at the same path (the key is a
+ * path hash, so it comes back identical), and source-bindings.mjs already treats
+ * a row whose plugin/profile no longer exists as "no binding".
+ */
+const SOURCE_BINDINGS_DDL = `
+CREATE TABLE IF NOT EXISTS source_bindings (
+  scope_type TEXT NOT NULL,   -- 'project' | 'workspace'
+  scope_key  TEXT NOT NULL,   -- projects.key | workspaces.id
+  plugin     TEXT NOT NULL,
+  source_id  TEXT NOT NULL,
+  profile    TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (scope_type, scope_key, plugin, source_id)
+);
+`;
+
 const GUARDRAIL_SETS_DDL = `
 CREATE TABLE IF NOT EXISTS guardrail_sets (
   id         TEXT PRIMARY KEY,
@@ -576,12 +601,27 @@ const INCREMENTAL_COLUMNS = {
 };
 
 /**
+ * Tables added after v1, keyed by name -> their IF-NOT-EXISTS DDL. Same hazard
+ * as INCREMENTAL_COLUMNS: a divergent ladder in another checkout can stamp the
+ * user_version past the step that creates one, so schemaGaps probes for them
+ * version-independently rather than trusting the stamp.
+ */
+const INCREMENTAL_TABLES = {
+  step_questions: STEP_QUESTIONS_DDL,
+  guardrail_sets: GUARDRAIL_SETS_DDL,
+  cost_ledger: COST_LEDGER_DDL,
+  model_cost_flags: MODEL_COST_FLAGS_DDL,
+  source_bindings: SOURCE_BINDINGS_DDL,
+};
+
+/**
  * Return [{table, col, type}] for every INCREMENTAL_COLUMNS entry absent from the
- * live schema, plus `stepQuestionsTable`/`guardrailSetsTable: true` flags when
- * those IF-NOT-EXISTS tables are missing (safe to reassert on any stamped DB).
- * Cheap and read-only: one PRAGMA table_info per known table + one sqlite_master
- * probe each, no writes. A table absent from INCREMENTAL_COLUMNS' map (table_info
- * returns []) is skipped — creating base tables is the version ladder's job.
+ * live schema, plus the names of any INCREMENTAL_TABLES that do not exist yet
+ * (their CREATEs are all IF-NOT-EXISTS, so reasserting one on any stamped DB is
+ * safe). Cheap and read-only: one PRAGMA table_info per known table + one
+ * sqlite_master probe, no writes. A table absent from INCREMENTAL_COLUMNS' map
+ * (table_info returns []) is skipped — creating base tables is the version
+ * ladder's job.
  */
 function schemaGaps(db) {
   const missing = [];
@@ -592,25 +632,10 @@ function schemaGaps(db) {
       if (!have.has(col)) missing.push({ table, col, type });
     }
   }
-  const hasStepQuestions = db.prepare(
-    "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='step_questions'"
-  ).get().n > 0;
-  const hasGuardrailSets = db.prepare(
-    "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='guardrail_sets'"
-  ).get().n > 0;
-  const hasCostLedger = db.prepare(
-    "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='cost_ledger'"
-  ).get().n > 0;
-  const hasModelCostFlags = db.prepare(
-    "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='model_cost_flags'"
-  ).get().n > 0;
-  return {
-    columns: missing,
-    stepQuestionsTable: !hasStepQuestions,
-    guardrailSetsTable: !hasGuardrailSets,
-    costLedgerTable: !hasCostLedger,
-    modelCostFlagsTable: !hasModelCostFlags,
-  };
+  const tables = Object.keys(INCREMENTAL_TABLES).filter((t) => db.prepare(
+    "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name=?"
+  ).get(t).n === 0);
+  return { columns: missing, tables };
 }
 
 /** Apply the gap repairs with NO transaction control of its own — the caller owns
@@ -619,10 +644,7 @@ function repairSchemaGaps(db, gaps) {
   for (const { table, col, type } of gaps.columns) {
     db.exec(`ALTER TABLE ${table} ADD COLUMN ${col} ${type}`);
   }
-  if (gaps.stepQuestionsTable) db.exec(STEP_QUESTIONS_DDL);
-  if (gaps.guardrailSetsTable) db.exec(GUARDRAIL_SETS_DDL);
-  if (gaps.costLedgerTable) db.exec(COST_LEDGER_DDL);
-  if (gaps.modelCostFlagsTable) db.exec(MODEL_COST_FLAGS_DDL);
+  for (const table of gaps.tables || []) db.exec(INCREMENTAL_TABLES[table]);
 }
 
 /**
@@ -638,8 +660,7 @@ function repairSchemaGaps(db, gaps) {
  */
 function reconcileSchema(db) {
   const gaps = schemaGaps(db);
-  if (gaps.columns.length === 0 && !gaps.stepQuestionsTable && !gaps.guardrailSetsTable
-      && !gaps.costLedgerTable && !gaps.modelCostFlagsTable) return; // clean — no lock
+  if (gaps.columns.length === 0 && gaps.tables.length === 0) return; // clean — no lock
   db.exec('BEGIN IMMEDIATE');
   try {
     repairSchemaGaps(db, schemaGaps(db)); // re-probe under the lock: race-safe
@@ -666,7 +687,7 @@ function applySchemaV12(db) {
 /**
  * Incremental v12 -> v13 migration (plugin task-sources, spec 2026-07-12 §10):
  *   pipelines.source_type TEXT DEFAULT 'prompt'  -- 'prompt' | 'markdown' | 'plugin'
- *   pipelines.source_ref  TEXT                   -- JSON {plugin,sourceId,taskId,url,title}; NULL unless plugin
+ *   pipelines.source_ref  TEXT                   -- JSON {plugin,sourceId,taskId,profile,inputs,url,title}; NULL unless plugin
  *   workflows.origin      TEXT                   -- 'plugin:<name>' provenance; NULL = user-created
  * Implemented as a CONDITIONAL repair (same shape as applySchemaV12), NOT a plain
  * DDL string: the three columns live in INCREMENTAL_COLUMNS (hard rule above), so
@@ -791,6 +812,9 @@ export function migrate(db) {
     if (current < 15) applySchemaV15(db);
     if (current < 16) applySchemaV16(db);
     if (current < 17) db.exec(MODEL_COST_FLAGS_DDL); // IF NOT EXISTS — reconcile-safe
+    // v17 -> v18 (task-source profiles): source_bindings. IF NOT EXISTS —
+    // reconcileSchema may already have created it on a divergently-stamped DB.
+    if (current < 18) db.exec(SOURCE_BINDINGS_DDL);
     db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`);
     db.exec('COMMIT');
   } catch (err) {

--- a/src/core/plugin-config.mjs
+++ b/src/core/plugin-config.mjs
@@ -7,9 +7,9 @@
 // multiProfile simply never uses more than the DEFAULT_PROFILE bucket, which is
 // created implicitly, so single-profile plugins need no special handling here.
 //
-//   config.json  { "profiles": { "<id>": { key: value } } }
-//   secrets.json { "profiles": { "<id>": { key: value } } }   mode 0600
-//   state.json   { "profiles": { "<id>": { key: value } } }
+//   config.json  { "$format": "profiles/1", "profiles": { "<id>": { key: value } } }
+//   secrets.json { "$format": "profiles/1", "profiles": { "<id>": { … } } }   mode 0600
+//   state.json   { "$format": "profiles/1", "profiles": { "<id>": { … } } }
 //
 // Secrets: mode 0600, atomic temp+rename (settings.mjs:89-92 idiom),
 // {"$env":"VAR"} indirection resolved at READ time only — stored verbatim so the
@@ -48,24 +48,26 @@ function readJson(file) {
   }
 }
 
-/** The { profiles: {...} } envelope, tolerant of a missing/garbage file.
- *  Pre-profiles files were one flat bag ({ key: value } at the top level); read
- *  those as the implicit DEFAULT_PROFILE bucket so an upgrade never orphans
- *  stored config/secrets/state — the next writeBucket persists the envelope.
- *  The envelope is recognised STRICTLY — exactly one top-level key ("profiles")
- *  whose entries are all <valid id> -> plain object — because a legacy flat file
- *  may legally carry a schema field KEYED "profiles" (KEY_RE allows the name,
- *  and a {"$env":…} ref stores an object): misreading that as the envelope
- *  would silently drop every other stored key, permanently after the next
- *  write. Only writeBucket/deleteProfile ever produce the envelope, and they
- *  produce exactly this shape. */
+/** In-band format marker for the profile envelope. No shape heuristic can be
+ *  exact here: config keys come from configSchema, but STATE keys are whatever
+ *  a connector passed to ctx.state.set(), so a legacy flat file may legally be
+ *  { "profiles": { <id>: {...} } } byte-for-byte — data, not envelope. Only the
+ *  marker distinguishes the two, and only writeBucket/deleteProfile emit it. */
+const ENVELOPE_FORMAT = 'profiles/1';
+
+const isBag = (v) => !!v && typeof v === 'object' && !Array.isArray(v);
+
+/** The marked { $format, profiles: {...} } envelope, tolerant of a
+ *  missing/garbage file. A file WITHOUT the marker is a pre-profiles flat bag
+ *  ({ key: value } at the top level) — read it, whole and unjudged, as the
+ *  implicit DEFAULT_PROFILE bucket so an upgrade never orphans stored
+ *  config/secrets/state; the next writeBucket persists the marked envelope. */
 function readBuckets(file) {
   const raw = readJson(file);
-  const p = raw.profiles;
-  const isBag = (v) => !!v && typeof v === 'object' && !Array.isArray(v);
-  if (isBag(p) && Object.keys(raw).length === 1
-      && Object.entries(p).every(([id, bag]) => isValidProfileId(id) && isBag(bag))) {
-    return p;
+  if (raw.$format === ENVELOPE_FORMAT && isBag(raw.profiles)) {
+    return Object.fromEntries(
+      Object.entries(raw.profiles).filter(([id, bag]) => isValidProfileId(id) && isBag(bag)),
+    );
   }
   return Object.keys(raw).length ? { [DEFAULT_PROFILE]: raw } : {};
 }
@@ -88,7 +90,7 @@ function writeJsonAtomic(file, obj, { mode } = {}) {
 function writeBucket(file, profile, bucket, opts) {
   const all = readBuckets(file);
   all[profile] = bucket;
-  writeJsonAtomic(file, { profiles: all }, opts);
+  writeJsonAtomic(file, { $format: ENVELOPE_FORMAT, profiles: all }, opts);
 }
 
 const isEnvRef = (v) => !!v && typeof v === 'object' && !Array.isArray(v) && typeof v.$env === 'string';
@@ -166,7 +168,7 @@ export function deleteProfile(name, id) {
     const all = readBuckets(file);
     if (!(pid in all)) continue;
     delete all[pid];
-    writeJsonAtomic(file, { profiles: all }, opts);
+    writeJsonAtomic(file, { $format: ENVELOPE_FORMAT, profiles: all }, opts);
   }
   return { ok: true };
 }

--- a/src/core/plugin-config.mjs
+++ b/src/core/plugin-config.mjs
@@ -51,13 +51,23 @@ function readJson(file) {
 /** The { profiles: {...} } envelope, tolerant of a missing/garbage file.
  *  Pre-profiles files were one flat bag ({ key: value } at the top level); read
  *  those as the implicit DEFAULT_PROFILE bucket so an upgrade never orphans
- *  stored config/secrets/state — the next writeBucket persists the envelope. */
+ *  stored config/secrets/state — the next writeBucket persists the envelope.
+ *  The envelope is recognised STRICTLY — exactly one top-level key ("profiles")
+ *  whose entries are all <valid id> -> plain object — because a legacy flat file
+ *  may legally carry a schema field KEYED "profiles" (KEY_RE allows the name,
+ *  and a {"$env":…} ref stores an object): misreading that as the envelope
+ *  would silently drop every other stored key, permanently after the next
+ *  write. Only writeBucket/deleteProfile ever produce the envelope, and they
+ *  produce exactly this shape. */
 function readBuckets(file) {
   const raw = readJson(file);
   const p = raw.profiles;
-  if (p && typeof p === 'object' && !Array.isArray(p)) return p;
-  const { profiles: _garbage, ...flat } = raw;
-  return Object.keys(flat).length ? { [DEFAULT_PROFILE]: flat } : {};
+  const isBag = (v) => !!v && typeof v === 'object' && !Array.isArray(v);
+  if (isBag(p) && Object.keys(raw).length === 1
+      && Object.entries(p).every(([id, bag]) => isValidProfileId(id) && isBag(bag))) {
+    return p;
+  }
+  return Object.keys(raw).length ? { [DEFAULT_PROFILE]: raw } : {};
 }
 
 /** One profile's bag from a file. */
@@ -124,6 +134,11 @@ export function listProfileIds(name) {
  */
 export function createProfile(name, id, label) {
   const pid = profileId(id);
+  // The default bucket is shared plumbing, not a profile: chat channels, model
+  // secrets and migrated pre-profiles config all live in it via profile-less
+  // reads. Enrolling "default" in the roster would make that shared bucket
+  // deletable like any member — one Remove click away from wiping them all.
+  if (pid === DEFAULT_PROFILE) throw new Error(`profile id "${DEFAULT_PROFILE}" is reserved`);
   const list = listProfiles(name);
   const at = list.findIndex((p) => p.id === pid);
   const entry = { id: pid, label: String(label || (at >= 0 ? list[at].label : pid)) };
@@ -140,6 +155,11 @@ export function createProfile(name, id, label) {
  */
 export function deleteProfile(name, id) {
   const pid = profileId(id);
+  // Same reservation as createProfile — and a backstop for a roster that
+  // enrolled "default" before the reservation existed: deleting it would strip
+  // the shared bucket (chat-channel config, model secrets, migrated legacy
+  // data) out of all three files.
+  if (pid === DEFAULT_PROFILE) throw new Error(`profile id "${DEFAULT_PROFILE}" is reserved — its bucket backs every profile-less read`);
   const f = files(name);
   writeJsonAtomic(f.profiles, { profiles: listProfiles(name).filter((p) => p.id !== pid) });
   for (const [file, opts] of [[f.config, undefined], [f.secrets, { mode: 0o600 }], [f.state, undefined]]) {

--- a/src/core/plugin-config.mjs
+++ b/src/core/plugin-config.mjs
@@ -1,14 +1,43 @@
 // src/core/plugin-config.mjs
 // Per-plugin settings/secrets/state under <pluginDir>/data (spec §5, §7.6).
-// Secrets: data/secrets.json, mode 0600, atomic temp+rename (settings.mjs:89-92
-// idiom), {"$env":"VAR"} indirection resolved at READ time only — stored
-// verbatim so the value never touches disk. Explicitly NOT in worca-cc.db.
+//
+// PROFILES: every file is keyed by profile id, so one plugin can hold several
+// complete, independent setups — two Jira servers, two GitHub orgs — instead of
+// one that gets overwritten each time you switch. A source that does not declare
+// multiProfile simply never uses more than the DEFAULT_PROFILE bucket, which is
+// created implicitly, so single-profile plugins need no special handling here.
+//
+//   config.json  { "profiles": { "<id>": { key: value } } }
+//   secrets.json { "profiles": { "<id>": { key: value } } }   mode 0600
+//   state.json   { "profiles": { "<id>": { key: value } } }
+//
+// Secrets: mode 0600, atomic temp+rename (settings.mjs:89-92 idiom),
+// {"$env":"VAR"} indirection resolved at READ time only — stored verbatim so the
+// value never touches disk. Explicitly NOT in worca-cc.db.
 // All functions are sync (contract; callers are the shim + server routes).
 
 import { readFileSync, writeFileSync, renameSync, mkdirSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { pluginDataDir } from './plugins-lock.mjs';
+
+/** The bucket every source gets for free; the only one a single-profile source uses. */
+export const DEFAULT_PROFILE = 'default';
+
+/** Profile ids are directory-safe and URL-safe: they become path segments in a
+ *  connector's own storage (jira-source hangs a $JTR_CONFIG_DIR off one) and
+ *  route params on /api/plugins/:name/profiles/:id. */
+export const PROFILE_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+export function isValidProfileId(id) {
+  return PROFILE_ID_RE.test(String(id ?? ''));
+}
+
+function profileId(id) {
+  const p = id == null || id === '' ? DEFAULT_PROFILE : String(id);
+  if (!isValidProfileId(p)) throw new Error(`invalid profile id "${p}" (lowercase letters, digits and dashes)`);
+  return p;
+}
 
 function readJson(file) {
   try {
@@ -19,6 +48,24 @@ function readJson(file) {
   }
 }
 
+/** The { profiles: {...} } envelope, tolerant of a missing/garbage file.
+ *  Pre-profiles files were one flat bag ({ key: value } at the top level); read
+ *  those as the implicit DEFAULT_PROFILE bucket so an upgrade never orphans
+ *  stored config/secrets/state — the next writeBucket persists the envelope. */
+function readBuckets(file) {
+  const raw = readJson(file);
+  const p = raw.profiles;
+  if (p && typeof p === 'object' && !Array.isArray(p)) return p;
+  const { profiles: _garbage, ...flat } = raw;
+  return Object.keys(flat).length ? { [DEFAULT_PROFILE]: flat } : {};
+}
+
+/** One profile's bag from a file. */
+function readBucket(file, profile) {
+  const b = readBuckets(file)[profile];
+  return b && typeof b === 'object' && !Array.isArray(b) ? b : {};
+}
+
 function writeJsonAtomic(file, obj, { mode } = {}) {
   mkdirSync(dirname(file), { recursive: true });
   const tmp = `${file}.${randomBytes(4).toString('hex')}.tmp`;
@@ -27,20 +74,91 @@ function writeJsonAtomic(file, obj, { mode } = {}) {
   renameSync(tmp, file);
 }
 
+/** Replace one profile's bag inside a file, leaving every other profile alone. */
+function writeBucket(file, profile, bucket, opts) {
+  const all = readBuckets(file);
+  all[profile] = bucket;
+  writeJsonAtomic(file, { profiles: all }, opts);
+}
+
 const isEnvRef = (v) => !!v && typeof v === 'object' && !Array.isArray(v) && typeof v.$env === 'string';
 /** The exact redaction marker redactedConfig emits — must never be persisted. */
 const isSetMarker = (v) => !!v && typeof v === 'object' && v.set === true && Object.keys(v).length === 1;
 
 function files(name) {
   const dir = pluginDataDir(name);
-  return { config: join(dir, 'config.json'), secrets: join(dir, 'secrets.json'), state: join(dir, 'state.json') };
+  return {
+    config: join(dir, 'config.json'),
+    secrets: join(dir, 'secrets.json'),
+    state: join(dir, 'state.json'),
+    profiles: join(dir, 'profiles.json'),
+  };
 }
 
-/** Merged config.json + secrets.json (secrets win), schema defaults applied,
- *  {"$env":"VAR"} resolved (unset env -> null). */
-export function readPluginConfig(name, configSchema = []) {
+// ── profiles ──────────────────────────────────────────────────────────────────
+// The roster lives in its own file rather than being inferred from config.json's
+// keys: a profile is real the moment it is created, BEFORE anything is saved into
+// it, and it keeps a human label the id cannot carry.
+
+/**
+ * Every profile of a plugin, in creation order.
+ * @returns {Array<{id:string, label:string}>}
+ */
+export function listProfiles(name) {
+  const raw = readJson(files(name).profiles);
+  const list = Array.isArray(raw.profiles) ? raw.profiles : [];
+  return list
+    .filter((p) => p && isValidProfileId(p.id))
+    .map((p) => ({ id: String(p.id), label: String(p.label || p.id) }));
+}
+
+/** Just the ids — the shape resolveProfile()/the UI gate want. */
+export function listProfileIds(name) {
+  return listProfiles(name).map((p) => p.id);
+}
+
+/**
+ * Create a profile. Idempotent on the id (a repeat call updates the label only),
+ * so a caller that ensures DEFAULT_PROFILE on every save cannot duplicate it.
+ * @returns {{id:string, label:string}}
+ */
+export function createProfile(name, id, label) {
+  const pid = profileId(id);
+  const list = listProfiles(name);
+  const at = list.findIndex((p) => p.id === pid);
+  const entry = { id: pid, label: String(label || (at >= 0 ? list[at].label : pid)) };
+  if (at >= 0) list[at] = entry;
+  else list.push(entry);
+  writeJsonAtomic(files(name).profiles, { profiles: list });
+  return entry;
+}
+
+/**
+ * Delete a profile and everything stored under it (config, secrets, state).
+ * Callers are responsible for the bindings that named it — see
+ * source-bindings.mjs#clearBindingsForProfile.
+ */
+export function deleteProfile(name, id) {
+  const pid = profileId(id);
   const f = files(name);
-  const raw = { ...readJson(f.config), ...readJson(f.secrets) };
+  writeJsonAtomic(f.profiles, { profiles: listProfiles(name).filter((p) => p.id !== pid) });
+  for (const [file, opts] of [[f.config, undefined], [f.secrets, { mode: 0o600 }], [f.state, undefined]]) {
+    const all = readBuckets(file);
+    if (!(pid in all)) continue;
+    delete all[pid];
+    writeJsonAtomic(file, { profiles: all }, opts);
+  }
+  return { ok: true };
+}
+
+// ── config ────────────────────────────────────────────────────────────────────
+
+/** Merged config.json + secrets.json for ONE profile (secrets win), schema
+ *  defaults applied, {"$env":"VAR"} resolved (unset env -> null). */
+export function readPluginConfig(name, configSchema = [], profile) {
+  const pid = profileId(profile);
+  const f = files(name);
+  const raw = { ...readBucket(f.config, pid), ...readBucket(f.secrets, pid) };
   const out = {};
   for (const field of configSchema) {
     let v = raw[field.key];
@@ -51,13 +169,15 @@ export function readPluginConfig(name, configSchema = []) {
   return out;
 }
 
-/** Route values by schema: secret:true -> secrets.json (0600), else config.json.
- *  undefined / redaction-marker values keep the prior stored value; null clears.
- *  $env refs are stored verbatim. Both writes are temp+rename atomic. */
-export function writePluginConfig(name, configSchema = [], values = {}) {
+/** Route values by schema: secret:true -> secrets.json (0600), else config.json,
+ *  both inside `profile`'s bucket. undefined / redaction-marker values keep the
+ *  prior stored value; null clears. $env refs are stored verbatim. Both writes
+ *  are temp+rename atomic. */
+export function writePluginConfig(name, configSchema = [], values = {}, profile) {
+  const pid = profileId(profile);
   const f = files(name);
-  const config = readJson(f.config);
-  const secrets = readJson(f.secrets);
+  const config = readBucket(f.config, pid);
+  const secrets = readBucket(f.secrets, pid);
   const secretKeys = new Set(configSchema.filter((x) => x && x.secret).map((x) => x.key));
   for (const [k, v] of Object.entries(values && typeof values === 'object' ? values : {})) {
     if (v === undefined || isSetMarker(v)) continue; // absent / echoed marker -> keep prior
@@ -67,17 +187,19 @@ export function writePluginConfig(name, configSchema = [], values = {}) {
     if (v === null) delete bucket[k];
     else bucket[k] = v;
   }
-  writeJsonAtomic(f.config, config);
-  writeJsonAtomic(f.secrets, secrets, { mode: 0o600 });
+  writeBucket(f.config, pid, config);
+  writeBucket(f.secrets, pid, secrets, { mode: 0o600 });
   return { ok: true };
 }
 
-/** UI echo shape: secrets -> { set: true|false } markers, non-secrets verbatim
- *  (with defaults). Secret VALUES never reach the browser after save (§7.6). */
-export function redactedConfig(name, configSchema = []) {
+/** UI echo shape for ONE profile: secrets -> { set: true|false } markers,
+ *  non-secrets verbatim (with defaults). Secret VALUES never reach the browser
+ *  after save (§7.6). */
+export function redactedConfig(name, configSchema = [], profile) {
+  const pid = profileId(profile);
   const f = files(name);
-  const config = readJson(f.config);
-  const secrets = readJson(f.secrets);
+  const config = readBucket(f.config, pid);
+  const secrets = readBucket(f.secrets, pid);
   const out = {};
   for (const field of configSchema) {
     if (field.secret) out[field.key] = { set: secrets[field.key] !== undefined };
@@ -86,15 +208,21 @@ export function redactedConfig(name, configSchema = []) {
   return out;
 }
 
-/** Connector KV (cursors, etags) — host-persisted ctx.state backing (§7.1). */
-export function readPluginState(name) {
-  return readJson(files(name).state);
+// ── connector state ───────────────────────────────────────────────────────────
+
+/** Connector KV for ONE profile (cursors, etags) — host-persisted ctx.state
+ *  backing (§7.1). Per-profile so two instances of the same source cannot read
+ *  back each other's cached cursors. */
+export function readPluginState(name, profile) {
+  return readBucket(files(name).state, profileId(profile));
 }
 
-/** Shallow-merge patch into state.json, atomic write. Returns the new state. */
-export function writePluginState(name, patch = {}) {
+/** Shallow-merge patch into one profile's state, atomic write. Returns the new
+ *  bag for that profile. */
+export function writePluginState(name, patch = {}, profile) {
+  const pid = profileId(profile);
   const f = files(name);
-  const next = { ...readJson(f.state), ...(patch && typeof patch === 'object' ? patch : {}) };
-  writeJsonAtomic(f.state, next);
+  const next = { ...readBucket(f.state, pid), ...(patch && typeof patch === 'object' ? patch : {}) };
+  writeBucket(f.state, pid, next);
   return next;
 }

--- a/src/core/plugin-manifest.mjs
+++ b/src/core/plugin-manifest.mjs
@@ -17,7 +17,7 @@ const SOURCE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 const FIELD_TYPES = new Set(['text', 'select']);
 const INPUT_TYPES = new Set(['text', 'select', 'remote-select', 'task-browser']);
 const KNOWN_TOP = new Set(['name', 'version', 'description', 'author', 'homepage', 'license', 'engines', 'taskSources', 'chatChannels', 'setup', 'models', 'modelSecrets']);
-const KNOWN_SOURCE = new Set(['id', 'displayName', 'module', 'configSchema', 'inputs']);
+const KNOWN_SOURCE = new Set(['id', 'displayName', 'module', 'configSchema', 'inputs', 'multiProfile']);
 const KNOWN_CHANNEL = new Set(['id', 'displayName', 'platform', 'module', 'ingress', 'capabilities', 'configSchema']);
 const CHANNEL_INGRESS = new Set(['connect', 'webhook']);
 const KNOWN_FIELD = new Set(['key', 'type', 'label', 'secret', 'required', 'default', 'help', 'options']);
@@ -195,7 +195,14 @@ export function normalizeManifest(raw, { dir = '' } = {}) {
       if (browsers !== 1) {
         errors.push(`${at} ("${id}"): must declare exactly ONE input of type "task-browser" (found ${browsers}) — it is what produces the task (spec §7.4)`);
       }
-      taskSources.push({ id, displayName: str(s.displayName) || id, module, configSchema, inputs });
+      // multiProfile: the source can hold several independent configurations
+      // (two Jira servers, two GitHub orgs), each bound to a project/workspace.
+      // Opt-in, because it changes the settings UI from one form to a roster —
+      // a single-instance source should not pay that.
+      taskSources.push({
+        id, displayName: str(s.displayName) || id, module, configSchema, inputs,
+        multiProfile: s.multiProfile === true,
+      });
     });
   }
   const ids = taskSources.map((s) => s.id);

--- a/src/core/plugin-shim-child.mjs
+++ b/src/core/plugin-shim-child.mjs
@@ -22,6 +22,10 @@ async function main() {
   const stateDelta = {};
   const ctx = {
     apiVersion: msg.apiVersion ?? 1,
+    // Which profile this op runs against. config/state are ALREADY that
+    // profile's — the id is here for connectors that keep their own storage and
+    // must key it the same way (e.g. a per-profile CLI config dir).
+    profile: typeof msg.profile === 'string' && msg.profile ? msg.profile : 'default',
     config: msg.config && typeof msg.config === 'object' ? msg.config : {},
     state: {
       get: async (k) => (k in stateDelta ? stateDelta[k] : (snapshot[k] ?? null)),

--- a/src/core/plugin-shim-child.mjs
+++ b/src/core/plugin-shim-child.mjs
@@ -41,9 +41,11 @@ async function main() {
   const source = mod.default(ctx);
   const fn = source?.[msg.op];
   if (typeof fn !== 'function') {
-    // Optional ops (e.g. capabilities) land here; the host treats this kind +
-    // message as "op not implemented" (Task 13 defaults writeBack:true on it).
-    throw Object.assign(new Error(`connector does not implement op "${msg.op}"`), { kind: 'plugin' });
+    // Optional ops (e.g. capabilities) land here. The kind is 'unimplemented',
+    // NOT 'plugin': an op the connector lacks and an implemented op that
+    // CRASHED must stay distinguishable — the capabilities probe defaults
+    // writeBack:true only for the former (Task 13 / sources.mjs).
+    throw Object.assign(new Error(`connector does not implement op "${msg.op}"`), { kind: 'unimplemented' });
   }
 
   // §7.1 signatures: getTask(id) and reportResult(id, r) are positional; every

--- a/src/core/plugin-shim.mjs
+++ b/src/core/plugin-shim.mjs
@@ -144,6 +144,19 @@ export async function callSource({ plugin, sourceId, op, args = {}, profile, tim
   }
 
   const { dir, source, apiVersion } = loadSource(plugin, sourceId);
+  // The profile invariant is enforced HERE, not only at the HTTP routes, so
+  // every caller — the CLI's `worca plugin exec`, future workers — is safe by
+  // construction. A multi-profile source silently defaulting to the (empty)
+  // default bucket yields false "not configured" verdicts and persists state
+  // into a bucket no real run reads; a profile on a single-profile source
+  // would read (and write) a phantom bucket instead of the real config.
+  if (source.multiProfile === true && !profile) {
+    throw new PluginOpError('plugin',
+      `task source "${plugin}/${sourceId}" has per-profile configuration — pass a profile (e.g. --profile <id>)`);
+  }
+  if (source.multiProfile !== true && profile && profile !== DEFAULT_PROFILE) {
+    throw new PluginOpError('plugin', `task source "${plugin}/${sourceId}" does not use profiles`);
+  }
   const payload = JSON.stringify({
     apiVersion,
     module: resolve(dir, source.module), // './'-relative, '..'-free (normalizeManifest)

--- a/src/core/plugin-shim.mjs
+++ b/src/core/plugin-shim.mjs
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'node:url';
 import { WORCA_PLUGIN_API } from './plugin-api.mjs';
 import { normalizeManifest, negotiatedApi } from './plugin-manifest.mjs';
 import { readPluginsLock, pluginCurrentDir } from './plugins-lock.mjs';
-import { readPluginConfig, readPluginState, writePluginState } from './plugin-config.mjs';
+import { readPluginConfig, readPluginState, writePluginState, DEFAULT_PROFILE } from './plugin-config.mjs';
 
 const CHILD_PATH = fileURLToPath(new URL('./plugin-shim-child.mjs', import.meta.url));
 
@@ -125,17 +125,21 @@ export function scrubbedEnv() {
  * ctx.log lines route there (default: console.error, since stdout is the UI's).
  * @returns {Promise<any>}
  */
-export async function callSource({ plugin, sourceId, op, args = {}, timeoutMs = 30000, logger } = {}) {
+export async function callSource({ plugin, sourceId, op, args = {}, profile, timeoutMs = 30000, logger } = {}) {
   const log = typeof logger === 'function'
     ? logger
     : (level, msg) => console.error(`[plugin:${plugin}] ${level}: ${msg}`);
+  // Which configuration of the source to run against (plugin-config.mjs
+  // profiles). Absent -> DEFAULT_PROFILE, which is what every single-profile
+  // source uses, so this parameter is invisible unless a plugin opts in.
+  const prof = profile || DEFAULT_PROFILE;
 
   if (mockMode()) {
     // Canned responses, no spawn, no plugin needed. reportResult additionally
     // records its args into the plugin state — mirroring the real-child
     // stateDelta path — so the offline smoke (Task 19) can assert write-back ran.
     const r = await mockCall(op, args);
-    if (op === 'reportResult') writePluginState(plugin, { lastReport: JSON.stringify(args) });
+    if (op === 'reportResult') writePluginState(plugin, { lastReport: JSON.stringify(args) }, prof);
     return r;
   }
 
@@ -144,8 +148,12 @@ export async function callSource({ plugin, sourceId, op, args = {}, timeoutMs = 
     apiVersion,
     module: resolve(dir, source.module), // './'-relative, '..'-free (normalizeManifest)
     op,
-    config: readPluginConfig(plugin, source.configSchema),
-    state: readPluginState(plugin),
+    // The connector sees ONE profile's config/state and is told which — a
+    // connector that keeps its own storage (jira-source hangs a $JTR_CONFIG_DIR
+    // off it) needs the id, not just the values.
+    profile: prof,
+    config: readPluginConfig(plugin, source.configSchema, prof),
+    state: readPluginState(plugin, prof),
     args,
   });
 
@@ -191,7 +199,7 @@ export async function callSource({ plugin, sourceId, op, args = {}, timeoutMs = 
     throw new PluginOpError(frame.error?.kind || 'plugin', frame.error?.message || `plugin "${plugin}" op "${op}" failed`);
   }
   if (frame.stateDelta && typeof frame.stateDelta === 'object' && Object.keys(frame.stateDelta).length) {
-    writePluginState(plugin, frame.stateDelta); // host-side persist; child never touches the store
+    writePluginState(plugin, frame.stateDelta, prof); // host-side persist; child never touches the store
   }
   return frame.result;
 }

--- a/src/core/plugin-shim.mjs
+++ b/src/core/plugin-shim.mjs
@@ -19,16 +19,19 @@ import { fileURLToPath } from 'node:url';
 import { WORCA_PLUGIN_API } from './plugin-api.mjs';
 import { normalizeManifest, negotiatedApi } from './plugin-manifest.mjs';
 import { readPluginsLock, pluginCurrentDir } from './plugins-lock.mjs';
-import { readPluginConfig, readPluginState, writePluginState, DEFAULT_PROFILE } from './plugin-config.mjs';
+import { readPluginConfig, readPluginState, writePluginState, listProfileIds, DEFAULT_PROFILE } from './plugin-config.mjs';
 
 const CHILD_PATH = fileURLToPath(new URL('./plugin-shim-child.mjs', import.meta.url));
 
-/** Error kinds an op can surface (spec §11); anything else normalizes to 'plugin'. */
-const KINDS = new Set(['auth', 'rate-limit', 'network', 'plugin', 'timeout', 'protocol']);
+/** Error kinds an op can surface (spec §11) plus the host-synthesized
+ *  'unimplemented' (the connector lacks the op — distinct from an implemented
+ *  op that CRASHED, because callers like the capabilities probe must default
+ *  differently for the two); anything else normalizes to 'plugin'. */
+const KINDS = new Set(['auth', 'rate-limit', 'network', 'plugin', 'timeout', 'protocol', 'unimplemented']);
 
 export class PluginOpError extends Error {
   /**
-   * @param {'auth'|'rate-limit'|'network'|'plugin'|'timeout'|'protocol'} kind
+   * @param {'auth'|'rate-limit'|'network'|'plugin'|'timeout'|'protocol'|'unimplemented'} kind
    * @param {string} message
    */
   constructor(kind, message) {
@@ -74,7 +77,7 @@ async function mockCall(op, args) {
   if (entry === undefined) {
     // Mirror the real child's answer for an unimplemented op — Task 13's
     // capabilities tolerant-default keys on exactly this kind.
-    throw new PluginOpError('plugin', `mock: no canned response for op "${op}"`);
+    throw new PluginOpError('unimplemented', `mock: no canned response for op "${op}"`);
   }
   try {
     return await (typeof entry === 'function' ? entry(args) : entry);
@@ -119,13 +122,46 @@ export function scrubbedEnv() {
   return env;
 }
 
+/** The profile invariant, enforced in the shim itself so EVERY caller — the
+ *  CLI's `worca plugin exec`, future workers — is safe by construction, not
+ *  just the HTTP routes. Presence alone is not enough: a typo'd or deleted
+ *  profile passes a presence check, silently runs against an EMPTY bucket
+ *  (false "not configured" verdicts) and then persists state into a phantom
+ *  bucket the DELETE route can never purge — so membership in the roster is
+ *  checked here too. `allowLegacyDefault` is the ONE host-internal exception:
+ *  write-back for a pipeline row that predates profiles targets the
+ *  DEFAULT_PROFILE bucket, because that is where the pre-upgrade flat config
+ *  migrated — i.e. the instance the task actually came from (sources.mjs). */
+function assertProfileInvariant({ plugin, sourceId, source, profile, allowLegacyDefault }) {
+  if (source.multiProfile === true) {
+    if (!profile) {
+      throw new PluginOpError('plugin',
+        `task source "${plugin}/${sourceId}" has per-profile configuration — pass a profile (e.g. --profile <id>)`);
+    }
+    if (profile === DEFAULT_PROFILE) {
+      if (!allowLegacyDefault) {
+        throw new PluginOpError('plugin',
+          `"${DEFAULT_PROFILE}" is the reserved shared bucket, not a profile of "${plugin}/${sourceId}" — pass a profile from the roster`);
+      }
+    } else if (!listProfileIds(plugin).includes(profile)) {
+      throw new PluginOpError('plugin',
+        `plugin "${plugin}" has no profile "${profile}" — create it in Plugins settings (or POST /api/plugins/${plugin}/profiles) first`);
+    }
+  } else if (profile && profile !== DEFAULT_PROFILE) {
+    throw new PluginOpError('plugin', `task source "${plugin}/${sourceId}" does not use profiles`);
+  }
+}
+
 /**
  * Run ONE connector op in an ephemeral child. Resolves with the op result;
  * rejects with PluginOpError. `logger(level, msg)` is optional — connector
  * ctx.log lines route there (default: console.error, since stdout is the UI's).
+ * `allowLegacyDefault` (host-internal, never surfaced to CLI/routes) lets the
+ * legacy write-back path name DEFAULT_PROFILE on a multiProfile source — see
+ * assertProfileInvariant.
  * @returns {Promise<any>}
  */
-export async function callSource({ plugin, sourceId, op, args = {}, profile, timeoutMs = 30000, logger } = {}) {
+export async function callSource({ plugin, sourceId, op, args = {}, profile, timeoutMs = 30000, logger, allowLegacyDefault = false } = {}) {
   const log = typeof logger === 'function'
     ? logger
     : (level, msg) => console.error(`[plugin:${plugin}] ${level}: ${msg}`);
@@ -135,28 +171,22 @@ export async function callSource({ plugin, sourceId, op, args = {}, profile, tim
   const prof = profile || DEFAULT_PROFILE;
 
   if (mockMode()) {
-    // Canned responses, no spawn, no plugin needed. reportResult additionally
-    // records its args into the plugin state — mirroring the real-child
-    // stateDelta path — so the offline smoke (Task 19) can assert write-back ran.
+    // Canned responses, no spawn, no plugin needed. The profile invariant still
+    // holds whenever the plugin IS installed (behavioral parity so mock runs
+    // catch missing/typo'd profiles too); an uninstalled plugin — the offline
+    // smoke's whole point — skips it. reportResult additionally records its
+    // args into the plugin state — mirroring the real-child stateDelta path —
+    // so the offline smoke (Task 19) can assert write-back ran.
+    let mockSource = null;
+    try { mockSource = loadSource(plugin, sourceId).source; } catch { mockSource = null; }
+    if (mockSource) assertProfileInvariant({ plugin, sourceId, source: mockSource, profile, allowLegacyDefault });
     const r = await mockCall(op, args);
     if (op === 'reportResult') writePluginState(plugin, { lastReport: JSON.stringify(args) }, prof);
     return r;
   }
 
   const { dir, source, apiVersion } = loadSource(plugin, sourceId);
-  // The profile invariant is enforced HERE, not only at the HTTP routes, so
-  // every caller — the CLI's `worca plugin exec`, future workers — is safe by
-  // construction. A multi-profile source silently defaulting to the (empty)
-  // default bucket yields false "not configured" verdicts and persists state
-  // into a bucket no real run reads; a profile on a single-profile source
-  // would read (and write) a phantom bucket instead of the real config.
-  if (source.multiProfile === true && !profile) {
-    throw new PluginOpError('plugin',
-      `task source "${plugin}/${sourceId}" has per-profile configuration — pass a profile (e.g. --profile <id>)`);
-  }
-  if (source.multiProfile !== true && profile && profile !== DEFAULT_PROFILE) {
-    throw new PluginOpError('plugin', `task source "${plugin}/${sourceId}" does not use profiles`);
-  }
+  assertProfileInvariant({ plugin, sourceId, source, profile, allowLegacyDefault });
   const payload = JSON.stringify({
     apiVersion,
     module: resolve(dir, source.module), // './'-relative, '..'-free (normalizeManifest)

--- a/src/core/plugin-store.mjs
+++ b/src/core/plugin-store.mjs
@@ -24,6 +24,7 @@ import { addPluginRepo, fetchCandidate, exportVersion, repoCacheDir } from './pl
 import { importPluginWorkflows, removePluginWorkflows, referencedPluginAgents } from './plugin-workflows.mjs';
 import { pluginModelSecretStatus } from './plugin-models.mjs';
 import { referencedPluginModels } from './config.mjs';
+import { clearBindingsForPlugin } from './source-bindings.mjs';
 
 const execFileP = promisify(execFile);
 const defaultExec = (cmd, args, opts = {}) =>
@@ -326,6 +327,12 @@ export async function uninstallPlugin(name, { purge = false } = {}) {
     );
   }
   await removePluginWorkflows(name); // throws its ReferencedError with the referencing list
+  // Bindings live in the DB, not in the plugin's data dir, so they would
+  // outlive the uninstall: a stale row silently rebinds a project the moment
+  // the plugin is reinstalled with a same-named profile — possibly pointing at
+  // a different tracker. Cleared HERE (not only in the server's DELETE route)
+  // so the CLI's `worca plugin remove` drops them too.
+  clearBindingsForPlugin(name);
   rmSync(pluginCurrentDir(name), { force: true });
   rmSync(join(pluginDir(name), 'versions'), { recursive: true, force: true });
   delete lock[name];
@@ -453,9 +460,16 @@ export async function doctorPlugin(name) {
       for (const s of manifest.taskSources) {
         // A multi-profile source stores nothing in the implicit default bucket;
         // validating that would flag a fully configured plugin as broken. Check
-        // each roster profile instead (falling back to the default bucket only
-        // when no profile exists yet — same "unconfigured" verdict either way).
+        // each roster profile instead. An EMPTY roster is not healthy-by-vacuity
+        // either: every run of the source is rejected ("profile is required")
+        // until one exists, and validating the default bucket instead can even
+        // report green off legacy config migrated under 'default' after an
+        // upgrade flipped the source to multiProfile — a plugin nothing can run.
         const profiles = s.multiProfile ? listProfileIds(name) : [];
+        if (s.multiProfile && !profiles.length) {
+          c(`config:${s.id}`, false, 'no profiles yet — create one in Plugins settings (every run is rejected until then)');
+          continue;
+        }
         for (const profile of profiles.length ? profiles : [undefined]) {
           const id = profile ? `config:${s.id}@${profile}` : `config:${s.id}`;
           try {

--- a/src/core/plugin-store.mjs
+++ b/src/core/plugin-store.mjs
@@ -449,12 +449,21 @@ export async function doctorPlugin(name) {
     try { shim = await import('./plugin-shim.mjs'); } // Task 11 module — may not exist yet
     catch (err) { if (err?.code !== 'ERR_MODULE_NOT_FOUND') throw err; }
     if (shim) {
+      const { listProfileIds } = await import('./plugin-config.mjs');
       for (const s of manifest.taskSources) {
-        try {
-          const r = await shim.callSource({ plugin: name, sourceId: s.id, op: 'validateConfig' });
-          c(`config:${s.id}`, r?.ok !== false, r?.ok === false ? JSON.stringify(r.errors ?? r) : 'validateConfig ok');
-        } catch (err) {
-          c(`config:${s.id}`, false, String(err?.message || err));
+        // A multi-profile source stores nothing in the implicit default bucket;
+        // validating that would flag a fully configured plugin as broken. Check
+        // each roster profile instead (falling back to the default bucket only
+        // when no profile exists yet — same "unconfigured" verdict either way).
+        const profiles = s.multiProfile ? listProfileIds(name) : [];
+        for (const profile of profiles.length ? profiles : [undefined]) {
+          const id = profile ? `config:${s.id}@${profile}` : `config:${s.id}`;
+          try {
+            const r = await shim.callSource({ plugin: name, sourceId: s.id, op: 'validateConfig', profile });
+            c(id, r?.ok !== false, r?.ok === false ? JSON.stringify(r.errors ?? r) : 'validateConfig ok');
+          } catch (err) {
+            c(id, false, String(err?.message || err));
+          }
         }
       }
     }

--- a/src/core/source-bindings.mjs
+++ b/src/core/source-bindings.mjs
@@ -12,10 +12,20 @@
 // pulls from two different sources binds each independently.
 //
 // Deliberately tolerant on read: an unbound scope, an uninstalled plugin and a
-// profile that was since deleted all collapse to the same answer (null / the
-// fallback), because every caller's next move is identical — ask the user.
+// profile that was since deleted all collapse to the same answer (null), because
+// every caller's next move is identical — ask the user. But "never bound" and
+// "was bound, then the profile went away" are NOT the same for the single-
+// profile convenience fallback: a scope that once chose a tracker must be ASKED
+// again, never silently re-pointed at whichever profile happens to survive. So
+// deleting a profile TOMBSTONES its bindings (profile = '') instead of dropping
+// the rows; a tombstone reads as unbound everywhere except resolveProfile's
+// 'only' fallback, which it suppresses.
 
 import { getDb, prepare } from './db.mjs';
+
+/** Deleted-profile marker. Reads as "unbound" (getBinding -> null) but records
+ *  that this scope HAD chosen — resolveProfile must ask, not guess. */
+const TOMBSTONE = '';
 
 /** The two scopes a binding can hang off. */
 const SCOPES = new Set(['project', 'workspace']);
@@ -32,12 +42,9 @@ const key = (o = {}) => ({
   sourceId: String(o.sourceId || ''),
 });
 
-/**
- * The profile explicitly bound to this scope, or null. No fallback logic — use
- * resolveProfile() for that.
- * @returns {string|null}
- */
-export function getBinding(ref) {
+/** Raw row value: null (no row) | '' (tombstone) | profile id. Internal —
+ *  resolveProfile needs the three-way answer; everyone else wants getBinding. */
+function rawBinding(ref) {
   const k = key(ref);
   if (!k.scopeKey || !k.plugin || !k.sourceId) return null;
   getDb();
@@ -45,6 +52,16 @@ export function getBinding(ref) {
     'SELECT profile FROM source_bindings WHERE scope_type = ? AND scope_key = ? AND plugin = ? AND source_id = ?'
   ).get(k.scopeType, k.scopeKey, k.plugin, k.sourceId);
   return row ? String(row.profile) : null;
+}
+
+/**
+ * The profile explicitly bound to this scope, or null (a tombstoned binding
+ * reads as unbound). No fallback logic — use resolveProfile() for that.
+ * @returns {string|null}
+ */
+export function getBinding(ref) {
+  const p = rawBinding(ref);
+  return p === TOMBSTONE ? null : p;
 }
 
 /** Bind (or re-bind) a scope to a profile. Returns the stored profile. */
@@ -73,25 +90,30 @@ export function clearBinding(ref) {
   return { ok: true };
 }
 
-/** Every binding for one scope: [{ plugin, sourceId, profile }]. */
+/** Every LIVE binding for one scope: [{ plugin, sourceId, profile }].
+ *  Tombstones are bookkeeping for resolveProfile, not bindings — excluded. */
 export function listBindingsForScope(scopeType, scopeKey) {
   getDb();
   return prepare(
-    'SELECT plugin, source_id, profile FROM source_bindings WHERE scope_type = ? AND scope_key = ? ORDER BY plugin, source_id'
+    "SELECT plugin, source_id, profile FROM source_bindings WHERE scope_type = ? AND scope_key = ? AND profile != '' ORDER BY plugin, source_id"
   ).all(checkScope(scopeType), String(scopeKey || ''))
     .map((r) => ({ plugin: r.plugin, sourceId: r.source_id, profile: r.profile }));
 }
 
-/** Drop every binding naming a profile — called when that profile is deleted, so
- *  a project never points at a profile that is gone. Plugin-wide (no sourceId):
- *  profiles and their buckets are per-PLUGIN, so deleting one dangles every
- *  source's binding to it, not just the source the delete came in through.
- *  Returns the row count. */
+/** Tombstone every binding naming a profile — called when that profile is
+ *  deleted, so a project never points at a profile that is gone, and never
+ *  silently re-points at a survivor either (the tombstone suppresses the
+ *  single-profile fallback until the user chooses again). Plugin-wide (no
+ *  sourceId): profiles and their buckets are per-PLUGIN, so deleting one
+ *  dangles every source's binding to it, not just the source the delete came
+ *  in through. Returns the row count. */
 export function clearBindingsForProfile(plugin, profile) {
   getDb();
+  const p = String(profile || '');
+  if (!p) return 0; // '' is the tombstone itself, never a deletable profile
   const r = prepare(
-    'DELETE FROM source_bindings WHERE plugin = ? AND profile = ?'
-  ).run(String(plugin || ''), String(profile || ''));
+    'UPDATE source_bindings SET profile = ?, updated_at = ? WHERE plugin = ? AND profile = ?'
+  ).run(TOMBSTONE, new Date().toISOString(), String(plugin || ''), p);
   return Number(r?.changes ?? 0);
 }
 
@@ -111,7 +133,10 @@ export function clearBindingsForPlugin(plugin) {
  *      decide — but only if they AGREE. Members split across two trackers is a
  *      real ambiguity, and guessing one would be the silent-wrong-tracker bug
  *      this module exists to prevent, so it stays unresolved;
- *   3. a source with exactly one profile needs no ceremony — use it;
+ *   3. a source with exactly one profile needs no ceremony — use it, UNLESS
+ *      this scope once chose a profile that has since gone away (a tombstoned
+ *      or stale binding): its next run against a tracker it never picked is
+ *      the exact silent-wrong-tracker bug again, so it degrades to "ask";
  *   4. otherwise null: the caller must ask.
  *
  * `available` is the source's profile id list (plugin-config#listProfiles). A
@@ -127,19 +152,24 @@ export function resolveProfile(ref = {}) {
   const available = Array.isArray(ref.available) ? ref.available.map(String) : null;
   const known = (p) => !!p && (!available || available.includes(p));
 
-  const own = getBinding(ref);
+  const own = rawBinding(ref);
   if (known(own)) return { profile: own, via: 'binding' };
+  // A row that no longer names a live profile — tombstoned by a delete, or
+  // stale (its profile left the roster while we weren't looking) — means this
+  // scope HAD chosen. It must choose again; no fallback may choose for it.
+  let hadBinding = own !== null;
 
   if (ref.scopeType === 'workspace' && Array.isArray(ref.memberKeys) && ref.memberKeys.length) {
     const found = new Set();
     for (const k of ref.memberKeys) {
-      const p = getBinding({ scopeType: 'project', scopeKey: k, plugin: ref.plugin, sourceId: ref.sourceId });
+      const p = rawBinding({ scopeType: 'project', scopeKey: k, plugin: ref.plugin, sourceId: ref.sourceId });
       if (known(p)) found.add(p);
+      else if (p !== null) hadBinding = true; // a member's lapsed choice suppresses the fallback too
     }
     if (found.size === 1) return { profile: [...found][0], via: 'members' };
     if (found.size > 1) return { profile: null, via: 'conflict', candidates: [...found] };
   }
 
-  if (available && available.length === 1) return { profile: available[0], via: 'only' };
+  if (!hadBinding && available && available.length === 1) return { profile: available[0], via: 'only' };
   return { profile: null, via: 'none' };
 }

--- a/src/core/source-bindings.mjs
+++ b/src/core/source-bindings.mjs
@@ -1,0 +1,145 @@
+// src/core/source-bindings.mjs
+// Which PROFILE of a plugin task source a project (or workspace) pulls from.
+//
+// The problem this solves: one worca install drives several projects, and each
+// may belong to a different tracker instance — repo A files tickets in one Jira,
+// repo B in another. Making that a per-run dropdown is how you start a pipeline
+// against the wrong tracker: the mistake is silent (the wrong ticket text simply
+// lands in the prompt) and only visible once the run is underway. So the choice
+// is made ONCE per project and remembered here.
+//
+// Rows are (scope_type, scope_key, plugin, source_id) -> profile. A project that
+// pulls from two different sources binds each independently.
+//
+// Deliberately tolerant on read: an unbound scope, an uninstalled plugin and a
+// profile that was since deleted all collapse to the same answer (null / the
+// fallback), because every caller's next move is identical — ask the user.
+
+import { getDb, prepare } from './db.mjs';
+
+/** The two scopes a binding can hang off. */
+const SCOPES = new Set(['project', 'workspace']);
+
+function checkScope(scopeType) {
+  if (!SCOPES.has(scopeType)) throw new Error(`invalid binding scope "${scopeType}"`);
+  return scopeType;
+}
+
+const key = (o = {}) => ({
+  scopeType: checkScope(o.scopeType),
+  scopeKey: String(o.scopeKey || ''),
+  plugin: String(o.plugin || ''),
+  sourceId: String(o.sourceId || ''),
+});
+
+/**
+ * The profile explicitly bound to this scope, or null. No fallback logic — use
+ * resolveProfile() for that.
+ * @returns {string|null}
+ */
+export function getBinding(ref) {
+  const k = key(ref);
+  if (!k.scopeKey || !k.plugin || !k.sourceId) return null;
+  getDb();
+  const row = prepare(
+    'SELECT profile FROM source_bindings WHERE scope_type = ? AND scope_key = ? AND plugin = ? AND source_id = ?'
+  ).get(k.scopeType, k.scopeKey, k.plugin, k.sourceId);
+  return row ? String(row.profile) : null;
+}
+
+/** Bind (or re-bind) a scope to a profile. Returns the stored profile. */
+export function setBinding(ref, profile) {
+  const k = key(ref);
+  const p = String(profile || '').trim();
+  if (!k.scopeKey || !k.plugin || !k.sourceId) throw new Error('binding needs scopeKey, plugin and sourceId');
+  if (!p) throw new Error('binding needs a profile');
+  getDb();
+  prepare(`
+    INSERT INTO source_bindings (scope_type, scope_key, plugin, source_id, profile, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT (scope_type, scope_key, plugin, source_id)
+    DO UPDATE SET profile = excluded.profile, updated_at = excluded.updated_at
+  `).run(k.scopeType, k.scopeKey, k.plugin, k.sourceId, p, new Date().toISOString());
+  return p;
+}
+
+/** Remove a binding. Silent when there was none. */
+export function clearBinding(ref) {
+  const k = key(ref);
+  getDb();
+  prepare(
+    'DELETE FROM source_bindings WHERE scope_type = ? AND scope_key = ? AND plugin = ? AND source_id = ?'
+  ).run(k.scopeType, k.scopeKey, k.plugin, k.sourceId);
+  return { ok: true };
+}
+
+/** Every binding for one scope: [{ plugin, sourceId, profile }]. */
+export function listBindingsForScope(scopeType, scopeKey) {
+  getDb();
+  return prepare(
+    'SELECT plugin, source_id, profile FROM source_bindings WHERE scope_type = ? AND scope_key = ? ORDER BY plugin, source_id'
+  ).all(checkScope(scopeType), String(scopeKey || ''))
+    .map((r) => ({ plugin: r.plugin, sourceId: r.source_id, profile: r.profile }));
+}
+
+/** Drop every binding naming a profile — called when that profile is deleted, so
+ *  a project never points at a profile that is gone. Plugin-wide (no sourceId):
+ *  profiles and their buckets are per-PLUGIN, so deleting one dangles every
+ *  source's binding to it, not just the source the delete came in through.
+ *  Returns the row count. */
+export function clearBindingsForProfile(plugin, profile) {
+  getDb();
+  const r = prepare(
+    'DELETE FROM source_bindings WHERE plugin = ? AND profile = ?'
+  ).run(String(plugin || ''), String(profile || ''));
+  return Number(r?.changes ?? 0);
+}
+
+/** Drop every binding for a plugin — called on uninstall. */
+export function clearBindingsForPlugin(plugin) {
+  getDb();
+  prepare('DELETE FROM source_bindings WHERE plugin = ?').run(String(plugin || ''));
+  return { ok: true };
+}
+
+/**
+ * The profile a run should use, with the fallbacks that make the common case
+ * invisible:
+ *
+ *   1. an explicit binding on this scope wins;
+ *   2. for a WORKSPACE with no binding of its own, the member projects' bindings
+ *      decide — but only if they AGREE. Members split across two trackers is a
+ *      real ambiguity, and guessing one would be the silent-wrong-tracker bug
+ *      this module exists to prevent, so it stays unresolved;
+ *   3. a source with exactly one profile needs no ceremony — use it;
+ *   4. otherwise null: the caller must ask.
+ *
+ * `available` is the source's profile id list (plugin-config#listProfiles). A
+ * binding naming a profile that is no longer in it is treated as absent, so
+ * deleting a profile degrades to "ask" rather than to a broken run.
+ *
+ * @param {{scopeType:string, scopeKey:string, plugin:string, sourceId:string,
+ *          memberKeys?:string[], available?:string[]}} ref
+ * @returns {{profile:string|null, via:'binding'|'members'|'only'|'none'|'conflict',
+ *           candidates?:string[]}}
+ */
+export function resolveProfile(ref = {}) {
+  const available = Array.isArray(ref.available) ? ref.available.map(String) : null;
+  const known = (p) => !!p && (!available || available.includes(p));
+
+  const own = getBinding(ref);
+  if (known(own)) return { profile: own, via: 'binding' };
+
+  if (ref.scopeType === 'workspace' && Array.isArray(ref.memberKeys) && ref.memberKeys.length) {
+    const found = new Set();
+    for (const k of ref.memberKeys) {
+      const p = getBinding({ scopeType: 'project', scopeKey: k, plugin: ref.plugin, sourceId: ref.sourceId });
+      if (known(p)) found.add(p);
+    }
+    if (found.size === 1) return { profile: [...found][0], via: 'members' };
+    if (found.size > 1) return { profile: null, via: 'conflict', candidates: [...found] };
+  }
+
+  if (available && available.length === 1) return { profile: available[0], via: 'only' };
+  return { profile: null, via: 'none' };
+}

--- a/src/core/sources.mjs
+++ b/src/core/sources.mjs
@@ -10,7 +10,7 @@ import { readFileSync } from 'node:fs';
 import { isAbsolute, join, resolve } from 'node:path';
 import { callSource } from './plugin-shim.mjs';
 import { readPluginsLock, pluginCurrentDir } from './plugins-lock.mjs';
-import { listProfiles } from './plugin-config.mjs';
+import { listProfiles, DEFAULT_PROFILE } from './plugin-config.mjs';
 import { normalizeManifest } from './plugin-manifest.mjs';
 import { getDb } from './db.mjs';
 import { runDirForRow, readStoreMeta } from './artifacts.mjs';
@@ -26,6 +26,20 @@ function resolveAgainst(base, p) {
  *  plugin's data dir is unreadable (it degrades to "no profiles yet"). */
 function safeProfiles(name) {
   try { return listProfiles(name); } catch { return []; }
+}
+
+/** Whether an installed source declares multiProfile; never throws (an
+ *  uninstalled plugin or broken manifest answers false — the callers below
+ *  degrade to pre-profiles behavior, which is the only thing they could do). */
+function isMultiProfileSource(plugin, sourceId) {
+  try {
+    const dir = pluginCurrentDir(plugin);
+    const norm = normalizeManifest(JSON.parse(readFileSync(join(dir, 'worca-cc-plugin.json'), 'utf8')), { dir });
+    if (!norm.ok) return false;
+    return (norm.manifest.taskSources || []).some((s) => s.id === sourceId && s.multiProfile === true);
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -188,32 +202,46 @@ export async function reportResultForPipeline(pipelineRow, resultsBundle) {
     try { ref = pipelineRow.source_ref ? JSON.parse(pipelineRow.source_ref) : null; } catch { ref = null; }
     if (!ref?.plugin || !ref?.sourceId || !ref?.taskId) return { ok: true, skipped: true };
 
+    // Which profile to report against. Normally the one pinned on the row when
+    // the task was fetched (resolveTaskInput). A row that PREDATES profiles has
+    // none — and if the plugin has since upgraded to multiProfile, refusing to
+    // report would strand the row forever (no code path can attach a profile to
+    // an existing source_ref, so the results-view retry would fail identically
+    // every time). Its task came from the instance whose flat config migrated
+    // into the DEFAULT_PROFILE bucket, so that is exactly where the report
+    // belongs — allowLegacyDefault is the shim's host-internal opt-in for it.
+    const profile = ref.profile || null;
+    const allowLegacyDefault = !profile && isMultiProfileSource(ref.plugin, ref.sourceId);
+    const callRef = {
+      plugin: ref.plugin,
+      sourceId: ref.sourceId,
+      profile: allowLegacyDefault ? DEFAULT_PROFILE : profile,
+      allowLegacyDefault,
+    };
+
     // Capability probe. capabilities() is optional in the connector contract
     // (§7.1: "defaults: writeBack true"): a connector without the op makes the
-    // child answer { ok:false, error:{ kind:'plugin', message: 'connector does
-    // not implement op "capabilities"' } } -> callSource throws
-    // PluginOpError('plugin') -> we default to writeBack:true.
+    // child answer kind 'unimplemented' -> we default to writeBack:true.
     // The run's pinned source-panel inputs travel to BOTH ops so a connector
-    // can make write-back a per-run choice (jira-source's writeBack input):
-    // capabilities({inputs}) answers for THIS run.
-    // Transport errors (auth/network/timeout/protocol/rate-limit) mean the
+    // can make write-back a per-run choice: the opt-out rides the reserved
+    // input key `writeBack` (jira-source's "Write result back" input;
+    // capabilities({inputs}) answers for THIS run).
+    // Every OTHER probe error — an implemented capabilities() that crashed, a
+    // transport failure (auth/network/timeout/protocol/rate-limit) — means the
     // connector could not answer, and what happens next depends on whether an
-    // answer could have mattered: a per-run opt-out can only ride the pinned
-    // inputs, so a run that pinned NONE fails OPEN (default writeBack:true —
-    // a transient rate-limit on the probe must not silently drop the ticket
-    // comment when the report itself would have succeeded), while a run WITH
-    // pinned inputs fails CLOSED (the opt-out may be in them and we could not
-    // hear it; writing would violate it) — the caller surfaces the error and
-    // the results-view retry re-probes.
+    // answer could have mattered: a run that pinned no `writeBack` input fails
+    // OPEN (default writeBack:true — a transient rate-limit on the probe must
+    // not silently drop the ticket comment when the report itself would have
+    // succeeded), while a run WITH one fails CLOSED (the opt-out may be 'no'
+    // and we could not hear it; writing would violate it) — the caller
+    // surfaces the error and the results-view retry re-probes.
     const inputs = ref.inputs && typeof ref.inputs === 'object' ? ref.inputs : {};
     let writeBack = true;
     try {
-      const caps = await callSource({
-        plugin: ref.plugin, sourceId: ref.sourceId, op: 'capabilities', args: { inputs }, profile: ref.profile,
-      });
+      const caps = await callSource({ ...callRef, op: 'capabilities', args: { inputs } });
       if (caps && caps.writeBack === false) writeBack = false;
     } catch (err) {
-      if ((err?.kind || 'plugin') !== 'plugin' && Object.keys(inputs).length) {
+      if ((err?.kind || 'plugin') !== 'unimplemented' && 'writeBack' in inputs) {
         return { ok: false, error: `write-back capability probe failed: ${err?.message || String(err)}` };
       }
       writeBack = true;
@@ -221,10 +249,7 @@ export async function reportResultForPipeline(pipelineRow, resultsBundle) {
     if (!writeBack) return { ok: true, skipped: true };
 
     await callSource({
-      plugin: ref.plugin,
-      sourceId: ref.sourceId,
-      // The profile recorded when the task was fetched — see resolveTaskInput.
-      profile: ref.profile,
+      ...callRef,
       op: 'reportResult',
       args: {
         id: ref.taskId,

--- a/src/core/sources.mjs
+++ b/src/core/sources.mjs
@@ -10,6 +10,7 @@ import { readFileSync } from 'node:fs';
 import { isAbsolute, join, resolve } from 'node:path';
 import { callSource } from './plugin-shim.mjs';
 import { readPluginsLock, pluginCurrentDir } from './plugins-lock.mjs';
+import { listProfiles } from './plugin-config.mjs';
 import { normalizeManifest } from './plugin-manifest.mjs';
 import { getDb } from './db.mjs';
 import { runDirForRow, readStoreMeta } from './artifacts.mjs';
@@ -19,6 +20,12 @@ import { hasGh, findPrForBranch } from './git-info.mjs';
 /** Same resolve-against-projectDir semantics as artifacts.mjs#resolveAgainst. */
 function resolveAgainst(base, p) {
   return isAbsolute(p) ? p : resolve(base, p);
+}
+
+/** Profile roster for a plugin; never throws — the pane must render even when a
+ *  plugin's data dir is unreadable (it degrades to "no profiles yet"). */
+function safeProfiles(name) {
+  try { return listProfiles(name); } catch { return []; }
 }
 
 /**
@@ -50,6 +57,12 @@ export function listTaskSources() {
         sourceId: ts.id,
         displayName: ts.displayName || `${name}/${ts.id}`,
         inputs: ts.inputs || [],
+        // A multi-profile source cannot be used until the pane knows WHICH
+        // configuration to run against, so the roster ships with the listing —
+        // the New Pipeline pane resolves the project's binding against it
+        // without a second round trip.
+        multiProfile: ts.multiProfile === true,
+        profiles: ts.multiProfile === true ? safeProfiles(name) : [],
       });
     }
   }
@@ -68,9 +81,9 @@ function taskPromptText(task) {
 /**
  * Resolve a source descriptor to the pipeline's task input.
  *   { type:'prompt', prompt } | { type:'markdown', promptText?, promptFile? }
- * | { type:'plugin', plugin, sourceId, taskId, inputs? }
+ * | { type:'plugin', plugin, sourceId, taskId, inputs?, profile? }
  * @returns {Promise<{promptText:string, promptFile:string|null,
- *   sourceMeta:{plugin,sourceId,taskId,url,title}|null}>}
+ *   sourceMeta:{plugin,sourceId,taskId,profile,url,title}|null}>}
  */
 export async function resolveTaskInput(source, { projectDir } = {}) {
   const src = source && typeof source === 'object' ? source : { type: 'prompt', prompt: '' };
@@ -94,7 +107,10 @@ export async function resolveTaskInput(source, { projectDir } = {}) {
   }
 
   if (type === 'plugin') {
-    const task = await callSource({ plugin: src.plugin, sourceId: src.sourceId, op: 'getTask', args: { id: src.taskId } });
+    const task = await callSource({
+      plugin: src.plugin, sourceId: src.sourceId, op: 'getTask',
+      args: { id: src.taskId }, profile: src.profile,
+    });
     if (!task) {
       throw new Error(`task-source ${src.plugin}/${src.sourceId}: task "${src.taskId}" not found`);
     }
@@ -105,6 +121,14 @@ export async function resolveTaskInput(source, { projectDir } = {}) {
         plugin: src.plugin,
         sourceId: src.sourceId,
         taskId: src.taskId,
+        // Pinned on the ROW, not re-derived at write-back time: the project's
+        // binding may have moved to another tracker by then, and a result must
+        // always be reported to the instance the task actually came from.
+        profile: src.profile || null,
+        // The source-panel inputs at fetch time, pinned for the same reason:
+        // a per-RUN choice (e.g. jira-source's "Write result back") must gate
+        // this run's report with what the user picked when they started it.
+        inputs: src.inputs && typeof src.inputs === 'object' ? src.inputs : null,
         url: task.url ?? null,
         title: task.title ?? null,
       },
@@ -164,18 +188,29 @@ export async function reportResultForPipeline(pipelineRow, resultsBundle) {
     try { ref = pipelineRow.source_ref ? JSON.parse(pipelineRow.source_ref) : null; } catch { ref = null; }
     if (!ref?.plugin || !ref?.sourceId || !ref?.taskId) return { ok: true, skipped: true };
 
-    // Capability probe with a TOLERANT DEFAULT. capabilities() is optional in the
-    // connector contract (§7.1: "defaults: writeBack true"): a connector without
-    // the op makes the child answer { ok:false, error:{ kind:'plugin', message:
-    // 'connector does not implement op "capabilities"' } } -> callSource throws
+    // Capability probe. capabilities() is optional in the connector contract
+    // (§7.1: "defaults: writeBack true"): a connector without the op makes the
+    // child answer { ok:false, error:{ kind:'plugin', message: 'connector does
+    // not implement op "capabilities"' } } -> callSource throws
     // PluginOpError('plugin') -> we default to writeBack:true. Transport errors
-    // (auth/network/timeout/protocol) ALSO default to true — the reportResult
-    // call below is the one that surfaces the real failure to the caller.
+    // (auth/network/timeout/protocol/rate-limit) FAIL CLOSED instead: the
+    // connector may have opted this run out via its inputs and we could not
+    // hear the answer, so writing would violate the opt-out — the caller
+    // surfaces the error and the results-view retry re-probes.
+    // The run's pinned source-panel inputs travel to BOTH ops so a connector
+    // can make write-back a per-run choice (jira-source's writeBack input):
+    // capabilities({inputs}) answers for THIS run.
+    const inputs = ref.inputs && typeof ref.inputs === 'object' ? ref.inputs : {};
     let writeBack = true;
     try {
-      const caps = await callSource({ plugin: ref.plugin, sourceId: ref.sourceId, op: 'capabilities', args: {} });
+      const caps = await callSource({
+        plugin: ref.plugin, sourceId: ref.sourceId, op: 'capabilities', args: { inputs }, profile: ref.profile,
+      });
       if (caps && caps.writeBack === false) writeBack = false;
-    } catch {
+    } catch (err) {
+      if ((err?.kind || 'plugin') !== 'plugin') {
+        return { ok: false, error: `write-back capability probe failed: ${err?.message || String(err)}` };
+      }
       writeBack = true;
     }
     if (!writeBack) return { ok: true, skipped: true };
@@ -183,12 +218,15 @@ export async function reportResultForPipeline(pipelineRow, resultsBundle) {
     await callSource({
       plugin: ref.plugin,
       sourceId: ref.sourceId,
+      // The profile recorded when the task was fetched — see resolveTaskInput.
+      profile: ref.profile,
       op: 'reportResult',
       args: {
         id: ref.taskId,
         status: statusToResult(pipelineRow.status),
         summary: buildResultSummary(pipelineRow, resultsBundle),
         links: buildResultLinks(resultsBundle),
+        inputs,
       },
     });
     return { ok: true };

--- a/src/core/sources.mjs
+++ b/src/core/sources.mjs
@@ -192,14 +192,19 @@ export async function reportResultForPipeline(pipelineRow, resultsBundle) {
     // (§7.1: "defaults: writeBack true"): a connector without the op makes the
     // child answer { ok:false, error:{ kind:'plugin', message: 'connector does
     // not implement op "capabilities"' } } -> callSource throws
-    // PluginOpError('plugin') -> we default to writeBack:true. Transport errors
-    // (auth/network/timeout/protocol/rate-limit) FAIL CLOSED instead: the
-    // connector may have opted this run out via its inputs and we could not
-    // hear the answer, so writing would violate the opt-out — the caller
-    // surfaces the error and the results-view retry re-probes.
+    // PluginOpError('plugin') -> we default to writeBack:true.
     // The run's pinned source-panel inputs travel to BOTH ops so a connector
     // can make write-back a per-run choice (jira-source's writeBack input):
     // capabilities({inputs}) answers for THIS run.
+    // Transport errors (auth/network/timeout/protocol/rate-limit) mean the
+    // connector could not answer, and what happens next depends on whether an
+    // answer could have mattered: a per-run opt-out can only ride the pinned
+    // inputs, so a run that pinned NONE fails OPEN (default writeBack:true —
+    // a transient rate-limit on the probe must not silently drop the ticket
+    // comment when the report itself would have succeeded), while a run WITH
+    // pinned inputs fails CLOSED (the opt-out may be in them and we could not
+    // hear it; writing would violate it) — the caller surfaces the error and
+    // the results-view retry re-probes.
     const inputs = ref.inputs && typeof ref.inputs === 'object' ? ref.inputs : {};
     let writeBack = true;
     try {
@@ -208,7 +213,7 @@ export async function reportResultForPipeline(pipelineRow, resultsBundle) {
       });
       if (caps && caps.writeBack === false) writeBack = false;
     } catch (err) {
-      if ((err?.kind || 'plugin') !== 'plugin') {
+      if ((err?.kind || 'plugin') !== 'plugin' && Object.keys(inputs).length) {
         return { ok: false, error: `write-back capability probe failed: ${err?.message || String(err)}` };
       }
       writeBack = true;

--- a/test/api-sources.test.mjs
+++ b/test/api-sources.test.mjs
@@ -37,6 +37,15 @@ const MANIFEST = {
       { key: 'repo', type: 'remote-select', label: 'Repo', optionsFrom: 'listRepos' },
       { key: 'task', type: 'task-browser', label: 'Task' },
     ],
+  }, {
+    // A second, multiProfile source: the profile-required guards on /api/run,
+    // /api/sources/call and the config echo all branch on this flag.
+    id: 'prof',
+    displayName: 'Profiled Source',
+    module: './connector/index.mjs',
+    multiProfile: true,
+    configSchema: [{ key: 'token', type: 'text', label: 'Token', secret: true, required: true }],
+    inputs: [{ key: 'task', type: 'task-browser', label: 'Task' }],
   }],
 };
 const CONNECTOR = `export default function createTaskSource(ctx) {
@@ -102,7 +111,9 @@ after(async () => {
   if (srv) await new Promise((r) => srv.close(r));
   delete process.env.WORCA_MOCK;
   if (prevHome === undefined) delete process.env.WORCA_HOME; else process.env.WORCA_HOME = prevHome;
-  await rm(homeDir, { recursive: true, force: true });
+  // A fire-and-forget mock run may still be writing into the store when this
+  // hook runs — same ENOTEMPTY race rmWithRetry exists for.
+  await rmWithRetry(homeDir);
   await rm(pluginDir, { recursive: true, force: true });
 });
 
@@ -164,6 +175,30 @@ test('POST /api/run source-shape guards -> 400 with pointed messages', async () 
   });
   assert.equal(r.status, 400);
   assert.match((await r.json()).error, /not both/);
+});
+
+test('multiProfile source without a profile is rejected at submit, not mid-run', async () => {
+  const projectDir = join(tmpdir(), 'worca-cc-never-created'); // guard fires before any mkdir
+  // /api/run: a run against the (empty) default bucket would die mid-pipeline
+  // with a confusing connector error — the submit is where the client can fix it.
+  let r = await post('/api/run', {
+    projectDir, source: { type: 'plugin', plugin: 'local-src', sourceId: 'prof', taskId: 't1' },
+  });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /source\.profile is required/);
+  // The single-profile sibling is untouched by the guard (shape-checked only).
+  r = await post('/api/run', { projectDir, source: { type: 'plugin', plugin: 'local-src', sourceId: 'main', taskId: 't1', profile: 'NOT-valid!' } });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /not a valid profile id/);
+  // /api/sources/call has the same requirement.
+  r = await post('/api/sources/call', { plugin: 'local-src', sourceId: 'prof', op: 'listTasks', args: { inputs: {} } });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /profile is required/);
+  // Config echo: a profile that is not in the roster is a caller error — an
+  // empty form for it would let Save quietly create the typo as a profile.
+  r = await get('/api/plugins/local-src/config?profile=no-such');
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /has no profile/);
 });
 
 test('POST /api/run with a plugin source stamps pipelines.source_type/source_ref', async () => {

--- a/test/api-sources.test.mjs
+++ b/test/api-sources.test.mjs
@@ -253,6 +253,62 @@ test('legacy POST /api/run { prompt } is byte-identical: 200 + runId, default so
   assert.equal((await bad.json()).error, 'prompt or promptMarkdown is required');
 });
 
+test('profiles: "default" is reserved, and a save never mints a profile the roster does not know', async () => {
+  const put = (p, b) => fetch(`${base}${p}`, { method: 'PUT', headers: JSONH, body: JSON.stringify(b) });
+  const del = (p) => fetch(`${base}${p}`, { method: 'DELETE' });
+  // "default" backs every profile-less read (chat channels, model secrets,
+  // migrated legacy config) — it must be neither creatable nor deletable.
+  let r = await post('/api/plugins/local-src/profiles', { sourceId: 'prof', id: 'default', label: 'Nope' });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /reserved/);
+  r = await del('/api/plugins/local-src/profiles/default?sourceId=prof');
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /reserved/);
+  // A save into a non-roster profile is the GET guard's typo scenario from the
+  // write side: 400, and the typo is NOT quietly minted as a real profile.
+  r = await put('/api/plugins/local-src/config', { sourceId: 'prof', profile: 'wrok', values: { token: 't' } });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /has no profile "wrok"/);
+  let cfg = await (await get('/api/plugins/local-src/config')).json();
+  assert.deepEqual(cfg.sources.find((s) => s.id === 'prof').profiles, [], 'roster untouched by the rejected save');
+  // The sanctioned path: POST /profiles first, then the save lands.
+  r = await post('/api/plugins/local-src/profiles', { sourceId: 'prof', id: 'work', label: 'Work' });
+  assert.equal(r.status, 200);
+  r = await put('/api/plugins/local-src/config', { sourceId: 'prof', profile: 'work', values: { token: 't' } });
+  assert.equal(r.status, 200);
+  cfg = await (await get('/api/plugins/local-src/config')).json();
+  assert.deepEqual(cfg.sources.find((s) => s.id === 'prof').profiles, [{ id: 'work', label: 'Work' }]);
+});
+
+test('a deleted (or stray) profile is rejected at submit on /api/run and /api/sources/call', async () => {
+  const projectDir = join(tmpdir(), 'worca-cc-never-created'); // guards fire before any mkdir
+  // multiProfile + a profile the roster does not know (deleted in another tab):
+  // 400 at submit, not a confusing connector failure mid-pipeline.
+  let r = await post('/api/run', {
+    projectDir, source: { type: 'plugin', plugin: 'local-src', sourceId: 'prof', taskId: 't1', profile: 'ghost' },
+  });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /has no profile "ghost"/);
+  // A profile on a single-profile source would read a phantom bucket instead
+  // of the real config — rejected, not silently honored.
+  r = await post('/api/run', {
+    projectDir, source: { type: 'plugin', plugin: 'local-src', sourceId: 'main', taskId: 't1', profile: 'work' },
+  });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /does not use profiles/);
+  // Same pair of guards on the pane's data channel.
+  r = await post('/api/sources/call', { plugin: 'local-src', sourceId: 'prof', op: 'listTasks', profile: 'ghost', args: { inputs: {} } });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /has no profile "ghost"/);
+  r = await post('/api/sources/call', { plugin: 'local-src', sourceId: 'main', op: 'listTasks', profile: 'work', args: { inputs: {} } });
+  assert.equal(r.status, 400);
+  assert.match((await r.json()).error, /does not use profiles/);
+  // The roster member sails through (mock cans listTasks).
+  r = await post('/api/sources/call', { plugin: 'local-src', sourceId: 'prof', op: 'listTasks', profile: 'work', args: { inputs: {} } });
+  assert.equal(r.status, 200);
+  assert.equal((await r.json()).ok, true);
+});
+
 test('POST /api/pipelines/:id/report-result: 404 unknown id; mock write-back retry -> { ok: true }', async () => {
   assert.equal((await post('/api/pipelines/deadbeef/report-result', {})).status, 404);
   // Seed a TERMINAL plugin-sourced row directly (deterministic — no dependence

--- a/test/db-pause-schema.test.mjs
+++ b/test/db-pause-schema.test.mjs
@@ -7,7 +7,7 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { useTempHome } from './helpers/temp-home.mjs';
-import { getDb } from '../src/core/db.mjs';
+import { getDb, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { writeState } from '../src/core/artifacts.mjs';
 
 useTempHome(after);
@@ -20,7 +20,7 @@ test('v5 adds resume_point and session_id columns', () => {
   assert.ok(cols('pipelines').includes('resume_point'), 'pipelines.resume_point exists');
   assert.ok(cols('pipeline_steps').includes('session_id'), 'pipeline_steps.session_id exists');
   const v = getDb().prepare('PRAGMA user_version').get().user_version;
-  assert.equal(v, 17);
+  assert.equal(v, SCHEMA_VERSION);
 });
 
 test('writeState persists resumePoint and per-step sessionId', async () => {

--- a/test/db.test.mjs
+++ b/test/db.test.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
-import { getDb, closeDb, _resetForTests, prepare, tx, migrate as _migrateForTest } from '../src/core/db.mjs';
+import { getDb, closeDb, _resetForTests, prepare, tx, migrate as _migrateForTest, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { worcaHome } from '../src/core/projects.mjs';
 import { _migrateFromFsCallCount, _resetMigrateFromFsCallCount } from '../src/core/migrate-fs-to-db.mjs';
 
@@ -134,16 +134,16 @@ test('migrate creates every required index', () => {
   }
 });
 
-test('migrate stamps user_version = 17', () => {
+test('migrate stamps user_version = SCHEMA_VERSION', () => {
   const db = getDb();
   const { user_version } = db.prepare('PRAGMA user_version').get();
-  assert.equal(user_version, 17, 'schema version is 17 after migrate');
+  assert.equal(user_version, SCHEMA_VERSION, 'schema version is current after migrate');
 });
 
 test('migrate() reaches v11 and adds workflows.domain + liveness columns', async () => {
   await freshHome();
   const db = getDb();                                   // triggers migrate()
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const wfCols = db.prepare('PRAGMA table_info(workflows)').all().map((c) => c.name);
   assert.ok(wfCols.includes('domain'), 'workflows.domain column exists');
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
@@ -263,7 +263,7 @@ test('getDb() calls maybeMigrateFromFs(db) once after migrate()', () => {
   assert.equal(_migrateFromFsCallCount(), 1, 'hook invoked exactly once on first open');
   // The schema must already exist when the hook runs (it reads/writes rows).
   const { user_version } = db.prepare('PRAGMA user_version').get();
-  assert.equal(user_version, 17, 'migrate() ran before the hook');
+  assert.equal(user_version, SCHEMA_VERSION, 'migrate() ran before the hook');
   // Cached singleton: a repeat getDb() must NOT re-run the one-shot hook.
   getDb();
   assert.equal(_migrateFromFsCallCount(), 1, 'hook not re-run on cached getDb()');
@@ -313,7 +313,7 @@ test('getDb() first-launch is concurrency-safe across N processes (no lock/exist
 
   // The shared DB is migrated exactly once: v2 stamped, exactly one projects table.
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'migrated to v17');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'migrated to the current version');
   assert.equal(
     db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='projects'").get().n,
     1, 'exactly one projects table after the race');

--- a/test/migrate-v10.test.mjs
+++ b/test/migrate-v10.test.mjs
@@ -3,13 +3,13 @@ import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';
 import { useTempHome } from './helpers/temp-home.mjs';
-import { getDb, migrate } from '../src/core/db.mjs';
+import { getDb, migrate, SCHEMA_VERSION } from '../src/core/db.mjs';
 
 useTempHome(after);
 
-test('v10 adds nullable owner_pid/owner_host/heartbeat_at; user_version becomes 15', () => {
+test('v10 adds nullable owner_pid/owner_host/heartbeat_at; user_version becomes the current version', () => {
   const db = getDb(); // getDb() opens + migrates to SCHEMA_VERSION
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const cols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   for (const c of ['owner_pid', 'owner_host', 'heartbeat_at']) assert.ok(cols.includes(c), c);
 });
@@ -51,7 +51,7 @@ test('incremental v9->v10 migration: migrate() adds columns on a v9 DB and stamp
   // Now run the incremental migration
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const cols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   for (const c of ['owner_pid', 'owner_host', 'heartbeat_at']) assert.ok(cols.includes(c), c);
   const row = db.prepare('SELECT owner_pid, owner_host, heartbeat_at FROM pipelines WHERE id = ?').get('seed1');

--- a/test/migrate-v12.test.mjs
+++ b/test/migrate-v12.test.mjs
@@ -16,7 +16,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { useTempHome } from './helpers/temp-home.mjs';
-import { getDb, migrate, _resetForTests } from '../src/core/db.mjs';
+import { getDb, migrate, _resetForTests, SCHEMA_VERSION } from '../src/core/db.mjs';
 
 useTempHome(after);
 
@@ -35,7 +35,7 @@ const V10_NODES_SEED = `
 
 test('fresh DB migrates to v12 with ask_questions + step_questions present', () => {
   const db = getDb(); // opens + migrates to SCHEMA_VERSION
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const cols = db.prepare('PRAGMA table_info(config_workflow_nodes)').all().map((c) => c.name);
   assert.ok(cols.includes('ask_questions'), 'ask_questions column exists');
   const tbl = db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='step_questions'").get();
@@ -50,7 +50,7 @@ test('repairs a stale-stamped v11 DB (version says 11, v11 DDL never ran)', () =
 
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const cols = db.prepare('PRAGMA table_info(config_workflow_nodes)').all().map((c) => c.name);
   assert.ok(cols.includes('ask_questions'), 'repair added ask_questions');
   const tbl = db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='step_questions'").get();
@@ -75,7 +75,7 @@ test('getDb() repairs a stale-stamped on-disk DB at WORCA_HOME', () => {
   _resetForTests();
   try {
     const db = getDb();
-    assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+    assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
     const cols = db.prepare('PRAGMA table_info(config_workflow_nodes)').all().map((c) => c.name);
     assert.ok(cols.includes('ask_questions'));
     assert.equal(db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE name='step_questions'").get().n, 1);
@@ -91,9 +91,9 @@ test('fast-path reconcile heals missing column/table on a DB already stamped to 
   const db = new DatabaseSync(':memory:');
   db.exec(V10_NODES_SEED);
   db.exec('CREATE TABLE workflows (id TEXT PRIMARY KEY, name TEXT)'); // pre-`domain` shape
-  db.exec('PRAGMA user_version = 17'); // stamped current: the ladder must no-op...
+  db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`); // stamped current: the ladder must no-op...
   migrate(db);
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'stamp untouched');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'stamp untouched');
   // ...yet the incremental gaps are healed anyway.
   const nodeCols = db.prepare('PRAGMA table_info(config_workflow_nodes)').all().map((c) => c.name);
   assert.ok(nodeCols.includes('ask_questions'), 'ask_questions healed');
@@ -126,7 +126,7 @@ test('no-op on a correctly-migrated v11 DB (no duplicate-column / existing-table
 
   migrate(db); // must not throw (duplicate column / table exists)
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   // Existing data in both v11 structures is untouched.
   assert.equal(db.prepare('SELECT ask_questions FROM config_workflow_nodes WHERE node_id = ?').get('n1').ask_questions, 1);
   assert.equal(db.prepare('SELECT count(*) AS n FROM step_questions').get().n, 1);

--- a/test/migrate-v13.test.mjs
+++ b/test/migrate-v13.test.mjs
@@ -13,7 +13,7 @@ import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';
 import { useTempHome } from './helpers/temp-home.mjs';
-import { getDb, migrate } from '../src/core/db.mjs';
+import { getDb, migrate, SCHEMA_VERSION } from '../src/core/db.mjs';
 
 useTempHome(after);
 
@@ -26,7 +26,7 @@ const V12_MINIMAL_SEED = `
 
 test('fresh DB migrates to v13 with source columns + workflow origin, defaults correct', () => {
   const db = getDb(); // opens + migrates to SCHEMA_VERSION
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('source_type'), 'pipelines.source_type exists');
   assert.ok(pipCols.includes('source_ref'), 'pipelines.source_ref exists');
@@ -50,7 +50,7 @@ test('a v12-stamped DB upgrades: columns added, pre-existing rows backfill the d
 
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const row = db.prepare("SELECT source_type, source_ref FROM pipelines WHERE id = 'pre'").get();
   assert.equal(row.source_type, 'prompt', 'legacy row reads the ALTER default');
   assert.equal(row.source_ref, null);
@@ -65,11 +65,11 @@ test('fast-path reconcile heals a current-stamped DB missing the v13 columns (pa
   const db = new DatabaseSync(':memory:');
   db.exec(V12_MINIMAL_SEED);
   db.exec('ALTER TABLE pipelines ADD COLUMN source_ref TEXT'); // present; source_type + origin missing
-  db.exec('PRAGMA user_version = 17'); // stamped current: the ladder must no-op...
+  db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`); // stamped current: the ladder must no-op...
 
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'stamp untouched');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'stamp untouched');
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('source_type'), 'source_type healed');
   assert.ok(pipCols.includes('source_ref'), 'pre-existing source_ref survived (no duplicate-column throw)');
@@ -97,7 +97,7 @@ test('ladder from below 12 does not double-add the v13 columns', () => {
     PRAGMA user_version = 11;
   `);
   migrate(db); // v12 heal adds source_*/origin, then the v13 step must no-op — not throw
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('source_type') && pipCols.includes('source_ref'));
 });
@@ -108,5 +108,5 @@ test('migrate() is idempotent at v13 (second call is a clean no-op)', () => {
   db.exec('PRAGMA user_version = 12');
   migrate(db);
   migrate(db); // fast path + reconcile: must not throw duplicate column / table
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
 });

--- a/test/migrate-v14.test.mjs
+++ b/test/migrate-v14.test.mjs
@@ -12,7 +12,7 @@ import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';
 import { useTempHome } from './helpers/temp-home.mjs';
-import { getDb, migrate } from '../src/core/db.mjs';
+import { getDb, migrate, SCHEMA_VERSION } from '../src/core/db.mjs';
 
 useTempHome(after);
 
@@ -26,7 +26,7 @@ const V13_MINIMAL_SEED = `
 
 test('fresh DB migrates to v14 with the guardrail_sets table + pipelines.guardrails_id', () => {
   const db = getDb(); // opens + migrates to SCHEMA_VERSION
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('guardrails_id'), 'pipelines.guardrails_id exists');
   assert.equal(
@@ -48,7 +48,7 @@ test('a v13-stamped DB upgrades: column + table added, pre-existing rows read NU
 
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   assert.equal(db.prepare("SELECT guardrails_id FROM pipelines WHERE id = 'pre'").get().guardrails_id, null,
     'legacy row reads NULL (selection unknown)');
   assert.equal(
@@ -59,11 +59,11 @@ test('a v13-stamped DB upgrades: column + table added, pre-existing rows read NU
 test('a current-stamped DB missing the additions is healed by the fast-path reconcile, stamp untouched', () => {
   const db = new DatabaseSync(':memory:');
   db.exec(V13_MINIMAL_SEED);
-  db.exec('PRAGMA user_version = 17'); // divergent-ladder stamp: version says done, schema says otherwise
+  db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`); // divergent-ladder stamp: version says done, schema says otherwise
 
   migrate(db); // fast path -> reconcileSchema self-heal
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'stamp not rewritten');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'stamp not rewritten');
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('guardrails_id'), 'column healed');
   assert.equal(
@@ -81,7 +81,7 @@ test('ladder from below 13 does not double-add the v14 additions (conditional-re
   // tables BEFORE the v14 step runs. If someone "simplifies" applySchemaV14 to a
   // plain ALTER/CREATE string, this throws "duplicate column" / "table already exists".
   migrate(db);
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
 });
 
 test('migrate() is idempotent (second call is a clean no-op)', () => {
@@ -90,5 +90,5 @@ test('migrate() is idempotent (second call is a clean no-op)', () => {
   db.exec('PRAGMA user_version = 13');
   migrate(db);
   migrate(db);
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
 });

--- a/test/migrate-v15.test.mjs
+++ b/test/migrate-v15.test.mjs
@@ -17,16 +17,16 @@ import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { useTempHome } from './helpers/temp-home.mjs';
 import { seedPipeline } from './helpers/db-seed.mjs';
-import { getDb, _resetForTests } from '../src/core/db.mjs';
+import { getDb, _resetForTests, SCHEMA_VERSION } from '../src/core/db.mjs';
 
 useTempHome(after);
 
 const cols = (db, table) =>
   db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
 
-test('fresh DB lands on user_version 17 with cost_ledger and the six new pipelines columns', () => {
+test('fresh DB lands on the current user_version with cost_ledger and the six new pipelines columns', () => {
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const ledger = db.prepare(
     "SELECT name FROM sqlite_master WHERE type='table' AND name='cost_ledger'").get();
   assert.ok(ledger, 'cost_ledger exists');
@@ -55,9 +55,9 @@ test('self-heal: a dropped new column is re-added on reopen (divergent-stamp rep
   assert.ok(cols(db, 'pipelines').includes('pr_checked_at'));
 });
 
-test('idempotent double-open: no error, version stays 17', () => {
+test('idempotent double-open: no error, version stays current', () => {
   getDb();
   _resetForTests();
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
 });

--- a/test/migrate-v16.test.mjs
+++ b/test/migrate-v16.test.mjs
@@ -15,7 +15,7 @@ import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { useTempHome } from './helpers/temp-home.mjs';
 import { seedPipeline } from './helpers/db-seed.mjs';
-import { getDb, _resetForTests } from '../src/core/db.mjs';
+import { getDb, _resetForTests, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { getStats } from '../src/core/stats.mjs';
 
 useTempHome(after);
@@ -66,7 +66,7 @@ test('v15 -> v16 backfills cost_ledger from pre-ledger pipeline costs', async ()
   _resetForTests();
   const db2 = getDb();
 
-  assert.equal(db2.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db2.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
 
   const rowsFor = db2.prepare(
     'SELECT step_key, amount_usd, ts FROM cost_ledger WHERE pipeline_id = ? ORDER BY id');
@@ -93,7 +93,7 @@ test('v15 -> v16 backfills cost_ledger from pre-ledger pipeline costs', async ()
 test('reopen after backfill is a no-op: no duplicate synthetic rows', () => {
   _resetForTests();
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
   const { n } = db.prepare('SELECT COUNT(*) AS n FROM cost_ledger').get();
   assert.equal(n, 4, 'still exactly A + B + E + D’s pre-existing row');
 });

--- a/test/migrate-v18.test.mjs
+++ b/test/migrate-v18.test.mjs
@@ -1,0 +1,55 @@
+// test/migrate-v18.test.mjs
+//
+// v18 adds source_bindings (task-source profiles): which PROFILE of a plugin
+// task source a project/workspace pulls from, one row per (scope, plugin,
+// source). The ladder step is a plain IF-NOT-EXISTS DDL, and the table also
+// lives in INCREMENTAL_TABLES so the version-independent reconcile heals a
+// divergently-stamped DB (repo hard rule after two recorded cross-branch stamp
+// collisions). Structure mirrors test/migrate-v14.test.mjs.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { useTempHome } from './helpers/temp-home.mjs';
+import { getDb, migrate, SCHEMA_VERSION } from '../src/core/db.mjs';
+
+useTempHome(after);
+
+const hasBindings = (db) => db.prepare(
+  "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='source_bindings'"
+).get().n === 1;
+
+test('fresh DB migrates to the current version with the source_bindings table', () => {
+  const db = getDb(); // opens + migrates to SCHEMA_VERSION
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
+  assert.ok(hasBindings(db), 'source_bindings table exists');
+  const cols = db.prepare('PRAGMA table_info(source_bindings)').all().map((c) => c.name);
+  assert.deepEqual(cols, ['scope_type', 'scope_key', 'plugin', 'source_id', 'profile', 'updated_at']);
+});
+
+test('a v17-stamped DB upgrades in place: source_bindings created, stamp advances', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA user_version = 17'); // pre-profiles DB: ladder runs only the v18 step
+
+  migrate(db);
+
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
+  assert.ok(hasBindings(db), 'source_bindings created');
+});
+
+test('a current-stamped DB missing the table is healed by the fast-path reconcile, stamp untouched', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`); // divergent-ladder stamp: version says done, schema says otherwise
+
+  migrate(db); // fast path -> reconcileSchema self-heal
+
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'stamp not rewritten');
+  assert.ok(hasBindings(db), 'table healed');
+});
+
+test('migrate() is idempotent at v18 (second call is a clean no-op)', () => {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA user_version = 17');
+  migrate(db);
+  migrate(db); // IF-NOT-EXISTS + fast path: must not throw "table already exists"
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION);
+});

--- a/test/plugin-config.test.mjs
+++ b/test/plugin-config.test.mjs
@@ -25,9 +25,11 @@ test('writePluginConfig routes secret fields to secrets.json with mode 0600', ()
   const dir = pluginDataDir(NAME);
   const secrets = JSON.parse(readFileSync(join(dir, 'secrets.json'), 'utf8'));
   const config = JSON.parse(readFileSync(join(dir, 'config.json'), 'utf8'));
-  // Every file is profile-keyed; an unnamed write lands in DEFAULT_PROFILE.
-  assert.deepEqual(secrets, { profiles: { default: { token: 'ghp_abc123' } } });
-  assert.deepEqual(config, { profiles: { default: { repo: 'acme/api' } } });
+  // Every file is a MARKED profile envelope; an unnamed write lands in
+  // DEFAULT_PROFILE. The $format marker is what tells an envelope apart from a
+  // legacy flat file — no shape heuristic can (state keys are arbitrary).
+  assert.deepEqual(secrets, { $format: 'profiles/1', profiles: { default: { token: 'ghp_abc123' } } });
+  assert.deepEqual(config, { $format: 'profiles/1', profiles: { default: { repo: 'acme/api' } } });
   assert.equal(statSync(join(dir, 'secrets.json')).mode & 0o777, 0o600);
   assert.deepEqual(readdirSync(dir).filter((f) => f.endsWith('.tmp')), [], 'atomic: no temp litter');
 });
@@ -151,6 +153,33 @@ test('a legacy flat file with a field KEYED "profiles" reads as data, not as the
   process.env.WORCA_TEST_PROFILES = 'kept';
   assert.equal(readPluginConfig(Q, LEGACY_SCHEMA).profiles, 'kept');
   delete process.env.WORCA_TEST_PROFILES;
+});
+
+test('legacy state whose lone "profiles" key even LOOKS like the envelope reads as data (the $format marker decides)', () => {
+  // ctx.state accepts ARBITRARY keys, so a pre-profiles connector may have
+  // legally stored state.set('profiles', { work: {…}, client: {…} }) — a file
+  // byte-identical to a shape-recognised envelope. Only the marker written by
+  // writeBucket says "envelope"; without it the whole file is the legacy
+  // default-profile bag, cursors intact.
+  const P = 'legacy-profiles-state';
+  mkdirSync(pluginDataDir(P), { recursive: true });
+  writeFileSync(join(pluginDataDir(P), 'state.json'),
+    JSON.stringify({ profiles: { work: { cursor: 'w9' }, client: { cursor: 'c4' } } }));
+
+  assert.deepEqual(readPluginState(P),
+    { profiles: { work: { cursor: 'w9' }, client: { cursor: 'c4' } } },
+    'the connector reads back exactly what it stored');
+  assert.deepEqual(readPluginState(P, 'work'), {}, 'no phantom "work" bucket is minted');
+
+  // The first write migrates to the MARKED envelope without losing the key…
+  writePluginState(P, { etag: 'abc' });
+  const onDisk = JSON.parse(readFileSync(join(pluginDataDir(P), 'state.json'), 'utf8'));
+  assert.equal(onDisk.$format, 'profiles/1');
+  assert.deepEqual(onDisk.profiles.default,
+    { profiles: { work: { cursor: 'w9' }, client: { cursor: 'c4' } } , etag: 'abc' });
+  // …and the marked envelope round-trips.
+  assert.deepEqual(readPluginState(P).etag, 'abc');
+  assert.deepEqual(readPluginState(P).profiles.work.cursor, 'w9');
 });
 
 test('profile ids are path-safe: traversal and junk are rejected', () => {

--- a/test/plugin-config.test.mjs
+++ b/test/plugin-config.test.mjs
@@ -3,7 +3,7 @@
 // markers, shallow-merge state, atomic writes.
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { statSync, readFileSync, readdirSync, existsSync } from 'node:fs';
+import { statSync, readFileSync, readdirSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { useTempHome } from './helpers/temp-home.mjs';
 import { pluginDataDir } from '../src/core/plugins-lock.mjs';
@@ -104,6 +104,53 @@ test('profile roster: create is idempotent, delete removes the data too', () => 
   const secrets = JSON.parse(readFileSync(join(pluginDataDir(P), 'secrets.json'), 'utf8'));
   assert.equal('client' in secrets.profiles, false, 'bucket removed, not just emptied');
   assert.equal(statSync(join(pluginDataDir(P), 'secrets.json')).mode & 0o777, 0o600, 'delete keeps 0600');
+});
+
+test('the roster reserves "default": the shared bucket is never creatable or deletable', () => {
+  const P = 'reserved-plugin';
+  // "default" backs every profile-less read (chat channels, model secrets,
+  // migrated legacy config) — enrolled in the roster it would be one Remove
+  // click away from wiping them all.
+  assert.throws(() => createProfile(P, DEFAULT_PROFILE), /reserved/);
+  assert.throws(() => deleteProfile(P, DEFAULT_PROFILE), /reserved/);
+  writePluginConfig(P, SCHEMA, { token: 'shared' }); // profile-less -> default bucket
+  assert.equal(readPluginConfig(P, SCHEMA).token, 'shared', 'the shared bucket is intact');
+  assert.deepEqual(listProfiles(P), [], 'nothing was enrolled');
+});
+
+test('a legacy flat file with a field KEYED "profiles" reads as data, not as the envelope', () => {
+  // A pre-profiles connector may legally declare a configSchema field named
+  // "profiles" and store an object (a {"$env":…} ref) under it. Mistaking that
+  // for the { profiles: { <id>: {...} } } envelope would silently drop every
+  // other stored key — and the next write would persist the loss.
+  const P = 'legacy-profiles-key';
+  const LEGACY_SCHEMA = [
+    { key: 'baseUrl', type: 'text', label: 'Base URL', secret: false },
+    { key: 'profiles', type: 'text', label: 'Profiles var', secret: false },
+  ];
+  mkdirSync(pluginDataDir(P), { recursive: true });
+  writeFileSync(join(pluginDataDir(P), 'config.json'),
+    JSON.stringify({ baseUrl: 'https://x.test', profiles: { $env: 'WORCA_TEST_PROFILES' } }));
+
+  process.env.WORCA_TEST_PROFILES = 'a,b';
+  assert.deepEqual(readPluginConfig(P, LEGACY_SCHEMA), { baseUrl: 'https://x.test', profiles: 'a,b' });
+  // A write migrates to the envelope WITHOUT losing either key.
+  writePluginConfig(P, LEGACY_SCHEMA, { baseUrl: 'https://y.test' });
+  const onDisk = JSON.parse(readFileSync(join(pluginDataDir(P), 'config.json'), 'utf8'));
+  assert.deepEqual(onDisk.profiles.default,
+    { baseUrl: 'https://y.test', profiles: { $env: 'WORCA_TEST_PROFILES' } });
+  assert.deepEqual(readPluginConfig(P, LEGACY_SCHEMA), { baseUrl: 'https://y.test', profiles: 'a,b' });
+  delete process.env.WORCA_TEST_PROFILES;
+
+  // Same when "profiles" is the ONLY key: an env-ref value is no envelope
+  // (its key "$env" is not a profile id, its value not a bucket).
+  const Q = 'legacy-profiles-only';
+  mkdirSync(pluginDataDir(Q), { recursive: true });
+  writeFileSync(join(pluginDataDir(Q), 'config.json'),
+    JSON.stringify({ profiles: { $env: 'WORCA_TEST_PROFILES' } }));
+  process.env.WORCA_TEST_PROFILES = 'kept';
+  assert.equal(readPluginConfig(Q, LEGACY_SCHEMA).profiles, 'kept');
+  delete process.env.WORCA_TEST_PROFILES;
 });
 
 test('profile ids are path-safe: traversal and junk are rejected', () => {

--- a/test/plugin-config.test.mjs
+++ b/test/plugin-config.test.mjs
@@ -9,6 +9,7 @@ import { useTempHome } from './helpers/temp-home.mjs';
 import { pluginDataDir } from '../src/core/plugins-lock.mjs';
 import {
   readPluginConfig, writePluginConfig, redactedConfig, readPluginState, writePluginState,
+  listProfiles, listProfileIds, createProfile, deleteProfile, isValidProfileId, DEFAULT_PROFILE,
 } from '../src/core/plugin-config.mjs';
 
 useTempHome(after);
@@ -24,8 +25,9 @@ test('writePluginConfig routes secret fields to secrets.json with mode 0600', ()
   const dir = pluginDataDir(NAME);
   const secrets = JSON.parse(readFileSync(join(dir, 'secrets.json'), 'utf8'));
   const config = JSON.parse(readFileSync(join(dir, 'config.json'), 'utf8'));
-  assert.deepEqual(secrets, { token: 'ghp_abc123' });
-  assert.deepEqual(config, { repo: 'acme/api' });
+  // Every file is profile-keyed; an unnamed write lands in DEFAULT_PROFILE.
+  assert.deepEqual(secrets, { profiles: { default: { token: 'ghp_abc123' } } });
+  assert.deepEqual(config, { profiles: { default: { repo: 'acme/api' } } });
   assert.equal(statSync(join(dir, 'secrets.json')).mode & 0o777, 0o600);
   assert.deepEqual(readdirSync(dir).filter((f) => f.endsWith('.tmp')), [], 'atomic: no temp litter');
 });
@@ -39,7 +41,7 @@ test('readPluginConfig merges both files and applies schema defaults', () => {
 test('{"$env":"VAR"} indirection resolves at read time, stored verbatim', () => {
   writePluginConfig(NAME, SCHEMA, { token: { $env: 'WORCA_TEST_TOK' } });
   const onDisk = JSON.parse(readFileSync(join(pluginDataDir(NAME), 'secrets.json'), 'utf8'));
-  assert.deepEqual(onDisk.token, { $env: 'WORCA_TEST_TOK' });
+  assert.deepEqual(onDisk.profiles.default.token, { $env: 'WORCA_TEST_TOK' });
   process.env.WORCA_TEST_TOK = 'from-env';
   assert.equal(readPluginConfig(NAME, SCHEMA).token, 'from-env');
   delete process.env.WORCA_TEST_TOK;
@@ -58,6 +60,59 @@ test('echoed { set: true } marker never clobbers the stored secret', () => {
   writePluginConfig(NAME, SCHEMA, { token: { set: true }, repo: 'other/repo' }); // UI round-trip
   assert.equal(readPluginConfig(NAME, SCHEMA).token, 'keep-me');
   assert.equal(readPluginConfig(NAME, SCHEMA).repo, 'other/repo');
+});
+
+// ── profiles ──────────────────────────────────────────────────────────────────
+
+test('two profiles hold completely independent config, secrets and state', () => {
+  const P = 'multi-plugin';
+  writePluginConfig(P, SCHEMA, { token: 'tok-work', repo: 'acme/work' }, 'work');
+  writePluginConfig(P, SCHEMA, { token: 'tok-client', repo: 'other/client' }, 'client');
+  writePluginState(P, { cursor: 'w1' }, 'work');
+  writePluginState(P, { cursor: 'c1' }, 'client');
+
+  assert.deepEqual(readPluginConfig(P, SCHEMA, 'work'), { token: 'tok-work', repo: 'acme/work' });
+  assert.deepEqual(readPluginConfig(P, SCHEMA, 'client'), { token: 'tok-client', repo: 'other/client' });
+  assert.equal(readPluginState(P, 'work').cursor, 'w1');
+  assert.equal(readPluginState(P, 'client').cursor, 'c1');
+  // Writing one profile must not disturb the other's file bucket.
+  writePluginConfig(P, SCHEMA, { repo: 'acme/changed' }, 'work');
+  assert.equal(readPluginConfig(P, SCHEMA, 'client').repo, 'other/client');
+  // An unnamed read is the default profile — which has nothing here.
+  assert.equal(readPluginConfig(P, SCHEMA).repo, 'octo/hello');
+  assert.deepEqual(redactedConfig(P, SCHEMA, 'client'), { token: { set: true }, repo: 'other/client' });
+});
+
+test('profile roster: create is idempotent, delete removes the data too', () => {
+  const P = 'roster-plugin';
+  assert.deepEqual(listProfiles(P), [], 'no profiles until one is created');
+  createProfile(P, 'work', 'Work Jira');
+  createProfile(P, 'client', 'Client Jira');
+  createProfile(P, 'work', 'Work Jira (renamed)'); // repeat id -> label update, no duplicate
+  assert.deepEqual(listProfiles(P), [
+    { id: 'work', label: 'Work Jira (renamed)' },
+    { id: 'client', label: 'Client Jira' },
+  ]);
+  assert.deepEqual(listProfileIds(P), ['work', 'client']);
+
+  writePluginConfig(P, SCHEMA, { token: 'gone-soon', repo: 'x/y' }, 'client');
+  writePluginState(P, { cursor: 'c' }, 'client');
+  deleteProfile(P, 'client');
+  assert.deepEqual(listProfileIds(P), ['work']);
+  assert.deepEqual(readPluginState(P, 'client'), {}, 'state purged with the profile');
+  assert.equal(readPluginConfig(P, SCHEMA, 'client').token, null, 'secret purged with the profile');
+  const secrets = JSON.parse(readFileSync(join(pluginDataDir(P), 'secrets.json'), 'utf8'));
+  assert.equal('client' in secrets.profiles, false, 'bucket removed, not just emptied');
+  assert.equal(statSync(join(pluginDataDir(P), 'secrets.json')).mode & 0o777, 0o600, 'delete keeps 0600');
+});
+
+test('profile ids are path-safe: traversal and junk are rejected', () => {
+  for (const bad of ['../evil', 'a/b', 'UPPER', '', ' ', 'x'.repeat(65), '-lead']) {
+    assert.equal(isValidProfileId(bad), false, `${JSON.stringify(bad)} must be rejected`);
+  }
+  assert.equal(isValidProfileId(DEFAULT_PROFILE), true);
+  assert.throws(() => readPluginConfig('any-plugin', SCHEMA, '../escape'), /invalid profile id/);
+  assert.throws(() => createProfile('any-plugin', 'a/b'), /invalid profile id/);
 });
 
 test('readPluginState defaults to {}; writePluginState shallow-merges atomically', () => {

--- a/test/plugin-shim.test.mjs
+++ b/test/plugin-shim.test.mjs
@@ -10,7 +10,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { useTempHome } from './helpers/temp-home.mjs';
 import { writePluginsLock, pluginCurrentDir } from '../src/core/plugins-lock.mjs';
-import { writePluginConfig, writePluginState, readPluginState } from '../src/core/plugin-config.mjs';
+import { writePluginConfig, writePluginState, readPluginState, createProfile, deleteProfile } from '../src/core/plugin-config.mjs';
 import { callSource, PluginOpError, setMockSourceResponses } from '../src/core/plugin-shim.mjs';
 
 useTempHome(after);
@@ -98,11 +98,13 @@ test('connector-thrown error maps to PluginOpError with the connector kind', asy
   );
 });
 
-test("unimplemented op yields kind 'plugin' + a 'does not implement' message", async () => {
-  // Task 13's capabilities tolerant-default depends on exactly this behavior.
+test("unimplemented op yields kind 'unimplemented' + a 'does not implement' message", async () => {
+  // Task 13's capabilities tolerant-default keys on exactly this kind — it must
+  // stay distinguishable from an IMPLEMENTED op that crashed (kind 'plugin'),
+  // or a crash would force writeBack:true past a pinned per-run opt-out.
   await rejectsKind(
     callSource({ plugin: NAME, sourceId: 'main', op: 'capabilities' }),
-    'plugin', /does not implement op "capabilities"/,
+    'unimplemented', /does not implement op "capabilities"/,
   );
 });
 
@@ -122,10 +124,36 @@ test('profile invariant is enforced in callSource itself (CLI-safe, not just the
   // Naming the implicit bucket explicitly is fine — it is the one that runs.
   const viaDefault = await callSource({ plugin: NAME, sourceId: 'main', op: 'echoOp', profile: 'default' });
   assert.equal(viaDefault.token, 'sekret');
-  // And a named profile reaches ITS bucket, not the default one.
+  // And a named ROSTER profile reaches ITS bucket, not the default one.
+  createProfile(NAME, 'work', 'Work');
   writePluginConfig(NAME, SCHEMA, { token: 'work-tok' }, 'work');
   const viaWork = await callSource({ plugin: NAME, sourceId: 'prof', op: 'echoOp', profile: 'work' });
   assert.equal(viaWork.token, 'work-tok');
+});
+
+test('profile MEMBERSHIP is enforced too: typo, reserved default, deleted — all refused', async () => {
+  // Presence alone is not enough (`worca plugin exec … --profile wokr`): a
+  // typo'd profile would run against an EMPTY bucket, yield a false "not
+  // configured" verdict, and then MINT a phantom state bucket the DELETE route
+  // can never purge. The roster is the source of truth.
+  await rejectsKind(
+    callSource({ plugin: NAME, sourceId: 'prof', op: 'echoOp', profile: 'wokr' }),
+    'plugin', /has no profile "wokr"/,
+  );
+  // "default" on a multiProfile source is the reserved shared bucket (chat
+  // channels, model secrets, migrated legacy config) — never a profile.
+  await rejectsKind(
+    callSource({ plugin: NAME, sourceId: 'prof', op: 'echoOp', profile: 'default' }),
+    'plugin', /reserved shared bucket/,
+  );
+  // A profile deleted between submit and a later call is caught at call time,
+  // not read as an empty bucket mid-run.
+  createProfile(NAME, 'gone', 'Doomed');
+  deleteProfile(NAME, 'gone');
+  await rejectsKind(
+    callSource({ plugin: NAME, sourceId: 'prof', op: 'echoOp', profile: 'gone' }),
+    'plugin', /has no profile "gone"/,
+  );
 });
 
 test('timeout kills the child and rejects with kind timeout', async () => {
@@ -178,8 +206,16 @@ test('WORCA_MOCK=1 short-circuits without spawning (plugin need not exist)', asy
     setMockSourceResponses({ listTasks: { tasks: [{ id: 'T-override', title: 't', state: 'open', updatedAt: 'now' }] } });
     const overridden = await callSource({ plugin: 'x', sourceId: 'x', op: 'listTasks' });
     assert.equal(overridden.tasks[0].id, 'T-override');
-    // …and an op with NO canned response mirrors the real child's kind 'plugin'.
-    await rejectsKind(callSource({ plugin: 'x', sourceId: 'x', op: 'capabilities' }), 'plugin');
+    // …and an op with NO canned response mirrors the real child's kind
+    // 'unimplemented' (the capabilities tolerant-default keys on it).
+    await rejectsKind(callSource({ plugin: 'x', sourceId: 'x', op: 'capabilities' }), 'unimplemented');
+    // Behavioral parity: when the plugin IS installed, the profile invariant
+    // holds in mock mode too — a mock run must catch a missing profile exactly
+    // like a real one would.
+    await rejectsKind(
+      callSource({ plugin: NAME, sourceId: 'prof', op: 'listTasks' }),
+      'plugin', /per-profile configuration/,
+    );
   } finally {
     delete process.env.WORCA_MOCK;
     setMockSourceResponses(null);

--- a/test/plugin-shim.test.mjs
+++ b/test/plugin-shim.test.mjs
@@ -52,6 +52,15 @@ function installFixture() {
       module: './connector/index.mjs',
       configSchema: SCHEMA,
       inputs: [{ key: 'task', type: 'task-browser', label: 'Task' }],
+    }, {
+      // multiProfile sibling: callSource must refuse to run it profile-less
+      // (the guard lives in the shim so the CLI is covered, not just the routes).
+      id: 'prof',
+      displayName: 'Mock Echo (profiled)',
+      module: './connector/index.mjs',
+      multiProfile: true,
+      configSchema: SCHEMA,
+      inputs: [{ key: 'task', type: 'task-browser', label: 'Task' }],
     }],
   }));
   writeFileSync(join(cur, 'connector', 'index.mjs'), CONNECTOR);
@@ -95,6 +104,28 @@ test("unimplemented op yields kind 'plugin' + a 'does not implement' message", a
     callSource({ plugin: NAME, sourceId: 'main', op: 'capabilities' }),
     'plugin', /does not implement op "capabilities"/,
   );
+});
+
+test('profile invariant is enforced in callSource itself (CLI-safe, not just the routes)', async () => {
+  // A multi-profile source silently defaulting to the empty default bucket
+  // would report false "not configured" verdicts and persist state into a
+  // bucket no real run reads — refuse before any spawn.
+  await rejectsKind(
+    callSource({ plugin: NAME, sourceId: 'prof', op: 'echoOp' }),
+    'plugin', /per-profile configuration/,
+  );
+  // A profile on a single-profile source would read a phantom bucket.
+  await rejectsKind(
+    callSource({ plugin: NAME, sourceId: 'main', op: 'echoOp', profile: 'work' }),
+    'plugin', /does not use profiles/,
+  );
+  // Naming the implicit bucket explicitly is fine — it is the one that runs.
+  const viaDefault = await callSource({ plugin: NAME, sourceId: 'main', op: 'echoOp', profile: 'default' });
+  assert.equal(viaDefault.token, 'sekret');
+  // And a named profile reaches ITS bucket, not the default one.
+  writePluginConfig(NAME, SCHEMA, { token: 'work-tok' }, 'work');
+  const viaWork = await callSource({ plugin: NAME, sourceId: 'prof', op: 'echoOp', profile: 'work' });
+  assert.equal(viaWork.token, 'work-tok');
 });
 
 test('timeout kills the child and rejects with kind timeout', async () => {

--- a/test/plugin-store.test.mjs
+++ b/test/plugin-store.test.mjs
@@ -16,7 +16,8 @@ import { useTempHome } from './helpers/temp-home.mjs';
 import {
   pluginDir, pluginCurrentDir, pluginDataDir, readPluginsLock, pluginsRoot, writePluginsLock,
 } from '../src/core/plugins-lock.mjs';
-import { writePluginConfig } from '../src/core/plugin-config.mjs';
+import { writePluginConfig, createProfile } from '../src/core/plugin-config.mjs';
+import { setBinding, listBindingsForScope } from '../src/core/source-bindings.mjs';
 import {
   installPlugin, buildInstallInventory, runSetup, updatePlugin, uninstallPlugin,
   setPluginEnabled, listInstalledPlugins, doctorPlugin, linkPlugin,
@@ -194,10 +195,14 @@ test('doctorPlugin: detects missing node_modules when setup.node; heals detectio
 
 test('uninstallPlugin keeps data/ by default; purge removes everything', async () => {
   writePluginConfig(NAME, [{ key: 'token', secret: true }], { token: 'keep' });
+  // Bindings live in the DB, not in data/: uninstall must drop them (CLI path
+  // included) or a reinstall with a same-named profile silently rebinds.
+  setBinding({ scopeType: 'project', scopeKey: 'proj-x', plugin: NAME, sourceId: 'demo' }, 'work');
   const r = await uninstallPlugin(NAME);
   assert.equal(r.ok, true);
   assert.equal(r.dataKept, true);
   assert.match(r.note, /kept/);
+  assert.deepEqual(listBindingsForScope('project', 'proj-x'), [], 'bindings cleared with the uninstall');
   assert.equal(existsSync(join(pluginDataDir(NAME), 'secrets.json')), true, 'secrets survive uninstall');
   assert.equal(existsSync(join(pluginDir(NAME), 'versions')), false);
   assert.equal(existsSync(pluginCurrentDir(NAME)), false);
@@ -377,4 +382,37 @@ test('doctor + uninstall guard for plugin models: block-with-list, clear, then u
   await setNodeModel(proj, 'wf_m', 's1_0', { model: '', effort: '' });
   const r = await uninstallPlugin('modelful-plugin', { purge: true });
   assert.equal(r.ok, true);
+});
+
+test('doctorPlugin: a multiProfile source with an EMPTY roster is unhealthy, not green', async () => {
+  // Every run of such a source is rejected ("profile is required") until a
+  // profile exists — validating the implicit default bucket instead can report
+  // green off migrated legacy config while nothing can actually run.
+  const dir = join(scratch, 'profiled-dev');
+  writeTree(dir, {
+    'worca-cc-plugin.json': JSON.stringify({
+      name: 'profiled-plugin', version: '0.1.0', engines: { 'worca-cc-api': '>=1 <2' },
+      taskSources: [{
+        id: 'src', displayName: 'Profiled', module: './connector/index.mjs', multiProfile: true,
+        configSchema: [{ key: 'token', type: 'text', secret: true, required: true, label: 'Token' }],
+        inputs: [{ key: 'task', type: 'task-browser', label: 'Task' }],
+      }],
+    }),
+    'connector/index.mjs': 'export default () => ({});\n',
+  });
+  linkPlugin('profiled-plugin', dir);
+
+  const empty = await doctorPlugin('profiled-plugin');
+  assert.equal(empty.ok, false);
+  const gap = empty.checks.find((c) => c.id === 'config:src');
+  assert.equal(gap.ok, false);
+  assert.match(gap.detail, /no profiles yet/);
+
+  // With a roster the check runs per profile (WORCA_MOCK cans validateConfig ok).
+  createProfile('profiled-plugin', 'work', 'Work');
+  const withProfile = await doctorPlugin('profiled-plugin');
+  assert.ok(withProfile.checks.some((c) => c.id === 'config:src@work' && c.ok));
+  assert.ok(!withProfile.checks.some((c) => c.id === 'config:src'), 'no default-bucket check for a rostered source');
+
+  await uninstallPlugin('profiled-plugin', { purge: true });
 });

--- a/test/plugins-view.test.mjs
+++ b/test/plugins-view.test.mjs
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict';
 import { JSDOM } from 'jsdom';
 import {
   renderPluginList, renderInstallConsent, renderUpdatePreview,
-  renderConfigForm, collectConfigForm, renderDoctorReport, renderReferences409,
+  renderConfigForm, collectConfigForm, renderConnectResult, renderDoctorReport, renderReferences409,
   renderOrphanList, renderAvailableList, renderMarketplaceList, relTime,
 } from '../ui/public/plugins-view.mjs';
 
@@ -76,6 +76,55 @@ test('config form masks secrets; collect skips untouched {set:true} markers', ()
   assert.equal(collectConfigForm(form).values.token, 'ghp_new');
 });
 
+// ── profiles ───────────────────────────────────────────────────────────────────
+// A multiProfile source holds several independent configurations (two Jira
+// instances, two GitHub orgs). The settings pane becomes a roster + the
+// selected profile's form; a single-profile source must not pay for any of it.
+test('a multiProfile source renders a profile roster and stamps the form with it', () => {
+  const schema = [{ key: 'ticketUrl', type: 'text', label: 'Ticket URL', secret: false, required: true, default: null, help: null, options: [] }];
+  const root = renderConfigForm([{
+    id: 'jira', schema, multiProfile: true,
+    profile: 'acme',
+    profiles: [{ id: 'acme', label: 'Acme' }, { id: 'globex', label: null }],
+    values: { ticketUrl: 'https://t.example.com/browse/A-1' },
+  }], { doc });
+
+  const sel = root.querySelector('.pl-profile-sel');
+  assert.ok(sel, 'roster select must render');
+  assert.deepEqual([...sel.options].map((o) => o.value), ['acme', 'globex']);
+  assert.equal(sel.value, 'acme', 'the echoed profile is the selected one');
+  assert.match([...sel.options][0].textContent, /Acme/);
+  assert.equal([...sel.options][1].textContent, 'globex', 'no label falls back to the id');
+  assert.ok(root.querySelector('.pl-profile-add'), 'can add a profile');
+  assert.ok(root.querySelector('.pl-profile-del'), 'can remove one');
+
+  // The form carries the profile, so a save/connect targets the right bucket
+  // rather than whichever the server would have defaulted to.
+  const form = root.querySelector('.pl-config-form');
+  assert.equal(form.dataset.profile, 'acme');
+  assert.deepEqual(collectConfigForm(form), {
+    sourceId: 'jira', profile: 'acme', values: { ticketUrl: 'https://t.example.com/browse/A-1' },
+  });
+});
+
+test('a multiProfile source with NO profiles yet asks for one instead of showing a form', () => {
+  // Saving into a profile that does not exist is the one thing the server
+  // rejects outright, so an empty roster must not render a fillable form.
+  const schema = [{ key: 'ticketUrl', type: 'text', label: 'Ticket URL', secret: false, required: true, default: null, help: null, options: [] }];
+  const root = renderConfigForm([{ id: 'jira', schema, multiProfile: true, profile: null, profiles: [], values: {} }], { doc });
+  assert.equal(root.querySelector('.pl-config-form'), null, 'no form without a profile to write to');
+  assert.ok(root.querySelector('.pl-profile-add'), 'the only offered action is creating one');
+  assert.match(root.textContent, /No profiles yet/i);
+});
+
+test('a single-profile source is untouched: no roster, and collect omits profile', () => {
+  const schema = [{ key: 'apiBase', type: 'text', label: 'API base', secret: false, required: false, default: null, help: null, options: [] }];
+  const root = renderConfigForm([{ id: 'github', schema, values: { apiBase: 'https://api.github.com' } }], { doc });
+  assert.equal(root.querySelector('.pl-profile-bar'), null, 'no profile UI for a single-instance source');
+  const got = collectConfigForm(root.querySelector('.pl-config-form'));
+  assert.ok(!('profile' in got), 'the profile key never appears for a single-profile source');
+});
+
 test('update preview shows commit subjects + diffstat + enabled confirm', () => {
   const el = renderUpdatePreview({
     pinnedSha: 'a1b2c3d4e5f6', candidateSha: 'f00dfacecafe',
@@ -120,6 +169,32 @@ test('plugin list shows enabled toggle, disabled state, broken badge, contributi
   assert.ok(cards[1].querySelector('.pl-broken'), 'broken badge must render');
   assert.equal(cards[1].querySelector('.pl-version').textContent, 'deadbee', 'sha7 stands in for a missing version');
   assert.equal(cards[1].querySelector('.pl-remove').dataset.name, 'jira-source'); // delegation hook
+});
+
+test('connect result: connected / waiting / field errors, and a bare transport error', () => {
+  const okEl = renderConnectResult(
+    { ok: true, identity: 'Jane Doe', instance: { baseUrl: 'https://tracker.example.com/jira', project: 'PROJ' } },
+    { doc },
+  );
+  assert.equal(okEl.querySelector('.badge').textContent, 'connected');
+  assert.match(okEl.textContent, /Jane Doe/);
+  assert.match(okEl.textContent, /tracker\.example\.com\/jira · PROJ/); // which instance, not just who
+  // An older/unknown instance is simply omitted, never rendered as "null".
+  assert.doesNotMatch(renderConnectResult({ ok: true, identity: 'X' }, { doc }).textContent, /null/);
+
+  // pending is the poll signal: setup is legitimately mid-flight, not failed.
+  const waitEl = renderConnectResult({ ok: false, pending: true, message: 'Browser opening — sign in there.' }, { doc });
+  assert.equal(waitEl.querySelector('.badge').textContent, 'waiting');
+  assert.match(waitEl.textContent, /Browser opening/);
+
+  const errEl = renderConnectResult({ ok: false, errors: [{ field: 'ticketUrl', message: 'Paste any ticket URL.' }] }, { doc });
+  assert.equal(errEl.querySelector('.badge').textContent, 'not connected');
+  assert.equal(errEl.querySelectorAll('.pl-connect-err').length, 1);
+  assert.match(errEl.textContent, /ticketUrl/);
+
+  // No envelope at all (shim transport failure) still renders one row.
+  const bare = renderConnectResult({ ok: false, error: { kind: 'timeout', message: 'jtr whoami timed out' } }, { doc });
+  assert.match(bare.textContent, /timed out/);
 });
 
 test('doctor report + references-409 render rows', () => {

--- a/test/source-bindings.test.mjs
+++ b/test/source-bindings.test.mjs
@@ -54,9 +54,18 @@ test('a binding naming a deleted profile degrades to "ask", never to a wrong run
   setBinding(proj('r-3'), 'retired');
   assert.deepEqual(resolveProfile({ ...proj('r-3'), available: ['work', 'client'] }),
     { profile: null, via: 'none' }, 'stale binding is ignored');
-  // ...and with a single surviving profile it lands on that one instead.
+  // EVEN with a single surviving profile: this scope once chose a tracker, and
+  // silently re-pointing it at whichever profile happens to survive is the
+  // silent-wrong-tracker bug this module exists to prevent. It must be asked.
   assert.deepEqual(resolveProfile({ ...proj('r-3'), available: ['work'] }),
+    { profile: null, via: 'none' });
+  // A scope that NEVER chose keeps the no-ceremony fallback.
+  assert.deepEqual(resolveProfile({ ...proj('r-3-never-bound'), available: ['work'] }),
     { profile: 'work', via: 'only' });
+  // Re-choosing (or explicitly clearing) lifts the suppression.
+  setBinding(proj('r-3'), 'work');
+  assert.deepEqual(resolveProfile({ ...proj('r-3'), available: ['work'] }),
+    { profile: 'work', via: 'binding' });
 });
 
 test('a workspace inherits from its members only when they agree', () => {
@@ -84,18 +93,33 @@ test('a workspace inherits from its members only when they agree', () => {
   );
 });
 
-test('deleting a profile or a plugin clears the bindings that named it', () => {
+test('deleting a profile TOMBSTONES the bindings that named it; uninstall drops them', () => {
   setBinding(proj('d-1'), 'doomed');
   setBinding(proj('d-2'), 'survivor');
-  // Every scope bound to the deleted profile is cleared, across all projects —
-  // and across the plugin's sources: the profile's buckets are per-plugin, so a
-  // sibling source's binding to it would dangle just the same.
+  // Every scope bound to the deleted profile is tombstoned, across all projects
+  // — and across the plugin's sources: the profile's buckets are per-plugin, so
+  // a sibling source's binding to it would dangle just the same.
   setBinding(proj('d-3'), 'doomed');
   setBinding({ scopeType: 'project', scopeKey: 'd-4', plugin: 'jira-source', sourceId: 'other' }, 'doomed');
   assert.equal(clearBindingsForProfile('jira-source', 'doomed'), 3);
-  assert.equal(getBinding(proj('d-1')), null);
+  assert.equal(getBinding(proj('d-1')), null, 'a tombstone reads as unbound');
   assert.equal(getBinding(proj('d-3')), null);
   assert.equal(getBinding(proj('d-2')), 'survivor', 'other profiles untouched');
+  assert.deepEqual(listBindingsForScope('project', 'd-1'), [], 'tombstones are not listed as bindings');
+
+  // The tombstone is what makes "deleting a profile degrades to ask" REACHABLE
+  // when exactly one profile remains: without it the 'only' fallback would
+  // silently re-point d-1 at a tracker it never chose.
+  assert.deepEqual(resolveProfile({ ...proj('d-1'), available: ['survivor'] }),
+    { profile: null, via: 'none' });
+  // Re-binding over a tombstone works like any bind…
+  setBinding(proj('d-1'), 'survivor');
+  assert.equal(getBinding(proj('d-1')), 'survivor');
+  // …and an EXPLICIT clear (PUT profile:null) removes the row outright, so the
+  // deliberate-removal path returns to the no-ceremony fallback.
+  clearBinding(proj('d-3'));
+  assert.deepEqual(resolveProfile({ ...proj('d-3'), available: ['survivor'] }),
+    { profile: 'survivor', via: 'only' });
 
   clearBindingsForPlugin('jira-source');
   assert.equal(getBinding(proj('d-2')), null);

--- a/test/source-bindings.test.mjs
+++ b/test/source-bindings.test.mjs
@@ -1,0 +1,106 @@
+// test/source-bindings.test.mjs — which profile of a plugin task source a
+// project/workspace pulls from, and the fallbacks that keep the common case
+// invisible (single profile, workspace inheriting from unanimous members).
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { useTempHome } from './helpers/temp-home.mjs';
+import {
+  getBinding, setBinding, clearBinding, listBindingsForScope,
+  clearBindingsForProfile, clearBindingsForPlugin, resolveProfile,
+} from '../src/core/source-bindings.mjs';
+
+useTempHome(after);
+
+const SRC = { plugin: 'jira-source', sourceId: 'jira' };
+const proj = (key) => ({ scopeType: 'project', scopeKey: key, ...SRC });
+
+test('a binding is per (scope, plugin, source) and survives re-binding', () => {
+  assert.equal(getBinding(proj('proj-a')), null, 'unbound reads as null');
+  setBinding(proj('proj-a'), 'work');
+  setBinding(proj('proj-b'), 'client');
+  assert.equal(getBinding(proj('proj-a')), 'work');
+  assert.equal(getBinding(proj('proj-b')), 'client');
+
+  setBinding(proj('proj-a'), 'client'); // re-bind, not a second row
+  assert.equal(getBinding(proj('proj-a')), 'client');
+  assert.deepEqual(listBindingsForScope('project', 'proj-a'),
+    [{ plugin: 'jira-source', sourceId: 'jira', profile: 'client' }]);
+
+  // A second source on the same project binds independently.
+  setBinding({ scopeType: 'project', scopeKey: 'proj-a', plugin: 'gh-source', sourceId: 'issues' }, 'oss');
+  assert.equal(getBinding(proj('proj-a')), 'client', 'untouched by the other source');
+  assert.equal(listBindingsForScope('project', 'proj-a').length, 2);
+
+  clearBinding(proj('proj-a'));
+  assert.equal(getBinding(proj('proj-a')), null);
+  clearBinding(proj('proj-a')); // idempotent
+});
+
+test('resolveProfile prefers an explicit binding, then falls back to the only profile', () => {
+  setBinding(proj('r-1'), 'work');
+  assert.deepEqual(resolveProfile({ ...proj('r-1'), available: ['work', 'client'] }),
+    { profile: 'work', via: 'binding' });
+
+  // No binding, one profile -> no ceremony.
+  assert.deepEqual(resolveProfile({ ...proj('r-2'), available: ['only-one'] }),
+    { profile: 'only-one', via: 'only' });
+
+  // No binding, several profiles -> the caller must ask.
+  assert.deepEqual(resolveProfile({ ...proj('r-2'), available: ['a', 'b'] }),
+    { profile: null, via: 'none' });
+});
+
+test('a binding naming a deleted profile degrades to "ask", never to a wrong run', () => {
+  setBinding(proj('r-3'), 'retired');
+  assert.deepEqual(resolveProfile({ ...proj('r-3'), available: ['work', 'client'] }),
+    { profile: null, via: 'none' }, 'stale binding is ignored');
+  // ...and with a single surviving profile it lands on that one instead.
+  assert.deepEqual(resolveProfile({ ...proj('r-3'), available: ['work'] }),
+    { profile: 'work', via: 'only' });
+});
+
+test('a workspace inherits from its members only when they agree', () => {
+  const ws = { scopeType: 'workspace', scopeKey: 'wks-1', ...SRC };
+  setBinding(proj('m-1'), 'work');
+  setBinding(proj('m-2'), 'work');
+  assert.deepEqual(
+    resolveProfile({ ...ws, memberKeys: ['m-1', 'm-2'], available: ['work', 'client'] }),
+    { profile: 'work', via: 'members' },
+  );
+
+  // Members split across two trackers is a real ambiguity — guessing one is the
+  // silent-wrong-tracker bug this module exists to prevent.
+  setBinding(proj('m-2'), 'client');
+  assert.deepEqual(
+    resolveProfile({ ...ws, memberKeys: ['m-1', 'm-2'], available: ['work', 'client'] }),
+    { profile: null, via: 'conflict', candidates: ['work', 'client'] },
+  );
+
+  // The workspace's own binding overrides the members either way.
+  setBinding(ws, 'client');
+  assert.deepEqual(
+    resolveProfile({ ...ws, memberKeys: ['m-1', 'm-2'], available: ['work', 'client'] }),
+    { profile: 'client', via: 'binding' },
+  );
+});
+
+test('deleting a profile or a plugin clears the bindings that named it', () => {
+  setBinding(proj('d-1'), 'doomed');
+  setBinding(proj('d-2'), 'survivor');
+  // Every scope bound to the deleted profile is cleared, across all projects —
+  // and across the plugin's sources: the profile's buckets are per-plugin, so a
+  // sibling source's binding to it would dangle just the same.
+  setBinding(proj('d-3'), 'doomed');
+  setBinding({ scopeType: 'project', scopeKey: 'd-4', plugin: 'jira-source', sourceId: 'other' }, 'doomed');
+  assert.equal(clearBindingsForProfile('jira-source', 'doomed'), 3);
+  assert.equal(getBinding(proj('d-1')), null);
+  assert.equal(getBinding(proj('d-3')), null);
+  assert.equal(getBinding(proj('d-2')), 'survivor', 'other profiles untouched');
+
+  clearBindingsForPlugin('jira-source');
+  assert.equal(getBinding(proj('d-2')), null);
+});
+
+test('an invalid scope is a programming error, not a silent no-op', () => {
+  assert.throws(() => getBinding({ scopeType: 'galaxy', scopeKey: 'x', ...SRC }), /invalid binding scope/);
+});

--- a/test/source-pane.test.mjs
+++ b/test/source-pane.test.mjs
@@ -3,7 +3,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { JSDOM } from 'jsdom';
-import { renderSourcePane, collectSourcePane, debounce } from '../ui/public/source-pane.mjs';
+import {
+  renderSourcePane, collectSourcePane, debounce, formatUpdated, renderProfileGate, renderProfileBar,
+} from '../ui/public/source-pane.mjs';
 
 const win = new JSDOM('<!doctype html><body></body>').window;
 const doc = win.document;
@@ -45,8 +47,12 @@ test('renders all 4 input types in schema order; remote-select loads lazily, onc
   const tb = pane.querySelector('.sp-task-browser[data-input-key="task"]');
   assert.ok(tb.querySelector('.sp-search') && tb.querySelector('.sp-results')
     && tb.querySelector('.sp-preview') && tb.querySelector('.sp-task-id'));
-  // Lazy population: nothing fetched at render; first focus fetches; second is a no-op.
-  assert.equal(calls.length, 0);
+  // Lazy population applies to the remote-select: it must NOT fetch its options
+  // until focused. The task list is different — it loads once on render so the
+  // browser isn't blank before the user types.
+  await pane._initial;
+  assert.equal(calls.filter(([op]) => op === 'listRepos').length, 0);
+  assert.deepEqual(calls.filter(([op]) => op === 'listTasks').map(([, a]) => a.search), ['']);
   remote.dispatchEvent(new win.Event('focus'));
   remote.dispatchEvent(new win.Event('focus'));
   await remote._load;
@@ -74,7 +80,9 @@ test('search -> pick a row: taskId set, preview rendered, collect round-trips', 
     if (op === 'getTask') return { id: args.id, title: 'Fix the flaky test', body: 'It fails on CI only.', state: 'open', updatedAt: '' };
     return null;
   };
-  const pane = renderSourcePane(SOURCE, { call, doc, timers: clock });
+  const pane = renderSourcePane(SOURCE, {
+    call, doc, timers: clock, now: () => Date.parse('2026-07-04T10:00:00Z'),
+  });
   const search = pane.querySelector('.sp-search');
   search.value = 'flaky';
   search.dispatchEvent(new win.Event('input'));
@@ -84,7 +92,7 @@ test('search -> pick a row: taskId set, preview rendered, collect round-trips', 
   assert.ok(row, 'result row renders');
   assert.match(row.textContent, /Fix the flaky test/);
   assert.match(row.textContent, /bug/);              // labels
-  assert.match(row.textContent, /2026-07-01/);       // updatedAt
+  assert.match(row.textContent, /updated 3d ago/);   // updatedAt, humanised
   row.dispatchEvent(new win.MouseEvent('click', { bubbles: true }));
   const preview = pane.querySelector('.sp-preview');
   await preview._load;
@@ -97,7 +105,192 @@ test('search -> pick a row: taskId set, preview rendered, collect round-trips', 
   assert.deepEqual(picked.inputs, { repo: '', filter: 'assignee:@me state:open', kind: 'issue' });
 });
 
+test('editing a filter input re-runs the listing with the new value', async () => {
+  const clock = manualTimers();
+  const seen = [];
+  const call = async (op, args) => {
+    if (op === 'listTasks') { seen.push(args.inputs.filter); return { tasks: [] }; }
+    return null;
+  };
+  const pane = renderSourcePane(SOURCE, { call, doc, timers: clock });
+  await pane._initial;
+  seen.length = 0;
+
+  // Typing a filter must take effect on its own — before this, only the search
+  // box re-queried, so a typed filter looked like it was being ignored.
+  const filter = pane.querySelector('input[data-input-key="filter"]');
+  filter.value = 'label:urgent';
+  filter.dispatchEvent(new win.Event('input'));
+  clock.flush();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(seen, ['label:urgent']);
+
+  // <select> fires 'change'; the shared debounce collapses any duplicate.
+  const kind = pane.querySelector('select[data-input-key="kind"]');
+  kind.value = 'pr';
+  kind.dispatchEvent(new win.Event('change'));
+  clock.flush();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(seen.length, 2);
+});
+
+test('empty results: "Type to search." with nothing asked for, "No tasks matched." otherwise', async () => {
+  const clock = manualTimers();
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const bare = { ...SOURCE, inputs: [
+    { key: 'filter', type: 'text', label: 'Filter', default: null, options: [], optionsFrom: null },
+    { key: 'task', type: 'task-browser', label: 'Issue', options: [], optionsFrom: null, default: null },
+  ] };
+  const pane = renderSourcePane(bare, { call: async () => ({ tasks: [] }), doc: doc2, timers: clock });
+  await pane._initial;
+  assert.match(pane.querySelector('.sp-results').textContent, /Type to search\./);
+
+  await pane._search('flaky');
+  assert.match(pane.querySelector('.sp-results').textContent, /No tasks matched\./);
+});
+
+test('formatUpdated: relative while recent, absolute past a week, hover keeps full precision', () => {
+  const now = Date.parse('2026-07-31T12:00:00Z');
+  const at = (ms) => formatUpdated(new Date(now - ms).toISOString(), now).text;
+  assert.equal(at(5_000), 'just now');
+  assert.equal(at(12 * 60_000), '12m ago');
+  assert.equal(at(5 * 3600_000), '5h ago');
+  assert.equal(at(3 * 86400_000), '3d ago');
+  assert.equal(at(-60_000), 'just now');                       // clock skew, not "in 1 minute"
+
+  // Past a week: a date, and the year only when it isn't the current one.
+  const thisYear = formatUpdated('2026-05-28T08:47:54.000Z', now);
+  assert.match(thisYear.text, /28/);
+  assert.doesNotMatch(thisYear.text, /2026/);
+  assert.match(formatUpdated('2025-05-28T08:47:54.000Z', now).text, /2025/);
+  assert.match(thisYear.title, /2026/);                        // hover is always full precision
+  assert.equal(formatUpdated('not a date', now).text, 'not a date');
+});
+
+test('task rows label the timestamp as "updated" and carry the exact value', async () => {
+  const clock = manualTimers();
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const call = async () => ({ tasks: [{
+    id: 'PROJ-1', title: 'Fix Login Session Cache for REST Service',
+    labels: ['backend'], updatedAt: '2026-05-28T08:47:54.000Z', state: 'open',
+  }] });
+  const pane = renderSourcePane(SOURCE, {
+    call, doc: doc2, timers: clock, now: () => Date.parse('2026-07-31T12:00:00Z'),
+  });
+  await pane._initial;
+  const el = pane.querySelector('.sp-updated');
+  assert.match(el.textContent, /^updated /, 'a bare date would leave created-vs-updated ambiguous');
+  assert.match(el.title, /^Updated /);
+  assert.equal(el.dataset.updatedAt, '2026-05-28T08:47:54.000Z');
+  assert.doesNotMatch(el.textContent, /T08:47|\.000Z/, 'raw ISO no longer leaks into the row');
+});
+
+test('task rows show the id ahead of the title, without disturbing the row layout', async () => {
+  const clock = manualTimers();
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const call = async () => ({ tasks: [
+    { id: 'PROJ-42', title: 'Fix Login Session Cache for REST Service', labels: [], updatedAt: '', state: 'open' },
+    // Trackers that already prefix the key must not render it twice.
+    { id: 'PROJ-43', title: 'PROJ-43 Already prefixed', labels: [], updatedAt: '', state: 'open' },
+  ] });
+  const pane = renderSourcePane(SOURCE, { call, doc: doc2, timers: clock });
+  await pane._initial;
+  const [a, b] = pane.querySelectorAll('.sp-row');
+
+  assert.equal(a.querySelector('.sp-key').textContent, 'PROJ-42');
+  assert.match(a.querySelector('.sp-row-title').textContent, /^PROJ-42Fix Login/);
+  assert.equal(a.dataset.taskId, 'PROJ-42', 'picking still round-trips the raw id');
+  // .sp-row is a space-between flex; a third child would spread the row apart.
+  assert.equal(a.children.length, 2);
+
+  assert.equal(b.querySelector('.sp-key'), null, 'id already in the title -> not repeated');
+  assert.equal(b.querySelector('.sp-row-title').textContent, 'PROJ-43 Already prefixed');
+});
+
 test('collect errors when no task is picked', () => {
   const pane = renderSourcePane(SOURCE, { call: async () => null, doc });
   assert.match(collectSourcePane(pane).error, /Pick a task/);
+});
+
+// ── profile gate ───────────────────────────────────────────────────────────────
+// A multi-profile source cannot list anything until it is known WHICH instance
+// to ask. The gate is deliberately a one-time choice bound to the project
+// rather than a per-run dropdown: a dropdown is how you start a pipeline
+// against the wrong tracker, and the mistake is invisible until the run is
+// already underway.
+const JIRA = { plugin: 'jira-source', sourceId: 'jira', displayName: 'Jira (jtr)' };
+const PROFILES = [{ id: 'acme', label: 'Acme' }, { id: 'globex', label: null }];
+
+test('profile gate: unbound project offers the roster and binds what was picked', async () => {
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const picked = [];
+  const gate = renderProfileGate(
+    { source: JIRA, profiles: PROFILES, via: 'none', scopeLabel: 'worca-cc' },
+    { doc: doc2, onPick: (p) => { picked.push(p); } },
+  );
+  const sel = gate.querySelector('.sp-profile-sel');
+  assert.deepEqual([...sel.options].map((o) => o.value), ['acme', 'globex']);
+  assert.match(gate.textContent, /worca-cc/, 'says WHICH project is being bound');
+  sel.value = 'globex';
+  gate.querySelector('.sp-profile-use').click();
+  assert.deepEqual(picked, ['globex']);
+});
+
+test('profile gate: a workspace whose projects disagree names the candidates', () => {
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const gate = renderProfileGate(
+    { source: JIRA, profiles: PROFILES, via: 'conflict', candidates: ['acme', 'globex'], scopeLabel: 'ws-1' },
+    { doc: doc2, onPick: () => {} },
+  );
+  // Guessing one of them is the exact silent-wrong-tracker bug; say so instead.
+  assert.match(gate.textContent, /acme/);
+  assert.match(gate.textContent, /globex/);
+  assert.match(gate.textContent, /disagree|differ|conflict/i);
+});
+
+// Once bound, the choice stays ON SCREEN. Hiding it after the first answer is
+// how you end up reading the wrong tracker without noticing — the bar is the
+// standing answer to "which instance am I about to pull from". Changing it
+// REBINDS the project (persistent), which is what keeps it from degenerating
+// into the per-run dropdown the gate exists to avoid.
+test('profile bar: always shows the roster with the active profile selected', () => {
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const picked = [];
+  const bar = renderProfileBar(
+    { source: JIRA, profiles: PROFILES, profile: 'globex', via: 'binding', scopeLabel: 'worca-cc' },
+    { doc: doc2, onChange: (p) => picked.push(p) },
+  );
+  const sel = bar.querySelector('.sp-profile-sel');
+  assert.deepEqual([...sel.options].map((o) => o.value), ['acme', 'globex']);
+  assert.equal(sel.value, 'globex', 'the bound profile is the selected one');
+  sel.value = 'acme';
+  sel.dispatchEvent(new doc2.defaultView.Event('change'));
+  assert.deepEqual(picked, ['acme'], 'switching rebinds rather than just filtering this run');
+});
+
+test('profile bar: says HOW the profile was resolved, so an inherited one is not mistaken for a choice', () => {
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const only = renderProfileBar({ source: JIRA, profiles: [PROFILES[0]], profile: 'acme', via: 'only' }, { doc: doc2 });
+  assert.match(only.textContent, /only profile/i);
+  const members = renderProfileBar({ source: JIRA, profiles: PROFILES, profile: 'acme', via: 'members' }, { doc: doc2 });
+  assert.match(members.textContent, /member|project/i);
+});
+
+test('profile bar: a roster that grew in settings is reflected without a reload', () => {
+  // The bar is re-rendered from the /api/sources roster, so a profile added (or
+  // removed) in Plugins settings shows up here as soon as that list refreshes.
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const before = renderProfileBar({ source: JIRA, profiles: PROFILES, profile: 'acme', via: 'binding' }, { doc: doc2 });
+  assert.equal(before.querySelectorAll('.sp-profile-sel option').length, 2);
+  const after = renderProfileBar({
+    source: JIRA, profiles: [...PROFILES, { id: 'third', label: 'Third' }], profile: 'acme', via: 'binding',
+  }, { doc: doc2 });
+  assert.deepEqual([...after.querySelectorAll('.sp-profile-sel option')].map((o) => o.value), ['acme', 'globex', 'third']);
+});
+
+test('profile gate: no profiles at all points at Plugins settings, not an empty picker', () => {
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const gate = renderProfileGate({ source: JIRA, profiles: [], via: 'none' }, { doc: doc2, onPick: () => {} });
+  assert.equal(gate.querySelector('.sp-profile-use'), null, 'nothing to pick, so no confirm button');
+  assert.ok(gate.querySelector('.sp-profile-settings'), 'the way out is creating a profile');
 });

--- a/test/source-pane.test.mjs
+++ b/test/source-pane.test.mjs
@@ -149,6 +149,62 @@ test('empty results: "Type to search." with nothing asked for, "No tasks matched
   assert.match(pane.querySelector('.sp-results').textContent, /No tasks matched\./);
 });
 
+test('a slow stale listTasks response never paints over a newer search (latest wins)', async () => {
+  // The debounce collapses pending timers, not in-flight fetches: the
+  // mount-time empty search can resolve AFTER a fast typed search. Without a
+  // sequence guard it would repaint the unfiltered list over the filtered one
+  // — and the user could then pick a task that does not match their filter.
+  const clock = manualTimers();
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const bare = { ...SOURCE, inputs: [
+    { key: 'filter', type: 'text', label: 'Filter', default: null, options: [], optionsFrom: null },
+    { key: 'task', type: 'task-browser', label: 'Issue', options: [], optionsFrom: null, default: null },
+  ] };
+  let resolveSlow;
+  const slow = new Promise((r) => { resolveSlow = r; });
+  const call = async (op, args) => {
+    if (op !== 'listTasks') return null;
+    if (args.search === '') return slow; // the mount-time search hangs…
+    return { tasks: [{ id: 'F-1', title: 'Filtered hit', labels: [], updatedAt: '', state: 'open' }] };
+  };
+  const pane = renderSourcePane(bare, { call, doc: doc2, timers: clock });
+  await pane._search('flaky'); // …while the typed one answers immediately
+  assert.match(pane.querySelector('.sp-results').textContent, /Filtered hit/);
+
+  resolveSlow({ tasks: [{ id: 'S-1', title: 'Stale unfiltered', labels: [], updatedAt: '', state: 'open' }] });
+  await pane._initial;
+  assert.match(pane.querySelector('.sp-results').textContent, /Filtered hit/, 'newer results survive');
+  assert.doesNotMatch(pane.querySelector('.sp-results').textContent, /Stale unfiltered/);
+});
+
+test('a connector that throws on empty inputs shows "Type to search.", not an error, on open', async () => {
+  // The contract lets listTasks throw when it has nothing to go on; pre-pane
+  // nothing was fetched at render, so opening the pane must not paint a
+  // failure the user did nothing to cause. A real (asked-for) search still
+  // surfaces its error.
+  const clock = manualTimers();
+  const doc2 = new JSDOM('<!doctype html><body></body>').window.document;
+  const bare = { ...SOURCE, inputs: [
+    { key: 'filter', type: 'text', label: 'Filter', default: null, options: [], optionsFrom: null },
+    { key: 'task', type: 'task-browser', label: 'Issue', options: [], optionsFrom: null, default: null },
+  ] };
+  const call = async (op, args) => {
+    if (op === 'listTasks' && !args.search) throw new Error('a repo is required');
+    return { tasks: [] };
+  };
+  const pane = renderSourcePane(bare, { call, doc: doc2, timers: clock });
+  await pane._initial;
+  assert.match(pane.querySelector('.sp-results').textContent, /Type to search\./);
+  assert.doesNotMatch(pane.querySelector('.sp-results').textContent, /search failed/);
+
+  const failing = renderSourcePane(bare, {
+    call: async () => { throw new Error('boom'); }, doc: doc2, timers: clock,
+  });
+  await failing._initial;
+  await failing._search('flaky');
+  assert.match(failing.querySelector('.sp-results').textContent, /search failed: boom/);
+});
+
 test('formatUpdated: relative while recent, absolute past a week, hover keeps full precision', () => {
   const now = Date.parse('2026-07-31T12:00:00Z');
   const at = (ms) => formatUpdated(new Date(now - ms).toISOString(), now).text;

--- a/test/sources.test.mjs
+++ b/test/sources.test.mjs
@@ -63,8 +63,20 @@ test('plugin source: getTask -> "# title\\n\\nbody" + fenced json meta + sourceM
     );
     assert.equal(input.promptFile, null);
     assert.deepEqual(input.sourceMeta, {
-      plugin: 'gh', sourceId: 'issues', taskId: 'T-9', url: 'https://tracker.test/T-9', title: 'Fix login',
+      plugin: 'gh', sourceId: 'issues', taskId: 'T-9', profile: null, inputs: null,
+      url: 'https://tracker.test/T-9', title: 'Fix login',
     });
+
+    // A multi-profile source pins WHICH configuration the task came from, so
+    // write-back later reports to that instance even if the project has since
+    // been re-bound to another one. The source-panel inputs are pinned for the
+    // same reason: a per-run choice (e.g. writeBack) gates THIS run's report.
+    const bound = await resolveTaskInput(
+      { type: 'plugin', plugin: 'gh', sourceId: 'issues', taskId: 'T-9', profile: 'client', inputs: { writeBack: 'yes' } },
+      { projectDir: tmp() },
+    );
+    assert.equal(bound.sourceMeta.profile, 'client');
+    assert.deepEqual(bound.sourceMeta.inputs, { writeBack: 'yes' });
     // empty meta => no fence; null task => throws
     setMockSourceResponses({ getTask: { id: 'T-1', title: 'T', state: 'open', updatedAt: 'x', body: 'b', meta: {} } });
     const bare = await resolveTaskInput({ type: 'plugin', plugin: 'gh', sourceId: 'issues', taskId: 'T-1' }, { projectDir: tmp() });

--- a/test/subagent-migration-v3.test.mjs
+++ b/test/subagent-migration-v3.test.mjs
@@ -10,7 +10,7 @@ import { mkdtemp, rm, realpath } from 'node:fs/promises';
 import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { getDb, _resetForTests, dbPath } from '../src/core/db.mjs';
+import { getDb, _resetForTests, dbPath, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { worcaHome } from '../src/core/projects.mjs';
 
 const _require = createRequire(import.meta.url);
@@ -82,7 +82,7 @@ test('opening a user_version=2 DB forward-migrates to v3 (adds sub_agents.ui_pha
   seed.close();
 
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'forward-migrated to v18');
   const cols = db.prepare('PRAGMA table_info(sub_agents)').all().map((c) => c.name);
   assert.ok(cols.includes('ui_phase'), 'ui_phase column added by v2->v3 migration');
   assert.equal(

--- a/test/subagent-migration-v6.test.mjs
+++ b/test/subagent-migration-v6.test.mjs
@@ -6,7 +6,7 @@ import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
-import { getDb, dbPath, _resetForTests } from '../src/core/db.mjs';
+import { getDb, dbPath, _resetForTests, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { worcaHome } from '../src/core/projects.mjs';
 
 const _require = createRequire(import.meta.url);
@@ -39,7 +39,7 @@ test('opening a user_version=5 DB forward-migrates to v6 (adds skills to both ag
   seed.close();
 
   const db = getDb(); // production open → runs migrate()
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'forward-migrated to v18');
   assert.ok(db.prepare('PRAGMA table_info(sub_agents)').all().map((c) => c.name).includes('skills'));
   assert.ok(db.prepare('PRAGMA table_info(pipeline_steps)').all().map((c) => c.name).includes('skills'));
   assert.ok(db.prepare("SELECT 1 FROM pipelines WHERE id='p1'").get(), 'pre-existing data preserved');

--- a/test/subagent-migration-v7.test.mjs
+++ b/test/subagent-migration-v7.test.mjs
@@ -6,7 +6,7 @@ import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
-import { getDb, dbPath, _resetForTests } from '../src/core/db.mjs';
+import { getDb, dbPath, _resetForTests, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { worcaHome } from '../src/core/projects.mjs';
 
 const _require = createRequire(import.meta.url);
@@ -41,7 +41,7 @@ test('opening a user_version=6 DB forward-migrates to v7 (adds subagent_type to 
   seed.close();
 
   const db = getDb(); // production open → runs migrate()
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'forward-migrated to v18');
   assert.ok(db.prepare('PRAGMA table_info(sub_agents)').all().map((c) => c.name).includes('subagent_type'));
   assert.ok(db.prepare("SELECT 1 FROM pipelines WHERE id='p1'").get(), 'pre-existing data preserved');
 });

--- a/test/subagent-migration-v8.test.mjs
+++ b/test/subagent-migration-v8.test.mjs
@@ -6,7 +6,7 @@ import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
-import { getDb, dbPath, _resetForTests } from '../src/core/db.mjs';
+import { getDb, dbPath, _resetForTests, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { worcaHome } from '../src/core/projects.mjs';
 
 const _require = createRequire(import.meta.url);
@@ -41,7 +41,7 @@ test('opening a user_version=7 DB forward-migrates to v8 (adds graphify_count to
   seed.close();
 
   const db = getDb(); // production open → runs migrate()
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'forward-migrated to v18');
   assert.ok(db.prepare('PRAGMA table_info(sub_agents)').all().map((c) => c.name).includes('graphify_count'));
   assert.ok(db.prepare('PRAGMA table_info(pipeline_steps)').all().map((c) => c.name).includes('graphify_count'));
   assert.ok(db.prepare("SELECT 1 FROM pipelines WHERE id='p1'").get(), 'pre-existing data preserved');

--- a/test/subagent-migration.test.mjs
+++ b/test/subagent-migration.test.mjs
@@ -13,7 +13,7 @@ import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { getDb, _resetForTests, dbPath } from '../src/core/db.mjs';
+import { getDb, _resetForTests, dbPath, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { worcaHome } from '../src/core/projects.mjs';
 
 const _require = createRequire(import.meta.url);
@@ -80,7 +80,7 @@ test('opening a user_version=1 DB forward-migrates to v2 (adds sub_agents + inde
 
   // 2) Open through production getDb() — migrate() must run the v2 ladder step.
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17 (the v2 step added sub_agents)');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'forward-migrated to v18 (the v2 step added sub_agents)');
   assert.equal(
     db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='sub_agents'").get().n,
     1, 'sub_agents table created by the v1->v2 migration');

--- a/test/ui-plugin-connect.test.mjs
+++ b/test/ui-plugin-connect.test.mjs
@@ -1,0 +1,131 @@
+// test/ui-plugin-connect.test.mjs — the Settings modal's Connect flow in app.js.
+// Two invariants:
+//   1. one result block PER SOURCE — a later source's success must never paint
+//      over an earlier source's failure (one shared slot did exactly that);
+//   2. a channels-only plugin gets NO Connect button at all — every outcome the
+//      button could render ("Add a profile first.") is a lie for a plugin that
+//      cannot have profiles, and validateConfig is a task-source op.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
+const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
+
+const json = (body) => Promise.resolve({ ok: true, status: 200, json: async () => body });
+
+// Boot app.js in jsdom with a controllable fetch (mirrors ui-source-pane-mount).
+async function boot(handlers) {
+  const dom = new JSDOM(readFileSync(htmlPath, 'utf8'), { url: 'http://localhost:4319/' });
+  const { window } = dom;
+  window.Element.prototype.scrollIntoView = function () {};
+  window.WebSocket = class {
+    constructor() { this.readyState = 1; this._listeners = {}; }
+    send() {} close() {}
+    addEventListener(t, fn) { (this._listeners[t] ||= []).push(fn); }
+  };
+  window.fetch = (url, opts) => {
+    const u = String(url);
+    for (const [prefix, fn] of Object.entries(handlers)) {
+      if (u.includes(prefix)) return fn(u, opts || {});
+    }
+    if (u.includes('/api/projects')) return json({ projects: [] });
+    if (u.includes('/api/sources') && !u.includes('/call')) return json({ sources: [] });
+    if (u.includes('/api/workflows')) return json({ workflows: [] });
+    return json({ config: { steps: {}, customModels: [] }, models: [], efforts: [], branches: [] });
+  };
+  for (const k of ['window', 'document', 'location', 'localStorage', 'WebSocket', 'fetch', 'navigator', 'HTMLInputElement', 'HTMLSelectElement']) {
+    try { Object.defineProperty(globalThis, k, { value: window[k], configurable: true, writable: true }); } catch {}
+  }
+  globalThis.window = window; globalThis.document = window.document;
+  await import(appPath + `?b=${Date.now()}_${Math.random()}`);
+  await new Promise((r) => setTimeout(r, 0));
+  return { window };
+}
+
+async function waitFor(fn, what, { timeoutMs = 3000, everyMs = 10 } = {}) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = fn();
+    if (v) return v;
+    if (Date.now() - t0 > timeoutMs) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, everyMs));
+  }
+}
+
+// The Plugins list has one delegated click listener; a .pl-settings button with
+// data-name is all it takes to open the Settings modal (no list render needed).
+function openSettings(doc, window, name) {
+  const btn = doc.createElement('button');
+  btn.className = 'pl-settings';
+  btn.dataset.name = name;
+  doc.querySelector('#plugins-list').appendChild(btn);
+  btn.click();
+}
+
+const modalButtons = (doc) =>
+  [...doc.querySelectorAll('#plugin-modal-actions button')].map((b) => b.textContent);
+
+test('Connect renders one outcome PER SOURCE — a later success never hides an earlier failure', async () => {
+  const { window } = await boot({
+    '/api/plugins/dual/config': (u, opts) => {
+      if ((opts.method || 'GET') === 'PUT') return json({ ok: true });
+      return json({
+        sources: [
+          { id: 'alpha', schema: [{ key: 'token', type: 'text', label: 'Token' }], values: {} },
+          { id: 'beta', schema: [{ key: 'token', type: 'text', label: 'Token' }], values: {} },
+        ],
+        channels: [],
+      });
+    },
+    '/api/sources/call': (u, opts) => {
+      const body = JSON.parse(opts.body || '{}');
+      if (body.sourceId === 'alpha') {
+        return json({ ok: true, result: { ok: false, errors: [{ field: 'token', message: 'bad token' }] } });
+      }
+      return json({ ok: true, result: { ok: true, identity: 'beta-bot' } });
+    },
+  });
+  const doc = window.document;
+
+  openSettings(doc, window, 'dual');
+  await waitFor(() => !doc.querySelector('#plugin-modal').classList.contains('hidden'), 'the settings modal');
+  const connect = await waitFor(
+    () => [...doc.querySelectorAll('#plugin-modal-actions button')].find((b) => b.textContent === 'Connect'),
+    'the Connect button');
+  connect.click();
+
+  const slot = doc.querySelector('.pl-connect-slot');
+  await waitFor(() => slot.querySelectorAll('.pl-connect-result').length >= 2
+    && !slot.textContent.includes('Connecting'), 'both results settled');
+
+  const subs = slot.querySelectorAll('.pl-connect-sub');
+  assert.equal(subs.length, 2, 'one block per source');
+  assert.match(subs[0].textContent, /alpha/, 'the block names its source');
+  assert.match(subs[0].textContent, /not connected/, "alpha's failure is still on screen…");
+  assert.match(subs[0].textContent, /bad token/);
+  assert.match(subs[1].textContent, /beta/);
+  assert.match(subs[1].textContent, /connected/, '…next to beta\'s success');
+  assert.match(subs[1].textContent, /beta-bot/);
+});
+
+test('a channels-only plugin has no Connect button (and no "Add a profile first." dead end)', async () => {
+  const { window } = await boot({
+    '/api/plugins/chatty/config': () => json({
+      sources: [],
+      channels: [{ id: 'tg', displayName: 'Telegram', platform: 'telegram', schema: [{ key: 'botToken', type: 'text', label: 'Bot token', secret: true }], values: {} }],
+    }),
+  });
+  const doc = window.document;
+
+  openSettings(doc, window, 'chatty');
+  await waitFor(() => !doc.querySelector('#plugin-modal').classList.contains('hidden'), 'the settings modal');
+  await waitFor(() => doc.querySelector('#plugin-modal-actions button'), 'the modal actions');
+
+  assert.deepEqual(modalButtons(doc), ['Cancel', 'Save'],
+    'Connect is absent — channels cannot have profiles, and validateConfig is a task-source op');
+  assert.ok(doc.querySelector('#plugin-modal-body .pl-config-form[data-channel-id="tg"]'),
+    'the channel form itself still renders and saves');
+});

--- a/test/ui-source-pane-mount.test.mjs
+++ b/test/ui-source-pane-mount.test.mjs
@@ -119,3 +119,91 @@ test('a failed profile resolve on project switch clears the stale pane and offer
   await waitFor(() => pane.querySelector('.sp-task-browser'), 'remounted task browser');
   assert.equal(pane.querySelector('.sp-profile-bar').dataset.profile, 'acme');
 });
+
+test('the old pane is torn down SYNCHRONOUSLY on remount — nothing submittable while the binding fetch is in flight', async () => {
+  // The window between "project switched" and "binding resolved" must not keep
+  // the previous project's task list, picked task and profile live: a Start
+  // clicked in that window would run the new project against the old project's
+  // tracker. The fetch here never resolves, so anything still visible IS the
+  // stale-window content.
+  let bindingsMode = 'ok';
+  const { window } = await boot({
+    '/api/source-bindings': () => {
+      if (bindingsMode === 'hang') return new Promise(() => {});
+      return json({ scopeType: 'project', scopeKey: 'k', profile: 'acme', via: 'binding' });
+    },
+    '/api/sources/call': (u, opts) => {
+      const body = JSON.parse(opts.body || '{}');
+      if (body.op === 'validateConfig') return json({ ok: true, result: { ok: true } });
+      if (body.op === 'listTasks') {
+        return json({ ok: true, result: { tasks: [
+          { id: 'A-1', title: 'Alpha task', state: 'open', labels: [], updatedAt: '' },
+        ] } });
+      }
+      return json({ ok: true, result: null });
+    },
+  });
+  const doc = window.document;
+
+  const projectSelect = doc.querySelector('#projectSelect');
+  projectSelect.value = '/tmp/alpha';
+  projectSelect.dispatchEvent(new window.Event('change'));
+  const srcBtn = await waitFor(() => doc.querySelector('#source-seg button[data-plugin-src="jira/jira"]'), 'plugin source button');
+  srcBtn.click();
+  const pane = doc.querySelector('#plugin-source-pane');
+  await waitFor(() => pane.querySelector('.sp-row'), 'the initial task listing');
+
+  // Switch projects with the binding fetch hung: the pane must empty NOW.
+  bindingsMode = 'hang';
+  projectSelect.value = '/tmp/beta';
+  projectSelect.dispatchEvent(new window.Event('change'));
+  await waitFor(() => /Checking/.test(pane.textContent) && !pane.querySelector('.sp-row'),
+    'the placeholder replacing the stale pane');
+  assert.equal(pane.querySelector('.sp-row'), null, 'no stale task row to submit');
+  assert.equal(pane.querySelector('.sp-profile-bar'), null, 'no stale profile bar');
+  // …and it STAYS empty while the fetch hangs (nothing repaints the old pane).
+  await new Promise((r) => setTimeout(r, 50));
+  assert.equal(pane.querySelector('.sp-row'), null);
+});
+
+test('an HTTP failure on the binding GET offers a retry — never the first-time gate', async () => {
+  // ok:false (a transient 500) is not "no binding": rendering the gate would
+  // invite the user to overwrite a correct standing binding. Only a real
+  // "unbound" answer may gate.
+  let bindingsMode = 'ok';
+  const { window } = await boot({
+    '/api/source-bindings': () => {
+      if (bindingsMode === '500') {
+        return Promise.resolve({ ok: false, status: 500, json: async () => ({ error: 'db locked' }) });
+      }
+      return json({ scopeType: 'project', scopeKey: 'k', profile: 'acme', via: 'binding' });
+    },
+    '/api/sources/call': (u, opts) => {
+      const body = JSON.parse(opts.body || '{}');
+      if (body.op === 'validateConfig') return json({ ok: true, result: { ok: true } });
+      if (body.op === 'listTasks') return json({ ok: true, result: { tasks: [] } });
+      return json({ ok: true, result: null });
+    },
+  });
+  const doc = window.document;
+
+  const projectSelect = doc.querySelector('#projectSelect');
+  projectSelect.value = '/tmp/alpha';
+  projectSelect.dispatchEvent(new window.Event('change'));
+  const srcBtn = await waitFor(() => doc.querySelector('#source-seg button[data-plugin-src="jira/jira"]'), 'plugin source button');
+  bindingsMode = '500';
+  srcBtn.click();
+  const pane = doc.querySelector('#plugin-source-pane');
+  await waitFor(() => /Could not resolve the source profile/.test(pane.textContent), 'the resolve-failure notice');
+  assert.match(pane.textContent, /db locked/, 'the server error is surfaced');
+  assert.equal(pane.querySelector('.sp-profile-gate'), null, 'no gate on an HTTP failure');
+  assert.equal(pane.querySelector('.sp-profile-use'), null);
+
+  // The server recovers: Retry lands on the STANDING binding, no gate involved.
+  bindingsMode = 'ok';
+  const retry = pane.querySelector('button');
+  assert.match(retry.textContent, /Retry/);
+  retry.click();
+  await waitFor(() => pane.querySelector('.sp-profile-bar'), 'the pane on the standing binding');
+  assert.equal(pane.querySelector('.sp-profile-bar').dataset.profile, 'acme');
+});

--- a/test/ui-source-pane-mount.test.mjs
+++ b/test/ui-source-pane-mount.test.mjs
@@ -1,0 +1,121 @@
+// test/ui-source-pane-mount.test.mjs — app.js's mountPluginSourcePane error
+// path: a FAILED binding resolve (server unreachable mid project switch) must
+// tear down the previous scope's pane instead of leaving its task list and
+// resolved profile live — a submit would otherwise run the new project against
+// the old project's tracker, the exact mistake bindings exist to prevent.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
+const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
+
+const SOURCES = { sources: [
+  { type: 'prompt', displayName: 'Prompt' },
+  { type: 'markdown', displayName: 'Markdown' },
+  {
+    type: 'plugin', plugin: 'jira', sourceId: 'jira', displayName: 'Jira',
+    multiProfile: true,
+    profiles: [{ id: 'acme', label: 'Acme' }, { id: 'globex', label: 'Globex' }],
+    inputs: [{ key: 'task', type: 'task-browser', label: 'Task', options: [], optionsFrom: null, default: null }],
+  },
+] };
+
+const json = (body) => Promise.resolve({ ok: true, status: 200, json: async () => body });
+
+// Boot app.js in jsdom with a controllable fetch (mirrors newpipeline-config.test.mjs).
+async function boot(handlers) {
+  const dom = new JSDOM(readFileSync(htmlPath, 'utf8'), { url: 'http://localhost:4319/' });
+  const { window } = dom;
+  window.Element.prototype.scrollIntoView = function () {};
+  window.WebSocket = class {
+    constructor() { this.readyState = 1; this._listeners = {}; }
+    send() {} close() {}
+    addEventListener(t, fn) { (this._listeners[t] ||= []).push(fn); }
+  };
+  window.fetch = (url, opts) => {
+    const u = String(url);
+    for (const [prefix, fn] of Object.entries(handlers)) {
+      if (u.includes(prefix)) return fn(u, opts || {});
+    }
+    if (u.includes('/api/projects')) {
+      return json({ projects: [
+        { name: 'alpha', path: '/tmp/alpha', exists: true },
+        { name: 'beta', path: '/tmp/beta', exists: true },
+      ] });
+    }
+    if (u.includes('/api/sources') && !u.includes('/call')) return json(SOURCES);
+    if (u.includes('/api/workflows')) return json({ workflows: [] });
+    return json({ config: { steps: {}, customModels: [] }, models: [], efforts: [], branches: [] });
+  };
+  for (const k of ['window', 'document', 'location', 'localStorage', 'WebSocket', 'fetch', 'navigator', 'HTMLInputElement', 'HTMLSelectElement']) {
+    try { Object.defineProperty(globalThis, k, { value: window[k], configurable: true, writable: true }); } catch {}
+  }
+  globalThis.window = window; globalThis.document = window.document;
+  await import(appPath + `?b=${Date.now()}_${Math.random()}`);
+  await new Promise((r) => setTimeout(r, 0));
+  return { window };
+}
+
+async function waitFor(fn, what, { timeoutMs = 3000, everyMs = 10 } = {}) {
+  const t0 = Date.now();
+  for (;;) {
+    const v = fn();
+    if (v) return v;
+    if (Date.now() - t0 > timeoutMs) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, everyMs));
+  }
+}
+
+test('a failed profile resolve on project switch clears the stale pane and offers a retry', async () => {
+  let bindingsMode = 'ok';
+  const { window } = await boot({
+    '/api/source-bindings': () => {
+      if (bindingsMode === 'fail') return Promise.reject(new TypeError('fetch failed'));
+      return json({ scopeType: 'project', scopeKey: 'k', profile: 'acme', via: 'binding' });
+    },
+    '/api/sources/call': (u, opts) => {
+      const body = JSON.parse(opts.body || '{}');
+      if (body.op === 'validateConfig') return json({ ok: true, result: { ok: true } });
+      if (body.op === 'listTasks') {
+        return json({ ok: true, result: { tasks: [
+          { id: 'A-1', title: 'Alpha task', state: 'open', labels: [], updatedAt: '' },
+        ] } });
+      }
+      return json({ ok: true, result: null });
+    },
+  });
+  const doc = window.document;
+
+  // Select a project, then the plugin source: the pane mounts fully.
+  const projectSelect = doc.querySelector('#projectSelect');
+  projectSelect.value = '/tmp/alpha';
+  projectSelect.dispatchEvent(new window.Event('change'));
+  const srcBtn = await waitFor(() => doc.querySelector('#source-seg button[data-plugin-src="jira/jira"]'), 'plugin source button');
+  srcBtn.click();
+  const pane = doc.querySelector('#plugin-source-pane');
+  await waitFor(() => pane.querySelector('.sp-task-browser'), 'mounted task browser');
+  await waitFor(() => pane.querySelector('.sp-row'), 'the initial task listing');
+  assert.match(pane.textContent, /Alpha task/);
+  assert.equal(pane.querySelector('.sp-profile-bar').dataset.profile, 'acme');
+
+  // Switch projects while the server is unreachable: the resolve rejects.
+  bindingsMode = 'fail';
+  projectSelect.value = '/tmp/beta';
+  projectSelect.dispatchEvent(new window.Event('change'));
+  await waitFor(() => /Could not resolve the source profile/.test(pane.textContent), 'the resolve-failure notice');
+  // Nothing of the previous project's pane survives — no task rows to submit,
+  // no profile bar claiming the old binding still applies.
+  assert.equal(pane.querySelector('.sp-row'), null, 'stale task list torn down');
+  assert.equal(pane.querySelector('.sp-profile-bar'), null, 'stale profile bar torn down');
+  const retry = pane.querySelector('button');
+  assert.match(retry.textContent, /Retry/);
+
+  // The server comes back; Retry remounts against the NEW scope.
+  bindingsMode = 'ok';
+  retry.click();
+  await waitFor(() => pane.querySelector('.sp-task-browser'), 'remounted task browser');
+  assert.equal(pane.querySelector('.sp-profile-bar').dataset.profile, 'acme');
+});

--- a/test/upgrade-integration.test.mjs
+++ b/test/upgrade-integration.test.mjs
@@ -29,7 +29,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
-import { getDb, _resetForTests, prepare } from '../src/core/db.mjs';
+import { getDb, _resetForTests, prepare, SCHEMA_VERSION } from '../src/core/db.mjs';
 import { listProjects } from '../src/core/projects.mjs';
 import { listWorkspaces, readWorkspace } from '../src/core/workspaces.mjs';
 import { readConfig, readRunConfig } from '../src/core/config.mjs';
@@ -156,7 +156,7 @@ test('first getDb() auto-runs the fs->db migration (DB is empty + legacy JSON pr
   const db = getDb(); // triggers migrate(db) then maybeMigrateFromFs(db)
   const n = db.prepare('SELECT COUNT(*) AS c FROM pipelines').get().c;
   assert.ok(n >= 1, 'the legacy pipeline was imported into the pipelines table');
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'schema stamped');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, SCHEMA_VERSION, 'schema stamped');
   // every relevant table populated by the one-time importer
   const count = (t) => db.prepare(`SELECT COUNT(*) AS c FROM ${t}`).get().c;
   assert.equal(count('projects'), 2, 'projects.json -> projects');

--- a/test/writeback.test.mjs
+++ b/test/writeback.test.mjs
@@ -106,6 +106,33 @@ test('the run\'s pinned source inputs reach capabilities AND reportResult (per-r
   assert.deepEqual(caps.at(-1), { inputs: {} });
 });
 
+test('probe transport error with NO pinned inputs fails OPEN: the report still runs', async () => {
+  // No pinned inputs means no per-run opt-out was possible, so a transient
+  // rate-limit/timeout on the probe must not silently drop the ticket comment
+  // — the pre-profiles behavior, which reportResult itself then confirms.
+  const calls = [];
+  setMockSourceResponses({
+    capabilities: () => { throw Object.assign(new Error('capabilities timed out'), { kind: 'timeout' }); },
+    reportResult: (args) => { calls.push(args); return { ok: true }; },
+  });
+  const p = await seedDonePluginPipeline(); // META has no inputs
+  assert.deepEqual(await retryWriteback(p.id), { ok: true });
+  assert.equal(calls.length, 1, 'write-back proceeded despite the failed probe');
+});
+
+test('probe transport error WITH pinned inputs fails CLOSED: the opt-out may be in them', async () => {
+  const calls = [];
+  setMockSourceResponses({
+    capabilities: () => { throw Object.assign(new Error('rate limited'), { kind: 'rate-limit' }); },
+    reportResult: (args) => { calls.push(args); return { ok: true }; },
+  });
+  const p = await seedDonePluginPipeline({ ...META, inputs: { writeBack: 'no', jql: 'project = X' } });
+  const out = await retryWriteback(p.id);
+  assert.equal(out.ok, false);
+  assert.match(out.error, /capability probe failed: rate limited/);
+  assert.equal(calls.length, 0, 'never write when the run may have opted out and we could not hear');
+});
+
 test('reportResult failure returns {ok:false,error} and NEVER throws', async () => {
   setMockSourceResponses({ reportResult: () => { throw new Error('rate limited'); } });
   const p = await seedDonePluginPipeline();

--- a/test/writeback.test.mjs
+++ b/test/writeback.test.mjs
@@ -1,17 +1,19 @@
 // test/writeback.test.mjs — spec §7.5 result write-back, all in WORCA_MOCK mode.
 // The mock registry has NO canned 'capabilities' default, so every test here also
-// exercises the tolerant-default: PluginOpError kind 'plugin' => writeBack:true.
+// exercises the tolerant-default: PluginOpError kind 'unimplemented' => writeBack:true.
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp } from 'node:fs/promises';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { useTempHome } from './helpers/temp-home.mjs';
 import { getDb } from '../src/core/db.mjs';
 import { createPipeline } from '../src/core/artifacts.mjs';
 import { createOrchestrator } from '../src/core/orchestrator.mjs';
-import { setMockSourceResponses } from '../src/core/plugin-shim.mjs';
+import { setMockSourceResponses, callSource } from '../src/core/plugin-shim.mjs';
+import { writePluginsLock, pluginCurrentDir } from '../src/core/plugins-lock.mjs';
+import { createProfile, readPluginState } from '../src/core/plugin-config.mjs';
 import { retryWriteback, reportResultForPipeline } from '../src/core/sources.mjs';
 
 useTempHome(after);
@@ -120,7 +122,7 @@ test('probe transport error with NO pinned inputs fails OPEN: the report still r
   assert.equal(calls.length, 1, 'write-back proceeded despite the failed probe');
 });
 
-test('probe transport error WITH pinned inputs fails CLOSED: the opt-out may be in them', async () => {
+test('probe transport error WITH a pinned writeBack input fails CLOSED: the opt-out may be in it', async () => {
   const calls = [];
   setMockSourceResponses({
     capabilities: () => { throw Object.assign(new Error('rate limited'), { kind: 'rate-limit' }); },
@@ -131,6 +133,38 @@ test('probe transport error WITH pinned inputs fails CLOSED: the opt-out may be 
   assert.equal(out.ok, false);
   assert.match(out.error, /capability probe failed: rate limited/);
   assert.equal(calls.length, 0, 'never write when the run may have opted out and we could not hear');
+});
+
+test('probe transport error with pinned inputs but NO writeBack key fails OPEN', async () => {
+  // The UI pins EVERY source-panel input (defaults and empty strings included),
+  // so "has pinned inputs" is true for essentially every plugin run — it must
+  // not be what flips the probe to fail-closed. Only the reserved `writeBack`
+  // input can carry a per-run opt-out; without it a transient probe error must
+  // not silently drop the ticket comment.
+  const calls = [];
+  setMockSourceResponses({
+    capabilities: () => { throw Object.assign(new Error('rate limited'), { kind: 'rate-limit' }); },
+    reportResult: (args) => { calls.push(args); return { ok: true }; },
+  });
+  const p = await seedDonePluginPipeline({ ...META, inputs: { repo: 'octo/hello', filter: '' } });
+  assert.deepEqual(await retryWriteback(p.id), { ok: true });
+  assert.equal(calls.length, 1, 'write-back proceeded despite the failed probe');
+});
+
+test('an implemented capabilities() that CRASHES with a pinned writeBack input fails CLOSED', async () => {
+  // A crash (kind "plugin") is not "op not implemented" (kind "unimplemented"):
+  // the connector HAS an opt-out concept and we could not hear its answer, so
+  // writing could violate an explicit per-run opt-out.
+  const calls = [];
+  setMockSourceResponses({
+    capabilities: () => { throw new Error('bad response parse'); }, // no kind -> 'plugin'
+    reportResult: (args) => { calls.push(args); return { ok: true }; },
+  });
+  const p = await seedDonePluginPipeline({ ...META, inputs: { writeBack: 'no' } });
+  const out = await retryWriteback(p.id);
+  assert.equal(out.ok, false);
+  assert.match(out.error, /capability probe failed: bad response parse/);
+  assert.equal(calls.length, 0, 'a crash must not default past the pinned opt-out');
 });
 
 test('reportResult failure returns {ok:false,error} and NEVER throws', async () => {
@@ -153,6 +187,51 @@ test('prompt-source pipelines never call the connector (silent skip); unknown id
   assert.deepEqual(await retryWriteback(p.id), { ok: true, skipped: true });
   assert.equal(calls.length, 0);
   assert.equal((await retryWriteback('deadbeef')).ok, false);
+});
+
+test('a pre-profiles row still writes back after its plugin turns multiProfile (legacy default bucket)', async () => {
+  // The row's source_ref pinned NO profile (it predates the field). Once the
+  // plugin's manifest declares multiProfile, a bare callSource would refuse it
+  // with CLI-flavored advice, retry would fail identically forever, and the
+  // migrated flat config would sit unreachable in the reserved default bucket.
+  // The legacy path reports against DEFAULT_PROFILE explicitly — that bucket
+  // IS the instance the task came from.
+  const P = 'legacy-mp';
+  const cur = pluginCurrentDir(P);
+  mkdirSync(cur, { recursive: true });
+  writeFileSync(join(cur, 'index.mjs'), 'export default () => ({});\n');
+  writeFileSync(join(cur, 'worca-cc-plugin.json'), JSON.stringify({
+    name: P,
+    taskSources: [{
+      id: 'jira', displayName: 'Jira', module: './index.mjs', multiProfile: true,
+      inputs: [{ key: 'task', type: 'task-browser', label: 'Task' }],
+    }],
+  }));
+  writePluginsLock({
+    [P]: {
+      repo: 'local-fixture', subdir: null, pinnedSha: 'f'.repeat(40),
+      version: null, enabled: true, installedAt: '2026-07-12T00:00:00.000Z',
+    },
+  });
+  createProfile(P, 'work', 'Work'); // a roster exists, but the legacy row names none of it
+  // Canary: the fixture manifest actually loads and the profile invariant is
+  // live for this plugin — otherwise this test would pass vacuously.
+  await assert.rejects(
+    callSource({ plugin: P, sourceId: 'jira', op: 'listTasks', profile: 'nope' }),
+    /has no profile "nope"/,
+  );
+
+  const calls = [];
+  setMockSourceResponses({ reportResult: (args) => { calls.push(args); return { ok: true }; } });
+  const p = await seedDonePluginPipeline({ plugin: P, sourceId: 'jira', taskId: 'L-1', url: 'https://x.test/L-1', title: 'Legacy' });
+
+  assert.deepEqual(await retryWriteback(p.id), { ok: true });
+  assert.equal(calls.length, 1, 'the legacy row reported instead of being stranded');
+  assert.equal(calls[0].id, 'L-1');
+  // The mock reportResult path persists into the profile it ran against: the
+  // legacy DEFAULT bucket, never a phantom one.
+  assert.ok(readPluginState(P).lastReport, 'state landed in the default bucket');
+  assert.deepEqual(readPluginState(P, 'work'), {}, 'the roster profile stays untouched');
 });
 
 test('e2e: write-back failure completes the run anyway, with a warn log event', async () => {

--- a/test/writeback.test.mjs
+++ b/test/writeback.test.mjs
@@ -26,9 +26,9 @@ const RESULTS = {
   nitpicks: [],
 };
 
-async function seedDonePluginPipeline() {
+async function seedDonePluginPipeline(meta = META) {
   const p = await createPipeline(await mkdtemp(join(tmpdir(), 'worca-cc-wb-')), {
-    promptText: '# Fix login\n\nbody', sourceType: 'plugin', sourceMeta: META, title: 'Fix login',
+    promptText: '# Fix login\n\nbody', sourceType: 'plugin', sourceMeta: meta, title: 'Fix login',
   });
   getDb().prepare("UPDATE pipelines SET status = 'done' WHERE id = ?").run(p.id);
   writeFileSync(join(p.dir, 'results.json'), JSON.stringify(RESULTS));
@@ -79,6 +79,31 @@ test('connector capabilities {writeBack:false} skips the report', async () => {
   const out = await retryWriteback(p.id);
   assert.deepEqual(out, { ok: true, skipped: true });
   assert.equal(calls.length, 0);
+});
+
+test('the run\'s pinned source inputs reach capabilities AND reportResult (per-run write-back)', async () => {
+  const caps = [];
+  const calls = [];
+  setMockSourceResponses({
+    // A jira-source-style connector: write-back is whatever THIS run chose.
+    capabilities: (args) => { caps.push(args); return { writeBack: args.inputs?.writeBack === 'yes', incrementalSync: false }; },
+    reportResult: (args) => { calls.push(args); return { ok: true }; },
+  });
+
+  const optedIn = await seedDonePluginPipeline({ ...META, inputs: { writeBack: 'yes', jql: 'project = X' } });
+  assert.deepEqual(await retryWriteback(optedIn.id), { ok: true });
+  assert.deepEqual(caps[0], { inputs: { writeBack: 'yes', jql: 'project = X' } });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].inputs, { writeBack: 'yes', jql: 'project = X' }, 'connector can re-check the run\'s choice');
+
+  const optedOut = await seedDonePluginPipeline({ ...META, inputs: { writeBack: 'no' } });
+  assert.deepEqual(await retryWriteback(optedOut.id), { ok: true, skipped: true });
+  assert.equal(calls.length, 1, 'an opted-out run is never reported');
+
+  // A row with no pinned inputs (predates the field) probes with an empty bag.
+  const legacy = await seedDonePluginPipeline();
+  assert.deepEqual(await retryWriteback(legacy.id), { ok: true, skipped: true });
+  assert.deepEqual(caps.at(-1), { inputs: {} });
 });
 
 test('reportResult failure returns {ok:false,error} and NEVER throws', async () => {

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -4769,14 +4769,18 @@ async function resolveSourceProfile(src) {
   const ref = bindingScopeRef();
   if (!ref) return null;
   const qs = new URLSearchParams({ ...ref, plugin: src.plugin, sourceId: src.sourceId });
-  const { ok, data } = await pluginApi('GET', `/api/source-bindings?${qs.toString()}`);
-  if (ok && data.profile) return { profile: data.profile, via: data.via };
+  const { ok, status, data } = await pluginApi('GET', `/api/source-bindings?${qs.toString()}`);
+  // An HTTP failure is NOT "no binding": rendering the first-time gate on a
+  // transient 500 invites the user to overwrite a correct standing binding.
+  // Throw so the caller's retry branch handles it like a network error.
+  if (!ok) throw new Error((data && data.error) || `HTTP ${status}`);
+  if (data.profile) return { profile: data.profile, via: data.via };
   return {
     gate: {
       source: src,
       profiles: src.profiles || [],
-      via: (ok && data.via) || 'none',
-      candidates: (ok && data.candidates) || [],
+      via: data.via || 'none',
+      candidates: data.candidates || [],
       scopeLabel: bindingScopeLabel(),
     },
     ref,
@@ -4800,12 +4804,18 @@ async function mountPluginSourcePane(src) {
   host.dataset.gateRun = String(run);
   const owns = () => host.isConnected && host.dataset.gateRun === String(run)
     && state.activePluginSource === src;
+  // Tear the previous pane down BEFORE the first await, not after it resolves:
+  // while the binding fetch is in flight the old scope's task list, picked
+  // task and resolved profile would otherwise stay live and SUBMITTABLE — a
+  // Start in that window runs the new project against the old project's
+  // tracker, the exact silent-wrong-tracker mistake bindings exist to prevent.
+  state.activePluginProfile = null;
+  host.replaceChildren(Object.assign(document.createElement('small'),
+    { className: 'hint', textContent: `Checking ${src.displayName}…` }));
   // A multi-profile source cannot be asked anything until it is known WHICH
   // instance to ask, so the binding is resolved before the connection check.
   // A FAILED resolve (server briefly unreachable mid project switch) must not
-  // leave the previous scope's pane — and its resolved profile — live: a
-  // submit would then run the new project against the old project's tracker,
-  // the exact silent-wrong-tracker mistake bindings exist to prevent.
+  // resurrect the previous scope's pane either — error box with retry.
   let resolved;
   try {
     resolved = await resolveSourceProfile(src);
@@ -7970,16 +7980,38 @@ async function openPluginSettings(name, profile) {
   const connectable = sources.filter((s) => !s.multiProfile || s.profile);
   pluginModal(`Settings: ${name}`, body, [
     ['Cancel', 'btn btn-ghost btn-mini', closePluginModal],
-    ['Connect', 'btn btn-ghost btn-mini', async () => {
+    // Connect only exists for task sources (validateConfig is a task-source
+    // op): a channels-only chat plugin would get a button whose every outcome
+    // misleads — "Add a profile first." for a plugin that CANNOT have
+    // profiles — so it gets no button at all.
+    ...(sources.length ? [['Connect', 'btn btn-ghost btn-mini', async () => {
       if (!connectable.length) {
         return slot.replaceChildren(renderConnectResult({ ok: false, errors: [{ message: 'Add a profile first.' }] }));
       }
       const failed = await savePluginConfigForms(name, body);
       if (failed) return slot.replaceChildren(renderConnectResult({ ok: false, errors: [{ message: failed }] }));
-      slot.replaceChildren(renderConnectResult({ ok: false, pending: true, message: 'Connecting…' }));
+      // One result block PER SOURCE, kept side by side: a later source's
+      // success must never paint over an earlier source's failure.
+      slot.replaceChildren();
+      const subs = connectable.map((s) => {
+        const sub = document.createElement('div');
+        sub.className = 'pl-connect-sub';
+        if (connectable.length > 1) {
+          sub.appendChild(Object.assign(document.createElement('div'),
+            { className: 'pl-config-h', textContent: s.id }));
+        }
+        const out = document.createElement('div');
+        sub.appendChild(out);
+        out.replaceChildren(renderConnectResult({ ok: false, pending: true, message: 'Connecting…' }));
+        slot.appendChild(sub);
+        return out;
+      });
       // Sequential so two sources never race the same browser launch.
-      for (const s of connectable) await connectPluginSource(name, s.id, slot, s.profile || undefined);
-    }],
+      for (let i = 0; i < connectable.length; i++) {
+        const s = connectable[i];
+        await connectPluginSource(name, s.id, subs[i], s.profile || undefined);
+      }
+    }]] : []),
     ['Save', 'btn btn-primary btn-mini', async () => {
       const failed = await savePluginConfigForms(name, body);
       closePluginModal();

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -42,6 +42,10 @@ const state = {
   // --- Pluggable task sources (New Pipeline) ---
   pluginSources: [],        // GET /api/sources entries with type:'plugin'
   activePluginSource: null, // selected plugin source | null (legacy prompt/markdown)
+  // The profile the active source resolved to for the selected project /
+  // workspace (multiProfile sources only; null otherwise). Submitted with the
+  // run so the pipeline records WHICH instance the task came from.
+  activePluginProfile: null,
 };
 
 import {
@@ -63,7 +67,7 @@ import { sourceBadge, workflowPickerLabel } from './results-view.mjs';
 import { splitPatchSections, parseFileSection, patchIndex, sectionKey } from './diff-view.mjs';
 import {
   renderPluginList, renderInstallConsent, renderUpdatePreview,
-  renderConfigForm, collectConfigForm, renderDoctorReport, renderReferences409,
+  renderConfigForm, collectConfigForm, renderConnectResult, renderDoctorReport, renderReferences409,
   renderOrphanList, channelBadge, renderAvailableList, renderMarketplaceList,
 } from './plugins-view.mjs';
 import { renderChatSettings, collectChatSettings } from './chat-settings-view.mjs';
@@ -75,7 +79,9 @@ import {
   renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, deleteRefsSummary,
   renderExportWizard, collectExportWizard,
 } from './models-view.mjs';
-import { renderSourcePane, collectSourcePane } from './source-pane.mjs';
+import {
+  renderSourcePane, collectSourcePane, renderProfileGate, renderProfileBar,
+} from './source-pane.mjs';
 import { renderStatsBody, renderBudgetIndicator, renderBudgetRing, renderBudgetReadout, renderCostPauseBanner, BUDGET_WARN_AT } from './stats-view.mjs';
 
 // ---------------------------------------------------------------------------
@@ -4684,21 +4690,35 @@ async function loadTaskSources() {
     el.sourceSeg.appendChild(b);
   }
   // Active source vanished (uninstalled/disabled)? Fall back to the radios.
-  if (state.activePluginSource && !state.pluginSources.some((s) =>
-      s.plugin === state.activePluginSource.plugin && s.sourceId === state.activePluginSource.sourceId)) {
+  const fresh = state.activePluginSource && state.pluginSources.find((s) =>
+    s.plugin === state.activePluginSource.plugin && s.sourceId === state.activePluginSource.sourceId);
+  if (state.activePluginSource && !fresh) {
     state.activePluginSource = null;
     el.pluginSourcePane.replaceChildren();
     syncSourceToggle();
+  } else if (fresh && fresh !== state.activePluginSource
+      && JSON.stringify(fresh) !== JSON.stringify(state.activePluginSource)) {
+    // Same source, CHANGED payload — its `profiles` roster is the usual thing
+    // that moves behind the pane's back (added/removed in Plugins settings).
+    // Re-point and re-mount, or the profile bar keeps offering a stale list.
+    // `fresh` is a new object on EVERY fetch, so equality is by value: an
+    // unchanged source keeps the mounted pane (and the user's search, results
+    // and picked task) instead of rebuilding it on each return to this view.
+    state.activePluginSource = fresh;
+    mountPluginSourcePane(fresh);
   }
 }
 
 // The pane's injected `call`: one connector op via POST /api/sources/call.
-function sourceCall(src) {
+// `profile` is the project's binding for a multi-profile source (undefined
+// otherwise) — without it the connector would run against whichever instance
+// the server defaulted to.
+function sourceCall(src, profile) {
   return async (op, args) => {
     const res = await fetch('/api/sources/call', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ plugin: src.plugin, sourceId: src.sourceId, op, args: args || {} }),
+      body: JSON.stringify({ plugin: src.plugin, sourceId: src.sourceId, op, args: args || {}, profile }),
     });
     const data = await safeJson(res);
     if (!res.ok || data.ok === false) {
@@ -4719,24 +4739,119 @@ function selectPluginSource(src, btn) {
   mountPluginSourcePane(src);
 }
 
+// Which project/workspace a binding hangs off, in the shape both binding routes
+// accept. null when nothing is selected yet.
+function bindingScopeRef() {
+  if (state.runTarget === 'workspace') {
+    const id = (el.workspaceSelect && el.workspaceSelect.value) || '';
+    return id ? { workspaceId: id } : null;
+  }
+  const dir = selectedProjectPath();
+  return dir ? { projectDir: dir } : null;
+}
+
+function bindingScopeLabel() {
+  if (state.runTarget === 'workspace') {
+    const ws = state.workspaces.find((w) => w && w.id === (el.workspaceSelect && el.workspaceSelect.value));
+    return (ws && ws.name) || 'this workspace';
+  }
+  return selectedProjectName() || 'this project';
+}
+
+/**
+ * The profile this project/workspace pulls from, or null when the user still
+ * has to say. Only multi-profile sources ask; everything else resolves to
+ * undefined and behaves exactly as it did before profiles existed.
+ * @returns {Promise<{profile?:string, gate?:object}|null>} null = no scope yet
+ */
+async function resolveSourceProfile(src) {
+  if (!src.multiProfile) return { profile: undefined };
+  const ref = bindingScopeRef();
+  if (!ref) return null;
+  const qs = new URLSearchParams({ ...ref, plugin: src.plugin, sourceId: src.sourceId });
+  const { ok, data } = await pluginApi('GET', `/api/source-bindings?${qs.toString()}`);
+  if (ok && data.profile) return { profile: data.profile, via: data.via };
+  return {
+    gate: {
+      source: src,
+      profiles: src.profiles || [],
+      via: (ok && data.via) || 'none',
+      candidates: (ok && data.candidates) || [],
+      scopeLabel: bindingScopeLabel(),
+    },
+    ref,
+  };
+}
+
 // validateConfig gate first (= "Test connection"); then the declarative pane.
 async function mountPluginSourcePane(src) {
   const host = el.pluginSourcePane;
-  const call = sourceCall(src);
-  host.replaceChildren(Object.assign(document.createElement('small'),
-    { className: 'hint', textContent: `Checking ${src.displayName} configuration…` }));
-  let v;
-  try { v = await call('validateConfig', {}); }
-  catch (e) { v = { ok: false, errors: [{ message: e.message }] }; }
-  if (state.activePluginSource !== src) return;   // user switched away meanwhile
-  host.replaceChildren();
-  if (!v || v.ok === false) {
+  // A caller that lost the pane while it awaited (an onPick/retry resolving
+  // after the user switched sources) must not claim it back and orphan the
+  // current owner's loop. Synchronous, so it cannot race the claim below.
+  if (state.activePluginSource !== src) return;
+  // Claim the pane BEFORE the first await. Every mount takes a run id, and any
+  // older mount still in flight (a slow binding fetch, the SSO poll loop) stands
+  // down at its next owns() check. Source identity alone is NOT enough: the
+  // same src object is remounted when the project changes, and the binding is
+  // per-project — an old project's late resolve must never paint (or pin a
+  // profile for) the newly selected project's pane.
+  const run = (Number(host.dataset.gateRun) || 0) + 1;
+  host.dataset.gateRun = String(run);
+  const owns = () => host.isConnected && host.dataset.gateRun === String(run)
+    && state.activePluginSource === src;
+  // A multi-profile source cannot be asked anything until it is known WHICH
+  // instance to ask, so the binding is resolved before the connection check.
+  const resolved = await resolveSourceProfile(src);
+  if (!owns()) return;
+  if (!resolved) {
+    host.replaceChildren(Object.assign(document.createElement('small'),
+      { className: 'hint', textContent: 'Select a project first — the source profile is bound to it.' }));
+    return;
+  }
+  if (resolved.gate) {
+    host.replaceChildren(renderProfileGate(resolved.gate, {
+      onPick: async (profile) => {
+        const r = await pluginApi('PUT', '/api/source-bindings',
+          { ...resolved.ref, plugin: src.plugin, sourceId: src.sourceId, profile });
+        if (!r.ok) return setFormMsg(r.data.error || 'could not save the profile binding', 'err');
+        mountPluginSourcePane(src);
+      },
+    }));
+    return;
+  }
+  state.activePluginProfile = resolved.profile || null;
+  // The resolved profile stays on screen above the pane: "which tracker am I
+  // about to read from" has to be answerable at a glance, not only on the run
+  // that first bound it. Switching it rebinds the scope, same as the gate.
+  const bar = src.multiProfile ? renderProfileBar({
+    source: src,
+    profiles: src.profiles || [],
+    profile: resolved.profile,
+    via: resolved.via,
+    scopeLabel: bindingScopeLabel(),
+  }, {
+    onChange: async (profile) => {
+      const ref = bindingScopeRef();
+      if (!ref) return;
+      const r = await pluginApi('PUT', '/api/source-bindings',
+        { ...ref, plugin: src.plugin, sourceId: src.sourceId, profile });
+      if (!r.ok) return setFormMsg(r.data.error || 'could not save the profile binding', 'err');
+      mountPluginSourcePane(src);
+    },
+  }) : null;
+  const call = sourceCall(src, resolved.profile);
+  // Above EVERY outcome: a failed connection check is one of the likeliest
+  // moments to discover the wrong profile is bound, so the switcher has to be
+  // reachable from the error and waiting states too.
+  const show = (...nodes) => { host.replaceChildren(); if (bar) host.appendChild(bar); host.append(...nodes); };
+  const hint = (text, cls = 'hint') => Object.assign(document.createElement('small'), { className: cls, textContent: text });
+  const failBox = (message) => {
     const box = document.createElement('div');
     box.className = 'sp-config-missing';
     const msg = document.createElement('p');
     msg.className = 'hint err';
-    msg.textContent = `${src.displayName} is not configured: ${((v && v.errors) || [])
-      .map((x) => x.message).join('; ') || 'connection check failed'}`;
+    msg.textContent = message;
     const link = document.createElement('a');
     link.href = '#plugins';
     link.textContent = 'Open Plugins settings';
@@ -4747,10 +4862,34 @@ async function mountPluginSourcePane(src) {
     retry.textContent = 'Test connection';
     retry.addEventListener('click', () => mountPluginSourcePane(src));
     box.append(msg, link, retry);
-    host.appendChild(box);
+    return box;
+  };
+  host.replaceChildren(hint(`Checking ${src.displayName} configuration…`));
+  const started = Date.now();
+  for (;;) {
+    let v;
+    try { v = await call('validateConfig', {}); }
+    catch (e) { v = { ok: false, errors: [{ message: e.message }] }; }
+    if (!owns()) return;   // user switched away / remounted meanwhile
+    if (v && v.ok === true) break;
+    // { pending } is setup legitimately mid-flight (an SSO sign-in the
+    // connector just launched in a browser) — NOT a failure. Show the
+    // connector's own message neutrally and keep polling, exactly like the
+    // settings pane's Connect, so the pane flips to the inputs by itself
+    // once the sign-in completes.
+    if (v && v.pending && Date.now() - started <= CONNECT_MAX_MS) {
+      show(hint(v.message || `Waiting for ${src.displayName} to connect…`));
+      await new Promise((r) => setTimeout(r, CONNECT_POLL_MS));
+      if (!owns()) return;
+      continue;
+    }
+    const detail = v && v.pending
+      ? 'timed out waiting for the sign-in — press Test connection to try again'
+      : ((v && v.errors) || []).map((x) => x.message).join('; ') || 'connection check failed';
+    show(failBox(`${src.displayName} is not connected: ${detail}`));
     return;
   }
-  host.appendChild(renderSourcePane(src, { call }));
+  show(renderSourcePane(src, { call }));
 }
 
 // ---------------------------------------------------------------------------
@@ -5376,6 +5515,11 @@ function renderProjectOptions(selectName) {
 
 function onProjectChanged() {
   const path = selectedProjectPath();
+  // The source profile is bound to the PROJECT, so a different project may pull
+  // from a different tracker: re-resolve rather than keep listing the old one's.
+  if (state.activePluginSource && state.activePluginSource.multiProfile) {
+    mountPluginSourcePane(state.activePluginSource);
+  }
   if (path) {
     state.projectDir = path;
     localStorage.setItem(LAST_PROJECT_KEY, selectedProjectName());
@@ -5661,6 +5805,11 @@ function setRunTarget(target) {
     // Config panel: no projectDir → built-in models/efforts; workflow picker still works.
     loadConfig('');
     ensureWorkspaceOptions();
+    // The binding scope just changed from a project to a workspace; the project
+    // mode branch below re-resolves via onProjectChanged().
+    if (state.activePluginSource && state.activePluginSource.multiProfile) {
+      mountPluginSourcePane(state.activePluginSource);
+    }
   } else {
     // Restore the single project-driven dropdown; clear the per-project list.
     if (el.sourceBranchWrap) el.sourceBranchWrap.classList.remove('hidden');
@@ -5797,6 +5946,11 @@ if (el.workspaceSelect) {
     if (state.selectedWorkspaceId) localStorage.setItem(LAST_WORKSPACE_KEY, state.selectedWorkspaceId);
     renderWorkspaceMembers();
     renderWorkspaceSourceBranches();
+    // Same as onProjectChanged: a workspace has its own binding (or inherits
+    // one from its members), so the resolved profile can differ.
+    if (state.activePluginSource && state.activePluginSource.multiProfile) {
+      mountPluginSourcePane(state.activePluginSource);
+    }
   });
 }
 
@@ -7094,7 +7248,14 @@ el.form.addEventListener('submit', async (e) => {
   if (psrc) {
     const picked = collectSourcePane(el.pluginSourcePane);
     if (picked.error) return setFormMsg(picked.error, 'err');
-    body.source = { type: 'plugin', plugin: psrc.plugin, sourceId: psrc.sourceId, taskId: picked.taskId, inputs: picked.inputs };
+    // The profile travels with the run and is pinned onto the row, so a result
+    // is reported back to the instance the task actually came from even if the
+    // project is re-bound in the meantime.
+    body.source = {
+      type: 'plugin', plugin: psrc.plugin, sourceId: psrc.sourceId,
+      taskId: picked.taskId, inputs: picked.inputs,
+      profile: state.activePluginProfile || undefined,
+    };
   } else if (source === 'markdown') {
     if (!mdText) return setFormMsg('Provide markdown text or load a .md file.', 'err');
     body.promptMarkdown = mdText;
@@ -7652,8 +7813,91 @@ function openInstallConsent(entry) {
   ]);
 }
 
-async function openPluginSettings(name) {
-  const { ok, data } = await pluginApi('GET', `/api/plugins/${encodeURIComponent(name)}/config`);
+// One PUT per source form, each with ITS OWN sourceId — merging every form
+// into a single sourceId-less PUT would 400 for multi-source plugins (the
+// server only infers sourceId when the plugin has exactly one source).
+async function savePluginConfigForms(name, body) {
+  for (const f of body.querySelectorAll('.pl-config-form')) {
+    // `profile` is absent for a single-profile source, so this PUT is identical
+    // to the pre-profiles one there. Channel forms carry channelId instead of
+    // sourceId; the model-secrets form routes through { target: 'modelSecrets' }.
+    const collected = collectConfigForm(f); // { sourceId | channelId, values } (+ profile)
+    const payload = f.dataset.target === 'modelSecrets'
+      ? { target: 'modelSecrets', values: collected.values }
+      : collected;
+    const r = await pluginApi('PUT', `/api/plugins/${encodeURIComponent(name)}/config`, payload);
+    if (!r.ok) return r.data.error || 'save failed';
+  }
+  return null;
+}
+
+// Creating a profile is its own call: the roster entry has to exist before the
+// config form has anything to write into. Reopens on the NEW profile, which is
+// what the user wants to fill in next.
+async function addPluginProfile(name, sourceId) {
+  const id = (window.prompt('Profile id (lowercase letters, digits and dashes — e.g. "work"):') || '').trim();
+  if (!id) return;
+  const label = (window.prompt('Display name (optional):', id) || '').trim();
+  const r = await pluginApi('POST', `/api/plugins/${encodeURIComponent(name)}/profiles`, { sourceId, id, label });
+  if (!r.ok) return setPluginsMsg(r.data.error || 'could not create the profile', 'err');
+  loadTaskSources();               // the New Pipeline profile bar lists this roster
+  openPluginSettings(name, id);
+}
+
+async function deletePluginProfile(name, sourceId, profile) {
+  if (!profile) return;
+  // The server also drops every project binding that named it, so this is not
+  // just a settings delete — say so before it happens, not after.
+  if (!window.confirm(`Delete profile "${profile}"? Its settings, token and any project bound to it are removed.`)) return;
+  const url = `/api/plugins/${encodeURIComponent(name)}/profiles/${encodeURIComponent(profile)}?sourceId=${encodeURIComponent(sourceId)}`;
+  const r = await pluginApi('DELETE', url);
+  if (!r.ok) return setPluginsMsg(r.data.error || 'could not delete the profile', 'err');
+  // Deleting also drops the bindings that named it, so the pane may fall back
+  // to the gate — refresh it rather than leaving a profile that no longer exists.
+  loadTaskSources();
+  openPluginSettings(name);
+}
+
+// Connect: save the form, then poll validateConfig until it settles. Polling
+// is what lets an interactive sign-in (a browser the connector launched, which
+// outlives the 30s op budget) finish without the user clicking again — the
+// connector answers { pending: true } for as long as it is still waiting.
+const CONNECT_POLL_MS = 5000;
+const CONNECT_MAX_MS = 5 * 60 * 1000;
+
+async function connectPluginSource(name, sourceId, slot, profile) {
+  // A second Connect click starts a NEW loop over the same slot; the run id
+  // makes the old one stand down instead of the two fighting over what the
+  // slot shows (each has already re-launched validateConfig).
+  const run = (Number(slot.dataset.connectRun) || 0) + 1;
+  slot.dataset.connectRun = String(run);
+  const owns = () => slot.isConnected && slot.dataset.connectRun === String(run);
+  const started = Date.now();
+  for (;;) {
+    // The modal can be dismissed mid-poll (or the loop superseded by a newer
+    // Connect); stop rather than render into a detached or stolen node.
+    if (!owns()) return;
+    const { ok, data } = await pluginApi('POST', '/api/sources/call', { plugin: name, sourceId, op: 'validateConfig', profile });
+    if (!owns()) return; // superseded while the call was in flight
+    const result = ok && data.ok ? data.result : { ok: false, ...(data || {}) };
+    slot.replaceChildren(renderConnectResult(result));
+    if (result.ok || !result.pending) return;
+    if (Date.now() - started > CONNECT_MAX_MS) {
+      slot.replaceChildren(renderConnectResult({
+        ok: false,
+        errors: [{ message: 'Timed out waiting for the sign-in. Click Connect to try again.' }],
+      }));
+      return;
+    }
+    await new Promise((r) => setTimeout(r, CONNECT_POLL_MS));
+  }
+}
+
+// profile: which configuration of a multiProfile source to echo. Absent = the
+// server's pick (the first in the roster), which is what opening from the list does.
+async function openPluginSettings(name, profile) {
+  const qs = profile ? `?profile=${encodeURIComponent(profile)}` : '';
+  const { ok, data } = await pluginApi('GET', `/api/plugins/${encodeURIComponent(name)}/config${qs}`);
   if (!ok) return setPluginsMsg(data.error || 'config load failed', 'err');
   // Multi-source { sources:[{id,schema,values}] }, single-source { schema, values } tolerated.
   const sources = Array.isArray(data.sources) ? data.sources
@@ -7671,21 +7915,51 @@ async function openPluginSettings(name) {
     msForm.dataset.target = 'modelSecrets';
     body.appendChild(msForm);
   }
+  // Roster controls (multiProfile sources only — absent otherwise). Switching
+  // profile REOPENS the pane: the values are the server's per-profile echo, so
+  // there is nothing sensible to show until it has answered for the new one.
+  // Reopening discards typed-but-unsaved edits, so a dirty form asks first —
+  // and puts the select back when the answer is no.
+  const sourceById = (id) => sources.find((s) => (s.id || '') === id) || {};
+  let dirty = false;
+  body.querySelectorAll('.pl-config-form').forEach((f) => {
+    f.addEventListener('input', () => { dirty = true; });
+  });
+  body.querySelectorAll('.pl-profile-sel').forEach((sel) => {
+    const prev = sel.value;
+    sel.addEventListener('change', () => {
+      if (dirty && !window.confirm('Discard unsaved changes and switch profiles?')) {
+        sel.value = prev;
+        return;
+      }
+      openPluginSettings(name, sel.value);
+    });
+  });
+  body.querySelectorAll('.pl-profile-add').forEach((btn) => {
+    btn.addEventListener('click', () => addPluginProfile(name, btn.dataset.sourceId));
+  });
+  body.querySelectorAll('.pl-profile-del').forEach((btn) => {
+    btn.addEventListener('click', () => deletePluginProfile(name, btn.dataset.sourceId, sourceById(btn.dataset.sourceId).profile));
+  });
+  const slot = document.createElement('div');
+  slot.className = 'pl-connect-slot';
+  body.appendChild(slot);
+  // A multi-profile source with an empty roster has nothing to connect WITH.
+  const connectable = sources.filter((s) => !s.multiProfile || s.profile);
   pluginModal(`Settings: ${name}`, body, [
     ['Cancel', 'btn btn-ghost btn-mini', closePluginModal],
-    ['Save', 'btn btn-primary btn-mini', async () => {
-      // One PUT per source form, each with ITS OWN sourceId — merging every form
-      // into a single sourceId-less PUT would 400 for multi-source plugins (the
-      // server only infers sourceId when the plugin has exactly one source).
-      let failed = null;
-      for (const f of body.querySelectorAll('.pl-config-form')) {
-        const collected = collectConfigForm(f); // { sourceId | channelId, values }
-        const payload = f.dataset.target === 'modelSecrets'
-          ? { target: 'modelSecrets', values: collected.values }
-          : collected;
-        const r = await pluginApi('PUT', `/api/plugins/${encodeURIComponent(name)}/config`, payload);
-        if (!r.ok) { failed = r.data.error || 'save failed'; break; }
+    ['Connect', 'btn btn-ghost btn-mini', async () => {
+      if (!connectable.length) {
+        return slot.replaceChildren(renderConnectResult({ ok: false, errors: [{ message: 'Add a profile first.' }] }));
       }
+      const failed = await savePluginConfigForms(name, body);
+      if (failed) return slot.replaceChildren(renderConnectResult({ ok: false, errors: [{ message: failed }] }));
+      slot.replaceChildren(renderConnectResult({ ok: false, pending: true, message: 'Connecting…' }));
+      // Sequential so two sources never race the same browser launch.
+      for (const s of connectable) await connectPluginSource(name, s.id, slot, s.profile || undefined);
+    }],
+    ['Save', 'btn btn-primary btn-mini', async () => {
+      const failed = await savePluginConfigForms(name, body);
       closePluginModal();
       setPluginsMsg(failed || 'Settings saved.', failed ? 'err' : 'ok');
     }],

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -4802,7 +4802,29 @@ async function mountPluginSourcePane(src) {
     && state.activePluginSource === src;
   // A multi-profile source cannot be asked anything until it is known WHICH
   // instance to ask, so the binding is resolved before the connection check.
-  const resolved = await resolveSourceProfile(src);
+  // A FAILED resolve (server briefly unreachable mid project switch) must not
+  // leave the previous scope's pane — and its resolved profile — live: a
+  // submit would then run the new project against the old project's tracker,
+  // the exact silent-wrong-tracker mistake bindings exist to prevent.
+  let resolved;
+  try {
+    resolved = await resolveSourceProfile(src);
+  } catch (err) {
+    if (!owns()) return;
+    state.activePluginProfile = null;
+    const box = document.createElement('div');
+    box.className = 'sp-config-missing';
+    box.appendChild(Object.assign(document.createElement('p'),
+      { className: 'hint err', textContent: `Could not resolve the source profile: ${err.message}` }));
+    const retry = document.createElement('button');
+    retry.type = 'button';
+    retry.className = 'btn btn-ghost btn-mini';
+    retry.textContent = 'Retry';
+    retry.addEventListener('click', () => mountPluginSourcePane(src));
+    box.appendChild(retry);
+    host.replaceChildren(box);
+    return;
+  }
   if (!owns()) return;
   if (!resolved) {
     host.replaceChildren(Object.assign(document.createElement('small'),

--- a/ui/public/plugins-view.mjs
+++ b/ui/public/plugins-view.mjs
@@ -234,6 +234,37 @@ export function renderUpdatePreview(preview, { doc = globalThis.document } = {})
   return root;
 }
 
+// The roster row for a multiProfile source: which configuration is being
+// edited, plus add/remove. app.js owns the actions (each is a server round trip
+// that re-opens the pane), so this only renders the controls and marks them.
+function profileBar(doc, src) {
+  const bar = h(doc, 'div', 'pl-profile-bar');
+  bar.dataset.sourceId = src.id || '';
+  bar.appendChild(h(doc, 'label', '', 'Profile'));
+  const sel = h(doc, 'select', 'select pl-profile-sel');
+  sel.dataset.sourceId = src.id || '';
+  for (const p of src.profiles || []) {
+    const id = typeof p === 'string' ? p : String(p.id || '');
+    const label = typeof p === 'string' ? '' : (p.label || '');
+    const opt = h(doc, 'option', '', label ? `${label} (${id})` : id);
+    opt.value = id;
+    sel.appendChild(opt);
+  }
+  if (src.profile) sel.value = src.profile;
+  if (!(src.profiles || []).length) sel.disabled = true;
+  bar.appendChild(sel);
+  const add = h(doc, 'button', 'btn btn-ghost btn-mini pl-profile-add', 'Add');
+  add.type = 'button';
+  add.dataset.sourceId = src.id || '';
+  bar.appendChild(add);
+  const del = h(doc, 'button', 'btn btn-ghost btn-mini pl-profile-del', 'Remove');
+  del.type = 'button';
+  del.dataset.sourceId = src.id || '';
+  if (!src.profile) del.disabled = true;
+  bar.appendChild(del);
+  return bar;
+}
+
 // renderConfigForm(sections) — one <form.pl-config-form>
 // per task source. secret:true fields (text-only per normalizeManifest) render
 // type=password, NEVER prefilled; a stored value arrives redacted as {set:true}
@@ -250,12 +281,25 @@ export function renderConfigForm(sections, { doc = globalThis.document } = {}) {
     ...channels.map((x) => ({ ...x, _kind: 'channel' })),
   ];
   for (const src of rows) {
+    // A multiProfile source is a ROSTER of configurations, not one form: the
+    // bar picks which profile the form below edits. Rendered before the form so
+    // "which instance am I editing" is answered above the fields, not after.
+    if (src._kind === 'source' && src.multiProfile) {
+      root.appendChild(profileBar(doc, src));
+      // Nothing to write into: creating the profile is a separate call, and the
+      // server rejects a save without one. Offer the add button, not a form.
+      if (!src.profile) {
+        root.appendChild(h(doc, 'p', 'hint', 'No profiles yet — add one to configure this source.'));
+        continue;
+      }
+    }
     const form = h(doc, 'form', 'pl-config-form');
     if (src._kind === 'channel') {
       form.dataset.channelId = src.id || '';
       form.appendChild(h(doc, 'div', 'pl-config-h', `${src.displayName || src.id} (${src.platform || 'chat'} channel)`));
     } else {
       form.dataset.sourceId = src.id || '';
+      if (src.multiProfile) form.dataset.profile = src.profile;
     }
     for (const f of src.schema || []) {
       const field = h(doc, 'div', 'field');
@@ -291,7 +335,9 @@ export function renderConfigForm(sections, { doc = globalThis.document } = {}) {
   return root;
 }
 
-// collectConfigForm(formEl) -> { sourceId | channelId, values }. An untouched
+// collectConfigForm(formEl) -> { sourceId | channelId, values } (+ profile for
+// a multiProfile source; the key is ABSENT otherwise, so a single-profile save
+// stays byte-identical to what it sent before profiles existed). An untouched
 // {set:true} secret (data-set="1", still empty) is OMITTED — saving never
 // wipes a secret. Channel forms carry data-channel-id instead of data-source-id.
 export function collectConfigForm(formEl) {
@@ -301,7 +347,47 @@ export function collectConfigForm(formEl) {
     values[input.dataset.key] = input.value;
   }
   if (formEl.dataset.channelId) return { channelId: formEl.dataset.channelId, values };
-  return { sourceId: formEl.dataset.sourceId || '', values };
+  const out = { sourceId: formEl.dataset.sourceId || '', values };
+  if (formEl.dataset.profile) out.profile = formEl.dataset.profile;
+  return out;
+}
+
+// renderConnectResult(result) — outcome of a source's validateConfig, rendered
+// under the settings form. Three states, because setup can legitimately be
+// mid-flight: connected (ok), waiting (ok:false + pending — the caller keeps
+// polling), or failed (ok:false + errors[], each pinned to its config field).
+// A connector may return no envelope at all on a transport error; `result`
+// then carries { error: { kind, message } } from the /api/sources/call frame.
+export function renderConnectResult(result, { doc = globalThis.document } = {}) {
+  const r = result || {};
+  const root = h(doc, 'div', 'pl-connect-result');
+  if (r.ok) {
+    root.appendChild(h(doc, 'div', 'badge green', 'connected'));
+    if (r.identity) root.appendChild(h(doc, 'span', 'hint', `signed in as ${r.identity}`));
+    // Which server/project the connector actually resolved — a mistyped sample
+    // URL otherwise connects successfully to the wrong instance.
+    if (r.instance && r.instance.baseUrl) {
+      const where = r.instance.project ? `${r.instance.baseUrl} · ${r.instance.project}` : r.instance.baseUrl;
+      root.appendChild(h(doc, 'div', 'hint mono', where));
+    }
+    return root;
+  }
+  if (r.pending) {
+    root.appendChild(h(doc, 'div', 'badge', 'waiting'));
+    root.appendChild(h(doc, 'span', 'hint', r.message || 'Waiting…'));
+    return root;
+  }
+  root.appendChild(h(doc, 'div', 'badge red', 'not connected'));
+  const errors = Array.isArray(r.errors) && r.errors.length
+    ? r.errors
+    : [{ message: (r.error && r.error.message) || r.message || 'connection failed' }];
+  for (const e of errors) {
+    const row = h(doc, 'div', 'pl-connect-err');
+    if (e.field) row.appendChild(h(doc, 'span', 'mono', e.field));
+    row.appendChild(h(doc, 'span', 'hint err', e.message || ''));
+    root.appendChild(row);
+  }
+  return root;
 }
 
 // renderDoctorReport(report: {ok, checks:[{id,ok,detail}]}) — row per check.

--- a/ui/public/source-pane.mjs
+++ b/ui/public/source-pane.mjs
@@ -34,13 +34,62 @@ function collectInputs(pane) {
   return inputs;
 }
 
-function taskRow(doc, t) {
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * Task timestamps read as "how stale is this", so recent ones are relative
+ * ("3d ago") and older ones absolute ("28 May") — past a week, relative time
+ * stops distinguishing two tickets from each other. Always LOCAL time: the
+ * contract carries UTC ISO strings, and printing the Z value would be an hour
+ * or two off for most readers.
+ * @returns {{ text: string, title: string }} short label + full-precision hover
+ */
+export function formatUpdated(iso, now = Date.now()) {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return { text: String(iso), title: String(iso) };
+  const title = d.toLocaleString(undefined, {
+    day: 'numeric', month: 'long', year: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+  const age = now - d.getTime();
+  let text;
+  if (age < 0 || age < MINUTE) text = 'just now';        // clock skew reads as "now"
+  else if (age < HOUR) text = `${Math.floor(age / MINUTE)}m ago`;
+  else if (age < DAY) text = `${Math.floor(age / HOUR)}h ago`;
+  else if (age < 7 * DAY) text = `${Math.floor(age / DAY)}d ago`;
+  else {
+    const sameYear = d.getFullYear() === new Date(now).getFullYear();
+    text = d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', ...(sameYear ? {} : { year: 'numeric' }) });
+  }
+  return { text, title };
+}
+
+function taskRow(doc, t, now) {
   const row = h(doc, 'div', 'sp-row');
   row.dataset.taskId = t.id;
-  row.appendChild(h(doc, 'span', 'sp-row-title', t.title));
+  // The id goes INSIDE the title span, not beside it: .sp-row is a
+  // space-between flex with exactly two children, so a third would spread all
+  // three across the row. Prefixing t.title in the connector would be worse
+  // still — that string also feeds the preview header and sourceMeta.title,
+  // which is stored on the pipeline and shown as provenance.
+  const title = h(doc, 'span', 'sp-row-title');
+  const id = t.id == null ? '' : String(t.id);
+  const text = t.title == null ? '' : String(t.title);
+  if (id && !text.startsWith(id)) title.appendChild(h(doc, 'span', 'sp-key', id));
+  title.appendChild(doc.createTextNode(text));
+  row.appendChild(title);
   const meta = h(doc, 'span', 'sp-row-meta');
   for (const l of t.labels || []) meta.appendChild(h(doc, 'span', 'sp-label', l));
-  if (t.updatedAt) meta.appendChild(h(doc, 'span', 'sp-updated mono', t.updatedAt));
+  if (t.updatedAt) {
+    // Say WHICH date it is: the summary contract carries only a last-modified
+    // time, so a bare date leaves the reader guessing created-vs-updated.
+    const { text, title } = formatUpdated(t.updatedAt, now);
+    const el = h(doc, 'span', 'sp-updated', `updated ${text}`);
+    el.title = `Updated ${title}`;
+    el.dataset.updatedAt = t.updatedAt;
+    meta.appendChild(el);
+  }
   row.appendChild(meta);
   return row;
 }
@@ -51,10 +100,15 @@ function taskRow(doc, t) {
 // dropdown populated ONCE on first focus via call(optionsFrom) (promise kept on
 // ._load for deterministic tests); task-browser -> debounced (300ms) search +
 // result list + preview (call getTask on pick) + hidden selected taskId.
-export function renderSourcePane(source, { call, doc = globalThis.document, timers } = {}) {
+export function renderSourcePane(source, { call, doc = globalThis.document, timers, now } = {}) {
+  const clock = typeof now === 'function' ? now : () => Date.now();
   const pane = h(doc, 'div', 'sp-pane');
   pane.dataset.plugin = source.plugin;
   pane.dataset.sourceId = source.sourceId;
+  // Set by the task-browser branch below; re-runs the listing with whatever
+  // the other inputs currently hold. Declared out here because those inputs
+  // may be built BEFORE the browser they filter.
+  let rerun = null;
   for (const input of source.inputs || []) {
     const field = h(doc, 'div', 'field');
     field.appendChild(h(doc, 'label', '', input.label || input.key));
@@ -111,17 +165,25 @@ export function renderSourcePane(source, { call, doc = globalThis.document, time
       const runSearch = async (text) => {
         results.replaceChildren(h(doc, 'div', 'hint', 'Searching…'));
         try {
-          const r = await call('listTasks', { inputs: collectInputs(pane), search: text });
+          const inputs = collectInputs(pane);
+          const r = await call('listTasks', { inputs, search: text });
           results.replaceChildren();
           const tasks = (r && r.tasks) || [];
-          for (const t of tasks) results.appendChild(taskRow(doc, t));
-          if (!tasks.length) results.appendChild(h(doc, 'div', 'hint', 'No tasks matched.'));
+          for (const t of tasks) results.appendChild(taskRow(doc, t, clock()));
+          if (!tasks.length) {
+            // Nothing asked for is not the same as nothing found — a source may
+            // legitimately list nothing until it is given something to go on.
+            const asked = text || Object.values(inputs).some((v) => String(v || '').trim());
+            results.appendChild(h(doc, 'div', 'hint', asked ? 'No tasks matched.' : 'Type to search.'));
+          }
         } catch (e) {
           results.replaceChildren(h(doc, 'div', 'hint err', `search failed: ${e.message}`));
         }
       };
       const debounced = debounce(runSearch, 300, timers);
       search.addEventListener('input', () => debounced(search.value.trim()));
+      rerun = () => debounced(search.value.trim());
+      pane._search = runSearch;                  // deterministic awaiting in tests
       results.addEventListener('click', (e) => {
         const row = e.target.closest('.sp-row');
         if (!row) return;
@@ -143,7 +205,116 @@ export function renderSourcePane(source, { call, doc = globalThis.document, time
     }
     pane.appendChild(field);
   }
+  // A filter the user types must actually take effect: every non-browser input
+  // re-runs the listing. Without this, editing a JQL/filter field changed
+  // nothing until you also touched the search box, which reads as "my filter
+  // is ignored". 'change' covers <select>, 'input' covers text; the shared
+  // debounce collapses the two when a browser fires both.
+  if (rerun) {
+    for (const node of pane.querySelectorAll('[data-input-key]')) {
+      if (node.classList.contains('sp-task-browser')) continue;
+      node.addEventListener('input', rerun);
+      node.addEventListener('change', rerun);
+    }
+    // Populate on open rather than showing an empty list until the user types.
+    pane._initial = pane._search('');
+  }
   return pane;
+}
+
+/** <option> per profile, accepting both {id,label} and bare id strings. */
+function profileOptions(doc, sel, profiles) {
+  for (const p of profiles || []) {
+    const id = typeof p === 'string' ? p : String(p.id || '');
+    const label = typeof p === 'string' ? '' : (p.label || '');
+    const opt = h(doc, 'option', '', label ? `${label} (${id})` : id);
+    opt.value = id;
+    sel.appendChild(opt);
+  }
+  return sel;
+}
+
+/** How the profile was arrived at, in words. An inherited or implicit profile
+ *  must not read as a deliberate choice — that is how the wrong one survives. */
+const VIA_NOTE = {
+  only: 'the only profile configured',
+  members: 'inherited from this workspace’s projects',
+  binding: '',
+};
+
+/**
+ * The standing profile row above the pane: which configuration this
+ * project/workspace pulls from, always visible once resolved.
+ *
+ * It stays on screen deliberately. The gate below answers "which instance?"
+ * once; this answers "which instance am I reading from right now?" every time,
+ * which is the check that catches a wrong binding before a run rather than
+ * after. Changing it REBINDS the scope (the same PUT the gate makes), so it is
+ * a persistent property of the project — never a per-run filter.
+ *
+ * @param {{source, profiles, profile, via, scopeLabel?}} info
+ * @param {{doc?, onChange?: (profileId: string) => any}} opts
+ */
+export function renderProfileBar(info, { doc = globalThis.document, onChange } = {}) {
+  const { source = {}, profiles = [], profile, via, scopeLabel = '' } = info || {};
+  const bar = h(doc, 'div', 'sp-profile-bar');
+  bar.dataset.plugin = source.plugin || '';
+  bar.dataset.sourceId = source.sourceId || '';
+  if (profile) bar.dataset.profile = profile;
+  bar.appendChild(h(doc, 'label', '', 'Profile'));
+
+  const sel = profileOptions(doc, h(doc, 'select', 'select sp-profile-sel'), profiles);
+  if (profile) sel.value = profile;
+  sel.addEventListener('change', () => { if (typeof onChange === 'function') onChange(sel.value); });
+  bar.appendChild(sel);
+
+  const note = VIA_NOTE[via] || '';
+  if (note) bar.appendChild(h(doc, 'small', 'hint', note));
+  else if (scopeLabel) bar.appendChild(h(doc, 'small', 'hint', `bound to ${scopeLabel}`));
+  return bar;
+}
+
+/**
+ * The gate shown INSTEAD of the pane when a multi-profile source has no
+ * resolved profile for the selected project/workspace.
+ *
+ * Why a gate and not a dropdown inside the pane: the choice is "which tracker
+ * does this project belong to", which is a property of the project, not of the
+ * run. Asked once and remembered, a wrong answer is visible immediately and
+ * fixable; asked every run, it is a control nobody reads until a pipeline has
+ * already been started against the wrong instance.
+ *
+ * @param {{source, profiles, via, candidates?, scopeLabel?}} info
+ *        via: 'none' (nothing bound) | 'conflict' (workspace members disagree)
+ * @param {{doc?, onPick: (profileId: string) => any}} opts
+ */
+export function renderProfileGate(info, { doc = globalThis.document, onPick } = {}) {
+  const { source = {}, profiles = [], via, candidates = [], scopeLabel = '' } = info || {};
+  const root = h(doc, 'div', 'sp-profile-gate');
+  const name = source.displayName || source.sourceId || 'This source';
+
+  if (!profiles.length) {
+    root.appendChild(h(doc, 'p', 'hint', `${name} has no profiles configured yet.`));
+    const link = h(doc, 'a', 'sp-profile-settings', 'Add one in Plugins settings');
+    link.href = '#plugins';
+    root.appendChild(link);
+    return root;
+  }
+
+  root.appendChild(h(doc, 'p', 'hint', via === 'conflict'
+    // Naming them is the point: the reader has to know it is ambiguous, and
+    // between WHICH instances, to fix it at the right project.
+    ? `The projects in ${scopeLabel || 'this workspace'} disagree about which ${name} profile to use (${candidates.join(', ')}). Pick the one this run should read from.`
+    : `Which ${name} profile does ${scopeLabel || 'this project'} pull from? Asked once, then remembered.`));
+
+  const sel = profileOptions(doc, h(doc, 'select', 'select sp-profile-sel'), profiles);
+  root.appendChild(sel);
+
+  const use = h(doc, 'button', 'btn btn-primary btn-mini sp-profile-use', 'Use this profile');
+  use.type = 'button';
+  use.addEventListener('click', () => { if (typeof onPick === 'function') onPick(sel.value); });
+  root.appendChild(use);
+  return root;
 }
 
 // collectSourcePane(paneEl) -> { inputs, taskId } | { error } when nothing picked.

--- a/ui/public/source-pane.mjs
+++ b/ui/public/source-pane.mjs
@@ -162,22 +162,33 @@ export function renderSourcePane(source, { call, doc = globalThis.document, time
       preview.hidden = true;
       const hidden = h(doc, 'input', 'sp-task-id');
       hidden.type = 'hidden';
+      // Latest-wins: responses paint only if no newer search started meanwhile.
+      // The debounce collapses pending TIMERS, not in-flight fetches — without
+      // this, the slow mount-time empty search can resolve after a fast typed
+      // one and repaint the unfiltered list over the filtered results.
+      let searchSeq = 0;
       const runSearch = async (text) => {
+        const seq = ++searchSeq;
         results.replaceChildren(h(doc, 'div', 'hint', 'Searching…'));
+        const inputs = collectInputs(pane);
+        // Nothing asked for is not the same as nothing found — a source may
+        // legitimately list nothing (or even refuse to list: the contract lets
+        // listTasks throw) until it is given something to go on.
+        const asked = text || Object.values(inputs).some((v) => String(v || '').trim());
         try {
-          const inputs = collectInputs(pane);
           const r = await call('listTasks', { inputs, search: text });
+          if (seq !== searchSeq) return;
           results.replaceChildren();
           const tasks = (r && r.tasks) || [];
           for (const t of tasks) results.appendChild(taskRow(doc, t, clock()));
           if (!tasks.length) {
-            // Nothing asked for is not the same as nothing found — a source may
-            // legitimately list nothing until it is given something to go on.
-            const asked = text || Object.values(inputs).some((v) => String(v || '').trim());
             results.appendChild(h(doc, 'div', 'hint', asked ? 'No tasks matched.' : 'Type to search.'));
           }
         } catch (e) {
-          results.replaceChildren(h(doc, 'div', 'hint err', `search failed: ${e.message}`));
+          if (seq !== searchSeq) return;
+          results.replaceChildren(asked
+            ? h(doc, 'div', 'hint err', `search failed: ${e.message}`)
+            : h(doc, 'div', 'hint', 'Type to search.'));
         }
       };
       const debounced = debounce(runSearch, 300, timers);

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1515,10 +1515,29 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .sp-row.sel{background:var(--green-bg);color:var(--green-ink);}
 .sp-row-meta{display:inline-flex;gap:6px;align-items:center;color:var(--ink-3);font-size:11.5px;flex:0 0 auto;}
 .sp-label{background:var(--chip-bg,#f0f0f4);border-radius:999px;padding:1px 8px;font-weight:600;}
+.sp-updated{white-space:nowrap;}
+/* Task identifier ahead of the title: reads as an id, and never wraps — a long
+   title gives way before the key does. */
+.sp-key{font-family:var(--mono);color:var(--ink-3);white-space:nowrap;margin-right:7px;}
 .sp-preview{margin-top:8px;max-height:260px;overflow:auto;}
 .sp-preview .sp-prev-body{white-space:pre-wrap;font-size:12.5px;margin:6px 0 0;}
 .sp-pane .mono{font-family:var(--mono);}
 .sp-config-missing{display:flex;flex-direction:column;gap:8px;align-items:flex-start;margin-top:11px;}
+/* Profile gate: shown INSTEAD of the pane until the project is bound to one
+   configuration of a multi-profile source. Same column shape as the
+   not-configured box above — both are "answer this before you can browse". */
+.sp-profile-gate{display:flex;flex-direction:column;gap:8px;align-items:flex-start;margin-top:11px;}
+.sp-profile-gate .select{min-width:220px;}
+/* Standing profile row above the pane: which instance the listing below is
+   coming from. One line, quiet, but never hidden. */
+.sp-profile-bar{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:0 0 10px;padding-bottom:9px;border-bottom:1px solid var(--line);}
+.sp-profile-bar label{font-weight:600;font-size:12.5px;color:var(--ink-2);}
+.sp-profile-bar .select{min-width:180px;}
+/* Profile roster in plugin settings: label, picker and the two actions on one
+   row above the form they apply to. */
+.pl-profile-bar{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:10px;}
+.pl-profile-bar label{font-weight:600;font-size:12.5px;color:var(--ink-2);}
+.pl-profile-bar .select{min-width:180px;}
 
 /* ---- Plugin provenance (results header, history cards) ---- */
 .src-badge{display:inline-flex;gap:6px;align-items:center;font-size:11.5px;background:var(--chip-bg,#f0f0f4);border-radius:999px;padding:2px 10px;}

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -83,7 +83,14 @@ import {
   addMarketplace, listMarketplaces, syncMarketplace, refreshAllMarketplaces,
   removeMarketplace, readMarketplaces, seedBuiltinMarketplace,
 } from '../src/core/marketplaces.mjs';
-import { redactedConfig, writePluginConfig, readPluginConfig } from '../src/core/plugin-config.mjs';
+import {
+  redactedConfig, writePluginConfig, readPluginConfig, listProfiles, listProfileIds,
+  createProfile, deleteProfile, isValidProfileId,
+} from '../src/core/plugin-config.mjs';
+import {
+  setBinding, clearBinding, listBindingsForScope,
+  clearBindingsForProfile, clearBindingsForPlugin, resolveProfile,
+} from '../src/core/source-bindings.mjs';
 import { createChannelHost } from '../src/core/chat/channel-host.mjs';
 import { createCommandRouter } from '../src/core/chat/command-router.mjs';
 import { createChatContext } from '../src/core/chat/chat-context.mjs';
@@ -694,6 +701,9 @@ function normalizeRunSource(raw) {
         return { ok: false, error: `source.${k} is required for type "plugin"` };
       }
     }
+    if (raw.profile !== undefined && !isValidProfileId(raw.profile)) {
+      return { ok: false, error: 'source.profile is not a valid profile id' };
+    }
     return {
       ok: true,
       source: {
@@ -702,6 +712,9 @@ function normalizeRunSource(raw) {
         sourceId: raw.sourceId.trim(),
         taskId: raw.taskId.trim(),
         inputs: raw.inputs && typeof raw.inputs === 'object' && !Array.isArray(raw.inputs) ? raw.inputs : undefined,
+        // Which configuration of the source the task came from. Absent is legal
+        // (single-profile sources); an id that is not path-safe is not.
+        profile: typeof raw.profile === 'string' && raw.profile ? raw.profile : undefined,
       },
     };
   }
@@ -746,6 +759,18 @@ app.post('/api/run', async (req, res) => {
     const sourceCheck = normalizeRunSource(body.source);
     if (sourceCheck && !sourceCheck.ok) return badRequest(res, sourceCheck.error);
     const source = sourceCheck ? sourceCheck.source : null;
+
+    // A multiProfile source without a profile would run against the (empty)
+    // default bucket and die mid-pipeline with a confusing connector error —
+    // reject it here, at submit, where the client can still fix it. A broken
+    // or uninstalled plugin is left for resolveTaskInput to report.
+    if (source && source.type === 'plugin' && !source.profile) {
+      const m = readInstalledManifest(source.plugin);
+      const ts = m && (m.taskSources || []).find((s) => s.id === source.sourceId);
+      if (ts && ts.multiProfile) {
+        return badRequest(res, `source.profile is required — task source "${source.sourceId}" has per-profile configuration`);
+      }
+    }
 
     // prompt OR promptMarkdown. promptMarkdown is treated as the prompt text.
     const prompt = typeof body.prompt === 'string' && body.prompt.trim() ? body.prompt : undefined;
@@ -3129,6 +3154,10 @@ app.delete('/api/plugins/:name', async (req, res) => {
   const purge = isTruthy(req.query.purge) || !!(req.body && req.body.purge === true);
   try {
     await uninstallPlugin(name, { purge });
+    // Bindings live in the DB, not in the plugin's data dir, so they outlive an
+    // uninstall unless dropped here — a stale row would silently rebind if the
+    // same plugin were reinstalled with a different profile roster.
+    clearBindingsForPlugin(name);
     reloadChatWorkers(name);
     res.json({ ok: true, purged: purge });
   } catch (err) {
@@ -3165,17 +3194,38 @@ app.post('/api/plugins/:name/doctor', async (req, res) => {
 // GET /api/plugins/:name/config -> per-source schema + redacted values. Secrets
 // NEVER travel to the browser: redactedConfig replaces a stored secret with
 // { set: true } (§7.6).
+// ?profile=<id> selects which configuration to echo (multi-profile sources);
+// absent = the default bucket, which is all a single-profile source ever uses.
 app.get('/api/plugins/:name/config', (req, res) => {
   const name = requirePlugin(req, res);
   if (!name) return;
   const manifest = readInstalledManifest(name);
   if (!manifest) return res.status(409).json({ error: 'plugin manifest unreadable — run doctor' });
+  const wanted = typeof req.query.profile === 'string' && req.query.profile ? req.query.profile : null;
+  if (wanted && !isValidProfileId(wanted)) return badRequest(res, 'invalid profile id');
   try {
-    const sources = (manifest.taskSources || []).map((s) => ({
-      id: s.id,
-      schema: s.configSchema,
-      values: redactedConfig(name, s.configSchema),
-    }));
+    const profiles = listProfiles(name);
+    const sources = (manifest.taskSources || []).map((s) => {
+      // For a multi-profile source, "which profile" is a real choice: echo the
+      // requested one, else the first in the roster. A source with no profiles
+      // yet has nothing to show — the UI's move is "create one", not a form.
+      // A requested profile that is not in the roster is a caller error (a
+      // typo'd URL) — echoing an empty form for it would let a Save quietly
+      // create the typo as a real profile. Checked inside the map so the guard
+      // only fires for sources that use profiles at all.
+      if (s.multiProfile && wanted && !profiles.some((p) => p.id === wanted)) {
+        throw Object.assign(new Error(`plugin "${name}" has no profile "${wanted}"`), { code: 'BAD_REQUEST' });
+      }
+      const profile = s.multiProfile ? (wanted || profiles[0]?.id || null) : null;
+      return {
+        id: s.id,
+        schema: s.configSchema,
+        multiProfile: s.multiProfile === true,
+        profile,
+        profiles: s.multiProfile ? profiles : [],
+        values: s.multiProfile && !profile ? {} : redactedConfig(name, s.configSchema, profile),
+      };
+    });
     const channels = (manifest.chatChannels || []).map((c) => ({
       id: c.id,
       displayName: c.displayName,
@@ -3196,7 +3246,65 @@ app.get('/api/plugins/:name/config', (req, res) => {
   }
 });
 
-// PUT /api/plugins/:name/config { sourceId | channelId, values } ->
+// POST /api/plugins/:name/profiles { sourceId, id, label } — create (or relabel)
+// a profile of a multi-profile source. Creating a profile is deliberately
+// separate from saving into it: the roster entry must exist BEFORE the config
+// form has anything to write to.
+app.post('/api/plugins/:name/profiles', (req, res) => {
+  const name = requirePlugin(req, res);
+  if (!name) return;
+  const body = req.body || {};
+  const manifest = readInstalledManifest(name);
+  if (!manifest) return res.status(409).json({ error: 'plugin manifest unreadable — run doctor' });
+  const source = (manifest.taskSources || []).find((s) => s.id === body.sourceId);
+  if (!source) return badRequest(res, 'sourceId does not match a task source of this plugin');
+  if (!source.multiProfile) return badRequest(res, `task source "${source.id}" does not support profiles`);
+  if (!isValidProfileId(body.id)) {
+    return badRequest(res, 'profile id must be lowercase letters, digits and dashes');
+  }
+  try {
+    res.json({ ok: true, profile: createProfile(name, body.id, body.label) });
+  } catch (err) {
+    sendPluginError(res, err);
+  }
+});
+
+// DELETE /api/plugins/:name/profiles/:id?sourceId=… — drop a profile, its stored
+// config/secrets/state, and every project binding that named it (a binding
+// pointing at a deleted profile would otherwise resolve to nothing at run time).
+// Binding cleanup is PLUGIN-wide, not per-source: deleteProfile removes the
+// profile's buckets for the whole plugin, so a sibling source's binding naming
+// it would dangle just the same. sourceId is still required — it authorizes the
+// call against a source that actually uses profiles.
+app.delete('/api/plugins/:name/profiles/:id', (req, res) => {
+  const name = requirePlugin(req, res);
+  if (!name) return;
+  const manifest = readInstalledManifest(name);
+  if (!manifest) return res.status(409).json({ error: 'plugin manifest unreadable — run doctor' });
+  const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : '';
+  const sources = manifest.taskSources || [];
+  const source = sources.find((s) => s.id === sourceId) || (sources.length === 1 ? sources[0] : null);
+  if (!source) return badRequest(res, 'sourceId does not match a task source of this plugin');
+  // Mirror the POST guard: a single-profile source only has the implicit
+  // 'default' bucket, and deleting THAT would wipe its entire config/secrets/
+  // state. Same for ids not in the roster — deleteProfile would still drop
+  // whatever buckets happen to share the id (e.g. migrated legacy data under
+  // 'default'), so only roster members are deletable.
+  if (!source.multiProfile) return badRequest(res, `task source "${source.id}" does not support profiles`);
+  if (!isValidProfileId(req.params.id)) return badRequest(res, 'invalid profile id');
+  if (!listProfiles(name).some((p) => p.id === req.params.id)) {
+    return badRequest(res, `plugin "${name}" has no profile "${req.params.id}"`);
+  }
+  try {
+    deleteProfile(name, req.params.id);
+    const unbound = clearBindingsForProfile(name, req.params.id);
+    res.json({ ok: true, unbound });
+  } catch (err) {
+    sendPluginError(res, err);
+  }
+});
+
+// PUT /api/plugins/:name/config { sourceId | channelId, values, profile? } ->
 // writePluginConfig routes secret:true keys to data/secrets.json (0600,
 // atomic). Request values are NEVER logged and NEVER echoed back (the response
 // is a bare receipt). A channelId save also hot-restarts the channel worker.
@@ -3222,6 +3330,8 @@ app.put('/api/plugins/:name/config', (req, res) => {
     }
   }
   let schema;
+  let source = null;
+  let profile = null;
   if (typeof body.channelId === 'string' && body.channelId) {
     const channel = (manifest.chatChannels || []).find((c) => c.id === body.channelId);
     if (!channel) return badRequest(res, 'channelId does not match a chat channel of this plugin');
@@ -3231,12 +3341,19 @@ app.put('/api/plugins/:name/config', (req, res) => {
     const sourceId = typeof body.sourceId === 'string' && body.sourceId
       ? body.sourceId
       : (sources.length === 1 ? sources[0].id : '');
-    const source = sources.find((s) => s.id === sourceId);
+    source = sources.find((s) => s.id === sourceId);
     if (!source) return badRequest(res, 'sourceId does not match a task source of this plugin');
+    profile = typeof body.profile === 'string' && body.profile ? body.profile : null;
+    if (profile && !isValidProfileId(profile)) return badRequest(res, 'invalid profile id');
+    if (source.multiProfile && !profile) return badRequest(res, 'profile is required for this task source');
     schema = source.configSchema;
   }
   try {
-    writePluginConfig(name, schema, body.values);
+    writePluginConfig(name, schema, body.values, profile);
+    // A multi-profile save implies the roster entry (a profile created in the UI
+    // then saved into is the normal path; this also heals a roster file that was
+    // removed out from under an open form).
+    if (source && source.multiProfile) createProfile(name, profile);
     reloadChatWorkers(name);
     res.json({ ok: true });
   } catch (err) {
@@ -3262,6 +3379,78 @@ app.get('/api/plugins/:name/model-env', (req, res) => {
     else secretKeys.push(k);
   }
   res.json({ id: model.id, label: model.label, efforts: model.efforts, env, secretKeys });
+});
+
+// ---------------------------------------------------------------------------
+// /api/source-bindings -> which PROFILE of a task source a project/workspace
+// pulls from. Set once per project; every run then resolves it silently, which
+// is the point — a per-run dropdown is how you start a pipeline against the
+// wrong tracker without noticing (see src/core/source-bindings.mjs).
+// ---------------------------------------------------------------------------
+
+/** Shared scope parsing for the two binding routes. Accepts a project by key or
+ *  by path (the New Pipeline form knows the path, the Projects view the key). */
+function bindingScope(q = {}) {
+  const workspaceId = typeof q.workspaceId === 'string' && q.workspaceId.trim() ? q.workspaceId.trim() : '';
+  if (workspaceId) return { scopeType: 'workspace', scopeKey: workspaceId };
+  const key = typeof q.projectKey === 'string' && q.projectKey.trim() ? q.projectKey.trim() : '';
+  if (key) return { scopeType: 'project', scopeKey: key };
+  const dir = typeof q.projectDir === 'string' && q.projectDir.trim() ? q.projectDir.trim() : '';
+  if (dir) return { scopeType: 'project', scopeKey: projectKey(path.resolve(dir)) };
+  return null;
+}
+
+// GET /api/source-bindings?projectDir=…|projectKey=…|workspaceId=…
+//   [&plugin=&sourceId=] -> { bindings: [...] } or, when a source is named,
+//   the RESOLVED profile for it: { profile, via, candidates? }.
+app.get('/api/source-bindings', async (req, res) => {
+  const scope = bindingScope(req.query);
+  if (!scope) return badRequest(res, 'projectDir, projectKey or workspaceId is required');
+  const plugin = typeof req.query.plugin === 'string' ? req.query.plugin.trim() : '';
+  const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId.trim() : '';
+  try {
+    if (!plugin || !sourceId) return res.json({ ...scope, bindings: listBindingsForScope(scope.scopeType, scope.scopeKey) });
+    // A workspace with no binding of its own inherits from its members when they
+    // agree, so the member keys have to be resolved before asking.
+    let memberKeys;
+    if (scope.scopeType === 'workspace') {
+      const ws = await readWorkspace(scope.scopeKey);
+      memberKeys = ws ? ws.projectKeys : [];
+    }
+    res.json({
+      ...scope,
+      ...resolveProfile({ ...scope, plugin, sourceId, memberKeys, available: listProfileIds(plugin) }),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err && err.message ? err.message : String(err) });
+  }
+});
+
+// PUT /api/source-bindings { projectDir|projectKey|workspaceId, plugin,
+//   sourceId, profile } — profile:null clears the binding.
+app.put('/api/source-bindings', (req, res) => {
+  const body = req.body || {};
+  const scope = bindingScope(body);
+  if (!scope) return badRequest(res, 'projectDir, projectKey or workspaceId is required');
+  const plugin = typeof body.plugin === 'string' ? body.plugin.trim() : '';
+  const sourceId = typeof body.sourceId === 'string' ? body.sourceId.trim() : '';
+  if (!plugin || !sourceId) return badRequest(res, 'plugin and sourceId are required');
+  const ref = { ...scope, plugin, sourceId };
+  try {
+    if (body.profile === null || body.profile === '') {
+      clearBinding(ref);
+      return res.json({ ok: true, ...scope, profile: null });
+    }
+    if (!isValidProfileId(body.profile)) return badRequest(res, 'invalid profile id');
+    // Binding to a profile that does not exist would resolve to nothing at run
+    // time — reject it here, where the user can still see why.
+    if (!listProfileIds(plugin).includes(body.profile)) {
+      return badRequest(res, `plugin "${plugin}" has no profile "${body.profile}"`);
+    }
+    res.json({ ok: true, ...scope, profile: setBinding(ref, body.profile) });
+  } catch (err) {
+    res.status(500).json({ error: err && err.message ? err.message : String(err) });
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -3303,8 +3492,11 @@ app.post('/api/sources/call', async (req, res) => {
     if (input && typeof input.optionsFrom === 'string' && input.optionsFrom) allowed.add(input.optionsFrom);
   }
   if (!allowed.has(op)) return badRequest(res, `op "${op}" is not allowed for this source`);
+  const profile = typeof body.profile === 'string' && body.profile ? body.profile : null;
+  if (profile && !isValidProfileId(profile)) return badRequest(res, 'invalid profile id');
+  if (source.multiProfile && !profile) return badRequest(res, 'profile is required for this task source');
   try {
-    const result = await callSource({ plugin, sourceId, op, args });
+    const result = await callSource({ plugin, sourceId, op, args, profile });
     res.json({ ok: true, result });
   } catch (err) {
     if (err instanceof PluginOpError) {

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -85,11 +85,11 @@ import {
 } from '../src/core/marketplaces.mjs';
 import {
   redactedConfig, writePluginConfig, readPluginConfig, listProfiles, listProfileIds,
-  createProfile, deleteProfile, isValidProfileId,
+  createProfile, deleteProfile, isValidProfileId, DEFAULT_PROFILE,
 } from '../src/core/plugin-config.mjs';
 import {
   setBinding, clearBinding, listBindingsForScope,
-  clearBindingsForProfile, clearBindingsForPlugin, resolveProfile,
+  clearBindingsForProfile, resolveProfile,
 } from '../src/core/source-bindings.mjs';
 import { createChannelHost } from '../src/core/chat/channel-host.mjs';
 import { createCommandRouter } from '../src/core/chat/command-router.mjs';
@@ -762,13 +762,24 @@ app.post('/api/run', async (req, res) => {
 
     // A multiProfile source without a profile would run against the (empty)
     // default bucket and die mid-pipeline with a confusing connector error —
-    // reject it here, at submit, where the client can still fix it. A broken
-    // or uninstalled plugin is left for resolveTaskInput to report.
-    if (source && source.type === 'plugin' && !source.profile) {
+    // reject it here, at submit, where the client can still fix it. The same
+    // goes for a profile that is no longer IN the roster (deleted in another
+    // tab after the client resolved it) and for a profile supplied to a source
+    // that does not use them (it would read a phantom bucket instead of the
+    // real config). A broken or uninstalled plugin is left for
+    // resolveTaskInput to report.
+    if (source && source.type === 'plugin') {
       const m = readInstalledManifest(source.plugin);
       const ts = m && (m.taskSources || []).find((s) => s.id === source.sourceId);
       if (ts && ts.multiProfile) {
-        return badRequest(res, `source.profile is required — task source "${source.sourceId}" has per-profile configuration`);
+        if (!source.profile) {
+          return badRequest(res, `source.profile is required — task source "${source.sourceId}" has per-profile configuration`);
+        }
+        if (!listProfileIds(source.plugin).includes(source.profile)) {
+          return badRequest(res, `plugin "${source.plugin}" has no profile "${source.profile}" — it may have been deleted; re-select one`);
+        }
+      } else if (ts && source.profile) {
+        return badRequest(res, `task source "${source.sourceId}" does not use profiles — omit source.profile`);
       }
     }
 
@@ -3153,11 +3164,9 @@ app.delete('/api/plugins/:name', async (req, res) => {
   if (!name) return;
   const purge = isTruthy(req.query.purge) || !!(req.body && req.body.purge === true);
   try {
+    // uninstallPlugin also drops the plugin's source bindings (core-side, so
+    // the CLI's `worca plugin remove` clears them identically).
     await uninstallPlugin(name, { purge });
-    // Bindings live in the DB, not in the plugin's data dir, so they outlive an
-    // uninstall unless dropped here — a stale row would silently rebind if the
-    // same plugin were reinstalled with a different profile roster.
-    clearBindingsForPlugin(name);
     reloadChatWorkers(name);
     res.json({ ok: true, purged: purge });
   } catch (err) {
@@ -3262,6 +3271,13 @@ app.post('/api/plugins/:name/profiles', (req, res) => {
   if (!isValidProfileId(body.id)) {
     return badRequest(res, 'profile id must be lowercase letters, digits and dashes');
   }
+  // "default" is the implicit bucket every profile-less read/write shares
+  // (chat channels, model secrets, migrated legacy config). Enrolled in the
+  // roster it would become deletable like any member — and deleting it wipes
+  // that shared bucket. createProfile throws too; 400 with the reason here.
+  if (body.id === DEFAULT_PROFILE) {
+    return badRequest(res, `profile id "${DEFAULT_PROFILE}" is reserved — pick another name`);
+  }
   try {
     res.json({ ok: true, profile: createProfile(name, body.id, body.label) });
   } catch (err) {
@@ -3292,6 +3308,12 @@ app.delete('/api/plugins/:name/profiles/:id', (req, res) => {
   // 'default'), so only roster members are deletable.
   if (!source.multiProfile) return badRequest(res, `task source "${source.id}" does not support profiles`);
   if (!isValidProfileId(req.params.id)) return badRequest(res, 'invalid profile id');
+  // Reserved even if a pre-reservation roster enrolled it: deleting "default"
+  // would strip the shared bucket (chat-channel config, model secrets,
+  // migrated legacy data) out of all three files.
+  if (req.params.id === DEFAULT_PROFILE) {
+    return badRequest(res, `profile id "${DEFAULT_PROFILE}" is reserved — it cannot be deleted`);
+  }
   if (!listProfiles(name).some((p) => p.id === req.params.id)) {
     return badRequest(res, `plugin "${name}" has no profile "${req.params.id}"`);
   }
@@ -3346,14 +3368,17 @@ app.put('/api/plugins/:name/config', (req, res) => {
     profile = typeof body.profile === 'string' && body.profile ? body.profile : null;
     if (profile && !isValidProfileId(profile)) return badRequest(res, 'invalid profile id');
     if (source.multiProfile && !profile) return badRequest(res, 'profile is required for this task source');
+    // Saves go only into EXISTING roster members — mirroring the GET guard,
+    // whose whole point is that a Save must not quietly mint a typo'd (or
+    // just-deleted) id as a real profile with secrets stored under it.
+    // Creation stays solely on POST /profiles.
+    if (source.multiProfile && !listProfiles(name).some((p) => p.id === profile)) {
+      return badRequest(res, `plugin "${name}" has no profile "${profile}" — create it first`);
+    }
     schema = source.configSchema;
   }
   try {
     writePluginConfig(name, schema, body.values, profile);
-    // A multi-profile save implies the roster entry (a profile created in the UI
-    // then saved into is the normal path; this also heals a roster file that was
-    // removed out from under an open form).
-    if (source && source.multiProfile) createProfile(name, profile);
     reloadChatWorkers(name);
     res.json({ ok: true });
   } catch (err) {
@@ -3495,6 +3520,16 @@ app.post('/api/sources/call', async (req, res) => {
   const profile = typeof body.profile === 'string' && body.profile ? body.profile : null;
   if (profile && !isValidProfileId(profile)) return badRequest(res, 'invalid profile id');
   if (source.multiProfile && !profile) return badRequest(res, 'profile is required for this task source');
+  // Same submit-time guards as /api/run: a deleted profile must 400 here, not
+  // fail deep in the connector against an empty bucket, and a profile on a
+  // single-profile source would read (and persist state into) a phantom
+  // bucket instead of the real config.
+  if (source.multiProfile && !listProfileIds(plugin).includes(profile)) {
+    return badRequest(res, `plugin "${plugin}" has no profile "${profile}"`);
+  }
+  if (!source.multiProfile && profile) {
+    return badRequest(res, `task source "${sourceId}" does not use profiles — omit profile`);
+  }
   try {
     const result = await callSource({ plugin, sourceId, op, args, profile });
     res.json({ ok: true, result });


### PR DESCRIPTION
## Summary
Adds multi-profile support for plugin task sources with project/workspace → profile bindings. Rebuilt as five logical commits on current `dev`.

- **Core** — plugin task-source config is stored per named profile instead of a single global bucket (`plugin-config.mjs`), with project/workspace → profile bindings (`source-bindings.mjs`, DB migration **v18**, also self-healing via the generic `INCREMENTAL_TABLES` gap-repair map). The source registry, shim, and CLI (`worca plugin exec … --profile <id>`) resolve the bound profile at run time; manifests may mark a task source `multiProfile`.
- **Server** — profile roster endpoints (`POST`/`DELETE /api/plugins/:name/profiles`), profile-aware config GET/PUT coexisting with channel and model-secrets forms, `/api/source-bindings`, and binding cleanup on uninstall/profile delete.
- **UI** — the source pane shows the bound profile with a per-profile Connect flow; New Workflow is gated on a bound, connected profile, understands SSO-pending, and polls until the connection resolves. The Plugins settings modal gains the profile bar (add/remove/switch with a dirty-form guard).
- **Tests** — new `source-bindings` and `migrate-v18` suites; all migration tests now assert the imported `SCHEMA_VERSION` instead of hardcoded literals, so future schema bumps touch no test file.

The Jira Server/DC connector that originally shipped here as `examples/plugins/jira-source` now lives in the `jtr` repo; this PR carries only the core profile mechanics.

## Test plan
- `npm test`: 2951/2956 pass. The 5 failures are pre-existing on `dev` (verified on a clean `origin/dev` checkout: `getDb` environment, plugin-store uninstall, exportVersion symlink, plugin-models doctor guard, DELETE plugin 409 guard).

34 files changed, +1585 / −215 vs `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)