### PR TITLE
feat: agent-log parity with worca + log filtering UI

### DIFF
--- a/src/core/orchestrator.mjs
+++ b/src/core/orchestrator.mjs
@@ -2701,18 +2701,30 @@ class Orchestrator extends EventEmitter {
     // add `sub`. {...null} === {}, so attr === null (the clarify pre-step) is safe.
     const logAttr = sub ? { ...attr, sub: true } : attr;
 
+    // Human-readable assistant text (if any). NO early return: a single
+    // assistant turn can carry BOTH a text block and tool_use blocks — fall
+    // through so each tool call is logged too. A text-only turn has no
+    // tool_use/tool_result blocks, so the loops below are empty and its output
+    // is identical to the pre-change path.
     const text = (e.text || '').trim();
-    if (text) {
-      this._log(source, 'info', text, logAttr);
-      return;
+    if (text) this._log(source, 'info', text, logAttr);
+
+    // The `system`/init event has no text and no tool blocks — surface the
+    // model (parity with worca's `[init] model=<model>`) instead of dropping it.
+    if (e.raw && e.raw.type === 'system' && e.raw.subtype === 'init') {
+      this._log(source, 'debug', `[init] model=${e.raw.model || '?'}`, logAttr);
     }
-    // No human-readable text. Rather than echo the bare stream-json envelope
-    // type (the old noisy `[planner] user` / `[planner] system` lines), surface
-    // the concrete tool calls the agent made this turn. Contentless envelope
-    // events — tool_result echoes (`user`) and the init `system` event — carry
-    // no information and are dropped.
+
+    // Concrete tool calls the agent made this turn (assistant.tool_use blocks).
     for (const call of describeToolUses(e.raw, this.projectDir)) {
       this._log(source, 'debug', `→ ${call}`, logAttr);
+    }
+
+    // Tool-result outcomes (`user`-envelope + child tool_result blocks).
+    // ADDITIVE ONLY — _recordSubAgentFinishes (above) still owns sub-agent
+    // lifecycle state; this loop never mutates state, it only logs.
+    for (const line of describeToolResults(e.raw)) {
+      this._log(source, 'debug', `← ${line}`, logAttr);
     }
   }
 
@@ -3553,6 +3565,27 @@ function describeToolUses(raw, projectDir) {
     }
   }
   return calls;
+}
+
+/**
+ * Describe tool_result blocks in a stream-json event as short outcome one-liners
+ * (`result ok <id8>` / `result error <id8>`). Scans message.content for
+ * {type:'tool_result', tool_use_id, is_error?}. Returns [] when `raw` is a string
+ * (non-JSON runner line) or carries no tool_result blocks (assistant turns, the
+ * init event), so the caller adds no line. The 8-char tool_use_id prefix matches
+ * worca's contract and is enough to correlate a result with its call within one
+ * turn. Mirrors describeToolUses: the `← ` arrow prefix is added by the caller.
+ */
+function describeToolResults(raw) {
+  const content = raw?.message?.content;
+  if (!Array.isArray(content)) return [];
+  const lines = [];
+  for (const b of content) {
+    if (b?.type !== 'tool_result') continue;
+    const id = typeof b.tool_use_id === 'string' ? b.tool_use_id.slice(0, 8) : '?';
+    lines.push(`result ${b.is_error ? 'error' : 'ok'} ${id}`);
+  }
+  return lines;
 }
 
 /** A short, human-readable target for a tool call (file, command, pattern…). */

--- a/test/agent-log.test.mjs
+++ b/test/agent-log.test.mjs
@@ -37,7 +37,7 @@ test('assistant tool_use is logged as a readable tool call, not bare "assistant"
   assert.equal(logs[0].text, '→ Read src/app.js');
 });
 
-test('bare user (tool_result) envelope events are dropped (log) and emit no subagent', () => {
+test('user tool_result envelope logs ← result at debug and emits no subagent', () => {
   const orch = createOrchestrator({ projectDir: '/tmp/proj' });
   const logs = []; const subs = [];
   orch.on('log', (l) => logs.push(l));
@@ -46,13 +46,20 @@ test('bare user (tool_result) envelope events are dropped (log) and emit no suba
     type: 'user',
     raw: { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'x', content: 'ok' }] } },
   });
-  assert.equal(logs.length, 0, 'tool_result echoes carry no log line');
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].level, 'debug');
+  assert.equal(logs[0].text, '← result ok x');
   assert.equal(subs.length, 0, 'an untracked tool_use_id is not a sub-agent finish');
 });
 
