### PR TITLE
Configurable models: global catalog, env routing, cost honesty + model plugins

### DIFF
--- a/configurable-models-design.md
+++ b/configurable-models-design.md
@@ -92,7 +92,7 @@ Model env **wins over** inherited/allowlisted values and **survives scrub**: it 
 - Prefix: `WORCA_` — protects `WORCA_MOCK`, `WORCA_CLAUDE_BIN`, `WORCA_EFFORT_FLAG`, `WORCA_SUBAGENT_HOOKS`, `WORCA_RUN_ROOT`, all of which the runner reads from `process.env` and any of which injection could otherwise subvert (mock mode, binary path).
 - Everything else — including all `ANTHROPIC_*` / `CLAUDE_*` — is allowed: routing them is the point.
 
-The list lives in one exported constant in `claude-runner.mjs` next to `SPAWN_ENV_BASE`, used by both the settings validator and the spawn-time filter.
+The policy lives in `src/core/model-env.mjs`, a zero-import leaf module, imported by both the settings validator and the runner's spawn-time filter. (It cannot live next to `SPAWN_ENV_BASE` in `claude-runner.mjs` as originally drafted: `settings.mjs` is bound to a no-core-graph-imports contract and must validate against the same list.) `EFFORTS` moves there too, re-exported from `config.mjs` for import-compat, for the same reason.
 
 ### 4.5 Validation
 
@@ -149,7 +149,7 @@ No destructive auto-migration. Transition plan:
 
 ## 6. Implementation order
 
-1. `settings.mjs` catalog storage + sanitization + reserved-key constant in `claude-runner.mjs` (pure, fully unit-testable).
+1. `settings.mjs` catalog storage + sanitization + the `model-env.mjs` leaf (reserved-key policy, `${VAR}` refs, spawn-time filter) (pure, fully unit-testable).
 2. `config.mjs` effective catalog + `resolveModelEnv` + validation parity + removal semantics.
 3. `claude-runner.mjs` `modelEnv` seam + spawn-env merge; orchestrator dispatch wiring + aux call sites.
 4. API endpoints + masking.

--- a/configurable-models-design.md
+++ b/configurable-models-design.md
@@ -175,3 +175,105 @@ Each lands as its own PR against `dev`, tests first, per repo workflow.
 ## 8. Out of scope / future
 
 Named profiles (would layer cleanly on this catalog), per-model pricing for budget correctness, `/orchestrate` skill unification, OS-keychain secret storage, per-project catalog overrides.
+
+## 9. Model plugins (team dissemination)
+
+A team member configures a custom model locally, adapts pipelines to it, and wants teammates to reuse it without hand-copying `settings.json` snippets. Distribution rides the **existing plugin subsystem** (spec §4–§9: git repo + `worca-cc-plugin.json`, pinned-SHA install with consent inventory, update diff preview, per-plugin secrets store). Models become a fifth contribution type next to task sources, agents, skills, and workflows. **Git-only** distribution — no zip/tarball import path; the pinned-SHA update/consent trust model is the point.
+
+### 9.1 Manifest: `models` + `modelSecrets`
+
+```json
+{
+  "name": "discretestack-models",
+  "description": "Team routing for the DiscreteStack endpoint",
+  "models": [
+    { "id": "discretestack-stable", "label": "DiscreteStack Stable",
+      "efforts": ["medium", "high"],
+      "env": {
+        "ANTHROPIC_BASE_URL": "https://api.discretestack.com",
+        "API_TIMEOUT_MS": "3000000",
+        "ANTHROPIC_AUTH_TOKEN": { "secret": "discretestack-token" }
+      } }
+  ],
+  "modelSecrets": [
+    { "key": "discretestack-token", "label": "DiscreteStack API token" }
+  ]
+}
+```
+
+Env values take three forms: a **literal** string (travels verbatim — base URLs, timeouts, tier remaps), a whole-value **`${VAR}` ref** (travels as text, expanded from the teammate's process env at spawn resolution — existing `model-env.mjs` semantics), or a **secret placeholder** `{"secret": "<key>"}` referencing a plugin-level `modelSecrets` entry. Secrets are plugin-level, not per-model, so N models sharing one token prompt for it once.
+
+Validation (`plugin-manifest.mjs`, install fails on error): model ids non-empty + case-insensitively unique within the plugin, efforts a subset of `EFFORTS`, env keys pass `isReservedModelEnvKey` (the same write-time gate as `POST /api/models` — the spawn-time `prepareModelEnv` drop stays as the second gate), every `{"secret"}` ref names a declared `modelSecrets` key, `modelSecrets` keys match the config-field `KEY_RE` and are unique. Unknown fields warn (error under `--strict`), like everything else in the manifest.
+
+### 9.2 Catalog composition: a fourth layer
+
+Precedence: **predefined < plugin < global (user) < — legacy project lowest, unchanged**. Plugin entries come from *enabled* installed plugins' `current/worca-cc-plugin.json` (read fresh per composition, like `listGlobalModels`); a new `src/core/plugin-models.mjs` module owns the read (imports: `plugins-lock.mjs`, `plugin-manifest.mjs`, `plugin-config.mjs` — no cycle; `config.mjs` imports it). Catalog shape: `custom: 'plugin'` (truthy string, so existing `m.custom` checks keep working) plus `plugin: '<name>'`; `hasEnv` as usual.
+
+- A **user global entry with the same id shadows the plugin entry** (badge: `overrides plugin`) — plugin content stays immutable/versioned; local tweaks go through "Edit a copy" (below).
+- A plugin entry with a **predefined id** shadows the built-in (same rule as global shadows, `overridden` badge on the built-in card).
+- **Two plugins shipping the same id**: alphabetical plugin-name order wins deterministically; the loser is dropped with a warning (doctor/list surface it).
+- Disabled/uninstalled plugin → its models leave the catalog; selections referencing them behave like any unknown id (write-time validation, runtime pass-through — §4.5 unchanged).
+- Test hermeticity is inherited: `readPluginsLock` resolves through `worcaHome()`, whose `NODE_TEST_CONTEXT` guard already makes plugin reads return empty in unsandboxed tests.
+
+### 9.3 Env resolution and secrets
+
+`resolveModelEnv(modelId)` extends: user global entry first (current behavior); else the winning enabled plugin entry. Placeholders resolve from the plugin's **existing secrets store** (`plugin-config.mjs`: `data/secrets.json`, 0600, atomic, `{"$env":"VAR"}` indirection honored, values never echoed to the browser) via a schema synthesized from `modelSecrets` (`secret: true` fields). An unset secret drops that key with a warning naming the plugin and key — same degradation as an unresolvable `${VAR}`. The assembled map then flows through `prepareModelEnv` unchanged (reserved-key drop + ref expansion).
+
+`modelHasBaseUrlRouting` extends to plugin entries (key presence in any form), so §4.6 cost observation works for plugin models with no further changes.
+
+### 9.4 Lifecycle integration
+
+- **Install consent** (`buildInstallInventory`): a `models` section listing each model's id, label, efforts, env keys, and the `ANTHROPIC_BASE_URL` value **verbatim** (a model env can redirect all API traffic — the reviewer must see where), plus requested `modelSecrets`. The install flow then prompts for secrets (plugins view config panel).
+- **Update delta** (`fetchCandidate`/`computeManifestDelta`): `newModels`, `removedModels`, `envChangedModels` (ids whose env map differs — base-URL changes called out explicitly), `newModelSecrets`. Red-highlighted like `newSecrets`, turning a malicious routing change into a human review event.
+- **Uninstall guard** — **block-with-list** (decision): `referencedPluginModels(name)` computes, for each of the plugin's model ids, the cross-project step/node refs (reusing `globalModelRefs` machinery) *minus* ids shadowed by a user global entry (those keep resolving after uninstall). Non-empty → `REFERENCED`-code error with the list, same shape as the plugin-agents guard; the user clears selections (or copies the model) first. Disable is not guarded — it is reversible.
+- **Doctor**: per `modelSecrets` key, a check whether it is set (unset → failing check naming the key).
+
+### 9.5 Export wizard ("Share as plugin…", Models page)
+
+Three steps, server does the packing:
+
+1. **Pick models** — checkboxes over the user's global entries.
+2. **Env policy** — one row per distinct env key across the selection: *Include value* / *Require at install* (→ secret placeholder + `modelSecrets` entry) / *Keep as `${VAR}` ref* (only offered where the stored value already is one). Keys matching `/TOKEN|KEY|SECRET|PASSWORD|AUTH/i` default to *Require at install*; choosing *Include value* on such a key shows a "this value will be committed to a git repo" warning. A key shared by several selected models is decided once.
+3. **Metadata + destination** — plugin name (kebab-case, `PLUGIN_NAME_RE`), description, version; a **destination folder path** (must not exist or be empty). Export writes the scaffold: `worca-cc-plugin.json` + a README with `git init`/push and `worca plugin add` instructions. No zip: distribution is git-only, and the scaffold folder is what gets pushed.
+
+The export endpoint reads raw env values server-side (same trust model as `GET /api/models/:id/env-value` — the user's own values, deliberate action); *Require at install* strips the value entirely.
+
+### 9.6 UI
+
+- **Models page**: a read-only **"From plugins"** card section (provenance badge `plugin: <name>`, env summary, secret status, `overrides built-in` / shadowed states) with an **"Edit a copy"** action → create-mode editor prefilled with id/label/efforts and literal/`${VAR}` env values; secret-placeholder keys become empty rows the user must fill. Saving creates the global entry, which shadows the plugin one. Plus the **"Share as plugin…"** toolbar button (wizard above).
+- **New Pipeline dropdown**: a third optgroup between the existing two — **Your models / Plugins / Built-in** (one combined group; alphabetical within, per the existing sort). Provenance suffixes stay removed; when the same *label* appears in more than one group (or twice within Plugins), the ambiguous options get ` (<plugin-name>)` appended — collision-only, no steady-state noise. `⚠cost` marker semantics unchanged.
+- **Plugins view**: contributions count gains `models`; the config panel gains a "Model secrets" section (masked `{set:true}` markers, write-only — exactly the task-source secret UX).
+
+### 9.7 API
+
+- `GET /api/models` gains `plugin: [...]` entries (read-only; literals masked with the standard masker, `${VAR}` refs readable, placeholders as `{secret: key, set: bool}`).
+- `GET /api/plugins/:name/config` gains a `models: {schema, values}` section synthesized from `modelSecrets`; `PUT` accepts `{target: 'modelSecrets', values}` alongside the per-source shape.
+- `POST /api/models/export-plugin` `{name, description, version, dest, models: [{id, env: {KEY: 'value'|'ref'|'secret'}}]}` → writes the scaffold, returns the path + next-step instructions.
+- Install/update/uninstall/doctor routes are unchanged — richer payloads only (inventory `models`, delta fields, `REFERENCED` list).
+
+### 9.8 Testing
+
+- **plugin-manifest**: models/modelSecrets normalization + every rejection (reserved env key, dup id, unknown effort, dangling secret ref, bad secret key), strict-mode warnings.
+- **plugin-models**: composition precedence (all four layers + both shadow directions + two-plugin collision), disabled-plugin exclusion, secret resolution (set / unset-drop / `$env` indirection), refs guard incl. the shadowed-id carve-out.
+- **plugin-store**: inventory `models` section, update delta fields, uninstall `REFERENCED` block + success after clearing, doctor secret checks.
+- **server**: plugin entries in `GET /api/models`, modelSecrets config round-trip (write-only), export endpoint (scaffold content, value-stripping, dest guards, name validation).
+- **UI (jsdom)**: plugin cards read-only + Edit-a-copy prefill, wizard collect (env policy modes, secret defaulting heuristic), dropdown third group + collision-only suffix.
+
+### 9.9 Implementation order (stacked on phases 1–6)
+
+7. Manifest: `models`/`modelSecrets` normalization + `validatePluginDir` checks.
+8. `plugin-models.mjs` + catalog composition layer + `resolveModelEnv`/`modelHasBaseUrlRouting` extension.
+9. Lifecycle: consent inventory, update delta, uninstall block-with-list, doctor secret checks.
+10. API: plugin entries in `/api/models`, modelSecrets config routes, export endpoint.
+11. UI: Models-page plugin section + Edit-a-copy + export wizard, plugins-view secrets panel, dropdown grouping.
+
+### 9.10 Decision log
+
+| Decision | Choice | Why |
+|---|---|---|
+| Distribution | **Git-only** (existing plugin flow) | Pinned-SHA consent/update trust model; zip import has no update story |
+| Secrets | **Full placeholder + install-time prompt** (plugin secrets store) | Storage and redaction already exist; strictly better UX than shell-env conventions |
+| Uninstall with refs | **Block with references list** | Mirrors the plugin-agents guard; uninstall is rare and the block is actionable |
+| Dropdown grouping | **One combined "Plugins" group** | Per-plugin groups add noise for the common one-plugin case; collision-only suffix disambiguates |
+| Precedence | predefined < plugin < user global | User sovereignty: a local copy always wins; plugin entries stay immutable |
+| Same-label collision | Suffix ` (<plugin-name>)` only when ambiguous | Consistent with the provenance-suffix removal |

--- a/src/core/agent-gen.mjs
+++ b/src/core/agent-gen.mjs
@@ -17,6 +17,7 @@ import { join } from 'node:path';
 import { mkdir, rm, readFile, writeFile } from 'node:fs/promises';
 import { worcaHome } from './projects.mjs';
 import { runClaude } from './claude-runner.mjs';
+import { resolveModelEnv } from './config.mjs';
 import { normalizeMeta } from './agent-registry.mjs';
 
 const SYSTEM_PROMPT =
@@ -75,6 +76,7 @@ class AgentGen extends EventEmitter {
         allowedTools: ['Read', 'Write'],
         permissionMode: this.claude.permissionMode || 'acceptEdits',
         model: this.claude.model,
+        modelEnv: resolveModelEnv(this.claude.model), // catalog routing env (design §4.8)
         bin: this.claude.bin,
         mock: this.claude.mock,
         signal: this.abort.signal,

--- a/src/core/claude-runner.mjs
+++ b/src/core/claude-runner.mjs
@@ -34,6 +34,7 @@
 
 import { spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
+import { prepareModelEnv } from './model-env.mjs';
 import { writeFile, mkdir, appendFile, readFile, access } from 'node:fs/promises';
 import { constants as FS } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -205,6 +206,9 @@ function mockEnabled(opts) {
  * @param {boolean} [o.envScrub]         guardrail: spawn with a minimal env instead of
  *   inheriting process.env (absent/false => spawn inherits, today's behavior)
  * @param {string[]} [o.envAllowlist]    guardrail: extra env var names to keep under scrub
+ * @param {Record<string,string>} [o.modelEnv] per-model routing env (design §4.4), merged
+ *   LAST over the spawn env (it survives scrub and wins collisions — explicit operator
+ *   config outranks ambient-env hygiene); reserved keys are re-dropped here defensively
  * @param {string[]} [o.workspaceWriteTargets] §8.10 MOCK-ONLY member checkouts the mock
  *   implementer writes into instead of `cwd` (empty/absent => today's cwd behavior).
  *   Never reaches argv: `runReal` ignores it by construction.
@@ -231,6 +235,7 @@ export async function runClaude(o = {}) {
     permissionRules,
     envScrub,
     envAllowlist,
+    modelEnv,
     workspaceWriteTargets,
     resumeSessionId,
     bin = DEFAULT_BIN,
@@ -267,6 +272,7 @@ export async function runClaude(o = {}) {
     permissionRules,
     envScrub,
     envAllowlist,
+    modelEnv,
   });
 }
 
@@ -320,7 +326,7 @@ export function buildClaudeArgs({
   return args;
 }
 
-function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, model, effort, onEvent, signal, bin, resumeSessionId, mcpConfigPath, mcpServerGrants, permissionRules, envScrub, envAllowlist }) {
+function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, model, effort, onEvent, signal, bin, resumeSessionId, mcpConfigPath, mcpServerGrants, permissionRules, envScrub, envAllowlist, modelEnv }) {
   return new Promise((resolveP, rejectP) => {
     const args = buildClaudeArgs({
       prompt, systemPrompt, permissionMode, model, effort, allowedTools, resumeSessionId,
@@ -329,7 +335,23 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
 
     // undefined when the guardrail is off, and the spread then adds NO `env` key —
     // spawn inherits process.env exactly as it did before guardrails existed.
-    const spawnEnv = buildSpawnEnv(envScrub, envAllowlist);
+    const guardrailEnv = buildSpawnEnv(envScrub, envAllowlist);
+
+    // Per-model routing env (design §4.4) merges LAST: it survives scrub and
+    // wins collisions (explicit operator config outranks ambient-env hygiene),
+    // except reserved keys, which are re-dropped here defensively — the write
+    // path already rejects them, so a drop means a hand-edited settings file.
+    // With no modelEnv (or nothing surviving the filter) the spawn env is
+    // byte-identical to the pre-feature behavior, including the undefined
+    // -> inherit-process.env case.
+    let spawnEnv = guardrailEnv;
+    if (modelEnv && Object.keys(modelEnv).length) {
+      const { env: safe, dropped } = prepareModelEnv(modelEnv);
+      for (const k of dropped) {
+        console.warn(`[worca] modelEnv: dropping reserved/invalid key ${JSON.stringify(k)}`);
+      }
+      if (Object.keys(safe).length) spawnEnv = { ...(guardrailEnv ?? process.env), ...safe };
+    }
 
     let child;
     try {

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -17,6 +17,7 @@ import { projectKey } from './store.mjs';
 import { loadAgentRegistry, registryToSteps } from './agent-registry.mjs';
 import { EFFORTS, prepareModelEnv } from './model-env.mjs';
 import { listGlobalModels, addGlobalModel, removeGlobalModel } from './settings.mjs';
+import { listPluginModels, allPluginModels, flattenPluginModelEnv } from './plugin-models.mjs';
 
 /**
  * Recompute the agent step list FRESH from the layered registry (repo agents/ +
@@ -163,28 +164,38 @@ export async function readConfig(projectDir) {
 }
 
 /**
- * Compose the EFFECTIVE catalog (configurable-models-design.md §4.2):
- * predefined ⊕ global settings entries ⊕ legacy per-project custom models.
- * A global entry whose id matches a predefined one OVERRIDES it (label,
- * efforts, env) — the predefined id casing is kept so existing step/node refs
- * stay stable. Legacy project entries rank lowest and are dropped on any id
- * collision. `custom` widens from a boolean to false | 'global' | 'project'
- * (both strings truthy, so existing `m.custom` checks keep working); `hasEnv`
- * advertises routing env WITHOUT the values (this shape feeds UI dropdowns).
+ * Compose the EFFECTIVE catalog (configurable-models-design.md §4.2, §9.2):
+ * predefined ⊕ plugin models ⊕ global settings entries ⊕ legacy per-project
+ * custom models. Precedence on an id collision: global (user) beats plugin
+ * beats predefined; legacy ranks lowest and is dropped. A shadowing entry
+ * keeps the shadowed id's casing so existing step/node refs stay stable.
+ * `custom` is false | 'global' | 'plugin' | 'project' (strings truthy, so
+ * existing `m.custom` checks keep working); plugin entries also carry
+ * `plugin: '<name>'`; `hasEnv` advertises routing env WITHOUT the values
+ * (this shape feeds UI dropdowns).
  */
 function composeCatalog(projectCustom = []) {
   const globals = listGlobalModels();
   const globalByIdLc = new Map(globals.map((m) => [m.id.toLowerCase(), m]));
+  const plugins = listPluginModels();
+  const pluginByIdLc = new Map(plugins.map((m) => [m.id.toLowerCase(), m]));
   const flagged = costUnreliableModelIds();
   const out = [];
   const seen = new Set();
   const unreliable = (lc) => (flagged.has(lc) ? { costUnreliable: true } : {});
+  const pluginShape = (id, m, lc) => ({
+    id, label: m.label, efforts: [...m.efforts], custom: 'plugin', plugin: m.plugin,
+    hasEnv: !!m.env, ...unreliable(lc),
+  });
   for (const m of PREDEFINED_MODELS) {
     const lc = m.id.toLowerCase();
     const shadow = globalByIdLc.get(lc);
+    const pshadow = pluginByIdLc.get(lc);
     out.push(shadow
       ? { id: m.id, label: shadow.label, efforts: [...shadow.efforts], custom: 'global', hasEnv: !!shadow.env, ...unreliable(lc) }
-      : { ...m, custom: false, hasEnv: false });
+      : pshadow
+        ? pluginShape(m.id, pshadow, lc)
+        : { ...m, custom: false, hasEnv: false });
     seen.add(lc);
   }
   for (const m of globals) {
@@ -193,8 +204,14 @@ function composeCatalog(projectCustom = []) {
     seen.add(lc);
     out.push({ id: m.id, label: m.label, efforts: [...m.efforts], custom: 'global', hasEnv: !!m.env, ...unreliable(lc) });
   }
+  for (const m of plugins) {
+    const lc = m.id.toLowerCase();
+    if (seen.has(lc)) continue; // predefined/global shadow wins
+    seen.add(lc);
+    out.push(pluginShape(m.id, m, lc));
+  }
   for (const m of projectCustom) {
-    if (seen.has(m.id.toLowerCase())) continue; // predefined/global wins
+    if (seen.has(m.id.toLowerCase())) continue; // predefined/global/plugin wins
     seen.add(m.id.toLowerCase());
     out.push({ id: m.id, label: m.label, efforts: [...EFFORTS], custom: 'project', hasEnv: false });
   }
@@ -207,14 +224,19 @@ function composeCatalog(projectCustom = []) {
 // cost run of the same model auto-clears it. Never assumed from config alone —
 // a proxy that reports real costs is never badged.
 
-/** Whether the model's GLOBAL entry declares an ANTHROPIC_BASE_URL override
- *  (directly or as a ${VAR} ref — key presence is the signal). Only such
- *  models are ever observed; the direct Anthropic path is never flagged. */
+/** Whether the model's env-carrying entry (user GLOBAL first, else the winning
+ *  PLUGIN entry — design §9.3) declares an ANTHROPIC_BASE_URL override
+ *  (directly, as a ${VAR} ref, or as a {secret} placeholder — key presence is
+ *  the signal). Only such models are ever observed; the direct Anthropic path
+ *  is never flagged. */
 export function modelHasBaseUrlRouting(modelId) {
   const id = typeof modelId === 'string' ? modelId.trim() : '';
   if (!id) return false;
-  const entry = listGlobalModels().find((m) => m.id.toLowerCase() === id.toLowerCase());
-  return !!(entry && entry.env && 'ANTHROPIC_BASE_URL' in entry.env);
+  const lc = id.toLowerCase();
+  const entry = listGlobalModels().find((m) => m.id.toLowerCase() === lc);
+  if (entry) return !!(entry.env && 'ANTHROPIC_BASE_URL' in entry.env);
+  const pm = listPluginModels().find((m) => m.id.toLowerCase() === lc);
+  return !!(pm && pm.env && 'ANTHROPIC_BASE_URL' in pm.env);
 }
 
 /** Lowercased ids currently flagged cost-unreliable. Never throws ({} on any
@@ -275,23 +297,42 @@ export async function listModels(projectDir) {
 }
 
 /**
- * The routing env for a model id (design §4.4), or undefined when none is
- * configured. Only GLOBAL catalog entries carry env. Whole-value ${VAR} refs
- * are expanded from worca's own process env HERE (the resolution point);
- * reserved or unresolvable keys are dropped with a warning — write-time
- * validation rejects reserved keys, so a drop means a hand-edited file.
- * Synchronous; never throws.
+ * The routing env for a model id (design §4.4, §9.3), or undefined when none
+ * is configured. The user's GLOBAL entry wins; otherwise the winning enabled
+ * PLUGIN entry applies, with {secret} placeholders resolved from that plugin's
+ * secrets store (unset secrets dropped with a warning naming plugin and key).
+ * Whole-value ${VAR} refs are expanded from worca's own process env HERE (the
+ * resolution point); reserved or unresolvable keys are dropped with a warning —
+ * write-time validation rejects reserved keys, so a drop means a hand-edited
+ * file (or manifest). Synchronous; never throws.
  * @param {string} modelId
  * @returns {Record<string,string>|undefined}
  */
 export function resolveModelEnv(modelId) {
   const id = typeof modelId === 'string' ? modelId.trim() : '';
   if (!id) return undefined;
-  const entry = listGlobalModels().find((m) => m.id.toLowerCase() === id.toLowerCase());
-  if (!entry || !entry.env) return undefined;
-  const { env, dropped } = prepareModelEnv(entry.env);
+  const lc = id.toLowerCase();
+  let rawEnv;
+  let who;
+  const entry = listGlobalModels().find((m) => m.id.toLowerCase() === lc);
+  if (entry && entry.env) {
+    rawEnv = entry.env;
+    who = JSON.stringify(entry.id);
+  } else if (!entry) {
+    const pm = listPluginModels().find((m) => m.id.toLowerCase() === lc);
+    if (pm && pm.env) {
+      const { env, droppedSecrets } = flattenPluginModelEnv(pm);
+      for (const d of droppedSecrets) {
+        console.warn(`[worca] plugin "${pm.plugin}" model ${JSON.stringify(pm.id)}: dropping env ${d} — set it in the plugin's Model secrets`);
+      }
+      rawEnv = env;
+      who = `${JSON.stringify(pm.id)} (plugin "${pm.plugin}")`;
+    }
+  }
+  if (!rawEnv) return undefined;
+  const { env, dropped } = prepareModelEnv(rawEnv);
   for (const k of dropped) {
-    console.warn(`[worca] model ${JSON.stringify(entry.id)}: dropping env key ${JSON.stringify(k)} (reserved or unresolvable \${VAR} ref)`);
+    console.warn(`[worca] model ${who}: dropping env key ${JSON.stringify(k)} (reserved or unresolvable \${VAR} ref)`);
   }
   return Object.keys(env).length ? env : undefined;
 }
@@ -692,7 +733,12 @@ export function globalModelRefs(id) {
   if (PREDEFINED_MODELS.some((m) => m.id.toLowerCase() === lc)) {
     return { predefinedShadow: true, steps: [], nodes: [] };
   }
-  const rows = allProjectConfigRows();
+  return { predefinedShadow: false, ...refsForModelId(lc, allProjectConfigRows()) };
+}
+
+/** Cross-project step/node refs to one lowercased model id, minus projects
+ *  whose legacy customModels carry the same id (those keep resolving). */
+function refsForModelId(lc, rows) {
   const keep = new Set(rows
     .filter((r) => r.customModels.some((m) => m.id.toLowerCase() === lc))
     .map((r) => r.projectKey));
@@ -708,7 +754,36 @@ export function globalModelRefs(id) {
   ).all(lc)
     .filter((r) => !keep.has(r.project_key))
     .map((r) => ({ projectKey: r.project_key, workflowId: r.workflow_id, nodeId: r.node_id }));
-  return { predefinedShadow: false, steps, nodes };
+  return { steps, nodes };
+}
+
+/**
+ * Uninstall guard input (design §9.4, block-with-list): the plugin's model ids
+ * that pipeline configuration still references AND that would stop resolving
+ * once the plugin is gone. Carve-outs — the id keeps resolving, so it does not
+ * block — mirror removeGlobalModelAndRefs: (1) a user GLOBAL entry shadows it;
+ * (2) a PREDEFINED id (removal reverts to the built-in); (3) another enabled
+ * plugin ships the same id; (4) per-project legacy customModels (inside
+ * refsForModelId). Synchronous; never throws.
+ * @param {string} pluginName
+ * @returns {Array<{id:string, steps:Array, nodes:Array}>}
+ */
+export function referencedPluginModels(pluginName) {
+  const all = allPluginModels();
+  const mine = all.filter((m) => m.plugin === pluginName);
+  if (!mine.length) return [];
+  const globalIds = new Set(listGlobalModels().map((m) => m.id.toLowerCase()));
+  const predefinedIds = new Set(PREDEFINED_MODELS.map((m) => m.id.toLowerCase()));
+  const rows = allProjectConfigRows();
+  const out = [];
+  for (const m of mine) {
+    const lc = m.id.toLowerCase();
+    if (globalIds.has(lc) || predefinedIds.has(lc)) continue;
+    if (all.some((o) => o.plugin !== pluginName && o.id.toLowerCase() === lc)) continue;
+    const { steps, nodes } = refsForModelId(lc, rows);
+    if (steps.length || nodes.length) out.push({ id: m.id, steps, nodes });
+  }
+  return out;
 }
 
 /**

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -16,7 +16,7 @@ import { getDb, prepare, tx } from './db.mjs';
 import { projectKey } from './store.mjs';
 import { loadAgentRegistry, registryToSteps } from './agent-registry.mjs';
 import { EFFORTS, prepareModelEnv } from './model-env.mjs';
-import { listGlobalModels, removeGlobalModel } from './settings.mjs';
+import { listGlobalModels, addGlobalModel, removeGlobalModel } from './settings.mjs';
 
 /**
  * Recompute the agent step list FRESH from the layered registry (repo agents/ +
@@ -370,6 +370,29 @@ export async function removeCustomModel(projectDir, id) {
       'DELETE FROM config_workflow_nodes WHERE project_key = ? AND model = ? COLLATE NOCASE'
     ).run(key, target);
   });
+  return updated;
+}
+
+/**
+ * Promote a legacy per-project custom model into the GLOBAL catalog (design
+ * §4.9): create the global entry (skipped when one with that id already
+ * exists) and drop only the project-local entry. Deliberately NOT
+ * addGlobalModel + removeCustomModel — the latter purges node/step refs, and
+ * promotion must be invisible to refs (the id keeps resolving, now globally).
+ * @returns {Promise<{steps:object, customModels:Array}>} the updated legacy view
+ * @throws {Error} when the project has no such custom model
+ */
+export async function promoteCustomModel(projectDir, id) {
+  const target = (typeof id === 'string' ? id : '').trim();
+  const lc = target.toLowerCase();
+  const cfg = readRaw(projectDir);
+  const entry = cfg.customModels.find((m) => m.id.toLowerCase() === lc);
+  if (!entry) throw new Error(`unknown project model "${target}"`);
+  if (!listGlobalModels().some((m) => m.id.toLowerCase() === lc)) {
+    await addGlobalModel({ id: entry.id, label: entry.label });
+  }
+  const updated = { ...cfg, customModels: cfg.customModels.filter((m) => m !== entry) };
+  writeLegacy(projectKey(projectDir), updated);
   return updated;
 }
 

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -15,7 +15,8 @@
 import { getDb, prepare, tx } from './db.mjs';
 import { projectKey } from './store.mjs';
 import { loadAgentRegistry, registryToSteps } from './agent-registry.mjs';
-import { EFFORTS } from './model-env.mjs';
+import { EFFORTS, prepareModelEnv } from './model-env.mjs';
+import { listGlobalModels, removeGlobalModel } from './settings.mjs';
 
 /**
  * Recompute the agent step list FRESH from the layered registry (repo agents/ +
@@ -162,14 +163,71 @@ export async function readConfig(projectDir) {
 }
 
 /**
- * All selectable models = predefined + this project's custom models. Custom models
- * advertise the full effort set (their support is unknown — the user owns the raw id).
+ * Compose the EFFECTIVE catalog (configurable-models-design.md §4.2):
+ * predefined ⊕ global settings entries ⊕ legacy per-project custom models.
+ * A global entry whose id matches a predefined one OVERRIDES it (label,
+ * efforts, env) — the predefined id casing is kept so existing step/node refs
+ * stay stable. Legacy project entries rank lowest and are dropped on any id
+ * collision. `custom` widens from a boolean to false | 'global' | 'project'
+ * (both strings truthy, so existing `m.custom` checks keep working); `hasEnv`
+ * advertises routing env WITHOUT the values (this shape feeds UI dropdowns).
+ */
+function composeCatalog(projectCustom = []) {
+  const globals = listGlobalModels();
+  const globalByIdLc = new Map(globals.map((m) => [m.id.toLowerCase(), m]));
+  const out = [];
+  const seen = new Set();
+  for (const m of PREDEFINED_MODELS) {
+    const shadow = globalByIdLc.get(m.id.toLowerCase());
+    out.push(shadow
+      ? { id: m.id, label: shadow.label, efforts: [...shadow.efforts], custom: 'global', hasEnv: !!shadow.env }
+      : { ...m, custom: false, hasEnv: false });
+    seen.add(m.id.toLowerCase());
+  }
+  for (const m of globals) {
+    if (seen.has(m.id.toLowerCase())) continue; // predefined shadow, already emitted
+    seen.add(m.id.toLowerCase());
+    out.push({ id: m.id, label: m.label, efforts: [...m.efforts], custom: 'global', hasEnv: !!m.env });
+  }
+  for (const m of projectCustom) {
+    if (seen.has(m.id.toLowerCase())) continue; // predefined/global wins
+    seen.add(m.id.toLowerCase());
+    out.push({ id: m.id, label: m.label, efforts: [...EFFORTS], custom: 'project', hasEnv: false });
+  }
+  return out;
+}
+
+/**
+ * All selectable models for a project = the effective catalog (predefined ⊕
+ * global ⊕ this project's legacy custom models). Legacy custom models
+ * advertise the full effort set (their support is unknown — the user owns the
+ * raw id); global entries advertise their configured subset.
  */
 export async function listModels(projectDir) {
   const { customModels } = readRaw(projectDir);
-  const predefined = PREDEFINED_MODELS.map((m) => ({ ...m, custom: false }));
-  const custom = customModels.map((m) => ({ id: m.id, label: m.label, efforts: [...EFFORTS], custom: true }));
-  return [...predefined, ...custom];
+  return composeCatalog(customModels);
+}
+
+/**
+ * The routing env for a model id (design §4.4), or undefined when none is
+ * configured. Only GLOBAL catalog entries carry env. Whole-value ${VAR} refs
+ * are expanded from worca's own process env HERE (the resolution point);
+ * reserved or unresolvable keys are dropped with a warning — write-time
+ * validation rejects reserved keys, so a drop means a hand-edited file.
+ * Synchronous; never throws.
+ * @param {string} modelId
+ * @returns {Record<string,string>|undefined}
+ */
+export function resolveModelEnv(modelId) {
+  const id = typeof modelId === 'string' ? modelId.trim() : '';
+  if (!id) return undefined;
+  const entry = listGlobalModels().find((m) => m.id.toLowerCase() === id.toLowerCase());
+  if (!entry || !entry.env) return undefined;
+  const { env, dropped } = prepareModelEnv(entry.env);
+  for (const k of dropped) {
+    console.warn(`[worca] model ${JSON.stringify(entry.id)}: dropping env key ${JSON.stringify(k)} (reserved or unresolvable \${VAR} ref)`);
+  }
+  return Object.keys(env).length ? env : undefined;
 }
 
 /**
@@ -264,6 +322,9 @@ export async function addCustomModel(projectDir, input = {}) {
   if (!id) throw new Error('model id is required');
   if (PREDEFINED_MODELS.some((m) => m.id.toLowerCase() === id.toLowerCase())) {
     throw new Error(`"${id}" is already a predefined model`);
+  }
+  if (listGlobalModels().some((m) => m.id.toLowerCase() === id.toLowerCase())) {
+    throw new Error(`"${id}" is already a global model`);
   }
   const key = projectKey(projectDir);
   const cfg = readRaw(projectDir);
@@ -397,7 +458,10 @@ export async function readRunConfig(projectDir) {
  * workflow. A cleaned selection of null (all blank) deletes the row. fanOut and
  * askQuestions are preserved when the caller omits them (read from the existing
  * row) and set when a boolean. Writes only the config_workflow_nodes table
- * (legacy view + extra untouched).
+ * (legacy view + extra untouched). Model/effort validate against the effective
+ * catalog exactly like setStep (design §4.5 — the two write paths must not
+ * disagree); rows persisted before this hardening are validated only when
+ * next written.
  * @param {string} projectDir
  * @param {string} workflowId
  * @param {string} nodeId
@@ -405,6 +469,19 @@ export async function readRunConfig(projectDir) {
  * @returns {Promise<void>}
  */
 export async function setNodeModel(projectDir, workflowId, nodeId, selection = {}) {
+  const model = typeof selection.model === 'string' ? selection.model.trim() : '';
+  const effort = typeof selection.effort === 'string' ? selection.effort.trim() : '';
+  const models = await listModels(projectDir);
+  const entry = model ? models.find((m) => m.id === model) : null;
+  if (model && !entry) throw new Error(`unknown model "${model}"`);
+  if (effort) {
+    if (!EFFORTS.includes(effort)) throw new Error(`unknown effort "${effort}"`);
+    if (!entry) throw new Error('select a model before choosing an effort');
+    if (!entry.efforts.includes(effort)) {
+      throw new Error(`model "${model}" does not support effort "${effort}"`);
+    }
+  }
+
   const key = projectKey(projectDir);
   getDb();
   const prev = prepare(
@@ -492,4 +569,101 @@ export async function resolveRunConfig(projectDir, workflowId) {
     nodes: wf.nodes && typeof wf.nodes === 'object' ? wf.nodes : {},
     feedbacks: wf.feedbacks && typeof wf.feedbacks === 'object' ? wf.feedbacks : {},
   };
+}
+
+// ── global catalog removal (design §4.5) ──────────────────────────────────────
+// Removing a GLOBAL entry can dangle refs in EVERY project, unlike
+// removeCustomModel's single-project scope. Two carve-outs keep refs that stay
+// resolvable: (1) removing a predefined SHADOW merely reverts to the built-in
+// entry, so nothing dangles; (2) a project whose legacy customModels carries
+// the same id keeps its refs — the id still resolves there (composeCatalog
+// ranks the legacy entry back in once the global one is gone).
+
+/** All project_config rows with parsed steps/customModels (raw, all projects). */
+function allProjectConfigRows() {
+  getDb();
+  return prepare('SELECT project_key, steps, custom_models FROM project_config').all().map((r) => ({
+    projectKey: r.project_key,
+    steps: sanitizeSteps(parseJson(r.steps, {})),
+    customModels: sanitizeCustom(parseJson(r.custom_models, [])),
+  }));
+}
+
+/**
+ * Preview what removing a global catalog entry would clear, for the UI's
+ * confirmation dialog. `predefinedShadow: true` means the removal only reverts
+ * an override and clears nothing. Synchronous; never throws.
+ * @param {string} id
+ * @returns {{predefinedShadow: boolean,
+ *            steps: Array<{projectKey:string, step:string}>,
+ *            nodes: Array<{projectKey:string, workflowId:string, nodeId:string}>}}
+ */
+export function globalModelRefs(id) {
+  const lc = (typeof id === 'string' ? id : '').trim().toLowerCase();
+  if (PREDEFINED_MODELS.some((m) => m.id.toLowerCase() === lc)) {
+    return { predefinedShadow: true, steps: [], nodes: [] };
+  }
+  const rows = allProjectConfigRows();
+  const keep = new Set(rows
+    .filter((r) => r.customModels.some((m) => m.id.toLowerCase() === lc))
+    .map((r) => r.projectKey));
+  const steps = [];
+  for (const r of rows) {
+    if (keep.has(r.projectKey)) continue;
+    for (const [step, v] of Object.entries(r.steps)) {
+      if (v?.model && v.model.toLowerCase() === lc) steps.push({ projectKey: r.projectKey, step });
+    }
+  }
+  const nodes = prepare(
+    'SELECT project_key, workflow_id, node_id FROM config_workflow_nodes WHERE model = ? COLLATE NOCASE'
+  ).all(lc)
+    .filter((r) => !keep.has(r.project_key))
+    .map((r) => ({ projectKey: r.project_key, workflowId: r.workflow_id, nodeId: r.node_id }));
+  return { predefinedShadow: false, steps, nodes };
+}
+
+/**
+ * Remove a global catalog entry AND every ref it would dangle (per-node rows
+ * and legacy step selections, across all projects, minus the carve-outs
+ * above). Ref purge and settings removal are not one transaction — a purge
+ * that lands without the removal (or vice versa on a crash) is harmless, since
+ * refs can be re-set and purging is idempotent.
+ * @param {string} id
+ * @returns {Promise<{clearedSteps:number, clearedNodes:number, predefinedShadow:boolean}>}
+ * @throws {Error} on an unknown id (from removeGlobalModel)
+ */
+export async function removeGlobalModelAndRefs(id) {
+  const target = (typeof id === 'string' ? id : '').trim();
+  if (!listGlobalModels().some((m) => m.id.toLowerCase() === target.toLowerCase())) {
+    // Guard BEFORE the purge: an unknown id must throw without touching refs
+    // (they may belong to a legacy per-project model with the same string).
+    throw new Error(`unknown model id ${JSON.stringify(target)}`);
+  }
+  const refs = globalModelRefs(id);
+  let clearedSteps = 0;
+  let clearedNodes = 0;
+  if (!refs.predefinedShadow && (refs.steps.length || refs.nodes.length)) {
+    const lc = String(id).trim().toLowerCase();
+    const rows = allProjectConfigRows();
+    const stepKeysByProject = new Map(refs.steps.map((s) => [s.projectKey, true]));
+    tx(() => {
+      for (const r of rows) {
+        if (!stepKeysByProject.has(r.projectKey)) continue;
+        const filtered = {};
+        for (const [k, v] of Object.entries(r.steps)) {
+          if (v?.model && v.model.toLowerCase() === lc) { clearedSteps += 1; continue; }
+          filtered[k] = v;
+        }
+        prepare('UPDATE project_config SET steps = ? WHERE project_key = ?')
+          .run(JSON.stringify(filtered), r.projectKey);
+      }
+      for (const n of refs.nodes) {
+        clearedNodes += prepare(
+          'DELETE FROM config_workflow_nodes WHERE project_key = ? AND workflow_id = ? AND node_id = ?'
+        ).run(n.projectKey, n.workflowId, n.nodeId).changes;
+      }
+    });
+  }
+  await removeGlobalModel(id); // throws on unknown id — AFTER the idempotent purge
+  return { clearedSteps, clearedNodes, predefinedShadow: refs.predefinedShadow };
 }

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -175,19 +175,23 @@ export async function readConfig(projectDir) {
 function composeCatalog(projectCustom = []) {
   const globals = listGlobalModels();
   const globalByIdLc = new Map(globals.map((m) => [m.id.toLowerCase(), m]));
+  const flagged = costUnreliableModelIds();
   const out = [];
   const seen = new Set();
+  const unreliable = (lc) => (flagged.has(lc) ? { costUnreliable: true } : {});
   for (const m of PREDEFINED_MODELS) {
-    const shadow = globalByIdLc.get(m.id.toLowerCase());
+    const lc = m.id.toLowerCase();
+    const shadow = globalByIdLc.get(lc);
     out.push(shadow
-      ? { id: m.id, label: shadow.label, efforts: [...shadow.efforts], custom: 'global', hasEnv: !!shadow.env }
+      ? { id: m.id, label: shadow.label, efforts: [...shadow.efforts], custom: 'global', hasEnv: !!shadow.env, ...unreliable(lc) }
       : { ...m, custom: false, hasEnv: false });
-    seen.add(m.id.toLowerCase());
+    seen.add(lc);
   }
   for (const m of globals) {
-    if (seen.has(m.id.toLowerCase())) continue; // predefined shadow, already emitted
-    seen.add(m.id.toLowerCase());
-    out.push({ id: m.id, label: m.label, efforts: [...m.efforts], custom: 'global', hasEnv: !!m.env });
+    const lc = m.id.toLowerCase();
+    if (seen.has(lc)) continue; // predefined shadow, already emitted
+    seen.add(lc);
+    out.push({ id: m.id, label: m.label, efforts: [...m.efforts], custom: 'global', hasEnv: !!m.env, ...unreliable(lc) });
   }
   for (const m of projectCustom) {
     if (seen.has(m.id.toLowerCase())) continue; // predefined/global wins
@@ -195,6 +199,67 @@ function composeCatalog(projectCustom = []) {
     out.push({ id: m.id, label: m.label, efforts: [...EFFORTS], custom: 'project', hasEnv: false });
   }
   return out;
+}
+
+// ── cost-reliability observations (design §4.6) ───────────────────────────────
+// DERIVED state in the central DB (model_cost_flags): an env-routed endpoint
+// that reports no cost while consuming tokens gets flagged; a later positive-
+// cost run of the same model auto-clears it. Never assumed from config alone —
+// a proxy that reports real costs is never badged.
+
+/** Whether the model's GLOBAL entry declares an ANTHROPIC_BASE_URL override
+ *  (directly or as a ${VAR} ref — key presence is the signal). Only such
+ *  models are ever observed; the direct Anthropic path is never flagged. */
+export function modelHasBaseUrlRouting(modelId) {
+  const id = typeof modelId === 'string' ? modelId.trim() : '';
+  if (!id) return false;
+  const entry = listGlobalModels().find((m) => m.id.toLowerCase() === id.toLowerCase());
+  return !!(entry && entry.env && 'ANTHROPIC_BASE_URL' in entry.env);
+}
+
+/** Lowercased ids currently flagged cost-unreliable. Never throws ({} on any
+ *  DB trouble) — reads feed catalog composition, which must never fail. */
+export function costUnreliableModelIds() {
+  try {
+    getDb();
+    return new Set(prepare('SELECT model_id FROM model_cost_flags').all()
+      .map((r) => String(r.model_id).toLowerCase()));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Evaluate one terminal result event for cost reliability (design §4.6).
+ * Applies ONLY to models with base-URL routing; the caller must already have
+ * excluded mock runs. `usage` is the raw result event's usage object.
+ * @param {string} modelId
+ * @param {number|null} costUsd  the reported cost (null when absent)
+ * @param {object} [usage]
+ * @returns {'flagged'|'cleared'|null} what changed — 'flagged' asks the caller
+ *   to surface its one-per-run warning; null = no observation recorded
+ */
+export function observeModelCost(modelId, costUsd, usage) {
+  if (!modelHasBaseUrlRouting(modelId)) return null;
+  const u = usage && typeof usage === 'object' ? usage : {};
+  const tokens = ['input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens']
+    .reduce((n, k) => n + (Number(u[k]) || 0), 0);
+  const id = String(modelId).trim();
+  getDb();
+  if (Number.isFinite(costUsd) && costUsd > 0) {
+    // Positive cost = the endpoint reports real spend — auto-clear.
+    const cleared = prepare('DELETE FROM model_cost_flags WHERE model_id = ?').run(id).changes > 0;
+    return cleared ? 'cleared' : null;
+  }
+  if (tokens > 0) {
+    // Tokens consumed, cost absent/zero — the USD budget cannot see this spend.
+    prepare(`
+      INSERT INTO model_cost_flags (model_id, flagged_at) VALUES (?, ?)
+      ON CONFLICT(model_id) DO NOTHING
+    `).run(id, new Date().toISOString());
+    return 'flagged';
+  }
+  return null; // no cost AND no tokens (e.g. an errored run) — no signal either way
 }
 
 /**

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -204,6 +204,7 @@ function composeCatalog(projectCustom = []) {
  * raw id); global entries advertise their configured subset.
  */
 export async function listModels(projectDir) {
+  if (!projectDir) return composeCatalog([]); // project-less: predefined ⊕ global only
   const { customModels } = readRaw(projectDir);
   return composeCatalog(customModels);
 }

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -15,6 +15,7 @@
 import { getDb, prepare, tx } from './db.mjs';
 import { projectKey } from './store.mjs';
 import { loadAgentRegistry, registryToSteps } from './agent-registry.mjs';
+import { EFFORTS } from './model-env.mjs';
 
 /**
  * Recompute the agent step list FRESH from the layered registry (repo agents/ +
@@ -36,8 +37,10 @@ export const AGENT_STEPS = agentSteps();
 /** Live key set (recomputed per call so runtime-added user agents validate). */
 const stepKeys = () => new Set(agentSteps().map((s) => s.key));
 
-/** All effort levels the UI can offer (ordering is not a ranking). */
-export const EFFORTS = ['medium', 'high', 'xhigh', 'max'];
+/** All effort levels the UI can offer (ordering is not a ranking). Canonical
+ *  home is model-env.mjs (so settings.mjs can validate catalog entries without
+ *  importing the core graph); re-exported here for import-compat. */
+export { EFFORTS };
 
 /**
  * Built-in models. `efforts` is the subset of EFFORTS each model supports.

--- a/src/core/db.mjs
+++ b/src/core/db.mjs
@@ -51,7 +51,7 @@ const OPEN_RETRY_LIMIT = 100;
 const OPEN_BACKOFF_MS = 15;
 
 /** Latest schema version. Bump + append a new migration step when the DDL grows. */
-const SCHEMA_VERSION = 16;
+const SCHEMA_VERSION = 17;
 
 /** Absolute path to the database file: <worcaHome>/worca-cc.db. */
 export function dbPath() {
@@ -537,6 +537,18 @@ CREATE TABLE IF NOT EXISTS cost_ledger (
 CREATE INDEX IF NOT EXISTS idx_cost_ledger_ts ON cost_ledger (ts);
 `;
 
+/** v17: per-model cost-reliability observations (configurable-models-design.md
+ *  §4.6). DERIVED state, not user config (which is why it lives here and not in
+ *  settings.json): a row means an env-routed model reported no/zero cost while
+ *  consuming tokens; the row is deleted when a later run reports a positive
+ *  cost. COLLATE NOCASE mirrors the catalog's case-insensitive id semantics. */
+const MODEL_COST_FLAGS_DDL = `
+CREATE TABLE IF NOT EXISTS model_cost_flags (
+  model_id   TEXT PRIMARY KEY COLLATE NOCASE,
+  flagged_at TEXT NOT NULL
+);
+`;
+
 const SCHEMA_V11 = `
 ALTER TABLE config_workflow_nodes ADD COLUMN ask_questions INTEGER;
 ${STEP_QUESTIONS_DDL}
@@ -589,11 +601,15 @@ function schemaGaps(db) {
   const hasCostLedger = db.prepare(
     "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='cost_ledger'"
   ).get().n > 0;
+  const hasModelCostFlags = db.prepare(
+    "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='model_cost_flags'"
+  ).get().n > 0;
   return {
     columns: missing,
     stepQuestionsTable: !hasStepQuestions,
     guardrailSetsTable: !hasGuardrailSets,
     costLedgerTable: !hasCostLedger,
+    modelCostFlagsTable: !hasModelCostFlags,
   };
 }
 
@@ -606,6 +622,7 @@ function repairSchemaGaps(db, gaps) {
   if (gaps.stepQuestionsTable) db.exec(STEP_QUESTIONS_DDL);
   if (gaps.guardrailSetsTable) db.exec(GUARDRAIL_SETS_DDL);
   if (gaps.costLedgerTable) db.exec(COST_LEDGER_DDL);
+  if (gaps.modelCostFlagsTable) db.exec(MODEL_COST_FLAGS_DDL);
 }
 
 /**
@@ -622,7 +639,7 @@ function repairSchemaGaps(db, gaps) {
 function reconcileSchema(db) {
   const gaps = schemaGaps(db);
   if (gaps.columns.length === 0 && !gaps.stepQuestionsTable && !gaps.guardrailSetsTable
-      && !gaps.costLedgerTable) return; // clean — no lock
+      && !gaps.costLedgerTable && !gaps.modelCostFlagsTable) return; // clean — no lock
   db.exec('BEGIN IMMEDIATE');
   try {
     repairSchemaGaps(db, schemaGaps(db)); // re-probe under the lock: race-safe
@@ -773,6 +790,7 @@ export function migrate(db) {
     if (current < 14) applySchemaV14(db);
     if (current < 15) applySchemaV15(db);
     if (current < 16) applySchemaV16(db);
+    if (current < 17) db.exec(MODEL_COST_FLAGS_DDL); // IF NOT EXISTS — reconcile-safe
     db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`);
     db.exec('COMMIT');
   } catch (err) {

--- a/src/core/model-env.mjs
+++ b/src/core/model-env.mjs
@@ -1,0 +1,74 @@
+// src/core/model-env.mjs
+// Shared, dependency-free definitions for configurable models
+// (configurable-models-design.md §4.1/§4.4): the effort vocabulary, the
+// reserved-key policy for per-model routing env, whole-value ${VAR}
+// indirection, and the defensive spawn-time filter.
+//
+// This module imports NOTHING. settings.mjs — whose import contract forbids
+// core-graph modules (it would cycle via projects.mjs) — validates catalog
+// writes against this policy, and claude-runner.mjs applies the same policy
+// defensively at spawn time. Keeping the single source of truth in a
+// zero-import leaf lets both sides share it without bending either module's
+// import contract; that is why the constant does NOT live next to
+// SPAWN_ENV_BASE in claude-runner.mjs.
+
+/** Reasoning-effort vocabulary. Canonical home is HERE (not config.mjs, which
+ *  re-exports it) so settings.mjs can validate a catalog entry's `efforts`
+ *  without importing the core graph. */
+export const EFFORTS = ['medium', 'high', 'xhigh', 'max'];
+
+// Env keys a model entry may NOT set (§4.4): process fundamentals and worca's
+// own runtime knobs, any of which injection could otherwise subvert (mock
+// mode, the claude binary path, the effort flag name). Everything else —
+// including all ANTHROPIC_* / CLAUDE_* — is allowed: routing them is the
+// point. CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is the CLI-2.1.220 permission-mode
+// landmine documented at claude-runner.mjs#buildSpawnEnv.
+export const RESERVED_MODEL_ENV_KEYS = [
+  'PATH', 'HOME', 'TMPDIR', 'SHELL', 'USER', 'LOGNAME', 'TERM',
+  'NODE_OPTIONS', 'NODE_EXTRA_CA_CERTS',
+  'CLAUDECODE', 'CLAUDE_CODE_SUBPROCESS_ENV_SCRUB',
+];
+export const RESERVED_MODEL_ENV_PREFIXES = ['WORCA_'];
+
+/** Whether a model-env key is reserved (exact match or reserved prefix). */
+export function isReservedModelEnvKey(key) {
+  return RESERVED_MODEL_ENV_KEYS.includes(key)
+    || RESERVED_MODEL_ENV_PREFIXES.some((p) => typeof key === 'string' && key.startsWith(p));
+}
+
+// Whole-value indirection only (§4.1): `${VARNAME}` and nothing else. Embedded
+// refs ("prefix-${X}") are deliberately literals — no templating language.
+const ENV_REF_RE = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
+
+/** The var name a whole-value `${VARNAME}` env value points at, or null for a literal. */
+export function modelEnvRef(value) {
+  const m = typeof value === 'string' ? value.match(ENV_REF_RE) : null;
+  return m ? m[1] : null;
+}
+
+/**
+ * Defensive spawn-time pass over a model entry's env (§4.4): drops reserved
+ * keys and non-string values, and expands whole-value ${VAR} refs from
+ * `sourceEnv` (an unset or empty var drops the key). Write-time validation
+ * already rejects reserved keys, so a drop here means a hand-edited settings
+ * file — the caller owns warning about `dropped`.
+ * @param {Record<string,*>|undefined} modelEnv
+ * @param {Record<string,string|undefined>} [sourceEnv]
+ * @returns {{env: Record<string,string>, dropped: string[]}}
+ */
+export function prepareModelEnv(modelEnv, sourceEnv = process.env) {
+  const env = {};
+  const dropped = [];
+  for (const [k, v] of Object.entries(modelEnv || {})) {
+    if (isReservedModelEnvKey(k) || typeof v !== 'string') { dropped.push(k); continue; }
+    const ref = modelEnvRef(v);
+    if (ref !== null) {
+      const resolved = sourceEnv ? sourceEnv[ref] : undefined;
+      if (resolved === undefined || resolved === '') { dropped.push(k); continue; }
+      env[k] = resolved;
+    } else {
+      env[k] = v;
+    }
+  }
+  return { env, dropped };
+}

--- a/src/core/orchestrator.mjs
+++ b/src/core/orchestrator.mjs
@@ -2851,6 +2851,15 @@ class Orchestrator extends EventEmitter {
     // model (parity with worca's `[init] model=<model>`) instead of dropping it.
     if (e.raw && e.raw.type === 'system' && e.raw.subtype === 'init') {
       this._log(source, 'debug', `[init] model=${e.raw.model || '?'}`, logAttr);
+      // §4.7: stamp the session's ACTUAL model on the step (mirrors the
+      // sessionId stamp above) so the UI can resolve the "default" caption to
+      // a concrete name. Display-only; sub-agent events never carry init.
+      const step = !sub && e.raw.model && attr?.stepKey
+        ? this.state.steps.find((s) => s.key === attr.stepKey) : null;
+      if (step && step.modelUsed !== e.raw.model) {
+        step.modelUsed = e.raw.model;
+        this._persist().catch(() => {});
+      }
     }
 
     // Concrete tool calls the agent made this turn (assistant.tool_use blocks).

--- a/src/core/orchestrator.mjs
+++ b/src/core/orchestrator.mjs
@@ -70,7 +70,7 @@ import {
   probeClaudeCapabilities,
 } from './preflight.mjs';
 import { fanoutCap, mapWithCap } from './fanout.mjs';
-import { resolveStepModels } from './config.mjs';
+import { resolveStepModels, observeModelCost } from './config.mjs';
 import { readGuardrailSet } from './guardrail-store.mjs';
 import { unionGuardrails, guardrailsToPermissionRules, mergePermissionRules } from './guardrails.mjs';
 import { hasBlocking, blockingIssues, readQuestionsFile } from './protocol.mjs';
@@ -2689,7 +2689,9 @@ class Orchestrator extends EventEmitter {
       cycle,
       isEntry: stepIndex === 0,
       extras: this.extrasFiles || [],
-      onEvent: (e) => this._onAgentEvent(node.key, e, { nodeId: node.nodeId, stepIndex, cycle, stepKey, uiPhase: node.uiPhase || node.key }),
+      // `model` rides along so the result-event handler can attribute cost
+      // reliability (§4.6) to the DISPATCHED model without re-resolving it.
+      onEvent: (e) => this._onAgentEvent(node.key, e, { nodeId: node.nodeId, stepIndex, cycle, stepKey, uiPhase: node.uiPhase || node.key, model: node.model || this.claude.model }),
       claudeOpts: {
         bin: this.claude.bin,
         permissionMode: this.claude.permissionMode,
@@ -2789,6 +2791,22 @@ class Orchestrator extends EventEmitter {
     if (Number.isFinite(cost)) this._recordCost(cost, attr?.stepKey);
     else if (e.raw && e.raw.type === 'result' && !this.claude.mock) {
       this._log('orchestrator', 'warn', 'result event carried no cost estimate (total_cost_usd absent)', attr);
+    }
+
+    // §4.6 cost-reliability observation: only terminal result events of REAL
+    // runs, only for the dispatched model (attr.model — the legacy role path
+    // carries no attr and is skipped), and only env-routed models inside
+    // observeModelCost. One warning per model per run; the observation itself
+    // is derived state and must never fail the run.
+    if (e.raw && e.raw.type === 'result' && !this.claude.mock && attr?.model) {
+      try {
+        const verdict = observeModelCost(attr.model, Number.isFinite(cost) ? cost : null, e.raw.usage);
+        if (verdict === 'flagged' && !(this._costUnreliableWarned ||= new Set()).has(attr.model)) {
+          this._costUnreliableWarned.add(attr.model);
+          this._log('orchestrator', 'warn',
+            `model "${attr.model}" reported no cost despite token usage (custom endpoint) — USD budget enforcement cannot see this spend`, attr);
+        }
+      } catch { /* derived state — never fail the run over it */ }
     }
 
     // Sub-agent attribution. A child (Task/Agent) event carries parent_tool_use_id

--- a/src/core/overview-agent.mjs
+++ b/src/core/overview-agent.mjs
@@ -6,6 +6,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { runClaude } from './claude-runner.mjs';
+import { resolveModelEnv } from './config.mjs';
 import { safeParseJson } from './protocol.mjs';
 import {
   lookupPipelineRow, runDirForRow, upsertSubAgent, readPipelineExtras,
@@ -100,6 +101,7 @@ export async function generateOverview(key, id, { model, signal, force = false, 
     prompt,
     allowedTools: [],                 // pure reasoning over the prompt; no tools needed
     model,
+    modelEnv: resolveModelEnv(model), // catalog routing env travels with the id (design §4.8)
     signal,
     onEvent: (e) => { if (e.costUsd != null) costUsd = e.costUsd; },
   });

--- a/src/core/phases.mjs
+++ b/src/core/phases.mjs
@@ -14,6 +14,7 @@
 // prompt so the system prompt is never empty. Interface is locked by docs/ARCHITECTURE.md §3.5.
 
 import { runClaude } from './claude-runner.mjs';
+import { resolveModelEnv } from './config.mjs';
 import { readClarify, readReview } from './protocol.mjs';
 import { writeClarify, readClarifyRow } from './artifacts.mjs';
 import { renderAttachmentsBlock } from './channels.mjs';
@@ -420,6 +421,12 @@ function runOpts(ctx, { role, prompt, systemPrompt, allowedTools }) {
     permissionMode: c.permissionMode || 'acceptEdits',
     model: c.model,
     effort: c.effort,          // per-role effort from the orchestrator
+    // Per-model routing env (design §4.4), resolved HERE — the one funnel every
+    // dispatched node/role passes through — so _phaseCtx/_nodeCtx and the
+    // workspace-scan path all inherit it without per-caller edits. undefined
+    // when the model carries no env (or no model is set), keeping the spawn
+    // env byte-identical.
+    modelEnv: resolveModelEnv(c.model),
     // Guardrails: worca policy + lifted repo deny rules as {deny,...} rules ->
     // ONE --settings payload; envScrub/envAllowlist -> spawn env. All undefined
     // when the project has no guardrails, so the argv and env stay byte-identical

--- a/src/core/plugin-manifest.mjs
+++ b/src/core/plugin-manifest.mjs
@@ -6,6 +6,7 @@
 import { readFileSync, readdirSync, readlinkSync, existsSync } from 'node:fs';
 import { join, resolve, dirname, sep, isAbsolute } from 'node:path';
 import { WORCA_PLUGIN_API } from './plugin-api.mjs';
+import { EFFORTS, isReservedModelEnvKey } from './model-env.mjs';
 
 /** Plugin names are kebab-case, machine-unique, dir-name safe (spec §4.1). */
 export const PLUGIN_NAME_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
@@ -15,10 +16,15 @@ const KEY_RE = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 const SOURCE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 const FIELD_TYPES = new Set(['text', 'select']);
 const INPUT_TYPES = new Set(['text', 'select', 'remote-select', 'task-browser']);
-const KNOWN_TOP = new Set(['name', 'version', 'description', 'author', 'homepage', 'license', 'engines', 'taskSources', 'setup']);
+const KNOWN_TOP = new Set(['name', 'version', 'description', 'author', 'homepage', 'license', 'engines', 'taskSources', 'setup', 'models', 'modelSecrets']);
 const KNOWN_SOURCE = new Set(['id', 'displayName', 'module', 'configSchema', 'inputs']);
 const KNOWN_FIELD = new Set(['key', 'type', 'label', 'secret', 'required', 'default', 'help', 'options']);
 const KNOWN_INPUT = new Set(['key', 'type', 'label', 'default', 'optionsFrom', 'options']);
+const KNOWN_MODEL = new Set(['id', 'label', 'efforts', 'env']);
+const KNOWN_MODEL_SECRET = new Set(['key', 'label']);
+/** A manifest env value that defers to the plugin's secrets store (design §9.1). */
+const isSecretRef = (v) => !!v && typeof v === 'object' && !Array.isArray(v)
+  && typeof v.secret === 'string' && Object.keys(v).length === 1;
 
 /**
  * Tiny '>=N <M' / '>=N' / exact 'N' range check against the integer host API.
@@ -170,6 +176,78 @@ export function normalizeManifest(raw, { dir = '' } = {}) {
     errors.push(`${where}: duplicate taskSources id "${dup}"`);
   }
 
+  // models + modelSecrets (design §9.1). Manifest-only contribution: no files
+  // to check, so ALL validation lives here. Write-time env rules mirror the
+  // global-catalog setters (settings.mjs assertEnvPairs): reserved keys are a
+  // hard error — the spawn-time prepareModelEnv drop stays as the second gate.
+  const secretsRaw = raw.modelSecrets ?? [];
+  const modelSecrets = [];
+  if (!Array.isArray(secretsRaw)) {
+    errors.push(`${where}: "modelSecrets" must be an array`);
+  } else {
+    secretsRaw.forEach((f, i) => {
+      const at = `${where}: modelSecrets[${i}]`;
+      if (!f || typeof f !== 'object') { errors.push(`${at} must be an object`); return; }
+      collectUnknown(f, KNOWN_MODEL_SECRET, at, warnings);
+      const key = str(f.key);
+      if (!KEY_RE.test(key)) { errors.push(`${at}: "key" must be an identifier, got "${key}"`); return; }
+      modelSecrets.push({ key, label: str(f.label) || key });
+    });
+    const skeys = modelSecrets.map((f) => f.key);
+    for (const dup of new Set(skeys.filter((v, i) => skeys.indexOf(v) !== i))) {
+      errors.push(`${where}: duplicate modelSecrets key "${dup}"`);
+    }
+  }
+  const secretKeys = new Set(modelSecrets.map((f) => f.key));
+
+  const modelsRaw = raw.models ?? [];
+  const models = [];
+  if (!Array.isArray(modelsRaw)) {
+    errors.push(`${where}: "models" must be an array`);
+  } else {
+    modelsRaw.forEach((m, i) => {
+      const at = `${where}: models[${i}]`;
+      if (!m || typeof m !== 'object') { errors.push(`${at} must be an object`); return; }
+      collectUnknown(m, KNOWN_MODEL, at, warnings);
+      const id = str(m.id);
+      if (!id) { errors.push(`${at}: "id" is required`); return; }
+      const efforts = [];
+      if (m.efforts !== undefined) {
+        if (!Array.isArray(m.efforts)) { errors.push(`${at} ("${id}"): "efforts" must be an array`); return; }
+        for (const e of m.efforts) {
+          if (!EFFORTS.includes(e)) { errors.push(`${at} ("${id}"): unknown effort ${JSON.stringify(e)} — must be one of ${EFFORTS.join(' | ')}`); return; }
+        }
+        efforts.push(...EFFORTS.filter((e) => m.efforts.includes(e))); // canonical order, deduped
+      }
+      const env = {};
+      const envRaw = m.env && typeof m.env === 'object' && !Array.isArray(m.env) ? m.env : {};
+      if (m.env !== undefined && (typeof m.env !== 'object' || Array.isArray(m.env))) {
+        errors.push(`${at} ("${id}"): "env" must be an object`);
+        return;
+      }
+      for (const [k, v] of Object.entries(envRaw)) {
+        if (isReservedModelEnvKey(k)) { errors.push(`${at} ("${id}"): env key ${JSON.stringify(k)} is reserved and cannot be set on a model`); continue; }
+        if (isSecretRef(v)) {
+          if (!secretKeys.has(v.secret)) { errors.push(`${at} ("${id}"): env ${k} references undeclared modelSecrets key ${JSON.stringify(v.secret)}`); continue; }
+          env[k] = { secret: v.secret };
+        } else if (typeof v === 'string' && v) {
+          env[k] = v;
+        } else {
+          errors.push(`${at} ("${id}"): env value for ${JSON.stringify(k)} must be a non-empty string or {"secret": "<key>"}`);
+        }
+      }
+      models.push({
+        id, label: str(m.label) || id,
+        efforts: efforts.length ? efforts : [...EFFORTS],
+        ...(Object.keys(env).length ? { env } : {}),
+      });
+    });
+    const mids = models.map((m) => m.id.toLowerCase());
+    for (const dup of new Set(mids.filter((v, i) => mids.indexOf(v) !== i))) {
+      errors.push(`${where}: duplicate models id "${dup}" (ids are case-insensitive)`);
+    }
+  }
+
   if (errors.length) return { ok: false, errors };
   return {
     ok: true,
@@ -178,7 +256,7 @@ export function normalizeManifest(raw, { dir = '' } = {}) {
       name, version,
       description: str(raw.description), author: str(raw.author),
       homepage: str(raw.homepage), license: str(raw.license),
-      engines: { worcaApi }, setup, taskSources,
+      engines: { worcaApi }, setup, taskSources, models, modelSecrets,
     },
   };
 }

--- a/src/core/plugin-models.mjs
+++ b/src/core/plugin-models.mjs
@@ -1,0 +1,130 @@
+// src/core/plugin-models.mjs
+// Model contributions from installed plugins (configurable-models-design.md §9):
+// read `models` + `modelSecrets` out of every ENABLED plugin's current manifest,
+// dedupe cross-plugin id collisions deterministically, and resolve {secret}
+// placeholders through the existing per-plugin secrets store (plugin-config.mjs).
+// Reads never throw and are hermetic under node:test for free: readPluginsLock
+// resolves through worcaHome(), whose NODE_TEST_CONTEXT guard makes the lock
+// read return {} unless the test sandboxes WORCA_HOME itself.
+//
+// Import graph: plugins-lock + plugin-manifest + plugin-config only — config.mjs
+// imports THIS module (never the reverse), and plugin-store.mjs may import
+// config.mjs, so nothing here may import either of them.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { readPluginsLock, pluginCurrentDir } from './plugins-lock.mjs';
+import { normalizeManifest } from './plugin-manifest.mjs';
+import { readPluginConfig, redactedConfig } from './plugin-config.mjs';
+
+/** Normalized manifest of an installed plugin's current/, or null. Never throws. */
+function manifestAt(name) {
+  try {
+    const raw = JSON.parse(readFileSync(join(pluginCurrentDir(name), 'worca-cc-plugin.json'), 'utf8'));
+    const res = normalizeManifest(raw, { dir: pluginCurrentDir(name) });
+    return res.ok ? res.manifest : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * RAW model contributions of every enabled plugin, alphabetical by plugin name,
+ * models in manifest order: [{plugin, id, label, efforts, env?, secrets:[key]}].
+ * `secrets` lists the modelSecrets keys this model's env references. No
+ * cross-plugin dedupe here — that is listPluginModels' job; the uninstall
+ * guard needs the raw view to compute its carve-outs. Never throws.
+ */
+export function allPluginModels() {
+  const lock = readPluginsLock();
+  const out = [];
+  for (const name of Object.keys(lock).sort()) {
+    if (!lock[name] || lock[name].enabled === false) continue;
+    const manifest = manifestAt(name);
+    if (!manifest) continue;
+    for (const m of manifest.models) {
+      const secrets = Object.values(m.env ?? {})
+        .filter((v) => v && typeof v === 'object')
+        .map((v) => v.secret);
+      out.push({
+        plugin: name, id: m.id, label: m.label, efforts: [...m.efforts],
+        ...(m.env ? { env: m.env } : {}),
+        secrets: [...new Set(secrets)],
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * The EFFECTIVE plugin model layer: allPluginModels with cross-plugin id
+ * collisions resolved — alphabetical plugin-name order wins deterministically,
+ * losers dropped with a warning (design §9.2). Never throws.
+ */
+export function listPluginModels() {
+  const out = [];
+  const seen = new Map(); // lc id -> winning plugin
+  for (const m of allPluginModels()) {
+    const lc = m.id.toLowerCase();
+    const winner = seen.get(lc);
+    if (winner) {
+      console.warn(`[worca] plugin "${m.plugin}": model id ${JSON.stringify(m.id)} already provided by plugin "${winner}" — dropped`);
+      continue;
+    }
+    seen.set(lc, m.plugin);
+    out.push(m);
+  }
+  return out;
+}
+
+/** modelSecrets of a plugin as a plugin-config schema (all secret text fields). */
+export function modelSecretsSchema(name) {
+  const manifest = manifestAt(name);
+  return (manifest?.modelSecrets ?? []).map((f) => ({
+    key: f.key, type: 'text', label: f.label,
+    secret: true, required: false, default: null, help: null, options: [],
+  }));
+}
+
+/** Set-ness of a plugin's modelSecrets, values never included:
+ *  [{key, label, set}]. Never throws. */
+export function pluginModelSecretStatus(name) {
+  const schema = modelSecretsSchema(name);
+  if (!schema.length) return [];
+  try {
+    const red = redactedConfig(name, schema);
+    return schema.map((f) => ({ key: f.key, label: f.label, set: red[f.key]?.set === true }));
+  } catch {
+    return schema.map((f) => ({ key: f.key, label: f.label, set: false }));
+  }
+}
+
+/**
+ * Flatten one plugin model's env to plain strings: literals and ${VAR} ref text
+ * pass through; {secret} placeholders resolve via the plugin's secrets store
+ * ({"$env":"VAR"} indirection honored there). Unresolvable secrets are dropped
+ * and reported — same degradation as an unresolvable ${VAR} ref downstream.
+ * @param {{plugin:string, env?:object}} model  an allPluginModels entry
+ * @returns {{env: Record<string,string>, droppedSecrets: string[]}}
+ */
+export function flattenPluginModelEnv(model) {
+  const env = {};
+  const droppedSecrets = [];
+  const entries = Object.entries(model?.env ?? {});
+  if (!entries.length) return { env, droppedSecrets };
+  let secrets = {};
+  const schema = modelSecretsSchema(model.plugin);
+  if (schema.length) {
+    try { secrets = readPluginConfig(model.plugin, schema); } catch { secrets = {}; }
+  }
+  for (const [k, v] of entries) {
+    if (typeof v === 'string') {
+      env[k] = v;
+    } else {
+      const resolved = secrets[v.secret];
+      if (typeof resolved === 'string' && resolved) env[k] = resolved;
+      else droppedSecrets.push(`${k} (secret "${v.secret}")`);
+    }
+  }
+  return { env, droppedSecrets };
+}

--- a/src/core/plugin-repo.mjs
+++ b/src/core/plugin-repo.mjs
@@ -88,6 +88,14 @@ function manifestSecretKeys(manifest) {
     (s.configSchema || []).filter((f) => f && f.secret === true).map((f) => `${s.id}.${f.key}`));
 }
 
+/** Normalized models/modelSecrets view of a RAW manifest ({} on any failure —
+ *  a manifest invalid to THIS host contributes no models here either). */
+function manifestModels(raw) {
+  if (!raw) return { models: [], modelSecrets: [] };
+  const r = normalizeManifest(raw);
+  return r.ok ? { models: r.manifest.models, modelSecrets: r.manifest.modelSecrets } : { models: [], modelSecrets: [] };
+}
+
 async function showManifest(cache, sha, subdir, exec) {
   const p = subdir ? `${subdir}/worca-cc-plugin.json` : 'worca-cc-plugin.json';
   try { return JSON.parse(await gitDir(cache, ['show', `${sha}:${p}`], exec)); } catch { return null; }
@@ -113,11 +121,26 @@ async function computeManifestDelta(cache, entry, pinnedSha, candidateSha, exec)
       .filter((l) => l.startsWith('A') && l.endsWith('.meta.json'))
       .map((l) => l.split('\t').pop().split('/').pop().replace(/\.meta\.json$/, ''));
   } catch { newAgents = []; }
+  // Model delta (design §9.4): env changes — a base-URL swap redirects ALL API
+  // traffic for that model — are the red-highlight review inputs.
+  const pinM = manifestModels(pin);
+  const candM = manifestModels(cand);
+  const byLc = (list) => new Map(list.map((m) => [m.id.toLowerCase(), m]));
+  const pinModels = byLc(pinM.models);
+  const candModels = byLc(candM.models);
+  const envOf = (m) => JSON.stringify(m.env ?? {});
   return {
     newSecrets: candSecrets.filter((k) => !pinSecrets.includes(k)),
     newTaskSources: candIds.filter((id) => !pinIds.includes(id)),
     newAgents,
     setupChanged: JSON.stringify(pin?.setup ?? null) !== JSON.stringify(cand?.setup ?? null),
+    newModels: [...candModels.values()].filter((m) => !pinModels.has(m.id.toLowerCase())).map((m) => m.id),
+    removedModels: [...pinModels.values()].filter((m) => !candModels.has(m.id.toLowerCase())).map((m) => m.id),
+    envChangedModels: [...candModels.values()]
+      .filter((m) => pinModels.has(m.id.toLowerCase()) && envOf(pinModels.get(m.id.toLowerCase())) !== envOf(m))
+      .map((m) => m.id),
+    newModelSecrets: candM.modelSecrets.map((f) => f.key)
+      .filter((k) => !pinM.modelSecrets.some((f) => f.key === k)),
   };
 }
 
@@ -136,7 +159,10 @@ export async function fetchCandidate(name, { exec = defaultExec, fullDiff = fals
   let commits = [];
   let diffstat = '';
   let diffFull = '';
-  let manifestDelta = { newSecrets: [], newTaskSources: [], newAgents: [], setupChanged: false };
+  let manifestDelta = {
+    newSecrets: [], newTaskSources: [], newAgents: [], setupChanged: false,
+    newModels: [], removedModels: [], envChangedModels: [], newModelSecrets: [],
+  };
   if (candidateSha !== pinnedSha) {
     const log = await gitDir(cache, ['log', '--format=%H%x09%s', `${pinnedSha}..${candidateSha}`], exec);
     commits = log.split('\n').filter(Boolean).map((l) => {

--- a/src/core/plugin-store.mjs
+++ b/src/core/plugin-store.mjs
@@ -22,6 +22,8 @@ import {
 } from './plugins-lock.mjs';
 import { addPluginRepo, fetchCandidate, exportVersion, repoCacheDir } from './plugin-repo.mjs';
 import { importPluginWorkflows, removePluginWorkflows, referencedPluginAgents } from './plugin-workflows.mjs';
+import { pluginModelSecretStatus } from './plugin-models.mjs';
+import { referencedPluginModels } from './config.mjs';
 
 const execFileP = promisify(execFile);
 const defaultExec = (cmd, args, opts = {}) =>
@@ -49,11 +51,14 @@ function frontmatterTools(text) {
   return line.replace(/^tools\s*:/, '').split(',').map((s) => s.trim()).filter(Boolean);
 }
 
-/** The "Will install" consent inventory (spec §6.1): agents + their frontmatter
- *  tools, sources + their secret fields, skills, workflows, npm dep count from
- *  the lockfile, and the exact setup commands that would run. */
+/** The "Will install" consent inventory (spec §6.1, design §9.4): agents +
+ *  their frontmatter tools, sources + their secret fields, models with their
+ *  base-URL value VERBATIM (a model env can redirect all API traffic — the
+ *  reviewer must see where) + requested model secrets, skills, workflows, npm
+ *  dep count from the lockfile, and the exact setup commands that would run. */
 export function buildInstallInventory(versionDir) {
-  const manifest = readManifestAt(versionDir) ?? { taskSources: [], setup: { node: false, python: null } };
+  const manifest = readManifestAt(versionDir)
+    ?? { taskSources: [], models: [], modelSecrets: [], setup: { node: false, python: null } };
   const agents = [];
   const aDir = join(versionDir, 'agents');
   if (existsSync(aDir)) {
@@ -68,6 +73,15 @@ export function buildInstallInventory(versionDir) {
     id: s.id, displayName: s.displayName,
     secrets: (s.configSchema || []).filter((x) => x.secret).map((x) => x.key),
   }));
+  const models = (manifest.models || []).map((m) => {
+    const bu = m.env?.ANTHROPIC_BASE_URL;
+    return {
+      id: m.id, label: m.label, efforts: m.efforts,
+      envKeys: Object.keys(m.env ?? {}),
+      baseUrl: typeof bu === 'string' ? bu : bu ? `(from secret "${bu.secret}")` : null,
+    };
+  });
+  const modelSecrets = (manifest.modelSecrets || []).map((f) => ({ key: f.key, label: f.label }));
   const skills = [];
   const sDir = join(versionDir, 'skills');
   if (existsSync(sDir)) {
@@ -88,7 +102,7 @@ export function buildInstallInventory(versionDir) {
   const setupCommands = [];
   if (manifest.setup?.node) setupCommands.push(`npm ci --prefix ${versionDir} --ignore-scripts --omit=dev`);
   if (manifest.setup?.python === 'pyproject') setupCommands.push(`uv sync --project ${versionDir}`);
-  return { agents, taskSources, skills: skills.sort(), workflows, depCount, setupCommands };
+  return { agents, taskSources, models, modelSecrets, skills: skills.sort(), workflows, depCount, setupCommands };
 }
 
 /** Declared setup FACTS only (spec §4.1): setup.node -> npm ci (lockfile
@@ -289,6 +303,18 @@ export async function uninstallPlugin(name, { purge = false } = {}) {
       { code: 'REFERENCED', references: refs },
     );
   }
+  // Block-with-list model guard (design §9.4): same code/payload contract as
+  // the agents guard above. Only ids that would actually stop resolving block —
+  // referencedPluginModels applies the shadow/other-plugin/legacy carve-outs.
+  const modelRefs = referencedPluginModels(name);
+  if (modelRefs.length) {
+    const lines = modelRefs.map((r) =>
+      `${r.id} (${r.nodes.length + r.steps.length} selection${r.nodes.length + r.steps.length === 1 ? '' : 's'})`);
+    throw Object.assign(
+      new Error(`plugin "${name}" models are still selected in pipeline configuration: ${lines.join(', ')} — clear those selections (or copy the model to your catalog) first`),
+      { code: 'REFERENCED', references: modelRefs },
+    );
+  }
   await removePluginWorkflows(name); // throws its ReferencedError with the referencing list
   rmSync(pluginCurrentDir(name), { force: true });
   rmSync(join(pluginDir(name), 'versions'), { recursive: true, force: true });
@@ -365,8 +391,8 @@ export function listInstalledPlugins() {
       linked: e.linked === true,
       broken: !manifest,
       contributions: inv
-        ? { agents: inv.agents.length, taskSources: inv.taskSources.length, skills: inv.skills.length, workflows: inv.workflows.length }
-        : { agents: 0, taskSources: 0, skills: 0, workflows: 0 },
+        ? { agents: inv.agents.length, taskSources: inv.taskSources.length, models: inv.models.length, skills: inv.skills.length, workflows: inv.workflows.length }
+        : { agents: 0, taskSources: 0, models: 0, skills: 0, workflows: 0 },
     };
   });
 }
@@ -401,6 +427,10 @@ export async function doctorPlugin(name) {
     c('uv', onPath, onPath ? 'uv on PATH' : 'uv not found on PATH (required by setup.python)');
   }
   if (entry.linked) c('linked', true, 'dev-linked plugin — pin/hash checks reduced');
+  for (const s of pluginModelSecretStatus(name)) {
+    c(`model-secret:${s.key}`, s.set,
+      s.set ? `"${s.label}" set` : `model secret "${s.key}" is not set — configure it under Model secrets`);
+  }
   if (manifest && (manifest.taskSources || []).length) {
     let shim = null;
     try { shim = await import('./plugin-shim.mjs'); } // Task 11 module — may not exist yet

--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -459,6 +459,12 @@ function sanitizeGlobalModel(raw) {
  * throws.
  */
 export function listGlobalModels() {
+  // Under the node:test runner the real ~/.worca-cc/settings.json must not
+  // leak models into tests (mirrors projects.mjs#worcaHome's guard): treat the
+  // catalog as EMPTY unless the test sandboxes HOME/USERPROFILE itself and
+  // says so via WORCA_TEST_ALLOW_HOME_FALLBACK. Reads never throw, so empty —
+  // not an error — is the degradation.
+  if (process.env.NODE_TEST_CONTEXT && !process.env.WORCA_TEST_ALLOW_HOME_FALLBACK) return [];
   const raw = readSettings().models;
   if (raw === undefined) return [];
   if (!Array.isArray(raw)) {
@@ -514,6 +520,17 @@ function assertEnvPairs(env, { allowNull = false } = {}) {
   return { ...env };
 }
 
+/** Catalog WRITES under node:test would hit the user's REAL settings.json —
+ *  throw unless the test sandboxes HOME and opts in (worcaHome-guard mirror). */
+function assertTestSettingsAccess() {
+  if (process.env.NODE_TEST_CONTEXT && !process.env.WORCA_TEST_ALLOW_HOME_FALLBACK) {
+    throw new Error(
+      'global model catalog write under the node:test runner — sandbox HOME/USERPROFILE ' +
+      'and set WORCA_TEST_ALLOW_HOME_FALLBACK=1 (tests must never touch the real ~/.worca-cc)'
+    );
+  }
+}
+
 /** The MINIMAL stored shape for validated parts (see section comment). */
 function storedModelShape(id, label, efforts, env) {
   return {
@@ -543,6 +560,7 @@ function rawModels(settings) {
  * @throws {Error} on invalid input or a case-insensitively duplicate id
  */
 export async function addGlobalModel({ id, label, efforts, env } = {}) {
+  assertTestSettingsAccess();
   const vid = assertModelId(id);
   if (!isClearInput(label) && typeof label !== 'string') throw new Error('label must be a string');
   const vefforts = assertEfforts(efforts);
@@ -565,6 +583,7 @@ export async function addGlobalModel({ id, label, efforts, env } = {}) {
  * @throws {Error} on an unknown id or invalid input
  */
 export async function updateGlobalModel(id, { label, efforts, env } = {}) {
+  assertTestSettingsAccess();
   const vid = assertModelId(id);
   const settings = readSettings();
   const models = rawModels(settings);
@@ -603,6 +622,7 @@ export async function updateGlobalModel(id, { label, efforts, env } = {}) {
  * @throws {Error} on an unknown id
  */
 export async function removeGlobalModel(id) {
+  assertTestSettingsAccess();
   const vid = assertModelId(id);
   const settings = readSettings();
   const models = rawModels(settings);

--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -14,6 +14,10 @@
 //   pipelineCostLimitUsd   — per-pipeline lifetime USD spend cap; unset = no limit.
 //   totalCostLimitUsd      — windowed all-pipelines USD spend cap; unset = no limit.
 //   costLimitResetPeriod   — total-budget window, 'weekly' | 'monthly' (default).
+//   models                 — the global model catalog (configurable-models-design.md
+//                            §4.1): [{id, label?, efforts?, env?}]. Entries shadow
+//                            PREDEFINED_MODELS by id; env is per-model routing env
+//                            merged into the claude spawn (reserved keys rejected).
 // All of them are OPTIONAL and read through the same read-modify-write object, so
 // a new key needs no migration and never disturbs the others (unknown keys — e.g.
 // written by a newer version — survive a write by the same property).
@@ -25,8 +29,9 @@
 // bootstrap value or a plain scalar toggle, so a table would buy nothing.
 //
 // IMPORTANT: this module imports NOTHING from the core graph (Node builtins
-// only). projects.mjs imports it, so importing projects.mjs back would make
-// worcaHome() -> getWorcaRoot() -> projects.mjs an infinite cycle.
+// plus the zero-import model-env.mjs leaf only). projects.mjs imports it, so
+// importing projects.mjs back would make worcaHome() -> getWorcaRoot() ->
+// projects.mjs an infinite cycle.
 //
 // Reads are synchronous + never-throwing (worcaHome's callers are sync). There
 // is deliberately no in-module cache: worcaHome() is read fresh per operation,
@@ -37,6 +42,7 @@ import { readFileSync, existsSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
+import { EFFORTS, isReservedModelEnvKey } from './model-env.mjs';
 
 /**
  * The real OS home base, honoring HOME/USERPROFILE so tests can sandbox it.
@@ -402,4 +408,207 @@ export async function setCostLimitResetPeriod(input) {
   else settings.costLimitResetPeriod = input;
   await persistSettings(settings);
   return { costLimitResetPeriod: costLimitResetPeriod() };
+}
+
+// ---------------------------------------------------------------------------
+// Global model catalog (configurable-models-design.md §4.1). Stored entries are
+// MINIMAL — label only when it differs from id, efforts only when a proper
+// subset, env only when non-empty — so an entry with default metadata keeps
+// tracking a future EFFORTS change instead of freezing today's list. Readers
+// are loud-and-lenient per this module's contract; setters throw. Effort
+// SUBSET validation happens here; catalog COMPOSITION (shadowing
+// PREDEFINED_MODELS, legacy per-project entries) is config.mjs's job.
+// ---------------------------------------------------------------------------
+
+/** Order-normalize an efforts subset to EFFORTS order, deduplicated. */
+const orderEfforts = (list) => EFFORTS.filter((e) => list.includes(e));
+
+/**
+ * Sanitize one raw catalog entry to its EFFECTIVE shape, or null when it is
+ * not salvageable (no id). Unknown efforts and reserved/malformed env pairs
+ * are dropped with a warning naming the entry — a reserved key here means a
+ * hand-edited settings file, since setters reject them.
+ */
+function sanitizeGlobalModel(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const id = typeof raw.id === 'string' ? raw.id.trim() : '';
+  if (!id) return null;
+  const label = (typeof raw.label === 'string' && raw.label.trim()) || id;
+  const efforts = Array.isArray(raw.efforts) ? orderEfforts(raw.efforts) : [];
+  const env = {};
+  const rawEnv = raw.env && typeof raw.env === 'object' && !Array.isArray(raw.env) ? raw.env : {};
+  for (const [k, v] of Object.entries(rawEnv)) {
+    if (isReservedModelEnvKey(k) || typeof v !== 'string' || !v) {
+      console.warn(`[worca] models entry ${JSON.stringify(id)}: dropping env key ${JSON.stringify(k)} (reserved or not a non-empty string)`);
+      continue;
+    }
+    env[k] = v;
+  }
+  return {
+    id,
+    label,
+    efforts: efforts.length ? efforts : [...EFFORTS],
+    ...(Object.keys(env).length ? { env } : {}),
+  };
+}
+
+/**
+ * The sanitized global model catalog: [{id, label, efforts, env?}], effective
+ * shape (label/efforts always present). Missing/corrupt -> []. Malformed and
+ * case-insensitively duplicate entries are dropped loudly (first wins). Never
+ * throws.
+ */
+export function listGlobalModels() {
+  const raw = readSettings().models;
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    console.warn(`[worca] invalid models ${JSON.stringify(raw)} — treating as empty`);
+    return [];
+  }
+  const out = [];
+  const seen = new Set();
+  for (const entry of raw) {
+    const m = sanitizeGlobalModel(entry);
+    if (!m) {
+      console.warn(`[worca] invalid models entry ${JSON.stringify(entry)} — ignored`);
+      continue;
+    }
+    const key = m.id.toLowerCase();
+    if (seen.has(key)) {
+      console.warn(`[worca] duplicate models id ${JSON.stringify(m.id)} — keeping the first`);
+      continue;
+    }
+    seen.add(key);
+    out.push(m);
+  }
+  return out;
+}
+
+/** @throws {Error} unless `id` is a non-empty string; returns it trimmed. */
+function assertModelId(id) {
+  const v = typeof id === 'string' ? id.trim() : '';
+  if (!v) throw new Error('model id must be a non-empty string');
+  return v;
+}
+
+/** @throws {Error} unless every member is a known effort; returns EFFORTS-ordered subset ([] = default/full). */
+function assertEfforts(input) {
+  if (isClearInput(input) || (Array.isArray(input) && input.length === 0)) return [];
+  if (!Array.isArray(input)) throw new Error(`efforts must be an array drawn from ${EFFORTS.join(' | ')}`);
+  for (const e of input) {
+    if (!EFFORTS.includes(e)) throw new Error(`unknown effort ${JSON.stringify(e)} — must be one of ${EFFORTS.join(' | ')}`);
+  }
+  return orderEfforts(input);
+}
+
+/** @throws {Error} on a reserved key or a non-string value. `allowNull` admits
+ *  the PATCH delete marker (env: {KEY: null}). Returns entries as given. */
+function assertEnvPairs(env, { allowNull = false } = {}) {
+  if (isClearInput(env)) return {};
+  if (typeof env !== 'object' || Array.isArray(env)) throw new Error('env must be an object of string values');
+  for (const [k, v] of Object.entries(env)) {
+    if (isReservedModelEnvKey(k)) throw new Error(`env key ${JSON.stringify(k)} is reserved and cannot be set on a model`);
+    if (allowNull && v === null) continue;
+    if (typeof v !== 'string' || !v) throw new Error(`env value for ${JSON.stringify(k)} must be a non-empty string`);
+  }
+  return { ...env };
+}
+
+/** The MINIMAL stored shape for validated parts (see section comment). */
+function storedModelShape(id, label, efforts, env) {
+  return {
+    id,
+    ...(label && label !== id ? { label } : {}),
+    ...(efforts.length && efforts.length !== EFFORTS.length ? { efforts } : {}),
+    ...(Object.keys(env).length ? { env } : {}),
+  };
+}
+
+/** Find the index of the raw `models` entry matching `id` (case-insensitive). */
+function findModelIndex(models, id) {
+  const key = id.toLowerCase();
+  return models.findIndex((e) => e && typeof e === 'object'
+    && typeof e.id === 'string' && e.id.trim().toLowerCase() === key);
+}
+
+/** Read the raw models array for a read-modify-write (non-array -> []). */
+function rawModels(settings) {
+  return Array.isArray(settings.models) ? settings.models : [];
+}
+
+/**
+ * Add a global catalog entry. `label` defaults to the id; `efforts` must be a
+ * subset of EFFORTS (empty/absent = all); `env` keys must not be reserved.
+ * @returns {Promise<{id:string,label:string,efforts:string[],env?:object}>} the effective entry
+ * @throws {Error} on invalid input or a case-insensitively duplicate id
+ */
+export async function addGlobalModel({ id, label, efforts, env } = {}) {
+  const vid = assertModelId(id);
+  if (!isClearInput(label) && typeof label !== 'string') throw new Error('label must be a string');
+  const vefforts = assertEfforts(efforts);
+  const venv = assertEnvPairs(env);
+  const settings = readSettings();
+  const models = rawModels(settings);
+  if (findModelIndex(models, vid) !== -1) throw new Error(`a model with id ${JSON.stringify(vid)} already exists`);
+  const vlabel = (typeof label === 'string' && label.trim()) || vid;
+  settings.models = [...models, storedModelShape(vid, vlabel, vefforts, venv)];
+  await persistSettings(settings);
+  return listGlobalModels().find((m) => m.id.toLowerCase() === vid.toLowerCase());
+}
+
+/**
+ * Patch a global catalog entry. Omitted fields are kept. `label`: ''/null
+ * resets to the id. `efforts`: []/null resets to all. `env`: null clears the
+ * whole map; an object merges per key, where a null value DELETES that key and
+ * a string sets it (write-only PATCH semantics, design §4.10).
+ * @returns {Promise<object>} the effective entry
+ * @throws {Error} on an unknown id or invalid input
+ */
+export async function updateGlobalModel(id, { label, efforts, env } = {}) {
+  const vid = assertModelId(id);
+  const settings = readSettings();
+  const models = rawModels(settings);
+  const idx = findModelIndex(models, vid);
+  if (idx === -1) throw new Error(`unknown model id ${JSON.stringify(vid)}`);
+  const current = sanitizeGlobalModel(models[idx]);
+
+  let nextLabel = current.label;
+  if (label !== undefined) {
+    if (!isClearInput(label) && typeof label !== 'string') throw new Error('label must be a string');
+    nextLabel = (typeof label === 'string' && label.trim()) || current.id;
+  }
+  const nextEfforts = efforts === undefined
+    ? orderEfforts(current.efforts)
+    : assertEfforts(efforts);
+  let nextEnv = { ...(current.env || {}) };
+  if (env === null) {
+    nextEnv = {};
+  } else if (env !== undefined) {
+    const patch = assertEnvPairs(env, { allowNull: true });
+    for (const [k, v] of Object.entries(patch)) {
+      if (v === null) delete nextEnv[k];
+      else nextEnv[k] = v;
+    }
+  }
+
+  settings.models = models.slice();
+  settings.models[idx] = storedModelShape(current.id, nextLabel, nextEfforts, nextEnv);
+  await persistSettings(settings);
+  return listGlobalModels().find((m) => m.id.toLowerCase() === vid.toLowerCase());
+}
+
+/**
+ * Remove a global catalog entry. Dangling per-node/per-step refs are the
+ * caller's (config.mjs's) responsibility — design §4.5.
+ * @throws {Error} on an unknown id
+ */
+export async function removeGlobalModel(id) {
+  const vid = assertModelId(id);
+  const settings = readSettings();
+  const models = rawModels(settings);
+  const idx = findModelIndex(models, vid);
+  if (idx === -1) throw new Error(`unknown model id ${JSON.stringify(vid)}`);
+  settings.models = models.slice(0, idx).concat(models.slice(idx + 1));
+  if (!settings.models.length) delete settings.models;
+  await persistSettings(settings);
 }

--- a/src/core/title.mjs
+++ b/src/core/title.mjs
@@ -1,5 +1,6 @@
 // src/core/title.mjs
 import { runClaude } from './claude-runner.mjs';
+import { resolveModelEnv } from './config.mjs';
 
 // A fast, cheap model is enough for a one-line summary. Overridable for tests/cost tuning.
 const DEFAULT_TITLE_MODEL =
@@ -39,6 +40,10 @@ export async function generateTitle(prompt, opts = {}) {
       systemPrompt: SYSTEM,
       prompt: `Write the title for this task:\n\n${text.slice(0, 4000)}`,
       model: opts.model || DEFAULT_TITLE_MODEL,
+      // Aux calls keep their model choice but still route through the catalog's
+      // env (design §4.8) — a global entry matching this id carries its routing
+      // env everywhere the id is used.
+      modelEnv: resolveModelEnv(opts.model || DEFAULT_TITLE_MODEL),
       effort: 'low',
       permissionMode: 'acceptEdits',
       allowedTools: [],            // empty → no --allowedTools flag → claude defaults; pure text gen

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -113,6 +113,24 @@ test('PATCH /api/models/:id: write-only env — masked echoes mean KEEP, null de
   assert.equal(raw.env.X_REF, undefined, 'null deleted the key');
 });
 
+test('GET /api/models/:id/env-value reveals raw values (per key and whole map); GET surface stays masked', async () => {
+  const one = await jfetch(`/api/models/glm-4.7/env-value?${q({ key: 'ANTHROPIC_AUTH_TOKEN' })}`);
+  assert.equal(one.status, 200);
+  assert.deepEqual(one.body, { key: 'ANTHROPIC_AUTH_TOKEN', value: 'sk-live-abcdef1234' });
+
+  const all = await jfetch('/api/models/glm-4.7/env-value');
+  assert.equal(all.status, 200);
+  assert.equal(all.body.env.ANTHROPIC_AUTH_TOKEN, 'sk-live-abcdef1234');
+  assert.equal(all.body.env.ANTHROPIC_BASE_URL, 'https://new.example', 'reflects the earlier PATCH');
+
+  assert.equal((await jfetch(`/api/models/nope/env-value`)).status, 400);
+  assert.equal((await jfetch(`/api/models/glm-4.7/env-value?${q({ key: 'NOT_THERE' })}`)).status, 400);
+
+  // The reveal endpoint does not weaken the default surface.
+  const masked = (await jfetch('/api/models')).body.models.find((m) => m.id === 'glm-4.7');
+  assert.match(masked.env.ANTHROPIC_AUTH_TOKEN, /^••/);
+});
+
 test('PATCH /api/models/:id: unknown id and reserved key -> 400', async () => {
   assert.equal((await patch('/api/models/nope', { label: 'x' })).status, 400);
   assert.equal((await patch('/api/models/glm-4.7', { env: { WORCA_MOCK: '1' } })).status, 400);

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -176,3 +176,115 @@ test('POST /api/models/promote moves a legacy entry global; its refs SURVIVE (un
 
   assert.equal((await post('/api/models/promote', { projectDir: proj, id: 'nope' })).status, 400);
 });
+
+// ── plugin model entries + export scaffold (design §9.5, §9.7) ───────────────
+
+test('GET /api/models: plugin entries — masked literals, readable refs, secret markers + set-ness', async () => {
+  const { writePluginsLock, pluginCurrentDir } = await import('../src/core/plugins-lock.mjs');
+  const { mkdirSync, writeFileSync } = await import('node:fs');
+  const cur = pluginCurrentDir('ds-models');
+  mkdirSync(cur, { recursive: true });
+  writeFileSync(join(cur, 'worca-cc-plugin.json'), JSON.stringify({
+    name: 'ds-models',
+    modelSecrets: [{ key: 'ds-token', label: 'DS token' }],
+    models: [{
+      id: 'ds-plugged', label: 'DS Plugged', efforts: ['medium', 'high'],
+      env: {
+        ANTHROPIC_BASE_URL: 'https://api.ds.example',
+        X_REF: '${MY_VAR}',
+        ANTHROPIC_AUTH_TOKEN: { secret: 'ds-token' },
+      },
+    }],
+  }));
+  writePluginsLock({ 'ds-models': { repo: 'https://example.com/r', subdir: '', pinnedSha: 'x'.repeat(40), version: '1', enabled: true } });
+
+  const { body } = await jfetch('/api/models');
+  const pm = body.plugin.find((m) => m.id === 'ds-plugged');
+  assert.ok(pm, 'plugin entry surfaced');
+  assert.equal(pm.plugin, 'ds-models');
+  assert.deepEqual(pm.efforts, ['medium', 'high']);
+  assert.equal(pm.env.ANTHROPIC_BASE_URL, '••••••mple', 'literal masked');
+  assert.equal(pm.env.X_REF, '${MY_VAR}', 'ref readable');
+  assert.equal(pm.env.ANTHROPIC_AUTH_TOKEN, '(secret: ds-token)');
+  assert.deepEqual(pm.secrets, [{ key: 'ds-token', label: 'DS token', set: false }]);
+
+  // The plugin model is selectable: it reaches the /api/config catalog.
+  const cfg = await jfetch(`/api/config?${q({ projectDir: proj })}`);
+  const inCatalog = cfg.body.models.find((m) => m.id === 'ds-plugged');
+  assert.equal(inCatalog.custom, 'plugin');
+  assert.equal(inCatalog.plugin, 'ds-models');
+});
+
+test('PUT /api/plugins/:name/config { target: modelSecrets } round-trips set-ness, never values', async () => {
+  const put = (path, body) => jfetch(path, {
+    method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  });
+  const r = await put('/api/plugins/ds-models/config', { target: 'modelSecrets', values: { 'ds-token': 'sk-team-secret' } });
+  assert.equal(r.status, 200);
+
+  const cfg = await jfetch('/api/plugins/ds-models/config');
+  assert.equal(cfg.status, 200);
+  assert.deepEqual(cfg.body.models.schema.map((f) => f.key), ['ds-token']);
+  assert.deepEqual(cfg.body.models.values, { 'ds-token': { set: true } }, 'redacted marker only');
+
+  const models = await jfetch('/api/models');
+  assert.deepEqual(models.body.plugin.find((m) => m.id === 'ds-plugged').secrets,
+    [{ key: 'ds-token', label: 'DS token', set: true }]);
+
+  // No modelSecrets declared -> 400 on the target write.
+  const { writePluginsLock, readPluginsLock, pluginCurrentDir } = await import('../src/core/plugins-lock.mjs');
+  const { mkdirSync, writeFileSync } = await import('node:fs');
+  const cur = pluginCurrentDir('bare-plug');
+  mkdirSync(cur, { recursive: true });
+  writeFileSync(join(cur, 'worca-cc-plugin.json'), JSON.stringify({ name: 'bare-plug' }));
+  writePluginsLock({ ...readPluginsLock(), 'bare-plug': { repo: 'r', subdir: '', pinnedSha: 'y'.repeat(40), version: '1', enabled: true } });
+  const bad = await put('/api/plugins/bare-plug/config', { target: 'modelSecrets', values: { x: 'y' } });
+  assert.equal(bad.status, 400);
+});
+
+test('POST /api/models/export-plugin: scaffold with value stripping; rejections', async () => {
+  const { readFileSync, existsSync, writeFileSync, mkdirSync } = await import('node:fs');
+  await post('/api/models', {
+    id: 'exp-m', label: 'Exportable', efforts: ['medium'],
+    env: { ANTHROPIC_BASE_URL: 'https://x.example', ANTHROPIC_AUTH_TOKEN: 'sk-live-strip-me', X_REF: '${VV}' },
+  });
+  const dest = join(proj, 'export', 'team-models');
+  const r = await post('/api/models/export-plugin', {
+    name: 'team-models', description: 'Team routing', dest,
+    models: [{ id: 'EXP-M', env: { ANTHROPIC_BASE_URL: 'include', ANTHROPIC_AUTH_TOKEN: 'secret', X_REF: 'include' } }],
+  });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.dir, dest);
+  assert.deepEqual(r.body.modelSecrets, [{ key: 'anthropic-auth-token', label: 'ANTHROPIC_AUTH_TOKEN' }]);
+
+  const manifest = JSON.parse(readFileSync(join(dest, 'worca-cc-plugin.json'), 'utf8'));
+  assert.equal(manifest.name, 'team-models');
+  assert.equal(manifest.version, '0.1.0');
+  const [m] = manifest.models;
+  assert.equal(m.id, 'exp-m', 'stored id casing, not the request casing');
+  assert.equal(m.label, 'Exportable');
+  assert.deepEqual(m.efforts, ['medium']);
+  assert.equal(m.env.ANTHROPIC_BASE_URL, 'https://x.example', 'include -> verbatim');
+  assert.equal(m.env.X_REF, '${VV}', 'ref text travels as-is');
+  assert.deepEqual(m.env.ANTHROPIC_AUTH_TOKEN, { secret: 'anthropic-auth-token' });
+  assert.deepEqual(manifest.modelSecrets, [{ key: 'anthropic-auth-token', label: 'ANTHROPIC_AUTH_TOKEN' }]);
+  const blob = readFileSync(join(dest, 'worca-cc-plugin.json'), 'utf8') + readFileSync(join(dest, 'README.md'), 'utf8');
+  assert.doesNotMatch(blob, /sk-live-strip-me/, 'secret value stripped from every scaffold file');
+  assert.ok(existsSync(join(dest, 'README.md')));
+
+  // Rejections.
+  const cases = [
+    [{ name: 'Bad Name', dest: join(proj, 'x1'), models: [{ id: 'exp-m' }] }, /kebab-case/],
+    [{ name: 'ok-name', dest: join(proj, 'x2'), models: [] }, /non-empty array/],
+    [{ name: 'ok-name', dest: join(proj, 'x3'), models: [{ id: 'nope' }] }, /unknown global model id/],
+    [{ name: 'ok-name', dest: join(proj, 'x4'), models: [{ id: 'exp-m', env: { NOT_THERE: 'include' } }] }, /has no env key/],
+    [{ name: 'ok-name', dest: join(proj, 'x5'), models: [{ id: 'exp-m', env: { X_REF: 'wat' } }] }, /include \| secret \| omit/],
+    [{ name: 'ok-name', dest: '', models: [{ id: 'exp-m' }] }, /dest is required/],
+    [{ name: 'ok-name', dest, models: [{ id: 'exp-m' }] }, /not empty/],
+  ];
+  for (const [bodyIn, re] of cases) {
+    const bad = await post('/api/models/export-plugin', bodyIn);
+    assert.equal(bad.status, 400, JSON.stringify(bodyIn));
+    assert.match(bad.body.error, re);
+  }
+});

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -288,3 +288,17 @@ test('POST /api/models/export-plugin: scaffold with value stripping; rejections'
     assert.match(bad.body.error, re);
   }
 });
+
+test('GET /api/plugins/:name/model-env: raw literals/refs for Edit-a-copy; secrets listed, never resolved', async () => {
+  const r = await jfetch(`/api/plugins/ds-models/model-env?${q({ id: 'DS-Plugged' })}`);
+  assert.equal(r.status, 200);
+  assert.equal(r.body.id, 'ds-plugged');
+  assert.equal(r.body.env.ANTHROPIC_BASE_URL, 'https://api.ds.example', 'literal RAW, not masked');
+  assert.equal(r.body.env.X_REF, '${MY_VAR}');
+  assert.equal(r.body.env.ANTHROPIC_AUTH_TOKEN, undefined, 'secret value never present');
+  assert.deepEqual(r.body.secretKeys, ['ANTHROPIC_AUTH_TOKEN']);
+  assert.doesNotMatch(JSON.stringify(r.body), /sk-team-secret/, 'the stored plugin secret does not leak');
+
+  assert.equal((await jfetch(`/api/plugins/ds-models/model-env?${q({ id: 'nope' })}`)).status, 400);
+  assert.equal((await jfetch(`/api/plugins/ghost/model-env?${q({ id: 'x' })}`)).status, 404);
+});

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -141,3 +141,20 @@ test('refs preview + DELETE /api/models/:id clears cross-project refs', async ()
 
   assert.equal((await jfetch(`/api/models/${encodeURIComponent('glm-4.7')}`, { method: 'DELETE' })).status, 400, 'second delete: unknown id');
 });
+
+test('POST /api/models/promote moves a legacy entry global; its refs SURVIVE (unlike delete)', async () => {
+  const { addCustomModel } = await import('../src/core/config.mjs');
+  await addCustomModel(proj, { id: 'legacy-m', label: 'Legacy M' });
+  await setNodeModel(proj, 'wf_p', 's1_0', { model: 'legacy-m' });
+
+  const r = await post('/api/models/promote', { projectDir: proj, id: 'legacy-m' });
+  assert.equal(r.status, 200);
+  assert.ok(r.body.models.some((m) => m.id === 'legacy-m'), 'now in the global catalog');
+  assert.deepEqual(r.body.config.customModels, [], 'project copy dropped');
+
+  const cfg = await jfetch(`/api/config?${q({ projectDir: proj })}`);
+  assert.equal(cfg.body.models.find((m) => m.id === 'legacy-m').custom, 'global');
+  assert.deepEqual(cfg.body.config.workflows.wf_p.nodes.s1_0, { model: 'legacy-m' }, 'node ref survived promotion');
+
+  assert.equal((await post('/api/models/promote', { projectDir: proj, id: 'nope' })).status, 400);
+});

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -1,0 +1,143 @@
+// test/api-models.test.mjs
+// Global model catalog HTTP API (configurable-models-design.md §4.10):
+// GET/POST/PATCH/DELETE /api/models with masked env values (write-only
+// editing, ${VAR} refs readable, masked echoes mean "keep"), the refs preview,
+// and the catalog surfacing in /api/config. Sandboxes WORCA_HOME (DB) and
+// HOME (settings.json) and opts into the catalog guard.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { _resetForTests } from '../src/core/db.mjs';
+import { listGlobalModels } from '../src/core/settings.mjs';
+import { setNodeModel } from '../src/core/config.mjs';
+import { EFFORTS } from '../src/core/model-env.mjs';
+
+let proj, srv, base, homeDir, worcaHomeDir;
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
+const q = (o) => new URLSearchParams(o).toString();
+const jfetch = async (path, opts) => {
+  const r = await fetch(`${base}${path}`, opts);
+  return { status: r.status, body: await r.json().catch(() => null) };
+};
+const post = (path, body) => jfetch(path, {
+  method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+});
+const patch = (path, body) => jfetch(path, {
+  method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+});
+
+before(async () => {
+  homeDir = await mkdtemp(join(tmpdir(), 'worca-cc-apimodels-home-'));
+  worcaHomeDir = await mkdtemp(join(tmpdir(), 'worca-cc-apimodels-whome-'));
+  process.env.HOME = homeDir; process.env.USERPROFILE = homeDir;
+  process.env.WORCA_HOME = worcaHomeDir;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1'; // catalog guard: HOME sandboxed above
+  _resetForTests();
+  proj = await mkdtemp(join(tmpdir(), 'worca-cc-apimodels-proj-'));
+  const { app } = await import('../ui/server.mjs'); // imported => does not bind a port
+  srv = http.createServer(app);
+  await new Promise((r) => srv.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${srv.address().port}`;
+});
+after(async () => {
+  if (srv) await new Promise((r) => srv.close(r));
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all([proj, homeDir, worcaHomeDir].map((d) => rm(d, { recursive: true, force: true })));
+});
+
+test('GET /api/models: empty catalog + predefined + efforts', async () => {
+  const { status, body } = await jfetch('/api/models');
+  assert.equal(status, 200);
+  assert.deepEqual(body.models, []);
+  assert.ok(body.predefined.some((m) => m.id === 'claude-opus-5'));
+  assert.deepEqual(body.efforts, EFFORTS);
+});
+
+test('POST /api/models adds a global entry; env values come back MASKED, ${VAR} refs readable', async () => {
+  const { status, body } = await post('/api/models', {
+    id: 'glm-4.7', label: 'GLM (proxy)', efforts: ['high', 'medium'],
+    env: { ANTHROPIC_BASE_URL: 'https://proxy.example/v1', ANTHROPIC_AUTH_TOKEN: 'sk-live-abcdef1234', X_REF: '${MY_VAR}' },
+  });
+  assert.equal(status, 200);
+  assert.equal(body.model.id, 'glm-4.7');
+  assert.deepEqual(body.model.efforts, ['medium', 'high']);
+  assert.equal(body.model.env.ANTHROPIC_BASE_URL, '••••••e/v1', 'literal masked to a suffix');
+  assert.equal(body.model.env.ANTHROPIC_AUTH_TOKEN, '••••••1234');
+  assert.equal(body.model.env.X_REF, '${MY_VAR}', 'a whole-value ref is config, not a secret');
+  // The store holds the RAW values (same process — read the core directly).
+  const raw = listGlobalModels().find((m) => m.id === 'glm-4.7');
+  assert.equal(raw.env.ANTHROPIC_AUTH_TOKEN, 'sk-live-abcdef1234');
+});
+
+test('the global entry reaches /api/config for projects AND project-less', async () => {
+  for (const path of ['/api/config', `/api/config?${q({ projectDir: proj })}`]) {
+    const { body } = await jfetch(path);
+    const glm = body.models.find((m) => m.id === 'glm-4.7');
+    assert.ok(glm, `present in ${path}`);
+    assert.equal(glm.custom, 'global');
+    assert.equal(glm.hasEnv, true);
+    assert.equal(glm.env, undefined, 'env values never enter the catalog shape');
+  }
+});
+
+test('POST /api/models rejections -> 400 (reserved env key, dup id, unknown effort)', async () => {
+  assert.equal((await post('/api/models', { id: 'x1', env: { PATH: '/evil' } })).status, 400);
+  assert.equal((await post('/api/models', { id: 'GLM-4.7' })).status, 400);
+  assert.equal((await post('/api/models', { id: 'x1', efforts: ['low'] })).status, 400);
+  assert.equal((await post('/api/models', {})).status, 400);
+});
+
+test('PATCH /api/models/:id: write-only env — masked echoes mean KEEP, null deletes, strings set', async () => {
+  const { status, body } = await patch('/api/models/glm-4.7', {
+    label: 'GLM routed',
+    env: {
+      ANTHROPIC_AUTH_TOKEN: '••••••1234',      // masked echo -> keep the stored value
+      ANTHROPIC_BASE_URL: 'https://new.example', // real string -> set
+      X_REF: null,                                // delete
+    },
+  });
+  assert.equal(status, 200);
+  assert.equal(body.model.label, 'GLM routed');
+  const raw = listGlobalModels().find((m) => m.id === 'glm-4.7');
+  assert.equal(raw.env.ANTHROPIC_AUTH_TOKEN, 'sk-live-abcdef1234', 'echo kept the secret');
+  assert.equal(raw.env.ANTHROPIC_BASE_URL, 'https://new.example');
+  assert.equal(raw.env.X_REF, undefined, 'null deleted the key');
+});
+
+test('PATCH /api/models/:id: unknown id and reserved key -> 400', async () => {
+  assert.equal((await patch('/api/models/nope', { label: 'x' })).status, 400);
+  assert.equal((await patch('/api/models/glm-4.7', { env: { WORCA_MOCK: '1' } })).status, 400);
+});
+
+test('PATCH /api/config with an unknown node model -> 400 (validation parity over HTTP)', async () => {
+  const { status } = await patch('/api/config', {
+    projectDir: proj, workflowId: 'wf_x', nodes: { s0_0: { model: 'no-such-model' } },
+  });
+  assert.equal(status, 400);
+});
+
+test('refs preview + DELETE /api/models/:id clears cross-project refs', async () => {
+  await setNodeModel(proj, 'wf_x', 's2_0', { model: 'glm-4.7', effort: 'high' });
+
+  const refs = await jfetch(`/api/models/${encodeURIComponent('glm-4.7')}/refs`);
+  assert.equal(refs.status, 200);
+  assert.equal(refs.body.predefinedShadow, false);
+  assert.equal(refs.body.nodes.length, 1);
+  assert.equal(refs.body.nodes[0].nodeId, 's2_0');
+
+  const del = await jfetch(`/api/models/${encodeURIComponent('glm-4.7')}`, { method: 'DELETE' });
+  assert.equal(del.status, 200);
+  assert.equal(del.body.clearedNodes, 1);
+  assert.deepEqual(del.body.models, []);
+
+  assert.equal((await jfetch(`/api/models/${encodeURIComponent('glm-4.7')}`, { method: 'DELETE' })).status, 400, 'second delete: unknown id');
+});

--- a/test/config-api.test.mjs
+++ b/test/config-api.test.mjs
@@ -120,13 +120,21 @@ test('POST /api/config with an unsupported effort -> 400', async () => {
   assert.equal(r.status, 400);
 });
 
-test('add then delete a custom model over HTTP', async () => {
+test('per-project custom-model ADD endpoint is gone; DELETE still cleans up legacy entries', async () => {
+  // POST /api/config/models was removed (configurable-models-design.md §4.9):
+  // new models are added GLOBALLY via POST /api/models.
   let r = await fetch(`${base}/api/config/models`, {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ projectDir: proj, id: 'my-model-x' }),
   });
-  assert.equal(r.status, 200);
-  assert.ok((await r.json()).models.some((m) => m.id === 'my-model-x'));
+  assert.equal(r.status, 404);
+
+  // Legacy entries (seeded via the core API existing projects still carry) can
+  // still be deleted over HTTP.
+  const { addCustomModel } = await import('../src/core/config.mjs');
+  await addCustomModel(proj, { id: 'my-model-x' });
+  r = await fetch(`${base}/api/config?${q({ projectDir: proj })}`);
+  assert.ok((await r.json()).models.some((m) => m.id === 'my-model-x' && m.custom === 'project'));
 
   r = await fetch(`${base}/api/config/models?${q({ projectDir: proj, id: 'my-model-x' })}`, { method: 'DELETE' });
   assert.equal(r.status, 200);

--- a/test/config-models-global.test.mjs
+++ b/test/config-models-global.test.mjs
@@ -23,7 +23,10 @@ import { getDb, _resetForTests } from '../src/core/db.mjs';
 import { projectKey } from '../src/core/store.mjs';
 
 const dirs = [];
-const prevEnv = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME };
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
 async function freshStores() {
   const home = await mkdtemp(join(tmpdir(), 'worca-cc-gm-home-'));
   const whome = await mkdtemp(join(tmpdir(), 'worca-cc-gm-whome-'));
@@ -31,6 +34,7 @@ async function freshStores() {
   _resetForTests();
   process.env.HOME = home; process.env.USERPROFILE = home;
   process.env.WORCA_HOME = whome;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1'; // catalog guard: HOME is sandboxed above
 }
 async function freshProject() {
   const d = await mkdtemp(join(tmpdir(), 'worca-cc-gm-proj-'));
@@ -40,7 +44,7 @@ async function freshProject() {
 beforeEach(freshStores);
 after(async () => {
   _resetForTests();
-  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME']) {
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
     if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
   }
   await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));

--- a/test/config-models-global.test.mjs
+++ b/test/config-models-global.test.mjs
@@ -1,0 +1,185 @@
+// test/config-models-global.test.mjs
+// Phase 2 of configurable models (design §4.2/§4.4/§4.5): effective catalog
+// composition (predefined ⊕ global ⊕ legacy project), resolveModelEnv, node
+// validation parity with setStep, and global removal clearing cross-project
+// refs with the shadow/legacy carve-outs.
+//
+// Sandboxes BOTH stores: WORCA_HOME (the DB) and HOME (settings.json, where
+// the global catalog lives).
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  listModels, resolveModelEnv, setStep, setNodeModel, addCustomModel,
+  resolveRunConfig, readConfig, globalModelRefs, removeGlobalModelAndRefs,
+  PREDEFINED_MODELS,
+} from '../src/core/config.mjs';
+import { addGlobalModel, listGlobalModels } from '../src/core/settings.mjs';
+import { EFFORTS } from '../src/core/model-env.mjs';
+import { getDb, _resetForTests } from '../src/core/db.mjs';
+import { projectKey } from '../src/core/store.mjs';
+
+const dirs = [];
+const prevEnv = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME };
+async function freshStores() {
+  const home = await mkdtemp(join(tmpdir(), 'worca-cc-gm-home-'));
+  const whome = await mkdtemp(join(tmpdir(), 'worca-cc-gm-whome-'));
+  dirs.push(home, whome);
+  _resetForTests();
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  process.env.WORCA_HOME = whome;
+}
+async function freshProject() {
+  const d = await mkdtemp(join(tmpdir(), 'worca-cc-gm-proj-'));
+  dirs.push(d);
+  return d;
+}
+beforeEach(freshStores);
+after(async () => {
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+test('catalog: global entries appear for every project; legacy project entries rank lowest', async () => {
+  const p = await freshProject();
+  await addGlobalModel({ id: 'glm-4.7', label: 'GLM', efforts: ['medium'], env: { ANTHROPIC_BASE_URL: 'https://x' } });
+  await addCustomModel(p, { id: 'proj-model' });
+
+  const models = await listModels(p);
+  const glm = models.find((m) => m.id === 'glm-4.7');
+  assert.deepEqual(glm, { id: 'glm-4.7', label: 'GLM', efforts: ['medium'], custom: 'global', hasEnv: true });
+  const proj = models.find((m) => m.id === 'proj-model');
+  assert.deepEqual(proj, { id: 'proj-model', label: 'proj-model', efforts: [...EFFORTS], custom: 'project', hasEnv: false });
+  // Env VALUES never leak into the catalog shape.
+  assert.equal(Object.keys(glm).includes('env'), false);
+  // Another project sees the global entry but not this project's legacy one.
+  const p2 = await freshProject();
+  const models2 = await listModels(p2);
+  assert.ok(models2.some((m) => m.id === 'glm-4.7'));
+  assert.ok(!models2.some((m) => m.id === 'proj-model'));
+});
+
+test('catalog: a global entry SHADOWS its predefined twin (id casing kept); legacy dup is dropped', async () => {
+  const p = await freshProject();
+  await addCustomModel(p, { id: 'glm-4.7' });                       // legacy first
+  await addGlobalModel({ id: 'GLM-4.7', label: 'Routed GLM' });     // global wins over legacy
+  await addGlobalModel({ id: 'claude-sonnet-4-6', label: 'Sonnet via proxy', efforts: ['medium', 'high'], env: { ANTHROPIC_BASE_URL: 'https://p' } });
+
+  const models = await listModels(p);
+  // Predefined shadow: same slot, predefined id casing, overridden metadata.
+  const sonnet = models.find((m) => m.id === 'claude-sonnet-4-6');
+  assert.deepEqual(sonnet, { id: 'claude-sonnet-4-6', label: 'Sonnet via proxy', efforts: ['medium', 'high'], custom: 'global', hasEnv: true });
+  assert.equal(models.filter((m) => m.id.toLowerCase() === 'claude-sonnet-4-6').length, 1);
+  // Legacy dup of a global id is dropped from the composed view.
+  assert.equal(models.filter((m) => m.id.toLowerCase() === 'glm-4.7').length, 1);
+  assert.equal(models.find((m) => m.id.toLowerCase() === 'glm-4.7').custom, 'global');
+  // Un-shadowed predefined entries are unchanged.
+  const opus = models.find((m) => m.id === 'claude-opus-5');
+  assert.deepEqual(opus, { ...PREDEFINED_MODELS[0], custom: false, hasEnv: false });
+});
+
+test('addCustomModel rejects an id that already exists globally', async () => {
+  const p = await freshProject();
+  await addGlobalModel({ id: 'glm-4.7' });
+  await assert.rejects(addCustomModel(p, { id: 'GLM-4.7' }), /already a global model/);
+});
+
+test('resolveModelEnv: global env only, ${VAR} expanded, case-insensitive id, undefined otherwise', async () => {
+  const p = await freshProject();
+  await addGlobalModel({ id: 'glm-4.7', env: { ANTHROPIC_BASE_URL: 'https://x', ANTHROPIC_AUTH_TOKEN: '${GM_TEST_TOKEN}' } });
+  await addGlobalModel({ id: 'plain-model' });
+  await addCustomModel(p, { id: 'proj-model' });
+
+  process.env.GM_TEST_TOKEN = 'sk-42';
+  try {
+    assert.deepEqual(resolveModelEnv('GLM-4.7'), { ANTHROPIC_BASE_URL: 'https://x', ANTHROPIC_AUTH_TOKEN: 'sk-42' });
+  } finally {
+    delete process.env.GM_TEST_TOKEN;
+  }
+  // Unset ref -> that key dropped, the rest survives.
+  assert.deepEqual(resolveModelEnv('glm-4.7'), { ANTHROPIC_BASE_URL: 'https://x' });
+  assert.equal(resolveModelEnv('plain-model'), undefined);   // global, no env
+  assert.equal(resolveModelEnv('proj-model'), undefined);    // legacy: never env
+  assert.equal(resolveModelEnv('claude-opus-5'), undefined); // predefined, unshadowed
+  assert.equal(resolveModelEnv(''), undefined);
+});
+
+test('setNodeModel validates like setStep: unknown model/effort, unsupported effort, effort-without-model', async () => {
+  const p = await freshProject();
+  await addGlobalModel({ id: 'narrow', efforts: ['medium'] });
+
+  await assert.rejects(setNodeModel(p, 'wf_x', 's0_0', { model: 'nope-9000' }), /unknown model "nope-9000"/);
+  await assert.rejects(setNodeModel(p, 'wf_x', 's0_0', { model: 'narrow', effort: 'low' }), /unknown effort "low"/);
+  await assert.rejects(setNodeModel(p, 'wf_x', 's0_0', { model: 'narrow', effort: 'max' }), /does not support effort/);
+  await assert.rejects(setNodeModel(p, 'wf_x', 's0_0', { effort: 'high' }), /select a model before choosing an effort/);
+  // Nothing was persisted by the failed writes.
+  assert.deepEqual((await resolveRunConfig(p, 'wf_x')).nodes, {});
+  // Valid writes still work, including toggle-only writes (no model/effort).
+  await setNodeModel(p, 'wf_x', 's0_0', { model: 'narrow', effort: 'medium' });
+  await setNodeModel(p, 'wf_x', 's1_0', { fanOut: true });
+  const { nodes } = await resolveRunConfig(p, 'wf_x');
+  assert.deepEqual(nodes.s0_0, { model: 'narrow', effort: 'medium' });
+  assert.deepEqual(nodes.s1_0, { fanOut: true });
+});
+
+test('globalModelRefs + removeGlobalModelAndRefs: cross-project purge with carve-outs', async () => {
+  const pA = await freshProject();
+  const pB = await freshProject();
+  const pC = await freshProject();
+  await addGlobalModel({ id: 'glm-4.7' });
+  // A: node + step refs (must be purged). B: node ref (must be purged).
+  await setStep(pA, 'implementer', { model: 'glm-4.7' });
+  await setNodeModel(pA, 'wf_x', 's2_0', { model: 'glm-4.7', effort: 'high' });
+  await setNodeModel(pB, 'wf_y', 's1_0', { model: 'glm-4.7' });
+  // C: carries a legacy custom model with the SAME id -> its refs survive.
+  // (Add the legacy entry by writing it while the global exists is rejected, so
+  // seed it via the DB row shape addCustomModel would have produced.)
+  getDb().prepare(`
+    INSERT INTO project_config (project_key, steps, custom_models, active_workflow_id, extra)
+    VALUES (?, '{}', ?, NULL, '{}')
+  `).run(projectKey(pC), JSON.stringify([{ id: 'glm-4.7', label: 'kept' }]));
+  await setNodeModel(pC, 'wf_z', 's0_0', { model: 'glm-4.7' });
+
+  const refs = globalModelRefs('glm-4.7');
+  assert.equal(refs.predefinedShadow, false);
+  assert.deepEqual(refs.steps, [{ projectKey: projectKey(pA), step: 'implementer' }]);
+  assert.deepEqual(new Set(refs.nodes.map((n) => n.projectKey)), new Set([projectKey(pA), projectKey(pB)]));
+
+  const result = await removeGlobalModelAndRefs('glm-4.7');
+  assert.deepEqual(result, { clearedSteps: 1, clearedNodes: 2, predefinedShadow: false });
+  assert.equal(listGlobalModels().length, 0);
+  assert.deepEqual((await readConfig(pA)).steps, {});
+  assert.deepEqual((await resolveRunConfig(pA, 'wf_x')).nodes, {});
+  assert.deepEqual((await resolveRunConfig(pB, 'wf_y')).nodes, {});
+  // The carve-out project keeps both its legacy entry and its node ref.
+  assert.deepEqual((await resolveRunConfig(pC, 'wf_z')).nodes.s0_0, { model: 'glm-4.7' });
+  assert.ok((await listModels(pC)).some((m) => m.id === 'glm-4.7' && m.custom === 'project'));
+});
+
+test('removing a predefined SHADOW reverts the override and purges nothing', async () => {
+  const p = await freshProject();
+  await addGlobalModel({ id: 'claude-sonnet-4-6', label: 'Proxied', env: { ANTHROPIC_BASE_URL: 'https://p' } });
+  await setNodeModel(p, 'wf_x', 's0_0', { model: 'claude-sonnet-4-6', effort: 'high' });
+
+  assert.deepEqual(globalModelRefs('claude-sonnet-4-6'), { predefinedShadow: true, steps: [], nodes: [] });
+  const result = await removeGlobalModelAndRefs('claude-sonnet-4-6');
+  assert.deepEqual(result, { clearedSteps: 0, clearedNodes: 0, predefinedShadow: true });
+  // The ref survives — it now points at the built-in entry again.
+  assert.deepEqual((await resolveRunConfig(p, 'wf_x')).nodes.s0_0, { model: 'claude-sonnet-4-6', effort: 'high' });
+  const entry = (await listModels(p)).find((m) => m.id === 'claude-sonnet-4-6');
+  assert.deepEqual(entry, { ...PREDEFINED_MODELS.find((m) => m.id === 'claude-sonnet-4-6'), custom: false, hasEnv: false });
+});
+
+test('removeGlobalModelAndRefs on an unknown id throws WITHOUT purging same-string legacy refs', async () => {
+  const p = await freshProject();
+  await addCustomModel(p, { id: 'only-legacy' });
+  await setNodeModel(p, 'wf_x', 's0_0', { model: 'only-legacy' });
+  await assert.rejects(removeGlobalModelAndRefs('only-legacy'), /unknown model id/);
+  assert.deepEqual((await resolveRunConfig(p, 'wf_x')).nodes.s0_0, { model: 'only-legacy' });
+});

--- a/test/config-ui.test.mjs
+++ b/test/config-ui.test.mjs
@@ -52,7 +52,8 @@ test('each agent step exposes model + effort selectors in markup', () => {
 test('app.js loads, renders, and saves per-step config', () => {
   assert.ok(appjs.includes('/api/config'), 'app.js does not use /api/config');
   assert.ok(appjs.includes('renderStepConfigs'), 'missing renderStepConfigs');
-  assert.ok(appjs.includes('addModelFlow'), 'missing custom-model add flow');
+  // The add flow navigates to the global Models view (configurable-models §4.9).
+  assert.ok(appjs.includes('goAddModel'), 'missing add-model navigation flow');
 });
 
 // ---------------------------------------------------------------------------

--- a/test/db-pause-schema.test.mjs
+++ b/test/db-pause-schema.test.mjs
@@ -20,7 +20,7 @@ test('v5 adds resume_point and session_id columns', () => {
   assert.ok(cols('pipelines').includes('resume_point'), 'pipelines.resume_point exists');
   assert.ok(cols('pipeline_steps').includes('session_id'), 'pipeline_steps.session_id exists');
   const v = getDb().prepare('PRAGMA user_version').get().user_version;
-  assert.equal(v, 16);
+  assert.equal(v, 17);
 });
 
 test('writeState persists resumePoint and per-step sessionId', async () => {

--- a/test/db.test.mjs
+++ b/test/db.test.mjs
@@ -134,16 +134,16 @@ test('migrate creates every required index', () => {
   }
 });
 
-test('migrate stamps user_version = 16', () => {
+test('migrate stamps user_version = 17', () => {
   const db = getDb();
   const { user_version } = db.prepare('PRAGMA user_version').get();
-  assert.equal(user_version, 16, 'schema version is 16 after migrate');
+  assert.equal(user_version, 17, 'schema version is 17 after migrate');
 });
 
 test('migrate() reaches v11 and adds workflows.domain + liveness columns', async () => {
   await freshHome();
   const db = getDb();                                   // triggers migrate()
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const wfCols = db.prepare('PRAGMA table_info(workflows)').all().map((c) => c.name);
   assert.ok(wfCols.includes('domain'), 'workflows.domain column exists');
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
@@ -263,7 +263,7 @@ test('getDb() calls maybeMigrateFromFs(db) once after migrate()', () => {
   assert.equal(_migrateFromFsCallCount(), 1, 'hook invoked exactly once on first open');
   // The schema must already exist when the hook runs (it reads/writes rows).
   const { user_version } = db.prepare('PRAGMA user_version').get();
-  assert.equal(user_version, 16, 'migrate() ran before the hook');
+  assert.equal(user_version, 17, 'migrate() ran before the hook');
   // Cached singleton: a repeat getDb() must NOT re-run the one-shot hook.
   getDb();
   assert.equal(_migrateFromFsCallCount(), 1, 'hook not re-run on cached getDb()');
@@ -313,7 +313,7 @@ test('getDb() first-launch is concurrency-safe across N processes (no lock/exist
 
   // The shared DB is migrated exactly once: v2 stamped, exactly one projects table.
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'migrated to v16');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'migrated to v17');
   assert.equal(
     db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='projects'").get().n,
     1, 'exactly one projects table after the race');

--- a/test/migrate-v10.test.mjs
+++ b/test/migrate-v10.test.mjs
@@ -9,7 +9,7 @@ useTempHome(after);
 
 test('v10 adds nullable owner_pid/owner_host/heartbeat_at; user_version becomes 15', () => {
   const db = getDb(); // getDb() opens + migrates to SCHEMA_VERSION
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const cols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   for (const c of ['owner_pid', 'owner_host', 'heartbeat_at']) assert.ok(cols.includes(c), c);
 });
@@ -51,7 +51,7 @@ test('incremental v9->v10 migration: migrate() adds columns on a v9 DB and stamp
   // Now run the incremental migration
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const cols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   for (const c of ['owner_pid', 'owner_host', 'heartbeat_at']) assert.ok(cols.includes(c), c);
   const row = db.prepare('SELECT owner_pid, owner_host, heartbeat_at FROM pipelines WHERE id = ?').get('seed1');

--- a/test/migrate-v12.test.mjs
+++ b/test/migrate-v12.test.mjs
@@ -35,7 +35,7 @@ const V10_NODES_SEED = `
 
 test('fresh DB migrates to v12 with ask_questions + step_questions present', () => {
   const db = getDb(); // opens + migrates to SCHEMA_VERSION
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const cols = db.prepare('PRAGMA table_info(config_workflow_nodes)').all().map((c) => c.name);
   assert.ok(cols.includes('ask_questions'), 'ask_questions column exists');
   const tbl = db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='step_questions'").get();
@@ -50,7 +50,7 @@ test('repairs a stale-stamped v11 DB (version says 11, v11 DDL never ran)', () =
 
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const cols = db.prepare('PRAGMA table_info(config_workflow_nodes)').all().map((c) => c.name);
   assert.ok(cols.includes('ask_questions'), 'repair added ask_questions');
   const tbl = db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='step_questions'").get();
@@ -75,7 +75,7 @@ test('getDb() repairs a stale-stamped on-disk DB at WORCA_HOME', () => {
   _resetForTests();
   try {
     const db = getDb();
-    assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+    assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
     const cols = db.prepare('PRAGMA table_info(config_workflow_nodes)').all().map((c) => c.name);
     assert.ok(cols.includes('ask_questions'));
     assert.equal(db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE name='step_questions'").get().n, 1);
@@ -91,9 +91,9 @@ test('fast-path reconcile heals missing column/table on a DB already stamped to 
   const db = new DatabaseSync(':memory:');
   db.exec(V10_NODES_SEED);
   db.exec('CREATE TABLE workflows (id TEXT PRIMARY KEY, name TEXT)'); // pre-`domain` shape
-  db.exec('PRAGMA user_version = 16'); // stamped current: the ladder must no-op...
+  db.exec('PRAGMA user_version = 17'); // stamped current: the ladder must no-op...
   migrate(db);
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'stamp untouched');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'stamp untouched');
   // ...yet the incremental gaps are healed anyway.
   const nodeCols = db.prepare('PRAGMA table_info(config_workflow_nodes)').all().map((c) => c.name);
   assert.ok(nodeCols.includes('ask_questions'), 'ask_questions healed');
@@ -126,7 +126,7 @@ test('no-op on a correctly-migrated v11 DB (no duplicate-column / existing-table
 
   migrate(db); // must not throw (duplicate column / table exists)
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   // Existing data in both v11 structures is untouched.
   assert.equal(db.prepare('SELECT ask_questions FROM config_workflow_nodes WHERE node_id = ?').get('n1').ask_questions, 1);
   assert.equal(db.prepare('SELECT count(*) AS n FROM step_questions').get().n, 1);

--- a/test/migrate-v13.test.mjs
+++ b/test/migrate-v13.test.mjs
@@ -26,7 +26,7 @@ const V12_MINIMAL_SEED = `
 
 test('fresh DB migrates to v13 with source columns + workflow origin, defaults correct', () => {
   const db = getDb(); // opens + migrates to SCHEMA_VERSION
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('source_type'), 'pipelines.source_type exists');
   assert.ok(pipCols.includes('source_ref'), 'pipelines.source_ref exists');
@@ -50,7 +50,7 @@ test('a v12-stamped DB upgrades: columns added, pre-existing rows backfill the d
 
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const row = db.prepare("SELECT source_type, source_ref FROM pipelines WHERE id = 'pre'").get();
   assert.equal(row.source_type, 'prompt', 'legacy row reads the ALTER default');
   assert.equal(row.source_ref, null);
@@ -65,11 +65,11 @@ test('fast-path reconcile heals a current-stamped DB missing the v13 columns (pa
   const db = new DatabaseSync(':memory:');
   db.exec(V12_MINIMAL_SEED);
   db.exec('ALTER TABLE pipelines ADD COLUMN source_ref TEXT'); // present; source_type + origin missing
-  db.exec('PRAGMA user_version = 16'); // stamped current: the ladder must no-op...
+  db.exec('PRAGMA user_version = 17'); // stamped current: the ladder must no-op...
 
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'stamp untouched');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'stamp untouched');
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('source_type'), 'source_type healed');
   assert.ok(pipCols.includes('source_ref'), 'pre-existing source_ref survived (no duplicate-column throw)');
@@ -97,7 +97,7 @@ test('ladder from below 12 does not double-add the v13 columns', () => {
     PRAGMA user_version = 11;
   `);
   migrate(db); // v12 heal adds source_*/origin, then the v13 step must no-op — not throw
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('source_type') && pipCols.includes('source_ref'));
 });
@@ -108,5 +108,5 @@ test('migrate() is idempotent at v13 (second call is a clean no-op)', () => {
   db.exec('PRAGMA user_version = 12');
   migrate(db);
   migrate(db); // fast path + reconcile: must not throw duplicate column / table
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
 });

--- a/test/migrate-v14.test.mjs
+++ b/test/migrate-v14.test.mjs
@@ -26,7 +26,7 @@ const V13_MINIMAL_SEED = `
 
 test('fresh DB migrates to v14 with the guardrail_sets table + pipelines.guardrails_id', () => {
   const db = getDb(); // opens + migrates to SCHEMA_VERSION
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('guardrails_id'), 'pipelines.guardrails_id exists');
   assert.equal(
@@ -48,7 +48,7 @@ test('a v13-stamped DB upgrades: column + table added, pre-existing rows read NU
 
   migrate(db);
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   assert.equal(db.prepare("SELECT guardrails_id FROM pipelines WHERE id = 'pre'").get().guardrails_id, null,
     'legacy row reads NULL (selection unknown)');
   assert.equal(
@@ -59,11 +59,11 @@ test('a v13-stamped DB upgrades: column + table added, pre-existing rows read NU
 test('a current-stamped DB missing the additions is healed by the fast-path reconcile, stamp untouched', () => {
   const db = new DatabaseSync(':memory:');
   db.exec(V13_MINIMAL_SEED);
-  db.exec('PRAGMA user_version = 16'); // divergent-ladder stamp: version says done, schema says otherwise
+  db.exec('PRAGMA user_version = 17'); // divergent-ladder stamp: version says done, schema says otherwise
 
   migrate(db); // fast path -> reconcileSchema self-heal
 
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'stamp not rewritten');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'stamp not rewritten');
   const pipCols = db.prepare('PRAGMA table_info(pipelines)').all().map((c) => c.name);
   assert.ok(pipCols.includes('guardrails_id'), 'column healed');
   assert.equal(
@@ -81,7 +81,7 @@ test('ladder from below 13 does not double-add the v14 additions (conditional-re
   // tables BEFORE the v14 step runs. If someone "simplifies" applySchemaV14 to a
   // plain ALTER/CREATE string, this throws "duplicate column" / "table already exists".
   migrate(db);
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
 });
 
 test('migrate() is idempotent (second call is a clean no-op)', () => {
@@ -90,5 +90,5 @@ test('migrate() is idempotent (second call is a clean no-op)', () => {
   db.exec('PRAGMA user_version = 13');
   migrate(db);
   migrate(db);
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
 });

--- a/test/migrate-v15.test.mjs
+++ b/test/migrate-v15.test.mjs
@@ -24,9 +24,9 @@ useTempHome(after);
 const cols = (db, table) =>
   db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
 
-test('fresh DB lands on user_version 16 with cost_ledger and the six new pipelines columns', () => {
+test('fresh DB lands on user_version 17 with cost_ledger and the six new pipelines columns', () => {
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const ledger = db.prepare(
     "SELECT name FROM sqlite_master WHERE type='table' AND name='cost_ledger'").get();
   assert.ok(ledger, 'cost_ledger exists');
@@ -55,9 +55,9 @@ test('self-heal: a dropped new column is re-added on reopen (divergent-stamp rep
   assert.ok(cols(db, 'pipelines').includes('pr_checked_at'));
 });
 
-test('idempotent double-open: no error, version stays 16', () => {
+test('idempotent double-open: no error, version stays 17', () => {
   getDb();
   _resetForTests();
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
 });

--- a/test/migrate-v16.test.mjs
+++ b/test/migrate-v16.test.mjs
@@ -66,7 +66,7 @@ test('v15 -> v16 backfills cost_ledger from pre-ledger pipeline costs', async ()
   _resetForTests();
   const db2 = getDb();
 
-  assert.equal(db2.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db2.prepare('PRAGMA user_version').get().user_version, 17);
 
   const rowsFor = db2.prepare(
     'SELECT step_key, amount_usd, ts FROM cost_ledger WHERE pipeline_id = ? ORDER BY id');
@@ -93,7 +93,7 @@ test('v15 -> v16 backfills cost_ledger from pre-ledger pipeline costs', async ()
 test('reopen after backfill is a no-op: no duplicate synthetic rows', () => {
   _resetForTests();
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16);
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17);
   const { n } = db.prepare('SELECT COUNT(*) AS n FROM cost_ledger').get();
   assert.equal(n, 4, 'still exactly A + B + E + D’s pre-existing row');
 });

--- a/test/model-cost-flags.test.mjs
+++ b/test/model-cost-flags.test.mjs
@@ -1,0 +1,85 @@
+// test/model-cost-flags.test.mjs
+// §4.6 cost-reliability observations: only env-routed models are observed,
+// flagged on zero/absent cost WITH token usage, auto-cleared on a positive
+// cost, surfaced through the catalog (costUnreliable) and GET /api/models.
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  listModels, observeModelCost, modelHasBaseUrlRouting, costUnreliableModelIds,
+} from '../src/core/config.mjs';
+import { addGlobalModel } from '../src/core/settings.mjs';
+import { getDb, _resetForTests } from '../src/core/db.mjs';
+
+const dirs = [];
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
+beforeEach(async () => {
+  const home = await mkdtemp(join(tmpdir(), 'worca-cc-mcf-home-'));
+  const whome = await mkdtemp(join(tmpdir(), 'worca-cc-mcf-whome-'));
+  dirs.push(home, whome);
+  _resetForTests();
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  process.env.WORCA_HOME = whome;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1'; // catalog guard: HOME is sandboxed above
+});
+after(async () => {
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+const USAGE = { input_tokens: 1200, output_tokens: 300 };
+
+test('modelHasBaseUrlRouting: only global entries with an ANTHROPIC_BASE_URL key (direct or ${VAR})', async () => {
+  await addGlobalModel({ id: 'routed', env: { ANTHROPIC_BASE_URL: 'https://p' } });
+  await addGlobalModel({ id: 'routed-ref', env: { ANTHROPIC_BASE_URL: '${MY_URL}' } });
+  await addGlobalModel({ id: 'token-only', env: { ANTHROPIC_AUTH_TOKEN: 'sk-x' } });
+  await addGlobalModel({ id: 'plain' });
+  assert.equal(modelHasBaseUrlRouting('ROUTED'), true, 'case-insensitive');
+  assert.equal(modelHasBaseUrlRouting('routed-ref'), true, 'a ref still routes');
+  assert.equal(modelHasBaseUrlRouting('token-only'), false);
+  assert.equal(modelHasBaseUrlRouting('plain'), false);
+  assert.equal(modelHasBaseUrlRouting('claude-opus-5'), false, 'unshadowed predefined never routes');
+  assert.equal(modelHasBaseUrlRouting(''), false);
+});
+
+test('observe: unrouted models are never observed, whatever they report', async () => {
+  await addGlobalModel({ id: 'plain' });
+  assert.equal(observeModelCost('plain', 0, USAGE), null);
+  assert.equal(observeModelCost('claude-opus-5', null, USAGE), null);
+  assert.equal(costUnreliableModelIds().size, 0);
+});
+
+test('observe: routed + zero/absent cost + tokens -> flagged; positive cost auto-clears', async () => {
+  await addGlobalModel({ id: 'routed', env: { ANTHROPIC_BASE_URL: 'https://p' } });
+
+  // No tokens (e.g. an errored run) -> no signal either way.
+  assert.equal(observeModelCost('routed', 0, {}), null);
+  assert.equal(observeModelCost('routed', null, undefined), null);
+  assert.equal(costUnreliableModelIds().size, 0);
+
+  assert.equal(observeModelCost('routed', 0, USAGE), 'flagged');
+  assert.deepEqual([...costUnreliableModelIds()], ['routed']);
+  // Re-flagging is idempotent (still reported so the caller's per-run warn set decides).
+  assert.equal(observeModelCost('routed', null, USAGE), 'flagged');
+  assert.equal(getDb().prepare('SELECT COUNT(*) AS n FROM model_cost_flags').get().n, 1);
+
+  // The catalog surfaces the observation...
+  const entry = (await listModels('')).find((m) => m.id === 'routed');
+  assert.equal(entry.costUnreliable, true);
+  assert.equal((await listModels('')).find((m) => m.id === 'claude-opus-5').costUnreliable, undefined);
+
+  // ...and a later positive-cost run clears it.
+  assert.equal(observeModelCost('ROUTED', 1.23, USAGE), 'cleared', 'case-insensitive clear');
+  assert.equal(costUnreliableModelIds().size, 0);
+  assert.equal((await listModels('')).find((m) => m.id === 'routed').costUnreliable, undefined);
+  assert.equal(observeModelCost('routed', 0.5, USAGE), null, 'clearing an unflagged model is a no-op');
+});

--- a/test/model-env-dispatch.test.mjs
+++ b/test/model-env-dispatch.test.mjs
@@ -14,7 +14,10 @@ import { addGlobalModel } from '../src/core/settings.mjs';
 import { _resetForTests } from '../src/core/db.mjs';
 
 const dirs = [];
-const prevEnv = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME };
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
 beforeEach(async () => {
   const home = await mkdtemp(join(tmpdir(), 'worca-cc-med-home-'));
   const whome = await mkdtemp(join(tmpdir(), 'worca-cc-med-whome-'));
@@ -22,10 +25,11 @@ beforeEach(async () => {
   _resetForTests();
   process.env.HOME = home; process.env.USERPROFILE = home;
   process.env.WORCA_HOME = whome;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1'; // catalog guard: HOME is sandboxed above
 });
 after(async () => {
   _resetForTests();
-  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME']) {
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
     if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
   }
   await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));

--- a/test/model-env-dispatch.test.mjs
+++ b/test/model-env-dispatch.test.mjs
@@ -1,0 +1,49 @@
+// test/model-env-dispatch.test.mjs
+// Phase 3 dispatch wiring: runOpts (phases.mjs) resolves the model's routing
+// env at the ONE funnel every dispatched node/role passes through, so
+// _phaseCtx/_nodeCtx and the workspace-scan path inherit it with no
+// per-caller edits (design §4.4/§4.8).
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { _runOptsForTests as runOpts } from '../src/core/phases.mjs';
+import { addGlobalModel } from '../src/core/settings.mjs';
+import { _resetForTests } from '../src/core/db.mjs';
+
+const dirs = [];
+const prevEnv = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME };
+beforeEach(async () => {
+  const home = await mkdtemp(join(tmpdir(), 'worca-cc-med-home-'));
+  const whome = await mkdtemp(join(tmpdir(), 'worca-cc-med-whome-'));
+  dirs.push(home, whome);
+  _resetForTests();
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  process.env.WORCA_HOME = whome;
+});
+after(async () => {
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+const CTX_BASE = { projectDir: '/tmp/p', claudeOpts: {} };
+const CALL = { role: 'implementer', prompt: 'p', systemPrompt: 's', allowedTools: ['Read'] };
+
+test('runOpts resolves modelEnv from the dispatched model id', async () => {
+  await addGlobalModel({ id: 'routed-model', env: { ANTHROPIC_BASE_URL: 'https://proxy.test/v1' } });
+  const opts = runOpts({ ...CTX_BASE, claudeOpts: { model: 'routed-model' } }, CALL);
+  assert.equal(opts.model, 'routed-model');
+  assert.deepEqual(opts.modelEnv, { ANTHROPIC_BASE_URL: 'https://proxy.test/v1' });
+});
+
+test('runOpts leaves modelEnv undefined for env-less and unconfigured models', async () => {
+  await addGlobalModel({ id: 'plain-model' });
+  assert.equal(runOpts({ ...CTX_BASE, claudeOpts: { model: 'plain-model' } }, CALL).modelEnv, undefined);
+  assert.equal(runOpts({ ...CTX_BASE, claudeOpts: { model: 'claude-opus-5' } }, CALL).modelEnv, undefined);
+  assert.equal(runOpts({ ...CTX_BASE, claudeOpts: {} }, CALL).modelEnv, undefined, 'no model -> no env');
+});

--- a/test/model-env.test.mjs
+++ b/test/model-env.test.mjs
@@ -1,0 +1,63 @@
+// test/model-env.test.mjs
+// The zero-import leaf shared by settings.mjs (write-time validation) and
+// claude-runner.mjs (spawn-time filter): effort vocabulary, reserved-key
+// policy, whole-value ${VAR} refs (configurable-models-design.md §4.1/§4.4).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  EFFORTS, RESERVED_MODEL_ENV_KEYS, isReservedModelEnvKey, modelEnvRef, prepareModelEnv,
+} from '../src/core/model-env.mjs';
+import { EFFORTS as CONFIG_EFFORTS } from '../src/core/config.mjs';
+
+test('EFFORTS: canonical here, config.mjs re-export is the SAME array', () => {
+  assert.deepEqual(EFFORTS, ['medium', 'high', 'xhigh', 'max']);
+  assert.equal(CONFIG_EFFORTS, EFFORTS); // identity, not a drifting copy
+});
+
+test('isReservedModelEnvKey: exact keys, WORCA_ prefix, and the allowed rest', () => {
+  for (const k of RESERVED_MODEL_ENV_KEYS) assert.equal(isReservedModelEnvKey(k), true, k);
+  // The prefix protects every worca runtime knob, present and future.
+  for (const k of ['WORCA_MOCK', 'WORCA_CLAUDE_BIN', 'WORCA_EFFORT_FLAG', 'WORCA_ANYTHING']) {
+    assert.equal(isReservedModelEnvKey(k), true, k);
+  }
+  // Routing env is the point — ANTHROPIC_*/CLAUDE_* must NOT be reserved
+  // (except the explicit scrub landmine, covered above via the exact list).
+  for (const k of ['ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_MODEL', 'CLAUDE_CODE_EXTRA']) {
+    assert.equal(isReservedModelEnvKey(k), false, k);
+  }
+  assert.equal(isReservedModelEnvKey(''), false);
+});
+
+test('modelEnvRef: whole-value form only', () => {
+  assert.equal(modelEnvRef('${MY_TOKEN}'), 'MY_TOKEN');
+  assert.equal(modelEnvRef('${_x1}'), '_x1');
+  assert.equal(modelEnvRef('prefix-${MY_TOKEN}'), null); // embedded = literal
+  assert.equal(modelEnvRef('${1BAD}'), null);
+  assert.equal(modelEnvRef('${}'), null);
+  assert.equal(modelEnvRef('plain'), null);
+  assert.equal(modelEnvRef(42), null);
+  assert.equal(modelEnvRef(undefined), null);
+});
+
+test('prepareModelEnv: literals pass, reserved/non-string dropped, refs expand', () => {
+  const source = { MY_TOKEN: 'sk-123', EMPTY: '' };
+  const { env, dropped } = prepareModelEnv({
+    ANTHROPIC_BASE_URL: 'https://proxy.example/v1', // literal
+    ANTHROPIC_AUTH_TOKEN: '${MY_TOKEN}',            // ref, set
+    X_UNSET: '${NOT_SET}',                          // ref, unset -> dropped
+    X_EMPTY: '${EMPTY}',                            // ref, empty -> dropped
+    PATH: '/evil',                                  // reserved -> dropped
+    WORCA_MOCK: '1',                                // reserved prefix -> dropped
+    X_NUM: 7,                                       // non-string -> dropped
+  }, source);
+  assert.deepEqual(env, {
+    ANTHROPIC_BASE_URL: 'https://proxy.example/v1',
+    ANTHROPIC_AUTH_TOKEN: 'sk-123',
+  });
+  assert.deepEqual(dropped.sort(), ['PATH', 'WORCA_MOCK', 'X_EMPTY', 'X_NUM', 'X_UNSET']);
+});
+
+test('prepareModelEnv: empty/absent input is a no-op', () => {
+  assert.deepEqual(prepareModelEnv(undefined, {}), { env: {}, dropped: [] });
+  assert.deepEqual(prepareModelEnv({}, {}), { env: {}, dropped: [] });
+});

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -1,0 +1,135 @@
+// test/models-view.test.mjs — pure jsdom tests for the Models-view renderers
+// (configurable-models-design.md §4.10). No app.js boot: every renderer takes
+// `doc` explicitly and returns detached DOM (guardrails-view test pattern).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import {
+  effortsSummary, envSummary, renderModelsList, renderModelEditor,
+  collectModelEditor, makeEnvRow, deleteRefsSummary,
+} from '../ui/public/models-view.mjs';
+
+const doc = new JSDOM('<!doctype html><body></body>').window.document;
+
+const EFFORTS = ['medium', 'high', 'xhigh', 'max'];
+const PREDEFINED = [
+  { id: 'claude-opus-5', label: 'Opus 5', efforts: EFFORTS },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', efforts: ['medium', 'high', 'max'] },
+];
+const GLOBAL = {
+  id: 'glm-4.7', label: 'GLM (proxy)', efforts: ['medium', 'high'],
+  env: { ANTHROPIC_BASE_URL: '••••••e/v1', ANTHROPIC_AUTH_TOKEN: '••••••1234', X_REF: '${MY_VAR}' },
+};
+const SHADOW = { id: 'claude-sonnet-4-6', label: 'Sonnet via proxy', efforts: ['medium'], env: { ANTHROPIC_BASE_URL: '••••••e/v1' } };
+
+test('effortsSummary/envSummary', () => {
+  assert.equal(effortsSummary(EFFORTS, EFFORTS), 'all efforts');
+  assert.equal(effortsSummary([], EFFORTS), 'all efforts');
+  assert.equal(effortsSummary(['medium', 'high'], EFFORTS), 'medium · high');
+  assert.equal(envSummary(undefined), '');
+  assert.equal(envSummary({ A: '1' }), '1 env var');
+  assert.equal(envSummary({ ANTHROPIC_BASE_URL: 'x', T: 'y' }), '2 env vars · routes via base URL');
+});
+
+test('list: global cards get Edit/Delete + shadow badge; legacy get Promote; built-ins read-only + overridden badge', () => {
+  const el = renderModelsList({
+    globals: [GLOBAL, SHADOW],
+    legacy: [{ id: 'old-local', label: 'Old Local' }],
+    predefined: PREDEFINED,
+    efforts: EFFORTS,
+    projectName: 'my-repo',
+  }, { doc });
+
+  const cards = el.querySelectorAll('.mv-card:not(.mv-legacy)');
+  assert.equal(cards.length, 2);
+  assert.equal(cards[0].dataset.id, 'glm-4.7');
+  assert.equal(cards[0].querySelector('.mv-shadow'), null, 'non-shadow entry has no override badge');
+  assert.ok(cards[0].querySelector('.mv-edit'));
+  assert.ok(cards[0].querySelector('.mv-delete'));
+  assert.match(cards[0].querySelector('.mv-summary').textContent, /3 env vars · routes via base URL/);
+  assert.equal(cards[1].querySelector('.mv-shadow').textContent, 'overrides built-in');
+
+  const legacy = el.querySelectorAll('.mv-legacy');
+  assert.equal(legacy.length, 1);
+  assert.equal(legacy[0].querySelector('.mv-origin').textContent, 'project (legacy)');
+  assert.equal(legacy[0].querySelector('.mv-promote').dataset.id, 'old-local');
+
+  const builtins = el.querySelectorAll('.mv-builtin');
+  assert.equal(builtins.length, 2);
+  assert.equal(builtins[0].querySelector('.mv-shadowed'), null);
+  assert.equal(builtins[1].querySelector('.mv-shadowed').textContent, 'overridden', 'sonnet is overridden by SHADOW');
+  assert.equal(builtins[0].querySelector('button'), null, 'built-ins carry no actions');
+});
+
+test('editor (create): id enabled, all efforts pre-checked, no env rows', () => {
+  const el = renderModelEditor(null, EFFORTS, { doc });
+  assert.equal(el.dataset.mode, 'create');
+  assert.equal(el.querySelector('.mv-id').disabled, false);
+  const cbs = [...el.querySelectorAll('.mv-effort-cb')];
+  assert.equal(cbs.length, 4);
+  assert.ok(cbs.every((c) => c.checked));
+  assert.equal(el.querySelectorAll('.mv-env-row').length, 0);
+  assert.ok(el.querySelector('.mv-save'));
+  assert.ok(el.querySelector('.mv-cancel'));
+});
+
+test('editor (edit): id locked, efforts reflect the entry, masked env rows carry data-original', () => {
+  const el = renderModelEditor(GLOBAL, EFFORTS, { doc });
+  assert.equal(el.dataset.mode, 'edit');
+  assert.equal(el.dataset.id, 'glm-4.7');
+  assert.equal(el.querySelector('.mv-id').disabled, true);
+  assert.deepEqual(
+    [...el.querySelectorAll('.mv-effort-cb')].filter((c) => c.checked).map((c) => c.value),
+    ['medium', 'high'],
+  );
+  const rows = [...el.querySelectorAll('.mv-env-row')];
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0].querySelector('.mv-env-val').value, '••••••e/v1');
+  assert.equal(rows[0].querySelector('.mv-env-val').dataset.original, '••••••e/v1');
+  assert.equal(el.dataset.envKeys, 'ANTHROPIC_BASE_URL\nANTHROPIC_AUTH_TOKEN\nX_REF');
+});
+
+test('collect (create): id from input, partial efforts, env rows as typed; full effort set collapses to []', () => {
+  const el = renderModelEditor(null, EFFORTS, { doc });
+  el.querySelector('.mv-id').value = '  my-model  ';
+  el.querySelector('.mv-label').value = 'Mine';
+  el.querySelector('.mv-efforts').appendChild(makeEnvRow({ doc })); // noop guard: env rows live in .mv-env
+  el.querySelector('.mv-env').appendChild(makeEnvRow({ doc }));
+  const row = el.querySelector('.mv-env .mv-env-row');
+  row.querySelector('.mv-env-key').value = 'ANTHROPIC_BASE_URL';
+  row.querySelector('.mv-env-val').value = 'https://x';
+
+  let { id, body } = collectModelEditor(el);
+  assert.equal(id, null);
+  assert.deepEqual(body, { id: 'my-model', label: 'Mine', efforts: [], env: { ANTHROPIC_BASE_URL: 'https://x' } });
+
+  // Uncheck one effort -> the subset is sent.
+  el.querySelector('.mv-effort-cb[value="max"]').checked = false;
+  ({ body } = collectModelEditor(el));
+  assert.deepEqual(body.efforts, ['medium', 'high', 'xhigh']);
+});
+
+test('collect (edit): removed env rows become null-deletes; kept masked values are echoed', () => {
+  const el = renderModelEditor(GLOBAL, EFFORTS, { doc });
+  // Remove the token row entirely; change the base URL; keep X_REF untouched.
+  const rows = [...el.querySelectorAll('.mv-env-row')];
+  rows[1].remove(); // ANTHROPIC_AUTH_TOKEN
+  rows[0].querySelector('.mv-env-val').value = 'https://new.example';
+
+  const { id, body } = collectModelEditor(el);
+  assert.equal(id, 'glm-4.7');
+  assert.equal(body.env.ANTHROPIC_BASE_URL, 'https://new.example');
+  assert.equal(body.env.ANTHROPIC_AUTH_TOKEN, null, 'removed row -> null delete');
+  assert.equal(body.env.X_REF, '${MY_VAR}', 'untouched value echoed (server keeps refs readable)');
+});
+
+test('deleteRefsSummary wording', () => {
+  assert.match(deleteRefsSummary('x', { predefinedShadow: true }), /Remove the override/);
+  assert.match(deleteRefsSummary('x', { predefinedShadow: false, nodes: [], steps: [] }), /No pipeline configuration references it/);
+  const refs = {
+    predefinedShadow: false,
+    nodes: [{ projectKey: 'a', workflowId: 'w', nodeId: 'n' }, { projectKey: 'b', workflowId: 'w', nodeId: 'n' }],
+    steps: [{ projectKey: 'a', step: 'implementer' }],
+  };
+  assert.match(deleteRefsSummary('x', refs), /2 node selections and 1 role selection across 2 projects/);
+});

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -89,6 +89,24 @@ test('editor (edit): id locked, efforts reflect the entry, masked env rows carry
   assert.equal(el.dataset.envKeys, 'ANTHROPIC_BASE_URL\nANTHROPIC_AUTH_TOKEN\nX_REF');
 });
 
+test('editor (edit): stored env rows carry a copy button + frozen data-key and a reveal toggle; create mode has neither', () => {
+  const el = renderModelEditor(GLOBAL, EFFORTS, { doc });
+  const rows = [...el.querySelectorAll('.mv-env-row')];
+  for (const row of rows) {
+    assert.ok(row.dataset.key, 'stored row keeps its persisted key');
+    assert.ok(row.querySelector('.mv-env-copy'), 'stored row gets a copy button');
+  }
+  assert.equal(rows[1].dataset.key, 'ANTHROPIC_AUTH_TOKEN');
+  assert.ok(el.querySelector('.mv-env-reveal'), 'reveal toggle present when stored rows exist');
+  assert.equal(el.querySelector('.mv-env-reveal').textContent, 'Show values');
+
+  const created = renderModelEditor(null, EFFORTS, { doc });
+  assert.equal(created.querySelector('.mv-env-reveal'), null, 'nothing to reveal in create mode');
+  const fresh = makeEnvRow({ doc });
+  assert.equal(fresh.querySelector('.mv-env-copy'), null, 'a NEW row has no stored value to copy');
+  assert.equal(fresh.dataset.key, undefined);
+});
+
 test('collect (create): id from input, partial efforts, env rows as typed; full effort set collapses to []', () => {
   const el = renderModelEditor(null, EFFORTS, { doc });
   el.querySelector('.mv-id').value = '  my-model  ';

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -7,6 +7,7 @@ import { JSDOM } from 'jsdom';
 import {
   effortsSummary, envSummary, renderModelsList, renderModelEditor,
   collectModelEditor, makeEnvRow, deleteRefsSummary,
+  renderExportWizard, collectExportWizard,
 } from '../ui/public/models-view.mjs';
 
 const doc = new JSDOM('<!doctype html><body></body>').window.document;
@@ -150,4 +151,79 @@ test('deleteRefsSummary wording', () => {
     steps: [{ projectKey: 'a', step: 'implementer' }],
   };
   assert.match(deleteRefsSummary('x', refs), /2 node selections and 1 role selection across 2 projects/);
+});
+
+// ── plugin section + export wizard (design §9.5–§9.6) ────────────────────────
+
+const PLUGINS = [
+  {
+    id: 'ds-stable', label: 'DS Stable', efforts: ['medium', 'high'], plugin: 'team-models',
+    env: { ANTHROPIC_BASE_URL: '••••••mple', ANTHROPIC_AUTH_TOKEN: '(secret: ds-token)' },
+    secrets: [{ key: 'ds-token', label: 'DS token', set: false }],
+  },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet via plugin', efforts: ['medium'], plugin: 'team-models', env: {}, secrets: [] },
+];
+
+test('list: plugin cards are read-only with provenance + secret status + Edit-a-copy; shadows badge both ways', () => {
+  const el = renderModelsList({
+    globals: [{ ...GLOBAL, id: 'ds-stable' }],
+    plugins: PLUGINS,
+    predefined: PREDEFINED,
+    efforts: EFFORTS,
+  }, { doc });
+
+  const cards = [...el.querySelectorAll('.mv-plugin')];
+  assert.equal(cards.length, 2);
+  assert.equal(cards[0].dataset.plugin, 'team-models');
+  assert.equal(cards[0].querySelector('.mv-origin').textContent, 'plugin: team-models');
+  assert.equal(cards[0].querySelector('.mv-edit'), null, 'no Edit on plugin cards');
+  assert.equal(cards[0].querySelector('.mv-delete'), null, 'no Delete on plugin cards');
+  const copy = cards[0].querySelector('.mv-copy');
+  assert.equal(copy.dataset.id, 'ds-stable');
+  assert.equal(copy.dataset.plugin, 'team-models');
+  assert.match(cards[0].querySelector('.mv-secret').textContent, /NOT SET/);
+  assert.match(cards[0].querySelector('.mv-shadowed').textContent, /overridden by your copy/,
+    'the user global with the same id shadows this plugin entry');
+
+  // The user's global card says it overrides the plugin (not a built-in).
+  const globalCard = el.querySelector('.mv-card:not(.mv-plugin):not(.mv-legacy)');
+  assert.equal(globalCard.querySelector('.mv-shadow').textContent, 'overrides plugin');
+
+  // A plugin entry with a predefined id marks the built-in overridden.
+  const sonnetRow = [...el.querySelectorAll('.mv-builtin')].find((r) => r.dataset.id === 'claude-sonnet-4-6');
+  assert.equal(sonnetRow.querySelector('.mv-shadowed').textContent, 'overridden');
+});
+
+test('export wizard: renders picks + env policy (secret-ish defaults) and collects the POST body', () => {
+  const globals = [
+    { id: 'ds-stable', label: 'DS Stable', efforts: EFFORTS, env: { ANTHROPIC_BASE_URL: '••••••mple', ANTHROPIC_AUTH_TOKEN: '••••••1234' } },
+    { id: 'other', label: 'Other', efforts: EFFORTS },
+  ];
+  const el = renderExportWizard(globals, { doc });
+  const cbs = [...el.querySelectorAll('.mvx-model-cb')];
+  assert.deepEqual(cbs.map((c) => c.value), ['ds-stable', 'other']);
+  assert.equal(cbs[0].dataset.envKeys, 'ANTHROPIC_BASE_URL\nANTHROPIC_AUTH_TOKEN');
+
+  const rows = [...el.querySelectorAll('.mvx-env-row')];
+  assert.deepEqual(rows.map((r) => r.dataset.key), ['ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN']);
+  assert.equal(rows[0].querySelector('.mvx-mode').value, 'include', 'base URL defaults to include');
+  assert.equal(rows[1].querySelector('.mvx-mode').value, 'secret', 'TOKEN-ish key defaults to require-at-install');
+  assert.ok(rows[1].querySelector('.mvx-warn'), 'credential-looking key is called out');
+
+  cbs[0].checked = true;
+  el.querySelector('.mvx-name').value = ' team-models ';
+  el.querySelector('.mvx-desc').value = 'Team routing';
+  el.querySelector('.mvx-dest').value = '~/dev/team-models';
+  const body = collectExportWizard(el);
+  assert.deepEqual(body, {
+    name: 'team-models', description: 'Team routing', dest: '~/dev/team-models',
+    models: [{ id: 'ds-stable', env: { ANTHROPIC_BASE_URL: 'include', ANTHROPIC_AUTH_TOKEN: 'secret' } }],
+  });
+
+  // Version is included only when set; mode changes flow into the body.
+  el.querySelector('.mvx-version').value = '1.0.0';
+  rows[1].querySelector('.mvx-mode').value = 'omit';
+  const body2 = collectExportWizard(el);
+  assert.equal(body2.version, '1.0.0');
+  assert.equal(body2.models[0].env.ANTHROPIC_AUTH_TOKEN, 'omit');
 });

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -227,3 +227,15 @@ test('export wizard: renders picks + env policy (secret-ish defaults) and collec
   assert.equal(body2.version, '1.0.0');
   assert.equal(body2.models[0].env.ANTHROPIC_AUTH_TOKEN, 'omit');
 });
+
+test('export wizard: token LIMITS are not credentials (MAX_OUTPUT_TOKENS defaults to include)', () => {
+  const el = renderExportWizard([{
+    id: 'm', label: 'M', efforts: EFFORTS,
+    env: { CLAUDE_CODE_MAX_OUTPUT_TOKENS: '8192', MAX_THINKING_TOKENS: '8191', ANTHROPIC_AUTH_TOKEN: '••1234', API_KEY: '••5678' },
+  }], { doc });
+  const mode = (k) => [...el.querySelectorAll('.mvx-env-row')].find((r) => r.dataset.key === k).querySelector('.mvx-mode').value;
+  assert.equal(mode('CLAUDE_CODE_MAX_OUTPUT_TOKENS'), 'include');
+  assert.equal(mode('MAX_THINKING_TOKENS'), 'include');
+  assert.equal(mode('ANTHROPIC_AUTH_TOKEN'), 'secret');
+  assert.equal(mode('API_KEY'), 'secret');
+});

--- a/test/newpipeline-config.test.mjs
+++ b/test/newpipeline-config.test.mjs
@@ -204,7 +204,7 @@ test('renderModelEffortPair fills a model dropdown (default + models + add) and 
   assert.match(caption.textContent, /Haiku 4\.5 · high/);
 });
 
-test('model dropdown: grouped (Your models first, Built-in second), alphabetical, no provenance suffix', async () => {
+test('model dropdown: grouped (Your models / Plugins / Built-in), alphabetical, collision-only plugin suffix', async () => {
   const { window } = await boot();
   const doc = window.document;
   const modelSel = doc.createElement('select');
@@ -214,14 +214,19 @@ test('model dropdown: grouped (Your models first, Built-in second), alphabetical
     { id: 'claude-haiku-4-5', label: 'Haiku 4.5', efforts: ['medium'], custom: false },
     { id: 'zz-model', label: 'Zeta', efforts: ['medium'], custom: 'global' },
     { id: 'aa-model', label: 'Alpha', efforts: ['medium'], custom: 'project' },
+    // Same LABEL as the user's Zeta -> this plugin option gets its plugin name;
+    // Beta is unambiguous and stays clean (design §9.6, collision-only).
+    { id: 'plug-zeta', label: 'Zeta', efforts: ['medium'], custom: 'plugin', plugin: 'team-models' },
+    { id: 'plug-beta', label: 'Beta', efforts: ['medium'], custom: 'plugin', plugin: 'team-models' },
   ]);
   window.__np.renderModelEffortPair(modelSel, effortSel, null, {});
   const groups = [...modelSel.querySelectorAll('optgroup')];
-  assert.deepEqual(groups.map((g) => g.label), ['Your models', 'Built-in']);
+  assert.deepEqual(groups.map((g) => g.label), ['Your models', 'Plugins', 'Built-in']);
   // Alphabetical by label inside each group; provenance carried by the group,
   // never a ·custom/·project suffix on the option text.
   assert.deepEqual([...groups[0].querySelectorAll('option')].map((o) => o.textContent), ['Alpha', 'Zeta']);
-  assert.deepEqual([...groups[1].querySelectorAll('option')].map((o) => o.textContent), ['Haiku 4.5', 'Sonnet 4.6']);
+  assert.deepEqual([...groups[1].querySelectorAll('option')].map((o) => o.textContent), ['Beta', 'Zeta (team-models)']);
+  assert.deepEqual([...groups[2].querySelectorAll('option')].map((o) => o.textContent), ['Haiku 4.5', 'Sonnet 4.6']);
   // The default + add affordances bracket the groups.
   assert.equal(modelSel.options[0].value, '');
   assert.equal(modelSel.options[modelSel.options.length - 1].value, '__add__');

--- a/test/newpipeline-config.test.mjs
+++ b/test/newpipeline-config.test.mjs
@@ -204,6 +204,29 @@ test('renderModelEffortPair fills a model dropdown (default + models + add) and 
   assert.match(caption.textContent, /Haiku 4\.5 · high/);
 });
 
+test('model dropdown: grouped (Your models first, Built-in second), alphabetical, no provenance suffix', async () => {
+  const { window } = await boot();
+  const doc = window.document;
+  const modelSel = doc.createElement('select');
+  const effortSel = doc.createElement('select');
+  window.__np._setModels([
+    { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', efforts: ['medium'], custom: false },
+    { id: 'claude-haiku-4-5', label: 'Haiku 4.5', efforts: ['medium'], custom: false },
+    { id: 'zz-model', label: 'Zeta', efforts: ['medium'], custom: 'global' },
+    { id: 'aa-model', label: 'Alpha', efforts: ['medium'], custom: 'project' },
+  ]);
+  window.__np.renderModelEffortPair(modelSel, effortSel, null, {});
+  const groups = [...modelSel.querySelectorAll('optgroup')];
+  assert.deepEqual(groups.map((g) => g.label), ['Your models', 'Built-in']);
+  // Alphabetical by label inside each group; provenance carried by the group,
+  // never a ·custom/·project suffix on the option text.
+  assert.deepEqual([...groups[0].querySelectorAll('option')].map((o) => o.textContent), ['Alpha', 'Zeta']);
+  assert.deepEqual([...groups[1].querySelectorAll('option')].map((o) => o.textContent), ['Haiku 4.5', 'Sonnet 4.6']);
+  // The default + add affordances bracket the groups.
+  assert.equal(modelSel.options[0].value, '');
+  assert.equal(modelSel.options[modelSel.options.length - 1].value, '__add__');
+});
+
 // A saved workflow served by the mocked API for the selector tests below.
 const SAVED_WF = {
   id: 'wf_x', name: 'Demo',

--- a/test/plugin-manifest.test.mjs
+++ b/test/plugin-manifest.test.mjs
@@ -39,6 +39,7 @@ test('minimal { name } manifest normalizes with full defaults', () => {
   assert.deepEqual(r.manifest, {
     name: 'my-plugin', version: null, description: '', author: '', homepage: '', license: '',
     engines: { worcaApi: null }, setup: { node: false, python: null }, taskSources: [],
+    models: [], modelSecrets: [],
   });
 });
 
@@ -235,4 +236,68 @@ test('validatePluginDir: missing/corrupt manifest', () => {
   const corrupt = validatePluginDir(mkPluginDir({ 'worca-cc-plugin.json': '{nope' }));
   assert.equal(corrupt.ok, false);
   assert.match(corrupt.problems[0].message, /invalid JSON/);
+});
+
+// ── models + modelSecrets (design §9.1) ──────────────────────────────────────
+
+const MODEL = (over = {}) => ({
+  id: 'discretestack-stable', label: 'DS Stable', efforts: ['medium', 'high'],
+  env: { ANTHROPIC_BASE_URL: 'https://api.ds.example', ANTHROPIC_AUTH_TOKEN: { secret: 'ds-token' } },
+  ...over,
+});
+const SECRETS = [{ key: 'ds-token', label: 'DS API token' }];
+
+test('models: normalization — defaults, canonical effort order, secret refs kept', () => {
+  const r = normalizeManifest({
+    name: 'p', modelSecrets: SECRETS,
+    models: [MODEL({ efforts: ['high', 'medium', 'high'] }), { id: 'bare' }],
+  });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.manifest.modelSecrets, [{ key: 'ds-token', label: 'DS API token' }]);
+  const [m, bare] = r.manifest.models;
+  assert.deepEqual(m.efforts, ['medium', 'high'], 'EFFORTS order, deduped');
+  assert.equal(m.env.ANTHROPIC_BASE_URL, 'https://api.ds.example');
+  assert.deepEqual(m.env.ANTHROPIC_AUTH_TOKEN, { secret: 'ds-token' });
+  assert.equal(bare.label, 'bare');
+  assert.deepEqual(bare.efforts, ['medium', 'high', 'xhigh', 'max'], 'absent efforts -> full set');
+  assert.equal(bare.env, undefined, 'no env key when empty');
+});
+
+test('models: rejections — reserved env key, dup id, unknown effort, dangling secret, bad value', () => {
+  const fail = (models, modelSecrets, re) => {
+    const r = normalizeManifest({ name: 'p', models, ...(modelSecrets ? { modelSecrets } : {}) });
+    assert.equal(r.ok, false);
+    assert.match(r.errors.join('\n'), re);
+  };
+  fail([MODEL({ env: { WORCA_MOCK: '1' } })], SECRETS, /env key "WORCA_MOCK" is reserved/);
+  fail([MODEL({ env: { PATH: '/evil' } })], SECRETS, /env key "PATH" is reserved/);
+  fail([MODEL({}), MODEL({ label: 'Twin', id: 'Discretestack-Stable' })], SECRETS, /duplicate models id/);
+  fail([MODEL({ efforts: ['low'] })], SECRETS, /unknown effort "low"/);
+  fail([MODEL()], undefined, /undeclared modelSecrets key "ds-token"/);
+  fail([MODEL({ env: { X: '' } })], SECRETS, /must be a non-empty string or \{"secret"/);
+  fail([MODEL({ env: { X: { secret: 'a', extra: 1 } } })], SECRETS, /must be a non-empty string or \{"secret"/);
+  fail([{ label: 'no id' }], undefined, /"id" is required/);
+  fail('nope', undefined, /"models" must be an array/);
+});
+
+test('modelSecrets: rejections — bad key, duplicate key, non-array', () => {
+  const bad = normalizeManifest({ name: 'p', modelSecrets: [{ key: 'has space' }] });
+  assert.equal(bad.ok, false);
+  assert.match(bad.errors.join('\n'), /"key" must be an identifier/);
+  const dup = normalizeManifest({ name: 'p', modelSecrets: [{ key: 'k' }, { key: 'k' }] });
+  assert.equal(dup.ok, false);
+  assert.match(dup.errors.join('\n'), /duplicate modelSecrets key "k"/);
+  const notArr = normalizeManifest({ name: 'p', modelSecrets: {} });
+  assert.equal(notArr.ok, false);
+  assert.match(notArr.errors.join('\n'), /"modelSecrets" must be an array/);
+});
+
+test('models: unknown fields warn (strict promotes via validatePluginDir)', () => {
+  const r = normalizeManifest({
+    name: 'p', modelSecrets: [{ key: 'k', magic: 1 }],
+    models: [{ id: 'm', pricing: {} }],
+  });
+  assert.equal(r.ok, true);
+  assert.match(r.warnings.join('\n'), /models\[0\]: unknown field "pricing" ignored/);
+  assert.match(r.warnings.join('\n'), /modelSecrets\[0\]: unknown field "magic" ignored/);
 });

--- a/test/plugin-models.test.mjs
+++ b/test/plugin-models.test.mjs
@@ -1,0 +1,204 @@
+// test/plugin-models.test.mjs — plugin model contributions (design §9.2–§9.4):
+// manifest reading, cross-plugin dedupe, secret flattening, catalog
+// composition precedence, resolveModelEnv/modelHasBaseUrlRouting extension,
+// and the uninstall-guard refs. Sandboxes HOME (settings.json) and WORCA_HOME
+// (plugins + DB) and opts into the catalog guard, mirroring api-models.test.mjs.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { _resetForTests } from '../src/core/db.mjs';
+import { readPluginsLock, writePluginsLock, pluginCurrentDir } from '../src/core/plugins-lock.mjs';
+import { writePluginConfig } from '../src/core/plugin-config.mjs';
+import {
+  allPluginModels, listPluginModels, modelSecretsSchema, pluginModelSecretStatus,
+  flattenPluginModelEnv,
+} from '../src/core/plugin-models.mjs';
+import {
+  listModels, resolveModelEnv, modelHasBaseUrlRouting, referencedPluginModels,
+  setNodeModel,
+} from '../src/core/config.mjs';
+import { addGlobalModel, removeGlobalModel } from '../src/core/settings.mjs';
+
+let homeDir, worcaHomeDir, proj;
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
+
+/** Fixture-install: current/ as a real dir with a manifest + a lock entry. */
+function installFixture(name, manifest, { enabled = true } = {}) {
+  const cur = pluginCurrentDir(name);
+  mkdirSync(cur, { recursive: true });
+  writeFileSync(join(cur, 'worca-cc-plugin.json'), JSON.stringify({ name, ...manifest }));
+  writePluginsLock({
+    ...readPluginsLock(),
+    [name]: { repo: 'https://example.com/r', subdir: '', pinnedSha: 'x'.repeat(40), version: '1', enabled },
+  });
+}
+
+const DS_MANIFEST = {
+  modelSecrets: [{ key: 'ds-token', label: 'DS token' }],
+  models: [
+    {
+      id: 'ds-stable', label: 'DS Stable', efforts: ['medium', 'high'],
+      env: {
+        ANTHROPIC_BASE_URL: 'https://api.ds.example',
+        X_REF: '${MY_DS_VAR}',
+        ANTHROPIC_AUTH_TOKEN: { secret: 'ds-token' },
+      },
+    },
+    { id: 'ds-fast', label: 'DS Fast' },
+  ],
+};
+
+before(async () => {
+  homeDir = await mkdtemp(join(tmpdir(), 'worca-cc-pm-home-'));
+  worcaHomeDir = await mkdtemp(join(tmpdir(), 'worca-cc-pm-whome-'));
+  proj = await mkdtemp(join(tmpdir(), 'worca-cc-pm-proj-'));
+  process.env.HOME = homeDir; process.env.USERPROFILE = homeDir;
+  process.env.WORCA_HOME = worcaHomeDir;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1'; // catalog guard: HOME sandboxed above
+  _resetForTests();
+  installFixture('discretestack-models', DS_MANIFEST);
+});
+after(async () => {
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all([homeDir, worcaHomeDir, proj].map((d) => rm(d, { recursive: true, force: true })));
+});
+
+test('allPluginModels: enabled plugins only, manifest order, secrets listed', () => {
+  const all = allPluginModels();
+  assert.equal(all.length, 2);
+  assert.equal(all[0].plugin, 'discretestack-models');
+  assert.equal(all[0].id, 'ds-stable');
+  assert.deepEqual(all[0].efforts, ['medium', 'high']);
+  assert.deepEqual(all[0].secrets, ['ds-token']);
+  assert.deepEqual(all[1].secrets, []);
+  assert.deepEqual(all[1].efforts, ['medium', 'high', 'xhigh', 'max']);
+});
+
+test('disabled plugin contributes nothing; re-enable restores', () => {
+  const lock = readPluginsLock();
+  writePluginsLock({ ...lock, 'discretestack-models': { ...lock['discretestack-models'], enabled: false } });
+  assert.deepEqual(allPluginModels(), []);
+  writePluginsLock(lock);
+  assert.equal(allPluginModels().length, 2);
+});
+
+test('listPluginModels: cross-plugin id collision — alphabetical plugin wins, loser dropped', () => {
+  installFixture('zz-other', { models: [{ id: 'DS-Stable', label: 'Other Stable' }, { id: 'zz-own', label: 'ZZ' }] });
+  const list = listPluginModels();
+  const stable = list.filter((m) => m.id.toLowerCase() === 'ds-stable');
+  assert.equal(stable.length, 1);
+  assert.equal(stable[0].plugin, 'discretestack-models', 'alphabetical winner');
+  assert.ok(list.some((m) => m.id === 'zz-own'), 'non-colliding entry of the loser survives');
+});
+
+test('modelSecretsSchema + status; flattenPluginModelEnv resolves/drops secrets', () => {
+  const schema = modelSecretsSchema('discretestack-models');
+  assert.equal(schema.length, 1);
+  assert.equal(schema[0].secret, true);
+  assert.deepEqual(pluginModelSecretStatus('discretestack-models'), [{ key: 'ds-token', label: 'DS token', set: false }]);
+
+  const [stable] = allPluginModels();
+  let flat = flattenPluginModelEnv(stable);
+  assert.equal(flat.env.ANTHROPIC_BASE_URL, 'https://api.ds.example');
+  assert.equal(flat.env.X_REF, '${MY_DS_VAR}', 'ref text passes through untouched');
+  assert.equal(flat.env.ANTHROPIC_AUTH_TOKEN, undefined);
+  assert.match(flat.droppedSecrets[0], /ANTHROPIC_AUTH_TOKEN \(secret "ds-token"\)/);
+
+  writePluginConfig('discretestack-models', schema, { 'ds-token': 'sk-team-1234' });
+  assert.deepEqual(pluginModelSecretStatus('discretestack-models'), [{ key: 'ds-token', label: 'DS token', set: true }]);
+  flat = flattenPluginModelEnv(stable);
+  assert.equal(flat.env.ANTHROPIC_AUTH_TOKEN, 'sk-team-1234');
+  assert.deepEqual(flat.droppedSecrets, []);
+});
+
+test('catalog composition: custom "plugin" + plugin name; global shadows plugin; plugin shadows predefined', async () => {
+  const models = await listModels('');
+  const stable = models.find((m) => m.id === 'ds-stable');
+  assert.equal(stable.custom, 'plugin');
+  assert.equal(stable.plugin, 'discretestack-models');
+  assert.equal(stable.hasEnv, true);
+  assert.equal(models.find((m) => m.id === 'ds-fast').hasEnv, false);
+
+  // A user global entry with the same id wins (case-insensitively).
+  await addGlobalModel({ id: 'DS-STABLE', label: 'My Stable', env: { OTHER: 'x' } });
+  const shadowed = (await listModels('')).find((m) => m.id.toLowerCase() === 'ds-stable');
+  assert.equal(shadowed.custom, 'global');
+  assert.equal(shadowed.label, 'My Stable');
+  await removeGlobalModel('DS-STABLE');
+
+  // A plugin entry with a predefined id shadows the built-in, keeping its casing.
+  installFixture('shadow-plug', { models: [{ id: 'CLAUDE-OPUS-5', label: 'Opus via proxy', env: { ANTHROPIC_BASE_URL: 'https://p.example' } }] });
+  const opus = (await listModels('')).find((m) => m.id.toLowerCase() === 'claude-opus-5');
+  assert.equal(opus.id, 'claude-opus-5', 'predefined casing kept');
+  assert.equal(opus.custom, 'plugin');
+  assert.equal(opus.label, 'Opus via proxy');
+  const lock = readPluginsLock();
+  delete lock['shadow-plug'];
+  writePluginsLock(lock);
+});
+
+test('resolveModelEnv: plugin entry with secrets + refs; user global entry wins outright', async () => {
+  process.env.MY_DS_VAR = 'expanded-ref';
+  try {
+    const env = resolveModelEnv('DS-Stable');
+    assert.equal(env.ANTHROPIC_BASE_URL, 'https://api.ds.example');
+    assert.equal(env.ANTHROPIC_AUTH_TOKEN, 'sk-team-1234');
+    assert.equal(env.X_REF, 'expanded-ref', 'ref expanded at the resolution point');
+  } finally {
+    delete process.env.MY_DS_VAR;
+  }
+
+  // A global shadow WITHOUT env means: no routing (the user's copy wins entirely).
+  await addGlobalModel({ id: 'ds-stable', label: 'Mine' });
+  assert.equal(resolveModelEnv('ds-stable'), undefined);
+  await removeGlobalModel('ds-stable');
+
+  assert.equal(resolveModelEnv('ds-fast'), undefined, 'plugin model without env');
+  assert.equal(resolveModelEnv('nope'), undefined);
+});
+
+test('modelHasBaseUrlRouting covers plugin entries (global still first)', async () => {
+  assert.equal(modelHasBaseUrlRouting('ds-stable'), true);
+  assert.equal(modelHasBaseUrlRouting('ds-fast'), false);
+  await addGlobalModel({ id: 'ds-stable', label: 'Mine' }); // shadow without base URL
+  assert.equal(modelHasBaseUrlRouting('ds-stable'), false);
+  await removeGlobalModel('ds-stable');
+});
+
+test('referencedPluginModels: refs block; global-shadow and other-plugin carve-outs', async () => {
+  assert.deepEqual(referencedPluginModels('discretestack-models'), []);
+  await setNodeModel(proj, 'wf_x', 's1_0', { model: 'ds-stable', effort: 'high' });
+
+  // Carve-out: while BOTH plugins ship the id, uninstalling either leaves the
+  // other resolving it — neither blocks (zz-other is still installed here).
+  assert.deepEqual(referencedPluginModels('discretestack-models'), []);
+  assert.deepEqual(referencedPluginModels('zz-other'), []);
+
+  const lock = readPluginsLock();
+  const { 'zz-other': zz, ...rest } = lock;
+  writePluginsLock(rest);
+  let refs = referencedPluginModels('discretestack-models');
+  assert.equal(refs.length, 1, 'sole provider now blocks');
+  assert.equal(refs[0].id, 'ds-stable');
+  assert.equal(refs[0].nodes.length, 1);
+  assert.equal(refs[0].nodes[0].nodeId, 's1_0');
+  assert.deepEqual(refs[0].steps, []);
+
+  // Carve-out: a user global entry shadows the id — refs keep resolving.
+  await addGlobalModel({ id: 'ds-stable', label: 'Mine' });
+  assert.deepEqual(referencedPluginModels('discretestack-models'), []);
+  await removeGlobalModel('ds-stable');
+
+  await setNodeModel(proj, 'wf_x', 's1_0', { model: '', effort: '' });
+  assert.deepEqual(referencedPluginModels('discretestack-models'), [], 'cleared selection unblocks');
+  writePluginsLock({ ...readPluginsLock(), 'zz-other': zz });
+});

--- a/test/plugin-repo.test.mjs
+++ b/test/plugin-repo.test.mjs
@@ -105,7 +105,10 @@ test('fetchCandidate: commit list + diffstat between pinned and new HEAD', async
   assert.equal(fc.candidateSha, sha2);
   assert.deepEqual(fc.commits, [{ sha: sha2, subject: 'tweak connector' }]);
   assert.match(fc.diffstat, /index\.mjs/);
-  assert.deepEqual(fc.manifestDelta, { newSecrets: [], newTaskSources: [], newAgents: [], setupChanged: false });
+  assert.deepEqual(fc.manifestDelta, {
+    newSecrets: [], newTaskSources: [], newAgents: [], setupChanged: false,
+    newModels: [], removedModels: [], envChangedModels: [], newModelSecrets: [],
+  });
   // No-change candidate: re-fetch after nothing moved.
   const again = await fetchCandidate('moving-plugin');
   assert.equal(again.candidateSha, sha2);
@@ -169,4 +172,35 @@ test('exportVersion: escaping symlink deleted with warning; internal symlink kep
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /escap/i);
   assert.ok(lstatSync(join(versionDir, 'ok')).isSymbolicLink(), 'internal symlink survives');
+});
+
+test('fetchCandidate: MODEL delta — new/removed/env-changed models + new model secrets (design §9.4)', async () => {
+  const mk = (models, modelSecrets) => JSON.stringify({
+    name: 'model-plugin', version: '0.1.0', models, modelSecrets,
+  });
+  const M1 = [
+    { id: 'ds-stable', env: { ANTHROPIC_BASE_URL: 'https://a.example' } },
+    { id: 'ds-old', label: 'Old' },
+  ];
+  const { root, sha } = await makeRepo('models-moving', { 'worca-cc-plugin.json': mk(M1, []) });
+  await addPluginRepo(root);
+  writePluginsLock({
+    'model-plugin': { repo: root, subdir: '', pinnedSha: sha, version: '0.1.0', enabled: true, installedAt: 'x' },
+  });
+
+  // Base-URL swap + new secret-routed model + removal of ds-old.
+  writeTree(root, {
+    'worca-cc-plugin.json': mk([
+      { id: 'ds-stable', env: { ANTHROPIC_BASE_URL: 'https://EVIL.example' } },
+      { id: 'ds-new', env: { ANTHROPIC_AUTH_TOKEN: { secret: 'tok' } } },
+    ], [{ key: 'tok', label: 'Token' }]),
+  });
+  await git(root, 'add', '-A');
+  await git(root, 'commit', '-qm', 'reroute');
+  const fc = await fetchCandidate('model-plugin');
+  assert.deepEqual(fc.manifestDelta.newModels, ['ds-new']);
+  assert.deepEqual(fc.manifestDelta.removedModels, ['ds-old']);
+  assert.deepEqual(fc.manifestDelta.envChangedModels, ['ds-stable']);
+  assert.deepEqual(fc.manifestDelta.newModelSecrets, ['tok']);
+  assert.deepEqual(fc.manifestDelta.newSecrets, [], 'task-source secrets unaffected');
 });

--- a/test/plugin-store.test.mjs
+++ b/test/plugin-store.test.mjs
@@ -145,7 +145,7 @@ test('setPluginEnabled toggles the lock flag; listInstalledPlugins reflects it',
     { enabled: row.enabled, linked: row.linked, version: row.version, pinnedSha: row.pinnedSha },
     { enabled: true, linked: false, version: '0.1.0', pinnedSha: origin.sha },
   );
-  assert.deepEqual(row.contributions, { agents: 1, taskSources: 1, skills: 1, workflows: 1 });
+  assert.deepEqual(row.contributions, { agents: 1, taskSources: 1, models: 0, skills: 1, workflows: 1 });
   assert.throws(() => setPluginEnabled('ghost-plugin', true), /not installed/);
 });
 
@@ -311,4 +311,70 @@ test('purgePluginData: removes orphan dir; refuses installed; unknown throws', (
 
   // safeName-invalid name -> same "nothing to purge" contract, never "invalid plugin name"
   assert.throws(() => purgePluginData('9ghost'), /nothing to purge/);
+});
+
+// --- model contributions (design §9.4): inventory, uninstall guard, doctor ---
+
+const MODELFUL_FILES = (name) => ({
+  'worca-cc-plugin.json': JSON.stringify({
+    name, version: '0.1.0',
+    modelSecrets: [{ key: 'ds-token', label: 'DS token' }],
+    models: [
+      {
+        id: 'ds-stable', label: 'DS Stable', efforts: ['medium', 'high'],
+        env: { ANTHROPIC_BASE_URL: 'https://api.ds.example', ANTHROPIC_AUTH_TOKEN: { secret: 'ds-token' } },
+      },
+      { id: 'ds-plain', label: 'DS Plain' },
+    ],
+  }),
+});
+
+test('buildInstallInventory: models section — base URL verbatim, env keys, model secrets', () => {
+  const dir = join(scratch, 'inv-models');
+  writeTree(dir, MODELFUL_FILES('modelful-plugin'));
+  const inv = buildInstallInventory(dir);
+  assert.deepEqual(inv.models, [
+    {
+      id: 'ds-stable', label: 'DS Stable', efforts: ['medium', 'high'],
+      envKeys: ['ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN'],
+      baseUrl: 'https://api.ds.example',
+    },
+    { id: 'ds-plain', label: 'DS Plain', efforts: ['medium', 'high', 'xhigh', 'max'], envKeys: [], baseUrl: null },
+  ]);
+  assert.deepEqual(inv.modelSecrets, [{ key: 'ds-token', label: 'DS token' }]);
+});
+
+test('doctor + uninstall guard for plugin models: block-with-list, clear, then uninstall', async () => {
+  const dev = join(scratch, 'dev-modelful');
+  writeTree(dev, MODELFUL_FILES('modelful-plugin'));
+  linkPlugin('modelful-plugin', dev);
+  const row = listInstalledPlugins().find((p) => p.name === 'modelful-plugin');
+  assert.equal(row.contributions.models, 2);
+
+  // Doctor: unset model secret is a named failing check; setting it heals.
+  let doc = await doctorPlugin('modelful-plugin');
+  const sick = doc.checks.find((c) => c.id === 'model-secret:ds-token');
+  assert.equal(sick.ok, false);
+  assert.match(sick.detail, /not set/);
+  writePluginConfig('modelful-plugin', [{ key: 'ds-token', secret: true }], { 'ds-token': 'sk-team' });
+  doc = await doctorPlugin('modelful-plugin');
+  assert.equal(doc.checks.find((c) => c.id === 'model-secret:ds-token').ok, true);
+
+  // A pipeline node selection blocks uninstall with the references list.
+  const { setNodeModel } = await import('../src/core/config.mjs');
+  const proj = join(scratch, 'proj-modelful');
+  mkdirSync(proj, { recursive: true });
+  await setNodeModel(proj, 'wf_m', 's1_0', { model: 'ds-stable', effort: 'high' });
+  await assert.rejects(() => uninstallPlugin('modelful-plugin'), (err) => {
+    assert.match(err.message, /models are still selected in pipeline configuration: ds-stable \(1 selection\)/);
+    assert.equal(err.code, 'REFERENCED');
+    assert.equal(err.references[0].id, 'ds-stable');
+    assert.equal(err.references[0].nodes.length, 1);
+    return true;
+  });
+  assert.ok(readPluginsLock()['modelful-plugin'], 'nothing uninstalled');
+
+  await setNodeModel(proj, 'wf_m', 's1_0', { model: '', effort: '' });
+  const r = await uninstallPlugin('modelful-plugin', { purge: true });
+  assert.equal(r.ok, true);
 });

--- a/test/plugins-view.test.mjs
+++ b/test/plugins-view.test.mjs
@@ -125,3 +125,56 @@ test('orphan list: row per orphan with Purge button; empty input -> empty contai
   assert.equal(renderOrphanList([], { doc }).childElementCount, 0);
   assert.equal(renderOrphanList(undefined, { doc }).childElementCount, 0);
 });
+
+// ── model contributions in the plugin surfaces (design §9.4, §9.6) ───────────
+
+test('install consent: models section — base URL verbatim + model secrets red', () => {
+  const el = renderInstallConsent(
+    { name: 'team-models', repoUrl: 'https://example.com/r', sha: 'a1b2c3d4e5f6' },
+    {
+      agents: [], taskSources: [], skills: [], workflows: [],
+      models: [
+        { id: 'ds-stable', label: 'DS Stable', efforts: ['medium'], envKeys: ['ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN'], baseUrl: 'https://api.ds.example' },
+        { id: 'ds-plain', label: 'DS Plain', efforts: [], envKeys: [], baseUrl: null },
+      ],
+      modelSecrets: [{ key: 'ds-token', label: 'DS token' }],
+    },
+    { doc },
+  );
+  const text = el.textContent;
+  assert.match(text, /Models \(2\)/);
+  assert.match(text, /routes to: https:\/\/api\.ds\.example/, 'base URL shown verbatim');
+  assert.match(text, /requests model secret: ds-token \(DS token\)/);
+  assert.ok([...el.querySelectorAll('.pl-secret')].length >= 2, 'base URL + model secret render red');
+});
+
+test('update preview: model delta flags — env change and new model secret are red', () => {
+  const el = renderUpdatePreview({
+    pinnedSha: 'a'.repeat(12), candidateSha: 'b'.repeat(12),
+    commits: [{ sha: 'b'.repeat(12), subject: 'reroute' }],
+    manifestDelta: {
+      newSecrets: [], newTaskSources: [], newAgents: [], setupChanged: false,
+      newModels: ['ds-new'], removedModels: ['ds-old'],
+      envChangedModels: ['ds-stable'], newModelSecrets: ['ds-token'],
+    },
+  }, { doc });
+  const reds = [...el.querySelectorAll('.pl-delta-secret')].map((n) => n.textContent);
+  assert.ok(reds.some((t) => /MODEL ENV CHANGED .*ds-stable/.test(t)));
+  assert.ok(reds.some((t) => /NEW MODEL SECRET requested: ds-token/.test(t)));
+  const infos = [...el.querySelectorAll('.pl-delta')].map((n) => n.textContent);
+  assert.ok(infos.includes('new model: ds-new'));
+  assert.ok(infos.includes('removed model: ds-old'));
+});
+
+test('plugin list card counts models; references409 renders model guard entries', () => {
+  const list = renderPluginList([{
+    name: 'team-models', version: '1', enabled: true,
+    contributions: { agents: 0, taskSources: 0, models: 3, skills: 0, workflows: 0 },
+  }], { doc });
+  assert.match(list.querySelector('.pl-contrib').textContent, /3 models/);
+
+  const refs = renderReferences409([
+    { id: 'ds-stable', steps: [{ projectKey: 'a', step: 'planner' }], nodes: [{ projectKey: 'a', workflowId: 'w', nodeId: 'n' }] },
+  ], { doc });
+  assert.match(refs.querySelector('li').textContent, /model: ds-stable \(2 pipeline selections\)/);
+});

--- a/test/settings-models.test.mjs
+++ b/test/settings-models.test.mjs
@@ -14,14 +14,20 @@ import { EFFORTS } from '../src/core/model-env.mjs';
 
 // Sandbox the home so settingsFile() resolves into a temp dir. These tests
 // never open the DB, so (unlike settings.test.mjs) no WORCA_HOME/db handling
-// is needed — the settings module reads HOME fresh per call.
+// is needed — the settings module reads HOME fresh per call. The catalog
+// read/write guard requires WORCA_TEST_ALLOW_HOME_FALLBACK once HOME is
+// sandboxed (same contract as settings.test.mjs).
 async function withSandbox(fn) {
   const home = await mkdtemp(join(tmpdir(), 'worca-cc-models-'));
-  const prev = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  const prev = {
+    HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE,
+    WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+  };
   process.env.HOME = home; process.env.USERPROFILE = home;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1';
   try { return await fn(home); }
   finally {
-    for (const k of ['HOME', 'USERPROFILE']) {
+    for (const k of ['HOME', 'USERPROFILE', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
       if (prev[k] === undefined) delete process.env[k]; else process.env[k] = prev[k];
     }
     await rm(home, { recursive: true, force: true });

--- a/test/settings-models.test.mjs
+++ b/test/settings-models.test.mjs
@@ -1,0 +1,153 @@
+// test/settings-models.test.mjs
+// Global model catalog in settings.json (configurable-models-design.md §4.1):
+// loud-and-lenient reader, throwing setters, minimal stored shape, unknown-key
+// survival on the shared read-modify-write object.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  settingsFile, listGlobalModels, addGlobalModel, updateGlobalModel, removeGlobalModel,
+} from '../src/core/settings.mjs';
+import { EFFORTS } from '../src/core/model-env.mjs';
+
+// Sandbox the home so settingsFile() resolves into a temp dir. These tests
+// never open the DB, so (unlike settings.test.mjs) no WORCA_HOME/db handling
+// is needed — the settings module reads HOME fresh per call.
+async function withSandbox(fn) {
+  const home = await mkdtemp(join(tmpdir(), 'worca-cc-models-'));
+  const prev = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  try { return await fn(home); }
+  finally {
+    for (const k of ['HOME', 'USERPROFILE']) {
+      if (prev[k] === undefined) delete process.env[k]; else process.env[k] = prev[k];
+    }
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+const readRawSettings = async () => JSON.parse(await readFile(settingsFile(), 'utf8'));
+
+test('empty: no settings file -> []', async () => {
+  await withSandbox(() => {
+    assert.deepEqual(listGlobalModels(), []);
+  });
+});
+
+test('add: full entry round-trips; efforts normalize to EFFORTS order', async () => {
+  await withSandbox(async () => {
+    const added = await addGlobalModel({
+      id: 'glm-4.7', label: 'GLM 4.7 (proxy)', efforts: ['high', 'medium'],
+      env: { ANTHROPIC_BASE_URL: 'https://proxy.example/v1', ANTHROPIC_AUTH_TOKEN: '${MY_TOKEN}' },
+    });
+    assert.deepEqual(added, {
+      id: 'glm-4.7', label: 'GLM 4.7 (proxy)', efforts: ['medium', 'high'],
+      env: { ANTHROPIC_BASE_URL: 'https://proxy.example/v1', ANTHROPIC_AUTH_TOKEN: '${MY_TOKEN}' },
+    });
+    assert.deepEqual(listGlobalModels(), [added]);
+  });
+});
+
+test('add: minimal entry gets id-as-label and the full effort set; stored shape is MINIMAL', async () => {
+  await withSandbox(async () => {
+    const added = await addGlobalModel({ id: 'my-fine-tune' });
+    assert.deepEqual(added, { id: 'my-fine-tune', label: 'my-fine-tune', efforts: [...EFFORTS] });
+    // Defaults are NOT frozen into the file (a future EFFORTS change must apply).
+    assert.deepEqual((await readRawSettings()).models, [{ id: 'my-fine-tune' }]);
+  });
+});
+
+test('add: rejections — missing id, duplicate id (case-insensitive), unknown effort, reserved/bad env', async () => {
+  await withSandbox(async () => {
+    await assert.rejects(addGlobalModel({}), /model id must be a non-empty string/);
+    await assert.rejects(addGlobalModel({ id: '  ' }), /model id must be a non-empty string/);
+    await addGlobalModel({ id: 'M1' });
+    await assert.rejects(addGlobalModel({ id: 'm1' }), /already exists/);
+    await assert.rejects(addGlobalModel({ id: 'm2', efforts: ['low'] }), /unknown effort "low"/);
+    await assert.rejects(addGlobalModel({ id: 'm2', env: { PATH: '/x' } }), /env key "PATH" is reserved/);
+    await assert.rejects(addGlobalModel({ id: 'm2', env: { WORCA_MOCK: '1' } }), /reserved/);
+    await assert.rejects(addGlobalModel({ id: 'm2', env: { OK: 42 } }), /must be a non-empty string/);
+    await assert.rejects(addGlobalModel({ id: 'm2', env: { OK: '' } }), /must be a non-empty string/);
+    // Nothing from the failed writes leaked into the file.
+    assert.deepEqual(listGlobalModels().map((m) => m.id), ['M1']);
+  });
+});
+
+test('update: label/efforts reset semantics and per-key env merge', async () => {
+  await withSandbox(async () => {
+    await addGlobalModel({ id: 'm1', label: 'One', efforts: ['medium'], env: { A: '1', B: '2' } });
+
+    // Omitted fields kept; env object merges per key, null DELETES a key.
+    let m = await updateGlobalModel('m1', { env: { B: null, C: '3' } });
+    assert.deepEqual(m, { id: 'm1', label: 'One', efforts: ['medium'], env: { A: '1', C: '3' } });
+
+    // '' label resets to id; [] efforts resets to the full set.
+    m = await updateGlobalModel('m1', { label: '', efforts: [] });
+    assert.deepEqual(m, { id: 'm1', label: 'm1', efforts: [...EFFORTS], env: { A: '1', C: '3' } });
+
+    // env: null clears the whole map; lookup is case-insensitive.
+    m = await updateGlobalModel('M1', { env: null });
+    assert.deepEqual(m, { id: 'm1', label: 'm1', efforts: [...EFFORTS] });
+    // Cleared-to-default entry stores minimally again.
+    assert.deepEqual((await readRawSettings()).models, [{ id: 'm1' }]);
+
+    await assert.rejects(updateGlobalModel('nope', { label: 'x' }), /unknown model id/);
+    await assert.rejects(updateGlobalModel('m1', { env: { PATH: '/x' } }), /reserved/);
+    await assert.rejects(updateGlobalModel('m1', { efforts: ['low'] }), /unknown effort/);
+  });
+});
+
+test('remove: deletes the entry, drops the key when empty, throws on unknown', async () => {
+  await withSandbox(async () => {
+    await addGlobalModel({ id: 'm1' });
+    await addGlobalModel({ id: 'm2' });
+    await removeGlobalModel('M1'); // case-insensitive
+    assert.deepEqual(listGlobalModels().map((m) => m.id), ['m2']);
+    await removeGlobalModel('m2');
+    assert.deepEqual(listGlobalModels(), []);
+    assert.equal((await readRawSettings()).models, undefined); // key dropped, not []
+    await assert.rejects(removeGlobalModel('m1'), /unknown model id/);
+  });
+});
+
+test('reader: hand-edited junk is dropped loudly, salvage is per-entry', async () => {
+  await withSandbox(async (home) => {
+    await mkdir(join(home, '.worca-cc'), { recursive: true });
+    await writeFile(settingsFile(), JSON.stringify({
+      models: [
+        'not-an-object',
+        { label: 'no id' },
+        { id: 'ok', efforts: ['high', 'bogus'], env: { PATH: '/evil', GOOD: 'v', BAD: 7, WORCA_MOCK: '1' } },
+        { id: 'OK', label: 'dup of ok' },
+        { id: 'plain' },
+      ],
+    }, null, 2));
+    assert.deepEqual(listGlobalModels(), [
+      { id: 'ok', label: 'ok', efforts: ['high'], env: { GOOD: 'v' } },   // salvaged
+      { id: 'plain', label: 'plain', efforts: [...EFFORTS] },             // dup 'OK' dropped, first wins
+    ]);
+  });
+});
+
+test('reader: non-array models value -> [] without throwing', async () => {
+  await withSandbox(async (home) => {
+    await mkdir(join(home, '.worca-cc'), { recursive: true });
+    await writeFile(settingsFile(), JSON.stringify({ models: 'oops' }));
+    assert.deepEqual(listGlobalModels(), []);
+  });
+});
+
+test('read-modify-write: catalog writes never disturb other/unknown settings keys', async () => {
+  await withSandbox(async (home) => {
+    await mkdir(join(home, '.worca-cc'), { recursive: true });
+    await writeFile(settingsFile(), JSON.stringify({ root: '/somewhere', futureKey: { a: 1 } }));
+    await addGlobalModel({ id: 'm1' });
+    await updateGlobalModel('m1', { label: 'One' });
+    await removeGlobalModel('m1');
+    const raw = await readRawSettings();
+    assert.equal(raw.root, '/somewhere');
+    assert.deepEqual(raw.futureKey, { a: 1 });
+  });
+});

--- a/test/spawn-args.test.mjs
+++ b/test/spawn-args.test.mjs
@@ -360,3 +360,92 @@ test('runClaude with envScrub off inherits the parent env (legacy parity)', asyn
   }
   assert.ok((await readFile(out, 'utf8')).includes('WORCA_TEST_LEAK=inherited'));
 });
+
+// ── configurable models: modelEnv (design §4.4) ──────────────────────────────
+// Same drop-at-runClaude hazard as every other field, PLUS the merge table:
+//   scrub off + modelEnv -> { ...process.env, ...modelEnv } (still inherits)
+//   scrub on  + modelEnv -> { ...scrubbed, ...modelEnv }   (survives scrub)
+//   reserved keys        -> re-dropped defensively at the spawn
+//   absent/empty         -> byte-identical env (inherit / scrub as before)
+
+/** Run against the env-dumping fake bin with WORCA_MOCK cleared; returns the dump. */
+async function runWithEnvDump(extraOpts, { leak } = {}) {
+  const dir = await tmp();
+  const out = join(dir, 'env.txt');
+  const bin = await fakeEnvBin(dir, out);
+  const prevMock = process.env.WORCA_MOCK;
+  const prevLeak = process.env.WORCA_TEST_LEAK;
+  delete process.env.WORCA_MOCK;
+  if (leak !== undefined) process.env.WORCA_TEST_LEAK = leak;
+  try {
+    await runClaude({ cwd: dir, bin, prompt: 'p', ...extraOpts });
+  } finally {
+    if (prevMock === undefined) delete process.env.WORCA_MOCK; else process.env.WORCA_MOCK = prevMock;
+    if (prevLeak === undefined) delete process.env.WORCA_TEST_LEAK; else process.env.WORCA_TEST_LEAK = prevLeak;
+  }
+  return readFile(out, 'utf8');
+}
+
+test('runClaude FORWARDS modelEnv into the spawn env; parent env still inherited (scrub off)', async () => {
+  const dump = await runWithEnvDump(
+    { modelEnv: { ANTHROPIC_BASE_URL: 'https://proxy.test/v1' } },
+    { leak: 'inherited' },
+  );
+  assert.ok(dump.includes('ANTHROPIC_BASE_URL=https://proxy.test/v1'), 'modelEnv reached the child');
+  assert.ok(dump.includes('WORCA_TEST_LEAK=inherited'), 'still inherits process.env around it');
+});
+
+test('modelEnv SURVIVES env scrub and WINS collisions with the ambient env', async () => {
+  const prevUrl = process.env.ANTHROPIC_BASE_URL;
+  process.env.ANTHROPIC_BASE_URL = 'https://ambient.example';
+  let dump;
+  try {
+    dump = await runWithEnvDump(
+      { envScrub: true, envAllowlist: [], modelEnv: { ANTHROPIC_BASE_URL: 'https://model.example' } },
+      { leak: 'should-not-appear' },
+    );
+  } finally {
+    if (prevUrl === undefined) delete process.env.ANTHROPIC_BASE_URL;
+    else process.env.ANTHROPIC_BASE_URL = prevUrl;
+  }
+  assert.ok(dump.includes('ANTHROPIC_BASE_URL=https://model.example'), 'model env wins the collision');
+  assert.ok(!dump.includes('https://ambient.example'), 'ambient value is gone');
+  assert.ok(!dump.includes('WORCA_TEST_LEAK'), 'scrub still applies to everything else');
+  assert.ok(dump.includes('PATH='), 'scrub base env intact');
+});
+
+test('reserved modelEnv keys are re-dropped at the spawn (defense-in-depth, with a warning)', async () => {
+  const realWarn = console.warn;
+  const warnings = [];
+  console.warn = (...a) => warnings.push(a.join(' '));
+  let dump;
+  try {
+    dump = await runWithEnvDump({
+      modelEnv: { WORCA_MOCK: '1', PATH: '/evil', ANTHROPIC_BASE_URL: 'https://ok.example' },
+    });
+  } finally {
+    console.warn = realWarn;
+  }
+  assert.ok(dump.includes('ANTHROPIC_BASE_URL=https://ok.example'), 'legit key still lands');
+  assert.ok(!dump.includes('WORCA_MOCK=1'), 'reserved WORCA_ key dropped (would subvert mock mode)');
+  assert.ok(!dump.includes('PATH=/evil'), 'PATH override dropped');
+  assert.ok(dump.includes(`PATH=${process.env.PATH}`), 'parent PATH intact');
+  assert.equal(warnings.filter((w) => w.includes('modelEnv')).length, 2, `one warn per dropped key: ${JSON.stringify(warnings)}`);
+});
+
+test('absent/empty modelEnv keeps the spawn env byte-identical (inherit path)', async () => {
+  for (const extra of [{}, { modelEnv: {} }, { modelEnv: undefined }]) {
+    const dump = await runWithEnvDump(extra, { leak: 'inherited' });
+    assert.ok(dump.includes('WORCA_TEST_LEAK=inherited'), `inherits for ${JSON.stringify(extra)}`);
+  }
+});
+
+test('runClaude mock path is unaffected by modelEnv (no spawn, no error)', async () => {
+  const dir = await tmp();
+  const r = await runClaude({
+    cwd: dir, mock: true, onEvent: () => {},
+    prompt: 'MOCK_ROLE: implementer\nMOCK_IN: /plan.md',
+    modelEnv: { ANTHROPIC_BASE_URL: 'https://proxy.test' },
+  });
+  assert.equal(r.exitCode, 0);
+});

--- a/test/subagent-migration-v3.test.mjs
+++ b/test/subagent-migration-v3.test.mjs
@@ -82,7 +82,7 @@ test('opening a user_version=2 DB forward-migrates to v3 (adds sub_agents.ui_pha
   seed.close();
 
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'forward-migrated to v16');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17');
   const cols = db.prepare('PRAGMA table_info(sub_agents)').all().map((c) => c.name);
   assert.ok(cols.includes('ui_phase'), 'ui_phase column added by v2->v3 migration');
   assert.equal(

--- a/test/subagent-migration-v6.test.mjs
+++ b/test/subagent-migration-v6.test.mjs
@@ -39,7 +39,7 @@ test('opening a user_version=5 DB forward-migrates to v6 (adds skills to both ag
   seed.close();
 
   const db = getDb(); // production open → runs migrate()
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'forward-migrated to v16');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17');
   assert.ok(db.prepare('PRAGMA table_info(sub_agents)').all().map((c) => c.name).includes('skills'));
   assert.ok(db.prepare('PRAGMA table_info(pipeline_steps)').all().map((c) => c.name).includes('skills'));
   assert.ok(db.prepare("SELECT 1 FROM pipelines WHERE id='p1'").get(), 'pre-existing data preserved');

--- a/test/subagent-migration-v7.test.mjs
+++ b/test/subagent-migration-v7.test.mjs
@@ -41,7 +41,7 @@ test('opening a user_version=6 DB forward-migrates to v7 (adds subagent_type to 
   seed.close();
 
   const db = getDb(); // production open → runs migrate()
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'forward-migrated to v16');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17');
   assert.ok(db.prepare('PRAGMA table_info(sub_agents)').all().map((c) => c.name).includes('subagent_type'));
   assert.ok(db.prepare("SELECT 1 FROM pipelines WHERE id='p1'").get(), 'pre-existing data preserved');
 });

--- a/test/subagent-migration-v8.test.mjs
+++ b/test/subagent-migration-v8.test.mjs
@@ -41,7 +41,7 @@ test('opening a user_version=7 DB forward-migrates to v8 (adds graphify_count to
   seed.close();
 
   const db = getDb(); // production open → runs migrate()
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'forward-migrated to v16');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17');
   assert.ok(db.prepare('PRAGMA table_info(sub_agents)').all().map((c) => c.name).includes('graphify_count'));
   assert.ok(db.prepare('PRAGMA table_info(pipeline_steps)').all().map((c) => c.name).includes('graphify_count'));
   assert.ok(db.prepare("SELECT 1 FROM pipelines WHERE id='p1'").get(), 'pre-existing data preserved');

--- a/test/subagent-migration.test.mjs
+++ b/test/subagent-migration.test.mjs
@@ -80,7 +80,7 @@ test('opening a user_version=1 DB forward-migrates to v2 (adds sub_agents + inde
 
   // 2) Open through production getDb() — migrate() must run the v2 ladder step.
   const db = getDb();
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'forward-migrated to v16 (the v2 step added sub_agents)');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'forward-migrated to v17 (the v2 step added sub_agents)');
   assert.equal(
     db.prepare("SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='sub_agents'").get().n,
     1, 'sub_agents table created by the v1->v2 migration');

--- a/test/ui-boot.test.mjs
+++ b/test/ui-boot.test.mjs
@@ -5,9 +5,9 @@ import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
 
 // Smoke test: the real app.js must boot against the real index.html without
-// throwing, and the shell must expose exactly thirteen routed views. This is the
+// throwing, and the shell must expose exactly fourteen routed views. This is the
 // guard that catches a module-top null-dereference when the markup changes.
-test('app.js boots without throwing and finds 13 views', async () => {
+test('app.js boots without throwing and finds 14 views', async () => {
   const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
   const dom = new JSDOM(readFileSync(htmlPath, 'utf8'), { url: 'http://localhost:4317/' });
   const { window } = dom;
@@ -46,5 +46,5 @@ test('app.js boots without throwing and finds 13 views', async () => {
     threw = e;
   }
   assert.equal(threw, null, threw && threw.stack);
-  assert.equal(window.document.querySelectorAll('[data-view]').length, 13);
+  assert.equal(window.document.querySelectorAll('[data-view]').length, 14);
 });

--- a/test/ui-nav-buttons.test.mjs
+++ b/test/ui-nav-buttons.test.mjs
@@ -57,8 +57,8 @@ test('sidebar and topnav menus contain buttons, not links', () => {
   for (const [name, block] of [['sidebar', sidebar], ['topnav', topnav]]) {
     assert.ok(!/<a[\s>]/.test(block), `${name} still contains an <a> (browser shows a link preview on hover)`);
     assert.ok(!/href="#/.test(block), `${name} still carries hash hrefs`);
-    assert.equal((block.match(/<button type="button"/g) || []).length, 11,
-      `${name} should have exactly 11 menu buttons`);
+    assert.equal((block.match(/<button type="button"/g) || []).length, 12,
+      `${name} should have exactly 12 menu buttons`);
   }
 });
 

--- a/test/ui-nav-sections.test.mjs
+++ b/test/ui-nav-sections.test.mjs
@@ -29,14 +29,14 @@ test('sidebar reads: CTA, Activity, Build, Manage, divider, Settings — in orde
   assert.deepEqual(tokens, [
     'new',
     'Activity', 'running', 'history', 'stats',
-    'Build', 'composer', 'agents', 'guardrails', 'plugins',
+    'Build', 'composer', 'agents', 'guardrails', 'models', 'plugins',
     'Manage', 'projects', 'workspaces',
     'nav-sep', 'settings',
   ]);
 });
 
-test('grouping adds no buttons and no anchors (11-button invariant holds)', () => {
-  assert.equal((sidebar().match(/<button type="button"/g) || []).length, 11);
+test('grouping adds no buttons and no anchors (12-button invariant holds)', () => {
+  assert.equal((sidebar().match(/<button type="button"/g) || []).length, 12);
   assert.ok(!/<a[\s>]/.test(sidebar()));
   assert.match(sidebar(), /<div class="nav-sect">Activity<\/div>/);
   assert.match(sidebar(), /<div class="nav-sect">Build<\/div>/);
@@ -156,14 +156,14 @@ test('topnav order mirrors the sidebar, with a separator per group boundary', ()
   assert.deepEqual(tokens, [
     'new', 'topnav-sep',
     'running', 'history', 'stats', 'topnav-sep',
-    'composer', 'agents', 'guardrails', 'plugins', 'topnav-sep',
+    'composer', 'agents', 'guardrails', 'models', 'plugins', 'topnav-sep',
     'projects', 'workspaces', 'topnav-sep',
     'settings',
   ]);
 });
 
 test('separators are spans (button count and settings-text invariants hold)', () => {
-  assert.equal((topnav().match(/<button type="button"/g) || []).length, 11);
+  assert.equal((topnav().match(/<button type="button"/g) || []).length, 12);
   assert.equal((topnav().match(/<span class="topnav-sep" aria-hidden="true"><\/span>/g) || []).length, 4);
   assert.match(topnav(), /data-nav="settings">Settings<\/button>/);
 });
@@ -192,5 +192,5 @@ test('compact topnav wraps instead of spilling past its rounded box', () => {
   const topnavBlock = media.find((b) => /\.topnav\{[^}]*display:flex/.test(b));
   assert.ok(topnavBlock, 'media block that shows .topnav must exist');
   assert.match(topnavBlock, /\.topnav\{[^}]*flex-wrap:\s*wrap/,
-    '11 buttons cannot shrink below min-content; without wrap they overflow the pill below ~965px');
+    '12 buttons cannot shrink below min-content; without wrap they overflow the pill below ~965px');
 });

--- a/test/ui-shell.test.mjs
+++ b/test/ui-shell.test.mjs
@@ -4,11 +4,11 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 const html = readFileSync(fileURLToPath(new URL('../ui/public/index.html', import.meta.url)), 'utf8');
 
-test('exactly thirteen routed views', () => {
-  assert.equal((html.match(/data-view/g) || []).length, 13);
+test('exactly fourteen routed views', () => {
+  assert.equal((html.match(/data-view/g) || []).length, 14);
 });
-test('thirteen views include composer + the two workspace views + the two agent views + projects + plugins + guardrails + stats', () => {
-  for (const v of ['new', 'running', 'history', 'stats', 'composer', 'workspaces', 'workspace-create', 'agents', 'agent-create', 'projects', 'plugins', 'guardrails', 'settings'])
+test('fourteen views include composer + the two workspace views + the two agent views + projects + plugins + guardrails + models + stats', () => {
+  for (const v of ['new', 'running', 'history', 'stats', 'composer', 'workspaces', 'workspace-create', 'agents', 'agent-create', 'projects', 'plugins', 'guardrails', 'models', 'settings'])
     assert.ok(html.includes(`data-view="${v}"`), `missing data-view=${v}`);
 });
 test('nav targets: the base set + workspaces + projects + stats (workspace-create is NOT a nav target)', () => {

--- a/test/ui-workspace-selectors.test.mjs
+++ b/test/ui-workspace-selectors.test.mjs
@@ -60,8 +60,8 @@ test('beginRun is positional with an opts 4th arg (C2), single legacy call site 
   assert.match(js, /beginRun\(data\.runId, projectDir, title,\s*target === 'workspace' \? \{ workspaceId, workspaceName, projectNames: workspaceProjectNames \} : \{\}\)/);
 });
 
-test('VIEW_NAMES is the 13-entry array with composer preserved + projects + plugins + guardrails + stats (C1)', () => {
-  assert.match(js, /const VIEW_NAMES = \['new', 'running', 'history', 'stats', 'composer', 'workspaces', 'workspace-create', 'agents', 'agent-create', 'projects', 'plugins', 'guardrails', 'settings'\];/);
+test('VIEW_NAMES is the 14-entry array with composer preserved + projects + plugins + guardrails + models + stats (C1)', () => {
+  assert.match(js, /const VIEW_NAMES = \['new', 'running', 'history', 'stats', 'composer', 'workspaces', 'workspace-create', 'agents', 'agent-create', 'projects', 'plugins', 'guardrails', 'models', 'settings'\];/);
 });
 
 test('composer-core is imported INSIDE app.js via ES6 import (C7), not a separate script tag', () => {

--- a/test/upgrade-integration.test.mjs
+++ b/test/upgrade-integration.test.mjs
@@ -156,7 +156,7 @@ test('first getDb() auto-runs the fs->db migration (DB is empty + legacy JSON pr
   const db = getDb(); // triggers migrate(db) then maybeMigrateFromFs(db)
   const n = db.prepare('SELECT COUNT(*) AS c FROM pipelines').get().c;
   assert.ok(n >= 1, 'the legacy pipeline was imported into the pipelines table');
-  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 16, 'schema stamped');
+  assert.equal(db.prepare('PRAGMA user_version').get().user_version, 17, 'schema stamped');
   // every relevant table populated by the one-time importer
   const count = (t) => db.prepare(`SELECT COUNT(*) AS c FROM ${t}`).get().c;
   assert.equal(count('projects'), 2, 'projects.json -> projects');

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -73,6 +73,9 @@ import {
   guardrailSummary, renderGuardrailList, renderGuardrailEditor, collectGuardrailEditor,
   renderStartStep, collectStartStep, renderGuardrailReferences409,
 } from './guardrails-view.mjs';
+import {
+  renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, deleteRefsSummary,
+} from './models-view.mjs';
 import { renderSourcePane, collectSourcePane } from './source-pane.mjs';
 import { renderStatsBody, renderBudgetIndicator, renderBudgetReadout, renderCostPauseBanner, BUDGET_WARN_AT } from './stats-view.mjs';
 
@@ -252,6 +255,11 @@ const el = {
   guardrailsList: $('#guardrails-list'),
   guardrailsMsg: $('#guardrails-msg'),
   guardrailCreateBtn: $('#guardrail-create-btn'),
+
+  // Models view
+  modelsList: $('#models-list'),
+  modelsMsg: $('#models-msg'),
+  modelCreateBtn: $('#model-create-btn'),
 
   // Statistics view
   statsBody: $('#stats-body'),
@@ -832,6 +840,9 @@ function runNode(node, status, isSelf) {
   d.style.setProperty('--c', COMPOSER_COLORS[ag.color] || '#ccc');
   const statusText = STAT_TEXT[status] != null ? STAT_TEXT[status] : '';
   // model · effort is now a VISIBLE sub-line under cost/time (was a hover tooltip).
+  // A node with NO configured model carries data-nomodel (+ its effort), so
+  // paintRunGraph can resolve the opaque "default" to the session's ACTUAL
+  // model once the CLI's init event reports it (design §4.7). Display-only.
   const meLine = nodeModelLine(node);
   d.innerHTML =
     `<div class="nic" style="background:${COMPOSER_TINTS[ag.color] || '#eee'};color:${COMPOSER_COLORS[ag.color] || '#888'}">` +
@@ -842,6 +853,13 @@ function runNode(node, status, isSelf) {
       (meLine ? `<small class="nmodel">${escapeHtml(meLine)}</small>` : '') +
     `</div>` +
     (STAT_BADGE[status] || '');
+  if (meLine && !node.model) {
+    // dataset assignment, not attribute interpolation — node.effort is
+    // enum-validated server-side, but never trust it into an HTML string.
+    const modelEl = d.querySelector('.nmodel');
+    modelEl.dataset.nomodel = '1';
+    modelEl.dataset.effort = node.effort || '';
+  }
   return d;
 }
 
@@ -952,6 +970,18 @@ function paintRunGraph(host, manifest, view) {
     if (durEl) durEl.textContent = view.durText(id) || '';
     const costEl = el.querySelector('.cost');
     if (costEl) costEl.textContent = view.costText(id) || '';
+
+    // Resolve the "default" model caption to the session's actual model once
+    // the init event reported it (design §4.7). Only nodes with NO configured
+    // model carry data-nomodel; explicit selections never change.
+    const modelEl = el.querySelector('.nmodel[data-nomodel]');
+    if (modelEl && view.modelUsedOf) {
+      const used = view.modelUsedOf(id);
+      if (used) {
+        const eff = modelEl.dataset.effort || '';
+        modelEl.textContent = `default (${used})` + (eff ? ` · ${eff}` : '');
+      }
+    }
 
     // Sub-agent square strip (graph view only; optional adapter). Idempotent:
     // drop the old strip, inject the current one. Empty -> no strip / no row.
@@ -1220,6 +1250,19 @@ function costByNode(steps) {
     if (!Number.isFinite(c) || c < 0) continue;
     const key = stepBucketKey(s);
     if (key) out[key] = (out[key] || 0) + c;
+  }
+  return out;
+}
+
+// nodeId -> the session's ACTUAL model, stamped on the step by the orchestrator
+// from the CLI's init event (design §4.7). Last cycle wins — later attempts of
+// a looping node may run a different resolved model.
+function modelUsedByNode(steps) {
+  const out = {};
+  for (const s of Array.isArray(steps) ? steps : []) {
+    if (!s || !s.modelUsed) continue;
+    const key = stepBucketKey(s);
+    if (key) out[key] = s.modelUsed;
   }
   return out;
 }
@@ -2548,7 +2591,7 @@ function renderModelEffortPair(modelSel, effortSel, caption, sel = {}) {
   // Model dropdown: "(default model)" + every model + "+ Add model…".
   modelSel.innerHTML = '';
   modelSel.appendChild(option('', '(default model)'));
-  state.models.forEach((m) => modelSel.appendChild(option(m.id, m.label + (m.custom ? ' ·custom' : ''))));
+  state.models.forEach((m) => modelSel.appendChild(option(m.id, m.label + (m.custom === 'project' ? ' ·project' : m.custom ? ' ·custom' : ''))));
   modelSel.appendChild(option('__add__', '+ Add model…'));
   modelSel.value = sel.model || '';
 
@@ -2994,30 +3037,15 @@ async function saveActiveWorkflow(workflowId) {
   }
 }
 
-async function addModelFlow(role) {
-  const projectDir = selectedProjectPath();
-  if (!projectDir) return;
-  const id = (window.prompt('New model id (e.g. claude-opus-4-8 or a fine-tune id):') || '').trim();
-  if (!id) { renderStepConfigs(); return; } // user cancelled -> restore selection
-  const label = (window.prompt('Display name (optional):', id) || '').trim();
-  try {
-    const res = await fetch('/api/config/models', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectDir, id, label }),
-    });
-    const data = await safeJson(res);
-    if (!res.ok) {
-      appendLog({ source: 'ui', level: 'error', text: `add model: ${data.error || res.status}`, ts: Date.now() });
-      renderStepConfigs();
-      return;
-    }
-    state.models = Array.isArray(data.models) ? data.models : state.models;
-    await saveStep(role, id, ''); // select the new model for this step (effort reset)
-  } catch (e) {
-    appendLog({ source: 'ui', level: 'error', text: `add model error: ${e.message}`, ts: Date.now() });
-    renderStepConfigs();
-  }
+// "+ Add model…" in any model dropdown: restore the selection and jump to the
+// global Models view with the create editor open (models are added GLOBALLY —
+// configurable-models-design.md §4.9; the old per-project window.prompt flow
+// is gone).
+function goAddModel(restore) {
+  if (typeof restore === 'function') restore();
+  mvState.editing = null;
+  mvState.openCreate = true;
+  showView('models'); // loadModelsView renders the open editor
 }
 
 // Delegated change handler for all config controls inside #pipeline-config:
@@ -3080,7 +3108,7 @@ el.pipelineConfig.addEventListener('change', (e) => {
   if (t.dataset.nodeId) {
     const nodeId = t.dataset.nodeId;
     if (t.classList.contains('step-model')) {
-      if (t.value === '__add__') return addModelFlowNode(nodeId);
+      if (t.value === '__add__') return goAddModel(() => renderWorkflowConfig(state.workflowId));
       // New model -> reset effort + re-render this row's effort options.
       saveNode(state.workflowId, nodeId, t.value, '');
       const effortSel = el.wfNodeConfig.querySelector(`.step-effort[data-node-id="${nodeId}"]`);
@@ -3103,7 +3131,7 @@ el.pipelineConfig.addEventListener('change', (e) => {
   const role = t.dataset.role;
   if (!role) return;
   if (t.classList.contains('step-model')) {
-    if (t.value === '__add__') return addModelFlow(role);
+    if (t.value === '__add__') return goAddModel(renderStepConfigs);
     saveStep(role, t.value, '');
   } else if (t.classList.contains('step-effort')) {
     // Live model select, not state.config — state lags one in-flight save.
@@ -3111,35 +3139,6 @@ el.pipelineConfig.addEventListener('change', (e) => {
     saveStep(role, modelSel ? modelSel.value : '', t.value);
   }
 });
-
-// "+ Add model…" picked on a per-node select: add the custom model, then select
-// it for that node (mirrors addModelFlow for the legacy role selects).
-async function addModelFlowNode(nodeId) {
-  const projectDir = selectedProjectPath();
-  if (!projectDir) { renderWorkflowConfig(state.workflowId); return; }
-  const id = (window.prompt('New model id (e.g. claude-opus-4-8 or a fine-tune id):') || '').trim();
-  if (!id) { renderWorkflowConfig(state.workflowId); return; }
-  const label = (window.prompt('Display name (optional):', id) || '').trim();
-  try {
-    const res = await fetch('/api/config/models', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ projectDir, id, label }),
-    });
-    const data = await safeJson(res);
-    if (!res.ok) {
-      appendLog({ source: 'ui', level: 'error', text: `add model: ${data.error || res.status}`, ts: Date.now() });
-      renderWorkflowConfig(state.workflowId);
-      return;
-    }
-    state.models = Array.isArray(data.models) ? data.models : state.models;
-    await saveNode(state.workflowId, nodeId, id, ''); // select the new model (effort reset)
-    renderWorkflowConfig(state.workflowId);           // repaint with the new model in the list
-  } catch (e) {
-    appendLog({ source: 'ui', level: 'error', text: `add model error: ${e.message}`, ts: Date.now() });
-    renderWorkflowConfig(state.workflowId);
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Log window
@@ -6535,6 +6534,158 @@ async function loadGuardrailsView(param = '') {
 }
 
 // ---------------------------------------------------------------------------
+// Models view (configurable-models-design.md §4.10). Global catalog CRUD over
+// /api/models; the selected project's legacy custom models are listed with a
+// Promote action. The editor renders inline at the top of the list; env values
+// arrive MASKED and are write-only (unchanged masked echoes mean "keep").
+// ---------------------------------------------------------------------------
+const mvState = { data: null, editing: null, openCreate: false };
+
+function setModelsMsg(text, kind) {
+  if (!el.modelsMsg) return;
+  el.modelsMsg.textContent = text || '';
+  el.modelsMsg.className = 'form-msg' + (kind ? ' ' + kind : '');
+}
+
+function renderModelsViewBody() {
+  if (!el.modelsList) return;
+  const d = mvState.data || { models: [], predefined: [], efforts: [] };
+  const pp = selectedProjectPath();
+  const legacy = pp && state.config && Array.isArray(state.config.customModels) ? state.config.customModels : [];
+  const frag = document.createDocumentFragment();
+  if (mvState.editing || mvState.openCreate) {
+    frag.appendChild(renderModelEditor(mvState.editing, d.efforts || []));
+  }
+  frag.appendChild(renderModelsList({
+    globals: d.models || [],
+    legacy,
+    predefined: d.predefined || [],
+    efforts: d.efforts || [],
+    projectName: pp ? pp.split('/').pop() : '',
+  }));
+  el.modelsList.replaceChildren(frag);
+}
+
+async function loadModelsView() {
+  if (!el.modelsList) return;
+  setModelsMsg('');
+  try {
+    const res = await fetch('/api/models');
+    const data = await safeJson(res);
+    if (!res.ok) return setModelsMsg(data.error || `HTTP ${res.status}`, 'err');
+    mvState.data = data;
+    renderModelsViewBody();
+  } catch (e) {
+    setModelsMsg(e.message, 'err');
+  }
+}
+
+// Any catalog mutation must repaint BOTH surfaces: this view and the composer's
+// model dropdowns (state.models comes from /api/config).
+async function refreshModelsEverywhere() {
+  await loadModelsView();
+  try { await loadConfig(selectedProjectPath() || ''); } catch { /* dropdowns refresh best-effort */ }
+}
+
+async function saveModelEditorFlow() {
+  const rootEl = el.modelsList && el.modelsList.querySelector('.mv-editor');
+  if (!rootEl) return;
+  const msg = rootEl.querySelector('.mv-editor-msg');
+  const say = (text) => { if (msg) { msg.textContent = text; msg.className = 'form-msg mv-editor-msg err'; } };
+  const { id, body } = collectModelEditor(rootEl);
+  if (!id && !body.id) return say('model id is required');
+  try {
+    const res = await fetch(id ? `/api/models/${encodeURIComponent(id)}` : '/api/models', {
+      method: id ? 'PATCH' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await safeJson(res);
+    if (!res.ok) return say(data.error || `HTTP ${res.status}`);
+    mvState.editing = null;
+    mvState.openCreate = false;
+    setModelsMsg(id ? 'Saved.' : 'Model added.', 'ok');
+    await refreshModelsEverywhere();
+  } catch (e) {
+    say(e.message);
+  }
+}
+
+async function deleteModelFlow(id) {
+  let refs = null;
+  try {
+    const r = await fetch(`/api/models/${encodeURIComponent(id)}/refs`);
+    refs = await safeJson(r);
+  } catch { /* preview is best-effort; the confirm still names the model */ }
+  const ok = await confirmModal({
+    title: refs && refs.predefinedShadow ? 'Remove override' : 'Delete model',
+    message: deleteRefsSummary(id, refs),
+    confirmLabel: refs && refs.predefinedShadow ? 'Remove override' : 'Delete',
+  });
+  if (!ok) return;
+  try {
+    const res = await fetch(`/api/models/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    const data = await safeJson(res);
+    if (!res.ok) return setModelsMsg(data.error || `HTTP ${res.status}`, 'err');
+    setModelsMsg('Deleted.', 'ok');
+    await refreshModelsEverywhere();
+  } catch (e) {
+    setModelsMsg(e.message, 'err');
+  }
+}
+
+async function promoteModelFlow(id) {
+  const projectDir = selectedProjectPath();
+  if (!projectDir) return;
+  try {
+    const res = await fetch('/api/models/promote', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectDir, id }),
+    });
+    const data = await safeJson(res);
+    if (!res.ok) return setModelsMsg(data.error || `HTTP ${res.status}`, 'err');
+    setModelsMsg(`"${id}" is now global.`, 'ok');
+    await refreshModelsEverywhere();
+  } catch (e) {
+    setModelsMsg(e.message, 'err');
+  }
+}
+
+if (el.modelsList) {
+  el.modelsList.addEventListener('click', (ev) => {
+    const t = ev.target.closest('button');
+    if (!t) return;
+    if (t.classList.contains('mv-edit')) {
+      mvState.editing = (mvState.data && mvState.data.models || []).find((m) => m.id === t.dataset.id) || null;
+      mvState.openCreate = false;
+      renderModelsViewBody();
+    } else if (t.classList.contains('mv-delete')) {
+      deleteModelFlow(t.dataset.id);
+    } else if (t.classList.contains('mv-promote')) {
+      promoteModelFlow(t.dataset.id);
+    } else if (t.classList.contains('mv-cancel')) {
+      mvState.editing = null; mvState.openCreate = false;
+      renderModelsViewBody();
+    } else if (t.classList.contains('mv-env-add')) {
+      const wrap = el.modelsList.querySelector('.mv-editor .mv-env');
+      if (wrap) wrap.appendChild(makeEnvRow());
+    } else if (t.classList.contains('mv-env-rm')) {
+      const row = t.closest('.mv-env-row');
+      if (row) row.remove();
+    } else if (t.classList.contains('mv-save')) {
+      saveModelEditorFlow();
+    }
+  });
+}
+if (el.modelCreateBtn) {
+  el.modelCreateBtn.addEventListener('click', () => {
+    mvState.editing = null;
+    mvState.openCreate = true;
+    renderModelsViewBody();
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Statistics view
 // ---------------------------------------------------------------------------
 const statsState = { range: null };
@@ -8302,6 +8453,7 @@ function paintHistStepper(detail, st) {
   const reached = histReachedCell(manifest, st);
   const durs = durByNode(st.steps, 0, false);
   const costs = costByNode(st.steps);
+  const modelsUsed = modelUsedByNode(st.steps);
 
   const cellOf = {};
   manifest.steps.forEach((cell, i) => cell.nodes.forEach((n) => { cellOf[n.id] = i; }));
@@ -8320,6 +8472,7 @@ function paintHistStepper(detail, st) {
     durText: (id) => { const d = durs[id]; return d != null ? fmtDuration(d) : ''; },
     costText: (id) => { const c = costs[id]; return c != null ? fmtUsd(c) : ''; },
     subsOf: (id) => subAgentsForNode(st, id),
+    modelUsedOf: (id) => modelsUsed[id],
   });
 }
 
@@ -8843,6 +8996,7 @@ function paintStepper(r) {
   const now = Date.now();
   const durs = durByNode(r.steps, now, true);
   const costs = r.costByNode || {};
+  const modelsUsed = modelUsedByNode(r.steps);
 
   // cellIdx per node id (for the frontier comparison).
   const cellOf = {};
@@ -8866,6 +9020,7 @@ function paintStepper(r) {
     durText: (id) => { const d = durs[id]; return d != null ? fmtDuration(d) : ''; },
     costText: (id) => { const c = costs[id]; return c != null ? fmtUsd(c) : ''; },
     subsOf: (id) => subAgentsForNode(r, id),
+    modelUsedOf: (id) => modelsUsed[id],
   });
 }
 
@@ -9243,7 +9398,7 @@ const views = $$('.view');
 const navLinks = $$('.nav button[data-nav], .topnav button[data-nav]');
 // [v2/C1] composer is PRESERVED; workspaces + workspace-create are appended.
 // workspace-create is in the array (so deep-links resolve) but has no nav link.
-const VIEW_NAMES = ['new', 'running', 'history', 'stats', 'composer', 'workspaces', 'workspace-create', 'agents', 'agent-create', 'projects', 'plugins', 'guardrails', 'settings'];
+const VIEW_NAMES = ['new', 'running', 'history', 'stats', 'composer', 'workspaces', 'workspace-create', 'agents', 'agent-create', 'projects', 'plugins', 'guardrails', 'models', 'settings'];
 
 function showView(name, param = '') {
   // Leave-guard: navigating away from the wizard while a scan is live aborts the
@@ -9313,6 +9468,7 @@ function showView(name, param = '') {
   if (name === 'agents') loadAgentsView();
   if (name === 'plugins') loadPluginsView();
   if (name === 'guardrails') loadGuardrailsView(param);
+  if (name === 'models') loadModelsView();
   if (name === 'agent-create') enterAgentWizard();
   if (name === 'projects') loadProjectsView();
   if (name === 'composer') initComposer();

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -2591,13 +2591,23 @@ if (typeof window !== 'undefined') {
 // {model,effort}. Shared by the legacy default-stage rows and the dynamic
 // per-node rows so the dropdown contents + effort filtering live in one place.
 function renderModelEffortPair(modelSel, effortSel, caption, sel = {}) {
-  // Model dropdown: "(default model)" + every model + "+ Add model…".
+  // Model dropdown: "(default model)", then the models grouped — user-defined
+  // (global + legacy project) first, built-ins second, each group sorted
+  // alphabetically by label — then "+ Add model…". Provenance is carried by
+  // the optgroup label, not a per-option suffix; only the observed §4.6
+  // "cost not verified" flag still marks an option.
   modelSel.innerHTML = '';
   modelSel.appendChild(option('', '(default model)'));
-  state.models.forEach((m) => modelSel.appendChild(option(m.id,
-    m.label
-    + (m.custom === 'project' ? ' ·project' : m.custom ? ' ·custom' : '')
-    + (m.costUnreliable ? ' ⚠cost' : '')))); // §4.6 observed "cost not verified"
+  const byLabel = (a, b) => (a.label || a.id).localeCompare(b.label || b.id, undefined, { sensitivity: 'base' });
+  const optgroup = (label, models) => {
+    if (!models.length) return;
+    const og = document.createElement('optgroup');
+    og.label = label;
+    for (const m of models) og.appendChild(option(m.id, m.label + (m.costUnreliable ? ' ⚠cost' : '')));
+    modelSel.appendChild(og);
+  };
+  optgroup('Your models', state.models.filter((m) => m.custom).sort(byLabel));
+  optgroup('Built-in', state.models.filter((m) => !m.custom).sort(byLabel));
   modelSel.appendChild(option('__add__', '+ Add model…'));
   modelSel.value = sel.model || '';
 

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -811,7 +811,10 @@ function nodeModelLine(node) {
   const effort = node.effort || '';
   if (!model && !effort) return 'default';
   const m = modelById(model);
-  const modelLabel = model ? (m ? m.label : model) : 'default';
+  // ⚠ = the model has an OBSERVED cost-unreliable flag (§4.6): its endpoint
+  // reported no cost while consuming tokens, so this node's cost readout may
+  // under-report.
+  const modelLabel = model ? (m ? m.label : model) + (m && m.costUnreliable ? ' ⚠' : '') : 'default';
   return `${modelLabel} · ${effort || 'default'}`;
 }
 
@@ -2591,7 +2594,10 @@ function renderModelEffortPair(modelSel, effortSel, caption, sel = {}) {
   // Model dropdown: "(default model)" + every model + "+ Add model…".
   modelSel.innerHTML = '';
   modelSel.appendChild(option('', '(default model)'));
-  state.models.forEach((m) => modelSel.appendChild(option(m.id, m.label + (m.custom === 'project' ? ' ·project' : m.custom ? ' ·custom' : ''))));
+  state.models.forEach((m) => modelSel.appendChild(option(m.id,
+    m.label
+    + (m.custom === 'project' ? ' ·project' : m.custom ? ' ·custom' : '')
+    + (m.costUnreliable ? ' ⚠cost' : '')))); // §4.6 observed "cost not verified"
   modelSel.appendChild(option('__add__', '+ Add model…'));
   modelSel.value = sel.model || '';
 

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -75,6 +75,7 @@ import {
 } from './guardrails-view.mjs';
 import {
   renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, deleteRefsSummary,
+  renderExportWizard, collectExportWizard,
 } from './models-view.mjs';
 import { renderSourcePane, collectSourcePane } from './source-pane.mjs';
 import { renderStatsBody, renderBudgetIndicator, renderBudgetReadout, renderCostPauseBanner, BUDGET_WARN_AT } from './stats-view.mjs';
@@ -260,6 +261,7 @@ const el = {
   modelsList: $('#models-list'),
   modelsMsg: $('#models-msg'),
   modelCreateBtn: $('#model-create-btn'),
+  modelShareBtn: $('#model-share-btn'),
 
   // Statistics view
   statsBody: $('#stats-body'),
@@ -2592,21 +2594,33 @@ if (typeof window !== 'undefined') {
 // per-node rows so the dropdown contents + effort filtering live in one place.
 function renderModelEffortPair(modelSel, effortSel, caption, sel = {}) {
   // Model dropdown: "(default model)", then the models grouped — user-defined
-  // (global + legacy project) first, built-ins second, each group sorted
-  // alphabetically by label — then "+ Add model…". Provenance is carried by
-  // the optgroup label, not a per-option suffix; only the observed §4.6
+  // (global + legacy project) first, plugin-provided second, built-ins third,
+  // each group sorted alphabetically by label — then "+ Add model…".
+  // Provenance is carried by the optgroup label, not a per-option suffix; only
+  // when the same LABEL appears more than once does a plugin option get its
+  // plugin name appended (design §9.6, collision-only), and the observed §4.6
   // "cost not verified" flag still marks an option.
   modelSel.innerHTML = '';
   modelSel.appendChild(option('', '(default model)'));
   const byLabel = (a, b) => (a.label || a.id).localeCompare(b.label || b.id, undefined, { sensitivity: 'base' });
+  const labelCounts = new Map();
+  for (const m of state.models) {
+    const lc = (m.label || m.id).toLowerCase();
+    labelCounts.set(lc, (labelCounts.get(lc) || 0) + 1);
+  }
   const optgroup = (label, models) => {
     if (!models.length) return;
     const og = document.createElement('optgroup');
     og.label = label;
-    for (const m of models) og.appendChild(option(m.id, m.label + (m.costUnreliable ? ' ⚠cost' : '')));
+    for (const m of models) {
+      const ambiguous = m.custom === 'plugin' && labelCounts.get((m.label || m.id).toLowerCase()) > 1;
+      og.appendChild(option(m.id,
+        m.label + (ambiguous ? ` (${m.plugin})` : '') + (m.costUnreliable ? ' ⚠cost' : '')));
+    }
     modelSel.appendChild(og);
   };
-  optgroup('Your models', state.models.filter((m) => m.custom).sort(byLabel));
+  optgroup('Your models', state.models.filter((m) => m.custom && m.custom !== 'plugin').sort(byLabel));
+  optgroup('Plugins', state.models.filter((m) => m.custom === 'plugin').sort(byLabel));
   optgroup('Built-in', state.models.filter((m) => !m.custom).sort(byLabel));
   modelSel.appendChild(option('__add__', '+ Add model…'));
   modelSel.value = sel.model || '';
@@ -3061,6 +3075,8 @@ function goAddModel(restore) {
   if (typeof restore === 'function') restore();
   mvState.editing = null;
   mvState.openCreate = true;
+  mvState.openShare = false;
+  mvState.prefill = null;
   showView('models'); // loadModelsView renders the open editor
 }
 
@@ -6302,6 +6318,18 @@ async function openPluginSettings(name) {
   const sources = Array.isArray(data.sources) ? data.sources
     : [{ id: data.sourceId || '', schema: data.schema || [], values: data.values || {} }];
   const body = renderConfigForm(sources);
+  // Model secrets (design §9.7): one extra form, marked with data-target so the
+  // save loop routes it through the { target: 'modelSecrets' } write.
+  if (data.models && Array.isArray(data.models.schema) && data.models.schema.length) {
+    const head = document.createElement('h4');
+    head.className = 'pl-config-h';
+    head.textContent = 'Model secrets';
+    body.appendChild(head);
+    const msForm = renderConfigForm([{ id: '', schema: data.models.schema, values: data.models.values }])
+      .querySelector('.pl-config-form');
+    msForm.dataset.target = 'modelSecrets';
+    body.appendChild(msForm);
+  }
   pluginModal(`Settings: ${name}`, body, [
     ['Cancel', 'btn btn-ghost btn-mini', closePluginModal],
     ['Save', 'btn btn-primary btn-mini', async () => {
@@ -6311,7 +6339,10 @@ async function openPluginSettings(name) {
       let failed = null;
       for (const f of body.querySelectorAll('.pl-config-form')) {
         const { sourceId, values } = collectConfigForm(f);
-        const r = await pluginApi('PUT', `/api/plugins/${encodeURIComponent(name)}/config`, { sourceId, values });
+        const payload = f.dataset.target === 'modelSecrets'
+          ? { target: 'modelSecrets', values }
+          : { sourceId, values };
+        const r = await pluginApi('PUT', `/api/plugins/${encodeURIComponent(name)}/config`, payload);
         if (!r.ok) { failed = r.data.error || 'save failed'; break; }
       }
       closePluginModal();
@@ -6555,7 +6586,7 @@ async function loadGuardrailsView(param = '') {
 // Promote action. The editor renders inline at the top of the list; env values
 // arrive MASKED and are write-only (unchanged masked echoes mean "keep").
 // ---------------------------------------------------------------------------
-const mvState = { data: null, editing: null, openCreate: false };
+const mvState = { data: null, editing: null, openCreate: false, openShare: false, prefill: null };
 
 function setModelsMsg(text, kind) {
   if (!el.modelsMsg) return;
@@ -6569,17 +6600,93 @@ function renderModelsViewBody() {
   const pp = selectedProjectPath();
   const legacy = pp && state.config && Array.isArray(state.config.customModels) ? state.config.customModels : [];
   const frag = document.createDocumentFragment();
-  if (mvState.editing || mvState.openCreate) {
-    frag.appendChild(renderModelEditor(mvState.editing, d.efforts || []));
+  if (mvState.openShare) {
+    frag.appendChild(renderExportWizard(d.models || []));
+  } else if (mvState.editing || mvState.openCreate) {
+    const editor = renderModelEditor(mvState.editing, d.efforts || []);
+    if (!mvState.editing && mvState.prefill) prefillModelEditor(editor, mvState.prefill);
+    frag.appendChild(editor);
   }
   frag.appendChild(renderModelsList({
     globals: d.models || [],
     legacy,
+    plugins: d.plugin || [],
     predefined: d.predefined || [],
     efforts: d.efforts || [],
     projectName: pp ? pp.split('/').pop() : '',
   }));
   el.modelsList.replaceChildren(frag);
+}
+
+// "Edit a copy" prefill (design §9.6): create-mode editor seeded from a plugin
+// model — id/label/efforts plus its literal/${VAR} env values; each {secret}
+// key becomes an EMPTY row the user must fill (the plugin's secret is never
+// copied). Saving POSTs a global entry that shadows the plugin one.
+function prefillModelEditor(editor, pre) {
+  const idInput = editor.querySelector('.mv-id');
+  if (idInput) idInput.value = pre.id;
+  const labelInput = editor.querySelector('.mv-label');
+  if (labelInput) labelInput.value = pre.label && pre.label !== pre.id ? pre.label : '';
+  const efforts = new Set(pre.efforts || []);
+  if (efforts.size) {
+    for (const cb of editor.querySelectorAll('.mv-effort-cb')) cb.checked = efforts.has(cb.value);
+  }
+  const wrap = editor.querySelector('.mv-env');
+  if (!wrap) return;
+  for (const [k, v] of Object.entries(pre.env || {})) {
+    const row = makeEnvRow();
+    row.querySelector('.mv-env-key').value = k;
+    row.querySelector('.mv-env-val').value = v;
+    wrap.appendChild(row);
+  }
+  for (const k of pre.secretKeys || []) {
+    const row = makeEnvRow();
+    row.querySelector('.mv-env-key').value = k;
+    row.querySelector('.mv-env-val').placeholder = 'value required — the plugin secret is not copied';
+    wrap.appendChild(row);
+  }
+  const msg = editor.querySelector('.mv-editor-msg');
+  if (msg && (pre.secretKeys || []).length) {
+    msg.textContent = `Fill in ${pre.secretKeys.join(', ')} — secret values never leave the plugin.`;
+  }
+}
+
+async function editPluginCopyFlow(plugin, id) {
+  try {
+    const res = await fetch(`/api/plugins/${encodeURIComponent(plugin)}/model-env?id=${encodeURIComponent(id)}`);
+    const data = await safeJson(res);
+    if (!res.ok) return setModelsMsg(data.error || `HTTP ${res.status}`, 'err');
+    mvState.editing = null;
+    mvState.openCreate = true;
+    mvState.openShare = false;
+    mvState.prefill = data;
+    renderModelsViewBody();
+  } catch (e) {
+    setModelsMsg(e.message, 'err');
+  }
+}
+
+async function exportPluginFlow() {
+  const wiz = el.modelsList && el.modelsList.querySelector('.mvx');
+  if (!wiz) return;
+  const msg = wiz.querySelector('.mvx-msg');
+  const say = (text) => { if (msg) { msg.textContent = text; msg.className = 'form-msg mvx-msg err'; } };
+  const body = collectExportWizard(wiz);
+  if (!body.models.length) return say('pick at least one model');
+  if (!body.name) return say('plugin name is required');
+  if (!body.dest) return say('destination folder is required');
+  try {
+    const res = await fetch('/api/models/export-plugin', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+    });
+    const data = await safeJson(res);
+    if (!res.ok) return say(data.error || `HTTP ${res.status}`);
+    mvState.openShare = false;
+    setModelsMsg(`Plugin scaffold written to ${data.dir} — git init + push it, then teammates install it from the Plugins view.`, 'ok');
+    renderModelsViewBody();
+  } catch (e) {
+    say(e.message);
+  }
 }
 
 async function loadModelsView() {
@@ -6687,6 +6794,7 @@ async function saveModelEditorFlow() {
     if (!res.ok) return say(data.error || `HTTP ${res.status}`);
     mvState.editing = null;
     mvState.openCreate = false;
+    mvState.prefill = null;
     setModelsMsg(id ? 'Saved.' : 'Model added.', 'ok');
     await refreshModelsEverywhere();
   } catch (e) {
@@ -6741,13 +6849,22 @@ if (el.modelsList) {
     if (t.classList.contains('mv-edit')) {
       mvState.editing = (mvState.data && mvState.data.models || []).find((m) => m.id === t.dataset.id) || null;
       mvState.openCreate = false;
+      mvState.openShare = false;
+      mvState.prefill = null;
       renderModelsViewBody();
     } else if (t.classList.contains('mv-delete')) {
       deleteModelFlow(t.dataset.id);
     } else if (t.classList.contains('mv-promote')) {
       promoteModelFlow(t.dataset.id);
+    } else if (t.classList.contains('mv-copy')) {
+      editPluginCopyFlow(t.dataset.plugin, t.dataset.id);
+    } else if (t.classList.contains('mvx-export')) {
+      exportPluginFlow();
+    } else if (t.classList.contains('mvx-cancel')) {
+      mvState.openShare = false;
+      renderModelsViewBody();
     } else if (t.classList.contains('mv-cancel')) {
-      mvState.editing = null; mvState.openCreate = false;
+      mvState.editing = null; mvState.openCreate = false; mvState.prefill = null;
       renderModelsViewBody();
     } else if (t.classList.contains('mv-env-add')) {
       const wrap = el.modelsList.querySelector('.mv-editor .mv-env');
@@ -6768,6 +6885,17 @@ if (el.modelCreateBtn) {
   el.modelCreateBtn.addEventListener('click', () => {
     mvState.editing = null;
     mvState.openCreate = true;
+    mvState.openShare = false;
+    mvState.prefill = null;
+    renderModelsViewBody();
+  });
+}
+if (el.modelShareBtn) {
+  el.modelShareBtn.addEventListener('click', () => {
+    mvState.editing = null;
+    mvState.openCreate = false;
+    mvState.prefill = null;
+    mvState.openShare = true;
     renderModelsViewBody();
   });
 }

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -6593,6 +6593,73 @@ async function refreshModelsEverywhere() {
   try { await loadConfig(selectedProjectPath() || ''); } catch { /* dropdowns refresh best-effort */ }
 }
 
+// Copy a stored env value to the clipboard — the REAL value, not the mask.
+// The user already owns it on disk (~/.worca-cc/settings.json); the reveal is
+// a deliberate single-value GET, keyed by the row's STORED key (dataset.key,
+// frozen at render), so it works even after the key input was edited.
+async function copyModelEnvValue(btn) {
+  const row = btn.closest('.mv-env-row');
+  const editor = btn.closest('.mv-editor');
+  const id = editor && editor.dataset.id;
+  const key = row && row.dataset.key;
+  if (!id || !key) return;
+  const flash = (text) => {
+    const prev = btn.textContent;
+    btn.textContent = text;
+    setTimeout(() => { btn.textContent = prev; }, 1200);
+  };
+  try {
+    const res = await fetch(`/api/models/${encodeURIComponent(id)}/env-value?key=${encodeURIComponent(key)}`);
+    const data = await safeJson(res);
+    if (!res.ok) return flash('!');
+    await navigator.clipboard.writeText(data.value);
+    flash('✓');
+  } catch {
+    flash('!');
+  }
+}
+
+// "Show values" toggle: swap every UNTOUCHED masked input to the real stored
+// value (fetched raw), and back. User-edited inputs are never clobbered in
+// either direction. dataset.original tracks what "untouched" means so the
+// write-only PATCH semantics keep working: a revealed raw value echoed on
+// save just rewrites the same value.
+async function toggleModelEnvReveal(btn) {
+  const editor = btn.closest('.mv-editor');
+  const id = editor && editor.dataset.id;
+  if (!id) return;
+  const rows = editor.querySelectorAll('.mv-env-row[data-key]');
+  if (btn.dataset.on) {
+    for (const row of rows) {
+      const v = row.querySelector('.mv-env-val');
+      if (v && v.dataset.masked !== undefined && v.value === v.dataset.original) {
+        v.value = v.dataset.masked;
+        v.dataset.original = v.dataset.masked;
+        delete v.dataset.masked;
+      }
+    }
+    delete btn.dataset.on;
+    btn.textContent = 'Show values';
+    return;
+  }
+  try {
+    const res = await fetch(`/api/models/${encodeURIComponent(id)}/env-value`);
+    const data = await safeJson(res);
+    if (!res.ok || !data.env) return;
+    for (const row of rows) {
+      const v = row.querySelector('.mv-env-val');
+      const key = row.dataset.key;
+      if (!v || !(key in data.env)) continue;
+      if (v.value !== v.dataset.original) continue; // user edited — keep their text
+      v.dataset.masked = v.dataset.original;
+      v.value = data.env[key];
+      v.dataset.original = data.env[key];
+    }
+    btn.dataset.on = '1';
+    btn.textContent = 'Hide values';
+  } catch { /* reveal is best-effort */ }
+}
+
 async function saveModelEditorFlow() {
   const rootEl = el.modelsList && el.modelsList.querySelector('.mv-editor');
   if (!rootEl) return;
@@ -6678,6 +6745,10 @@ if (el.modelsList) {
     } else if (t.classList.contains('mv-env-rm')) {
       const row = t.closest('.mv-env-row');
       if (row) row.remove();
+    } else if (t.classList.contains('mv-env-copy')) {
+      copyModelEnvValue(t);
+    } else if (t.classList.contains('mv-env-reveal')) {
+      toggleModelEnvReveal(t);
     } else if (t.classList.contains('mv-save')) {
       saveModelEditorFlow();
     }

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -54,6 +54,10 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.6-3 8.4-7 10-4-1.6-7-5.4-7-10V6z"></path></svg>
             <span>Guardrails</span>
           </button>
+          <button type="button" data-nav="models">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="10" height="10" rx="2"></rect><path d="M12 2v3M12 19v3M2 12h3M19 12h3M6 2.5v2M18 2.5v2M6 19.5v2M18 19.5v2"></path></svg>
+            <span>Models</span>
+          </button>
           <button type="button" data-nav="plugins">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3v5M15 3v5M7 8h10v4a5 5 0 0 1-10 0V8Z"></path><path d="M12 17v4"></path></svg>
             <span>Plugins</span>
@@ -96,6 +100,7 @@
           <button type="button" data-nav="composer">Composer</button>
           <button type="button" data-nav="agents">Agents</button>
           <button type="button" data-nav="guardrails">Guardrails</button>
+          <button type="button" data-nav="models">Models</button>
           <button type="button" data-nav="plugins">Plugins</button>
           <span class="topnav-sep" aria-hidden="true"></span>
           <button type="button" data-nav="projects">Projects</button>
@@ -761,6 +766,23 @@
           <div class="run-list" id="guardrails-list"></div>
         </section>
         <!-- /view guardrails -->
+
+        <!-- ===== VIEW: MODELS ===== -->
+        <section class="view hidden" data-view="models">
+          <div class="topbar">
+            <div>
+              <h1>Models</h1>
+              <div class="sub">Global model catalog — available in every project; entries can override built-ins and carry per-model routing env</div>
+            </div>
+            <button type="button" id="model-create-btn" class="btn-go" style="padding:11px 20px">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"></path></svg>
+              Add model
+            </button>
+          </div>
+          <p id="models-msg" class="form-msg" aria-live="polite"></p>
+          <div class="run-list" id="models-list"></div>
+        </section>
+        <!-- /view models -->
 
         <!-- ===== VIEW: PROJECTS ===== -->
         <section class="view hidden" data-view="projects">

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -774,10 +774,13 @@
               <h1>Models</h1>
               <div class="sub">Global model catalog — available in every project; entries can override built-ins and carry per-model routing env</div>
             </div>
-            <button type="button" id="model-create-btn" class="btn-go" style="padding:11px 20px">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"></path></svg>
-              Add model
-            </button>
+            <div style="display:flex;gap:8px">
+              <button type="button" id="model-share-btn" class="btn-ghost" style="padding:11px 20px">Share as plugin…</button>
+              <button type="button" id="model-create-btn" class="btn-go" style="padding:11px 20px">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"></path></svg>
+                Add model
+              </button>
+            </div>
           </div>
           <p id="models-msg" class="form-msg" aria-live="polite"></p>
           <div class="run-list" id="models-list"></div>

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -1,0 +1,264 @@
+// ui/public/models-view.mjs
+// Pure DOM renderers for the Models view (configurable-models-design.md §4.10).
+// Mirrors guardrails-view.mjs: every function takes `doc` via opts (defaults to
+// the browser global) and returns DETACHED elements — no fetch, no listeners
+// outside the returned tree. app.js owns endpoint calls and mounting.
+// Interactive elements carry data-id + a routing class (mv-edit, mv-delete,
+// mv-promote, mv-save, mv-cancel, mv-env-add, mv-env-rm) so app.js wires ONE
+// delegated listener on the list container.
+
+function h(doc, tag, cls, text) {
+  const n = doc.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = text;
+  return n;
+}
+
+/** "medium · high" or "all efforts" (the full set carries no signal). */
+export function effortsSummary(efforts, allEfforts) {
+  const list = Array.isArray(efforts) ? efforts : [];
+  if (!list.length || (allEfforts && list.length === allEfforts.length)) return 'all efforts';
+  return list.join(' · ');
+}
+
+/** "2 env vars · routes via base URL" | "1 env var" | '' (none). */
+export function envSummary(env) {
+  const keys = Object.keys(env || {});
+  if (!keys.length) return '';
+  const n = `${keys.length} env var${keys.length === 1 ? '' : 's'}`;
+  return keys.includes('ANTHROPIC_BASE_URL') ? `${n} · routes via base URL` : n;
+}
+
+/**
+ * The Models view body: global entries (editable), the selected project's
+ * legacy custom models (promotable), and the built-in catalog (read-only).
+ * `globals` come MASKED from GET /api/models. `predefinedShadowedIds` marks
+ * built-ins currently overridden by a global entry.
+ */
+export function renderModelsList({ globals = [], legacy = [], predefined = [], efforts = [], projectName = '' } = {}, { doc = globalThis.document } = {}) {
+  const root = h(doc, 'div', 'mv-list');
+  const predefLc = new Set(predefined.map((m) => m.id.toLowerCase()));
+
+  const section = (title, hint) => {
+    const s = h(doc, 'div', 'mv-section');
+    s.appendChild(h(doc, 'h3', 'mv-section-title', title));
+    if (hint) s.appendChild(h(doc, 'small', 'hint', hint));
+    return s;
+  };
+
+  // ── Your models (global) ──
+  const yours = section('Your models', 'Defined once, available in every project. An entry with a built-in id overrides that built-in.');
+  if (!globals.length) {
+    yours.appendChild(h(doc, 'div', 'hist-empty', 'No global models yet — Add model to define one.'));
+  }
+  for (const m of globals) {
+    const card = h(doc, 'section', 'card mv-card');
+    card.dataset.id = m.id;
+    const body = h(doc, 'div', 'mv-body');
+    const head = h(doc, 'div', 'mv-head');
+    head.appendChild(h(doc, 'b', 'mv-name', m.label || m.id));
+    if (predefLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadow', 'overrides built-in'));
+    if (m.costUnreliable) head.appendChild(h(doc, 'span', 'badge waiting mv-cost', 'cost not verified'));
+    body.appendChild(head);
+    const bits = [m.id, effortsSummary(m.efforts, efforts), envSummary(m.env)].filter(Boolean);
+    body.appendChild(h(doc, 'small', 'mv-summary hint', bits.join(' — ')));
+    card.appendChild(body);
+    const del = h(doc, 'button', 'btn-ghost mv-delete', 'Delete');
+    del.type = 'button'; del.dataset.id = m.id;
+    card.appendChild(del);
+    const edit = h(doc, 'button', 'btn-ghost mv-edit', 'Edit');
+    edit.type = 'button'; edit.dataset.id = m.id;
+    card.appendChild(edit);
+    yours.appendChild(card);
+  }
+  root.appendChild(yours);
+
+  // ── Legacy per-project models (promotable) ──
+  if (legacy.length) {
+    const leg = section(
+      `Project models${projectName ? ` — ${projectName}` : ''} (legacy)`,
+      'Defined only for this project. Promote to make them global; the id keeps working everywhere it is referenced.'
+    );
+    for (const m of legacy) {
+      const card = h(doc, 'section', 'card mv-card mv-legacy');
+      card.dataset.id = m.id;
+      const body = h(doc, 'div', 'mv-body');
+      const head = h(doc, 'div', 'mv-head');
+      head.appendChild(h(doc, 'b', 'mv-name', m.label || m.id));
+      head.appendChild(h(doc, 'span', 'badge waiting mv-origin', 'project (legacy)'));
+      body.appendChild(head);
+      body.appendChild(h(doc, 'small', 'mv-summary hint', m.id));
+      card.appendChild(body);
+      const promote = h(doc, 'button', 'btn-ghost mv-promote', 'Promote to global');
+      promote.type = 'button'; promote.dataset.id = m.id;
+      card.appendChild(promote);
+      leg.appendChild(card);
+    }
+    root.appendChild(leg);
+  }
+
+  // ── Built-ins (read-only) ──
+  const globalLc = new Set(globals.map((m) => m.id.toLowerCase()));
+  const builtins = section('Built-in models', 'Shipped with worca. Add a model with the same id to override its label, efforts, or routing.');
+  for (const m of predefined) {
+    const row = h(doc, 'div', 'mv-builtin');
+    row.dataset.id = m.id;
+    row.appendChild(h(doc, 'b', 'mv-name', m.label));
+    if (globalLc.has(m.id.toLowerCase())) row.appendChild(h(doc, 'span', 'badge violet mv-shadowed', 'overridden'));
+    row.appendChild(h(doc, 'small', 'mv-summary hint', `${m.id} — ${effortsSummary(m.efforts, efforts)}`));
+    builtins.appendChild(row);
+  }
+  root.appendChild(builtins);
+  return root;
+}
+
+/** One env key/value editor row. Existing values arrive MASKED; leaving a
+ *  masked value untouched means "keep" (the server drops masked echoes). */
+function envRow(doc, key = '', value = '') {
+  const row = h(doc, 'div', 'mv-env-row');
+  const k = h(doc, 'input', 'input mv-env-key');
+  k.type = 'text'; k.placeholder = 'ANTHROPIC_BASE_URL'; k.value = key;
+  const v = h(doc, 'input', 'input mv-env-val');
+  v.type = 'text'; v.placeholder = 'value, or ${VAR} to read your shell env'; v.value = value;
+  if (value) v.dataset.original = value; // masked echo detection on collect
+  const rm = h(doc, 'button', 'btn-ghost mv-env-rm', '✕');
+  rm.type = 'button';
+  row.appendChild(k); row.appendChild(v); row.appendChild(rm);
+  return row;
+}
+
+/**
+ * The add/edit form. `model` is a MASKED global entry, or null for create.
+ * Returns detached DOM; app.js wires mv-save / mv-cancel / mv-env-add /
+ * mv-env-rm and calls collectModelEditor on save.
+ */
+export function renderModelEditor(model, efforts, { doc = globalThis.document } = {}) {
+  const editing = !!model;
+  const root = h(doc, 'section', 'card mv-editor');
+  root.dataset.mode = editing ? 'edit' : 'create';
+  if (editing) {
+    root.dataset.id = model.id;
+    // The stored env keys, so collect can send null (= delete) for rows the
+    // user removed — the write-only PATCH can't infer deletions otherwise.
+    root.dataset.envKeys = Object.keys(model.env || {}).join('\n');
+  }
+  root.appendChild(h(doc, 'h3', 'mv-editor-title', editing ? `Edit ${model.label || model.id}` : 'Add model'));
+
+  const grid = h(doc, 'div', 'mv-editor-grid');
+  const field = (labelText, input, hint) => {
+    const wrap = h(doc, 'label', 'mv-field');
+    wrap.appendChild(h(doc, 'span', 'mv-field-label', labelText));
+    wrap.appendChild(input);
+    if (hint) wrap.appendChild(h(doc, 'small', 'hint', hint));
+    return wrap;
+  };
+
+  const idInput = h(doc, 'input', 'input mv-id');
+  idInput.type = 'text';
+  idInput.placeholder = 'claude-opus-4-8, glm-4.7, a fine-tune id…';
+  idInput.value = editing ? model.id : '';
+  idInput.disabled = editing; // the id IS the reference — delete + re-add to rename
+  grid.appendChild(field('Model id (passed to claude --model)', idInput,
+    editing ? '' : 'Use a built-in id to override that built-in.'));
+
+  const labelInput = h(doc, 'input', 'input mv-label');
+  labelInput.type = 'text';
+  labelInput.placeholder = 'Display name (defaults to the id)';
+  labelInput.value = editing ? (model.label === model.id ? '' : model.label) : '';
+  grid.appendChild(field('Label', labelInput));
+
+  const effWrap = h(doc, 'div', 'mv-efforts');
+  const selected = new Set(editing && Array.isArray(model.efforts) ? model.efforts : efforts);
+  for (const e of efforts) {
+    const lab = h(doc, 'label', 'mv-effort');
+    const cb = h(doc, 'input', 'mv-effort-cb');
+    cb.type = 'checkbox'; cb.value = e; cb.checked = selected.has(e);
+    lab.appendChild(cb);
+    lab.appendChild(h(doc, 'span', null, e));
+    effWrap.appendChild(lab);
+  }
+  grid.appendChild(field('Supported efforts', effWrap, 'All checked = every effort (the default).'));
+
+  const envWrap = h(doc, 'div', 'mv-env');
+  const rows = editing && model.env ? Object.entries(model.env) : [];
+  for (const [k, v] of rows) envWrap.appendChild(envRow(doc, k, v));
+  const add = h(doc, 'button', 'btn-ghost mv-env-add', '+ env var');
+  add.type = 'button';
+  grid.appendChild(field('Routing env (merged into the claude spawn for this model)', envWrap,
+    'e.g. ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN. Stored values show masked; leave masked to keep. WORCA_* and process keys are reserved.'));
+  grid.appendChild(add);
+
+  root.appendChild(grid);
+  const msg = h(doc, 'p', 'form-msg mv-editor-msg');
+  msg.setAttribute('aria-live', 'polite');
+  root.appendChild(msg);
+
+  const btns = h(doc, 'div', 'mv-editor-btns');
+  const save = h(doc, 'button', 'btn-go mv-save', editing ? 'Save' : 'Add model');
+  save.type = 'button';
+  const cancel = h(doc, 'button', 'btn-ghost mv-cancel', 'Cancel');
+  cancel.type = 'button';
+  btns.appendChild(save); btns.appendChild(cancel);
+  root.appendChild(btns);
+  return root;
+}
+
+/** app.js exposes envRow creation to the delegated mv-env-add handler. */
+export function makeEnvRow({ doc = globalThis.document } = {}) {
+  return envRow(doc);
+}
+
+/**
+ * Collect the editor into a request body. For EDIT mode the env is a write-only
+ * PATCH: unchanged masked values are echoed (the server treats them as "keep"),
+ * removed keys are sent as null. Returns { id, body } — id is null in create
+ * mode (POST carries it in the body instead).
+ */
+export function collectModelEditor(rootEl) {
+  const editing = rootEl.dataset.mode === 'edit';
+  const id = editing ? rootEl.dataset.id : (rootEl.querySelector('.mv-id')?.value || '').trim();
+  const label = (rootEl.querySelector('.mv-label')?.value || '').trim();
+  const efforts = [...rootEl.querySelectorAll('.mv-effort-cb')].filter((c) => c.checked).map((c) => c.value);
+  const allCount = rootEl.querySelectorAll('.mv-effort-cb').length;
+
+  const env = {};
+  const seen = new Set();
+  for (const row of rootEl.querySelectorAll('.mv-env-row')) {
+    const k = (row.querySelector('.mv-env-key')?.value || '').trim();
+    const v = row.querySelector('.mv-env-val')?.value ?? '';
+    if (!k) continue;
+    seen.add(k);
+    env[k] = v;
+  }
+  if (editing) {
+    // Keys the stored entry had but the editor no longer shows -> delete (null).
+    for (const k of (rootEl.dataset.envKeys || '').split('\n').filter(Boolean)) {
+      if (!seen.has(k)) env[k] = null;
+    }
+  }
+
+  const body = {
+    ...(editing ? {} : { id }),
+    label,
+    // All boxes checked = the full set = store the default (empty).
+    efforts: efforts.length === allCount ? [] : efforts,
+    env,
+  };
+  return { id: editing ? id : null, body };
+}
+
+/** Human summary of what deleting `id` clears, for the confirmation prompt. */
+export function deleteRefsSummary(id, refs) {
+  if (refs && refs.predefinedShadow) {
+    return `Remove the override of built-in "${id}"? The built-in entry comes back; nothing else changes.`;
+  }
+  const nodes = refs && Array.isArray(refs.nodes) ? refs.nodes.length : 0;
+  const steps = refs && Array.isArray(refs.steps) ? refs.steps.length : 0;
+  const projects = new Set([
+    ...((refs && refs.nodes) || []).map((n) => n.projectKey),
+    ...((refs && refs.steps) || []).map((s) => s.projectKey),
+  ]).size;
+  if (!nodes && !steps) return `Delete model "${id}"? No pipeline configuration references it.`;
+  return `Delete model "${id}"? This also clears ${nodes} node selection${nodes === 1 ? '' : 's'} and ` +
+    `${steps} role selection${steps === 1 ? '' : 's'} across ${projects} project${projects === 1 ? '' : 's'}.`;
+}

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -306,7 +306,10 @@ export function collectModelEditor(rootEl) {
 
 // ── Share-as-plugin export wizard (design §9.5) ─────────────────────────────
 
-const SECRETISH_RE = /token|key|secret|password|auth/i;
+// Credential-looking env keys default to "Require at install". Word-ish
+// boundaries keep limits like MAX_OUTPUT_TOKENS or MAX_THINKING_TOKENS (a
+// count, not a credential) out of the net.
+const SECRETISH_RE = /auth|secret|password|credential|api_?key|(?:^|_)key(?:_|$)|(?:^|_)token(?:_|$)/i;
 
 /**
  * The export wizard: pick global models, set the per-env-key policy, name the

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -35,9 +35,10 @@ export function envSummary(env) {
  * `globals` come MASKED from GET /api/models. `predefinedShadowedIds` marks
  * built-ins currently overridden by a global entry.
  */
-export function renderModelsList({ globals = [], legacy = [], predefined = [], efforts = [], projectName = '' } = {}, { doc = globalThis.document } = {}) {
+export function renderModelsList({ globals = [], legacy = [], plugins = [], predefined = [], efforts = [], projectName = '' } = {}, { doc = globalThis.document } = {}) {
   const root = h(doc, 'div', 'mv-list');
   const predefLc = new Set(predefined.map((m) => m.id.toLowerCase()));
+  const pluginLc = new Set(plugins.map((m) => m.id.toLowerCase()));
 
   const section = (title, hint) => {
     const s = h(doc, 'div', 'mv-section');
@@ -58,6 +59,7 @@ export function renderModelsList({ globals = [], legacy = [], predefined = [], e
     const head = h(doc, 'div', 'mv-head');
     head.appendChild(h(doc, 'b', 'mv-name', m.label || m.id));
     if (predefLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadow', 'overrides built-in'));
+    else if (pluginLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadow', 'overrides plugin'));
     if (m.costUnreliable) head.appendChild(h(doc, 'span', 'badge waiting mv-cost', 'cost not verified'));
     body.appendChild(head);
     const bits = [m.id, effortsSummary(m.efforts, efforts), envSummary(m.env)].filter(Boolean);
@@ -97,14 +99,46 @@ export function renderModelsList({ globals = [], legacy = [], predefined = [], e
     root.appendChild(leg);
   }
 
-  // ── Built-ins (read-only) ──
+  // ── From plugins (read-only; design §9.6) ──
   const globalLc = new Set(globals.map((m) => m.id.toLowerCase()));
+  if (plugins.length) {
+    const plug = section('From plugins',
+      'Installed by plugins — read-only and updated with the plugin. "Edit a copy" clones one into Your models, which then overrides it.');
+    for (const m of plugins) {
+      const card = h(doc, 'section', 'card mv-card mv-plugin');
+      card.dataset.id = m.id;
+      card.dataset.plugin = m.plugin;
+      const body = h(doc, 'div', 'mv-body');
+      const head = h(doc, 'div', 'mv-head');
+      head.appendChild(h(doc, 'b', 'mv-name', m.label || m.id));
+      head.appendChild(h(doc, 'span', 'badge waiting mv-origin', `plugin: ${m.plugin}`));
+      if (globalLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadowed', 'overridden by your copy'));
+      if (m.costUnreliable) head.appendChild(h(doc, 'span', 'badge waiting mv-cost', 'cost not verified'));
+      body.appendChild(head);
+      const bits = [m.id, effortsSummary(m.efforts, efforts), envSummary(m.env)].filter(Boolean);
+      body.appendChild(h(doc, 'small', 'mv-summary hint', bits.join(' — ')));
+      for (const s of m.secrets || []) {
+        body.appendChild(h(doc, 'small', `mv-secret hint${s.set ? '' : ' err'}`,
+          s.set ? `secret ${s.key}: set` : `secret ${s.key}: NOT SET — configure it in the plugin's settings`));
+      }
+      card.appendChild(body);
+      const copy = h(doc, 'button', 'btn-ghost mv-copy', 'Edit a copy');
+      copy.type = 'button'; copy.dataset.id = m.id; copy.dataset.plugin = m.plugin;
+      card.appendChild(copy);
+      plug.appendChild(card);
+    }
+    root.appendChild(plug);
+  }
+
+  // ── Built-ins (read-only) ──
   const builtins = section('Built-in models', 'Shipped with worca. Add a model with the same id to override its label, efforts, or routing.');
   for (const m of predefined) {
     const row = h(doc, 'div', 'mv-builtin');
     row.dataset.id = m.id;
     row.appendChild(h(doc, 'b', 'mv-name', m.label));
-    if (globalLc.has(m.id.toLowerCase())) row.appendChild(h(doc, 'span', 'badge violet mv-shadowed', 'overridden'));
+    if (globalLc.has(m.id.toLowerCase()) || pluginLc.has(m.id.toLowerCase())) {
+      row.appendChild(h(doc, 'span', 'badge violet mv-shadowed', 'overridden'));
+    }
     row.appendChild(h(doc, 'small', 'mv-summary hint', `${m.id} — ${effortsSummary(m.efforts, efforts)}`));
     builtins.appendChild(row);
   }
@@ -268,6 +302,115 @@ export function collectModelEditor(rootEl) {
     env,
   };
   return { id: editing ? id : null, body };
+}
+
+// ── Share-as-plugin export wizard (design §9.5) ─────────────────────────────
+
+const SECRETISH_RE = /token|key|secret|password|auth/i;
+
+/**
+ * The export wizard: pick global models, set the per-env-key policy, name the
+ * plugin, choose a destination folder. `globals` are MASKED entries from
+ * GET /api/models (only KEYS matter here — values are read server-side at
+ * export). Detached DOM; app.js wires mvx-export / mvx-cancel.
+ */
+export function renderExportWizard(globals, { doc = globalThis.document } = {}) {
+  const root = h(doc, 'section', 'card mv-editor mvx');
+  root.appendChild(h(doc, 'h3', 'mv-editor-title', 'Share models as a plugin'));
+
+  const step = (title, hint) => {
+    const s = h(doc, 'div', 'mvx-step');
+    s.appendChild(h(doc, 'h4', 'mvx-step-title', title));
+    if (hint) s.appendChild(h(doc, 'small', 'hint', hint));
+    root.appendChild(s);
+    return s;
+  };
+
+  const pick = step('1 — Models to include', 'Only your global models can be shared.');
+  for (const m of globals) {
+    const lab = h(doc, 'label', 'mvx-model');
+    const cb = h(doc, 'input', 'mvx-model-cb');
+    cb.type = 'checkbox'; cb.value = m.id;
+    cb.dataset.envKeys = Object.keys(m.env || {}).join('\n');
+    lab.appendChild(cb);
+    lab.appendChild(h(doc, 'span', null, `${m.label || m.id} `));
+    lab.appendChild(h(doc, 'small', 'hint', m.id));
+    pick.appendChild(lab);
+  }
+  if (!globals.length) pick.appendChild(h(doc, 'div', 'hist-empty', 'No global models to share yet.'));
+
+  const envKeys = [...new Set(globals.flatMap((m) => Object.keys(m.env || {})))];
+  const pol = step('2 — Env var policy',
+    'Include value commits the stored value to the plugin (it will live in a git repo). ' +
+    'Require at install strips it — teammates are prompted once and the value stays on their machine.');
+  for (const k of envKeys) {
+    const row = h(doc, 'div', 'mvx-env-row');
+    row.dataset.key = k;
+    row.appendChild(h(doc, 'span', 'mono mvx-env-key', k));
+    const sel = h(doc, 'select', 'select mvx-mode');
+    for (const [v, label] of [['include', 'Include value'], ['secret', 'Require at install'], ['omit', 'Omit']]) {
+      const opt = h(doc, 'option', null, label);
+      opt.value = v;
+      sel.appendChild(opt);
+    }
+    sel.value = SECRETISH_RE.test(k) ? 'secret' : 'include';
+    row.appendChild(sel);
+    if (SECRETISH_RE.test(k)) row.appendChild(h(doc, 'small', 'hint mvx-warn', 'looks like a credential'));
+    pol.appendChild(row);
+  }
+  if (!envKeys.length) pol.appendChild(h(doc, 'small', 'hint', 'No env vars on your models — nothing to decide.'));
+
+  const meta = step('3 — Plugin metadata + destination');
+  const field = (labelText, cls, placeholder, hint) => {
+    const wrap = h(doc, 'label', 'mv-field');
+    wrap.appendChild(h(doc, 'span', 'mv-field-label', labelText));
+    const input = h(doc, 'input', `input ${cls}`);
+    input.type = 'text'; input.placeholder = placeholder;
+    wrap.appendChild(input);
+    if (hint) wrap.appendChild(h(doc, 'small', 'hint', hint));
+    meta.appendChild(wrap);
+    return input;
+  };
+  field('Plugin name', 'mvx-name', 'discretestack-models', 'kebab-case; becomes the folder + install name');
+  field('Description', 'mvx-desc', 'Team routing for …');
+  field('Version', 'mvx-version', '0.1.0');
+  field('Destination folder', 'mvx-dest', '~/dev/discretestack-models',
+    'Must be new or empty. The scaffold goes here — git init + push it to share.');
+
+  const msg = h(doc, 'p', 'form-msg mvx-msg');
+  msg.setAttribute('aria-live', 'polite');
+  root.appendChild(msg);
+  const btns = h(doc, 'div', 'mv-editor-btns');
+  const go = h(doc, 'button', 'btn-go mvx-export', 'Export scaffold');
+  go.type = 'button';
+  const cancel = h(doc, 'button', 'btn-ghost mvx-cancel', 'Cancel');
+  cancel.type = 'button';
+  btns.appendChild(go); btns.appendChild(cancel);
+  root.appendChild(btns);
+  return root;
+}
+
+/** Collect the wizard into the POST /api/models/export-plugin body. */
+export function collectExportWizard(rootEl) {
+  const modes = {};
+  for (const row of rootEl.querySelectorAll('.mvx-env-row')) {
+    modes[row.dataset.key] = row.querySelector('.mvx-mode')?.value || 'include';
+  }
+  const models = [...rootEl.querySelectorAll('.mvx-model-cb')]
+    .filter((cb) => cb.checked)
+    .map((cb) => ({
+      id: cb.value,
+      env: Object.fromEntries((cb.dataset.envKeys || '').split('\n').filter(Boolean)
+        .map((k) => [k, modes[k] || 'include'])),
+    }));
+  const val = (cls) => (rootEl.querySelector(`.${cls}`)?.value || '').trim();
+  return {
+    name: val('mvx-name'),
+    description: val('mvx-desc'),
+    ...(val('mvx-version') ? { version: val('mvx-version') } : {}),
+    dest: val('mvx-dest'),
+    models,
+  };
 }
 
 /** Human summary of what deleting `id` clears, for the confirmation prompt. */

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -113,7 +113,10 @@ export function renderModelsList({ globals = [], legacy = [], predefined = [], e
 }
 
 /** One env key/value editor row. Existing values arrive MASKED; leaving a
- *  masked value untouched means "keep" (the server drops masked echoes). */
+ *  masked value untouched means "keep" (the server drops masked echoes).
+ *  STORED rows (a key was persisted) also get a copy button that fetches the
+ *  RAW value — the user owns it on disk anyway (design note: same trust
+ *  boundary as ~/.worca-cc/settings.json, made deliberate by the click). */
 function envRow(doc, key = '', value = '') {
   const row = h(doc, 'div', 'mv-env-row');
   const k = h(doc, 'input', 'input mv-env-key');
@@ -121,9 +124,19 @@ function envRow(doc, key = '', value = '') {
   const v = h(doc, 'input', 'input mv-env-val');
   v.type = 'text'; v.placeholder = 'value, or ${VAR} to read your shell env'; v.value = value;
   if (value) v.dataset.original = value; // masked echo detection on collect
+  row.appendChild(k); row.appendChild(v);
+  if (key) {
+    // The STORED key, frozen at render time — the copy must reveal what is on
+    // disk even after the user edits the key input.
+    row.dataset.key = key;
+    const cp = h(doc, 'button', 'btn-ghost mv-env-copy', '⧉');
+    cp.type = 'button';
+    cp.title = 'Copy the real (unmasked) value';
+    row.appendChild(cp);
+  }
   const rm = h(doc, 'button', 'btn-ghost mv-env-rm', '✕');
   rm.type = 'button';
-  row.appendChild(k); row.appendChild(v); row.appendChild(rm);
+  row.appendChild(rm);
   return row;
 }
 
@@ -186,7 +199,17 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
   add.type = 'button';
   grid.appendChild(field('Routing env (merged into the claude spawn for this model)', envWrap,
     'e.g. ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN. Stored values show masked; leave masked to keep. WORCA_* and process keys are reserved.'));
-  grid.appendChild(add);
+  const envBtns = h(doc, 'div', 'mv-env-btns');
+  envBtns.appendChild(add);
+  if (rows.length) {
+    // Reveal toggle: swaps the masked inputs to the REAL stored values (the
+    // user owns them on disk in ~/.worca-cc/settings.json). app.js wires it.
+    const reveal = h(doc, 'button', 'btn-ghost mv-env-reveal', 'Show values');
+    reveal.type = 'button';
+    reveal.title = 'Reveal the real stored values';
+    envBtns.appendChild(reveal);
+  }
+  grid.appendChild(envBtns);
 
   root.appendChild(grid);
   const msg = h(doc, 'p', 'form-msg mv-editor-msg');

--- a/ui/public/plugins-view.mjs
+++ b/ui/public/plugins-view.mjs
@@ -19,6 +19,7 @@ function contribSummary(c) {
   const n = (v) => (Array.isArray(v) ? v.length : (Number.isFinite(v) ? v : 0));
   const parts = [
     [n(c && c.agents), 'agent'], [n(c && c.taskSources), 'source'],
+    [n(c && c.models), 'model'],
     [n(c && c.skills), 'skill'], [n(c && c.workflows), 'workflow'],
   ].filter(([k]) => k > 0).map(([k, w]) => `${k} ${w}${k > 1 ? 's' : ''}`);
   return parts.join(' · ') || 'no contributions';
@@ -109,6 +110,22 @@ export function renderInstallConsent(entry, inventory, { doc = globalThis.docume
     for (const key of s.secrets || []) row.appendChild(h(doc, 'span', 'pl-secret', `requests secret: ${key}`));
     sources.appendChild(row);
   }
+  // Models (design §9.4): the base URL renders VERBATIM — a model's env can
+  // redirect all API traffic for that model, so the reviewer must see where.
+  if ((inv.models || []).length) {
+    const models = section(`Models (${inv.models.length})`);
+    for (const m of inv.models) {
+      const row = h(doc, 'div', 'pl-consent-row', `${m.label || m.id} `);
+      row.appendChild(h(doc, 'span', 'mono', `(${m.id})`));
+      if (m.baseUrl) row.appendChild(h(doc, 'span', 'pl-secret pl-baseurl', ` routes to: ${m.baseUrl}`));
+      if ((m.envKeys || []).length) row.appendChild(h(doc, 'small', 'hint', ` env: ${m.envKeys.join(', ')}`));
+      models.appendChild(row);
+    }
+    for (const s of inv.modelSecrets || []) {
+      models.appendChild(h(doc, 'div', 'pl-consent-row')).appendChild(
+        h(doc, 'span', 'pl-secret', `requests model secret: ${s.key}${s.label && s.label !== s.key ? ` (${s.label})` : ''}`));
+    }
+  }
   const skills = section(`Skills (${(inv.skills || []).length})`);
   for (const s of inv.skills || []) skills.appendChild(h(doc, 'div', 'pl-consent-row mono', s));
   const wfs = section(`Workflows (${(inv.workflows || []).length})`);
@@ -147,6 +164,12 @@ export function renderUpdatePreview(preview, { doc = globalThis.document } = {})
     ...(d.newTaskSources || []).map((s) => ['pl-delta', `new task source: ${s}`]),
     ...(d.newAgents || []).map((a) => ['pl-delta', `new agent: ${a}`]),
     ...(d.setupChanged ? [['pl-delta', 'setup commands changed']] : []),
+    // Model delta (design §9.4): an env change can silently reroute API traffic
+    // — red-flag it like a new secret.
+    ...(d.envChangedModels || []).map((m) => ['pl-delta-secret', `MODEL ENV CHANGED (check its base URL): ${m}`]),
+    ...(d.newModelSecrets || []).map((k) => ['pl-delta-secret', `NEW MODEL SECRET requested: ${k}`]),
+    ...(d.newModels || []).map((m) => ['pl-delta', `new model: ${m}`]),
+    ...(d.removedModels || []).map((m) => ['pl-delta', `removed model: ${m}`]),
   ];
   if (flags.length) {
     const box = h(doc, 'div', 'pl-manifest-delta');
@@ -234,8 +257,16 @@ export function renderReferences409(refs, { doc = globalThis.document } = {}) {
   root.appendChild(h(doc, 'p', 'hint err', 'Cannot uninstall: still referenced by'));
   const ul = h(doc, 'ul', 'pl-refs-list');
   for (const ref of refs || []) {
-    const text = typeof ref === 'string' ? ref
-      : `${ref.type || 'workflow'}: ${ref.name || ref.id || JSON.stringify(ref)}`;
+    let text;
+    if (typeof ref === 'string') {
+      text = ref;
+    } else if (Array.isArray(ref.nodes) || Array.isArray(ref.steps)) {
+      // A model-guard reference (design §9.4): { id, steps, nodes }.
+      const count = (ref.nodes || []).length + (ref.steps || []).length;
+      text = `model: ${ref.id} (${count} pipeline selection${count === 1 ? '' : 's'})`;
+    } else {
+      text = `${ref.type || 'workflow'}: ${ref.name || ref.id || JSON.stringify(ref)}`;
+    }
     ul.appendChild(h(doc, 'li', 'mono', text));
   }
   root.appendChild(ul);

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1365,3 +1365,30 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
   .stat-row{grid-template-columns:repeat(2,1fr);}
   .charts-grid{grid-template-columns:1fr;}
 }
+
+/* ---- Models view (configurable-models-design.md §4.10) ---- */
+.mv-list{display:grid;gap:18px;}
+.mv-section{display:grid;gap:10px;}
+.mv-section-title{margin:4px 0 0;font-size:13px;text-transform:uppercase;letter-spacing:.04em;opacity:.75;}
+.mv-card{padding:16px 20px;display:flex;align-items:center;gap:14px;}
+.mv-body{flex:1 1 auto;min-width:0;}
+.mv-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
+.mv-name{font-size:14.5px;}
+.mv-summary{display:block;margin:6px 0 0;word-break:break-all;}
+.mv-card .btn-ghost{flex:0 0 auto;padding:7px 12px;font-size:12px;}
+.mv-builtin{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:8px 12px;border:1px solid var(--line-2,#e6e6ec);border-radius:10px;}
+.mv-builtin .mv-summary{margin:0;flex:1 1 auto;text-align:right;}
+.mv-editor{padding:18px 22px;}
+.mv-editor-title{margin:0 0 14px;font-size:15px;}
+.mv-editor-grid{display:grid;gap:14px;}
+.mv-field{display:grid;gap:6px;}
+.mv-field-label{font-size:12.5px;font-weight:600;}
+.mv-efforts{display:flex;gap:14px;flex-wrap:wrap;}
+.mv-effort{display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;}
+.mv-env{display:grid;gap:8px;}
+.mv-env-row{display:flex;gap:8px;align-items:center;}
+.mv-env-row .mv-env-key{flex:0 0 34%;font-family:var(--mono);font-size:12.5px;}
+.mv-env-row .mv-env-val{flex:1 1 auto;font-family:var(--mono);font-size:12.5px;}
+.mv-env-row .mv-env-rm{flex:0 0 auto;padding:6px 10px;}
+.mv-env-add{justify-self:start;padding:7px 12px;font-size:12px;}
+.mv-editor-btns{display:flex;gap:10px;justify-content:flex-end;margin-top:14px;}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1392,3 +1392,6 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .mv-env-row .mv-env-rm{flex:0 0 auto;padding:6px 10px;}
 .mv-env-add{justify-self:start;padding:7px 12px;font-size:12px;}
 .mv-editor-btns{display:flex;gap:10px;justify-content:flex-end;margin-top:14px;}
+.mv-env-row .mv-env-copy{flex:0 0 auto;padding:6px 10px;}
+.mv-env-btns{display:flex;gap:10px;justify-content:flex-start;}
+.mv-env-btns .btn-ghost{padding:7px 12px;font-size:12px;}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1395,3 +1395,16 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .mv-env-row .mv-env-copy{flex:0 0 auto;padding:6px 10px;}
 .mv-env-btns{display:flex;gap:10px;justify-content:flex-start;}
 .mv-env-btns .btn-ghost{padding:7px 12px;font-size:12px;}
+
+/* ---- Model plugins (design §9.6): plugin cards + export wizard ---- */
+.mv-secret{display:block;margin:4px 0 0;}
+.mv-secret.err{color:var(--red,#c0392b);}
+.mvx-step{display:grid;gap:8px;margin:0 0 16px;}
+.mvx-step-title{margin:0;font-size:13px;}
+.mvx-model{display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;}
+.mvx-env-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;}
+.mvx-env-key{flex:0 0 34%;font-size:12.5px;word-break:break-all;}
+.mvx-env-row .select{flex:0 0 auto;}
+.mvx-warn{color:var(--red,#c0392b);}
+.pl-baseurl{word-break:break-all;}
+.pl-config-h{margin:14px 0 6px;font-size:13px;}

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -38,7 +38,7 @@ import {
   readConfig, setStep, addCustomModel, removeCustomModel, listModels,
   PREDEFINED_MODELS, agentSteps, EFFORTS,
   readRunConfig, setNodeModel, setFeedbackCycles, setActiveWorkflow,
-  globalModelRefs, removeGlobalModelAndRefs, promoteCustomModel,
+  globalModelRefs, removeGlobalModelAndRefs, promoteCustomModel, costUnreliableModelIds,
 } from '../src/core/config.mjs';
 import { listGlobalModels, addGlobalModel, updateGlobalModel } from '../src/core/settings.mjs';
 import { modelEnvRef } from '../src/core/model-env.mjs';
@@ -1935,7 +1935,13 @@ const maskedGlobalModel = (m) => (m.env
   ? { ...m, env: Object.fromEntries(Object.entries(m.env).map(([k, v]) => [k, maskEnvValue(v)])) }
   : m);
 const isMaskedEcho = (v) => typeof v === 'string' && v.startsWith('••');
-const maskedGlobalModels = () => listGlobalModels().map(maskedGlobalModel);
+const maskedGlobalModels = () => {
+  const flagged = costUnreliableModelIds(); // §4.6 observed flag, merged for the editor's badge
+  return listGlobalModels().map((m) => ({
+    ...maskedGlobalModel(m),
+    ...(flagged.has(m.id.toLowerCase()) ? { costUnreliable: true } : {}),
+  }));
+};
 
 app.get('/api/models', (req, res) => {
   res.json({ models: maskedGlobalModels(), predefined: PREDEFINED_MODELS, efforts: EFFORTS });

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -38,7 +38,7 @@ import {
   readConfig, setStep, addCustomModel, removeCustomModel, listModels,
   PREDEFINED_MODELS, agentSteps, EFFORTS,
   readRunConfig, setNodeModel, setFeedbackCycles, setActiveWorkflow,
-  globalModelRefs, removeGlobalModelAndRefs,
+  globalModelRefs, removeGlobalModelAndRefs, promoteCustomModel,
 } from '../src/core/config.mjs';
 import { listGlobalModels, addGlobalModel, updateGlobalModel } from '../src/core/settings.mjs';
 import { modelEnvRef } from '../src/core/model-env.mjs';
@@ -1949,6 +1949,23 @@ app.post('/api/models', async (req, res) => {
   } catch (err) {
     // addGlobalModel throws only on validation (empty/dup id, unknown effort,
     // reserved env key, non-string env value) -> client error.
+    return badRequest(res, err && err.message ? err.message : String(err));
+  }
+});
+
+// Promote a legacy per-project custom model to the global catalog (§4.9).
+// Refs survive by construction — see promoteCustomModel. Registered before the
+// :id routes only for readability; POST /api/models/promote shares no method
+// with them, so there is no capture conflict.
+app.post('/api/models/promote', async (req, res) => {
+  const b = req.body || {};
+  const projectDir = resolveProjectDir(b.projectDir);
+  if (!projectDir) return badRequest(res, 'projectDir is required');
+  try {
+    const config = await promoteCustomModel(projectDir, b.id);
+    res.json({ config, models: maskedGlobalModels() });
+  } catch (err) {
+    // Throws only on validation (unknown project model) -> client error.
     return badRequest(res, err && err.message ? err.message : String(err));
   }
 });

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -2001,6 +2001,20 @@ app.get('/api/models/:id/refs', (req, res) => {
   res.json(globalModelRefs(req.params.id));
 });
 
+// Reveal raw env value(s) for the editor's copy button and Show-values toggle.
+// The default GET surface stays masked (accidental exposure in screenshots/
+// devtools); this is a deliberate read of what the user already owns on disk
+// in ~/.worca-cc/settings.json — same trust boundary, explicit action.
+// ?key=K -> { key, value }; no key -> { env } (the whole raw map).
+app.get('/api/models/:id/env-value', (req, res) => {
+  const entry = listGlobalModels().find((m) => m.id.toLowerCase() === String(req.params.id).toLowerCase());
+  if (!entry) return badRequest(res, `unknown model id ${JSON.stringify(req.params.id)}`);
+  const key = typeof req.query.key === 'string' ? req.query.key : '';
+  if (!key) return res.json({ env: { ...(entry.env || {}) } });
+  if (!entry.env || !(key in entry.env)) return badRequest(res, `model has no env key ${JSON.stringify(key)}`);
+  res.json({ key, value: entry.env[key] });
+});
+
 app.delete('/api/models/:id', async (req, res) => {
   try {
     const result = await removeGlobalModelAndRefs(req.params.id);

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -38,7 +38,10 @@ import {
   readConfig, setStep, addCustomModel, removeCustomModel, listModels,
   PREDEFINED_MODELS, agentSteps, EFFORTS,
   readRunConfig, setNodeModel, setFeedbackCycles, setActiveWorkflow,
+  globalModelRefs, removeGlobalModelAndRefs,
 } from '../src/core/config.mjs';
+import { listGlobalModels, addGlobalModel, updateGlobalModel } from '../src/core/settings.mjs';
+import { modelEnvRef } from '../src/core/model-env.mjs';
 import { validateGuardrails } from '../src/core/guardrails.mjs';
 import {
   listBuiltinGuardrailSets, listGuardrailSets, readGuardrailSet,
@@ -1805,13 +1808,14 @@ app.post('/api/settings', async (req, res) => {
 // ---------------------------------------------------------------------------
 app.get('/api/config', async (req, res) => {
   const raw = req.query.projectDir;
-  // No project selected yet (e.g. a fresh clone): still return the built-in
-  // models so the picker is never empty. Custom models are per-project, so the
-  // project-less response carries only the predefined Opus/Sonnet/Haiku set.
+  // No project selected yet (e.g. a fresh clone): still return the catalog so
+  // the picker is never empty. The project-less catalog is predefined ⊕ GLOBAL
+  // entries (the global catalog is project-independent by design §4.2); only
+  // legacy per-project custom models need a projectDir.
   if (raw == null || raw === '') {
-    const models = PREDEFINED_MODELS.map((m) => ({ ...m, custom: false }));
     return res.json({
-      config: { steps: {}, customModels: [] }, models, steps: agentSteps(), efforts: EFFORTS,
+      config: { steps: {}, customModels: [] },
+      models: await listModels(''), steps: agentSteps(), efforts: EFFORTS,
     });
   }
   const projectDir = resolveProjectDir(raw);
@@ -1860,11 +1864,10 @@ app.post('/api/config', async (req, res) => {
 // PATCH /api/config -> write run-config: per-node model/effort, per-feedback
 // cycle counts, and the active workflow id. Keyed by workflowId + node/feedback
 // instance ids (see RunConfig in the design). Legacy per-role `steps` are
-// written via POST /api/config and are left untouched here. NOTE: the run-config
-// setters do NOT reject unknown models/efforts, and setFeedbackCycles COERCES
-// maxCycles to >= 1 (it never throws) — so the try/catch below guards I/O, not
-// validation. (Optional hardening: validate model/effort in setNodeModel via
-// listModels + EFFORTS, mirroring setStep at config.mjs:141-153.)
+// written via POST /api/config and are left untouched here. setNodeModel now
+// validates model/effort against the effective catalog exactly like setStep
+// (configurable-models-design.md §4.5) -> 400; setFeedbackCycles still COERCES
+// maxCycles to >= 1 (it never throws).
 // body: { projectDir, workflowId, nodes?:{[id]:{model,effort}}, feedbacks?:{[id]:{maxCycles}}, activeWorkflowId? }
 // ---------------------------------------------------------------------------
 app.patch('/api/config', async (req, res) => {
@@ -1900,19 +1903,10 @@ app.patch('/api/config', async (req, res) => {
   }
 });
 
-app.post('/api/config/models', async (req, res) => {
-  const body = req.body || {};
-  const projectDir = resolveProjectDir(body.projectDir);
-  if (!projectDir) return badRequest(res, 'projectDir is required');
-  try {
-    await addCustomModel(projectDir, { id: body.id, label: body.label });
-    res.json({ models: await listModels(projectDir) });
-  } catch (err) {
-    // addCustomModel throws only on validation (empty/duplicate/shadow) -> 400.
-    return badRequest(res, err && err.message ? err.message : String(err));
-  }
-});
-
+// POST /api/config/models (the per-project ADD) is deliberately GONE: new
+// models are added to the GLOBAL catalog via POST /api/models (design §4.9 —
+// the add flow moves entirely to the global Models view). DELETE stays so
+// legacy per-project entries can still be cleaned up.
 app.delete('/api/config/models', async (req, res) => {
   const projectDir = resolveProjectDir(req.query.projectDir);
   if (!projectDir) return badRequest(res, 'projectDir is required');
@@ -1923,6 +1917,74 @@ app.delete('/api/config/models', async (req, res) => {
     res.json({ config, models: await listModels(projectDir) });
   } catch (err) {
     res.status(500).json({ error: err && err.message ? err.message : String(err) });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Global model catalog (configurable-models-design.md §4.10). Project-less by
+// design — the catalog lives in ~/.worca-cc/settings.json (settings.mjs) and
+// applies to every project. Env VALUES are secrets-adjacent: responses carry
+// them MASKED (write-only editing; a whole-value ${VAR} ref is config, not a
+// secret, and passes through readable), and a PATCH that echoes a masked value
+// back means "keep" and is dropped from the write.
+// ---------------------------------------------------------------------------
+
+const maskEnvValue = (v) =>
+  (modelEnvRef(v) ? v : (v.length > 8 ? `••••••${v.slice(-4)}` : '••••••'));
+const maskedGlobalModel = (m) => (m.env
+  ? { ...m, env: Object.fromEntries(Object.entries(m.env).map(([k, v]) => [k, maskEnvValue(v)])) }
+  : m);
+const isMaskedEcho = (v) => typeof v === 'string' && v.startsWith('••');
+const maskedGlobalModels = () => listGlobalModels().map(maskedGlobalModel);
+
+app.get('/api/models', (req, res) => {
+  res.json({ models: maskedGlobalModels(), predefined: PREDEFINED_MODELS, efforts: EFFORTS });
+});
+
+app.post('/api/models', async (req, res) => {
+  const b = req.body || {};
+  try {
+    const model = await addGlobalModel({ id: b.id, label: b.label, efforts: b.efforts, env: b.env });
+    res.json({ model: maskedGlobalModel(model), models: maskedGlobalModels() });
+  } catch (err) {
+    // addGlobalModel throws only on validation (empty/dup id, unknown effort,
+    // reserved env key, non-string env value) -> client error.
+    return badRequest(res, err && err.message ? err.message : String(err));
+  }
+});
+
+app.patch('/api/models/:id', async (req, res) => {
+  const b = req.body || {};
+  // Write-only env: strip masked echoes (unchanged values a client sent back)
+  // so they read as "keep", never as a literal '••…' secret. env: null still
+  // means "clear the whole map" and passes through untouched.
+  let env = b.env;
+  if (env && typeof env === 'object' && !Array.isArray(env)) {
+    env = Object.fromEntries(Object.entries(env).filter(([, v]) => !isMaskedEcho(v)));
+  }
+  try {
+    const model = await updateGlobalModel(req.params.id, { label: b.label, efforts: b.efforts, env });
+    res.json({ model: maskedGlobalModel(model), models: maskedGlobalModels() });
+  } catch (err) {
+    // updateGlobalModel throws only on validation (unknown id, unknown effort,
+    // reserved env key) -> client error.
+    return badRequest(res, err && err.message ? err.message : String(err));
+  }
+});
+
+// Preview what deleting a global entry would clear (feeds the confirmation
+// dialog; design §4.5). Unknown ids just report empty refs — preview never 400s.
+app.get('/api/models/:id/refs', (req, res) => {
+  res.json(globalModelRefs(req.params.id));
+});
+
+app.delete('/api/models/:id', async (req, res) => {
+  try {
+    const result = await removeGlobalModelAndRefs(req.params.id);
+    res.json({ ...result, models: maskedGlobalModels() });
+  } catch (err) {
+    // Throws only on an unknown id -> client error.
+    return badRequest(res, err && err.message ? err.message : String(err));
   }
 });
 

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -2750,6 +2750,26 @@ app.put('/api/plugins/:name/config', (req, res) => {
   }
 });
 
+// GET /api/plugins/:name/model-env?id=<modelId> — the RAW manifest env of one
+// plugin model, for the Models view "Edit a copy" prefill (design §9.6).
+// Literals and ${VAR} ref text return verbatim (they came from a shared repo,
+// not this user's secrets); {secret} placeholders are NEVER resolved — their
+// env keys are listed in `secretKeys` so the editor renders empty rows.
+app.get('/api/plugins/:name/model-env', (req, res) => {
+  const name = requirePlugin(req, res);
+  if (!name) return;
+  const id = typeof req.query.id === 'string' ? req.query.id.trim() : '';
+  const model = listPluginModels().find((m) => m.plugin === name && m.id.toLowerCase() === id.toLowerCase());
+  if (!model) return badRequest(res, `plugin "${name}" provides no model ${JSON.stringify(id)}`);
+  const env = {};
+  const secretKeys = [];
+  for (const [k, v] of Object.entries(model.env ?? {})) {
+    if (typeof v === 'string') env[k] = v;
+    else secretKeys.push(k);
+  }
+  res.json({ id: model.id, label: model.label, efforts: model.efforts, env, secretKeys });
+});
+
 // ---------------------------------------------------------------------------
 // /api/sources* -> task-source discovery + browser-driven connector calls.
 // ---------------------------------------------------------------------------

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -42,6 +42,7 @@ import {
 } from '../src/core/config.mjs';
 import { listGlobalModels, addGlobalModel, updateGlobalModel } from '../src/core/settings.mjs';
 import { modelEnvRef } from '../src/core/model-env.mjs';
+import { listPluginModels, modelSecretsSchema, pluginModelSecretStatus } from '../src/core/plugin-models.mjs';
 import { validateGuardrails } from '../src/core/guardrails.mjs';
 import {
   listBuiltinGuardrailSets, listGuardrailSets, readGuardrailSet,
@@ -76,7 +77,7 @@ import {
 import { addPluginRepo, fetchCandidate, repoCacheDir } from '../src/core/plugin-repo.mjs';
 import { redactedConfig, writePluginConfig } from '../src/core/plugin-config.mjs';
 import { readPluginsLock, pluginCurrentDir } from '../src/core/plugins-lock.mjs';
-import { normalizeManifest } from '../src/core/plugin-manifest.mjs';
+import { normalizeManifest, PLUGIN_NAME_RE as MANIFEST_PLUGIN_NAME_RE } from '../src/core/plugin-manifest.mjs';
 import { listTaskSources, retryWriteback } from '../src/core/sources.mjs';
 import { callSource, PluginOpError } from '../src/core/plugin-shim.mjs';
 // discoveryInventory below needs these four — server.mjs currently imports NONE
@@ -1943,8 +1944,28 @@ const maskedGlobalModels = () => {
   }));
 };
 
+/** Read-only plugin model entries (design §9.7): literals masked with the
+ *  standard masker, ${VAR} refs readable, {secret} placeholders surfaced as
+ *  display markers with their set-ness. */
+const pluginModelsPayload = () => {
+  const flagged = costUnreliableModelIds();
+  const statusByPlugin = new Map();
+  return listPluginModels().map((m) => {
+    if (!statusByPlugin.has(m.plugin)) statusByPlugin.set(m.plugin, pluginModelSecretStatus(m.plugin));
+    const status = statusByPlugin.get(m.plugin);
+    return {
+      id: m.id, label: m.label, efforts: m.efforts, plugin: m.plugin,
+      env: Object.fromEntries(Object.entries(m.env ?? {}).map(([k, v]) => [
+        k, typeof v === 'string' ? maskEnvValue(v) : `(secret: ${v.secret})`,
+      ])),
+      secrets: status.filter((s) => m.secrets.includes(s.key)),
+      ...(flagged.has(m.id.toLowerCase()) ? { costUnreliable: true } : {}),
+    };
+  });
+};
+
 app.get('/api/models', (req, res) => {
-  res.json({ models: maskedGlobalModels(), predefined: PREDEFINED_MODELS, efforts: EFFORTS });
+  res.json({ models: maskedGlobalModels(), plugin: pluginModelsPayload(), predefined: PREDEFINED_MODELS, efforts: EFFORTS });
 });
 
 app.post('/api/models', async (req, res) => {
@@ -1974,6 +1995,123 @@ app.post('/api/models/promote', async (req, res) => {
     // Throws only on validation (unknown project model) -> client error.
     return badRequest(res, err && err.message ? err.message : String(err));
   }
+});
+
+// Export selected global models as a plugin scaffold (design §9.5). Body:
+// { name, description?, version?, dest, models: [{ id, env: {KEY: mode} }] }
+// with mode 'include' (stored value verbatim — literal or ${VAR} ref text),
+// 'secret' (strip the value; declare a modelSecrets placeholder the importer
+// fills at install), or 'omit'. Reads RAW env values server-side — same trust
+// boundary as GET /api/models/:id/env-value (the user's own settings.json,
+// deliberate action). Distribution is git-only: the scaffold folder is what
+// gets pushed; no zip.
+app.post('/api/models/export-plugin', async (req, res) => {
+  const b = req.body || {};
+  const name = typeof b.name === 'string' ? b.name.trim() : '';
+  if (!MANIFEST_PLUGIN_NAME_RE.test(name) || name.length > 64) {
+    return badRequest(res, 'name must be kebab-case (e.g. "discretestack-models")');
+  }
+  const picks = Array.isArray(b.models) ? b.models : [];
+  if (!picks.length) return badRequest(res, 'models must be a non-empty array');
+  const destRaw = typeof b.dest === 'string' ? b.dest.trim() : '';
+  if (!destRaw) return badRequest(res, 'dest is required');
+  const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+  const dest = path.resolve(destRaw.startsWith('~') ? path.join(home, destRaw.slice(1)) : destRaw);
+  try {
+    if (fs.existsSync(dest)) {
+      if (!fs.statSync(dest).isDirectory()) return badRequest(res, 'dest exists and is not a directory');
+      if (fs.readdirSync(dest).length) return badRequest(res, 'dest folder is not empty');
+    }
+  } catch (err) {
+    return badRequest(res, `dest is not usable: ${err.message}`);
+  }
+
+  const globals = listGlobalModels();
+  const secretKeyFor = (envKey) => envKey.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  const models = [];
+  const modelSecrets = new Map(); // secret key -> { key, label }
+  for (const pick of picks) {
+    const id = pick && typeof pick.id === 'string' ? pick.id.trim() : '';
+    const entry = globals.find((m) => m.id.toLowerCase() === id.toLowerCase());
+    if (!entry) return badRequest(res, `unknown global model id ${JSON.stringify(id)}`);
+    const modes = pick.env && typeof pick.env === 'object' && !Array.isArray(pick.env) ? pick.env : {};
+    const env = {};
+    for (const [k, mode] of Object.entries(modes)) {
+      if (!entry.env || !(k in entry.env)) return badRequest(res, `model ${JSON.stringify(entry.id)} has no env key ${JSON.stringify(k)}`);
+      if (mode === 'omit') continue;
+      if (mode === 'include') { env[k] = entry.env[k]; continue; }
+      if (mode === 'secret') {
+        const skey = secretKeyFor(k);
+        if (!skey) return badRequest(res, `cannot derive a secret key from ${JSON.stringify(k)}`);
+        if (!modelSecrets.has(skey)) modelSecrets.set(skey, { key: skey, label: k });
+        env[k] = { secret: skey };
+        continue;
+      }
+      return badRequest(res, `env mode for ${JSON.stringify(k)} must be include | secret | omit`);
+    }
+    models.push({
+      id: entry.id,
+      ...(entry.label !== entry.id ? { label: entry.label } : {}),
+      ...(entry.efforts.length && entry.efforts.length !== EFFORTS.length ? { efforts: entry.efforts } : {}),
+      ...(Object.keys(env).length ? { env } : {}),
+    });
+  }
+
+  const manifest = {
+    name,
+    ...(typeof b.version === 'string' && b.version.trim() ? { version: b.version.trim() } : { version: '0.1.0' }),
+    ...(typeof b.description === 'string' && b.description.trim() ? { description: b.description.trim() } : {}),
+    models,
+    ...(modelSecrets.size ? { modelSecrets: [...modelSecrets.values()] } : {}),
+  };
+  // Belt: the scaffold must install anywhere this host would — validate before writing.
+  const norm = normalizeManifest(manifest);
+  if (!norm.ok) return badRequest(res, `generated manifest is invalid: ${norm.errors.join('; ')}`);
+
+  const readme = [
+    `# ${name}`,
+    '',
+    manifest.description || 'Worca CC model plugin.',
+    '',
+    '## Models',
+    '',
+    ...models.map((m) => `- \`${m.id}\`${m.label ? ` — ${m.label}` : ''}`),
+    ...(modelSecrets.size ? [
+      '',
+      '## Secrets requested at install',
+      '',
+      ...[...modelSecrets.values()].map((s) => `- \`${s.key}\` (${s.label})`),
+      '',
+      'Teammates set these under the plugin\'s **Model secrets** after installing;',
+      'values live in their local `data/secrets.json` (0600) and never in this repo.',
+    ] : []),
+    '',
+    '## Publish',
+    '',
+    '```sh',
+    `cd ${dest}`,
+    'git init -b main && git add -A && git commit -m "model plugin"',
+    'git remote add origin <your-team-repo-url> && git push -u origin main',
+    '```',
+    '',
+    '## Install (teammates)',
+    '',
+    'Worca CC → Plugins → Add repo → paste the repo URL → Install.',
+    'Model secrets are prompted in the plugin\'s configuration panel.',
+    '',
+  ].join('\n');
+
+  try {
+    fs.mkdirSync(dest, { recursive: true });
+    fs.writeFileSync(path.join(dest, 'worca-cc-plugin.json'), JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+    fs.writeFileSync(path.join(dest, 'README.md'), readme, 'utf8');
+  } catch (err) {
+    return res.status(500).json({ error: `could not write the scaffold: ${err.message}` });
+  }
+  res.json({
+    ok: true, dir: dest, files: ['worca-cc-plugin.json', 'README.md'],
+    modelSecrets: [...modelSecrets.values()],
+  });
 });
 
 app.patch('/api/models/:id', async (req, res) => {
@@ -2562,7 +2700,13 @@ app.get('/api/plugins/:name/config', (req, res) => {
       schema: s.configSchema,
       values: redactedConfig(name, s.configSchema),
     }));
-    res.json({ sources });
+    // Model secrets (design §9.7): same redaction contract — { set: true|false }
+    // markers only, never values.
+    const msSchema = modelSecretsSchema(name);
+    res.json({
+      sources,
+      ...(msSchema.length ? { models: { schema: msSchema, values: redactedConfig(name, msSchema) } } : {}),
+    });
   } catch (err) {
     sendPluginError(res, err);
   }
@@ -2580,6 +2724,18 @@ app.put('/api/plugins/:name/config', (req, res) => {
   }
   const manifest = readInstalledManifest(name);
   if (!manifest) return res.status(409).json({ error: 'plugin manifest unreadable — run doctor' });
+  // { target: 'modelSecrets', values } writes the plugin-level model secrets
+  // (design §9.7) — same write-only semantics, routed by the synthesized schema.
+  if (body.target === 'modelSecrets') {
+    const schema = modelSecretsSchema(name);
+    if (!schema.length) return badRequest(res, 'plugin declares no modelSecrets');
+    try {
+      writePluginConfig(name, schema, body.values);
+      return res.json({ ok: true });
+    } catch (err) {
+      return sendPluginError(res, err);
+    }
+  }
   const sources = manifest.taskSources || [];
   const sourceId = typeof body.sourceId === 'string' && body.sourceId
     ? body.sourceId


### PR DESCRIPTION
## Summary

Two stacked feature sets, designed first (`configurable-models-design.md`, decision log included) and implemented in 16 phase-stacked commits.

**📋 Ship log with screenshots and demos: https://claude.ai/code/artifact/6bf8a1da-7c7b-46e3-aa1d-9d3dedda6873**

### Configurable models (design §1–§8)
- **Global model catalog** in `~/.worca-cc/settings.json` — define a model once, use it in every project; entries can shadow built-ins by id; legacy per-project models promote with one click (refs survive).
- **Per-model routing env** merged into the `claude` spawn (base URL, token, timeouts, `${VAR}` shell refs). Reserved keys (`WORCA_*`, PATH, NODE_OPTIONS, …) are rejected at write time and re-dropped at spawn time.
- **Write-only masking** on the API surface; deliberate per-click reveal/copy in the editor (`GET /api/models/:id/env-value`).
- **Cost honesty**: models routed via `ANTHROPIC_BASE_URL` are observed at runtime — zero/absent cost with tokens consumed flags the model `⚠cost` (schema v17 `model_cost_flags`), auto-cleared when a run reports real cost. Never assumed from config.
- **Models view** (14th view) with editor, promote, delete-with-refs-preview; grouped alphabetical model dropdowns (Your models / Plugins / Built-in), provenance suffixes removed.

### Model plugins (design §9)
- Plugins can ship `models` + `modelSecrets`; catalog precedence predefined < plugin < user global; user copies always win (badged both ways).
- **Install consent** lists each model with its base URL **verbatim**; update previews red-flag model env changes; uninstall **blocks with a references list** while pipeline selections would dangle; doctor checks secret set-ness.
- **Secrets**: `{"secret": "<key>"}` placeholders resolve from the per-plugin secrets store (0600, `$env` indirection, never echoed to the browser); prompted once at install.
- **Share-as-plugin wizard** on the Models page: pick models → per-key env policy (credential-looking keys default to *Require at install*; token *limits* don't) → git-ready scaffold with README. Git-only distribution keeps the pinned-SHA consent/update trust model.

## Test plan
- Full suite: **2,273 passing** (8 new suites, +1,703 test lines); the only 4 failures are the pre-existing `imagegen` ones that also fail on clean `dev`.
- Verified live end-to-end: created the DiscreteStack models through the UI, exported them via the wizard (token stripped from the scaffold — 0 occurrences), installed the scaffold as a plugin from a local git repo, entered the shared secret once, confirmed doctor/badges/dropdowns, uninstalled with purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)