### PR TITLE
Fix release procedure: annotated tags, explicit tag push, bump on dev

### DIFF
--- a/.claude/skills/worca-release/SKILL.md
+++ b/.claude/skills/worca-release/SKILL.md
@@ -138,18 +138,32 @@ means a runtime directory left it. Report either and stop.
 `npm version`'s own tagging writes a bare `v0.2.0`, which is the wrong shape
 for this repo — bump without a tag and create the prefixed tag yourself:
 
+The version bump belongs on the branch being released — `dev` — because the
+next release computes its number from `package.json`. A bump parked on a side
+branch leaves the line stale.
+
 ```bash
 npm version <VERSION> --no-git-tag-version
 git add package.json package-lock.json
 git commit -m "chore(release): @worca/app <VERSION>"
-git tag worca-app-v<VERSION>
-git push --follow-tags
+git tag -a worca-app-v<VERSION> -m "@worca/app <VERSION>"
+git push origin HEAD
+git push origin worca-app-v<VERSION>
 ```
 
 Substitute the literal computed version — e.g. `npm version 0.2.0-rc.1
---no-git-tag-version`, `git tag worca-app-v0.2.0-rc.1`.
+--no-git-tag-version`, `git tag -a worca-app-v0.2.0-rc.1 -m "@worca/app 0.2.0-rc.1"`.
 
-`git push` alone pushes no tags and triggers nothing. Use `--follow-tags`.
+**The tag must be annotated (`-a`) and pushed explicitly.** `git push` alone
+pushes no tags, and `--follow-tags` pushes *only annotated* ones — so the
+obvious-looking `git tag <name>` + `git push --follow-tags` reports success,
+pushes the commit, silently leaves the tag local, and fires no workflow.
+
+Confirm the tag actually landed before moving on:
+
+```bash
+git ls-remote --tags origin "worca-app-v<VERSION>"
+```
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -167,7 +167,9 @@ like a bad credential.
 
 ## 4. Regular release procedure
 
-Assumes §3 is done. Work on a release branch, never directly on `dev`.
+Assumes §3 is done. Release commits land on `dev` itself: the version bump has
+to be on the released branch, because the next release computes its number from
+`package.json`.
 
 > The `/worca-release` skill (`.claude/skills/worca-release/`) automates
 > everything in this section — preconditions, version arithmetic, tagging, and
@@ -185,14 +187,15 @@ yourself. That is the whole recipe, for every release:
 # first RC of a new line — `latest` is untouched, users stay on the old version
 npm version 0.2.0-rc.1 --no-git-tag-version
 git commit -am "chore(release): @worca/app 0.2.0-rc.1"
-git tag worca-app-v0.2.0-rc.1
-git push --follow-tags
+git tag -a worca-app-v0.2.0-rc.1 -m "@worca/app 0.2.0-rc.1"
+git push origin HEAD && git push origin worca-app-v0.2.0-rc.1
 
 # subsequent RCs — `prerelease` walks -rc.2, -rc.3, ...
-npm version prerelease --no-git-tag-version
-git commit -am "chore(release): @worca/app $(node -p "require('./package.json').version")"
-git tag "worca-app-v$(node -p "require('./package.json').version")"
-git push --follow-tags
+npm version prerelease --no-git-tag-version >/dev/null
+V=$(node -p "require('./package.json').version")
+git commit -am "chore(release): @worca/app $V"
+git tag -a "worca-app-v$V" -m "@worca/app $V"
+git push origin HEAD && git push origin "worca-app-v$V"
 ```
 
 Testers opt in with:
@@ -206,8 +209,8 @@ npm install @worca/app@rc
 ```bash
 npm version 0.2.0 --no-git-tag-version
 git commit -am "chore(release): @worca/app 0.2.0"
-git tag worca-app-v0.2.0
-git push --follow-tags
+git tag -a worca-app-v0.2.0 -m "@worca/app 0.2.0"
+git push origin HEAD && git push origin worca-app-v0.2.0
 ```
 
 The workflow publishes under `latest` and moves `rc` forward to the same
@@ -234,8 +237,11 @@ npm dist-tag add @worca/app@0.2.0 rc
 - **Release from a clean tree.** `--no-git-tag-version` skips npm's own
   clean-tree check, so this one is on you: the tag must describe exactly what
   CI will build.
-- **Push the tag, not just the commit.** `git push` alone pushes no tags and
-  triggers nothing. Use `--follow-tags`.
+- **Push the tag explicitly, and make it annotated.** `git push` alone pushes
+  no tags, and `--follow-tags` pushes *only annotated* ones — so `git tag <name>`
+  followed by `git push --follow-tags` succeeds, pushes the commit, and silently
+  leaves the tag local with no workflow fired. Use `git tag -a … -m …` plus
+  `git push origin <tag>`, then verify with `git ls-remote --tags origin`.
 - **Verify after the fact:**
 
   ```bash


### PR DESCRIPTION
Two defects the first live run of `/worca-release` exposed. `@worca/app@0.1.0-rc.1` published successfully, but only after working around both by hand.

## 1. The tag was never pushed

`git tag <name>` creates a **lightweight** tag. `git push --follow-tags` pushes **only annotated** ones. The documented recipe was:

```bash
git tag worca-app-v0.1.0-rc.1
git push --follow-tags
```

which printed `dev -> dev`, exited 0, and left the tag purely local. No workflow fired. `git ls-remote --tags origin` confirmed the tag was absent — this is precisely the silent failure the skill's preconditions exist to catch, reproduced by the skill's own instructions.

Now: `git tag -a … -m …`, an explicit `git push origin <tag>`, and a `git ls-remote` verification step.

## 2. "Never release directly from dev" was wrong

`docs/RELEASING.md` §4 said to work on a release branch. But the version bump has to land on the branch being released — the next release computes its number from `package.json`, so a bump parked on a side branch leaves the line stale and the following release proposes a number that was already used.

## 3. Drive-by

`V=$(npm version prerelease --no-git-tag-version && node -p "…")` would have captured npm's own stdout (`v0.2.0-rc.2`) ahead of the real value. Split into two statements.

## Verified

The corrected sequence is what actually shipped `0.1.0-rc.1`: tag on the remote, workflow triggered, published with SLSA provenance under the `rc` dist-tag, `latest` untouched on `0.0.1`, GitHub Release marked prerelease. `npm install @worca/app@rc` resolves it and the bin runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)