### PR TITLE
Release skill: accept an explicit --version target

### DIFF
--- a/.claude/skills/worca-release/SKILL.md
+++ b/.claude/skills/worca-release/SKILL.md
@@ -248,16 +248,14 @@ npm view @worca/app dist-tags
 #    before telling anyone to install it.
 npm view @worca/app@<VERSION> dist.attestations
 
-# 3. GA only: `rc` must not trail `latest`. The promote step runs
-#    continue-on-error, so it can silently not have happened.
+# 3. Both pointers read as expected.
 npm dist-tag ls @worca/app
 ```
 
-If `rc` is behind `latest` after a stable release, re-point it:
-
-```bash
-npm dist-tag add @worca/app@<VERSION> rc
-```
+After a GA release `rc` still points at the last release candidate, and that is
+correct — the OIDC credential is granted `npm publish` only and cannot move a
+dist-tag, so nothing promotes it. Report it as expected, not as a fault. The
+next `--rc` moves it ahead of `latest` again.
 
 ---
 

--- a/.claude/skills/worca-release/SKILL.md
+++ b/.claude/skills/worca-release/SKILL.md
@@ -22,8 +22,16 @@ something here doesn't fit; do not restate its contents back to the user.
 - `/worca-release --version:micro` — stable release from stable, patch bump
 - `/worca-release --version:minor` — stable release from stable, minor bump
 
-`--stable` and `--version:*` are mutually exclusive, and which one applies is
-decided by the current version, not by preference — see Step 2.
+`--version:` also accepts a **literal target** — `--version:1.0.0` — which
+pairs with either mode and says the number outright instead of relying on
+inferred arithmetic:
+
+- `/worca-release --rc --version:1.0.0` → `1.0.0-rc.1` (suffix appended)
+- `/worca-release --stable --version:1.0.0` → `1.0.0`
+
+Prefer the literal form for any jump the defaults would not reach — a major
+release, or opening a patch line as an RC. See Step 2 for which combinations
+are legal.
 
 ---
 
@@ -78,17 +86,47 @@ Read the current version:
 node -p "require('./package.json').version"
 ```
 
+`--version:` carries one of two things, and which one decides everything
+below:
+
+- a **keyword** — `micro` or `minor` — meaning "infer the number"
+- a **literal target** — anything matching `X.Y.Z` — meaning "use this number"
+
 The current version decides which flags are legal. Reject the wrong one rather
 than silently ignoring it — a flag that cannot change the outcome must not be
 accepted as if it did.
+
+### With a literal target
+
+The target is the release line. It is honoured as given; no arithmetic.
+
+- `--rc --version:1.0.0` → `1.0.0-rc.1`, appending the suffix. If the current
+  version is already on that line (`1.0.0-rc.2`), continue it: `1.0.0-rc.3`.
+  Never restart a line's numbering at `rc.1` — that number is burned.
+- `--stable --version:1.0.0` → `1.0.0` exactly.
+
+Two rejections, both hard:
+
+1. **The target must be strictly greater than the highest published version**
+   (`npm view @worca/app version`). Reject anything equal or lower: the number
+   is already burned and the publish would fail after the tag exists.
+2. **`--stable --version:X.Y.Z` while on a pre-release of a *different* line**
+   — e.g. on `1.0.0-rc.3` with `--version:2.0.0`. Stop and ask. Shipping a
+   number the RCs never rehearsed defeats the point of having cut them.
+
+`--version:<literal>` requires `--rc` or `--stable`. On its own it does not say
+which one you mean; do not guess.
+
+### Without a target
 
 **`--rc`** (semver pre-release, `X.Y.Z-rc.N`) — legal from either state:
 
 - Already a pre-release → increment N: `0.1.0-rc.4` → `0.1.0-rc.5`
 - Stable → open the next **minor** line as an RC: `0.1.0` → `0.2.0-rc.1`
 
-The stable → next-minor jump is a default, not a law. If the user wants a patch
-line instead (`0.0.1` → `0.0.2-rc.1`) or a major one, ask before computing.
+The stable → next-minor jump is only a default. For a major line, or a patch
+line, say so with `--version:` rather than talking the skill out of its
+arithmetic.
 
 **`--stable`** — legal **only from a pre-release**. Strip the suffix; that is
 the release:
@@ -98,7 +136,7 @@ the release:
 There is no bump to choose here. The micro-vs-minor decision was made when the
 RC line was opened, and the whole point of the RCs was to rehearse this exact
 number. If the current version is already stable, stop: there is no RC line to
-close out, and the user wants `--version:micro` or `--version:minor`.
+close out, and the user wants a keyword or a literal target.
 
 **`--version:micro` / `--version:minor`** — legal **only from a stable
 version**:
@@ -107,11 +145,26 @@ version**:
 - `minor`: `0.2.0` → `0.3.0`
 
 If the current version is a pre-release, stop: the line is already set, and
-neither flag can change what ships. The user wants `--stable`.
+neither keyword can change what ships. The user wants `--stable`.
 
 Never compute a stable version with `npm version minor`. From `0.2.0-rc.3`,
 semver makes `major`, `minor`, and `patch` all collapse to `0.2.0` — the
 command doesn't say what you'll get. Always pass the literal version.
+
+### Worked examples
+
+| Current | Invocation | Result |
+| --- | --- | --- |
+| `0.1.0` | `--rc` | `0.2.0-rc.1` (inferred next minor) |
+| `0.1.0` | `--rc --version:1.0.0` | `1.0.0-rc.1` |
+| `1.0.0-rc.2` | `--rc` | `1.0.0-rc.3` |
+| `1.0.0-rc.2` | `--rc --version:1.0.0` | `1.0.0-rc.3` (same line, continues) |
+| `1.0.0-rc.3` | `--stable` | `1.0.0` |
+| `1.0.0-rc.3` | `--stable --version:1.0.0` | `1.0.0` (identical, just explicit) |
+| `1.0.0-rc.3` | `--stable --version:2.0.0` | **stop** — RCs rehearsed 1.0.0 |
+| `0.1.0` | `--stable` | **stop** — no RC line open |
+| `1.0.0-rc.3` | `--version:minor` | **stop** — line already set |
+| any | `--version:0.1.0` | **stop** — already published |
 
 **Print the computed version and confirm with the user before proceeding.**
 

--- a/.github/workflows/release-npm-app.yml
+++ b/.github/workflows/release-npm-app.yml
@@ -80,21 +80,6 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public --provenance --tag ${{ steps.dist-tag.outputs.tag }}
 
-      # Without this, `rc` stays parked on the last release candidate forever
-      # and `npm install @worca/app@rc` resolves BEHIND `@latest`. On a GA
-      # release, move `rc` forward to the released version.
-      # The npm trusted-publisher allowlist grants `npm publish`; whether the
-      # OIDC credential may also move a dist-tag is not something that form
-      # lets you grant. The publish above has already succeeded and cannot be
-      # undone by this step failing, so a rejection here must not fail the
-      # release — it just leaves `rc` behind, to be re-pointed by hand.
-      - name: Promote rc dist-tag to the GA release
-        if: steps.dist-tag.outputs.tag == 'latest'
-        continue-on-error: true
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: npm dist-tag add "@worca/app@${TAG_NAME#worca-app-v}" rc
-
   release:
     needs: build-and-publish
     runs-on: ubuntu-latest

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -117,9 +117,10 @@ npmjs.com → the package → **Settings** → **Trusted Publisher** → GitHub 
 | Allowed actions | `npm publish` only |
 
 Leave **`npm stage publish`** unchecked — staged publishing is a separate
-review-then-promote flow these workflows do not use. Note that the allowlist
-covers publishing but says nothing about moving a dist-tag, so the GA `rc`
-promote step runs `continue-on-error` — see §4.2.
+review-then-promote flow these workflows do not use. Note that this allowlist
+is the *whole* grant: the OIDC credential can publish and nothing else. It
+cannot move a dist-tag — `npm dist-tag add` under it fails `E401` — which is
+why no workflow here tries. See §5 for what that means for `rc`.
 
 The workflow filename is matched **exactly**, and the registration covers
 **one package only** — `@worca/ui`'s publisher grants nothing to `@worca/app`,