-test('system init envelope events are dropped', () => {
-  const logs = capture('planner', { type: 'system', raw: { type: 'system', subtype: 'init' } });
-  assert.equal(logs.length, 0);
+test('system init envelope logs [init] model=… at debug', () => {
+  const logs = capture('planner', { type: 'system', raw: { type: 'system', subtype: 'init', model: 'claude-x' } });
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].level, 'debug');
+  assert.equal(logs[0].text, '[init] model=claude-x');
+  const noModel = capture('planner', { type: 'system', raw: { type: 'system', subtype: 'init' } });
+  assert.equal(noModel.length, 1);
+  assert.equal(noModel[0].text, '[init] model=?');
 });
 
 test('assistant text still logs at info unchanged', () => {
@@ -208,4 +215,135 @@ test('string raw (non-JSON runner line) stays under the plain role, no sub', () 
   assert.equal(logs[0].source, 'planner');
   assert.equal(logs[0].text, 'a non-JSON stdout line');
   assert.equal(logs[0].sub, undefined);
+});
+
+// ── Agent-log parity: mixed turns, tool results, init ───────────────────────
+
+test('mixed turn logs text at info AND each tool call at debug', () => {
+  const logs = capture('planner', {
+    type: 'assistant',
+    text: 'Planning.',
+    raw: {
+      type: 'assistant',
+      message: { content: [
+        { type: 'text', text: 'Planning.' },
+        { type: 'tool_use', name: 'Read', input: { file_path: '/tmp/proj/a.js' } },
+      ] },
+    },
+  });
+  assert.deepEqual(logs.map((l) => [l.level, l.text]), [
+    ['info', 'Planning.'],
+    ['debug', '→ Read a.js'],
+  ]);
+});
+
+test('mixed turn with two tools logs one info + two debug, in order', () => {
+  const logs = capture('planner', {
+    type: 'assistant',
+    text: 'Working.',
+    raw: {
+      type: 'assistant',
+      message: { content: [
+        { type: 'text', text: 'Working.' },
+        { type: 'tool_use', name: 'Read', input: { file_path: '/tmp/proj/a.js' } },
+        { type: 'tool_use', name: 'Bash', input: { command: 'npm test' } },
+      ] },
+    },
+  });
+  assert.deepEqual(logs.map((l) => [l.level, l.text]), [
+    ['info', 'Working.'],
+    ['debug', '→ Read a.js'],
+    ['debug', '→ Bash npm test'],
+  ]);
+});
+
+test('text-only turn stays a single info line (no trailing tool/result line)', () => {
+  const logs = capture('planner', {
+    type: 'assistant',
+    text: 'Just text.',
+    raw: { type: 'assistant', message: { content: [{ type: 'text', text: 'Just text.' }] } },
+  });
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].level, 'info');
+  assert.equal(logs[0].text, 'Just text.');
+});
+
+test('tool_result ok truncates id to 8 chars', () => {
+  const logs = capture('planner', {
+    type: 'user',
+    raw: { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_01ABCDEFGH', content: 'ok' }] } },
+  });
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].level, 'debug');
+  assert.equal(logs[0].text, '← result ok toolu_01');
+});
+
+test('tool_result error renders error', () => {
+  const logs = capture('planner', {
+    type: 'user',
+    raw: { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_9fXYZ', is_error: true, content: 'boom' }] } },
+  });
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].text, '← result error toolu_9f');
+});
+
+test('tool_result with missing id renders ?', () => {
+  const logs = capture('planner', {
+    type: 'user',
+    raw: { type: 'user', message: { content: [{ type: 'tool_result', content: 'ok' }] } },
+  });
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].text, '← result ok ?');
+});
+
+test('child tool_result is tagged "role ▸ label" + sub', () => {
+  const logs = captureSeq([
+    ['planner', { type: 'assistant', raw: { type: 'assistant', message: { content: [
+      { type: 'tool_use', id: 't1', name: 'Task', input: { description: 'research auth' } } ] } } }],
+    ['planner', { type: 'user', raw: { type: 'user', parent_tool_use_id: 't1', message: { content: [
+      { type: 'tool_result', tool_use_id: 'r1', content: 'ok' } ] } } }],
+  ]);
+  const line = logs.find((l) => l.text === '← result ok r1');
+  assert.ok(line, 'child tool_result line exists');
+  assert.equal(line.source, 'planner ▸ research auth');
+  assert.equal(line.sub, true);
+  assert.equal(line.level, 'debug');
+});
+
+test('sub-agent finish still fires lifecycle AND logs a result line', () => {
+  const orch = createOrchestrator({ projectDir: '/tmp/proj' });
+  const logs = []; const subs = [];
+  orch.on('log', (l) => logs.push(l));
+  orch.on('subagent', (m) => subs.push(m));
+  const attr = { nodeId: 'n1', stepIndex: 0, cycle: 1, stepKey: 'planner@1' };
+  orch._onAgentEvent('planner', { type: 'assistant', raw: { type: 'assistant', message: { content: [
+    { type: 'tool_use', id: 't1', name: 'Task', input: { description: 'research auth' } } ] } } }, attr);
+  orch._onAgentEvent('planner', { type: 'user', raw: { type: 'user', message: { content: [
+    { type: 'tool_result', tool_use_id: 't1', content: 'done' } ] } } }, attr);
+  assert.ok(subs.some((m) => m.id === 't1' && m.status === 'finished'), 'a sub-agent finish delta fired');
+  assert.ok(logs.some((l) => l.text === '← result ok t1'), 'the finish also logs a ← result line');
+});
+
+test('init line carries step attribution', () => {
+  const orch = createOrchestrator({ projectDir: '/tmp/proj' });
+  const logs = [];
+  orch.on('log', (l) => logs.push(l));
+  orch._onAgentEvent('planner',
+    { type: 'system', raw: { type: 'system', subtype: 'init', model: 'claude-x' } },
+    { nodeId: 'n1', stepIndex: 2, cycle: 1, stepKey: 'planner@1' });
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0].text, '[init] model=claude-x');
+  assert.equal(logs[0].nodeId, 'n1');
+  assert.equal(logs[0].stepIndex, 2);
+  assert.equal(logs[0].cycle, 1);
+});
+
+test('result event never logs a [done]/turns line', () => {
+  const logs = capture('planner', {
+    type: 'result',
+    costUsd: 0,
+    raw: { type: 'result', total_cost_usd: 0, result: '' },
+  });
+  assert.ok(!logs.some((l) => /turns|\[done\]/.test(l.text)), 'no [done]/turns line');
+  assert.ok(!logs.some((l) => /^[←→]|\[init\]/.test(l.text)), 'no arrow/init line either');
 });

