### PR TITLE
Release @worca/app to npm: tag-driven OIDC publishing, docs, and /worca-release

### DIFF
--- a/.claude/skills/worca-release/SKILL.md
+++ b/.claude/skills/worca-release/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: worca-release
+description: Cut a release candidate or a stable release of @worca/app — bumps the version, commits, tags `worca-app-v<version>`, and pushes so CI publishes to npm with provenance. Triggers on "cut a release", "cut an RC", "release candidate", "bump RC", "stable release", "worca-release", or any request to release @worca/app.
+---
+
+# Release @worca/app
+
+The git tag is the trigger and the source of truth. You bump the version, tag
+it, and push; `.github/workflows/release-npm-app.yml` validates, tests, and
+publishes with an OIDC provenance attestation. **Never run `npm publish` by
+hand** — a manual publish burns the version number and produces an unattested
+tarball.
+
+The rules behind this procedure live in `docs/RELEASING.md`. Read it when
+something here doesn't fit; do not restate its contents back to the user.
+
+**Usage:**
+
+- `/worca-release` — print status and stop
+- `/worca-release --rc` — cut the next release candidate
+- `/worca-release --version:micro` — stable release, patch bump
+- `/worca-release --version:minor` — stable release, minor bump
+
+---
+
+## Step 0: No-args mode (status)
+
+If invoked with **no arguments**, print the usage above, then report:
+
+```bash
+node -p "require('./package.json').version"          # local version
+npm view @worca/app dist-tags                        # what the registry serves
+git tag --sort=-v:refname | grep '^worca-app-v' | head -10
+```
+
+**Stop here.** Do not release. Tell the user to re-invoke with an argument.
+
+---
+
+## Step 1: Preconditions
+
+All four must hold. Stop and report on any failure — never "fix it and
+continue".
+
+```bash
+# 1. Clean working tree — the tag must describe exactly what CI will build.
+[ -z "$(git status --porcelain)" ] || { echo "ERROR: working tree is dirty"; exit 1; }
+
+# 2. The release workflow MUST exist in the commit being tagged. Tag-triggered
+#    workflows run from the tagged ref, not from the default branch — tagging a
+#    commit without it fires nothing at all, silently, and burns the tag.
+git cat-file -e HEAD:.github/workflows/release-npm-app.yml 2>/dev/null \
+  || { echo "ERROR: release-npm-app.yml is not in this commit — merge the release branch first"; exit 1; }
+
+# 3. Local branch is pushed and current, so the tag points at a commit that exists upstream.
+git fetch --quiet origin
+[ -z "$(git log @{u}..HEAD --oneline 2>/dev/null)" ] || { echo "ERROR: unpushed commits — push first"; exit 1; }
+
+# 4. Tests pass. CI gates on `npm test`; failing here costs 90 seconds,
+#    failing there costs a permanent tag.
+npm test
+```
+
+If `npm test` fails, **stop**. Report which tests failed. A release cannot
+proceed past a red suite — the workflow will refuse it anyway.
+
+---
+
+## Step 2: Compute the new version
+
+Read the current version:
+
+```bash
+node -p "require('./package.json').version"
+```
+
+**For `--rc`** (semver pre-release, `X.Y.Z-rc.N`):
+
+- Already a pre-release → increment N: `0.1.0-rc.4` → `0.1.0-rc.5`
+- Stable → open the next **minor** line as an RC: `0.1.0` → `0.2.0-rc.1`
+
+Ask the user to confirm the target line if the jump isn't obviously right.
+
+**For `--version:micro` / `--version:minor`** (stable):
+
+1. Strip any pre-release suffix first: `0.2.0-rc.3` → `0.2.0`
+2. Then apply the bump **only if the strip didn't already produce the target**:
+   - Closing out an RC line: `0.2.0-rc.3` → `0.2.0` (no further bump)
+   - From a stable version, `micro`: `0.2.0` → `0.2.1`
+   - From a stable version, `minor`: `0.2.0` → `0.3.0`
+
+Never compute the stable version with `npm version minor`. From `0.2.0-rc.3`,
+semver makes `major`, `minor`, and `patch` all collapse to `0.2.0` — the
+command doesn't say what you'll get. Always pass the literal version.
+
+**Print the computed version and confirm with the user before proceeding.**
+
+---
+
+## Step 3: Check the tarball contents
+
+The `files` allowlist in `package.json` decides what ships. Compare against the
+last release so nothing sneaks in or drops out:
+
+```bash
+npm pack --dry-run 2>&1 | tail -8
+```
+
+Verify the file count and package size are in line with the previous release
+(`npm view @worca/app dist.fileCount dist.unpackedSize`). A sudden jump usually
+means test fixtures or build artifacts entered the allowlist; a sudden drop
+means a runtime directory left it. Report either and stop.
+
+---
+
+## Step 4: Bump, commit, tag, push
+
+`npm version`'s own tagging writes a bare `v0.2.0`, which is the wrong shape
+for this repo — bump without a tag and create the prefixed tag yourself:
+
+```bash
+npm version <VERSION> --no-git-tag-version
+git add package.json package-lock.json
+git commit -m "chore(release): @worca/app <VERSION>"
+git tag worca-app-v<VERSION>
+git push --follow-tags
+```
+
+Substitute the literal computed version — e.g. `npm version 0.2.0-rc.1
+--no-git-tag-version`, `git tag worca-app-v0.2.0-rc.1`.
+
+`git push` alone pushes no tags and triggers nothing. Use `--follow-tags`.
+
+---
+
+## Step 5: Watch the release
+
+The workflow derives the npm dist-tag from the tag name: `-rc.` → `rc`,
+otherwise `latest`. Nobody has to remember a flag.
+
+```bash
+gh run watch "$(gh run list --workflow=release-npm-app.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+If the job fails **before** the publish step, fix it and re-tag with the next
+version — the burned number cannot be reused. If it fails **after** publish,
+the package is already live; treat it as a post-release fix, not a retry.
+
+---
+
+## Step 6: Verify the published result
+
+Three checks. All three matter; report each.
+
+```bash
+# 1. The version is serving under the expected dist-tag.
+npm view @worca/app dist-tags
+
+# 2. Provenance was attested. A missing `attestations` field means the trusted
+#    publisher is misconfigured and the tarball is unverifiable — investigate
+#    before telling anyone to install it.
+npm view @worca/app@<VERSION> dist.attestations
+
+# 3. GA only: `rc` must not trail `latest`. The promote step runs
+#    continue-on-error, so it can silently not have happened.
+npm dist-tag ls @worca/app
+```
+
+If `rc` is behind `latest` after a stable release, re-point it:
+
+```bash
+npm dist-tag add @worca/app@<VERSION> rc
+```
+
+---
+
+## Step 7: Print the summary
+
+```
+Release complete
+
+  @worca/app:  <OLD> → <NEW>   (dist-tag: rc | latest)
+  Tag pushed:  worca-app-v<NEW>
+  Provenance:  attested | MISSING — investigate
+
+  Install:
+    npm install -g @worca/app@<NEW>     # or: @rc for release candidates
+    npx @worca/app
+```
+
+Only claim `attested` when Step 6 actually showed an `attestations` field.

--- a/.claude/skills/worca-release/SKILL.md
+++ b/.claude/skills/worca-release/SKILL.md
@@ -18,8 +18,12 @@ something here doesn't fit; do not restate its contents back to the user.
 
 - `/worca-release` — print status and stop
 - `/worca-release --rc` — cut the next release candidate
-- `/worca-release --version:micro` — stable release, patch bump
-- `/worca-release --version:minor` — stable release, minor bump
+- `/worca-release --stable` — close out the current RC line
+- `/worca-release --version:micro` — stable release from stable, patch bump
+- `/worca-release --version:minor` — stable release from stable, minor bump
+
+`--stable` and `--version:*` are mutually exclusive, and which one applies is
+decided by the current version, not by preference — see Step 2.
 
 ---
 
@@ -74,22 +78,38 @@ Read the current version:
 node -p "require('./package.json').version"
 ```
 