@@ -230,15 +231,8 @@ git tag -a worca-app-v0.2.0 -m "@worca/app 0.2.0"
 git push origin HEAD && git push origin worca-app-v0.2.0
 ```
 
-The workflow publishes under `latest` and moves `rc` forward to the same
-version, so `@rc` never resolves behind `@latest`. That promote step is marked
-`continue-on-error`: the publish preceding it is already irreversible, so a
-credential rejection there must not paint a successful release red. If it does
-fail, `rc` simply stays behind and you re-point it by hand:
-
-```bash
-npm dist-tag add @worca/app@0.2.0 rc
-```
+The workflow publishes under `latest`. It does **not** touch `rc` — see §5 for
+why, and for what `rc` therefore means.
 
 > **Do not use `npm version minor` to close out an RC line.** From
 > `0.2.0-rc.3`, semver's rules make `major`, `minor`, and `patch` all collapse
@@ -288,7 +282,15 @@ Every other tag name is convention. Ours:
 | Tag | Meaning |
 | --- | --- |
 | `latest` | Stable. What a bare `npm install` gives you. |
-| `rc` | The current release candidate. Ahead of `latest` while a line is baking; equal to `latest` immediately after a GA release. |
+| `rc` | The **most recent release candidate**. Ahead of `latest` while a line is baking; behind it in the window between a GA release and the next RC. |
+
+`rc` sitting behind `latest` for a while is expected here, not a fault. The
+OIDC credential that publishes these releases is granted `npm publish` and
+nothing else — it cannot run `npm dist-tag add`, so no workflow can promote
+`rc` on a GA release. Rather than keep a step that fails `E401` on every stable
+release, or hold a long-lived token just to move a pointer, `rc` simply means
+what its name says: the last candidate published. Cutting the next RC moves it
+ahead again.
 
 Two mechanics that explain why this matters:
 
@@ -346,4 +348,4 @@ previously working pipeline breaks.
 | `You cannot publish over the previously published versions` | The version was already published — bump it; it cannot be reused |
 | `npm error code EOTP` | A manual publish against a 2FA-protected account — re-run with `--otp=<code>`. Never seen from CI, which authenticates over OIDC |
 | Workflow never starts | Only the commit was pushed, not the tag, or the tag does not match the prefix pattern |
-| `@rc` resolves behind `@latest` | The GA promote step did not run — re-point it with `npm dist-tag add` |
+| `@rc` resolves behind `@latest` | Expected between a GA release and the next RC — see §5. Only a concern if it persists across several release lines |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -204,6 +204,23 @@ Testers opt in with:
 npm install @worca/app@rc
 ```
 
+### 4.1b Naming the target explicitly
+
+The arithmetic above infers the next number, which is right for routine
+releases and wrong for a jump the defaults cannot reach — a major line, or a
+patch line opened as an RC. State the target instead of nudging the inference:
+
+```bash
+/worca-release --rc --version:1.0.0        # -> 1.0.0-rc.1
+/worca-release --stable --version:1.0.0    # -> 1.0.0
+```
+
+The target must be strictly greater than the highest published version
+(`npm view @worca/app version`) — anything equal or lower is already burned and
+would fail the publish *after* the tag exists. And closing out an RC line with a
+different number than the RCs rehearsed is refused: if `1.0.0-rc.3` is current,
+`--stable --version:2.0.0` stops and asks.
+
 ### 4.2 GA release
 
 ```bash


### PR DESCRIPTION
`--version:` now takes a literal `X.Y.Z` alongside the `micro`/`minor` keywords, and pairs with either mode:

```
/worca-release --rc --version:1.0.0        → 1.0.0-rc.1   (suffix appended)
/worca-release --stable --version:1.0.0    → 1.0.0
```

## Why

The inferred arithmetic can't reach a major line. From `0.1.0`, `--rc` opens the *next minor* — `0.2.0-rc.1` — so cutting `1.0.0-rc.1` meant letting the skill propose the wrong number and then talking it out of its own default mid-run. Stating the target is both shorter and auditable.

## Guards

An explicit number is easier to get wrong than a computed one, so two hard rejections:

1. **The target must exceed the highest published version.** Equal or lower is already burned, and the publish would fail *after* the tag exists — the worst place to find out.
2. **Closing an RC line with a number the RCs never rehearsed stops and asks.** On `1.0.0-rc.3`, `--stable --version:2.0.0` is almost certainly a mistake.

Continuing an existing line is handled too: on `1.0.0-rc.2`, `--rc --version:1.0.0` yields `1.0.0-rc.3`, never restarting at `rc.1` — that number is burned.

`--version:<literal>` requires `--rc` or `--stable`; alone it doesn't say which is meant, so it doesn't guess.

## Also

A worked-examples table in the skill covering all ten combinations including the four that stop, and a `§4.1b` in `docs/RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Also: drop the dead `rc` promote step

The `0.1.0` release proved it can never work. npm's trusted-publisher allowlist grants **`npm publish` and nothing else**, so the OIDC credential cannot run `npm dist-tag add`:

```
npm error code E401
npm error Unable to authenticate, your authentication token seems to be invalid.
```

`continue-on-error` kept the release green, but it was masking a step that would fail on *every* stable release forever.

The alternatives were a long-lived token held solely to move a pointer, or an honest definition of the tag. Taking the definition: **`rc` means the most recent release candidate** — ahead of `latest` while a line bakes, behind it in the window between a GA and the next RC. Cutting the next RC moves it ahead again.

Updated in the workflow (step deleted), `docs/RELEASING.md` §3.4/§4.2/§5/troubleshooting, and the skill's Step 6, which now reports a trailing `rc` as expected rather than as a fault.