--- a/test/log-filter.test.mjs
+++ b/test/log-filter.test.mjs
@@ -1,0 +1,63 @@
+// test/log-filter.test.mjs
+// Pure log-filtering rules for the run-card / history log panes: which lines a
+// {source, level, step} filter shows, and which facet values the dropdowns offer.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { logLineVisible, logFacets } from '../ui/public/log-filter.mjs';
+
+const L = (over = {}) => ({ source: 'planner', level: 'info', text: 'x', ts: 1, ...over });
+
+test('empty filter shows everything', () => {
+  assert.equal(logLineVisible(L(), {}), true);
+  assert.equal(logLineVisible(L(), { source: '', level: '', step: '' }), true);
+  assert.equal(logLineVisible(L({ stepIndex: 3, sub: true }), { source: '', level: '', step: '' }), true);
+});
+
+test('level filter is an exact match', () => {
+  assert.equal(logLineVisible(L({ level: 'debug' }), { level: 'debug' }), true);
+  assert.equal(logLineVisible(L({ level: 'info' }), { level: 'debug' }), false);
+  assert.equal(logLineVisible(L({ level: undefined }), { level: 'info' }), true, 'missing level counts as info');
+});
+
+test('source filter matches the role and its sub-agents', () => {
+  assert.equal(logLineVisible(L({ source: 'planner' }), { source: 'planner' }), true);
+  assert.equal(logLineVisible(L({ source: 'planner ▸ research auth' }), { source: 'planner' }), true);
+  assert.equal(logLineVisible(L({ source: 'implementer' }), { source: 'planner' }), false);
+  assert.equal(logLineVisible(L({ source: 'plannerX' }), { source: 'planner' }), false, 'no bare prefix match');
+});
+
+test('step filter matches stepIndex; attribution-less lines only show under all', () => {
+  assert.equal(logLineVisible(L({ stepIndex: 2 }), { step: '2' }), true);
+  assert.equal(logLineVisible(L({ stepIndex: 0 }), { step: '0' }), true);
+  assert.equal(logLineVisible(L({ stepIndex: 1 }), { step: '2' }), false);
+  assert.equal(logLineVisible(L(), { step: '2' }), false, 'no stepIndex → hidden when a step is chosen');
+  assert.equal(logLineVisible(L(), { step: '' }), true);
+});
+
+test('filters compose (AND)', () => {
+  const rec = L({ source: 'planner ▸ research auth', level: 'debug', stepIndex: 1 });
+  assert.equal(logLineVisible(rec, { source: 'planner', level: 'debug', step: '1' }), true);
+  assert.equal(logLineVisible(rec, { source: 'planner', level: 'info', step: '1' }), false);
+  assert.equal(logLineVisible(rec, { source: 'reviewer', level: 'debug', step: '1' }), false);
+});
+
+test('logFacets collects distinct levels, parent-role sources, and sorted steps', () => {
+  const facets = logFacets([
+    L({ source: 'planner', level: 'info', stepIndex: 0 }),
+    L({ source: 'planner ▸ research auth', level: 'debug', stepIndex: 0, sub: true }),
+    L({ source: 'implementer', level: 'debug', stepIndex: 2 }),
+    L({ source: 'orchestrator', level: 'warn' }), // no stepIndex → no step facet
+    L({ source: 'implementer', level: 'debug', stepIndex: 1 }),
+  ]);
+  assert.deepEqual(facets.sources, ['implementer', 'orchestrator', 'planner']);
+  assert.deepEqual(facets.levels, ['debug', 'info', 'warn']);
+  assert.deepEqual(facets.steps, [0, 1, 2]);
+});
+
+test('logFacets is safe on empty/malformed input', () => {
+  assert.deepEqual(logFacets([]), { sources: [], levels: [], steps: [] });
+  const facets = logFacets([{ text: 'no source or level' }]);
+  assert.deepEqual(facets.sources, []);
+  assert.deepEqual(facets.levels, ['info']);
+  assert.deepEqual(facets.steps, []);
+});

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -2924,9 +2924,12 @@ function onLog(r, msg) {
   if (r.logLines.length > MAX_LOG_LINES) r.logLines.shift();
 
   if (r.el) {
-    maybePaintLogFilters(r, rec);
+    // A repaint (true) already rendered rec from the model — appending again
+    // would duplicate the line.
+    const repainted = maybePaintLogFilters(r, rec);
     const logEl = r.el.querySelector('.log');
-    if (logEl && logLineVisible(rec, r.logFilter)) {
+    if (logEl && !repainted && logLineVisible(rec, r.logFilter)) {
+      clearLogPlaceholder(logEl);
       logEl.appendChild(buildLogLine(rec));
       while (logEl.childElementCount > MAX_LOG_LINES) logEl.removeChild(logEl.firstChild);
       maybeAutoscrollLog(r);
@@ -2956,13 +2959,33 @@ function fillFilterSelect(sel, allLabel, values, current, labelOf) {
 
 // (Re)populate a run card's three filter dropdowns from the lines seen so far.
 // `root` lets buildRunCard target the freshly-cloned node before r.el is assigned.
+// Returns true when the pane was fully repainted (see below), false otherwise.
 function paintLogFilters(r, root = r.el) {
-  if (!root) return;
+  if (!root) return false;
   const facets = logFacets(r.logLines);
-  fillFilterSelect(root.querySelector('.log-f-source'), 'all sources', facets.sources, r.logFilter.source);
-  fillFilterSelect(root.querySelector('.log-f-level'), 'all levels', facets.levels, r.logFilter.level);
-  fillFilterSelect(root.querySelector('.log-f-step'), 'all steps', facets.steps, r.logFilter.step, (i) => `step ${i + 1}`);
+  const selSource = root.querySelector('.log-f-source');
+  const selLevel = root.querySelector('.log-f-level');
+  const selStep = root.querySelector('.log-f-step');
+  fillFilterSelect(selSource, 'all sources', facets.sources, r.logFilter.source);
+  fillFilterSelect(selLevel, 'all levels', facets.levels, r.logFilter.level);
+  fillFilterSelect(selStep, 'all steps', facets.steps, r.logFilter.step, (i) => `step ${i + 1}`);
   r._logFacetKeys = facetKeys(facets);
+  // A selection whose value vanished from the facets (log rotation, rebuild)
+  // fell back to "all" in the DOM; mirror that into the model and repaint so
+  // the pane never stays filtered by a value the dropdowns no longer show.
+  const effective = {
+    source: selSource ? selSource.value : r.logFilter.source,
+    level: selLevel ? selLevel.value : r.logFilter.level,
+    step: selStep ? selStep.value : r.logFilter.step,
+  };
+  if (effective.source !== r.logFilter.source
+    || effective.level !== r.logFilter.level
+    || String(effective.step) !== String(r.logFilter.step)) {
+    r.logFilter = effective;
+    repaintFilteredLog(r, root);
+    return true;
+  }
+  return false;
 }
 
 // Cheap incremental check for onLog: only rebuild the dropdowns when `rec`
@@ -2974,24 +2997,41 @@ function facetKeys(facets) {
     ...facets.steps.map((i) => `t:${i}`),
   ]);
 }
+// Returns paintLogFilters' repaint flag (true when the pane was fully
+// repainted) so onLog can skip its own incremental append.
 function maybePaintLogFilters(r, rec) {
   const seen = r._logFacetKeys;
-  if (!seen) { paintLogFilters(r); return; }
+  if (!seen) return paintLogFilters(r);
   const f = logFacets([rec]);
   for (const k of facetKeys(f)) {
-    if (!seen.has(k)) { paintLogFilters(r); return; }
+    if (!seen.has(k)) return paintLogFilters(r);
   }
+  return false;
+}
+
+// The live-card empty-state note ('(no lines match the filter)') is plain text
+// stamped with data-empty; incremental appends must clear it first.
+function clearLogPlaceholder(logEl) {
+  if (logEl.dataset.empty) { logEl.textContent = ''; delete logEl.dataset.empty; }
 }
 
 // Re-render a card's log pane from the model through the current filter (called
-// when a filter changes; live appends stay incremental via onLog).
-function repaintFilteredLog(r) {
-  if (!r || !r.el) return;
-  const logEl = r.el.querySelector('.log');
+// on a filter change and by buildRunCard's hydration; live appends stay
+// incremental via onLog). `root` lets buildRunCard target the freshly-cloned
+// node before r.el is assigned.
+function repaintFilteredLog(r, root = r.el) {
+  if (!r || !root) return;
+  const logEl = root.querySelector('.log');
   if (!logEl) return;
   logEl.innerHTML = '';
+  delete logEl.dataset.empty;
+  let shown = 0;
   for (const rec of r.logLines) {
-    if (logLineVisible(rec, r.logFilter)) logEl.appendChild(buildLogLine(rec));
+    if (logLineVisible(rec, r.logFilter)) { logEl.appendChild(buildLogLine(rec)); shown++; }
+  }
+  if (shown === 0 && r.logLines.length) {
+    logEl.textContent = '(no lines match the filter)';
+    logEl.dataset.empty = '1';
   }
   maybeAutoscrollLog(r);
 }
@@ -7521,12 +7561,9 @@ function buildRunCard(r) {
 
   // Hydrate the log from any events that arrived before the card existed,
   // through the run's current filter, and offer the facets seen so far.
-  const logEl = node.querySelector('.log');
-  if (logEl) {
-    for (const rec of r.logLines) {
-      if (logLineVisible(rec, r.logFilter)) logEl.appendChild(buildLogLine(rec));
-    }
-  }
+  // paintLogFilters may repaint once more if a stale selection fell back to
+  // "all" — cheap, and it keeps the pane and the dropdowns consistent.
+  repaintFilteredLog(r, node);
   paintLogFilters(r, node);
 
   // The switch is cloned ON from the template; mirror the run's persisted choice so

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -57,6 +57,7 @@ import {
   groupPaletteByDomain,
 } from './composer-core.mjs';
 import { logLineClass } from './log-line.mjs';
+import { logLineVisible, logFacets } from './log-filter.mjs';
 import {
   statusChip, diffBadges, mergeFindings,
   sourceBadge, reportResultControl, workflowPickerLabel,
@@ -907,6 +908,7 @@ function makeRun({
     steps: [],         // raw steps[] from the latest state snapshot (for live timers)
     pendingQuestion,
     logLines: [],
+    logFilter: { source: '', level: '', step: '' }, // '' === all; render-time only (logLines keeps everything)
     autoscroll: true,   // Auto-scroll toggle state (source of truth; template default is ON)
     subAgents: [],     // Array<record> — sub-agent lifecycle for this run (see onSubagent/onState)
     stepSkills: {},   // {`${nodeId}|${cycle}`: string[]} — MAIN-agent skills per dropdown group
@@ -2907,21 +2909,91 @@ function setAutoscroll(r, on) {
 }
 
 // Per-run log: push to the model and, if the card is mounted, append the line.
+// Filtering is render-time only: the model keeps every line, so changing a
+// filter never loses history; a hidden line is simply not appended.
 function onLog(r, msg) {
   const text = msg.text;
   if (text === undefined || text === null) return;
-  const rec = { ts: msg.ts != null ? msg.ts : Date.now(), source: msg.source, level: msg.level, text, sub: !!msg.sub };
+  const rec = {
+    ts: msg.ts != null ? msg.ts : Date.now(), source: msg.source, level: msg.level, text, sub: !!msg.sub,
+    ...(msg.nodeId != null ? { nodeId: msg.nodeId } : {}),
+    ...(msg.stepIndex != null ? { stepIndex: msg.stepIndex } : {}),
+    ...(msg.cycle != null ? { cycle: msg.cycle } : {}),
+  };
   r.logLines.push(rec);
   if (r.logLines.length > MAX_LOG_LINES) r.logLines.shift();
 
   if (r.el) {
+    maybePaintLogFilters(r, rec);
     const logEl = r.el.querySelector('.log');
-    if (logEl) {
+    if (logEl && logLineVisible(rec, r.logFilter)) {
       logEl.appendChild(buildLogLine(rec));
       while (logEl.childElementCount > MAX_LOG_LINES) logEl.removeChild(logEl.firstChild);
       maybeAutoscrollLog(r);
     }
   }
+}
+
+// ── Log filtering (source / level / step) ───────────────────────────────────
+
+// Fill one filter <select> with an "all" option + the facet values, preserving
+// the current selection (a value that vanished from the facets falls back to all).
+function fillFilterSelect(sel, allLabel, values, current, labelOf) {
+  if (!sel) return;
+  sel.innerHTML = '';
+  const all = document.createElement('option');
+  all.value = '';
+  all.textContent = allLabel;
+  sel.appendChild(all);
+  for (const v of values) {
+    const opt = document.createElement('option');
+    opt.value = String(v);
+    opt.textContent = labelOf ? labelOf(v) : String(v);
+    sel.appendChild(opt);
+  }
+  sel.value = values.some((v) => String(v) === String(current)) ? String(current) : '';
+}
+
+// (Re)populate a run card's three filter dropdowns from the lines seen so far.
+// `root` lets buildRunCard target the freshly-cloned node before r.el is assigned.
+function paintLogFilters(r, root = r.el) {
+  if (!root) return;
+  const facets = logFacets(r.logLines);
+  fillFilterSelect(root.querySelector('.log-f-source'), 'all sources', facets.sources, r.logFilter.source);
+  fillFilterSelect(root.querySelector('.log-f-level'), 'all levels', facets.levels, r.logFilter.level);
+  fillFilterSelect(root.querySelector('.log-f-step'), 'all steps', facets.steps, r.logFilter.step, (i) => `step ${i + 1}`);
+  r._logFacetKeys = facetKeys(facets);
+}
+
+// Cheap incremental check for onLog: only rebuild the dropdowns when `rec`
+// introduces a facet value they don't offer yet.
+function facetKeys(facets) {
+  return new Set([
+    ...facets.sources.map((s) => `s:${s}`),
+    ...facets.levels.map((l) => `l:${l}`),
+    ...facets.steps.map((i) => `t:${i}`),
+  ]);
+}
+function maybePaintLogFilters(r, rec) {
+  const seen = r._logFacetKeys;
+  if (!seen) { paintLogFilters(r); return; }
+  const f = logFacets([rec]);
+  for (const k of facetKeys(f)) {
+    if (!seen.has(k)) { paintLogFilters(r); return; }
+  }
+}
+
+// Re-render a card's log pane from the model through the current filter (called
+// when a filter changes; live appends stay incremental via onLog).
+function repaintFilteredLog(r) {
+  if (!r || !r.el) return;
+  const logEl = r.el.querySelector('.log');
+  if (!logEl) return;
+  logEl.innerHTML = '';
+  for (const rec of r.logLines) {
+    if (logLineVisible(rec, r.logFilter)) logEl.appendChild(buildLogLine(rec));
+  }
+  maybeAutoscrollLog(r);
 }
 
 function onArtifact(r, msg) {
@@ -5850,7 +5922,13 @@ async function seedResumedLog(newRunId, prevLines, logUrl) {
       if (res.ok) {
         for (const raw of (await res.text()).split('\n')) {
           const t = raw.trim(); if (!t) continue;
-          try { const rec = JSON.parse(t); head.push({ source: rec.source, level: rec.level, text: rec.text, ts: rec.ts, sub: !!rec.sub }); } catch { /* torn line */ }
+          try {
+            const rec = JSON.parse(t);
+            head.push({
+              source: rec.source, level: rec.level, text: rec.text, ts: rec.ts, sub: !!rec.sub,
+              ...(rec.stepIndex != null ? { stepIndex: rec.stepIndex } : {}),
+            });
+          } catch { /* torn line */ }
         }
       }
     } catch { /* best-effort seed */ }
@@ -5971,6 +6049,22 @@ if (runListEl) {
     const card = sw.closest('.run-card');
     const r = card && runs.get(card.dataset.runId);
     if (r) setAutoscroll(r, r.autoscroll === false);
+  });
+
+  // Log filter dropdowns (source/level/step). Delegated like the switch above;
+  // read all three so one change event leaves the whole filter consistent.
+  runListEl.addEventListener('change', (e) => {
+    const sel = e.target.closest && e.target.closest('.log-f');
+    if (!sel) return;
+    const card = sel.closest('.run-card');
+    const r = card && runs.get(card.dataset.runId);
+    if (!r) return;
+    r.logFilter = {
+      source: card.querySelector('.log-f-source')?.value || '',
+      level: card.querySelector('.log-f-level')?.value || '',
+      step: card.querySelector('.log-f-step')?.value || '',
+    };
+    repaintFilteredLog(r);
   });
 }
 
@@ -6998,26 +7092,57 @@ function paintLiveLogsBar(barEl, logUrl, hasLog) {
 }
 
 // Fetch the persisted NDJSON and render each line with the SAME buildLogLine() the
-// live panel uses, so persisted logs look identical to live ones.
+// live panel uses, so persisted logs look identical to live ones — including the
+// same source/level/step filter bar as the live card.
 async function loadLiveLogs(panel, logUrl) {
+  const bar = document.createElement('div');
+  bar.className = 'log-filters';
   const box = document.createElement('div');
   box.className = 'log';
   panel.innerHTML = '';
-  panel.appendChild(box);
+  panel.append(bar, box);
   try {
     const res = await fetch(logUrl);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const text = await res.text();
-    let n = 0;
+    const recs = [];
     for (const raw of text.split('\n')) {
       const t = raw.trim();
       if (!t) continue;
       let rec;
       try { rec = JSON.parse(t); } catch { continue; } // skip a torn final line
-      box.appendChild(buildLogLine({ source: rec.source, level: rec.level, text: rec.text, ts: rec.ts, sub: !!rec.sub }));
-      n++;
+      recs.push({
+        source: rec.source, level: rec.level, text: rec.text, ts: rec.ts, sub: !!rec.sub,
+        ...(rec.stepIndex != null ? { stepIndex: rec.stepIndex } : {}),
+      });
     }
-    if (n === 0) box.textContent = '(no log lines)';
+    const filter = { source: '', level: '', step: '' };
+    const paint = () => {
+      box.innerHTML = '';
+      let n = 0;
+      for (const rec of recs) {
+        if (logLineVisible(rec, filter)) { box.appendChild(buildLogLine(rec)); n++; }
+      }
+      if (n === 0) box.textContent = recs.length ? '(no lines match the filter)' : '(no log lines)';
+    };
+    const facets = logFacets(recs);
+    for (const [cls, allLabel, values, labelOf] of [
+      ['log-f-source', 'all sources', facets.sources, null],
+      ['log-f-level', 'all levels', facets.levels, null],
+      ['log-f-step', 'all steps', facets.steps, (i) => `step ${i + 1}`],
+    ]) {
+      const sel = document.createElement('select');
+      sel.className = `log-f ${cls}`;
+      fillFilterSelect(sel, allLabel, values, '', labelOf);
+      sel.addEventListener('change', () => {
+        filter.source = bar.querySelector('.log-f-source')?.value || '';
+        filter.level = bar.querySelector('.log-f-level')?.value || '';
+        filter.step = bar.querySelector('.log-f-step')?.value || '';
+        paint();
+      });
+      bar.appendChild(sel);
+    }
+    paint();
   } catch (e) {
     box.textContent = `Could not load logs: ${e.message}`;
     panel.dataset.loaded = ''; // allow a retry on the next open
@@ -7394,9 +7519,15 @@ function buildRunCard(r) {
   }
   renderRunMeta(r, node);
 
-  // Hydrate the log from any events that arrived before the card existed.
+  // Hydrate the log from any events that arrived before the card existed,
+  // through the run's current filter, and offer the facets seen so far.
   const logEl = node.querySelector('.log');
-  if (logEl) for (const rec of r.logLines) logEl.appendChild(buildLogLine(rec));
+  if (logEl) {
+    for (const rec of r.logLines) {
+      if (logLineVisible(rec, r.logFilter)) logEl.appendChild(buildLogLine(rec));
+    }
+  }
+  paintLogFilters(r, node);
 
   // The switch is cloned ON from the template; mirror the run's persisted choice so
   // a rebuild (finish/resume/reconcile) never silently re-enables auto-scroll.

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -352,7 +352,7 @@
                 <div class="subs-panel" hidden></div>
               </div>
               <div class="run-log">
-                <div class="run-log-head"><span class="ll-label">Live log</span><div class="switch-row"><div class="switch on autoscroll" role="switch" aria-checked="true" tabindex="0"></div><span class="txt">Auto-scroll</span></div></div>
+                <div class="run-log-head"><span class="ll-label">Live log</span><div class="log-filters"><select class="log-f log-f-source" title="Filter by source" aria-label="Filter by source"></select><select class="log-f log-f-level" title="Filter by level" aria-label="Filter by level"></select><select class="log-f log-f-step" title="Filter by step" aria-label="Filter by step"></select></div><div class="switch-row"><div class="switch on autoscroll" role="switch" aria-checked="true" tabindex="0"></div><span class="txt">Auto-scroll</span></div></div>
                 <div class="log"></div>
               </div>
               <div class="qpanel hidden"></div>

--- a/ui/public/log-filter.mjs
+++ b/ui/public/log-filter.mjs
@@ -1,0 +1,54 @@
+// ui/public/log-filter.mjs
+
+// Pure, DOM-free log-filtering rules shared by the run-card live log and the
+// History "Live logs" panel. Extracted so the narrowing semantics are
+// unit-testable without booting app.js (mirrors log-line.mjs).
+//
+// A filter is { source, level, step } where '' / undefined means "all".
+// - level: exact match; a record with no level counts as 'info' (the same
+//   default logLineClass applies when rendering).
+// - source: matches the role itself AND its fanned-out sub-agents — a child
+//   line's source is "role ▸ label", so filtering by "planner" keeps
+//   "planner ▸ research auth" but not "plannerX".
+// - step: matches String(rec.stepIndex). Lines with no step attribution
+//   (preflight, orchestrator, ui notices) only show when no step is chosen.
+
+const SUB_SEP = ' ▸ ';
+
+export function logLineVisible(rec, filter) {
+  if (!filter) return true;
+  if (filter.level && (rec.level || 'info') !== filter.level) return false;
+  if (filter.source) {
+    const src = rec.source || '';
+    if (src !== filter.source && !src.startsWith(filter.source + SUB_SEP)) return false;
+  }
+  if (filter.step !== undefined && filter.step !== '') {
+    if (rec.stepIndex == null || String(rec.stepIndex) !== String(filter.step)) return false;
+  }
+  return true;
+}
+
+// Distinct facet values the filter dropdowns offer, from the lines seen so far:
+// sources collapsed to their parent role (sub-agents fold into the role they
+// belong to), levels defaulted to 'info', steps = the stepIndex values present.
+// All sorted (steps numerically) for stable dropdowns.
+export function logFacets(lines) {
+  const sources = new Set();
+  const levels = new Set();
+  const steps = new Set();
+  for (const rec of lines || []) {
+    if (!rec) continue;
+    const src = rec.source || '';
+    if (src) {
+      const sep = src.indexOf(SUB_SEP);
+      sources.add(sep === -1 ? src : src.slice(0, sep));
+    }
+    levels.add(rec.level || 'info');
+    if (rec.stepIndex != null) steps.add(rec.stepIndex);
+  }
+  return {
+    sources: [...sources].sort(),
+    levels: [...levels].sort(),
+    steps: [...steps].sort((a, b) => a - b),
+  };
+}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -484,9 +484,15 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .run-log{margin-top:16px;}
 .run-log[hidden]{display:none;}
 .run-log .log{min-height:210px;max-height:320px;overflow-y:auto;}
-.run-log-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;}
+.run-log-head{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px;}
 .run-log-head .ll-label{font-weight:700;font-size:13px;}
 .run-log-head .switch-row .txt{font-size:12.5px;font-weight:600;color:var(--ink-2);}
+
+/* log filter dropdowns (source / level / step) — run cards + history panel */
+.log-filters{display:flex;gap:6px;align-items:center;flex-wrap:wrap;}
+.log-filters .log-f{font:inherit;font-size:12px;padding:2px 6px;border:1px solid var(--line);border-radius:8px;
+  background:#FBFBF9;color:var(--ink-2);max-width:150px;}
+.logs-panel .log-filters{margin-top:8px;}
 
 /* needs-attention card + paused stage */
 .run-card.attention{border:1.5px solid var(--amber);box-shadow:0 0 0 4px var(--amber-bg),var(--shadow);}


### PR DESCRIPTION
## Summary

Brings the orchestrator's live agent log to parity with worca and adds filter dropdowns to the log panes.

- **Orchestrator log parity** (`f3bf1524`): mixed assistant turns log both the text (info) and each tool call (debug); tool results surface as `← result ok|error <id8>` lines; the `system`/init event logs `[init] model=<model>` instead of being dropped. Additive only — sub-agent lifecycle handling is unchanged.
- **Log filtering UI** (`8e83e45e`): source / level / step dropdowns on run cards and the History "Live logs" panel, backed by a pure, unit-tested `log-filter.mjs` (mirrors `log-line.mjs`). Filtering is render-time only — the model keeps every line.
- **Review fixes** (`1e15a20b`): a filter selection whose facet value vanished (log rotation, card rebuild) now syncs back to "all" and repaints instead of silently filtering; the live card shows `(no lines match the filter)` like the history panel.

## Test plan

- `test/agent-log.test.mjs` — mixed turns, tool-result lines, init line, step attribution, sub-agent tagging
- `test/log-filter.test.mjs` — visibility rules and facet collection
- Full suite: 1893 pass / 8 pre-existing environment failures (missing local `imagegen` skill, plugin/db), identical before and after these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)