-**For `--rc`** (semver pre-release, `X.Y.Z-rc.N`):
+The current version decides which flags are legal. Reject the wrong one rather
+than silently ignoring it — a flag that cannot change the outcome must not be
+accepted as if it did.
+
+**`--rc`** (semver pre-release, `X.Y.Z-rc.N`) — legal from either state:
 
 - Already a pre-release → increment N: `0.1.0-rc.4` → `0.1.0-rc.5`
 - Stable → open the next **minor** line as an RC: `0.1.0` → `0.2.0-rc.1`
 
-Ask the user to confirm the target line if the jump isn't obviously right.
+The stable → next-minor jump is a default, not a law. If the user wants a patch
+line instead (`0.0.1` → `0.0.2-rc.1`) or a major one, ask before computing.
 
-**For `--version:micro` / `--version:minor`** (stable):
+**`--stable`** — legal **only from a pre-release**. Strip the suffix; that is
+the release:
 
-1. Strip any pre-release suffix first: `0.2.0-rc.3` → `0.2.0`
-2. Then apply the bump **only if the strip didn't already produce the target**:
-   - Closing out an RC line: `0.2.0-rc.3` → `0.2.0` (no further bump)
-   - From a stable version, `micro`: `0.2.0` → `0.2.1`
-   - From a stable version, `minor`: `0.2.0` → `0.3.0`
+- `0.2.0-rc.3` → `0.2.0`
 
-Never compute the stable version with `npm version minor`. From `0.2.0-rc.3`,
+There is no bump to choose here. The micro-vs-minor decision was made when the
+RC line was opened, and the whole point of the RCs was to rehearse this exact
+number. If the current version is already stable, stop: there is no RC line to
+close out, and the user wants `--version:micro` or `--version:minor`.
+
+**`--version:micro` / `--version:minor`** — legal **only from a stable
+version**:
+
+- `micro`: `0.2.0` → `0.2.1`
+- `minor`: `0.2.0` → `0.3.0`
+
+If the current version is a pre-release, stop: the line is already set, and
+neither flag can change what ships. The user wants `--stable`.
+
+Never compute a stable version with `npm version minor`. From `0.2.0-rc.3`,
 semver makes `major`, `minor`, and `patch` all collapse to `0.2.0` — the
 command doesn't say what you'll get. Always pass the literal version.
 

--- a/.github/workflows/release-npm-app.yml
+++ b/.github/workflows/release-npm-app.yml
@@ -83,8 +83,14 @@ jobs:
       # Without this, `rc` stays parked on the last release candidate forever
       # and `npm install @worca/app@rc` resolves BEHIND `@latest`. On a GA
       # release, move `rc` forward to the released version.
+      # The npm trusted-publisher allowlist grants `npm publish`; whether the
+      # OIDC credential may also move a dist-tag is not something that form
+      # lets you grant. The publish above has already succeeded and cannot be
+      # undone by this step failing, so a rejection here must not fail the
+      # release — it just leaves `rc` behind, to be re-pointed by hand.
       - name: Promote rc dist-tag to the GA release
         if: steps.dist-tag.outputs.tag == 'latest'
+        continue-on-error: true
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: npm dist-tag add "@worca/app@${TAG_NAME#worca-app-v}" rc

--- a/.github/workflows/release-npm-app.yml
+++ b/.github/workflows/release-npm-app.yml
@@ -1,0 +1,113 @@
+name: Release @worca/app to npm
+
+# Tag-driven release. The git tag is the trigger AND the source of truth for
+# the published version and dist-tag:
+#
+#   worca-app-v0.1.0        -> publishes 0.1.0 under the `latest` dist-tag
+#   worca-app-v0.1.0-rc.1   -> publishes 0.1.0-rc.1 under the `rc` dist-tag
+#
+# The `worca-app-` prefix keeps this package's tags distinct from every other
+# releasable in this repo (see docs/RELEASING.md).
+on:
+  push:
+    tags:
+      - "worca-app-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1, which ships bundled
+      # with Node >= 24.5. Rely on the bundled npm rather than
+      # `npm install -g npm@latest` (that self-upgrade intermittently races and
+      # fails with MODULE_NOT_FOUND 'promise-retry'). Fail loudly if the
+      # bundled npm is ever too old.
+      - name: Verify npm supports Trusted Publishing
+        run: |
+          NPM_VERSION="$(npm --version)"
+          echo "npm version: $NPM_VERSION"
+          node -e 'const [a,b,c] = process.argv[1].split(".").map(Number); if (a < 11 || (a === 11 && (b < 5 || (b === 5 && c < 1)))) { console.error(`npm ${process.argv[1]} is < 11.5.1 (required for Trusted Publishing)`); process.exit(1); }' "$NPM_VERSION"
+
+      - name: Validate tag matches package.json version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${TAG_NAME#worca-app-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      # No build step: plain Node ESM plus a vanilla HTML/CSS/JS frontend.
+      - name: Run tests
+        run: npm test
+
+      - name: Determine npm dist-tag
+        id: dist-tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#worca-app-v}"
+          if echo "$VERSION" | grep -q -- '-rc\.'; then
+            echo "tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Auth is via OIDC Trusted Publishing (no NPM_TOKEN in this repo).
+      # Provenance is generated automatically under OIDC; --provenance makes
+      # the requirement explicit so a misconfiguration fails the job instead of
+      # silently publishing an unattested tarball.
+      - name: Publish to npm
+        run: npm publish --access public --provenance --tag ${{ steps.dist-tag.outputs.tag }}
+
+      # Without this, `rc` stays parked on the last release candidate forever
+      # and `npm install @worca/app@rc` resolves BEHIND `@latest`. On a GA
+      # release, move `rc` forward to the released version.
+      - name: Promote rc dist-tag to the GA release
+        if: steps.dist-tag.outputs.tag == 'latest'
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: npm dist-tag add "@worca/app@${TAG_NAME#worca-app-v}" rc
+
+  release:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#worca-app-v}"
+          PRERELEASE=""
+          if echo "$VERSION" | grep -q -- '-rc\.'; then
+            PRERELEASE="--prerelease"
+          fi
+          gh release create "$TAG_NAME" \
+            --title "@worca/app $VERSION" \
+            --generate-notes \
+            $PRERELEASE

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,300 @@
+# Releasing
+
+How Worca packages get published, and what has to be configured — once per
+package, and occasionally afterwards — for that to work.
+
+Everything here is **tag-driven**: you never run `npm publish` by hand for an
+established package. You push a git tag; a GitHub Actions workflow validates,
+tests, and publishes it with an OIDC-signed provenance attestation. The only
+manual publish in this document is the **bootstrap** of a brand-new package
+name, and it exists solely to break a chicken-and-egg problem described below.
+
+---
+
+## 1. Releasables in this repo
+
+| Package | Source | Tag prefix | Workflow |
+| --- | --- | --- | --- |
+| `@worca/app` | repo root | `worca-app-v*` | `.github/workflows/release-npm-app.yml` |
+| `@worca/ui` | `worca-ui/` | `worca-ui-v*` | `.github/workflows/release-npm.yml` |
+
+Every releasable gets its **own tag prefix and its own workflow file**. A bare
+`v1.2.3` tag is not usable here — the repo publishes more than one artifact, and
+the tag has to say which one it means.
+
+> The two packages currently live on divergent branch lines: `@worca/ui` and its
+> workflow are on the `master` line, `@worca/app` on the `dev` line. Workflows
+> only run from the branch or tag they exist on, so each package's workflow must
+> be present in the lineage its release tags point into.
+
+---
+
+## 2. Tag naming
+
+```
+worca-app-v0.1.0        GA release
+worca-app-v0.1.0-rc.1   release candidate
+```
+
+Rules:
+
+- **`<package>-v<version>`**, where `<version>` is exactly the string in that
+  package's `package.json`. The workflow refuses to publish when the two
+  disagree, so a typo fails in CI rather than shipping the wrong number.
+- The `v` is part of the prefix, not the version. `worca-app-v0.1.0` publishes
+  `0.1.0`, never `v0.1.0`.
+- Pre-releases use the `-rc.N` suffix, counting from 1. The workflow keys the
+  npm dist-tag off the literal substring `-rc.`, so `-beta.1` or `-rc1` will be
+  published as `latest`. Use `-rc.N`.
+- Tags are created by `npm version`, which also writes `package.json` and
+  commits — see §4.
+
+---
+
+## 3. One-time setup for a NEW package
+
+Do this once, when introducing a package name that has never been published.
+
+### 3.1 The npm scope
+
+`@worca` is an **organization** scope on npmjs.com and already exists, so a new
+package under it needs no scope-level work. Only a genuinely new scope
+(`@worcalabs/...`) would require creating an org first.
+
+Note that scoped packages default to **restricted** (private), which fails on a
+free org. Two independent guards, and you want both:
+
+- `"publishConfig": { "access": "public" }` in `package.json` — covers manual
+  publishes
+- `--access public` on the `npm publish` line in the workflow — covers CI
+
+### 3.2 `repository` must match the building repo
+
+`npm publish --provenance` refuses to run unless `package.json` `repository.url`
+points at the same GitHub repository as the workflow generating the
+attestation:
+
+```json
+"repository": {
+  "type": "git",
+  "url": "https://github.com/SinishaDjukic/worca-cc.git"
+}
+```
+
+For a package in a subdirectory, add `"directory": "<subdir>"`. A stale
+`repository` field inherited from a template is the single most common cause of
+a first release failing at the very last step.
+
+### 3.3 Bootstrap the name (the one manual publish)
+
+npm's Trusted Publishing is configured **per package**, under that package's
+Settings tab — which means the package has to exist before you can point an
+OIDC publisher at it. So the first version goes up with a token:
+
+```bash
+npm login                       # or: set a granular token in ~/.npmrc
+npm publish --access public     # version 0.0.1, no --provenance
+```
+
+That first tarball is unattested and that is expected; it exists to claim the
+name. Publish `0.0.1` — a deliberately inert placeholder — rather than a version
+anyone might install.
+
+> Check the package Settings UI first. npm has been adding support for
+> pre-registering a trusted publisher for a not-yet-published package; where
+> that is available, skip straight to §3.4 and let CI do the first publish.
+
+### 3.4 Configure the trusted publisher on npmjs.com
+
+npmjs.com → the package → **Settings** → **Trusted Publisher** → GitHub Actions:
+
+| Field | Value |
+| --- | --- |
+| Organization / user | `SinishaDjukic` |
+| Repository | `worca-cc` (the GitHub repo name, as-is) |
+| Workflow filename | `release-npm-app.yml` |
+| Environment | *(leave empty unless the job declares one)* |
+
+The workflow filename is matched **exactly**, and the registration covers
+**one package only** — `@worca/ui`'s publisher grants nothing to `@worca/app`,
+even though both live in this repo.
+
+### 3.5 Lock the bootstrap credential down
+
+Once §3.4 is in place, CI no longer needs a token. Revoke the granular token
+used in §3.3 (npmjs.com → Access Tokens), and — recommended — set the package's
+publishing access to **"Require two-factor authentication or trusted
+publishing"** so a leaked token cannot publish it.
+
+### 3.6 GitHub side
+
+Nothing to configure beyond the workflow file itself. There is no `NPM_TOKEN`
+secret in this repo and there should not be one. What the job *does* need:
+
+```yaml
+permissions:
+  id-token: write   # mints the OIDC token npm verifies
+  contents: read
+```
+
+`id-token: write` must be on the **job**, not only at workflow level. Without
+it the publish fails with an authentication error that looks, misleadingly,
+like a bad credential.
+
+### 3.7 Checklist
+
+- [ ] `name`, `version` (`0.0.1`), `license`, `repository`, `publishConfig.access`
+- [ ] `files` allowlist verified with `npm pack --dry-run`
+- [ ] Release workflow added, with its own tag prefix and `id-token: write`
+- [ ] Bootstrap publish of `0.0.1` done
+- [ ] Trusted publisher registered on npmjs.com (repo + workflow filename)
+- [ ] Bootstrap token revoked
+- [ ] First tag-driven release published with provenance
+
+---
+
+## 4. Regular release procedure
+
+Assumes §3 is done. Work on a release branch, never directly on `dev`.
+
+### 4.1 Release candidates
+
+`npm version`'s own tagging writes a bare `v0.2.0`, which is the wrong shape
+for this repo — so bump the version without a tag and create the prefixed tag
+yourself. That is the whole recipe, for every release:
+
+```bash
+# first RC of a new line — `latest` is untouched, users stay on the old version
+npm version 0.2.0-rc.1 --no-git-tag-version
+git commit -am "chore(release): @worca/app 0.2.0-rc.1"
+git tag worca-app-v0.2.0-rc.1
+git push --follow-tags
+
+# subsequent RCs — `prerelease` walks -rc.2, -rc.3, ...
+npm version prerelease --no-git-tag-version
+git commit -am "chore(release): @worca/app $(node -p "require('./package.json').version")"
+git tag "worca-app-v$(node -p "require('./package.json').version")"
+git push --follow-tags
+```
+
+Testers opt in with:
+
+```bash
+npm install @worca/app@rc
+```
+
+### 4.2 GA release
+
+```bash
+npm version 0.2.0 --no-git-tag-version
+git commit -am "chore(release): @worca/app 0.2.0"
+git tag worca-app-v0.2.0
+git push --follow-tags
+```
+
+The workflow publishes under `latest` and moves `rc` forward to the same
+version, so `@rc` never resolves behind `@latest`.
+
+> **Do not use `npm version minor` to close out an RC line.** From
+> `0.2.0-rc.3`, semver's rules make `major`, `minor`, and `patch` all collapse
+> to `0.2.0` — you cannot tell from the command which you will get, and from
+> `0.2.1-rc.1` the same three commands disagree. Always type the target version
+> literally.
+
+### 4.3 Rules that are not negotiable
+
+- **Versions are permanent.** A published `0.2.0-rc.2` can never be reused, even
+  after unpublishing inside the 24-hour window — the number is burned. Burn RC
+  numbers freely; never try to republish over one.
+- **Release from a clean tree.** `--no-git-tag-version` skips npm's own
+  clean-tree check, so this one is on you: the tag must describe exactly what
+  CI will build.
+- **Push the tag, not just the commit.** `git push` alone pushes no tags and
+  triggers nothing. Use `--follow-tags`.
+- **Verify after the fact:**
+
+  ```bash
+  npm view @worca/app dist-tags
+  npm view @worca/app@<version> dist.attestations
+  ```
+
+  A missing `attestations` field means the tarball published without
+  provenance — treat it as a misconfiguration and investigate before anyone
+  installs it.
+
+---
+
+## 5. dist-tags and rc semantics
+
+A dist-tag is a **mutable named pointer to one published version** — think git
+branch names pointing at commits. The registry stores nothing more than
+`{ latest: "0.2.0", rc: "0.2.0" }`.
+
+Only `latest` has behaviour wired into the npm client:
+
+- bare `npm install @worca/app` resolves `latest`
+- `npm publish` writes `latest` **unless** `--tag` is passed
+
+Every other tag name is convention. Ours:
+
+| Tag | Meaning |
+| --- | --- |
+| `latest` | Stable. What a bare `npm install` gives you. |
+| `rc` | The current release candidate. Ahead of `latest` while a line is baking; equal to `latest` immediately after a GA release. |
+
+Two mechanics that explain why this matters:
+
+- **Semver ranges never match pre-releases.** `^0.2.0` will not resolve to
+  `0.3.0-rc.1`. A pre-release is reachable only by exact version or by
+  dist-tag — that is the entire reason dist-tags exist.
+- **`npm publish` does not detect pre-releases.** Publishing `0.3.0-rc.1`
+  without `--tag` moves `latest` to it and every plain `npm install` in the
+  world gets the RC. The version string being a pre-release changes nothing.
+  This is why the workflow derives the dist-tag from the git tag instead of
+  trusting anyone to remember a flag.
+
+Also note that `npm install @worca/app@rc` records the **resolved version** in
+the consumer's `package.json` (`^0.3.0-rc.1`), not a live pointer to the tag.
+Consumers do not follow the tag over time.
+
+Housekeeping: keep the tag list minimal. Tags that stop being maintained
+resolve to ancient versions and quietly mislead — if a tag is not being moved
+by a workflow, remove it:
+
+```bash
+npm dist-tag ls @worca/app
+npm dist-tag rm @worca/app <tag>
+```
+
+Removing a dist-tag unpublishes nothing; the versions stay installable by exact
+number.
+
+---
+
+## 6. Configuration that may be needed later
+
+Most of these are silent until a release fails, so check this list first when a
+previously working pipeline breaks.
+
+| Change | What it requires |
+| --- | --- |
+| **Renaming the workflow file** | Update the workflow filename in the package's trusted publisher settings. The match is exact; a rename breaks publishing with an auth error. |
+| **Renaming or transferring the repo** | Update `repository.url` in `package.json` *and* the trusted publisher's org/repo fields. Both are checked. |
+| **Moving the job into a GitHub Environment** | Add the environment name to the trusted publisher config; leaving it blank while the job declares one fails the OIDC exchange. |
+| **Adding another package** | A full pass of §3 — new tag prefix, new workflow, new bootstrap, new trusted publisher registration. Nothing is inherited from a sibling package. |
+| **Publishing a package in a subdirectory** | Set `repository.directory`, and give the workflow steps a `working-directory`. |
+| **npm/Node upgrade in CI** | Trusted Publishing needs npm >= 11.5.1 (bundled with Node >= 24.5). The workflow asserts this explicitly rather than failing obscurely at publish time. |
+| **Adding a maintainer** | npmjs.com → org → members, then grant the team write access to the package. Not needed for CI publishing, which authenticates as the repo, not as a person. |
+| **A release that must go out with the pipeline broken** | Mint a short-lived granular token scoped to the single package, publish locally with `--access public`, revoke it immediately. Do not add a long-lived `NPM_TOKEN` secret to the repo. |
+| **Deprecating a bad version** | `npm deprecate @worca/app@<version> "<reason>"`. Prefer this to unpublishing — it warns installers without breaking anyone already pinned. |
+
+### Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| `npm error code ENEEDAUTH` in CI | Trusted publisher not registered, or workflow filename/repo mismatch, or missing `id-token: write` on the job |
+| `provenance generation failed` / repository mismatch | `repository.url` does not point at the building repo |
+| `You must sign up for private packages` | Missing `--access public` / `publishConfig.access` on a scoped package |
+| `You cannot publish over the previously published versions` | The version was already published — bump it; it cannot be reused |
+| Workflow never starts | Only the commit was pushed, not the tag, or the tag does not match the prefix pattern |
+| `@rc` resolves behind `@latest` | The GA promote step did not run — re-point it with `npm dist-tag add` |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -126,6 +126,12 @@ used in §3.3 (npmjs.com → Access Tokens), and — recommended — set the pac
 publishing access to **"Require two-factor authentication or trusted
 publishing"** so a leaked token cannot publish it.
 
+Note that 2FA applies to *interactive* publishes only: the bootstrap in §3.3
+will prompt for a one-time password (`npm publish … --otp=<code>`), while
+tag-driven releases authenticate as the repository over OIDC and never need
+one. That asymmetry is the point — the automated path is the one that stays
+usable without a human holding a phone.
+
 ### 3.6 GitHub side
 
 Nothing to configure beyond the workflow file itself. There is no `NPM_TOKEN`
@@ -296,5 +302,6 @@ previously working pipeline breaks.
 | `provenance generation failed` / repository mismatch | `repository.url` does not point at the building repo |
 | `You must sign up for private packages` | Missing `--access public` / `publishConfig.access` on a scoped package |
 | `You cannot publish over the previously published versions` | The version was already published — bump it; it cannot be reused |
+| `npm error code EOTP` | A manual publish against a 2FA-protected account — re-run with `--otp=<code>`. Never seen from CI, which authenticates over OIDC |
 | Workflow never starts | Only the commit was pushed, not the tag, or the tag does not match the prefix pattern |
 | `@rc` resolves behind `@latest` | The GA promote step did not run — re-point it with `npm dist-tag add` |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -114,6 +114,12 @@ npmjs.com → the package → **Settings** → **Trusted Publisher** → GitHub 
 | Repository | `worca-cc` (the GitHub repo name, as-is) |
 | Workflow filename | `release-npm-app.yml` |
 | Environment | *(leave empty unless the job declares one)* |
+| Allowed actions | `npm publish` only |
+
+Leave **`npm stage publish`** unchecked — staged publishing is a separate
+review-then-promote flow these workflows do not use. Note that the allowlist
+covers publishing but says nothing about moving a dist-tag, so the GA `rc`
+promote step runs `continue-on-error` — see §4.2.
 
 The workflow filename is matched **exactly**, and the registration covers
 **one package only** — `@worca/ui`'s publisher grants nothing to `@worca/app`,
@@ -199,7 +205,14 @@ git push --follow-tags
 ```
 
 The workflow publishes under `latest` and moves `rc` forward to the same
-version, so `@rc` never resolves behind `@latest`.
+version, so `@rc` never resolves behind `@latest`. That promote step is marked
+`continue-on-error`: the publish preceding it is already irreversible, so a
+credential rejection there must not paint a successful release red. If it does
+fail, `rc` simply stays behind and you re-point it by hand:
+
+```bash
+npm dist-tag add @worca/app@0.2.0 rc
+```
 
 > **Do not use `npm version minor` to close out an RC line.** From
 > `0.2.0-rc.3`, semver's rules make `major`, `minor`, and `patch` all collapse

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -169,6 +169,12 @@ like a bad credential.
 
 Assumes §3 is done. Work on a release branch, never directly on `dev`.
 
+> The `/worca-release` skill (`.claude/skills/worca-release/`) automates
+> everything in this section — preconditions, version arithmetic, tagging, and
+> the post-publish verification in §4.3. Use it in preference to running the
+> commands by hand; what follows is the specification it implements, and the
+> fallback when something goes wrong.
+
 ### 4.1 Release candidates
 
 `npm version`'s own tagging writes a bare `v0.2.0`, which is the wrong shape

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-  "name": "worca-cc",
-  "version": "0.1.0",
+  "name": "@worca/app",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "worca-cc",
-      "version": "0.1.0",
+      "name": "@worca/app",
+      "version": "0.0.1",
+      "license": "MIT",
       "dependencies": {
         "express": "^4.19.2",
         "ws": "^8.18.0"
       },
       "bin": {
-        "worca": "src/cli/worca-cc.mjs"
+        "worca": "src/cli/worca-cc.mjs",
+        "worca-app": "ui/server.mjs"
       },
       "devDependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SinishaDjukic/worca-cc.git"
+    "url": "git+https://github.com/SinishaDjukic/worca-cc.git"
   },
   "homepage": "https://github.com/SinishaDjukic/worca-cc#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,19 +1,44 @@
 {
-  "name": "worca-cc",
-  "version": "0.1.0",
-  "description": "Worca CC — deterministic multi-agent pipeline that drives Claude Code (headless) through Plan -> Refine -> Implement -> Review, with a CLI, an installable /worca skill, and a web UI.",
+  "name": "@worca/app",
+  "version": "0.0.1",
+  "description": "Worca — deterministic multi-agent pipeline that drives Claude Code (headless) through Plan -> Refine -> Implement -> Review, with a CLI, an installable /worca skill, and a web UI.",
+  "license": "MIT",
+  "author": "Sinisha Djukic",
   "type": "module",
   "engines": {
     "node": ">=22.13.0"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/denislavprinov/maestro.git"
+    "url": "https://github.com/SinishaDjukic/worca-cc.git"
   },
-  "homepage": "https://github.com/denislavprinov/maestro#readme",
+  "homepage": "https://github.com/SinishaDjukic/worca-cc#readme",
+  "bugs": {
+    "url": "https://github.com/SinishaDjukic/worca-cc/issues"
+  },
+  "keywords": [
+    "worca",
+    "pipeline",
+    "orchestrator",
+    "claude-code",
+    "ai-agents",
+    "autonomous-coding"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "worca": "src/cli/worca-cc.mjs"
   },
+  "files": [
+    "src/",
+    "ui/server.mjs",
+    "ui/public/",
+    "agents/",
+    "skills/",
+    "scripts/install.mjs",
+    "README.md"
+  ],
   "scripts": {
     "start": "node --disable-warning=ExperimentalWarning ui/server.mjs",
     "cli": "node --disable-warning=ExperimentalWarning src/cli/worca-cc.mjs",

--- a/test/channel-host.test.mjs
+++ b/test/channel-host.test.mjs
@@ -19,6 +19,17 @@ import {
 
 useTempHome(after);
 
+// The fake child processes below (makeFakeProc) are plain EventEmitters over
+// in-memory PassThroughs: unlike a real spawned child, they hold no libuv
+// handle. channel-host's rpc() unrefs its timeout timer — correct in
+// production, where an in-flight RPC must not keep the process alive — so with
+// nothing else ref'd the loop drains before the timer can fire, and any test
+// awaiting an RPC timeout is cancelled with "Promise resolution is still
+// pending but the event loop has already resolved". Hold one ref'd handle for
+// the lifetime of the file to model what a real child would keep open.
+const keepLoopAlive = setInterval(() => {}, 60_000);
+after(() => clearInterval(keepLoopAlive));
+
 const NAME = 'fixture-chat';
 const SCHEMA = [{ key: 'token', type: 'text', label: 'Token', secret: true, required: true }];
 


### PR DESCRIPTION
Publishes the root package to npm as **`@worca/app`** and gives this branch line the release machinery it never had.

`0.0.1` is already on the registry — the placeholder that bootstraps the name, since npm's Trusted Publishing can only be configured for a package that already exists. Everything after it is tag-driven.

## What's here

**`package.json` → `@worca/app` 0.0.1**
- `files` allowlist: 114 files, 740 kB packed. Verified end to end by installing the tarball into a scratch project — the `worca` bin runs, and `worca --install` resolves the bundled agents and skill out of `node_modules`.
- `repository.url` now points at this repo. It was `denislavprinov/maestro`, a leftover fork URL — and `npm publish --provenance` refuses to run unless that field matches the repo generating the attestation, so the first CI release would have died at the publish step.
- Single `worca` bin, so `npx @worca/app` is unambiguous. The UI is reached through `worca --ui`, which already spawns `ui/server.mjs`.

**`.github/workflows/release-npm-app.yml`** — triggers on `worca-app-v*`, publishes over OIDC Trusted Publishing with provenance. No `NPM_TOKEN`, and none should ever be added. The npm dist-tag is derived from the git tag (`-rc.` → `rc`, else `latest`) rather than from a flag someone has to remember. A GA release promotes `rc` forward so `@rc` never resolves behind `@latest` — that step is `continue-on-error`, because the publish preceding it is irreversible and a credential rejection must not paint a successful release red.

**`docs/RELEASING.md`** — one-time npmjs.com/GitHub setup for a new package, the RC → GA procedure, tag naming, dist-tag semantics, and a troubleshooting table.

**`.claude/skills/worca-release/`** — `/worca-release --rc | --version:micro | --version:minor`. The `master` line splits this across `worca-rc` + `worca-release` because it coordinates three version files across two packages; here there's one package and one version field, so it's one skill with flags. It gates on the failure modes this work surfaced: the release workflow must exist in the commit being tagged, `npm test` runs before any tag exists, the packed file list is diffed against the last release, and provenance is verified after publish rather than assumed.

## Verified

- Packed tarball installs and runs; `.claude/`, `docs/`, `.github/`, and `test/` all stay out of it
- Repo Actions settings already permit the workflow (`allowed_actions: all`, no secrets, the one ruleset targets branches not tags)
- Trusted publisher registered for `release-npm-app.yml`

## Test suite fixed

`npm test` exited 1 on `dev` — 0 failures but 4 **cancelled** tests in `test/channel-host.test.mjs`. Root cause: `channel-host`'s `rpc()` unrefs its timeout timer (correct in production — an in-flight RPC must not keep the process alive), but `makeFakeProc` builds a plain `EventEmitter` over in-memory `PassThrough`s and so, unlike a real spawned child, holds no libuv handle. With nothing ref'd the loop drained before the timer could fire, and every test awaiting an RPC timeout was cancelled.

Fixed test-side by holding one ref'd handle for the file's lifetime, modelling what a real child process keeps open. **Production code is untouched.** Suite is now **2629/2629, exit 0** — so the workflow's `npm test` gate can pass.

## Notes

- `0.0.1` went up without provenance, as expected for a token-based bootstrap. The first `worca-app-v*` tag will be the first attested release.
- `"license": "MIT"` matches `@worca/ui`, but there's no `LICENSE` file in this repo — worth adding.
- The dangling `build:presenter` script (points at a missing `scripts/build-presenter.mjs`) is left as-is.
- Naming drops "CC" in everything authored here. Remaining `worca-cc` strings are real identifiers — the GitHub repo name, `src/cli/worca-cc.mjs`, `.worca-cc-*` dirs, the `worca-cc-*.md` agent files. A repo-wide rename is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
