### PR TITLE
Improve history diff viewer with syntax highlighting and file tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@highlightjs/cdn-assets": "11.12.0",
         "express": "^4.19.2",
         "ws": "^8.18.0"
       },
       "bin": {
-        "worca": "src/cli/worca-cc.mjs",
-        "worca-app": "ui/server.mjs"
+        "worca": "src/cli/worca-cc.mjs"
       },
       "devDependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",
@@ -265,6 +265,15 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@highlightjs/cdn-assets": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@highlightjs/cdn-assets/-/cdn-assets-11.12.0.tgz",
+      "integrity": "sha512-KvOKXODaiFmId9xaq3xc5xCL66wVLUuOngDbO9B/kewbFTqdGbn2nJxNhN3H5R1cgDTVj6R8vH0zgiNDEGjpDw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test": "rm -rf .worca-cc-test && WORCA_HOME=.worca-cc-test node --disable-warning=ExperimentalWarning --test test/*.mjs"
   },
   "dependencies": {
+    "@highlightjs/cdn-assets": "11.12.0",
     "express": "^4.19.2",
     "ws": "^8.18.0"
   },

--- a/test/api-hljs-assets.test.mjs
+++ b/test/api-hljs-assets.test.mjs
@@ -1,0 +1,118 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { useTempHome } from './helpers/temp-home.mjs';
+import { SUPPORTED_LANGUAGE_IDS } from '../ui/public/syntax-highlight.mjs';
+
+useTempHome(after);
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+let srv;
+let base;
+let testing;
+
+before(async () => {
+  const mod = await import('../ui/server.mjs');
+  testing = mod._testing;
+  srv = http.createServer(mod.app);
+  await new Promise((resolve, reject) => {
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      srv.off('error', reject);
+      resolve();
+    });
+  });
+  base = `http://127.0.0.1:${srv.address().port}`;
+});
+
+after(async () => {
+  if (srv) {
+    await new Promise((resolve) => {
+      srv.close(resolve);
+      srv.closeAllConnections();
+    });
+  }
+});
+
+test('dependency and lock pin the reviewed runtime package exactly', () => {
+  const pkg = JSON.parse(readFileSync(`${root}/package.json`, 'utf8'));
+  const lock = JSON.parse(readFileSync(`${root}/package-lock.json`, 'utf8'));
+  assert.equal(pkg.dependencies['@highlightjs/cdn-assets'], '11.12.0');
+  assert.equal(pkg.dependencies['highlight.js'], undefined);
+  assert.equal(pkg.devDependencies['highlight.js'], undefined);
+  const locked = lock.packages['node_modules/@highlightjs/cdn-assets'];
+  assert.equal(locked.version, '11.12.0');
+  assert.equal(locked.integrity,
+    'sha512-KvOKXODaiFmId9xaq3xc5xCL66wVLUuOngDbO9B/kewbFTqdGbn2nJxNhN3H5R1cgDTVj6R8vH0zgiNDEGjpDw==');
+  assert.notEqual(locked.dev, true);
+  assert.equal(lock.packages['node_modules/highlight.js'], undefined);
+});
+
+test('vendor core and every reviewed grammar are exact JavaScript ESM assets', async () => {
+  const paths = [
+    '/vendor/hljs/core.min.js',
+    ...SUPPORTED_LANGUAGE_IDS.map((id) => `/vendor/hljs/languages/${id}.min.js`),
+    '/vendor/hljs/languages/javascript.min.js?retry=1',
+  ];
+  for (const pathname of paths) {
+    const res = await fetch(`${base}${pathname}`);
+    assert.equal(res.status, 200, pathname);
+    assert.match(res.headers.get('content-type') || '', /javascript/i, pathname);
+    assert.equal(res.headers.get('x-content-type-options'), 'nosniff', pathname);
+    const source = await res.text();
+    assert.match(source, /export(?:\s+default|\s*\{)/, pathname);
+    const mod = await import(`data:text/javascript;base64,${Buffer.from(source).toString('base64')}`);
+    assert.ok(mod.default, `${pathname} has a default export`);
+  }
+});
+
+test('vendor misses are plain, no-store responses and never the SPA shell', async () => {
+  const paths = [
+    '/vendor', '/vendor/', '/vendor/hljs/', '/vendor/hljs/package.json',
+    '/vendor/hljs/languages/javascript.js',
+    '/vendor/hljs/languages/missing.min.js',
+    '/vendor/hljs/languages/brainfuck.min.js',
+    '/vendor/hljs/languages/%2e%2e%2fcore.min.js',
+    '/vendor/hljs/languages/javascript.min.js.map',
+  ];
+  for (const pathname of paths) {
+    const res = await fetch(`${base}${pathname}`);
+    assert.equal(res.status, 404, pathname);
+    assert.doesNotMatch(res.headers.get('content-type') || '', /text\/html/i, pathname);
+    assert.match(res.headers.get('cache-control') || '', /no-store/i, pathname);
+    assert.doesNotMatch(await res.text(), /<!doctype html/i, pathname);
+  }
+});
+
+test('malformed vendor encoding becomes a plain 400', async () => {
+  const res = await fetch(`${base}/vendor/hljs/languages/%ZZ`);
+  assert.equal(res.status, 400);
+  assert.match(res.headers.get('content-type') || '', /text\/plain/i);
+  assert.match(res.headers.get('cache-control') || '', /no-store/i);
+  assert.doesNotMatch(await res.text(), /<!doctype html/i);
+});
+
+test('SPA fallback remains narrow and index has no highlighter script tag', async () => {
+  for (const pathname of ['/vendorish', '/history/example']) {
+    const res = await fetch(`${base}${pathname}`);
+    assert.equal(res.status, 200, pathname);
+    assert.match(res.headers.get('content-type') || '', /text\/html/i, pathname);
+    assert.match(await res.text(), /<!doctype html/i, pathname);
+  }
+  const index = readFileSync(`${root}/ui/public/index.html`, 'utf8');
+  assert.doesNotMatch(index, /highlight(?:\.min)?\.js|window\.hljs|vendor\/hljs/i);
+});
+
+test('asset resolution failure returns null and warns once', () => {
+  const warnings = [];
+  const result = testing.resolveHljsAssets(
+    () => { throw new Error('unavailable'); },
+    (message) => warnings.push(message),
+  );
+  assert.equal(result, null);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /syntax-highlighter assets unavailable: unavailable/);
+});

--- a/test/api-hljs-assets.test.mjs
+++ b/test/api-hljs-assets.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import { useTempHome } from './helpers/temp-home.mjs';
 import { SUPPORTED_LANGUAGE_IDS } from '../ui/public/syntax-highlight.mjs';
+import { HLJS_GRAMMAR_IDS } from '../ui/public/hljs-loader.mjs';
 
 useTempHome(after);
 
@@ -51,10 +52,14 @@ test('dependency and lock pin the reviewed runtime package exactly', () => {
   assert.equal(lock.packages['node_modules/highlight.js'], undefined);
 });
 
-test('vendor core and every reviewed grammar are exact JavaScript ESM assets', async () => {
+test('vendor core and every reviewed or sub-language grammar are exact JavaScript ESM assets', async () => {
+  // The loader's closure needs grammars that are not primaries (mojolicious for
+  // perl); the server allowlist is HLJS_GRAMMAR_IDS, a superset of the primaries.
+  assert.ok(SUPPORTED_LANGUAGE_IDS.every((id) => HLJS_GRAMMAR_IDS.includes(id)));
+  assert.ok(HLJS_GRAMMAR_IDS.length > SUPPORTED_LANGUAGE_IDS.length);
   const paths = [
     '/vendor/hljs/core.min.js',
-    ...SUPPORTED_LANGUAGE_IDS.map((id) => `/vendor/hljs/languages/${id}.min.js`),
+    ...HLJS_GRAMMAR_IDS.map((id) => `/vendor/hljs/languages/${id}.min.js`),
     '/vendor/hljs/languages/javascript.min.js?retry=1',
   ];
   for (const pathname of paths) {

--- a/test/diff-view.test.mjs
+++ b/test/diff-view.test.mjs
@@ -1,7 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  splitPatchSections, parseFileSection, patchIndex, sectionKey, MAX_FILE_SECTION_BYTES,
+  splitPatchSections, parseFileSection, patchIndex, sectionKey, hunkRange,
+  MAX_FILE_SECTION_CODE_UNITS, MAX_FILE_SECTION_RENDER_ITEMS,
 } from '../ui/public/diff-view.mjs';
 
 const SIMPLE = `diff --git a/src/a.js b/src/a.js
@@ -138,7 +139,7 @@ test('empty member patch (bare "# key" line) is tolerated', () => {
 
 test('oversized section is truncated at a line boundary and flagged', () => {
   const big = 'diff --git a/big.txt b/big.txt\n--- a/big.txt\n+++ b/big.txt\n@@ -1,1 +1,1 @@\n'
-    + '+x\n'.repeat(Math.ceil(MAX_FILE_SECTION_BYTES / 3));
+    + '+x\n'.repeat(Math.ceil(MAX_FILE_SECTION_CODE_UNITS / 3));
   const f = parseFileSection(splitPatchSections(big)[0].raw);
   assert.equal(f.truncated, true);
   assert.ok(f.hunks.length >= 1);
@@ -151,7 +152,7 @@ test('one line longer than the cap -> truncated hunk with ZERO lines (no crash)'
   // ever assumes `truncated === true` implies at least one line (Task 6 iterates
   // hunk.lines, so it renders the header + the truncation note and nothing else).
   const big = 'diff --git a/one.txt b/one.txt\n--- a/one.txt\n+++ b/one.txt\n@@ -1 +1 @@\n'
-    + '+' + 'x'.repeat(MAX_FILE_SECTION_BYTES + 10) + '\n';
+    + '+' + 'x'.repeat(MAX_FILE_SECTION_CODE_UNITS + 10) + '\n';
   const f = parseFileSection(splitPatchSections(big)[0].raw);
   assert.equal(f.truncated, true);
   assert.equal(f.hunks.length, 1);
@@ -161,4 +162,81 @@ test('one line longer than the cap -> truncated hunk with ZERO lines (no crash)'
 test('empty / junk input -> empty sections', () => {
   assert.deepEqual(splitPatchSections(''), []);
   assert.deepEqual(splitPatchSections('not a diff at all\njust text\n'), []);
+});
+
+test('hunkRange accepts unified headers and rejects unsafe or combined ranges', () => {
+  assert.deepEqual(hunkRange('@@ -4,2 +9,3 @@ label'), {
+    oldStart: 4, oldCount: 2, newStart: 9, newCount: 3,
+  });
+  assert.deepEqual(hunkRange('@@ -7 +8 @@\r'), {
+    oldStart: 7, oldCount: 1, newStart: 8, newCount: 1,
+  });
+  assert.deepEqual(hunkRange('@@ -0,0 +0,0 @@'), {
+    oldStart: 0, oldCount: 0, newStart: 0, newCount: 0,
+  });
+  assert.equal(hunkRange('@@ -0 +1 @@'), null);
+  assert.equal(hunkRange('@@@ -1,1 -1,1 +1,1 @@@'), null);
+  assert.equal(hunkRange(`@@ -${Number.MAX_SAFE_INTEGER},2 +1 @@`), null);
+  assert.equal(hunkRange('@@ -9007199254740992 +1 @@'), null);
+});
+
+test('parser numbers both sides locally, resets hunks, and preserves CR source', () => {
+  const parsed = parseFileSection([
+    '@@ -2,3 +8,3 @@',
+    ' context',
+    '-old',
+    '+new',
+    ' tail',
+    '\\ No newline at end of file',
+    '@@ -20 +30 @@',
+    '-gone\r',
+    '+fresh\r',
+  ].join('\n'));
+  assert.deepEqual(parsed.hunks[0].lines, [
+    { kind: 'ctx', text: 'context', oldNo: 2, newNo: 8 },
+    { kind: 'del', text: 'old', oldNo: 3, newNo: null },
+    { kind: 'add', text: 'new', oldNo: null, newNo: 9 },
+    { kind: 'ctx', text: 'tail', oldNo: 4, newNo: 10 },
+  ]);
+  assert.deepEqual(parsed.hunks[1].lines, [
+    { kind: 'del', text: 'gone\r', oldNo: 20, newNo: null },
+    { kind: 'add', text: 'fresh\r', oldNo: null, newNo: 30 },
+  ]);
+});
+
+test('malformed ranges have a stable null shape and never invent line numbers', () => {
+  const parsed = parseFileSection('@@@ -1,1 -1,1 +1,1 @@@\n line\n-extra\n+extra');
+  const hunk = parsed.hunks[0];
+  assert.deepEqual(
+    { oldStart: hunk.oldStart, oldCount: hunk.oldCount, newStart: hunk.newStart, newCount: hunk.newCount },
+    { oldStart: null, oldCount: null, newStart: null, newCount: null },
+  );
+  assert.ok(hunk.lines.every((line) => line.oldNo === null && line.newNo === null));
+});
+
+test('declared side counts prevent overlong bodies from receiving extra numbers', () => {
+  const parsed = parseFileSection('@@ -1 +1 @@\n one\n unexpected');
+  assert.deepEqual(parsed.hunks[0].lines.map(({ oldNo, newNo }) => [oldNo, newNo]), [
+    [1, 1], [null, null],
+  ]);
+});
+
+test('render item cap stops on a row boundary and never exceeds the cap', () => {
+  const lines = ['@@ -0,0 +1,6000 @@'];
+  for (let i = 0; i < MAX_FILE_SECTION_RENDER_ITEMS; i += 1) lines.push(`+${i}`);
+  const parsed = parseFileSection(lines.join('\n'));
+  assert.equal(parsed.truncated, true);
+  const retained = parsed.hunks.length + parsed.hunks.reduce((n, hunk) => n + hunk.lines.length, 0);
+  assert.equal(retained, MAX_FILE_SECTION_RENDER_ITEMS);
+  assert.equal(parsed.hunks[0].lines.at(-1).newNo, MAX_FILE_SECTION_RENDER_ITEMS - 1);
+});
+
+test('section cap is deliberately measured in UTF-16 code units', () => {
+  const source = '😀'.repeat(Math.ceil(MAX_FILE_SECTION_CODE_UNITS / 2) + 10);
+  const parsed = parseFileSection(`@@ -0,0 +1 @@\n+${source}`);
+  assert.equal(parsed.truncated, true);
+  if (parsed.hunks[0]?.lines[0]) {
+    const text = parsed.hunks[0].lines[0].text;
+    assert.ok(!/[\uD800-\uDBFF]$/.test(text), 'a mid-line cut never leaves a lone high surrogate');
+  }
 });

--- a/test/diff-view.test.mjs
+++ b/test/diff-view.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   splitPatchSections, parseFileSection, patchIndex, sectionKey, hunkRange,
-  MAX_FILE_SECTION_CODE_UNITS, MAX_FILE_SECTION_RENDER_ITEMS,
+  MAX_FILE_SECTION_CODE_UNITS,
 } from '../ui/public/diff-view.mjs';
 
 const SIMPLE = `diff --git a/src/a.js b/src/a.js
@@ -180,6 +180,18 @@ test('hunkRange accepts unified headers and rejects unsafe or combined ranges', 
   assert.equal(hunkRange('@@ -9007199254740992 +1 @@'), null);
 });
 
+test('hunkRange keeps the range when git\'s function context carries U+2028/U+2029 or a CR', () => {
+  // git copies the funcname line verbatim (default xfuncname = any letter-initial
+  // line), so these reach the header unescaped; `.` would reject all three.
+  const want = { oldStart: 5, oldCount: 7, newStart: 5, newCount: 7 };
+  assert.deepEqual(hunkRange('@@ -5,7 +5,7 @@ function f(sep = "\u2028") {'), want);
+  assert.deepEqual(hunkRange('@@ -5,7 +5,7 @@ const x = "\u2029"'), want);
+  assert.deepEqual(hunkRange('@@ -5,7 +5,7 @@ a\rb'), want);
+  assert.equal(hunkRange('@@ -5,7 +5,7 @@ a\n+b'), null, 'a second line is never part of a header');
+  const parsed = parseFileSection('@@ -5,2 +5,2 @@ function f(sep = "\u2028") {\n x\n-y\n+z\n');
+  assert.deepEqual(parsed.hunks[0].lines.map((l) => [l.oldNo, l.newNo]), [[5, 5], [6, null], [null, 6]]);
+});
+
 test('parser numbers both sides locally, resets hunks, and preserves CR source', () => {
   const parsed = parseFileSection([
     '@@ -2,3 +8,3 @@',
@@ -221,22 +233,35 @@ test('declared side counts prevent overlong bodies from receiving extra numbers'
   ]);
 });
 
-test('render item cap stops on a row boundary and never exceeds the cap', () => {
+test('every row under the section cap is parsed — the DOM window is the renderer\'s job', () => {
+  // A 6,000-line lockfile hunk is ~60 KB, far below MAX_FILE_SECTION_CODE_UNITS;
+  // the parser must hand back all of it with exact numbering and no truncation
+  // flag. app.js windows what it CONNECTS, never what it parses.
   const lines = ['@@ -0,0 +1,6000 @@'];
-  for (let i = 0; i < MAX_FILE_SECTION_RENDER_ITEMS; i += 1) lines.push(`+${i}`);
+  for (let i = 1; i <= 6000; i += 1) lines.push(`+${i}`);
   const parsed = parseFileSection(lines.join('\n'));
-  assert.equal(parsed.truncated, true);
-  const retained = parsed.hunks.length + parsed.hunks.reduce((n, hunk) => n + hunk.lines.length, 0);
-  assert.equal(retained, MAX_FILE_SECTION_RENDER_ITEMS);
-  assert.equal(parsed.hunks[0].lines.at(-1).newNo, MAX_FILE_SECTION_RENDER_ITEMS - 1);
+  assert.equal(parsed.truncated, false);
+  assert.equal(parsed.hunks.length, 1);
+  assert.equal(parsed.hunks[0].lines.length, 6000);
+  assert.equal(parsed.hunks[0].lines.at(-1).newNo, 6000);
 });
 
 test('section cap is deliberately measured in UTF-16 code units', () => {
   const source = '😀'.repeat(Math.ceil(MAX_FILE_SECTION_CODE_UNITS / 2) + 10);
   const parsed = parseFileSection(`@@ -0,0 +1 @@\n+${source}`);
   assert.equal(parsed.truncated, true);
-  if (parsed.hunks[0]?.lines[0]) {
-    const text = parsed.hunks[0].lines[0].text;
-    assert.ok(!/[\uD800-\uDBFF]$/.test(text), 'a mid-line cut never leaves a lone high surrogate');
-  }
+  // The only newline sits right after the header, so the cut snaps there and
+  // the hunk keeps no rows — the mid-line path is pinned by the next test.
+  assert.deepEqual(parsed.hunks[0].lines, []);
+});
+
+test('a mid-line cut (no newline within the cap) never leaves a lone high surrogate', () => {
+  // No newline anywhere, so lastIndexOf('\\n') is -1 and the cut lands on a code
+  // unit boundary: 3 + 499,997 units ends INSIDE a surrogate pair.
+  const parsed = parseFileSection('@@@' + '😀'.repeat(MAX_FILE_SECTION_CODE_UNITS));
+  assert.equal(parsed.truncated, true);
+  assert.equal(parsed.hunks.length, 1);
+  const { header } = parsed.hunks[0];
+  assert.ok(header.isWellFormed(), 'lone high surrogate dropped at the cut');
+  assert.equal(header.length, MAX_FILE_SECTION_CODE_UNITS - 1);
 });

--- a/test/file-tree.test.mjs
+++ b/test/file-tree.test.mjs
@@ -149,16 +149,33 @@ test('renderer uses native accessible controls, safe IDs, and visual-only initia
   assert.match(rename.getAttribute('aria-label'), /2 lines added, 3 lines removed/);
   assert.match(rename.title, /old\/y\.ts/);
   assert.ok([...rename.querySelectorAll('.hd-tree-status')].every((node) => node.getAttribute('aria-hidden') === 'true'));
+  const changedIcon = rename.querySelector('.hd-tree-file-icon');
+  assert.equal(changedIcon.tagName, 'svg');
+  assert.equal(changedIcon.getAttribute('stroke-width'), '1.45');
+  assert.equal(changedIcon.querySelectorAll('path').length, 4, 'changed paper has fold and text lines');
+
+  assert.equal(dir.children[0].classList.contains('hd-tree-chevron'), true);
+  assert.equal(dir.children[1].classList.contains('hd-tree-folder-icon'), true);
+  assert.equal(dir.children[2].classList.contains('hd-tree-dir-label'), true);
 });
 
-test('deleted-file marker uses an ASCII hyphen outside the count chip', () => {
-  const deleted = entry('gone.js', {
-    f: { path: 'gone.js', status: 'D', added: 0, removed: 3 },
-  });
-  const { nav } = render(buildFileTree([deleted]));
-  const button = nav.querySelector('.hd-tree-file.deleted');
-  assert.equal(button.querySelector('.hd-tree-status').textContent, '-');
-  assert.equal(button.querySelector('.counts').textContent, '+0 −3');
+test('file states use distinct paper icons outside the count chip', () => {
+  const rows = [
+    entry('changed.js'),
+    entry('new.js', { isNew: true, f: { path: 'new.js', status: 'A', added: 3, removed: 0 } }),
+    entry('gone.js', { f: { path: 'gone.js', status: 'D', added: 0, removed: 3 } }),
+  ];
+  const { nav } = render(buildFileTree(rows));
+  const changed = nav.querySelector('.hd-tree-file.mod');
+  const added = nav.querySelector('.hd-tree-file.add');
+  const deleted = nav.querySelector('.hd-tree-file.del');
+  assert.equal(changed.querySelector('.hd-tree-file-icon').querySelectorAll('path').length, 4);
+  assert.equal(added.querySelector('.hd-tree-file-icon').querySelectorAll('path').length, 3);
+  assert.equal(deleted.querySelector('.hd-tree-file-icon').querySelectorAll('path').length, 3);
+  assert.notEqual(added.querySelector('.hd-tree-file-icon path:last-child').getAttribute('d'),
+    deleted.querySelector('.hd-tree-file-icon path:last-child').getAttribute('d'));
+  assert.equal(deleted.querySelector('.hd-tree-status').textContent, '');
+  assert.equal(deleted.querySelector('.counts').textContent, '+0 −3');
 });
 
 test('directory toggles preserve children and selection without invoking onPick', () => {

--- a/test/file-tree.test.mjs
+++ b/test/file-tree.test.mjs
@@ -59,6 +59,25 @@ test('directory chains compact but never absorb a file basename', () => {
   assert.deepEqual(branching[0].children.map((node) => node.name), ['public', 'test']);
 });
 
+test('compacted labels determine nested project order, first file, and rendered order', () => {
+  const rows = [
+    entry('p/a/z/f.js', { project: 'alpha' }),
+    entry('p/a-b/f.js', { project: 'alpha' }),
+  ];
+  const nodes = buildFileTree(rows);
+  const project = nodes[0];
+  const parent = project.children[0];
+  assert.equal(parent.name, 'p');
+  assert.deepEqual(parent.children.map((node) => node.name), ['a-b', 'a/z']);
+  assert.equal(firstFile(nodes).path, 'p/a-b/f.js');
+
+  const { nav } = render(nodes);
+  assert.deepEqual([...nav.querySelectorAll('.hd-tree-file')].map((button) => button.dataset.path), [
+    'p/a-b/f.js',
+    'p/a/z/f.js',
+  ]);
+});
+
 test('file and directory with the same segment both survive directory-first', () => {
   const deleted = entry('a', { f: { path: 'a', status: 'D', added: 0, removed: 1 } });
   const added = entry('a/b', { isNew: true, f: { path: 'a/b', status: 'A', added: 1, removed: 0 } });
@@ -130,6 +149,16 @@ test('renderer uses native accessible controls, safe IDs, and visual-only initia
   assert.match(rename.getAttribute('aria-label'), /2 lines added, 3 lines removed/);
   assert.match(rename.title, /old\/y\.ts/);
   assert.ok([...rename.querySelectorAll('.hd-tree-status')].every((node) => node.getAttribute('aria-hidden') === 'true'));
+});
+
+test('deleted-file marker uses an ASCII hyphen outside the count chip', () => {
+  const deleted = entry('gone.js', {
+    f: { path: 'gone.js', status: 'D', added: 0, removed: 3 },
+  });
+  const { nav } = render(buildFileTree([deleted]));
+  const button = nav.querySelector('.hd-tree-file.deleted');
+  assert.equal(button.querySelector('.hd-tree-status').textContent, '-');
+  assert.equal(button.querySelector('.counts').textContent, '+0 −3');
 });
 
 test('directory toggles preserve children and selection without invoking onPick', () => {

--- a/test/file-tree.test.mjs
+++ b/test/file-tree.test.mjs
@@ -1,0 +1,182 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import {
+  buildFileTree, renderFileTree, firstFile, fileStatus,
+} from '../ui/public/file-tree.mjs';
+
+const entry = (path, over = {}) => ({
+  project: null,
+  isNew: false,
+  f: { path, status: 'M', added: 1, removed: 2 },
+  ...over,
+});
+
+function flatten(nodes, out = []) {
+  for (const node of nodes) {
+    out.push(node);
+    if (node.children) flatten(node.children, out);
+  }
+  return out;
+}
+
+function render(nodes, options = {}) {
+  const dom = new JSDOM('<!doctype html><body></body>');
+  const { document } = dom.window;
+  const nav = renderFileTree(nodes, {
+    doc: document,
+    counts(item) {
+      const span = document.createElement('span');
+      span.className = 'counts';
+      span.textContent = item.f.binary ? 'binary' : `+${item.f.added} −${item.f.removed}`;
+      return span;
+    },
+    ...options,
+  });
+  document.body.appendChild(nav);
+  return { dom, document, nav };
+}
+
+test('model order is deterministic, directories first, and numeric names lexical', () => {
+  const nodes = buildFileTree([
+    entry('z.js'), entry('a2.js'), entry('a10.js'), entry('B.js'), entry('b.js'),
+    entry('dir/z.js'), entry('Dir/a.js'), entry('é.js'), entry('E.js'),
+  ]);
+  assert.deepEqual(nodes.map((node) => node.name), [
+    'Dir', 'dir', 'a10.js', 'a2.js', 'B.js', 'b.js', 'E.js', 'z.js', 'é.js',
+  ]);
+});
+
+test('directory chains compact but never absorb a file basename', () => {
+  const compact = buildFileTree([entry('ui/public/src/x.js')]);
+  assert.equal(compact[0].name, 'ui/public/src');
+  assert.equal(compact[0].path, 'ui/public/src');
+  assert.equal(compact[0].children[0].name, 'x.js');
+
+  const branching = buildFileTree([entry('ui/public/a.js'), entry('ui/test/b.js')]);
+  assert.equal(branching[0].name, 'ui');
+  assert.deepEqual(branching[0].children.map((node) => node.name), ['public', 'test']);
+});
+
+test('file and directory with the same segment both survive directory-first', () => {
+  const deleted = entry('a', { f: { path: 'a', status: 'D', added: 0, removed: 1 } });
+  const added = entry('a/b', { isNew: true, f: { path: 'a/b', status: 'A', added: 1, removed: 0 } });
+  const nodes = buildFileTree([deleted, added]);
+  assert.deepEqual(nodes.map((node) => [node.type, node.name]), [['dir', 'a'], ['file', 'a']]);
+});
+
+test('project identity scopes duplicate paths and exact duplicates keep the first entry', () => {
+  const alpha = entry('src/x.js', { project: 'alpha' });
+  const duplicate = entry('src/x.js', { project: 'alpha', f: { path: 'src/x.js', status: 'D' } });
+  const beta = entry('src/x.js', { project: 'beta' });
+  const nodes = buildFileTree([duplicate, alpha, beta]);
+  assert.deepEqual(nodes.map((node) => node.name), ['alpha', 'beta']);
+  const files = flatten(nodes).filter((node) => node.type === 'file');
+  assert.equal(files.length, 2);
+  assert.notEqual(files[0].key, files[1].key);
+  assert.equal(files[0].entry, duplicate, 'first exact duplicate wins');
+});
+
+test('Map-backed tries tolerate hostile and selector-sensitive segments', () => {
+  const paths = [
+    '__proto__/x.js', 'constructor/y.js', 'a"b/q.js', 'a\\b/r.js',
+    'a[b]/s.js', 'a#b/t.js',
+  ];
+  const nodes = buildFileTree(paths.map((path) => entry(path)));
+  assert.deepEqual(flatten(nodes).filter((node) => node.type === 'file').map((node) => node.path).sort(),
+    [...paths].sort());
+  assert.equal(buildFileTree([{}, entry(''), null]).length, 0);
+});
+
+test('firstFile follows rendered order and statuses cover additions, copies and deletions', () => {
+  const nodes = buildFileTree([entry('z.js'), entry('a/x.js')]);
+  assert.equal(firstFile(nodes).path, 'a/x.js');
+  assert.equal(firstFile([]), null);
+  assert.equal(fileStatus(entry('a', { isNew: true })), 'add');
+  assert.equal(fileStatus(entry('a', { f: { path: 'a', status: 'A' } })), 'add');
+  assert.equal(fileStatus(entry('a', { f: { path: 'a', status: 'C' } })), 'add');
+  assert.equal(fileStatus(entry('a', { f: { path: 'a', status: 'D' } })), 'del');
+  assert.equal(fileStatus(entry('a', { f: { path: 'a', status: 'R' } })), 'mod');
+});
+
+test('renderer uses native accessible controls, safe IDs, and visual-only initialization', () => {
+  const rows = [
+    entry('src/x.js', { project: 'alpha' }),
+    entry('src/y.js', { project: 'alpha', f: { path: 'src/y.js', status: 'R', from: 'old/y.ts', added: 2, removed: 3 } }),
+  ];
+  const nodes = buildFileTree(rows);
+  const first = firstFile(nodes);
+  const picks = [];
+  const { document, nav } = render(nodes, { initialKey: first.key, onPick: (...args) => picks.push(args) });
+  assert.equal(nav.tagName, 'NAV');
+  assert.equal(nav.getAttribute('aria-label'), 'Changed files');
+  const heading = nav.querySelector('.hd-tree-project');
+  assert.equal(heading.getAttribute('role'), 'heading');
+  assert.equal(heading.getAttribute('aria-level'), '3');
+  for (const button of nav.querySelectorAll('button')) assert.equal(button.type, 'button');
+  const dir = nav.querySelector('.hd-tree-dir');
+  const group = document.getElementById(dir.getAttribute('aria-controls'));
+  assert.ok(group);
+  assert.equal(dir.nextElementSibling, group);
+  assert.equal(dir.getAttribute('aria-expanded'), 'true');
+  assert.equal(group.hidden, false);
+  assert.equal(nav.querySelectorAll('[aria-current="true"]').length, 1);
+  assert.equal(picks.length, 0, 'initialization is visual only');
+
+  const rename = [...nav.querySelectorAll('.hd-tree-file')].find((button) => button.dataset.path === 'src/y.js');
+  assert.equal(rename.querySelector('.hd-diff-path').textContent, 'y.js');
+  assert.match(rename.getAttribute('aria-label'), /Renamed from old\/y\.ts to src\/y\.js in project alpha/);
+  assert.match(rename.getAttribute('aria-label'), /2 lines added, 3 lines removed/);
+  assert.match(rename.title, /old\/y\.ts/);
+  assert.ok([...rename.querySelectorAll('.hd-tree-status')].every((node) => node.getAttribute('aria-hidden') === 'true'));
+});
+
+test('directory toggles preserve children and selection without invoking onPick', () => {
+  const rows = [entry('src/a.js'), entry('src/b.js')];
+  const nodes = buildFileTree(rows);
+  const picks = [];
+  const { dom, nav } = render(nodes, {
+    initialKey: firstFile(nodes).key,
+    onPick: (...args) => picks.push(args),
+  });
+  const dir = nav.querySelector('.hd-tree-dir');
+  const group = nav.querySelector(`#${dir.getAttribute('aria-controls')}`);
+  const children = [...group.childNodes];
+  dir.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  assert.equal(group.hidden, true);
+  assert.equal(dir.getAttribute('aria-expanded'), 'false');
+  assert.match(dir.getAttribute('aria-label'), /^Expand directory/);
+  assert.deepEqual([...group.childNodes], children);
+  assert.equal(nav.querySelectorAll('[aria-current="true"]').length, 1);
+  assert.equal(picks.length, 0);
+});
+
+test('duplicate project paths activate exactly one captured entry', () => {
+  const alpha = entry('src/x.js', { project: 'alpha' });
+  const beta = entry('src/x.js', { project: 'beta' });
+  const picks = [];
+  const { dom, nav } = render(buildFileTree([alpha, beta]), { onPick: (...args) => picks.push(args) });
+  const buttons = [...nav.querySelectorAll('.hd-tree-file')];
+  buttons[0].dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  buttons[1].dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  assert.equal(nav.querySelectorAll('[aria-current="true"]').length, 1);
+  assert.equal(nav.querySelector('[aria-current="true"]').dataset.project, 'beta');
+  assert.equal(picks.at(-1)[0], beta);
+});
+
+test('separately rendered trees have disjoint control IDs and unknown initialization is inert', () => {
+  const nodes = buildFileTree([entry('src/x.js')]);
+  const a = render(nodes, { initialKey: 'missing' });
+  const b = render(nodes);
+  a.document.body.appendChild(b.nav);
+  const aIds = new Set([...a.nav.querySelectorAll('[id]')].map((node) => node.id));
+  const bIds = new Set([...b.nav.querySelectorAll('[id]')].map((node) => node.id));
+  assert.ok([...aIds].every((id) => !bIds.has(id)));
+  assert.equal(a.nav.querySelector('[aria-current]'), null);
+  for (const nav of [a.nav, b.nav]) {
+    for (const control of nav.querySelectorAll('[aria-controls]')) {
+      assert.ok(nav.querySelector(`#${control.getAttribute('aria-controls')}`));
+    }
+  }
+});

--- a/test/hljs-loader.test.mjs
+++ b/test/hljs-loader.test.mjs
@@ -1,0 +1,196 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createHljsLoader, _testing } from '../ui/public/hljs-loader.mjs';
+
+function fakeFactory(log = []) {
+  return {
+    newInstance() {
+      const languages = new Map();
+      const instance = {
+        registerLanguage(lang, grammar) {
+          languages.set(lang, grammar);
+          log.push(['register', lang, instance]);
+        },
+        getLanguage(lang) { return languages.get(lang); },
+        highlight(text, options) {
+          log.push(['highlight', text, options, instance]);
+          return { value: `${options.language}:${text}` };
+        },
+        languages,
+      };
+      log.push(['instance', instance]);
+      return instance;
+    },
+  };
+}
+
+const grammar = () => ({});
+
+test('invalid and unmapped language IDs never call resource loaders', async () => {
+  let calls = 0;
+  const loader = createHljsLoader({
+    loadCore: async () => { calls += 1; return { default: fakeFactory() }; },
+    loadGrammar: async () => { calls += 1; return { default: grammar }; },
+  });
+  for (const id of ['', '../javascript', 'javascript/x', 'brainfuck', 'JavaScript',
+    { toString() { throw new Error('no'); } }]) {
+    assert.equal(await loader.forLanguage(id), null);
+  }
+  assert.equal(calls, 0);
+});
+
+test('concurrent languages share core loading but receive isolated primary-only instances', async () => {
+  const log = [];
+  let coreCalls = 0;
+  const grammarCalls = [];
+  const loader = createHljsLoader({
+    loadCore: async () => { coreCalls += 1; return { default: fakeFactory(log) }; },
+    loadGrammar: async (lang) => { grammarCalls.push(lang); return { default: grammar }; },
+  });
+  const [js, xml] = await Promise.all([
+    loader.forLanguage('javascript'), loader.forLanguage('xml'),
+  ]);
+  assert.equal(coreCalls, 1);
+  assert.deepEqual(grammarCalls.sort(), ['javascript', 'xml']);
+  assert.notEqual(js, xml);
+  assert.equal(log.filter(([kind]) => kind === 'instance').length, 2);
+  const registered = log.filter(([kind]) => kind === 'register');
+  assert.deepEqual(registered.map((entry) => entry[1]).sort(), ['javascript', 'xml']);
+  assert.notEqual(registered[0][2], registered[1][2]);
+});
+
+test('same-language concurrency and successful caches reuse one complete binding', async () => {
+  let coreCalls = 0;
+  let grammarCalls = 0;
+  const log = [];
+  const loader = createHljsLoader({
+    loadCore: async () => { coreCalls += 1; return { default: fakeFactory(log) }; },
+    loadGrammar: async () => { grammarCalls += 1; return { default: grammar }; },
+  });
+  const [a, b] = await Promise.all([
+    loader.forLanguage('javascript'), loader.forLanguage('javascript'),
+  ]);
+  const c = await loader.forLanguage('javascript');
+  assert.equal(a, b);
+  assert.equal(a, c);
+  assert.equal(coreCalls, 1);
+  assert.equal(grammarCalls, 1);
+  assert.equal(log.filter(([kind]) => kind === 'instance').length, 1);
+});
+
+test('failed core and grammar resources retry with monotonically increasing attempts', async () => {
+  const coreAttempts = [];
+  const grammarAttempts = [];
+  const loader = createHljsLoader({
+    loadCore: async (attempt) => {
+      coreAttempts.push(attempt);
+      if (attempt === 0) throw new Error('first core');
+      return { default: fakeFactory() };
+    },
+    loadGrammar: async (lang, attempt) => {
+      grammarAttempts.push([lang, attempt]);
+      return { default: grammar };
+    },
+  });
+  assert.equal(await loader.forLanguage('javascript'), null);
+  assert.ok(await loader.forLanguage('javascript'));
+  assert.deepEqual(coreAttempts, [0, 1]);
+  assert.deepEqual(grammarAttempts, [['javascript', 0]], 'successful grammar stays cached');
+
+  const grammarRetry = [];
+  const second = createHljsLoader({
+    loadCore: async () => ({ default: fakeFactory() }),
+    loadGrammar: async (lang, attempt) => {
+      grammarRetry.push([lang, attempt]);
+      if (attempt === 0) throw new Error('first grammar');
+      return { default: grammar };
+    },
+  });
+  assert.equal(await second.forLanguage('python'), null);
+  assert.ok(await second.forLanguage('python'));
+  assert.deepEqual(grammarRetry, [['python', 0], ['python', 1]]);
+});
+
+test('retry URLs use distinct query strings', () => {
+  assert.equal(_testing.coreUrl(0), '/vendor/hljs/core.min.js?retry=0');
+  assert.equal(_testing.coreUrl(1), '/vendor/hljs/core.min.js?retry=1');
+  assert.equal(_testing.grammarUrl('javascript', 0),
+    '/vendor/hljs/languages/javascript.min.js?retry=0');
+  assert.equal(_testing.grammarUrl('javascript', 1),
+    '/vendor/hljs/languages/javascript.min.js?retry=1');
+});
+
+test('binding failures do not refetch successful resources and retry with a fresh instance', async () => {
+  let coreCalls = 0;
+  let grammarCalls = 0;
+  let instances = 0;
+  const factory = {
+    newInstance() {
+      instances += 1;
+      if (instances === 1) throw new Error('fail once');
+      return fakeFactory().newInstance();
+    },
+  };
+  const loader = createHljsLoader({
+    loadCore: async () => { coreCalls += 1; return { default: factory }; },
+    loadGrammar: async () => { grammarCalls += 1; return { default: grammar }; },
+  });
+  assert.equal(await loader.forLanguage('javascript'), null);
+  assert.ok(await loader.forLanguage('javascript'));
+  assert.equal(instances, 2);
+  assert.equal(coreCalls, 1);
+  assert.equal(grammarCalls, 1);
+});
+
+test('bad module and instance shapes degrade to null', async () => {
+  const badCore = createHljsLoader({
+    loadCore: async () => ({ default: {} }), loadGrammar: async () => ({ default: grammar }),
+  });
+  assert.equal(await badCore.forLanguage('javascript'), null);
+
+  const badGrammar = createHljsLoader({
+    loadCore: async () => ({ default: fakeFactory() }), loadGrammar: async () => ({ default: {} }),
+  });
+  assert.equal(await badGrammar.forLanguage('javascript'), null);
+
+  const badInstance = createHljsLoader({
+    loadCore: async () => ({ default: { newInstance: () => ({}) } }),
+    loadGrammar: async () => ({ default: grammar }),
+  });
+  assert.equal(await badInstance.forLanguage('javascript'), null);
+});
+
+test('bound highlighter returns value and pins the primary language options', async () => {
+  const log = [];
+  const loader = createHljsLoader({
+    loadCore: async () => ({ default: fakeFactory(log) }),
+    loadGrammar: async () => ({ default: grammar }),
+  });
+  const bound = await loader.forLanguage('javascript');
+  assert.equal(bound.highlight('const x = 1;'), 'javascript:const x = 1;');
+  const call = log.find(([kind]) => kind === 'highlight');
+  assert.deepEqual(call[2], { language: 'javascript', ignoreIllegals: true });
+  assert.throws(() => bound.highlight('x', 'python'), /language mismatch/);
+});
+
+test('real isolated instances keep XML output independent of JavaScript load order', async () => {
+  const core = await import('@highlightjs/cdn-assets/es/core.min.js');
+  const loader = createHljsLoader({
+    loadCore: async () => core,
+    loadGrammar: async (lang) => import(`@highlightjs/cdn-assets/es/languages/${lang}.min.js`),
+  });
+  const xml = await loader.forLanguage('xml');
+  const source = '<script>const x = 1;</script>';
+  const before = xml.highlight(source);
+  await loader.forLanguage('javascript');
+  assert.equal(xml.highlight(source), before);
+
+  const reverse = createHljsLoader({
+    loadCore: async () => core,
+    loadGrammar: async (lang) => import(`@highlightjs/cdn-assets/es/languages/${lang}.min.js`),
+  });
+  await reverse.forLanguage('javascript');
+  const after = (await reverse.forLanguage('xml')).highlight(source);
+  assert.equal(after, before);
+});

--- a/test/hljs-loader.test.mjs
+++ b/test/hljs-loader.test.mjs
@@ -143,6 +143,42 @@ test('binding failures do not refetch successful resources and retry with a fres
   assert.equal(grammarCalls, 1);
 });
 
+test('throwing registration and lookup failures retry from cached resources with fresh instances', async () => {
+  for (const failure of ['register throws', 'lookup throws', 'lookup false']) {
+    let coreCalls = 0;
+    let grammarCalls = 0;
+    let instances = 0;
+    const factory = {
+      newInstance() {
+        instances += 1;
+        const fail = instances === 1;
+        let registered = false;
+        return {
+          registerLanguage() {
+            if (fail && failure === 'register throws') throw new Error(failure);
+            registered = true;
+          },
+          getLanguage() {
+            if (fail && failure === 'lookup throws') throw new Error(failure);
+            if (fail && failure === 'lookup false') return false;
+            return registered;
+          },
+          highlight(text) { return { value: String(text) }; },
+        };
+      },
+    };
+    const loader = createHljsLoader({
+      loadCore: async () => { coreCalls += 1; return { default: factory }; },
+      loadGrammar: async () => { grammarCalls += 1; return { default: grammar }; },
+    });
+    assert.equal(await loader.forLanguage('javascript'), null, failure);
+    assert.ok(await loader.forLanguage('javascript'), `${failure} retry succeeds`);
+    assert.equal(instances, 2, `${failure} builds a fresh instance`);
+    assert.equal(coreCalls, 1, `${failure} reuses the core factory`);
+    assert.equal(grammarCalls, 1, `${failure} reuses the grammar function`);
+  }
+});
+
 test('bad module and instance shapes degrade to null', async () => {
   const badCore = createHljsLoader({
     loadCore: async () => ({ default: {} }), loadGrammar: async () => ({ default: grammar }),
@@ -172,6 +208,72 @@ test('bound highlighter returns value and pins the primary language options', as
   const call = log.find(([kind]) => kind === 'highlight');
   assert.deepEqual(call[2], { language: 'javascript', ignoreIllegals: true });
   assert.throws(() => bound.highlight('x', 'python'), /language mismatch/);
+});
+
+test('throwing highlighters and invalid highlight results fail synchronously', async () => {
+  for (const result of [null, {}, { value: 1 }]) {
+    const loader = createHljsLoader({
+      loadCore: async () => ({
+        default: {
+          newInstance: () => ({
+            registerLanguage() {},
+            getLanguage() { return true; },
+            highlight() { return result; },
+          }),
+        },
+      }),
+      loadGrammar: async () => ({ default: grammar }),
+    });
+    const bound = await loader.forLanguage('javascript');
+    assert.ok(bound);
+    assert.throws(() => bound.highlight('x'), /invalid highlight result/);
+  }
+
+  const throwing = createHljsLoader({
+    loadCore: async () => ({
+      default: {
+        newInstance: () => ({
+          registerLanguage() {},
+          getLanguage() { return true; },
+          highlight() { throw new Error('highlight failed'); },
+        }),
+      },
+    }),
+    loadGrammar: async () => ({ default: grammar }),
+  });
+  const bound = await throwing.forLanguage('javascript');
+  assert.throws(() => bound.highlight('x'), /highlight failed/);
+});
+
+test('async loader and binding failures produce no unhandled rejection', async () => {
+  const unhandled = [];
+  const onUnhandled = (reason) => unhandled.push(reason);
+  process.on('unhandledRejection', onUnhandled);
+  try {
+    const importFailure = createHljsLoader({
+      loadCore: async () => { throw new Error('core failed'); },
+      loadGrammar: async () => { throw new Error('grammar failed'); },
+    });
+    assert.equal(await importFailure.forLanguage('javascript'), null);
+
+    const registrationFailure = createHljsLoader({
+      loadCore: async () => ({
+        default: {
+          newInstance: () => ({
+            registerLanguage() { throw new Error('register failed'); },
+            getLanguage() { throw new Error('lookup should not run'); },
+            highlight() { return { value: '' }; },
+          }),
+        },
+      }),
+      loadGrammar: async () => ({ default: grammar }),
+    });
+    assert.equal(await registrationFailure.forLanguage('javascript'), null);
+    await new Promise((resolve) => setImmediate(resolve));
+  } finally {
+    process.off('unhandledRejection', onUnhandled);
+  }
+  assert.deepEqual(unhandled, []);
 });
 
 test('real isolated instances keep XML output independent of JavaScript load order', async () => {

--- a/test/hljs-loader.test.mjs
+++ b/test/hljs-loader.test.mjs
@@ -1,7 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createHljsLoader, _testing } from '../ui/public/hljs-loader.mjs';
+import {
+  createHljsLoader, HLJS_SUB_LANGUAGES, HLJS_GRAMMAR_IDS, MAX_RESOURCE_FAILURES, _testing,
+} from '../ui/public/hljs-loader.mjs';
+import { SUPPORTED_LANGUAGE_IDS, rowsFromHtml } from '../ui/public/syntax-highlight.mjs';
+
+const ASSETS = '@highlightjs/cdn-assets/es';
+const realAssets = {
+  loadCore: () => import(`${ASSETS}/core.min.js`),
+  loadGrammar: (lang) => import(`${ASSETS}/languages/${lang}.min.js`),
+};
 
 function fakeFactory(log = []) {
   return {
@@ -40,7 +49,7 @@ test('invalid and unmapped language IDs never call resource loaders', async () =
   assert.equal(calls, 0);
 });
 
-test('concurrent languages share core loading but receive isolated primary-only instances', async () => {
+test('concurrent languages share core and grammar loading but receive isolated instances', async () => {
   const log = [];
   let coreCalls = 0;
   const grammarCalls = [];
@@ -52,21 +61,127 @@ test('concurrent languages share core loading but receive isolated primary-only 
     loader.forLanguage('javascript'), loader.forLanguage('xml'),
   ]);
   assert.equal(coreCalls, 1);
-  assert.deepEqual(grammarCalls.sort(), ['javascript', 'xml']);
+  // css/graphql/javascript/xml are each fetched ONCE even though both closures need them.
+  assert.deepEqual(grammarCalls.sort(), ['css', 'graphql', 'javascript', 'xml']);
   assert.notEqual(js, xml);
-  assert.equal(log.filter(([kind]) => kind === 'instance').length, 2);
-  const registered = log.filter(([kind]) => kind === 'register');
-  assert.deepEqual(registered.map((entry) => entry[1]).sort(), ['javascript', 'xml']);
-  assert.notEqual(registered[0][2], registered[1][2]);
+  const instances = log.filter(([kind]) => kind === 'instance').map(([, instance]) => instance);
+  assert.equal(instances.length, 2);
+  const registeredOn = (instance) => log
+    .filter(([kind, , target]) => kind === 'register' && target === instance)
+    .map((entry) => entry[1]).sort();
+  assert.deepEqual(instances.map(registeredOn).sort((a, b) => a.length - b.length), [
+    ['css', 'graphql', 'javascript', 'xml'],
+    ['css', 'graphql', 'javascript', 'xml'],
+  ]);
+  assert.deepEqual([...instances[0].languages.keys()].length, 4);
+});
+
+test('a language without sub-languages registers exactly its own grammar', async () => {
+  const log = [];
+  const grammarCalls = [];
+  const loader = createHljsLoader({
+    loadCore: async () => ({ default: fakeFactory(log) }),
+    loadGrammar: async (lang) => { grammarCalls.push(lang); return { default: grammar }; },
+  });
+  assert.ok(await loader.forLanguage('python'));
+  assert.deepEqual(grammarCalls, ['python']);
+  assert.deepEqual(log.filter(([kind]) => kind === 'register').map((entry) => entry[1]), ['python']);
+});
+
+test('the sub-language map is the transitive closure declared by the pinned grammars', async () => {
+  const core = (await realAssets.loadCore()).default;
+  const collect = (def, seen = new Set(), out = new Set()) => {
+    if (!def || typeof def !== 'object' || seen.has(def)) return out;
+    seen.add(def);
+    if (def.subLanguage !== undefined) {
+      for (const sub of [].concat(def.subLanguage)) out.add(sub);
+    }
+    for (const key of ['contains', 'starts', 'variants']) {
+      const value = def[key];
+      if (Array.isArray(value)) value.forEach((child) => collect(child, seen, out));
+      else if (value && typeof value === 'object') collect(value, seen, out);
+    }
+    return out;
+  };
+  const direct = new Map();
+  const directOf = async (lang) => {
+    if (!direct.has(lang)) {
+      const definition = (await realAssets.loadGrammar(lang)).default(core.newInstance());
+      direct.set(lang, [...collect(definition)]);
+    }
+    return direct.get(lang);
+  };
+  const expected = {};
+  for (const lang of SUPPORTED_LANGUAGE_IDS) {
+    const closure = new Set();
+    const queue = [lang];
+    while (queue.length) {
+      for (const sub of await directOf(queue.shift())) {
+        assert.equal(typeof sub, 'string', `${lang}: array sub-languages would autodetect`);
+        if (sub === lang || closure.has(sub)) continue;
+        closure.add(sub);
+        queue.push(sub);
+      }
+    }
+    if (closure.size) expected[lang] = [...closure].sort();
+  }
+  assert.deepEqual(JSON.parse(JSON.stringify(HLJS_SUB_LANGUAGES)), expected);
+  assert.ok(Object.isFrozen(HLJS_SUB_LANGUAGES));
+  for (const subs of Object.values(HLJS_SUB_LANGUAGES)) assert.ok(Object.isFrozen(subs));
+  const union = new Set([...SUPPORTED_LANGUAGE_IDS, ...Object.values(expected).flat()]);
+  assert.deepEqual([...HLJS_GRAMMAR_IDS], [...union].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)));
+  assert.ok(HLJS_GRAMMAR_IDS.includes('mojolicious'), 'perl delegates its __DATA__ templates');
+  assert.ok(!SUPPORTED_LANGUAGE_IDS.includes('mojolicious'), 'sub-languages are not primaries');
+});
+
+test('production-shaped bindings highlight embedded sub-languages', async () => {
+  const loader = createHljsLoader(realAssets);
+  const jsx = [
+    'export default function App({ items }) {',
+    '  return <ul className="list">{items.map((item) => <li key={item.id}>{item.label}</li>)}</ul>;',
+    '}',
+  ].join('\n');
+  const js = (await loader.forLanguage('javascript')).highlight(jsx);
+  assert.match(js, /<span class="language-xml"><span class="hljs-tag">/);
+  assert.match(js, /<span class="hljs-attr">className<\/span>/);
+  assert.equal(rowsFromHtml(js)?.length, 3, 'the strict row parser accepts sub-language wrappers');
+
+  const xml = (await loader.forLanguage('xml'))
+    .highlight('<style>.a{color:red}</style><script>const x = 1;</script>');
+  assert.match(xml, /<span class="language-css">.*hljs-selector-class/);
+  assert.match(xml, /<span class="language-javascript">.*hljs-keyword/);
+
+  const dockerfile = (await loader.forLanguage('dockerfile')).highlight('RUN apt-get install -y curl');
+  assert.match(dockerfile, /<span class="language-bash">/);
+
+  const typescript = (await loader.forLanguage('typescript')).highlight('const el = <div id="x" />;');
+  assert.match(typescript, /<span class="language-xml">/);
+});
+
+test('a failed sub-language grammar yields no binding, then retries only that grammar', async () => {
+  const attempts = [];
+  const loader = createHljsLoader({
+    loadCore: async () => ({ default: fakeFactory() }),
+    loadGrammar: async (lang, attempt) => {
+      attempts.push([lang, attempt]);
+      if (lang === 'graphql' && attempt === 0) throw new Error('graphql 404');
+      return { default: grammar };
+    },
+  });
+  assert.equal(await loader.forLanguage('javascript'), null);
+  assert.ok(await loader.forLanguage('javascript'));
+  assert.deepEqual(attempts.sort(), [
+    ['css', 0], ['graphql', 0], ['graphql', 1], ['javascript', 0], ['xml', 0],
+  ]);
 });
 
 test('same-language concurrency and successful caches reuse one complete binding', async () => {
   let coreCalls = 0;
-  let grammarCalls = 0;
+  const grammarCalls = [];
   const log = [];
   const loader = createHljsLoader({
     loadCore: async () => { coreCalls += 1; return { default: fakeFactory(log) }; },
-    loadGrammar: async () => { grammarCalls += 1; return { default: grammar }; },
+    loadGrammar: async (lang) => { grammarCalls.push(lang); return { default: grammar }; },
   });
   const [a, b] = await Promise.all([
     loader.forLanguage('javascript'), loader.forLanguage('javascript'),
@@ -75,7 +190,7 @@ test('same-language concurrency and successful caches reuse one complete binding
   assert.equal(a, b);
   assert.equal(a, c);
   assert.equal(coreCalls, 1);
-  assert.equal(grammarCalls, 1);
+  assert.deepEqual(grammarCalls.sort(), ['css', 'graphql', 'javascript', 'xml']);
   assert.equal(log.filter(([kind]) => kind === 'instance').length, 1);
 });
 
@@ -96,7 +211,9 @@ test('failed core and grammar resources retry with monotonically increasing atte
   assert.equal(await loader.forLanguage('javascript'), null);
   assert.ok(await loader.forLanguage('javascript'));
   assert.deepEqual(coreAttempts, [0, 1]);
-  assert.deepEqual(grammarAttempts, [['javascript', 0]], 'successful grammar stays cached');
+  assert.deepEqual(grammarAttempts.sort(), [
+    ['css', 0], ['graphql', 0], ['javascript', 0], ['xml', 0],
+  ], 'successful grammars stay cached');
 
   const grammarRetry = [];
   const second = createHljsLoader({
@@ -110,6 +227,36 @@ test('failed core and grammar resources retry with monotonically increasing atte
   assert.equal(await second.forLanguage('python'), null);
   assert.ok(await second.forLanguage('python'));
   assert.deepEqual(grammarRetry, [['python', 0], ['python', 1]]);
+});
+
+test('a resource that keeps failing is abandoned after MAX_RESOURCE_FAILURES loads', async () => {
+  let coreCalls = 0;
+  const grammarCalls = [];
+  const loader = createHljsLoader({
+    loadCore: async () => { coreCalls += 1; throw new Error('core 404'); },
+    loadGrammar: async (lang) => { grammarCalls.push(lang); return { default: grammar }; },
+  });
+  for (let i = 0; i < MAX_RESOURCE_FAILURES + 5; i += 1) {
+    assert.equal(await loader.forLanguage('python'), null);
+  }
+  assert.equal(coreCalls, MAX_RESOURCE_FAILURES, 'no further core imports after the ceiling');
+  assert.deepEqual(grammarCalls, ['python'], 'the successful grammar was fetched once and cached');
+
+  const grammarAttempts = [];
+  const perGrammar = createHljsLoader({
+    loadCore: async () => ({ default: fakeFactory() }),
+    loadGrammar: async (lang, attempt) => {
+      grammarAttempts.push([lang, attempt]);
+      if (lang === 'graphql') throw new Error('graphql 404');
+      return { default: grammar };
+    },
+  });
+  for (let i = 0; i < MAX_RESOURCE_FAILURES + 5; i += 1) {
+    assert.equal(await perGrammar.forLanguage('javascript'), null);
+  }
+  assert.deepEqual(grammarAttempts.filter(([lang]) => lang === 'graphql').map(([, a]) => a),
+    [...Array(MAX_RESOURCE_FAILURES).keys()], 'only the failing grammar retried, then abandoned');
+  assert.ok(await perGrammar.forLanguage('python'), 'other languages are unaffected');
 });
 
 test('retry URLs use distinct query strings', () => {
@@ -140,7 +287,7 @@ test('binding failures do not refetch successful resources and retry with a fres
   assert.ok(await loader.forLanguage('javascript'));
   assert.equal(instances, 2);
   assert.equal(coreCalls, 1);
-  assert.equal(grammarCalls, 1);
+  assert.equal(grammarCalls, 4, 'javascript + its 3 sub-language grammars, none refetched');
 });
 
 test('throwing registration and lookup failures retry from cached resources with fresh instances', async () => {
@@ -175,7 +322,7 @@ test('throwing registration and lookup failures retry from cached resources with
     assert.ok(await loader.forLanguage('javascript'), `${failure} retry succeeds`);
     assert.equal(instances, 2, `${failure} builds a fresh instance`);
     assert.equal(coreCalls, 1, `${failure} reuses the core factory`);
-    assert.equal(grammarCalls, 1, `${failure} reuses the grammar function`);
+    assert.equal(grammarCalls, 4, `${failure} reuses every cached grammar function`);
   }
 });
 
@@ -277,21 +424,15 @@ test('async loader and binding failures produce no unhandled rejection', async (
 });
 
 test('real isolated instances keep XML output independent of JavaScript load order', async () => {
-  const core = await import('@highlightjs/cdn-assets/es/core.min.js');
-  const loader = createHljsLoader({
-    loadCore: async () => core,
-    loadGrammar: async (lang) => import(`@highlightjs/cdn-assets/es/languages/${lang}.min.js`),
-  });
+  const loader = createHljsLoader(realAssets);
   const xml = await loader.forLanguage('xml');
   const source = '<script>const x = 1;</script>';
   const before = xml.highlight(source);
+  assert.match(before, /language-javascript/, 'the script body is highlighted, not plain');
   await loader.forLanguage('javascript');
   assert.equal(xml.highlight(source), before);
 
-  const reverse = createHljsLoader({
-    loadCore: async () => core,
-    loadGrammar: async (lang) => import(`@highlightjs/cdn-assets/es/languages/${lang}.min.js`),
-  });
+  const reverse = createHljsLoader(realAssets);
   await reverse.forLanguage('javascript');
   const after = (await reverse.forLanguage('xml')).highlight(source);
   assert.equal(after, before);

--- a/test/syntax-highlight.test.mjs
+++ b/test/syntax-highlight.test.mjs
@@ -1,0 +1,210 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import {
+  langForPath, SUPPORTED_LANGUAGE_IDS, rowsFromHtml, canHighlightParsed,
+  highlightHunk, highlightParsed, MAX_HIGHLIGHT_INPUT_BYTES,
+  MAX_HIGHLIGHT_INPUT_ROWS, MAX_HIGHLIGHT_OUTPUT_CHARS,
+  MAX_HIGHLIGHT_OUTPUT_ROWS, MAX_HIGHLIGHT_OUTPUT_SPANS, MAX_HIGHLIGHT_NESTING,
+} from '../ui/public/syntax-highlight.mjs';
+
+const escape = (text) => String(text)
+  .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;').replaceAll("'", '&#x27;');
+
+const hunk = (lines, over = {}) => ({
+  oldStart: 1,
+  oldCount: lines.filter((line) => line.kind !== 'add').length,
+  newStart: 1,
+  newCount: lines.filter((line) => line.kind !== 'del').length,
+  lines,
+  ...over,
+});
+
+test('reviewed path map is exact, case-insensitive, and fail-closed', () => {
+  const cases = {
+    'x.js': 'javascript', 'x.mjs': 'javascript', 'x.cjs': 'javascript', 'x.jsx': 'javascript',
+    'x.ts': 'typescript', 'x.mts': 'typescript', 'x.cts': 'typescript', 'x.tsx': 'typescript',
+    'x.json': 'json', 'x.jsonc': 'json', 'x.json5': 'json',
+    'x.css': 'css', 'x.scss': 'scss', 'x.sass': 'scss', 'x.less': 'less',
+    'x.html': 'xml', 'x.htm': 'xml', 'x.xml': 'xml', 'x.svg': 'xml', 'x.vue': 'xml',
+    'x.md': 'markdown', 'x.markdown': 'markdown', 'x.yml': 'yaml', 'x.yaml': 'yaml',
+    'x.toml': 'ini', 'x.ini': 'ini', 'x.properties': 'properties',
+    'x.sh': 'bash', 'x.bash': 'bash', 'x.zsh': 'bash', 'x.fish': 'bash',
+    'x.py': 'python', 'x.rb': 'ruby', 'x.php': 'php', 'x.go': 'go', 'x.rs': 'rust',
+    'x.java': 'java', 'x.kt': 'kotlin', 'x.kts': 'kotlin', 'x.swift': 'swift', 'x.scala': 'scala',
+    'x.c': 'c', 'x.h': 'c', 'x.cpp': 'cpp', 'x.cc': 'cpp', 'x.cxx': 'cpp', 'x.hpp': 'cpp',
+    'x.cs': 'csharp', 'x.sql': 'sql', 'x.graphql': 'graphql', 'x.gql': 'graphql',
+    'x.proto': 'protobuf', 'x.lua': 'lua', 'x.pl': 'perl', 'x.r': 'r', 'x.dart': 'dart',
+    'x.ex': 'elixir', 'x.exs': 'elixir', 'x.erl': 'erlang', 'x.hs': 'haskell', 'x.clj': 'clojure',
+    'x.diff': 'diff', 'x.patch': 'diff', 'x.nix': 'nix', 'x.gradle': 'gradle',
+    Dockerfile: 'dockerfile', Makefile: 'makefile', Gemfile: 'ruby', Rakefile: 'ruby',
+    Vagrantfile: 'ruby', Brewfile: 'ruby',
+  };
+  for (const [path, lang] of Object.entries(cases)) {
+    assert.equal(langForPath(`dir/${path}`), lang, path);
+    assert.equal(langForPath(`dir/${path.toUpperCase()}`), lang, `${path} uppercase`);
+  }
+  for (const path of ['', '.gitignore', 'README', 'x.tf', 'x.hcl', 'x.png',
+    'constructor', 'x.constructor', '__proto__', 'x.__proto__', 'toString', 'x.toString']) {
+    assert.equal(langForPath(path), null, path);
+  }
+  assert.ok(Object.isFrozen(SUPPORTED_LANGUAGE_IDS));
+  assert.deepEqual(SUPPORTED_LANGUAGE_IDS, [...new Set(SUPPORTED_LANGUAGE_IDS)].sort());
+  assert.deepEqual(SUPPORTED_LANGUAGE_IDS, [...new Set(Object.values(cases))].sort());
+});
+
+test('every mapped pinned grammar registers and emits strict round-trippable rows', async () => {
+  const coreModule = await import('@highlightjs/cdn-assets/es/core.min.js');
+  for (const lang of SUPPORTED_LANGUAGE_IDS) {
+    const instance = coreModule.default.newInstance();
+    const grammar = await import(`@highlightjs/cdn-assets/es/languages/${lang}.min.js`);
+    assert.equal(typeof grammar.default, 'function', lang);
+    instance.registerLanguage(lang, grammar.default);
+    assert.ok(instance.getLanguage(lang), lang);
+    const value = instance.highlight('value', { language: lang, ignoreIllegals: true }).value;
+    const rows = rowsFromHtml(value);
+    assert.ok(rows, lang);
+    const dom = new JSDOM('<!doctype html><body></body>');
+    const holder = dom.window.document.createElement('span');
+    holder.innerHTML = rows[0];
+    assert.equal(holder.textContent, 'value', lang);
+  }
+});
+
+test('strict parser balances multiline spans and accepts only reviewed markup', () => {
+  assert.deepEqual(rowsFromHtml('<span class="hljs-comment">a\nb</span>'), [
+    '<span class="hljs-comment">a</span>',
+    '<span class="hljs-comment">b</span>',
+  ]);
+  assert.deepEqual(rowsFromHtml('<span class="language-javascript">x</span>'), [
+    '<span class="language-javascript">x</span>',
+  ]);
+  assert.deepEqual(rowsFromHtml('<span class="hljs-title function_">x</span>'), [
+    '<span class="hljs-title function_">x</span>',
+  ]);
+  for (const bad of [
+    '<img src=x>', '<span onclick="x">x</span>', '<span class="hidden">x</span>',
+    '<span class="hljs-keyword hidden">x</span>', '</span>', '<span class="hljs-keyword">x',
+    '&nbsp;', '&wat;', '<', '\u0000', '<script>x</script>',
+  ]) assert.equal(rowsFromHtml(bad), null, bad);
+  assert.equal(rowsFromHtml(`${'<span class="hljs-keyword">'.repeat(MAX_HIGHLIGHT_NESTING + 1)}x${'</span>'.repeat(MAX_HIGHLIGHT_NESTING + 1)}`), null);
+});
+
+test('strict parser enforces exact raw, row, span, and nesting output limits', () => {
+  assert.equal(rowsFromHtml('x'.repeat(MAX_HIGHLIGHT_OUTPUT_CHARS)).length, 1);
+  assert.equal(rowsFromHtml('x'.repeat(MAX_HIGHLIGHT_OUTPUT_CHARS + 1)), null);
+  const exactRows = Array.from({ length: MAX_HIGHLIGHT_OUTPUT_ROWS }, () => 'x').join('\n');
+  assert.equal(rowsFromHtml(exactRows).length, MAX_HIGHLIGHT_OUTPUT_ROWS);
+  assert.equal(rowsFromHtml(`${exactRows}\nx`), null);
+  const span = '<span class="hljs-x"></span>';
+  assert.ok(rowsFromHtml(span.repeat(MAX_HIGHLIGHT_OUTPUT_SPANS)));
+  assert.equal(rowsFromHtml(span.repeat(MAX_HIGHLIGHT_OUTPUT_SPANS + 1)), null);
+  const exactNesting = `${'<span class="hljs-x">'.repeat(MAX_HIGHLIGHT_NESTING)}x${'</span>'.repeat(MAX_HIGHLIGHT_NESTING)}`;
+  assert.ok(rowsFromHtml(exactNesting));
+});
+
+test('real XML embedded-language wrappers are accepted and round-trip source', async () => {
+  const core = await import('@highlightjs/cdn-assets/es/core.min.js');
+  const xml = await import('@highlightjs/cdn-assets/es/languages/xml.min.js');
+  const javascript = await import('@highlightjs/cdn-assets/es/languages/javascript.min.js');
+  const instance = core.default.newInstance();
+  instance.registerLanguage('javascript', javascript.default);
+  instance.registerLanguage('xml', xml.default);
+  const source = '<script>const x = 1;</script>';
+  const html = instance.highlight(source, { language: 'xml', ignoreIllegals: true }).value;
+  assert.match(html, /class="language-javascript"/);
+  const rows = rowsFromHtml(html);
+  assert.ok(rows);
+  const dom = new JSDOM('<!doctype html><body></body>');
+  const holder = dom.window.document.createElement('span');
+  holder.innerHTML = rows[0];
+  assert.equal(holder.textContent, source);
+  assert.ok([...holder.querySelectorAll('*')].every((element) => (
+    element.tagName === 'SPAN'
+      && [...element.attributes].every((attribute) => attribute.name === 'class')
+  )));
+});
+
+test('input preflight uses UTF-8 bytes and exact per-side row work', () => {
+  const exactBytes = { hunks: [hunk([{ kind: 'add', text: 'x'.repeat(MAX_HIGHLIGHT_INPUT_BYTES) }], {
+    oldStart: 0, oldCount: 0, newStart: 1, newCount: 1,
+  })] };
+  assert.equal(canHighlightParsed(exactBytes), true);
+  exactBytes.hunks[0].lines[0].text += 'é';
+  assert.equal(canHighlightParsed(exactBytes), false);
+
+  const exactRows = { hunks: [hunk(Array.from({ length: MAX_HIGHLIGHT_INPUT_ROWS }, () => ({
+    kind: 'add', text: '',
+  })), { oldStart: 0, oldCount: 0, newStart: 1, newCount: MAX_HIGHLIGHT_INPUT_ROWS })] };
+  assert.equal(canHighlightParsed(exactRows), true);
+  exactRows.hunks[0].lines.push({ kind: 'add', text: '' });
+  exactRows.hunks[0].newCount += 1;
+  assert.equal(canHighlightParsed(exactRows), false);
+
+  const context = { hunks: [hunk(Array.from({ length: 1_501 }, () => ({ kind: 'ctx', text: '' })))] };
+  assert.equal(canHighlightParsed(context), false, 'context rows count once on each side');
+});
+
+test('highlighting is source-faithful, side-aware, and hunk-atomic', () => {
+  const lines = [
+    { kind: 'ctx', text: 'same' },
+    { kind: 'del', text: '<old>&"\'' },
+    { kind: 'add', text: 'new' },
+  ];
+  const item = hunk(lines);
+  let call = 0;
+  assert.equal(highlightHunk(item, 'javascript', (text) => {
+    call += 1;
+    return `<span class="${call === 1 ? 'hljs-keyword' : 'hljs-string'}">${escape(text)}</span>`;
+  }), true);
+  assert.match(lines[0].html, /hljs-string/, 'context takes new-side markup');
+  assert.match(lines[1].html, /hljs-keyword/, 'deletion takes old-side markup');
+  assert.match(lines[2].html, /hljs-string/, 'addition takes new-side markup');
+
+  for (const line of lines) line.html = 'stale';
+  assert.equal(highlightHunk(item, 'javascript', () => '<span class="hljs-keyword">wrong</span>'), false);
+  assert.ok(lines.every((line) => !Object.hasOwn(line, 'html')));
+});
+
+test('empty rows retain own html properties and CR is serialized safely', () => {
+  const empty = hunk([{ kind: 'add', text: '' }], {
+    oldStart: 0, oldCount: 0, newStart: 1, newCount: 1,
+  });
+  assert.equal(highlightHunk(empty, 'javascript', () => ''), true);
+  assert.equal(Object.hasOwn(empty.lines[0], 'html'), true);
+  assert.equal(empty.lines[0].html, '');
+
+  const cr = hunk([{ kind: 'add', text: 'x\r' }], {
+    oldStart: 0, oldCount: 0, newStart: 1, newCount: 1,
+  });
+  assert.equal(highlightHunk(cr, 'javascript', () => 'x\r'), true);
+  assert.equal(cr.lines[0].html, 'x&#13;');
+  const dom = new JSDOM('<!doctype html><body></body>');
+  const holder = dom.window.document.createElement('span');
+  holder.innerHTML = cr.lines[0].html;
+  assert.equal(holder.textContent, 'x\r');
+});
+
+test('malformed hunks stay plain while independent eligible hunks can succeed', () => {
+  const good = hunk([{ kind: 'add', text: 'ok' }], {
+    oldStart: 0, oldCount: 0, newStart: 1, newCount: 1,
+  });
+  const bad = hunk([{ kind: 'add', text: 'bad', html: 'stale' }], { newCount: 2 });
+  const parsed = { hunks: [good, bad] };
+  assert.equal(highlightParsed(parsed, 'javascript', (text) => escape(text)), true);
+  assert.equal(good.lines[0].html, 'ok');
+  assert.equal(Object.hasOwn(bad.lines[0], 'html'), false);
+  assert.equal(canHighlightParsed({ hunks: [bad] }), false);
+});
+
+test('unsupported languages, thrown highlighters, and over-limit direct calls fail closed', () => {
+  const item = hunk([{ kind: 'add', text: 'x' }], {
+    oldStart: 0, oldCount: 0, newStart: 1, newCount: 1,
+  });
+  assert.equal(highlightHunk(item, 'brainfuck', escape), false);
+  assert.equal(highlightHunk(item, 'javascript', () => { throw new Error('boom'); }), false);
+  item.lines[0].text = 'é'.repeat(MAX_HIGHLIGHT_INPUT_BYTES);
+  assert.equal(highlightHunk(item, 'javascript', escape), false);
+});

--- a/test/syntax-highlight.test.mjs
+++ b/test/syntax-highlight.test.mjs
@@ -22,6 +22,39 @@ const hunk = (lines, over = {}) => ({
   ...over,
 });
 
+const additionHunk = (texts) => hunk(texts.map((text) => ({ kind: 'add', text })), {
+  oldStart: 0,
+  oldCount: 0,
+  newStart: 1,
+  newCount: texts.length,
+});
+
+function rawMarkup(chars) {
+  const prefix = '<span class="hljs-';
+  const suffix = '"></span>';
+  const html = `${prefix}${'x'.repeat(chars - prefix.length - suffix.length)}${suffix}`;
+  assert.equal(html.length, chars);
+  return html;
+}
+
+function balancedMarkup(chars) {
+  const openPrefix = '<span class="';
+  const openSuffix = '">';
+  const close = '</span>';
+  const openLength = Math.floor((chars - close.length * 3) / 3);
+  const text = 'x'.repeat(chars - (openLength + close.length) * 3);
+  const className = `hljs-${'x'.repeat(openLength - openPrefix.length - openSuffix.length - 5)}`;
+  const open = `${openPrefix}${className}${openSuffix}`;
+  assert.equal(open.length, openLength);
+  return { html: `${open}${text}\n\n${close}`, texts: [text, '', ''] };
+}
+
+const spanMarkup = (count) => '<span class="hljs-x"></span>'.repeat(count);
+const outputRows = (count, text = '') => Array.from({ length: count }, () => text).join('\n');
+
+const hasHtml = (hunkValue) => hunkValue.lines.every((line) => Object.hasOwn(line, 'html'));
+const lacksHtml = (hunkValue) => hunkValue.lines.every((line) => !Object.hasOwn(line, 'html'));
+
 test('reviewed path map is exact, case-insensitive, and fail-closed', () => {
   const cases = {
     'x.js': 'javascript', 'x.mjs': 'javascript', 'x.cjs': 'javascript', 'x.jsx': 'javascript',
@@ -145,6 +178,166 @@ test('input preflight uses UTF-8 bytes and exact per-side row work', () => {
 
   const context = { hunks: [hunk(Array.from({ length: 1_501 }, () => ({ kind: 'ctx', text: '' })))] };
   assert.equal(canHighlightParsed(context), false, 'context rows count once on each side');
+});
+
+test('highlightParsed aggregates raw-character work across hunks at exact and one-over limits', () => {
+  const half = MAX_HIGHLIGHT_OUTPUT_CHARS / 2;
+  const changed = () => hunk([{ kind: 'del', text: '' }, { kind: 'add', text: '' }]);
+
+  const exact = { hunks: [changed()] };
+  let calls = 0;
+  assert.equal(highlightParsed(exact, 'javascript', () => {
+    calls += 1;
+    return rawMarkup(half);
+  }), true);
+  assert.equal(calls, 2);
+  assert.ok(exact.hunks.every(hasHtml), 'an exact cap is accepted when the second side is final');
+
+  const followed = { hunks: [changed(), additionHunk([''])] };
+  calls = 0;
+  assert.equal(highlightParsed(followed, 'javascript', () => {
+    calls += 1;
+    return rawMarkup(half);
+  }), true);
+  assert.equal(calls, 2, 'no later hunk call is made after both sides reach the exact cap');
+  assert.ok(hasHtml(followed.hunks[0]));
+  assert.ok(lacksHtml(followed.hunks[1]));
+
+  const over = { hunks: [additionHunk(['']), additionHunk(['']), additionHunk([''])] };
+  calls = 0;
+  assert.equal(highlightParsed(over, 'javascript', () => {
+    const size = calls++ === 0 ? half : half + 1;
+    return rawMarkup(size);
+  }), true, 'the already accepted first hunk remains highlighted');
+  assert.equal(calls, 2, 'one-over exhausts the budget and suppresses later work');
+  assert.ok(hasHtml(over.hunks[0]));
+  assert.ok(lacksHtml(over.hunks[1]));
+  assert.ok(lacksHtml(over.hunks[2]));
+});
+
+test('highlightParsed aggregates rebalanced characters including close/reopen amplification', () => {
+  const half = MAX_HIGHLIGHT_OUTPUT_CHARS / 2;
+  const first = balancedMarkup(half);
+  const second = balancedMarkup(half);
+  assert.ok(first.html.length + second.html.length < MAX_HIGHLIGHT_OUTPUT_CHARS,
+    'raw output remains below the cap so rebalancing is the limiting dimension');
+
+  const exact = { hunks: [additionHunk(first.texts), additionHunk(second.texts)] };
+  let calls = 0;
+  assert.equal(highlightParsed(exact, 'javascript', () => [first.html, second.html][calls++]), true);
+  assert.equal(calls, 2);
+  assert.ok(exact.hunks.every(hasHtml), 'exact rebalanced output is accepted on the final side');
+
+  const followed = {
+    hunks: [additionHunk(first.texts), additionHunk(second.texts), additionHunk([''])],
+  };
+  calls = 0;
+  assert.equal(highlightParsed(followed, 'javascript', () => [first.html, second.html][calls++]), true);
+  assert.equal(calls, 2, 'the exact rebalanced cap suppresses the next hunk');
+  assert.ok(followed.hunks.slice(0, 2).every(hasHtml));
+  assert.ok(lacksHtml(followed.hunks[2]));
+
+  const overSecond = balancedMarkup(half + 1);
+  const over = {
+    hunks: [additionHunk(first.texts), additionHunk(overSecond.texts), additionHunk([''])],
+  };
+  calls = 0;
+  assert.equal(highlightParsed(over, 'javascript', () => [first.html, overSecond.html][calls++]), true);
+  assert.equal(calls, 2, 'aggregate rebalanced one-over suppresses the third call');
+  assert.ok(hasHtml(over.hunks[0]));
+  assert.ok(lacksHtml(over.hunks[1]));
+  assert.ok(lacksHtml(over.hunks[2]));
+});
+
+test('highlightParsed aggregates output rows and suppresses work after malformed one-over output', () => {
+  const half = MAX_HIGHLIGHT_OUTPUT_ROWS / 2;
+  const exact = {
+    hunks: [
+      additionHunk(Array.from({ length: half }, () => '')),
+      additionHunk(Array.from({ length: half }, () => '')),
+    ],
+  };
+  let calls = 0;
+  assert.equal(highlightParsed(exact, 'javascript', (text) => {
+    calls += 1;
+    return text;
+  }), true);
+  assert.equal(calls, 2);
+  assert.ok(exact.hunks.every(hasHtml), 'the exact aggregate row cap is accepted when final');
+
+  const malformed = { hunks: [additionHunk(['a']), additionHunk(['b']), additionHunk(['c'])] };
+  calls = 0;
+  assert.equal(highlightParsed(malformed, 'javascript', () => {
+    calls += 1;
+    return calls === 1
+      ? outputRows(half, 'wrong')
+      : `${outputRows(half, 'wrong')}<img>`;
+  }), false);
+  assert.equal(calls, 2, 'mismatched and malformed rows consume the exact cap before rejection');
+  assert.ok(malformed.hunks.every(lacksHtml));
+
+  const over = { hunks: [additionHunk(['a']), additionHunk(['b']), additionHunk(['c'])] };
+  calls = 0;
+  assert.equal(highlightParsed(over, 'javascript', () => {
+    calls += 1;
+    return outputRows(calls === 1 ? half : half + 1, 'wrong');
+  }), false);
+  assert.equal(calls, 2, 'aggregate output-row one-over suppresses the third call');
+  assert.ok(over.hunks.every(lacksHtml));
+});
+
+test('highlightParsed aggregates rendered spans across hunks at exact and one-over limits', () => {
+  const half = MAX_HIGHLIGHT_OUTPUT_SPANS / 2;
+
+  const exact = { hunks: [additionHunk(['']), additionHunk([''])] };
+  let calls = 0;
+  assert.equal(highlightParsed(exact, 'javascript', () => {
+    calls += 1;
+    return spanMarkup(half);
+  }), true);
+  assert.equal(calls, 2);
+  assert.ok(exact.hunks.every(hasHtml), 'the exact aggregate span cap is accepted when final');
+
+  const followed = { hunks: [additionHunk(['']), additionHunk(['']), additionHunk([''])] };
+  calls = 0;
+  assert.equal(highlightParsed(followed, 'javascript', () => {
+    calls += 1;
+    return spanMarkup(half);
+  }), true);
+  assert.equal(calls, 2, 'the exact aggregate span cap suppresses later work');
+  assert.ok(followed.hunks.slice(0, 2).every(hasHtml));
+  assert.ok(lacksHtml(followed.hunks[2]));
+
+  const over = { hunks: [additionHunk(['']), additionHunk(['']), additionHunk([''])] };
+  calls = 0;
+  assert.equal(highlightParsed(over, 'javascript', () => {
+    calls += 1;
+    return spanMarkup(calls === 1 ? half : half + 1);
+  }), true);
+  assert.equal(calls, 2, 'aggregate span one-over suppresses the third call');
+  assert.ok(hasHtml(over.hunks[0]));
+  assert.ok(lacksHtml(over.hunks[1]));
+  assert.ok(lacksHtml(over.hunks[2]));
+});
+
+test('rejected malformed and text-mismatching output still consumes aggregate work', () => {
+  const mismatch = { hunks: [additionHunk(['expected']), additionHunk(['later'])] };
+  let calls = 0;
+  assert.equal(highlightParsed(mismatch, 'javascript', () => {
+    calls += 1;
+    return rawMarkup(MAX_HIGHLIGHT_OUTPUT_CHARS);
+  }), false);
+  assert.equal(calls, 1, 'text mismatch at the exact raw cap suppresses the later call');
+  assert.ok(mismatch.hunks.every(lacksHtml));
+
+  const malformed = { hunks: [additionHunk(['expected']), additionHunk(['later'])] };
+  calls = 0;
+  assert.equal(highlightParsed(malformed, 'javascript', () => {
+    calls += 1;
+    return `${outputRows(MAX_HIGHLIGHT_OUTPUT_ROWS, '')}<img>`;
+  }), false);
+  assert.equal(calls, 1, 'malformed markup at the exact row cap suppresses the later call');
+  assert.ok(malformed.hunks.every(lacksHtml));
 });
 
 test('highlighting is source-faithful, side-aware, and hunk-atomic', () => {

--- a/test/ui-diff-style.test.mjs
+++ b/test/ui-diff-style.test.mjs
@@ -1,0 +1,121 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const css = readFileSync(fileURLToPath(new URL('../ui/public/style.css', import.meta.url)), 'utf8');
+
+function bodyAfter(selector) {
+  const start = css.indexOf(selector);
+  assert.notEqual(start, -1, `missing selector ${selector}`);
+  const open = selector.endsWith('{')
+    ? start + selector.length - 1
+    : css.indexOf('{', start + selector.length);
+  const close = css.indexOf('}', open + 1);
+  return css.slice(open + 1, close).replace(/\s+/g, ' ');
+}
+
+test('diff source grid has two sticky gutters and one widest-code track', () => {
+  const body = bodyAfter('.hd-diff-body{');
+  assert.match(body, /grid-template-columns:var\(--hd-gutter-width\) var\(--hd-gutter-width\) minmax\(max-content,1fr\)/);
+  assert.match(body, /overflow:auto/);
+  assert.match(body, /max-height:520px/);
+  assert.match(bodyAfter('.hd-dl-row{'), /display:contents/);
+  assert.doesNotMatch(bodyAfter('.hd-dl-code{'), /display:contents/);
+  assert.match(bodyAfter('.hd-dl-code{'), /min-width:100%/);
+  assert.match(bodyAfter('.hd-dl-code{'), /white-space:pre/);
+  assert.match(bodyAfter('.hd-dl-hunk,.hd-diff-note{'), /grid-column:1\/-1/);
+  assert.match(bodyAfter('.hd-diff-body.hint{'), /display:block/);
+  assert.match(bodyAfter('.hd-dl-row.hd-dl-add > *{'), /background:var\(--green-bg\)/);
+  assert.match(bodyAfter('.hd-dl-row.hd-dl-del > *{'), /background:var\(--red-bg\)/);
+});
+
+test('gutters are opaque, sticky, non-selectable, and correctly offset', () => {
+  const gutter = bodyAfter('.hd-dl-n{');
+  assert.match(gutter, /position:sticky/);
+  assert.match(gutter, /z-index:2/);
+  assert.match(gutter, /background:var\(--panel\)/);
+  assert.match(gutter, /user-select:none/);
+  assert.match(bodyAfter('.hd-dl-n-old{'), /left:0/);
+  assert.match(bodyAfter('.hd-dl-n-new{'), /left:var\(--hd-gutter-width\)/);
+});
+
+test('tree native controls hide groups explicitly and preserve visible focus', () => {
+  assert.match(bodyAfter('.hd-tree-group[hidden]{'), /display:none/);
+  const buttons = bodyAfter('.hd-tree-dir,.hd-tree-file{');
+  for (const declaration of [
+    /width:100%/, /border:0/, /padding-block:9px/, /padding-inline-end:12px/,
+    /display:flex/, /align-items:center/, /gap:8px/, /cursor:pointer/,
+  ]) assert.match(buttons, declaration);
+  assert.match(bodyAfter('.hd-tree-dir:hover,.hd-tree-file:hover,.hd-tree-file.active{'),
+    /background:var\(--field\)/);
+  assert.match(bodyAfter('.hd-tree-dir:focus-visible,.hd-tree-file:focus-visible{'),
+    /outline:2px solid var\(--ink\)/);
+  const leaf = bodyAfter('.hd-tree-file .hd-diff-path{');
+  assert.match(leaf, /direction:ltr/);
+  assert.match(leaf, /text-overflow:ellipsis/);
+  assert.match(bodyAfter('.hd-tree-file .hd-diff-path::before{'), /content:none/);
+  const deleted = bodyAfter('.hd-tree-file.deleted .hd-diff-path{');
+  assert.match(deleted, /opacity:1/);
+  assert.doesNotMatch(deleted, /opacity:\.(?:[0-9]+)/);
+  assert.match(bodyAfter('.hd-diff-pane-head .hd-diff-path{'), /margin:0/);
+});
+
+function hex(value) {
+  const match = css.match(new RegExp(`${value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*:\\s*(#[0-9A-Fa-f]{6})`));
+  assert.ok(match, `missing color ${value}`);
+  return match[1];
+}
+
+function rgb(value) {
+  return [1, 3, 5].map((index) => Number.parseInt(value.slice(index, index + 2), 16) / 255);
+}
+
+function luminance(value) {
+  const channels = rgb(value).map((channel) => (
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  ));
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(foreground, background) {
+  const a = luminance(foreground);
+  const b = luminance(background);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+test('small diff text palette clears 4.5:1 on every possible row background', () => {
+  const foregrounds = [
+    '--ink-2', '--hd-syntax-comment', '--hd-syntax-keyword', '--hd-syntax-type',
+    '--hd-syntax-string', '--hd-syntax-literal', '--hd-syntax-title',
+  ];
+  const backgrounds = ['--panel', '--green-bg', '--red-bg'];
+  for (const fgName of foregrounds) {
+    for (const bgName of backgrounds) {
+      const ratio = contrast(hex(fgName), hex(bgName));
+      assert.ok(ratio >= 4.5, `${fgName} on ${bgName}: ${ratio.toFixed(2)}:1`);
+    }
+  }
+  for (const count of ['--hd-count-add', '--hd-count-del']) {
+    const ratio = contrast(hex(count), hex('--field'));
+    assert.ok(ratio >= 4.5, `${count} on --field: ${ratio.toFixed(2)}:1`);
+  }
+});
+
+test('syntax selectors use only measured foreground variables and never token backgrounds', () => {
+  const syntaxBlockStart = css.indexOf('.hd-diff-pane :is(.hljs-comment');
+  const syntaxBlockEnd = css.indexOf('.hd-diff-empty', syntaxBlockStart);
+  const block = css.slice(syntaxBlockStart, syntaxBlockEnd);
+  const colors = [...block.matchAll(/color:var\((--[^)]+)\)/g)].map((match) => match[1]);
+  const allowed = new Set([
+    '--hd-syntax-comment', '--hd-syntax-keyword', '--hd-syntax-type',
+    '--hd-syntax-string', '--hd-syntax-literal', '--hd-syntax-title', '--ink-2',
+  ]);
+  assert.ok(colors.length >= 7);
+  assert.ok(colors.every((color) => allowed.has(color)), colors.join(', '));
+  assert.doesNotMatch(block, /background(?:-color)?\s*:/);
+
+  const diffStart = css.indexOf('/* ---------- History detail: Diff tab ---------- */');
+  const diffEnd = css.indexOf('/* ---------- History detail: Overview tab ---------- */');
+  assert.doesNotMatch(css.slice(diffStart, diffEnd), /color:var\(--ink-3\)/);
+});

--- a/test/ui-diff-style.test.mjs
+++ b/test/ui-diff-style.test.mjs
@@ -19,7 +19,8 @@ test('diff source grid has two sticky gutters and one widest-code track', () => 
   const body = bodyAfter('.hd-diff-body{');
   assert.match(body, /grid-template-columns:var\(--hd-gutter-width\) var\(--hd-gutter-width\) minmax\(max-content,1fr\)/);
   assert.match(body, /overflow:auto/);
-  assert.match(body, /max-height:520px/);
+  assert.match(body, /max-height:860px/);
+  assert.match(bodyAfter('.hd-diff-rows{'), /max-height:860px/);
   assert.match(bodyAfter('.hd-dl-row{'), /display:contents/);
   assert.doesNotMatch(bodyAfter('.hd-dl-code{'), /display:contents/);
   assert.match(bodyAfter('.hd-dl-code{'), /min-width:100%/);
@@ -54,11 +55,23 @@ test('tree native controls hide groups explicitly and preserve visible focus', (
   const leaf = bodyAfter('.hd-tree-file .hd-diff-path{');
   assert.match(leaf, /direction:ltr/);
   assert.match(leaf, /text-overflow:ellipsis/);
+  assert.match(leaf, /font-size:12px/);
+  assert.match(leaf, /color:var\(--ink\)/);
   assert.match(bodyAfter('.hd-tree-file .hd-diff-path::before{'), /content:none/);
   const deleted = bodyAfter('.hd-tree-file.deleted .hd-diff-path{');
   assert.match(deleted, /opacity:1/);
   assert.doesNotMatch(deleted, /opacity:\.(?:[0-9]+)/);
-  assert.match(bodyAfter('.hd-diff-pane-head .hd-diff-path{'), /margin:0/);
+  assert.match(deleted, /text-decoration:none/);
+  assert.doesNotMatch(deleted, /line-through/);
+  const dirLabel = bodyAfter('.hd-tree-dir-label{');
+  assert.match(dirLabel, /font-size:12px/);
+  assert.match(dirLabel, /color:var\(--ink\)/);
+  assert.match(bodyAfter('.hd-tree-file.add .hd-tree-status{'), /color:var\(--green-ink\)/);
+  assert.match(bodyAfter('.hd-tree-file.del .hd-tree-status{'), /color:var\(--red-ink\)/);
+  assert.match(bodyAfter('.hd-tree-dir[aria-expanded="true"] .hd-tree-chevron{'), /rotate\(90deg\)/);
+  const panePath = bodyAfter('.hd-diff-pane-head .hd-diff-path{');
+  assert.match(panePath, /margin:0/);
+  assert.match(panePath, /font-size:12px/);
 });
 
 function hex(value) {

--- a/test/ui-diff-style.test.mjs
+++ b/test/ui-diff-style.test.mjs
@@ -26,7 +26,10 @@ test('diff source grid has two sticky gutters and one widest-code track', () => 
   assert.match(bodyAfter('.hd-dl-code{'), /min-width:100%/);
   assert.match(bodyAfter('.hd-dl-code{'), /white-space:pre/);
   assert.match(bodyAfter('.hd-dl-hunk,.hd-diff-note{'), /grid-column:1\/-1/);
+  assert.match(bodyAfter('.hd-dl-more{'), /grid-column:1\/-1/, 'show-more spans all three tracks');
   assert.match(bodyAfter('.hd-diff-body.hint{'), /display:block/);
+  assert.match(bodyAfter('.hd-diff-body.hint .hd-diff-note{'), /padding-inline:0/,
+    'placeholder note is not padded twice inside the block body');
   assert.match(bodyAfter('.hd-dl-row.hd-dl-add > *{'), /background:var\(--green-bg\)/);
   assert.match(bodyAfter('.hd-dl-row.hd-dl-del > *{'), /background:var\(--red-bg\)/);
 });
@@ -72,6 +75,7 @@ test('tree native controls hide groups explicitly and preserve visible focus', (
   const panePath = bodyAfter('.hd-diff-pane-head .hd-diff-path{');
   assert.match(panePath, /margin:0/);
   assert.match(panePath, /font-size:12px/);
+  assert.match(panePath, /font-weight:400/, 'the h3 must not keep the UA bold');
 });
 
 function hex(value) {

--- a/test/ui-history-detail.test.mjs
+++ b/test/ui-history-detail.test.mjs
@@ -4,6 +4,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
+import { MAX_FILE_SECTION_RENDER_ITEMS } from '../ui/public/diff-view.mjs';
+import { MAX_HIGHLIGHT_INPUT_BYTES } from '../ui/public/syntax-highlight.mjs';
 
 // Behavior tests for the History DETAIL header: the meta line, the branch-copy
 // row, Resume, Archive (honest copy through confirmModal), and the retained-work
@@ -22,7 +24,7 @@ const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
 
 const PROJECT = '/tmp/proj';
 
-async function boot({ fetchHandler, url = 'http://localhost:4317/' } = {}) {
+async function boot({ fetchHandler, url = 'http://localhost:4317/', hljsLoader = null } = {}) {
   const dom = new JSDOM(readFileSync(htmlPath, 'utf8'), { url });
   const { window } = dom;
 
@@ -76,6 +78,7 @@ async function boot({ fetchHandler, url = 'http://localhost:4317/' } = {}) {
   }
   globalThis.window = window;
   globalThis.document = window.document;
+  if (hljsLoader) window.__worcaTestHooks = { hljsLoader };
 
   await import(appPath + `?b=${Date.now()}_${Math.random()}`);
   await new Promise((r) => setTimeout(r, 0)); // let loadProjects/loadConfig settle
@@ -179,12 +182,16 @@ function historyArms(box) {
 
 // `box` is mutable so a test can withhold the list row at boot (the deep-link
 // case) and deliver it later through a `pipelines-changed` broadcast.
-async function bootDetail({ rows = [ROW], detail = DETAIL, budget = okBudget(), arms = null, deepLink = false } = {}) {
+async function bootDetail({
+  rows = [ROW], detail = DETAIL, budget = okBudget(), arms = null,
+  deepLink = false, hljsLoader = null,
+} = {}) {
   const box = { rows, detail, budget };
   const base = historyArms(box);
   const ctx = await boot({
     fetchHandler: (url, opts) => (arms && arms(url, opts, box)) || base(url, opts),
     url: deepLink ? `http://localhost:4317/#${detailHash}` : 'http://localhost:4317/',
+    hljsLoader,
   });
   ctx.box = box;
   return ctx;
@@ -813,6 +820,9 @@ const patchArm = (body) => (url) => (
 );
 
 const filesOf = (doc) => [...doc.querySelectorAll('#hist-detail .hd-diff-file')];
+const fileOf = (doc, path, project = '') => filesOf(doc).find((button) => (
+  button.dataset.path === path && button.dataset.project === project
+));
 const paneOf = (doc) => doc.querySelector('#hist-detail .hd-diff-pane');
 
 test("Diff tab lists files and renders the selected file's hunks", async () => {
@@ -825,14 +835,15 @@ test("Diff tab lists files and renders the selected file's hunks", async () => {
 
   const rows = filesOf(doc);
   assert.equal(rows.length, 1);
-  assert.match(rows[0].textContent, /src\/a\.js/);
+  assert.equal(rows[0].querySelector('.hd-diff-path').textContent, 'a.js');
+  assert.equal(rows[0].dataset.path, 'src/a.js');
 
   const pane = paneOf(doc);
   assert.match(pane.textContent, /@@ -1,2 \+1,2 @@/);
   // ASCII +/- in the patch BODY on purpose: these lines are a verbatim unified
   // diff a user may copy, and a U+2212 yields a patch `git apply` rejects.
-  assert.equal(pane.querySelector('.hd-dl-add').textContent, '+new');
-  assert.equal(pane.querySelector('.hd-dl-del').textContent, '-old');
+  assert.equal(pane.querySelector('.hd-dl-add .hd-dl-code').textContent, '+new');
+  assert.equal(pane.querySelector('.hd-dl-del .hd-dl-code').textContent, '-old');
   assert.equal(pane.querySelector('.hd-dl-hunk').textContent, '@@ -1,2 +1,2 @@');
 
   // The patch is fetched from the /diff twin of historyLogUrl, exactly once.
@@ -874,7 +885,7 @@ test('a deleted file counted in filesChanged is not double-counted in the head',
   assert.match(head.textContent, /2 files changed/);
   assert.doesNotMatch(head.textContent, /3 files changed/);
   assert.equal(filesOf(doc).length, 2);
-  assert.ok(filesOf(doc)[1].classList.contains('deleted'), 'a D row is flagged for the strike-through');
+  assert.ok(fileOf(doc, 'src/gone.js').classList.contains('deleted'), 'a D row is flagged for the strike-through');
 });
 
 test('file in results but missing from the patch shows the no-textual-diff note', async () => {
@@ -899,9 +910,10 @@ test('file in results but missing from the patch shows the no-textual-diff note'
   const rows = filesOf(doc);
   assert.equal(rows.length, 2);
   // A binary entry carries {binary:true} and NEVER {added,removed}.
-  assert.match(rows[1].textContent, /binary/);
+  const binary = fileOf(doc, 'assets/logo.png');
+  assert.match(binary.textContent, /binary/);
 
-  click(window, rows[1]);
+  click(window, binary);
   await settle(window);
   const pane = paneOf(doc);
   assert.match(pane.textContent, /\(no textual diff for this file\)/);
@@ -977,7 +989,7 @@ test('a failed patch fetch re-arms the Diff tab for a retry', async () => {
   const doc = ctx.window.document;
   assert.match(paneOf(doc).textContent, /Could not load the patch: HTTP 503/);
 
-  click(ctx.window, filesOf(doc)[1]);
+  click(ctx.window, fileOf(doc, 'src/b.js'));
   await settle(ctx.window, 4);
   assert.equal(ctx.calls.filter((c) => c.url.endsWith('/diff')).length, 2, 'the next select refetches');
   assert.match(paneOf(doc).textContent, /\+two/, 'and the retry renders');
@@ -1026,22 +1038,370 @@ diff --git a/a.js b/a.js
   const { window } = ctx;
   const doc = window.document;
 
-  const groups = [...doc.querySelectorAll('#hist-detail .hd-diff-proj')];
+  const groups = [...doc.querySelectorAll('#hist-detail .hd-tree-project')];
   assert.deepEqual(groups.map((g) => g.textContent), ['proj-a-00000001', 'proj-b-00000002']);
   const rows = filesOf(doc);
   assert.equal(rows.length, 2, 'the same file name appears once per project');
 
   // Auto-selection landed on the FIRST project's a.js.
   let pane = paneOf(doc);
-  assert.equal(pane.querySelector('.hd-dl-add').textContent, '+alpha');
-  assert.equal(pane.querySelector('.hd-dl-del').textContent, '-one');
+  assert.equal(pane.querySelector('.hd-dl-add .hd-dl-code').textContent, '+alpha');
+  assert.equal(pane.querySelector('.hd-dl-del .hd-dl-code').textContent, '-one');
 
   // The second same-named file resolves to the SECOND project's section.
-  click(window, rows[1]);
+  click(window, fileOf(doc, 'a.js', 'proj-b-00000002'));
   await settle(window);
   pane = paneOf(doc);
-  assert.equal(pane.querySelector('.hd-dl-add').textContent, '+beta');
+  assert.equal(pane.querySelector('.hd-dl-add .hd-dl-code').textContent, '+beta');
   assert.equal(pane.querySelector('.hd-dl-del'), null, 'proj-b removed nothing');
+});
+
+test('numbered rows keep exact copy cells, accessible gutters, identity data, and heading outline', async () => {
+  const ctx = await bootDetail({ detail: diffDetail(diffResults()), arms: patchArm(PATCH) });
+  await openDetail(ctx);
+  await settle(ctx.window);
+  const doc = ctx.window.document;
+  const section = secOf(doc, 'diff');
+  assert.equal(section.querySelector('h2.sr-only').textContent, 'Changed files and diff');
+  assert.equal(section.querySelector('.hd-diff-pane-head h3').textContent, 'src/a.js');
+  assert.equal(section.querySelector('.hd-tree-project'), null, 'single-project trees start at files');
+
+  const [context, deletion, addition] = [...section.querySelectorAll('.hd-dl-row')];
+  assert.deepEqual([context.dataset.old, context.dataset.new], ['1', '1']);
+  assert.deepEqual([deletion.dataset.old, deletion.dataset.new], ['2', '']);
+  assert.deepEqual([addition.dataset.old, addition.dataset.new], ['', '2']);
+  assert.equal(context.querySelector('.hd-dl-code').textContent, ' keep');
+  assert.equal(deletion.querySelector('.hd-dl-code').textContent, '-old');
+  assert.equal(addition.querySelector('.hd-dl-code').textContent, '+new');
+  assert.equal(deletion.querySelector('.hd-dl-n-old .sr-only').textContent, 'Old line 2');
+  assert.equal(deletion.querySelector('.hd-dl-n-new').getAttribute('aria-hidden'), 'true');
+  assert.equal(addition.querySelector('.hd-dl-n-new .hd-dl-n-v').getAttribute('aria-hidden'), 'true');
+
+  for (const item of section.querySelectorAll('.hd-dl-row,.hd-dl-hunk')) {
+    assert.ok(item.dataset.fileKey);
+    assert.equal(item.dataset.project, '');
+    assert.equal(item.dataset.path, 'src/a.js');
+    assert.equal(item.dataset.oldPath, 'src/a.js');
+    assert.equal(item.dataset.newPath, 'src/a.js');
+  }
+  assert.equal(section.querySelector('.hd-dl-hunk').classList.contains('hd-dl-row'), false);
+});
+
+test('omitted counts, zero ranges, and multiple hunks reset gutter counters', async () => {
+  const patch = `diff --git a/src/a.js b/src/a.js
+--- a/src/a.js
++++ b/src/a.js
+@@ -0,0 +1 @@
++first
+@@ -9 +20 @@
+-gone
++fresh
+`;
+  const results = diffResults({
+    summary: { linesAdded: 2, linesRemoved: 1 },
+    results: { changedFiles: [{ path: 'src/a.js', status: 'M', added: 2, removed: 1 }] },
+  });
+  const ctx = await bootDetail({ detail: diffDetail(results), arms: patchArm(patch) });
+  await openDetail(ctx);
+  await settle(ctx.window);
+  const rows = [...ctx.window.document.querySelectorAll('#hist-detail .hd-dl-row')];
+  assert.deepEqual(rows.map((row) => [row.dataset.old, row.dataset.new]), [
+    ['', '1'], ['9', ''], ['', '20'],
+  ]);
+  assert.equal(ctx.window.document.querySelectorAll('#hist-detail .hd-dl-hunk').length, 2);
+});
+
+test('plain numbered rows connect before loader completion, then enhance in place', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const languages = [];
+  const loader = {
+    forLanguage(lang) {
+      languages.push(lang);
+      return gate;
+    },
+  };
+  const ctx = await bootDetail({
+    detail: diffDetail(diffResults()), arms: patchArm(PATCH), hljsLoader: loader,
+  });
+  await openDetail(ctx);
+  await settle(ctx.window);
+  const doc = ctx.window.document;
+  const row = doc.querySelector('#hist-detail .hd-dl-add');
+  const source = row.querySelector('.hd-dl-src');
+  const sign = row.querySelector('.hd-dl-sign');
+  const oldGutter = row.querySelector('.hd-dl-n-old');
+  const newGutter = row.querySelector('.hd-dl-n-new');
+  assert.equal(row.isConnected, true);
+  assert.equal(source.textContent, 'new');
+  assert.equal(source.querySelector('span'), null);
+  assert.deepEqual(languages, ['javascript']);
+
+  release({
+    lang: 'javascript',
+    highlight: (text) => text.replace(/new/g, '<span class="hljs-keyword">new</span>'),
+  });
+  await settle(ctx.window, 6);
+  assert.equal(row.querySelector('.hd-dl-src'), source);
+  assert.equal(row.querySelector('.hd-dl-sign'), sign);
+  assert.equal(row.querySelector('.hd-dl-n-old'), oldGutter);
+  assert.equal(row.querySelector('.hd-dl-n-new'), newGutter);
+  assert.ok(source.querySelector('.hljs-keyword'));
+  assert.equal(row.querySelector('.hd-dl-code').textContent, '+new');
+});
+
+test('unsupported and input-over-limit files never consult the loader', async () => {
+  const calls = [];
+  const loader = { forLanguage: async (lang) => { calls.push(lang); return null; } };
+  const unsupportedResults = diffResults({
+    results: { changedFiles: [{ path: 'main.tf', status: 'M', added: 1, removed: 0 }] },
+  });
+  const unsupportedPatch = `diff --git a/main.tf b/main.tf
+--- a/main.tf
++++ b/main.tf
+@@ -0,0 +1 @@
++enabled = true
+`;
+  const unsupported = await bootDetail({
+    detail: diffDetail(unsupportedResults), arms: patchArm(unsupportedPatch), hljsLoader: loader,
+  });
+  await openDetail(unsupported);
+  await settle(unsupported.window);
+
+  const huge = 'x'.repeat(MAX_HIGHLIGHT_INPUT_BYTES + 1);
+  const overResults = diffResults({
+    results: { changedFiles: [{ path: 'big.js', status: 'M', added: 1, removed: 0 }] },
+  });
+  const overPatch = `diff --git a/big.js b/big.js
+--- a/big.js
++++ b/big.js
+@@ -0,0 +1 @@
++${huge}
+`;
+  const over = await bootDetail({
+    detail: diffDetail(overResults), arms: patchArm(overPatch), hljsLoader: loader,
+  });
+  await openDetail(over);
+  await settle(over.window);
+  assert.deepEqual(calls, []);
+});
+
+test('invalid highlighter markup stays plain while a separate valid hunk commits', async () => {
+  const patch = `diff --git a/src/a.js b/src/a.js
+--- a/src/a.js
++++ b/src/a.js
+@@ -0,0 +1 @@
++valid
+@@ -0,0 +10 @@
++invalid
+`;
+  const results = diffResults({
+    summary: { linesAdded: 2, linesRemoved: 0 },
+    results: { changedFiles: [{ path: 'src/a.js', status: 'M', added: 2, removed: 0 }] },
+  });
+  const loader = {
+    async forLanguage() {
+      return {
+        lang: 'javascript',
+        highlight: (text) => (text === 'valid'
+          ? '<span class="hljs-keyword">valid</span>'
+          : '<img src=x>'),
+      };
+    },
+  };
+  const ctx = await bootDetail({ detail: diffDetail(results), arms: patchArm(patch), hljsLoader: loader });
+  await openDetail(ctx);
+  await settle(ctx.window, 6);
+  const sources = [...ctx.window.document.querySelectorAll('#hist-detail .hd-dl-src')];
+  assert.ok(sources[0].querySelector('.hljs-keyword'));
+  assert.equal(sources[1].children.length, 0);
+  assert.equal(sources[1].textContent, 'invalid');
+});
+
+test('CR and empty source rows survive detached highlighted staging exactly', async () => {
+  const patch = 'diff --git a/src/a.js b/src/a.js\n--- a/src/a.js\n+++ b/src/a.js\n'
+    + '@@ -0,0 +1,2 @@\r\n+x\r\n+\r\n';
+  const results = diffResults({
+    summary: { linesAdded: 2, linesRemoved: 0 },
+    results: { changedFiles: [{ path: 'src/a.js', status: 'M', added: 2, removed: 0 }] },
+  });
+  const loader = { async forLanguage() { return { lang: 'javascript', highlight: (text) => text }; } };
+  const ctx = await bootDetail({ detail: diffDetail(results), arms: patchArm(patch), hljsLoader: loader });
+  await openDetail(ctx);
+  await settle(ctx.window, 6);
+  const sources = [...ctx.window.document.querySelectorAll('#hist-detail .hd-dl-src')];
+  assert.equal(sources[0].textContent, 'x\r');
+  assert.equal(sources[1].textContent, '\r');
+});
+
+test('stale highlighter completion cannot mutate the newly selected file', async () => {
+  const results = diffResults({
+    summary: { filesChanged: 2, linesAdded: 2, linesRemoved: 1 },
+    results: {
+      changedFiles: [
+        { path: 'src/a.js', status: 'M', added: 1, removed: 1 },
+        { path: 'src/b.tf', status: 'M', added: 1, removed: 0 },
+      ],
+    },
+  });
+  const patch = `${PATCH}diff --git a/src/b.tf b/src/b.tf
+--- a/src/b.tf
++++ b/src/b.tf
+@@ -0,0 +1 @@
++value = true
+`;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const loader = { forLanguage: () => gate };
+  const ctx = await bootDetail({ detail: diffDetail(results), arms: patchArm(patch), hljsLoader: loader });
+  await openDetail(ctx);
+  await settle(ctx.window);
+  const doc = ctx.window.document;
+  click(ctx.window, fileOf(doc, 'src/b.tf'));
+  await settle(ctx.window);
+  release({
+    lang: 'javascript',
+    highlight: (text) => `<span class="hljs-keyword">${text}</span>`,
+  });
+  await settle(ctx.window, 6);
+  assert.equal(paneOf(doc).querySelector('.hd-diff-path').textContent, 'src/b.tf');
+  assert.equal(paneOf(doc).querySelector('.hljs-keyword'), null);
+  assert.equal(paneOf(doc).querySelector('.hd-dl-code').textContent, '+value = true');
+});
+
+test('a patch resolving after navigation cannot append a body or start highlighting', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const loaderCalls = [];
+  const ctx = await bootDetail({
+    detail: diffDetail(diffResults()),
+    arms: (url) => (url.endsWith('/diff')
+      ? gate.then(() => ({ ok: true, status: 200, text: async () => PATCH }))
+      : null),
+    hljsLoader: { async forLanguage(lang) { loaderCalls.push(lang); return null; } },
+  });
+  await openDetail(ctx);
+  const retiredPane = paneOf(ctx.window.document);
+  assert.equal(retiredPane.querySelector('.hd-diff-body'), null);
+  go(ctx.window, 'history');
+  await settle(ctx.window);
+  release();
+  await settle(ctx.window, 6);
+  assert.equal(retiredPane.querySelector('.hd-diff-body'), null);
+  assert.deepEqual(loaderCalls, []);
+});
+
+test('a highlighter resolving after navigation leaves the retired plain body untouched', async () => {
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const ctx = await bootDetail({
+    detail: diffDetail(diffResults()), arms: patchArm(PATCH),
+    hljsLoader: { forLanguage: () => gate },
+  });
+  await openDetail(ctx);
+  await settle(ctx.window);
+  const retiredBody = paneOf(ctx.window.document).querySelector('.hd-diff-body');
+  assert.ok(retiredBody);
+  go(ctx.window, 'history');
+  await settle(ctx.window);
+  release({
+    lang: 'javascript',
+    highlight: (text) => `<span class="hljs-keyword">${text}</span>`,
+  });
+  await settle(ctx.window, 6);
+  assert.equal(retiredBody.querySelector('.hljs-keyword'), null);
+  assert.equal(retiredBody.querySelector('.hd-dl-add .hd-dl-code').textContent, '+new');
+});
+
+test('cross-extension rename uses the new path grammar and exposes both identities', async () => {
+  const results = diffResults({
+    results: {
+      changedFiles: [{
+        path: 'tools/new.py', from: 'tools/old.ts', status: 'R', added: 1, removed: 1,
+      }],
+    },
+  });
+  const patch = `diff --git a/tools/old.ts b/tools/new.py
+similarity index 80%
+rename from tools/old.ts
+rename to tools/new.py
+--- a/tools/old.ts
++++ b/tools/new.py
+@@ -1 +1 @@
+-const answer: number = 41;
++answer = 42
+`;
+  const calls = [];
+  const loader = { async forLanguage(lang) { calls.push(lang); return null; } };
+  const ctx = await bootDetail({ detail: diffDetail(results), arms: patchArm(patch), hljsLoader: loader });
+  await openDetail(ctx);
+  await settle(ctx.window, 5);
+  const doc = ctx.window.document;
+  assert.deepEqual(calls, ['python']);
+  const heading = paneOf(doc).querySelector('h3.hd-diff-path');
+  assert.equal(heading.textContent, 'tools/new.py');
+  assert.equal(heading.title, 'tools/old.ts → tools/new.py');
+  assert.equal(heading.getAttribute('aria-label'), 'Renamed from tools/old.ts to tools/new.py');
+  for (const row of paneOf(doc).querySelectorAll('.hd-dl-row')) {
+    assert.equal(row.dataset.oldPath, 'tools/old.ts');
+    assert.equal(row.dataset.newPath, 'tools/new.py');
+  }
+});
+
+test('base rendering stops at the item cap and reports truncation without a KB claim', async () => {
+  const lines = Array.from({ length: MAX_FILE_SECTION_RENDER_ITEMS }, (_, index) => `+const n${index} = ${index};`);
+  const patch = `diff --git a/many.js b/many.js
+--- /dev/null
++++ b/many.js
+@@ -0,0 +1,${lines.length} @@
+${lines.join('\n')}
+`;
+  const results = diffResults({
+    summary: { filesNew: 1, filesChanged: 0, linesAdded: lines.length, linesRemoved: 0 },
+    results: {
+      newFiles: [{ path: 'many.js', status: 'A', added: lines.length, removed: 0 }],
+      changedFiles: [],
+    },
+  });
+  const ctx = await bootDetail({ detail: diffDetail(results), arms: patchArm(patch) });
+  await openDetail(ctx);
+  await settle(ctx.window, 5);
+  const doc = ctx.window.document;
+  assert.equal(doc.querySelectorAll('#hist-detail .hd-dl-hunk,#hist-detail .hd-dl-row').length,
+    MAX_FILE_SECTION_RENDER_ITEMS);
+  const note = doc.querySelector('#hist-detail .hd-diff-trunc');
+  assert.match(note.textContent, /large file — diff truncated/);
+  assert.doesNotMatch(note.textContent, /KB/);
+  assert.equal(note.classList.contains('hd-dl-row'), false);
+  assert.match(doc.querySelector('#hist-detail .hd-diff-body').style.getPropertyValue('--hd-gutter-width'), /^calc\(/);
+});
+
+test('directory collapse changes no selection, pane body, or patch fetch', async () => {
+  const results = diffResults({
+    summary: { filesChanged: 2, linesAdded: 2, linesRemoved: 1 },
+    results: {
+      changedFiles: [
+        { path: 'src/a.js', status: 'M', added: 1, removed: 1 },
+        { path: 'src/b.js', status: 'M', added: 1, removed: 0 },
+      ],
+    },
+  });
+  const patch = `${PATCH}diff --git a/src/b.js b/src/b.js
+--- a/src/b.js
++++ b/src/b.js
+@@ -0,0 +1 @@
++two
+`;
+  const ctx = await bootDetail({ detail: diffDetail(results), arms: patchArm(patch) });
+  await openDetail(ctx);
+  await settle(ctx.window);
+  const doc = ctx.window.document;
+  const body = paneOf(doc).querySelector('.hd-diff-body');
+  const active = doc.querySelector('#hist-detail .hd-tree-file[aria-current="true"]');
+  click(ctx.window, doc.querySelector('#hist-detail .hd-tree-dir'));
+  assert.equal(paneOf(doc).querySelector('.hd-diff-body'), body);
+  assert.equal(doc.querySelector('#hist-detail .hd-tree-file[aria-current="true"]'), active);
+  assert.equal(ctx.calls.filter((call) => call.url.endsWith('/diff')).length, 1);
 });
 
 // ---------------------------------------------------------------------------
@@ -1270,7 +1630,7 @@ test('rapid selection does not stack two bodies in the pane', async () => {
   await settle(window, 6);
 
   assert.equal(doc.querySelectorAll('#hist-detail .hd-diff-body').length, 1);
-  assert.equal(paneOf(doc).querySelector('.hd-dl-add').textContent, '+two',
+  assert.equal(paneOf(doc).querySelector('.hd-dl-add .hd-dl-code').textContent, '+two',
     'the LAST selection owns the pane');
   // One fetch for three selections: the promise is memoized, not re-issued.
   assert.equal(ctx.calls.filter((c) => c.url.endsWith('/diff')).length, 1);

--- a/test/ui-history-detail.test.mjs
+++ b/test/ui-history-detail.test.mjs
@@ -4,8 +4,12 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
-import { MAX_FILE_SECTION_RENDER_ITEMS } from '../ui/public/diff-view.mjs';
+import { MAX_FILE_SECTION_CODE_UNITS } from '../ui/public/diff-view.mjs';
 import { MAX_HIGHLIGHT_INPUT_BYTES } from '../ui/public/syntax-highlight.mjs';
+
+// app.js connects at most this many source rows per step (HD_DIFF_WINDOW_LINES);
+// app.js exports nothing, so the tests pin the number here.
+const WINDOW = 5000;
 
 // Behavior tests for the History DETAIL header: the meta line, the branch-copy
 // row, Resume, Archive (honest copy through confirmModal), and the retained-work
@@ -1348,32 +1352,195 @@ rename to tools/new.py
   }
 });
 
-test('base rendering stops at the item cap and reports truncation without a KB claim', async () => {
-  const lines = Array.from({ length: MAX_FILE_SECTION_RENDER_ITEMS }, (_, index) => `+const n${index} = ${index};`);
-  const patch = `diff --git a/many.js b/many.js
+const addedLinesPatch = (path, n, { header = null } = {}) => {
+  const lines = Array.from({ length: n }, (_, index) => `+const n${index + 1} = ${index + 1};`);
+  return `diff --git a/${path} b/${path}
 --- /dev/null
-+++ b/many.js
-@@ -0,0 +1,${lines.length} @@
++++ b/${path}
+${header || `@@ -0,0 +1,${n} @@`}
 ${lines.join('\n')}
 `;
-  const results = diffResults({
-    summary: { filesNew: 1, filesChanged: 0, linesAdded: lines.length, linesRemoved: 0 },
-    results: {
-      newFiles: [{ path: 'many.js', status: 'A', added: lines.length, removed: 0 }],
-      changedFiles: [],
-    },
+};
+const addedFileResults = (path, n) => diffResults({
+  summary: { filesNew: 1, filesChanged: 0, linesAdded: n, linesRemoved: 0 },
+  results: { newFiles: [{ path, status: 'A', added: n, removed: 0 }], changedFiles: [] },
+});
+const bodyOf = (doc) => doc.querySelector('#hist-detail .hd-diff-body');
+const rowsOf = (doc) => doc.querySelectorAll('#hist-detail .hd-dl-row');
+const moreOf = (doc) => doc.querySelector('#hist-detail .hd-dl-more');
+
+test('a long diff connects one window of rows plus an honest show-more row, never a truncation note', async () => {
+  const N = WINDOW + 1000;
+  const ctx = await bootDetail({
+    detail: diffDetail(addedFileResults('many.js', N)), arms: patchArm(addedLinesPatch('many.js', N)),
   });
-  const ctx = await bootDetail({ detail: diffDetail(results), arms: patchArm(patch) });
   await openDetail(ctx);
   await settle(ctx.window, 5);
   const doc = ctx.window.document;
-  assert.equal(doc.querySelectorAll('#hist-detail .hd-dl-hunk,#hist-detail .hd-dl-row').length,
-    MAX_FILE_SECTION_RENDER_ITEMS);
-  const note = doc.querySelector('#hist-detail .hd-diff-trunc');
-  assert.match(note.textContent, /large file — diff truncated/);
+  assert.equal(rowsOf(doc).length, WINDOW);
+  assert.equal(doc.querySelectorAll('#hist-detail .hd-dl-hunk').length, 1);
+  assert.equal(doc.querySelector('#hist-detail .hd-diff-trunc'), null, 'nothing was dropped, so no truncation note');
+  const more = moreOf(doc);
+  assert.ok(more, 'the hidden rows are one click away');
+  assert.equal(more.classList.contains('hd-dl-row'), false, 'a real grid row, not display:contents');
+  assert.equal(more.dataset.path, 'many.js', 'carries the same section identity as every other row');
+  assert.match(more.querySelector('.hd-dl-more-hint').textContent, /^5000 of 6000 lines shown$/);
+  const button = more.querySelector('button.hd-dl-more-btn');
+  assert.equal(button.type, 'button');
+  assert.equal(button.textContent, 'Show 1000 more lines');
+  assert.equal(more, bodyOf(doc).lastElementChild);
+  // The gutter is sized for the WIDEST number in the whole file up front, so
+  // expanding never shifts the columns.
+  assert.equal(bodyOf(doc).style.getPropertyValue('--hd-gutter-width'), 'calc(4ch + 16px)');
+
+  click(ctx.window, button);
+  await settle(ctx.window);
+  assert.equal(rowsOf(doc).length, N);
+  assert.equal(moreOf(doc), null);
+  assert.equal(doc.querySelectorAll('#hist-detail .hd-dl-hunk').length, 1, 'the continued hunk gets no second header');
+  const last = [...rowsOf(doc)].at(-1);
+  assert.equal(last.dataset.new, String(N));
+  assert.equal(last.querySelector('.hd-dl-code').textContent, `+const n${N} = ${N};`);
+});
+
+test('show-more steps one window at a time, reporting the running total and the singular form', async () => {
+  const N = 2 * WINDOW + 1;
+  const ctx = await bootDetail({
+    detail: diffDetail(addedFileResults('big.js', N)), arms: patchArm(addedLinesPatch('big.js', N)),
+  });
+  await openDetail(ctx);
+  await settle(ctx.window, 5);
+  const doc = ctx.window.document;
+  assert.equal(rowsOf(doc).length, WINDOW);
+  assert.equal(moreOf(doc).querySelector('button').textContent, `Show ${WINDOW} more lines`);
+
+  click(ctx.window, moreOf(doc).querySelector('button'));
+  await settle(ctx.window);
+  assert.equal(rowsOf(doc).length, 2 * WINDOW);
+  assert.equal(doc.querySelectorAll('#hist-detail .hd-dl-more').length, 1, 'the used control is replaced, not stacked');
+  assert.match(moreOf(doc).querySelector('.hd-dl-more-hint').textContent, /^10000 of 10001 lines shown$/);
+  assert.equal(moreOf(doc).querySelector('button').textContent, 'Show 1 more line');
+
+  click(ctx.window, moreOf(doc).querySelector('button'));
+  await settle(ctx.window);
+  assert.equal(rowsOf(doc).length, N);
+  assert.equal(moreOf(doc), null);
+});
+
+test('a window boundary inside a hunk continues that hunk; later hunks still get their headers', async () => {
+  // hunk 1 fills the window exactly (WINDOW lines) and hunk 2 follows: the
+  // first window must not render hunk 2's header as a dangling last row.
+  const first = Array.from({ length: WINDOW }, (_, i) => `+a${i}`);
+  const second = ['+b1', '+b2', '+b3'];
+  const patch = `diff --git a/two.js b/two.js
+--- a/two.js
++++ b/two.js
+@@ -0,0 +1,${first.length} @@
+${first.join('\n')}
+@@ -10,0 +${first.length + 11},3 @@
+${second.join('\n')}
+`;
+  const ctx = await bootDetail({
+    detail: diffDetail(addedFileResults('two.js', first.length + 3)), arms: patchArm(patch),
+  });
+  await openDetail(ctx);
+  await settle(ctx.window, 5);
+  const doc = ctx.window.document;
+  assert.equal(rowsOf(doc).length, WINDOW);
+  assert.equal(doc.querySelectorAll('#hist-detail .hd-dl-hunk').length, 1);
+  assert.equal(moreOf(doc).querySelector('button').textContent, 'Show 3 more lines');
+  click(ctx.window, moreOf(doc).querySelector('button'));
+  await settle(ctx.window);
+  const hunks = [...doc.querySelectorAll('#hist-detail .hd-dl-hunk')];
+  assert.equal(hunks.length, 2);
+  assert.equal(hunks[1].nextElementSibling.querySelector('.hd-dl-code').textContent, '+b1');
+  assert.equal(rowsOf(doc).length, WINDOW + 3);
+});
+
+test('the section-size cap still reports truncation, after the show-more row', async () => {
+  // ~9 code units per row: well over MAX_FILE_SECTION_CODE_UNITS, so the parser
+  // drops the tail (that loss is real and is said so), and the renderer windows
+  // the ~55k rows that survive.
+  const N = Math.ceil(MAX_FILE_SECTION_CODE_UNITS / 9) + 500;
+  const lines = Array.from({ length: N }, () => '+xxxxxxxx');
+  const patch = `diff --git a/huge.txt b/huge.txt
+--- /dev/null
++++ b/huge.txt
+@@ -0,0 +1,${N} @@
+${lines.join('\n')}
+`;
+  const ctx = await bootDetail({
+    detail: diffDetail(addedFileResults('huge.txt', N)), arms: patchArm(patch),
+  });
+  await openDetail(ctx);
+  await settle(ctx.window, 5);
+  const doc = ctx.window.document;
+  assert.equal(rowsOf(doc).length, WINDOW);
+  const body = bodyOf(doc);
+  const note = body.querySelector('.hd-diff-trunc');
+  assert.equal(note.textContent, '(large file — diff truncated)');
   assert.doesNotMatch(note.textContent, /KB/);
-  assert.equal(note.classList.contains('hd-dl-row'), false);
-  assert.match(doc.querySelector('#hist-detail .hd-diff-body').style.getPropertyValue('--hd-gutter-width'), /^calc\(/);
+  assert.equal(note, body.lastElementChild, 'the note stays the last row');
+  assert.equal(note.previousElementSibling, moreOf(doc), 'show-more sits just above it');
+  const shown = Number(/^(\d+) of (\d+) lines shown$/.exec(moreOf(doc).querySelector('.hd-dl-more-hint').textContent)[2]);
+  assert.ok(shown > WINDOW && shown < N, `the total counts parsed rows only (${shown})`);
+});
+
+test('rows connected by show-more are highlighted once both the rows and the highlighter exist', async () => {
+  // Hunk 1 is ineligible for highlighting (its header count is wrong, so it
+  // stays plain) and fills the first window; hunk 2 is eligible but only
+  // connects after a click. Both orders must end with hunk 2 enhanced.
+  const bulk = Array.from({ length: WINDOW + 5 }, (_, i) => `+x${i}`);
+  const patch = `diff --git a/src/a.js b/src/a.js
+--- a/src/a.js
++++ b/src/a.js
+@@ -0,0 +1,2 @@
+${bulk.join('\n')}
+@@ -1 +1 @@
+-old
++valid
+`;
+  const results = diffResults({
+    summary: { linesAdded: bulk.length + 1, linesRemoved: 1 },
+    results: { changedFiles: [{ path: 'src/a.js', status: 'M', added: bulk.length + 1, removed: 1 }] },
+  });
+  const highlighter = {
+    lang: 'javascript',
+    highlight: (text) => text.replace(/valid/g, '<span class="hljs-keyword">valid</span>'),
+  };
+  const enhancedSources = (doc) => [...doc.querySelectorAll('#hist-detail .hd-dl-src')]
+    .filter((source) => source.querySelector('.hljs-keyword'))
+    .map((source) => source.textContent);
+
+  // Order A: the highlighter finishes first, the click comes later.
+  const ready = await bootDetail({
+    detail: diffDetail(results), arms: patchArm(patch),
+    hljsLoader: { async forLanguage() { return highlighter; } },
+  });
+  await openDetail(ready);
+  await settle(ready.window, 6);
+  assert.deepEqual(enhancedSources(ready.window.document), []);
+  click(ready.window, moreOf(ready.window.document).querySelector('button'));
+  await settle(ready.window);
+  assert.deepEqual(enhancedSources(ready.window.document), ['valid']);
+  assert.equal(rowsOf(ready.window.document).length, bulk.length + 2);
+
+  // Order B: the click lands while the grammar is still loading.
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const late = await bootDetail({
+    detail: diffDetail(results), arms: patchArm(patch), hljsLoader: { forLanguage: () => gate },
+  });
+  await openDetail(late);
+  await settle(late.window, 5);
+  click(late.window, moreOf(late.window.document).querySelector('button'));
+  await settle(late.window);
+  assert.deepEqual(enhancedSources(late.window.document), []);
+  release(highlighter);
+  await settle(late.window, 6);
+  assert.deepEqual(enhancedSources(late.window.document), ['valid']);
+  const plain = [...late.window.document.querySelectorAll('#hist-detail .hd-dl-src')][0];
+  assert.equal(plain.children.length, 0, 'the ineligible hunk stays plain');
 });
 
 test('directory collapse changes no selection, pane body, or patch fetch', async () => {

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -11184,13 +11184,14 @@ function hdDiffRow(doc, line, meta) {
 function afterDiffPaint(win = window) {
   return new Promise((resolve) => {
     let settled = false;
+    let timer;
     const finish = () => {
       if (settled) return;
       settled = true;
       win.clearTimeout(timer);
       resolve();
     };
-    const timer = win.setTimeout(finish, 50);
+    timer = win.setTimeout(finish, 50);
     if (typeof win.requestAnimationFrame === 'function') {
       win.requestAnimationFrame(() => win.setTimeout(finish, 0));
     } else {
@@ -11199,16 +11200,45 @@ function afterDiffPaint(win = window) {
   });
 }
 
-async function enhanceDiffBody({ parsed, lang, refs, ownsBody }) {
-  const loading = diffHljsLoader.forLanguage(lang);
-  await afterDiffPaint();
-  const loaded = await loading;
-  if (!loaded || !ownsBody()) return;
-  if (!highlightParsed(parsed, lang, loaded.highlight) || !ownsBody()) return;
+// Source rows connected per step. The parser keeps every row under its
+// 500,000-code-unit section cap (diff-view.mjs); this bounds what one paint
+// CONNECTS, so a 250k-row generated diff cannot mint a million gutter/source
+// nodes at once while every hidden row stays one click away.
+const HD_DIFF_WINDOW_LINES = 5_000;
 
+// One selected file's render state, shared by the window appender and the
+// highlighter so rows connected by a later "Show more" still get enhanced.
+function hdDiffView(parsed, ownsBody) {
+  let totalLines = 0;
+  let digits = 3;
   for (const hunk of parsed.hunks) {
-    const marked = hunk.lines.filter((line) => Object.hasOwn(line, 'html'));
-    if (!marked.length || marked.length !== hunk.lines.length) continue;
+    totalLines += hunk.lines.length;
+    for (const line of hunk.lines) {
+      for (const no of [line.oldNo, line.newNo]) {
+        if (Number.isSafeInteger(no)) digits = Math.max(digits, String(no).length);
+      }
+    }
+  }
+  return {
+    parsed, ownsBody, digits, totalLines,
+    refs: new Map(),      // parsed line -> live .hd-dl-src
+    applied: new Set(),   // hunks whose highlight decision is final
+    highlighted: false,   // highlightParsed() has run and set line.html
+    hunkIndex: 0, lineIndex: 0, renderedLines: 0,
+  };
+}
+
+// Commit highlighted markup for every hunk whose rows are ALL connected. Stages
+// each hunk in detached DOM and verifies the exact source text before touching
+// the live rows; a hunk is decided once (valid or not) and never re-checked. A
+// hunk cut by a window boundary waits, plain, until its remaining rows connect.
+function hdApplyHighlights(view) {
+  const { parsed, refs, applied, ownsBody } = view;
+  for (const hunk of parsed.hunks) {
+    if (applied.has(hunk) || !hunk.lines.length) continue;
+    if (!hunk.lines.every((line) => Object.hasOwn(line, 'html') && refs.has(line))) continue;
+    if (!ownsBody()) return;
+    applied.add(hunk);
     const staged = [];
     let valid = true;
     for (const line of hunk.lines) {
@@ -11216,7 +11246,7 @@ async function enhanceDiffBody({ parsed, lang, refs, ownsBody }) {
       const holder = document.createElement('span');
       holder.innerHTML = line.html;
       const elements = [...holder.querySelectorAll('*')];
-      if (!liveSource || holder.textContent !== line.text
+      if (holder.textContent !== line.text
         || elements.some((el) => el.tagName !== 'SPAN'
           || [...el.attributes].some((attribute) => attribute.name !== 'class'))) {
         valid = false;
@@ -11224,9 +11254,76 @@ async function enhanceDiffBody({ parsed, lang, refs, ownsBody }) {
       }
       staged.push({ liveSource, nodes: [...holder.childNodes] });
     }
-    if (!valid || !ownsBody()) continue;
+    if (!valid) continue;
     for (const { liveSource, nodes } of staged) liveSource.replaceChildren(...nodes);
   }
+}
+
+async function enhanceDiffBody(view, lang) {
+  const loading = diffHljsLoader.forLanguage(lang);
+  await afterDiffPaint();
+  const loaded = await loading;
+  if (!loaded || !view.ownsBody()) return;
+  if (!highlightParsed(view.parsed, lang, loaded.highlight) || !view.ownsBody()) return;
+  view.highlighted = true;
+  hdApplyHighlights(view);
+}
+
+// Connect the next window of rows before `tail` (the size-cap note, or null).
+// A hunk header is free — it never ends a window, so a boundary always falls
+// after a source row — and a hunk cut by the boundary continues without a
+// second header. When rows remain, a real grid row reports the running total
+// and offers exactly the next window.
+function hdDiffAppendWindow(doc, body, view, meta, tail) {
+  const { parsed, refs } = view;
+  const frag = doc.createDocumentFragment();
+  let added = 0;
+  while (view.hunkIndex < parsed.hunks.length) {
+    if (added >= HD_DIFF_WINDOW_LINES && view.renderedLines < view.totalLines) break;
+    const hunk = parsed.hunks[view.hunkIndex];
+    if (view.lineIndex === 0) {
+      const hh = doc.createElement('div');
+      hh.className = 'hd-dl hd-dl-hunk';
+      setSectionData(hh, meta);
+      hh.textContent = hunk.header;
+      frag.appendChild(hh);
+    }
+    while (view.lineIndex < hunk.lines.length && added < HD_DIFF_WINDOW_LINES) {
+      const line = hunk.lines[view.lineIndex];
+      const rendered = hdDiffRow(doc, line, meta);
+      refs.set(line, rendered.source);
+      frag.appendChild(rendered.row);
+      view.lineIndex += 1;
+      view.renderedLines += 1;
+      added += 1;
+    }
+    if (view.lineIndex < hunk.lines.length) break;
+    view.hunkIndex += 1;
+    view.lineIndex = 0;
+  }
+  if (view.hunkIndex < parsed.hunks.length) {
+    const remaining = view.totalLines - view.renderedLines;
+    const next = Math.min(remaining, HD_DIFF_WINDOW_LINES);
+    const more = doc.createElement('div');
+    more.className = 'hd-dl hd-dl-more';
+    setSectionData(more, meta);
+    const hint = doc.createElement('span');
+    hint.className = 'hd-dl-more-hint';
+    hint.textContent = `${view.renderedLines} of ${view.totalLines} lines shown`;
+    const button = doc.createElement('button');
+    button.type = 'button';
+    button.className = 'hd-dl-more-btn';
+    button.textContent = `Show ${next} more line${next === 1 ? '' : 's'}`;
+    button.addEventListener('click', () => {
+      if (!view.ownsBody()) return;
+      more.remove();
+      hdDiffAppendWindow(doc, body, view, meta, tail);
+      if (view.highlighted) hdApplyHighlights(view);
+    });
+    more.append(hint, button);
+    frag.appendChild(more);
+  }
+  body.insertBefore(frag, tail);
 }
 
 function buildHdDiff(sec, record, data) {
@@ -11354,42 +11451,30 @@ function buildHdDiff(sec, record, data) {
       pane.appendChild(body);
       return;
     }
-    const refs = new Map();
-    let digits = 3;
-    for (const hunk of parsed.hunks) {
-      const hh = document.createElement('div');
-      hh.className = 'hd-dl hd-dl-hunk';
-      setSectionData(hh, meta);
-      hh.textContent = hunk.header;
-      body.appendChild(hh);
-      for (const line of hunk.lines) {
-        for (const no of [line.oldNo, line.newNo]) {
-          if (Number.isSafeInteger(no)) digits = Math.max(digits, String(no).length);
-        }
-        const rendered = hdDiffRow(document, line, meta);
-        refs.set(line, rendered.source);
-        body.appendChild(rendered.row);
-      }
-    }
+    const ownsBody = () => epoch === pstate.selEpoch
+      && body.isConnected
+      && pane.isConnected
+      && pane.contains(body)
+      && histDetailState?.screen?.contains(pane);
+    const view = hdDiffView(parsed, ownsBody);
+    // The size-cap note is about rows the PARSER dropped, so it stays the last
+    // row; every window (and the show-more control) is inserted above it.
+    let tail = null;
     if (parsed.truncated) {
-      const t = document.createElement('div');
-      t.className = 'hint hd-diff-note hd-diff-trunc';
-      setSectionData(t, meta);
-      t.textContent = '(large file — diff truncated)';
-      body.appendChild(t);
+      tail = document.createElement('div');
+      tail.className = 'hint hd-diff-note hd-diff-trunc';
+      setSectionData(tail, meta);
+      tail.textContent = '(large file — diff truncated)';
+      body.appendChild(tail);
     }
-    body.style.setProperty('--hd-gutter-width', `calc(${digits}ch + 16px)`);
+    hdDiffAppendWindow(document, body, view, meta, tail);
+    body.style.setProperty('--hd-gutter-width', `calc(${view.digits}ch + 16px)`);
     pane.appendChild(body);
 
     const syntaxPath = section.path || entry.f.path || section.oldPath;
     const lang = langForPath(syntaxPath);
     if (lang && canHighlightParsed(parsed)) {
-      const ownsBody = () => epoch === pstate.selEpoch
-        && body.isConnected
-        && pane.isConnected
-        && pane.contains(body)
-        && histDetailState?.screen?.contains(pane);
-      void enhanceDiffBody({ parsed, lang, refs, ownsBody }).catch(() => {});
+      void enhanceDiffBody(view, lang).catch(() => {});
     }
   }
 

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -60,7 +60,16 @@ import { logLineVisible, logFacets, compileLogFilter } from './log-filter.mjs';
 // lost their last app.js caller with the retired card accordion. They stay EXPORTED
 // from results-view.mjs (test/results-view-helpers.test.mjs imports four of them).
 import { sourceBadge, workflowPickerLabel } from './results-view.mjs';
-import { splitPatchSections, parseFileSection, patchIndex, sectionKey } from './diff-view.mjs';
+import {
+  splitPatchSections, parseFileSection, patchIndex, sectionKey,
+} from './diff-view.mjs';
+import {
+  langForPath, canHighlightParsed, highlightParsed,
+} from './syntax-highlight.mjs';
+import { createHljsLoader } from './hljs-loader.mjs';
+import {
+  buildFileTree, renderFileTree, firstFile,
+} from './file-tree.mjs';
 import {
   renderPluginList, renderInstallConsent, renderUpdatePreview,
   renderConfigForm, collectConfigForm, renderDoctorReport, renderReferences409,
@@ -77,6 +86,8 @@ import {
 } from './models-view.mjs';
 import { renderSourcePane, collectSourcePane } from './source-pane.mjs';
 import { renderStatsBody, renderBudgetIndicator, renderBudgetRing, renderBudgetReadout, renderCostPauseBanner, BUDGET_WARN_AT } from './stats-view.mjs';
+
+const diffHljsLoader = window.__worcaTestHooks?.hljsLoader ?? createHljsLoader();
 
 // ---------------------------------------------------------------------------
 // Elements
@@ -11092,10 +11103,130 @@ function hdDiffFileRows(results) {
 
 // Per-file count chip. A file entry carries EITHER {added,removed} OR
 // {binary:true} — never both (results.mjs:22-53).
-function hdFileCountsHtml(f) {
-  if (f.binary) return '<span class="hint">binary</span>';
-  if (f.added == null) return '';
-  return `<span class="diff-add">+${f.added}</span> <span class="diff-del">−${f.removed}</span>`; // U+2212
+function hdFileCountsNode(doc, f) {
+  const out = doc.createElement('span');
+  out.className = 'mono hd-diff-counts';
+  if (f.binary) {
+    const binary = doc.createElement('span');
+    binary.className = 'hint';
+    binary.textContent = 'binary';
+    out.appendChild(binary);
+    return out;
+  }
+  if (f.added == null) return out;
+  const add = doc.createElement('span');
+  add.className = 'diff-add';
+  add.textContent = `+${f.added}`;
+  const del = doc.createElement('span');
+  del.className = 'diff-del';
+  del.textContent = `−${f.removed}`;
+  out.append(add, doc.createTextNode(' '), del);
+  return out;
+}
+
+function diffSectionMeta(entry, fileKey, section) {
+  const path = String(section?.path ?? entry?.f?.path ?? '');
+  return {
+    fileKey: String(fileKey ?? ''),
+    project: String(entry?.project ?? ''),
+    path,
+    oldPath: String(section?.oldPath ?? entry?.f?.from ?? path),
+    newPath: path,
+  };
+}
+
+function setSectionData(el, meta) {
+  el.dataset.fileKey = String(meta.fileKey ?? '');
+  el.dataset.project = String(meta.project ?? '');
+  el.dataset.path = String(meta.path ?? '');
+  el.dataset.oldPath = String(meta.oldPath ?? '');
+  el.dataset.newPath = String(meta.newPath ?? '');
+}
+
+function hdDiffRow(doc, line, meta) {
+  const row = doc.createElement('div');
+  row.className = `hd-dl hd-dl-row hd-dl-${line.kind}`;
+  setSectionData(row, meta);
+  row.dataset.old = line.oldNo == null ? '' : String(line.oldNo);
+  row.dataset.new = line.newNo == null ? '' : String(line.newNo);
+
+  const gutter = (side, no) => {
+    const cell = doc.createElement('span');
+    cell.className = `hd-dl-n hd-dl-n-${side}`;
+    if (no == null) {
+      cell.setAttribute('aria-hidden', 'true');
+    } else {
+      const visible = doc.createElement('span');
+      visible.className = 'hd-dl-n-v';
+      visible.setAttribute('aria-hidden', 'true');
+      visible.textContent = String(no);
+      const spoken = doc.createElement('span');
+      spoken.className = 'sr-only';
+      spoken.textContent = `${side === 'old' ? 'Old' : 'New'} line ${no}`;
+      cell.append(visible, spoken);
+    }
+    return cell;
+  };
+
+  const code = doc.createElement('span');
+  code.className = 'hd-dl-code';
+  const sign = doc.createElement('span');
+  sign.className = 'hd-dl-sign';
+  sign.textContent = line.kind === 'add' ? '+' : line.kind === 'del' ? '-' : ' ';
+  const source = doc.createElement('span');
+  source.className = 'hd-dl-src';
+  source.textContent = line.text;
+  code.append(sign, source);
+  row.append(gutter('old', line.oldNo), gutter('new', line.newNo), code);
+  return { row, source };
+}
+
+function afterDiffPaint(win = window) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      win.clearTimeout(timer);
+      resolve();
+    };
+    const timer = win.setTimeout(finish, 50);
+    if (typeof win.requestAnimationFrame === 'function') {
+      win.requestAnimationFrame(() => win.setTimeout(finish, 0));
+    } else {
+      win.setTimeout(finish, 0);
+    }
+  });
+}
+
+async function enhanceDiffBody({ parsed, lang, refs, ownsBody }) {
+  const loading = diffHljsLoader.forLanguage(lang);
+  await afterDiffPaint();
+  const loaded = await loading;
+  if (!loaded || !ownsBody()) return;
+  if (!highlightParsed(parsed, lang, loaded.highlight) || !ownsBody()) return;
+
+  for (const hunk of parsed.hunks) {
+    const marked = hunk.lines.filter((line) => Object.hasOwn(line, 'html'));
+    if (!marked.length || marked.length !== hunk.lines.length) continue;
+    const staged = [];
+    let valid = true;
+    for (const line of hunk.lines) {
+      const liveSource = refs.get(line);
+      const holder = document.createElement('span');
+      holder.innerHTML = line.html;
+      const elements = [...holder.querySelectorAll('*')];
+      if (!liveSource || holder.textContent !== line.text
+        || elements.some((el) => el.tagName !== 'SPAN'
+          || [...el.attributes].some((attribute) => attribute.name !== 'class'))) {
+        valid = false;
+        break;
+      }
+      staged.push({ liveSource, nodes: [...holder.childNodes] });
+    }
+    if (!valid || !ownsBody()) continue;
+    for (const { liveSource, nodes } of staged) liveSource.replaceChildren(...nodes);
+  }
 }
 
 function buildHdDiff(sec, record, data) {
@@ -11124,16 +11255,23 @@ function buildHdDiff(sec, record, data) {
   const pane = document.createElement('div');
   pane.className = 'hd-diff-pane';
   grid.append(listCard, pane);
-  sec.appendChild(grid);
+  const sectionHeading = document.createElement('h2');
+  sectionHeading.className = 'sr-only';
+  sectionHeading.textContent = 'Changed files and diff';
+  sec.append(sectionHeading, grid);
 
   const sums = results.summary || {};
   const head = document.createElement('div');
   head.className = 'hd-diff-list-head';
   // NOT + filesDeleted: 'D' rows already count in filesChanged (see HD_TABS).
   const nFiles = (sums.filesNew || 0) + (sums.filesChanged || 0);
-  head.innerHTML = `<b>${nFiles} file${nFiles === 1 ? '' : 's'} changed</b>` +
-    `<span class="mono"><span class="diff-add">+${sums.linesAdded || 0}</span> ` +
-    `<span class="diff-del">−${sums.linesRemoved || 0}</span></span>`; // U+2212
+  const total = document.createElement('b');
+  total.textContent = `${nFiles} file${nFiles === 1 ? '' : 's'} changed`;
+  const totals = hdFileCountsNode(document, {
+    added: sums.linesAdded || 0,
+    removed: sums.linesRemoved || 0,
+  });
+  head.append(total, totals);
   listCard.appendChild(head);
 
   const rowsHost = document.createElement('div');
@@ -11169,95 +11307,102 @@ function buildHdDiff(sec, record, data) {
     return pstate.patchPromise;
   }
 
-  async function select(rowEl, entry) {
+  async function select(entry, fileKey) {
     const epoch = ++pstate.selEpoch;
-    for (const r of rowsHost.querySelectorAll('.hd-diff-file')) r.classList.toggle('active', r === rowEl);
     pane.innerHTML = '';
     const ph = document.createElement('div');
     ph.className = 'hd-diff-pane-head mono';
-    ph.innerHTML = `<span class="hd-diff-path">${escapeHtml(entry.f.path)}</span>`
-      + `<span>${hdFileCountsHtml(entry.f)}</span>`;
+    const selectedPath = document.createElement('h3');
+    selectedPath.className = 'hd-diff-path';
+    selectedPath.textContent = entry.f.path;
+    selectedPath.title = entry.f.from ? `${entry.f.from} → ${entry.f.path}` : entry.f.path;
+    if (entry.f.from) {
+      selectedPath.setAttribute('aria-label', `Renamed from ${entry.f.from} to ${entry.f.path}`);
+    }
+    ph.append(selectedPath, hdFileCountsNode(document, entry.f));
     pane.appendChild(ph);
 
     await ensurePatch();
-    if (epoch !== pstate.selEpoch) return; // a newer selection took the pane
+    if (epoch !== pstate.selEpoch
+      || !pane.isConnected
+      || !histDetailState?.screen?.contains(pane)) return;
 
     const body = document.createElement('div');
     body.className = 'hd-diff-body mono';
     const section = pstate.index && pstate.index.get(sectionKey(entry.project, entry.f.path));
+    const meta = diffSectionMeta(entry, fileKey, section);
     if (!section) {
       body.classList.add('hint');
-      body.textContent = pstate.error
+      const note = document.createElement('div');
+      note.className = 'hd-diff-note';
+      setSectionData(note, meta);
+      note.textContent = pstate.error
         ? `Could not load the patch: ${pstate.error}`
         : '(no textual diff for this file)';
+      body.appendChild(note);
       pane.appendChild(body);
       return;
     }
     const parsed = parseFileSection(section.raw);
     if (parsed.binary || !parsed.hunks.length) {
       body.classList.add('hint');
-      body.textContent = '(no textual diff for this file)';
+      const note = document.createElement('div');
+      note.className = 'hd-diff-note';
+      setSectionData(note, meta);
+      note.textContent = '(no textual diff for this file)';
+      body.appendChild(note);
       pane.appendChild(body);
       return;
     }
+    const refs = new Map();
+    let digits = 3;
     for (const hunk of parsed.hunks) {
       const hh = document.createElement('div');
       hh.className = 'hd-dl hd-dl-hunk';
+      setSectionData(hh, meta);
       hh.textContent = hunk.header;
       body.appendChild(hh);
       for (const line of hunk.lines) {
-        const dl = document.createElement('div');
-        dl.className = `hd-dl hd-dl-${line.kind}`;
-        // ASCII prefixes on purpose: this is a verbatim patch a user may copy —
-        // a U+2212 here yields something `git apply` rejects. U+2212 stays in the
-        // COUNT chips above.
-        dl.textContent = (line.kind === 'add' ? '+' : line.kind === 'del' ? '-' : ' ') + line.text;
-        body.appendChild(dl);
+        for (const no of [line.oldNo, line.newNo]) {
+          if (Number.isSafeInteger(no)) digits = Math.max(digits, String(no).length);
+        }
+        const rendered = hdDiffRow(document, line, meta);
+        refs.set(line, rendered.source);
+        body.appendChild(rendered.row);
       }
     }
     if (parsed.truncated) {
       const t = document.createElement('div');
-      t.className = 'hint hd-diff-trunc';
-      t.textContent = '(large file — diff truncated at 500 KB)';
+      t.className = 'hint hd-diff-note hd-diff-trunc';
+      setSectionData(t, meta);
+      t.textContent = '(large file — diff truncated)';
       body.appendChild(t);
     }
+    body.style.setProperty('--hd-gutter-width', `calc(${digits}ch + 16px)`);
     pane.appendChild(body);
+
+    const syntaxPath = section.path || entry.f.path || section.oldPath;
+    const lang = langForPath(syntaxPath);
+    if (lang && canHighlightParsed(parsed)) {
+      const ownsBody = () => epoch === pstate.selEpoch
+        && body.isConnected
+        && pane.isConnected
+        && pane.contains(body)
+        && histDetailState?.screen?.contains(pane);
+      void enhanceDiffBody({ parsed, lang, refs, ownsBody }).catch(() => {});
+    }
   }
 
-  let lastProject = null;
-  let first = null;
-  for (const entry of rows) {
-    if (entry.project && entry.project !== lastProject) {
-      lastProject = entry.project;
-      const gh = document.createElement('div');
-      gh.className = 'hd-diff-proj mono';
-      gh.textContent = entry.project;
-      rowsHost.appendChild(gh);
-    }
-    const rowEl = document.createElement('div');
-    rowEl.className = 'hd-diff-file' + (entry.f.status === 'D' ? ' deleted' : '') + (entry.isNew ? ' new' : '');
-    rowEl.setAttribute('role', 'button');
-    rowEl.tabIndex = 0;
-    const path = document.createElement('span');
-    path.className = 'hd-diff-path mono';
-    path.textContent = entry.f.path;
-    path.title = entry.f.from ? `${entry.f.from} → ${entry.f.path}` : entry.f.path;
-    const counts = document.createElement('span');
-    counts.className = 'mono hd-diff-counts';
-    counts.innerHTML = hdFileCountsHtml(entry.f);
-    rowEl.append(path, counts);
-    // `select` is async and fire-and-forget from all three call sites, so it needs
-    // an explicit sink: node --test fails the WHOLE file on an unhandled rejection
-    // and pins it on whichever test happens to be in flight.
-    const pick = () => { select(rowEl, entry).catch(() => {}); };
-    rowEl.addEventListener('click', pick);
-    rowEl.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); pick(); }
-    });
-    rowsHost.appendChild(rowEl);
-    if (!first) first = { rowEl, entry };
-  }
-  if (first) select(first.rowEl, first.entry).catch(() => {});
+  const nodes = buildFileTree(rows);
+  const first = firstFile(nodes);
+  const tree = renderFileTree(nodes, {
+    doc: document,
+    initialKey: first?.key ?? null,
+    counts: (entry) => hdFileCountsNode(document, entry.f),
+    onPick: (entry, key) => { select(entry, key).catch(() => {}); },
+  });
+  rowsHost.appendChild(tree);
+  if (first) select(first.entry, first.key).catch(() => {});
   else {
     const none = document.createElement('div');
     none.className = 'hint hd-diff-none';

--- a/ui/public/diff-view.mjs
+++ b/ui/public/diff-view.mjs
@@ -4,10 +4,17 @@
 // workspace runs concatenate per-member patches, each prefixed with a
 // "# <projectKey>" comment line (orchestrator.mjs:3443).
 
+// The ONLY cap here: it bounds parsing work and is the only point where rows
+// are lost (and said so via `truncated`). Bounding the DOM is the renderer's
+// job — app.js connects rows in windows — so a 6,000-line lockfile hunk parses
+// in full and stays one click away instead of silently disappearing.
 export const MAX_FILE_SECTION_CODE_UNITS = 500_000;
-export const MAX_FILE_SECTION_RENDER_ITEMS = 5_000;
 
-const HUNK_RANGE_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$/;
+// `[^\n]` rather than `.`: git copies the function-context line verbatim, and
+// `.` excludes CR, U+2028 and U+2029 — a header such as
+// `@@ -5,7 +5,7 @@ function f(sep = "\u2028") {` would otherwise lose its range,
+// blanking both gutters and disabling highlighting for the hunk.
+const HUNK_RANGE_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: [^\n]*)?$/;
 
 export function hunkRange(header) {
   const raw = String(header || '');
@@ -122,7 +129,6 @@ export function parseFileSection(raw) {
   }
   const res = { binary: false, truncated, hunks: [] };
   let hunk = null;
-  let retainedItems = 0;
   let oldNo = null;
   let newNo = null;
   let oldRemaining = 0;
@@ -141,11 +147,6 @@ export function parseFileSection(raw) {
       continue;
     }
     if (structuralLine.startsWith('@@')) {
-      if (retainedItems >= MAX_FILE_SECTION_RENDER_ITEMS) {
-        res.truncated = true;
-        break;
-      }
-      retainedItems += 1;
       const range = hunkRange(structuralLine);
       hunk = {
         header: structuralLine,
@@ -164,11 +165,6 @@ export function parseFileSection(raw) {
     }
     if (!hunk) continue; // still in the header block
     if (line.startsWith('\\')) continue; // "\ No newline at end of file"
-    if (retainedItems >= MAX_FILE_SECTION_RENDER_ITEMS) {
-      res.truncated = true;
-      break;
-    }
-    retainedItems += 1;
 
     const kind = line.startsWith('+') ? 'add' : line.startsWith('-') ? 'del' : 'ctx';
     const source = kind === 'ctx'

--- a/ui/public/diff-view.mjs
+++ b/ui/public/diff-view.mjs
@@ -4,7 +4,25 @@
 // workspace runs concatenate per-member patches, each prefixed with a
 // "# <projectKey>" comment line (orchestrator.mjs:3443).
 
-export const MAX_FILE_SECTION_BYTES = 500_000;
+export const MAX_FILE_SECTION_CODE_UNITS = 500_000;
+export const MAX_FILE_SECTION_RENDER_ITEMS = 5_000;
+
+const HUNK_RANGE_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$/;
+
+export function hunkRange(header) {
+  const raw = String(header || '');
+  const m = HUNK_RANGE_RE.exec(raw.endsWith('\r') ? raw.slice(0, -1) : raw);
+  if (!m) return null;
+  const values = [m[1], m[2] ?? '1', m[3], m[4] ?? '1'].map(Number);
+  if (!values.every((n) => Number.isSafeInteger(n) && n >= 0)) return null;
+  const [oldStart, oldCount, newStart, newCount] = values;
+  const safeRange = (start, count) => {
+    if (count === 0) return start >= 0;
+    return start >= 1 && start <= Number.MAX_SAFE_INTEGER - (count - 1);
+  };
+  if (!safeRange(oldStart, oldCount) || !safeRange(newStart, newCount)) return null;
+  return { oldStart, oldCount, newStart, newCount };
+}
 
 // One cheap pass: split the patch into per-file sections. Lines outside any
 // "diff --git" section are ignored, EXCEPT "# <key>" markers, which set the
@@ -88,15 +106,15 @@ function stripSide(s) {
 export function parseFileSection(raw) {
   let text = String(raw || '');
   let truncated = false;
-  if (text.length > MAX_FILE_SECTION_BYTES) {
-    const cut = text.lastIndexOf('\n', MAX_FILE_SECTION_BYTES);
+  if (text.length > MAX_FILE_SECTION_CODE_UNITS) {
+    const cut = text.lastIndexOf('\n', MAX_FILE_SECTION_CODE_UNITS);
     if (cut > 0) {
       text = text.slice(0, cut);                    // snapped to a line boundary
     } else {
       // One line longer than the whole cap: there is no newline to snap to, so
       // cut mid-line and drop a trailing LONE HIGH SURROGATE (a '\n' can never
       // sit inside a pair, which is why the snapped path needs no such guard).
-      text = text.slice(0, MAX_FILE_SECTION_BYTES);
+      text = text.slice(0, MAX_FILE_SECTION_CODE_UNITS);
       const last = text.charCodeAt(text.length - 1);
       if (last >= 0xd800 && last <= 0xdbff) text = text.slice(0, -1);
     }
@@ -104,6 +122,11 @@ export function parseFileSection(raw) {
   }
   const res = { binary: false, truncated, hunks: [] };
   let hunk = null;
+  let retainedItems = 0;
+  let oldNo = null;
+  let newNo = null;
+  let oldRemaining = 0;
+  let newRemaining = 0;
   const rows = text.split('\n');
   // A \n-terminated section yields a trailing '' from split (and the workspace
   // '\n\n' member join leaves extras at each seam); without the pop each becomes
@@ -111,20 +134,56 @@ export function parseFileSection(raw) {
   // (one space), never '', so popping every trailing '' is safe.
   while (rows.length && rows[rows.length - 1] === '') rows.pop();
   for (const line of rows) {
-    if (line.startsWith('Binary files ') || line === 'GIT binary patch') {
+    const structuralLine = line.endsWith('\r') ? line.slice(0, -1) : line;
+    if (structuralLine.startsWith('Binary files ')
+      || structuralLine === 'GIT binary patch') {
       res.binary = true;
       continue;
     }
-    if (line.startsWith('@@')) {
-      hunk = { header: line, lines: [] };
+    if (structuralLine.startsWith('@@')) {
+      if (retainedItems >= MAX_FILE_SECTION_RENDER_ITEMS) {
+        res.truncated = true;
+        break;
+      }
+      retainedItems += 1;
+      const range = hunkRange(structuralLine);
+      hunk = {
+        header: structuralLine,
+        oldStart: range?.oldStart ?? null,
+        oldCount: range?.oldCount ?? null,
+        newStart: range?.newStart ?? null,
+        newCount: range?.newCount ?? null,
+        lines: [],
+      };
+      oldNo = range?.oldStart ?? null;
+      newNo = range?.newStart ?? null;
+      oldRemaining = range?.oldCount ?? 0;
+      newRemaining = range?.newCount ?? 0;
       res.hunks.push(hunk);
       continue;
     }
     if (!hunk) continue; // still in the header block
-    if (line.startsWith('+')) hunk.lines.push({ kind: 'add', text: line.slice(1) });
-    else if (line.startsWith('-')) hunk.lines.push({ kind: 'del', text: line.slice(1) });
-    else if (line.startsWith('\\')) continue; // "\ No newline at end of file"
-    else hunk.lines.push({ kind: 'ctx', text: line.startsWith(' ') ? line.slice(1) : line });
+    if (line.startsWith('\\')) continue; // "\ No newline at end of file"
+    if (retainedItems >= MAX_FILE_SECTION_RENDER_ITEMS) {
+      res.truncated = true;
+      break;
+    }
+    retainedItems += 1;
+
+    const kind = line.startsWith('+') ? 'add' : line.startsWith('-') ? 'del' : 'ctx';
+    const source = kind === 'ctx'
+      ? (line.startsWith(' ') ? line.slice(1) : line)
+      : line.slice(1);
+    const numbered = { kind, text: source, oldNo: null, newNo: null };
+    if (kind !== 'add' && oldNo != null && oldRemaining > 0) {
+      numbered.oldNo = oldNo++;
+      oldRemaining -= 1;
+    }
+    if (kind !== 'del' && newNo != null && newRemaining > 0) {
+      numbered.newNo = newNo++;
+      newRemaining -= 1;
+    }
+    hunk.lines.push(numbered);
   }
   return res;
 }

--- a/ui/public/file-tree.mjs
+++ b/ui/public/file-tree.mjs
@@ -1,0 +1,247 @@
+// Deterministic, project-scoped model and renderer for changed-file navigation.
+
+const nodeKey = (project, type, fullPath) =>
+  JSON.stringify([project ?? null, type, fullPath]);
+
+const cmpText = (a, b) => {
+  const af = a.toLowerCase();
+  const bf = b.toLowerCase();
+  return af < bf ? -1 : af > bf ? 1 : a < b ? -1 : a > b ? 1 : 0;
+};
+
+const sortNodes = (nodes) => nodes.sort((a, b) => {
+  if (a.type !== b.type) {
+    if (a.type === 'project') return -1;
+    if (b.type === 'project') return 1;
+    return a.type === 'dir' ? -1 : 1;
+  }
+  return cmpText(a.name, b.name);
+});
+
+function compactDir(node) {
+  let current = node;
+  const names = [current.name];
+  while (current.children.length === 1 && current.children[0].type === 'dir') {
+    current = current.children[0];
+    names.push(current.name);
+  }
+  return {
+    ...current,
+    name: names.join('/'),
+    children: current.children.map((child) =>
+      child.type === 'dir' ? compactDir(child) : child),
+  };
+}
+
+function makeChildren(rows, project) {
+  const root = new Map();
+  const seenFiles = new Set();
+  for (const entry of rows) {
+    const path = String(entry?.f?.path || '');
+    if (!path) continue;
+    const parts = path.split('/').filter(Boolean);
+    if (!parts.length) continue;
+    const fileKey = nodeKey(project, 'file', path);
+    if (seenFiles.has(fileKey)) continue;
+    seenFiles.add(fileKey);
+    let children = root;
+    let dirPath = '';
+    for (const segment of parts.slice(0, -1)) {
+      dirPath = dirPath ? `${dirPath}/${segment}` : segment;
+      const childKey = JSON.stringify(['dir', segment]);
+      let dir = children.get(childKey);
+      if (!dir) {
+        dir = {
+          type: 'dir', key: nodeKey(project, 'dir', dirPath), name: segment,
+          path: dirPath, project, childMap: new Map(),
+        };
+        children.set(childKey, dir);
+      }
+      children = dir.childMap;
+    }
+    const name = parts[parts.length - 1];
+    children.set(JSON.stringify(['file', name]), {
+      type: 'file', key: fileKey, name, path, project, entry,
+    });
+  }
+
+  const materialize = (children) => sortNodes([...children.values()].map((node) => {
+    if (node.type === 'file') return node;
+    const { childMap, ...dir } = node;
+    return { ...dir, children: materialize(childMap) };
+  })).map((node) => (node.type === 'dir' ? compactDir(node) : node));
+  return materialize(root);
+}
+
+export function buildFileTree(rows) {
+  const input = Array.isArray(rows) ? rows : [];
+  const projectRows = new Map();
+  const plainRows = [];
+  for (const entry of input) {
+    if (!entry?.f?.path) continue;
+    if (entry.project == null) {
+      plainRows.push(entry);
+      continue;
+    }
+    const project = String(entry.project);
+    if (!projectRows.has(project)) projectRows.set(project, []);
+    projectRows.get(project).push(entry);
+  }
+  const nodes = makeChildren(plainRows, null);
+  for (const project of [...projectRows.keys()].sort(cmpText)) {
+    nodes.push({
+      type: 'project',
+      key: nodeKey(project, 'project', project),
+      name: project,
+      project,
+      children: makeChildren(projectRows.get(project), project),
+    });
+  }
+  return sortNodes(nodes);
+}
+
+export function firstFile(nodes) {
+  for (const node of Array.isArray(nodes) ? nodes : []) {
+    if (node?.type === 'file') return node;
+    if (node?.children) {
+      const found = firstFile(node.children);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+export function fileStatus(entry) {
+  if (entry?.isNew || entry?.f?.status === 'A' || entry?.f?.status === 'C') return 'add';
+  if (entry?.f?.status === 'D') return 'del';
+  return 'mod';
+}
+
+let nextTreeInstance = 0;
+
+export function renderFileTree(nodes, options = {}) {
+  const { doc = document, onPick, counts = () => doc.createTextNode(''), initialKey } = options;
+  const idPrefix = `hd-tree-${nextTreeInstance++}`;
+  let nextGroup = 0;
+  const nav = doc.createElement('nav');
+  nav.className = 'hd-tree';
+  nav.setAttribute('aria-label', 'Changed files');
+  const fileButtons = new Map();
+  let activeButton = null;
+
+  function activate(button) {
+    if (!button) return;
+    if (activeButton && activeButton !== button) {
+      activeButton.classList.remove('active');
+      activeButton.removeAttribute('aria-current');
+    }
+    activeButton = button;
+    button.classList.add('active');
+    button.setAttribute('aria-current', 'true');
+  }
+
+  function renderFile(node, depth) {
+    const button = doc.createElement('button');
+    button.type = 'button';
+    const state = fileStatus(node.entry);
+    button.className = `hd-diff-file hd-tree-file ${state}`;
+    if (state === 'add') button.classList.add('new');
+    if (state === 'del') button.classList.add('deleted');
+    button.dataset.fileKey = node.key;
+    button.dataset.project = node.project ?? '';
+    button.dataset.path = node.path;
+    button.style.setProperty('--tree-indent', `${10 + depth * 14}px`);
+
+    const f = node.entry?.f || {};
+    const status = ({ A: 'Added', C: 'Copied', D: 'Deleted', R: 'Renamed', M: 'Modified' })[f.status]
+      || (node.entry?.isNew ? 'Added' : 'Changed');
+    const scope = node.project ? ` in project ${node.project}` : '';
+    const identity = f.from
+      ? `from ${String(f.from)} to ${node.path}`
+      : `file ${node.path}`;
+    const amount = f.binary
+      ? 'binary file'
+      : `${Number(f.added) || 0} lines added, ${Number(f.removed) || 0} lines removed`;
+    const label = `${status} ${identity}${scope}, ${amount}`;
+    button.setAttribute('aria-label', label);
+    button.title = label;
+
+    const marker = doc.createElement('span');
+    marker.className = 'hd-tree-status';
+    marker.setAttribute('aria-hidden', 'true');
+    marker.textContent = state === 'add' ? '+' : state === 'del' ? '−' : '•';
+    const path = doc.createElement('span');
+    path.className = 'hd-diff-path mono';
+    path.textContent = node.name;
+    const countNode = counts(node.entry);
+    button.append(marker, path);
+    if (countNode) button.appendChild(countNode);
+    button.addEventListener('click', () => {
+      activate(button);
+      onPick?.(node.entry, node.key);
+    });
+    fileButtons.set(node.key, button);
+    return button;
+  }
+
+  function renderDir(node, depth) {
+    const fragment = doc.createDocumentFragment();
+    const button = doc.createElement('button');
+    button.type = 'button';
+    button.className = 'hd-tree-dir';
+    button.style.setProperty('--tree-indent', `${10 + depth * 14}px`);
+    button.setAttribute('aria-expanded', 'true');
+    const fullLabel = node.project ? `${node.project}/${node.path}` : node.path;
+    button.setAttribute('aria-label', `Collapse directory ${fullLabel}`);
+    const group = doc.createElement('div');
+    group.className = 'hd-tree-group';
+    group.id = `${idPrefix}-group-${nextGroup++}`;
+    group.hidden = false;
+    button.setAttribute('aria-controls', group.id);
+    const chevron = doc.createElement('span');
+    chevron.className = 'hd-tree-chevron';
+    chevron.setAttribute('aria-hidden', 'true');
+    chevron.textContent = '▾';
+    const label = doc.createElement('span');
+    label.className = 'hd-tree-dir-label mono';
+    label.textContent = node.name;
+    button.append(chevron, label);
+    renderNodes(node.children, group, depth + 1);
+    button.addEventListener('click', () => {
+      const expanded = button.getAttribute('aria-expanded') === 'true';
+      button.setAttribute('aria-expanded', String(!expanded));
+      group.hidden = expanded;
+      chevron.textContent = expanded ? '›' : '▾';
+      button.setAttribute('aria-label',
+        `${expanded ? 'Expand' : 'Collapse'} directory ${fullLabel}`);
+    });
+    fragment.append(button, group);
+    return fragment;
+  }
+
+  function renderNodes(items, host, depth) {
+    for (const node of items || []) {
+      if (node.type === 'file') {
+        host.appendChild(renderFile(node, depth));
+      } else if (node.type === 'dir') {
+        host.appendChild(renderDir(node, depth));
+      } else if (node.type === 'project') {
+        const heading = doc.createElement('div');
+        heading.className = 'hd-tree-project';
+        heading.setAttribute('role', 'heading');
+        heading.setAttribute('aria-level', '3');
+        heading.textContent = node.name;
+        const group = doc.createElement('div');
+        group.className = 'hd-tree-group';
+        group.id = `${idPrefix}-group-${nextGroup++}`;
+        renderNodes(node.children, group, depth);
+        host.append(heading, group);
+      }
+    }
+  }
+
+  renderNodes(nodes, nav, 0);
+  const initial = fileButtons.get(initialKey);
+  if (initial) activate(initial);
+  return nav;
+}

--- a/ui/public/file-tree.mjs
+++ b/ui/public/file-tree.mjs
@@ -68,8 +68,8 @@ function makeChildren(rows, project) {
   const materialize = (children) => sortNodes([...children.values()].map((node) => {
     if (node.type === 'file') return node;
     const { childMap, ...dir } = node;
-    return { ...dir, children: materialize(childMap) };
-  })).map((node) => (node.type === 'dir' ? compactDir(node) : node));
+    return compactDir({ ...dir, children: materialize(childMap) });
+  }));
   return materialize(root);
 }
 
@@ -169,7 +169,7 @@ export function renderFileTree(nodes, options = {}) {
     const marker = doc.createElement('span');
     marker.className = 'hd-tree-status';
     marker.setAttribute('aria-hidden', 'true');
-    marker.textContent = state === 'add' ? '+' : state === 'del' ? '−' : '•';
+    marker.textContent = state === 'add' ? '+' : state === 'del' ? '-' : '•';
     const path = doc.createElement('span');
     path.className = 'hd-diff-path mono';
     path.textContent = node.name;

--- a/ui/public/file-tree.mjs
+++ b/ui/public/file-tree.mjs
@@ -1,5 +1,58 @@
 // Deterministic, project-scoped model and renderer for changed-file navigation.
 
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function svgNode(doc, tag, attrs = {}) {
+  const node = doc.createElementNS(SVG_NS, tag);
+  for (const [name, value] of Object.entries(attrs)) node.setAttribute(name, String(value));
+  return node;
+}
+
+function treeIcon(doc, kind) {
+  const svg = svgNode(doc, 'svg', {
+    viewBox: '0 0 20 20', fill: 'none', stroke: 'currentColor',
+    'stroke-width': '1.7', 'stroke-linecap': 'round', 'stroke-linejoin': 'round',
+    'aria-hidden': 'true', focusable: 'false',
+  });
+
+  if (kind === 'folder') {
+    svg.classList.add('hd-tree-folder-icon');
+    svg.appendChild(svgNode(doc, 'path', {
+      d: 'M2.5 5.25h5l1.7 2h8.3v7.5a1.5 1.5 0 0 1-1.5 1.5H4a1.5 1.5 0 0 1-1.5-1.5z',
+    }));
+    return svg;
+  }
+
+  svg.classList.add('hd-tree-file-icon');
+  svg.setAttribute('stroke-width', '1.45');
+  svg.append(
+    svgNode(doc, 'path', { d: 'M5 2.5h6.5l3.5 3.5v11.5H5z' }),
+    svgNode(doc, 'path', { d: 'M11.5 2.5V6H15' }),
+  );
+  if (kind === 'add') {
+    svg.appendChild(svgNode(doc, 'path', { d: 'M7.5 12h5M10 9.5v5' }));
+  } else if (kind === 'del') {
+    svg.appendChild(svgNode(doc, 'path', { d: 'M7.5 12h5' }));
+  } else {
+    svg.append(
+      svgNode(doc, 'path', { d: 'M7.5 10h5' }),
+      svgNode(doc, 'path', { d: 'M7.5 13h5' }),
+    );
+  }
+  return svg;
+}
+
+function chevronIcon(doc) {
+  const svg = svgNode(doc, 'svg', {
+    viewBox: '0 0 18 20', fill: 'none', stroke: 'currentColor',
+    'stroke-width': '1.8', 'stroke-linecap': 'round', 'stroke-linejoin': 'round',
+    'aria-hidden': 'true', focusable: 'false',
+  });
+  svg.classList.add('hd-tree-chevron');
+  svg.appendChild(svgNode(doc, 'path', { d: 'M6.5 5.5 11 10l-4.5 4.5' }));
+  return svg;
+}
+
 const nodeKey = (project, type, fullPath) =>
   JSON.stringify([project ?? null, type, fullPath]);
 
@@ -169,7 +222,7 @@ export function renderFileTree(nodes, options = {}) {
     const marker = doc.createElement('span');
     marker.className = 'hd-tree-status';
     marker.setAttribute('aria-hidden', 'true');
-    marker.textContent = state === 'add' ? '+' : state === 'del' ? '-' : '•';
+    marker.appendChild(treeIcon(doc, state));
     const path = doc.createElement('span');
     path.className = 'hd-diff-path mono';
     path.textContent = node.name;
@@ -198,20 +251,17 @@ export function renderFileTree(nodes, options = {}) {
     group.id = `${idPrefix}-group-${nextGroup++}`;
     group.hidden = false;
     button.setAttribute('aria-controls', group.id);
-    const chevron = doc.createElement('span');
-    chevron.className = 'hd-tree-chevron';
-    chevron.setAttribute('aria-hidden', 'true');
-    chevron.textContent = '▾';
+    const chevron = chevronIcon(doc);
+    const folder = treeIcon(doc, 'folder');
     const label = doc.createElement('span');
     label.className = 'hd-tree-dir-label mono';
     label.textContent = node.name;
-    button.append(chevron, label);
+    button.append(chevron, folder, label);
     renderNodes(node.children, group, depth + 1);
     button.addEventListener('click', () => {
       const expanded = button.getAttribute('aria-expanded') === 'true';
       button.setAttribute('aria-expanded', String(!expanded));
       group.hidden = expanded;
-      chevron.textContent = expanded ? '›' : '▾';
       button.setAttribute('aria-label',
         `${expanded ? 'Expand' : 'Collapse'} directory ${fullLabel}`);
     });

--- a/ui/public/hljs-loader.mjs
+++ b/ui/public/hljs-loader.mjs
@@ -1,0 +1,120 @@
+import { SUPPORTED_LANGUAGE_IDS } from './syntax-highlight.mjs';
+
+const LANGUAGE_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const ALLOWED_LANGUAGES = new Set(SUPPORTED_LANGUAGE_IDS);
+const coreUrl = (attempt) => `/vendor/hljs/core.min.js?retry=${attempt}`;
+const grammarUrl = (lang, attempt) =>
+  `/vendor/hljs/languages/${lang}.min.js?retry=${attempt}`;
+
+export function createHljsLoader(options = {}) {
+  const loadCore = options.loadCore || ((attempt) => import(coreUrl(attempt)));
+  const loadGrammar = options.loadGrammar
+    || ((lang, attempt) => import(grammarUrl(lang, attempt)));
+
+  let coreFactory = null;
+  let corePending = null;
+  let nextCoreAttempt = 0;
+  const grammarPending = new Map();
+  const grammarFunctions = new Map();
+  const nextGrammarAttempt = new Map();
+  const languagePending = new Map();
+  const languageReady = new Map();
+
+  const validInstance = (value) => value
+    && typeof value.getLanguage === 'function'
+    && typeof value.registerLanguage === 'function'
+    && typeof value.highlight === 'function';
+
+  function getCoreFactory() {
+    if (coreFactory) return Promise.resolve(coreFactory);
+    if (corePending) return corePending;
+    const attempt = nextCoreAttempt++;
+    const pending = Promise.resolve()
+      .then(() => loadCore(attempt))
+      .then((mod) => {
+        const exported = mod?.default;
+        if (typeof exported?.newInstance !== 'function') {
+          throw new TypeError('core module has no newInstance factory');
+        }
+        coreFactory = exported;
+        return coreFactory;
+      })
+      .catch(() => null)
+      .finally(() => {
+        if (corePending === pending) corePending = null;
+      });
+    corePending = pending;
+    return pending;
+  }
+
+  function getGrammar(lang) {
+    if (grammarFunctions.has(lang)) return Promise.resolve(grammarFunctions.get(lang));
+    const existing = grammarPending.get(lang);
+    if (existing) return existing;
+    const attempt = nextGrammarAttempt.get(lang) || 0;
+    nextGrammarAttempt.set(lang, attempt + 1);
+    const pending = Promise.resolve()
+      .then(() => loadGrammar(lang, attempt))
+      .then((mod) => {
+        if (typeof mod?.default !== 'function') throw new TypeError('invalid grammar module');
+        grammarFunctions.set(lang, mod.default);
+        return mod.default;
+      })
+      .catch(() => null)
+      .finally(() => {
+        if (grammarPending.get(lang) === pending) grammarPending.delete(lang);
+      });
+    grammarPending.set(lang, pending);
+    return pending;
+  }
+
+  function buildLanguage(lang) {
+    if (languageReady.has(lang)) return Promise.resolve(languageReady.get(lang));
+    const existing = languagePending.get(lang);
+    if (existing) return existing;
+    const pending = Promise.all([getCoreFactory(), getGrammar(lang)])
+      .then(([factory, grammar]) => {
+        if (!factory || !grammar) return null;
+        const hljs = factory.newInstance();
+        if (!validInstance(hljs)) throw new TypeError('invalid highlight.js instance');
+        hljs.registerLanguage(lang, grammar);
+        if (!hljs.getLanguage(lang)) throw new TypeError('grammar did not register');
+        const bound = Object.freeze({
+          lang,
+          highlight(text, requested = lang) {
+            if (requested !== lang) throw new TypeError('language mismatch');
+            const result = hljs.highlight(String(text), {
+              language: lang,
+              ignoreIllegals: true,
+            });
+            if (typeof result?.value !== 'string') {
+              throw new TypeError('invalid highlight result');
+            }
+            return result.value;
+          },
+        });
+        languageReady.set(lang, bound);
+        return bound;
+      })
+      .catch(() => null)
+      .finally(() => {
+        if (languagePending.get(lang) === pending) languagePending.delete(lang);
+      });
+    languagePending.set(lang, pending);
+    return pending;
+  }
+
+  return Object.freeze({
+    async forLanguage(input) {
+      try {
+        const lang = String(input ?? '');
+        if (!LANGUAGE_ID_RE.test(lang) || !ALLOWED_LANGUAGES.has(lang)) return null;
+        return await buildLanguage(lang);
+      } catch {
+        return null;
+      }
+    },
+  });
+}
+
+export const _testing = Object.freeze({ coreUrl, grammarUrl });

--- a/ui/public/hljs-loader.mjs
+++ b/ui/public/hljs-loader.mjs
@@ -2,6 +2,48 @@ import { SUPPORTED_LANGUAGE_IDS } from './syntax-highlight.mjs';
 
 const LANGUAGE_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const ALLOWED_LANGUAGES = new Set(SUPPORTED_LANGUAGE_IDS);
+const codeUnitCompare = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+
+// Grammars the pinned highlight.js build delegates to through `subLanguage`
+// regions (JSX markup inside javascript/typescript, <script>/<style> bodies
+// inside xml, RUN arguments in dockerfile, …), closed transitively: xml's
+// <style> body needs css even when xml itself is only reached from javascript.
+// Core emits a region as PLAIN TEXT when its grammar is missing from the
+// instance, so every primary language registers its whole closure up front.
+// The set is fixed per primary language, which keeps the output a pure
+// function of (language, text) rather than of which files were opened first.
+// Every declared sub-language is a string (never an autodetect list), so the
+// extra grammars can only fill those regions, never change the primary parse.
+// test/hljs-loader.test.mjs derives this table from the installed package and
+// fails on drift after an upgrade.
+export const HLJS_SUB_LANGUAGES = Object.freeze({
+  dart: Object.freeze(['css', 'graphql', 'javascript', 'markdown', 'xml']),
+  dockerfile: Object.freeze(['bash']),
+  javascript: Object.freeze(['css', 'graphql', 'xml']),
+  markdown: Object.freeze(['css', 'graphql', 'javascript', 'xml']),
+  nix: Object.freeze(['css', 'graphql', 'javascript', 'markdown', 'xml']),
+  perl: Object.freeze(['css', 'graphql', 'javascript', 'mojolicious', 'xml']),
+  typescript: Object.freeze(['css', 'graphql', 'javascript', 'xml']),
+  xml: Object.freeze(['css', 'graphql', 'javascript']),
+  yaml: Object.freeze(['ruby']),
+});
+
+const subLanguagesOf = (lang) => (
+  Object.hasOwn(HLJS_SUB_LANGUAGES, lang) ? HLJS_SUB_LANGUAGES[lang] : []
+);
+
+// Every grammar file the loader may request: the reviewed primaries plus their
+// sub-languages. ui/server.mjs serves exactly this set under /vendor/hljs.
+export const HLJS_GRAMMAR_IDS = Object.freeze(
+  [...new Set([...SUPPORTED_LANGUAGE_IDS, ...Object.values(HLJS_SUB_LANGUAGES).flat()])]
+    .sort(codeUnitCompare),
+);
+// Retry-on-next-call exists for a blip (a server restart mid-session), not for
+// a /vendor that fails forever: without a ceiling every selection costs one
+// doomed import per missing resource, one console error each, and a new
+// `?retry=N` entry in the module map. After this many failed loads of a
+// resource the loader answers null for the rest of the page's life.
+export const MAX_RESOURCE_FAILURES = 3;
 const coreUrl = (attempt) => `/vendor/hljs/core.min.js?retry=${attempt}`;
 const grammarUrl = (lang, attempt) =>
   `/vendor/hljs/languages/${lang}.min.js?retry=${attempt}`;
@@ -14,9 +56,11 @@ export function createHljsLoader(options = {}) {
   let coreFactory = null;
   let corePending = null;
   let nextCoreAttempt = 0;
+  let coreFailures = 0;
   const grammarPending = new Map();
   const grammarFunctions = new Map();
   const nextGrammarAttempt = new Map();
+  const grammarFailures = new Map();
   const languagePending = new Map();
   const languageReady = new Map();
 
@@ -28,6 +72,7 @@ export function createHljsLoader(options = {}) {
   function getCoreFactory() {
     if (coreFactory) return Promise.resolve(coreFactory);
     if (corePending) return corePending;
+    if (coreFailures >= MAX_RESOURCE_FAILURES) return Promise.resolve(null);
     const attempt = nextCoreAttempt++;
     const pending = Promise.resolve()
       .then(() => loadCore(attempt))
@@ -39,7 +84,10 @@ export function createHljsLoader(options = {}) {
         coreFactory = exported;
         return coreFactory;
       })
-      .catch(() => null)
+      .catch(() => {
+        coreFailures += 1;
+        return null;
+      })
       .finally(() => {
         if (corePending === pending) corePending = null;
       });
@@ -51,6 +99,7 @@ export function createHljsLoader(options = {}) {
     if (grammarFunctions.has(lang)) return Promise.resolve(grammarFunctions.get(lang));
     const existing = grammarPending.get(lang);
     if (existing) return existing;
+    if ((grammarFailures.get(lang) || 0) >= MAX_RESOURCE_FAILURES) return Promise.resolve(null);
     const attempt = nextGrammarAttempt.get(lang) || 0;
     nextGrammarAttempt.set(lang, attempt + 1);
     const pending = Promise.resolve()
@@ -60,7 +109,10 @@ export function createHljsLoader(options = {}) {
         grammarFunctions.set(lang, mod.default);
         return mod.default;
       })
-      .catch(() => null)
+      .catch(() => {
+        grammarFailures.set(lang, (grammarFailures.get(lang) || 0) + 1);
+        return null;
+      })
       .finally(() => {
         if (grammarPending.get(lang) === pending) grammarPending.delete(lang);
       });
@@ -72,13 +124,21 @@ export function createHljsLoader(options = {}) {
     if (languageReady.has(lang)) return Promise.resolve(languageReady.get(lang));
     const existing = languagePending.get(lang);
     if (existing) return existing;
-    const pending = Promise.all([getCoreFactory(), getGrammar(lang)])
-      .then(([factory, grammar]) => {
-        if (!factory || !grammar) return null;
+    const subs = subLanguagesOf(lang);
+    const pending = Promise.all([getCoreFactory(), getGrammar(lang), ...subs.map(getGrammar)])
+      .then(([factory, grammar, ...subGrammars]) => {
+        // All-or-nothing: a binding is cached only when its whole closure
+        // loaded, so a transient grammar failure degrades to plain rows now
+        // and retries just that grammar on the next selection — it never
+        // yields a cached binding whose output depends on what happened to load.
+        if (!factory || !grammar || subGrammars.some((sub) => !sub)) return null;
         const hljs = factory.newInstance();
         if (!validInstance(hljs)) throw new TypeError('invalid highlight.js instance');
         hljs.registerLanguage(lang, grammar);
-        if (!hljs.getLanguage(lang)) throw new TypeError('grammar did not register');
+        subs.forEach((sub, index) => hljs.registerLanguage(sub, subGrammars[index]));
+        if (![lang, ...subs].every((id) => hljs.getLanguage(id))) {
+          throw new TypeError('grammar did not register');
+        }
         const bound = Object.freeze({
           lang,
           highlight(text, requested = lang) {

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1892,7 +1892,7 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .hd-diff-counts .hint,.hd-diff-pane-head .hint{display:inline;margin-top:0;}
 .hd-diff-pane-head .hd-diff-path{
   margin:0;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
-  font-size:12px;
+  font-size:12px;font-weight:400;
 }
 /* The patch is the tall thing on this screen, so it scrolls INSIDE its pane
    rather than pushing the whole detail screen down — same cap and mechanism as
@@ -1924,8 +1924,18 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .hd-dl-n-new{left:var(--hd-gutter-width);}
 .hd-dl-code{min-width:100%;padding:0 18px 0 10px;white-space:pre;}
 .hd-dl-hunk,.hd-diff-note{grid-column:1/-1;padding-inline:18px;}
+/* Placeholder states are display:block bodies that pad 18px themselves. */
+.hd-diff-body.hint .hd-diff-note{padding-inline:0;}
 .hd-dl-hunk{white-space:pre;color:var(--ink-2);background:var(--field);}
 .hd-diff-trunc{padding-top:10px;color:var(--ink-2);}
+/* "N of M lines shown · Show K more lines": a real grid row spanning all three
+   tracks (like the hunk header), never display:contents. */
+.hd-dl-more{grid-column:1/-1;display:flex;align-items:center;gap:12px;padding:8px 18px;user-select:none;
+  border-top:1px solid var(--line);color:var(--ink-2);font:400 12px var(--sans);}
+.hd-dl-more-btn{border:none;background:none;color:var(--blue-ink);font:500 12.5px var(--sans);
+  cursor:pointer;padding:0;}
+.hd-dl-more-btn:hover{text-decoration:underline;}
+.hd-dl-more-btn:focus-visible{outline:2px solid var(--ink);outline-offset:2px;border-radius:3px;}
 .hd-dl-row.hd-dl-add > *{background:var(--green-bg);}
 .hd-dl-row.hd-dl-del > *{background:var(--red-bg);}
 .hd-tree{display:block;}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1729,7 +1729,7 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .hd .mono,.hist-card .mono,#shipit-modal .mono{font-family:var(--mono);}
 
 /* Card, not a full-bleed band: same border/radius/shadow language as `.card`, and
-   its own 20px/32px margin box supplies the inset the screen itself cannot — 
+   its own 20px/32px margin box supplies the inset the screen itself cannot —
    `.hist-screen-detail` keeps `padding:0` so the sticky `.hd-tabs` can still pin
    flush to the scrollport top. Inner padding drops 32 -> 24 so the title lands a
    card-like distance from the border instead of 56px from the viewport edge. */
@@ -1866,58 +1866,118 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 
 /* ---------- History detail: Diff tab ---------- */
 .hd-diff{display:grid;grid-template-columns:minmax(280px,340px) 1fr;gap:18px;align-items:start;}
+.hd-diff{
+  --hd-count-add:#176B4D;
+  --hd-count-del:#B31D28;
+}
+.hd-diff .diff-add{color:var(--hd-count-add);}
+.hd-diff .diff-del{color:var(--hd-count-del);}
 @media (max-width:900px){.hd-diff{grid-template-columns:1fr;}}
 .hd-diff-list,.hd-diff-pane{background:var(--panel);border:1px solid var(--line);border-radius:var(--r-card);overflow:hidden;}
+.hd-diff-pane{
+  --hd-syntax-comment:#5B6167;
+  --hd-syntax-keyword:#B31D28;
+  --hd-syntax-type:#9A3E00;
+  --hd-syntax-string:#176B4D;
+  --hd-syntax-literal:#713BB8;
+  --hd-syntax-title:#075C82;
+}
 .hd-diff-list-head,.hd-diff-pane-head{display:flex;align-items:center;justify-content:space-between;gap:10px;
   padding:15px 18px;border-bottom:1px solid var(--line);font-size:12.5px;}
 .hd-diff-rows{padding:6px;max-height:520px;overflow-y:auto;}
-.hd-diff-proj{padding:8px 12px 2px;color:var(--ink-3);font-size:11px;}
-.hd-diff-file{display:flex;align-items:center;gap:10px;padding:9px 12px;border-radius:9px;cursor:pointer;}
-.hd-diff-file:hover,.hd-diff-file.active{background:var(--field);}
-.hd-diff-file:focus-visible{outline:2px solid var(--ink);outline-offset:-2px;}
-.hd-diff-file.deleted .hd-diff-path{opacity:.55;text-decoration:line-through;}
 .hd-diff-file.new .hd-diff-path{color:var(--green-ink);}
-/* direction:rtl ellipsizes at the START (the file name matters more than the
-   directory). It also reorders a LEADING NEUTRAL character to the end, so
-   `.github/workflows/ci.yml` would render as `github/workflows/ci.yml.` — the
-   ::before LRM (U+200E) is a strong LTR anchor that pins the dot in place while
-   keeping the start-ellipsis. It lives in CSS, not in textContent, so the
-   `/src\/a\.js/` assertions stay clean. */
-.hd-diff-file .hd-diff-path{flex:1;min-width:0;font-size:12px;color:var(--ink-2);
-  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;direction:rtl;text-align:left;}
-.hd-diff-file .hd-diff-path::before{content:"\200E";}
 .hd-diff-counts{font-size:11.5px;white-space:nowrap;}
-/* hdFileCountsHtml's binary chip is a `.hint`, and `.hint` (style.css:283) is
+/* Binary count chips carry `.hint`, and `.hint` (style.css:283) is
    `display:block;margin-top:7px` — inside these flex rows it would sit visibly
    low. Same reset for the pane head. */
 .hd-diff-counts .hint,.hd-diff-pane-head .hint{display:inline;margin-top:0;}
-/* The `.hd-diff-path` ellipsis rule is scoped to `.hd-diff-file`, so the SAME class
-   in the pane head is unstyled and WRAPS: measured 49.8px -> 69px on a 78-char
-   path, while the identical path ellipsizes one column to the left. */
-.hd-diff-pane-head .hd-diff-path{min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.hd-diff-pane-head .hd-diff-path{margin:0;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 /* The patch is the tall thing on this screen, so it scrolls INSIDE its pane
    rather than pushing the whole detail screen down — same cap and mechanism as
    `.hd-diff-rows` opposite it, which keeps the two panes the same height.
-   Uncapped, a real patch measured 7479px and owned the screen's whole scroll.
-
-   The grid is what makes the row TINT correct. `.hd-dl` used to size itself with
-   `width:max-content;min-width:100%`, but max-content is EACH ROW'S OWN content:
-   in a 336-row patch that produced 11 different row widths (708…1015px), so every
-   line shorter than the longest had its --green-bg/--red-bg band stop mid-pane
-   and the padding land against the text instead of the edge. A single column of
-   `minmax(max-content,1fr)` is sized by the WIDEST row (1fr keeps it filling the
-   pane when the patch is narrow) and stretch makes every row match it — measured
-   uniform at 1015px with 0 of 217 tinted rows stopping short. D4 forbids syntax
-   highlighting, so this tint is the pane's only visual signal — it has to hold. */
-.hd-diff-body{padding:12px 0;font:400 12px/1.85 var(--mono);color:var(--ink-2);
-  display:grid;grid-template-columns:minmax(max-content,1fr);
-  max-height:520px;overflow-x:auto;overflow-y:auto;}
-.hd-diff-body.hint,.hd-diff-none{padding:18px;}
-.hd-dl{padding:0 18px;white-space:pre;}
-.hd-dl-hunk{color:var(--ink-3);background:var(--field);}
-.hd-dl-add{background:var(--green-bg);}
-.hd-dl-del{background:var(--red-bg);}
-.hd-diff-trunc{padding:10px 18px 0;}
+   Uncapped, a real patch measured 7479px and owned the screen's whole scroll. */
+.hd-diff-body{
+  --hd-gutter-width:calc(3ch + 16px);
+  padding:12px 0;
+  display:grid;
+  grid-template-columns:var(--hd-gutter-width) var(--hd-gutter-width) minmax(max-content,1fr);
+  max-height:520px;
+  overflow:auto;
+  font:400 12px/1.85 var(--mono);
+  color:var(--ink-2);
+}
+.hd-diff-body.hint{display:block;margin-top:0;padding:18px;color:var(--ink-2);}
+.hd-diff-none{padding:18px;color:var(--ink-2);}
+.hd-dl-row{display:contents;}
+.hd-dl-n{
+  position:sticky;
+  z-index:2;
+  padding:0 8px;
+  text-align:right;
+  color:var(--ink-2);
+  background:var(--panel);
+  user-select:none;
+}
+.hd-dl-n-old{left:0;}
+.hd-dl-n-new{left:var(--hd-gutter-width);}
+.hd-dl-code{min-width:100%;padding:0 18px 0 10px;white-space:pre;}
+.hd-dl-hunk,.hd-diff-note{grid-column:1/-1;padding-inline:18px;}
+.hd-dl-hunk{white-space:pre;color:var(--ink-2);background:var(--field);}
+.hd-diff-trunc{padding-top:10px;color:var(--ink-2);}
+.hd-dl-row.hd-dl-add > *{background:var(--green-bg);}
+.hd-dl-row.hd-dl-del > *{background:var(--red-bg);}
+.hd-tree{display:block;}
+.hd-tree-group{display:block;}
+.hd-tree-group[hidden]{display:none;}
+.hd-tree-project{padding:9px 12px 4px;color:var(--ink-2);font:600 11px var(--mono);}
+.hd-tree-dir,.hd-tree-file{
+  width:100%;
+  border:0;
+  margin:0;
+  padding-block:9px;
+  padding-inline-end:12px;
+  background:transparent;
+  color:inherit;
+  font:inherit;
+  text-align:left;
+  appearance:none;
+  display:flex;
+  align-items:center;
+  gap:8px;
+  cursor:pointer;
+  border-radius:9px;
+}
+.hd-tree-dir,.hd-tree-file{padding-inline-start:var(--tree-indent,10px);}
+.hd-tree-dir:hover,.hd-tree-file:hover,.hd-tree-file.active{background:var(--field);}
+.hd-tree-dir:focus-visible,.hd-tree-file:focus-visible{
+  outline:2px solid var(--ink);
+  outline-offset:-2px;
+}
+.hd-tree-file .hd-diff-path{
+  flex:1;
+  min-width:0;
+  font-size:12px;
+  color:var(--ink-2);
+  direction:ltr;
+  text-align:left;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+.hd-tree-file .hd-diff-path::before{content:none;}
+.hd-tree-file.deleted .hd-diff-path{opacity:1;color:var(--ink-2);text-decoration:line-through;}
+.hd-tree-status,.hd-tree-chevron{flex:0 0 auto;color:var(--ink-2);}
+.hd-tree-dir-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.hd-diff-pane :is(.hljs-comment,.hljs-quote,.hljs-punctuation){color:var(--hd-syntax-comment);}
+.hd-diff-pane :is(.hljs-keyword,.hljs-operator,.hljs-meta,.hljs-deletion){color:var(--hd-syntax-keyword);}
+.hd-diff-pane :is(.hljs-type,.hljs-built_in,.hljs-attr,.hljs-attribute,
+  .hljs-selector-class,.hljs-selector-id,.hljs-selector-tag){color:var(--hd-syntax-type);}
+.hd-diff-pane :is(.hljs-string,.hljs-regexp,.hljs-addition){color:var(--hd-syntax-string);}
+.hd-diff-pane :is(.hljs-number,.hljs-literal,.hljs-symbol,.hljs-bullet,
+  .hljs-variable,.hljs-template-variable){color:var(--hd-syntax-literal);}
+.hd-diff-pane :is(.hljs-title,.hljs-section,.hljs-name){color:var(--hd-syntax-title);}
+.hd-diff-pane :is(.hljs-comment,.hljs-quote){font-style:italic;}
+.hd-diff-pane .hint,.hd-diff-list .hint,.hd-tree .hint,.hd-diff-note{color:var(--ink-2);}
 .hd-diff-empty{margin-top:24px;padding:40px;text-align:center;color:var(--ink-2);
   background:var(--panel);border:1px solid var(--line);border-radius:var(--r-card);}
 

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1884,14 +1884,16 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 }
 .hd-diff-list-head,.hd-diff-pane-head{display:flex;align-items:center;justify-content:space-between;gap:10px;
   padding:15px 18px;border-bottom:1px solid var(--line);font-size:12.5px;}
-.hd-diff-rows{padding:6px;max-height:520px;overflow-y:auto;}
-.hd-diff-file.new .hd-diff-path{color:var(--green-ink);}
+.hd-diff-rows{padding:6px;max-height:860px;overflow-y:auto;}
 .hd-diff-counts{font-size:11.5px;white-space:nowrap;}
 /* Binary count chips carry `.hint`, and `.hint` (style.css:283) is
    `display:block;margin-top:7px` — inside these flex rows it would sit visibly
    low. Same reset for the pane head. */
 .hd-diff-counts .hint,.hd-diff-pane-head .hint{display:inline;margin-top:0;}
-.hd-diff-pane-head .hd-diff-path{margin:0;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.hd-diff-pane-head .hd-diff-path{
+  margin:0;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+  font-size:12px;
+}
 /* The patch is the tall thing on this screen, so it scrolls INSIDE its pane
    rather than pushing the whole detail screen down — same cap and mechanism as
    `.hd-diff-rows` opposite it, which keeps the two panes the same height.
@@ -1901,7 +1903,7 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
   padding:12px 0;
   display:grid;
   grid-template-columns:var(--hd-gutter-width) var(--hd-gutter-width) minmax(max-content,1fr);
-  max-height:520px;
+  max-height:860px;
   overflow:auto;
   font:400 12px/1.85 var(--mono);
   color:var(--ink-2);
@@ -1957,7 +1959,7 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
   flex:1;
   min-width:0;
   font-size:12px;
-  color:var(--ink-2);
+  color:var(--ink);
   direction:ltr;
   text-align:left;
   white-space:nowrap;
@@ -1965,9 +1967,19 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
   text-overflow:ellipsis;
 }
 .hd-tree-file .hd-diff-path::before{content:none;}
-.hd-tree-file.deleted .hd-diff-path{opacity:1;color:var(--ink-2);text-decoration:line-through;}
-.hd-tree-status,.hd-tree-chevron{flex:0 0 auto;color:var(--ink-2);}
-.hd-tree-dir-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.hd-tree-file.deleted .hd-diff-path{opacity:1;color:var(--ink);text-decoration:none;}
+.hd-tree-status,.hd-tree-chevron,.hd-tree-folder-icon{flex:0 0 auto;}
+.hd-tree-status{width:18px;height:18px;display:grid;place-items:center;color:var(--ink);}
+.hd-tree-file.add .hd-tree-status{color:var(--green-ink);}
+.hd-tree-file.del .hd-tree-status{color:var(--red-ink);}
+.hd-tree-file-icon,.hd-tree-folder-icon{width:18px;height:18px;display:block;}
+.hd-tree-chevron{width:12px;height:14px;color:var(--ink-2);transition:transform .15s;}
+.hd-tree-dir[aria-expanded="true"] .hd-tree-chevron{transform:rotate(90deg);}
+.hd-tree-folder-icon{color:var(--ink);}
+.hd-tree-dir-label{
+  flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  font-size:12px;color:var(--ink);
+}
 .hd-diff-pane :is(.hljs-comment,.hljs-quote,.hljs-punctuation){color:var(--hd-syntax-comment);}
 .hd-diff-pane :is(.hljs-keyword,.hljs-operator,.hljs-meta,.hljs-deletion){color:var(--hd-syntax-keyword);}
 .hd-diff-pane :is(.hljs-type,.hljs-built_in,.hljs-attr,.hljs-attribute,

--- a/ui/public/syntax-highlight.mjs
+++ b/ui/public/syntax-highlight.mjs
@@ -1,0 +1,270 @@
+// Bounded, DOM-free syntax highlighting helpers for the History diff viewer.
+
+export const MAX_HIGHLIGHT_INPUT_BYTES = 100_000;
+export const MAX_HIGHLIGHT_INPUT_ROWS = 3_000;
+export const MAX_HIGHLIGHT_OUTPUT_CHARS = 4_000_000;
+export const MAX_HIGHLIGHT_OUTPUT_ROWS = 3_000;
+export const MAX_HIGHLIGHT_OUTPUT_SPANS = 20_000;
+export const MAX_HIGHLIGHT_NESTING = 64;
+
+const BY_EXT = Object.freeze({
+  js: 'javascript', mjs: 'javascript', cjs: 'javascript', jsx: 'javascript',
+  ts: 'typescript', mts: 'typescript', cts: 'typescript', tsx: 'typescript',
+  json: 'json', jsonc: 'json', json5: 'json',
+  css: 'css', scss: 'scss', sass: 'scss', less: 'less',
+  html: 'xml', htm: 'xml', xml: 'xml', svg: 'xml', vue: 'xml',
+  md: 'markdown', markdown: 'markdown',
+  yml: 'yaml', yaml: 'yaml', toml: 'ini', ini: 'ini', properties: 'properties',
+  sh: 'bash', bash: 'bash', zsh: 'bash', fish: 'bash',
+  py: 'python', rb: 'ruby', php: 'php', go: 'go', rs: 'rust',
+  java: 'java', kt: 'kotlin', kts: 'kotlin', swift: 'swift', scala: 'scala',
+  c: 'c', h: 'c', cpp: 'cpp', cc: 'cpp', cxx: 'cpp', hpp: 'cpp',
+  cs: 'csharp', sql: 'sql', graphql: 'graphql', gql: 'graphql',
+  proto: 'protobuf', lua: 'lua', pl: 'perl', r: 'r', dart: 'dart',
+  ex: 'elixir', exs: 'elixir', erl: 'erlang', hs: 'haskell', clj: 'clojure',
+  diff: 'diff', patch: 'diff', nix: 'nix', gradle: 'gradle',
+});
+
+const BY_NAME = Object.freeze({
+  dockerfile: 'dockerfile', makefile: 'makefile', gemfile: 'ruby',
+  rakefile: 'ruby', vagrantfile: 'ruby', brewfile: 'ruby',
+});
+
+const codeUnitCompare = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+export const SUPPORTED_LANGUAGE_IDS = Object.freeze(
+  [...new Set([...Object.values(BY_EXT), ...Object.values(BY_NAME)])].sort(codeUnitCompare),
+);
+const SUPPORTED = new Set(SUPPORTED_LANGUAGE_IDS);
+
+export function langForPath(pathname) {
+  const base = String(pathname || '').split('/').pop() || '';
+  const nameKey = base.toLowerCase();
+  if (Object.hasOwn(BY_NAME, nameKey)) return BY_NAME[nameKey];
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const extKey = base.slice(dot + 1).toLowerCase();
+  return Object.hasOwn(BY_EXT, extKey) ? BY_EXT[extKey] : null;
+}
+
+const HLJS_CLASS_RE = /^(?:hljs-[A-Za-z0-9_-]+(?: [A-Za-z0-9-]+_+)*|language-[A-Za-z0-9_-]+)$/;
+const OPEN_RE = /<span class="([^"]+)">/y;
+const ENTITY_RE = /&(amp|lt|gt|quot|#x27);/y;
+const TEXT_RE = /[^<&\n\u0000]+/y;
+const ENTITIES = Object.freeze({
+  '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#x27;': "'",
+});
+
+function parseHighlightedRows(html) {
+  if (typeof html !== 'string' || html.length > MAX_HIGHLIGHT_OUTPUT_CHARS) return null;
+  const rows = [{ html: '', text: '' }];
+  const stack = [];
+  let i = 0;
+  let renderedSpans = 0;
+  let balancedChars = 0;
+
+  const row = () => rows[rows.length - 1];
+  const reopen = () => stack.map((cls) => `<span class="${cls}">`).join('');
+  const appendHtml = (value) => {
+    balancedChars += value.length;
+    if (balancedChars > MAX_HIGHLIGHT_OUTPUT_CHARS) return false;
+    row().html += value;
+    return true;
+  };
+
+  while (i < html.length) {
+    if (html.startsWith('</span>', i)) {
+      if (!stack.length || !appendHtml('</span>')) return null;
+      stack.pop();
+      i += 7;
+      continue;
+    }
+    if (html[i] === '<') {
+      OPEN_RE.lastIndex = i;
+      const match = OPEN_RE.exec(html);
+      if (!match || !HLJS_CLASS_RE.test(match[1])) return null;
+      renderedSpans += 1;
+      if (renderedSpans > MAX_HIGHLIGHT_OUTPUT_SPANS
+        || stack.length >= MAX_HIGHLIGHT_NESTING) return null;
+      if (!appendHtml(match[0])) return null;
+      stack.push(match[1]);
+      i += match[0].length;
+      continue;
+    }
+    if (html[i] === '\n') {
+      if (!appendHtml('</span>'.repeat(stack.length))) return null;
+      if (rows.length >= MAX_HIGHLIGHT_OUTPUT_ROWS) return null;
+      const opened = reopen();
+      renderedSpans += stack.length;
+      if (renderedSpans > MAX_HIGHLIGHT_OUTPUT_SPANS) return null;
+      balancedChars += opened.length;
+      if (balancedChars > MAX_HIGHLIGHT_OUTPUT_CHARS) return null;
+      rows.push({ html: opened, text: '' });
+      i += 1;
+      continue;
+    }
+    if (html[i] === '&') {
+      ENTITY_RE.lastIndex = i;
+      const match = ENTITY_RE.exec(html);
+      if (!match || !appendHtml(match[0])) return null;
+      row().text += ENTITIES[match[0]];
+      i += match[0].length;
+      continue;
+    }
+    TEXT_RE.lastIndex = i;
+    const match = TEXT_RE.exec(html);
+    if (!match) return null;
+    const serialized = match[0].replaceAll('\r', '&#13;');
+    if (!appendHtml(serialized)) return null;
+    row().text += match[0];
+    i += match[0].length;
+  }
+
+  if (stack.length) return null;
+  return { rows, balancedChars, renderedSpans };
+}
+
+export function rowsFromHtml(html) {
+  const parsed = parseHighlightedRows(html);
+  return parsed ? parsed.rows.map((row) => row.html) : null;
+}
+
+const encoder = new TextEncoder();
+
+function sideInputs(hunk) {
+  const oldLines = [];
+  const newLines = [];
+  for (const line of hunk.lines || []) {
+    if (line.kind !== 'add') oldLines.push(line);
+    if (line.kind !== 'del') newLines.push(line);
+  }
+  return {
+    old: { lines: oldLines, text: oldLines.map((line) => line.text).join('\n') },
+    new: { lines: newLines, text: newLines.map((line) => line.text).join('\n') },
+  };
+}
+
+function validSideRange(start, count) {
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(count) || count < 0) return false;
+  if (count === 0) return start >= 0;
+  return start >= 1 && start <= Number.MAX_SAFE_INTEGER - (count - 1);
+}
+
+function eligibleSides(hunk) {
+  if (!validSideRange(hunk?.oldStart, hunk?.oldCount)
+    || !validSideRange(hunk?.newStart, hunk?.newCount)) return null;
+  const sides = sideInputs(hunk);
+  if (sides.old.lines.length !== hunk.oldCount
+    || sides.new.lines.length !== hunk.newCount) return null;
+  return sides;
+}
+
+function withinInputBudget(eligible) {
+  let rows = 0;
+  let bytes = 0;
+  for (const sides of eligible) {
+    for (const side of [sides.old, sides.new]) {
+      rows += side.lines.length;
+      bytes += encoder.encode(side.text).byteLength;
+      if (rows > MAX_HIGHLIGHT_INPUT_ROWS || bytes > MAX_HIGHLIGHT_INPUT_BYTES) return false;
+    }
+  }
+  return rows > 0;
+}
+
+function eligibleInputs(parsed) {
+  return (parsed?.hunks || []).map(eligibleSides).filter(Boolean);
+}
+
+export function canHighlightParsed(parsed) {
+  return withinInputBudget(eligibleInputs(parsed));
+}
+
+const newOutputBudget = () => ({
+  rawChars: 0, balancedChars: 0, rows: 0, spans: 0, exhausted: false,
+});
+
+function countOutputRows(html) {
+  let rows = 1;
+  for (let i = html.indexOf('\n'); i !== -1; i = html.indexOf('\n', i + 1)) rows += 1;
+  return rows;
+}
+
+function highlightEligibleHunk(hunk, { old, new: next }, lang, highlight, budget) {
+  const run = (side) => {
+    if (!side.lines.length) return [];
+    if (budget.exhausted) return null;
+    if (budget.rawChars >= MAX_HIGHLIGHT_OUTPUT_CHARS
+      || budget.balancedChars >= MAX_HIGHLIGHT_OUTPUT_CHARS
+      || budget.rows >= MAX_HIGHLIGHT_OUTPUT_ROWS
+      || budget.spans >= MAX_HIGHLIGHT_OUTPUT_SPANS) {
+      budget.exhausted = true;
+      return null;
+    }
+    const html = highlight(side.text, lang);
+    if (typeof html !== 'string') return null;
+    budget.rawChars += html.length;
+    if (budget.rawChars > MAX_HIGHLIGHT_OUTPUT_CHARS) {
+      budget.exhausted = true;
+      return null;
+    }
+    const outputRows = countOutputRows(html);
+    budget.rows += outputRows;
+    if (budget.rows > MAX_HIGHLIGHT_OUTPUT_ROWS) {
+      budget.exhausted = true;
+      return null;
+    }
+    const parsed = parseHighlightedRows(html);
+    if (!parsed || parsed.rows.length !== outputRows) return null;
+    budget.balancedChars += parsed.balancedChars;
+    budget.spans += parsed.renderedSpans;
+    if (budget.balancedChars > MAX_HIGHLIGHT_OUTPUT_CHARS
+      || budget.spans > MAX_HIGHLIGHT_OUTPUT_SPANS) {
+      budget.exhausted = true;
+      return null;
+    }
+    if (parsed.rows.length !== side.lines.length) return null;
+    if (parsed.rows.some((row, index) => row.text !== side.lines[index].text)) return null;
+    return parsed.rows;
+  };
+
+  try {
+    const oldRows = run(old);
+    if (oldRows === null) return false;
+    const newRows = run(next);
+    if (newRows === null) return false;
+    const staged = [];
+    old.lines.forEach((line, index) => {
+      if (line.kind === 'del') staged.push([line, oldRows[index].html]);
+    });
+    next.lines.forEach((line, index) => staged.push([line, newRows[index].html]));
+    for (const [line, html] of staged) line.html = html;
+    return staged.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function highlightHunk(hunk, lang, highlight) {
+  for (const line of hunk?.lines || []) delete line.html;
+  const sides = eligibleSides(hunk);
+  if (!sides || !SUPPORTED.has(lang) || typeof highlight !== 'function'
+    || !withinInputBudget([sides])) return false;
+  return highlightEligibleHunk(hunk, sides, lang, highlight, newOutputBudget());
+}
+
+export function highlightParsed(parsed, lang, highlight) {
+  for (const hunk of parsed?.hunks || []) {
+    for (const line of hunk.lines || []) delete line.html;
+  }
+  if (!SUPPORTED.has(lang) || typeof highlight !== 'function') return false;
+  const eligible = (parsed?.hunks || [])
+    .map((hunk) => ({ hunk, sides: eligibleSides(hunk) }))
+    .filter((item) => item.sides);
+  if (!withinInputBudget(eligible.map((item) => item.sides))) return false;
+  const budget = newOutputBudget();
+  let any = false;
+  for (const { hunk, sides } of eligible) {
+    any = highlightEligibleHunk(hunk, sides, lang, highlight, budget) || any;
+  }
+  return any;
+}

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -95,7 +95,7 @@ import { readPluginsLock, pluginCurrentDir } from '../src/core/plugins-lock.mjs'
 import { normalizeManifest, PLUGIN_NAME_RE as MANIFEST_PLUGIN_NAME_RE } from '../src/core/plugin-manifest.mjs';
 import { listTaskSources, retryWriteback } from '../src/core/sources.mjs';
 import { callSource, PluginOpError } from '../src/core/plugin-shim.mjs';
-import { SUPPORTED_LANGUAGE_IDS } from './public/syntax-highlight.mjs';
+import { HLJS_GRAMMAR_IDS } from './public/hljs-loader.mjs';
 
 // ── node:sqlite runtime guard + warning filter ──────────────────────────────────
 // Drop ONLY the one-time ExperimentalWarning emitted by node:sqlite (the module is
@@ -121,8 +121,10 @@ const AGENTS_DIR = path.join(PROJECT_ROOT, 'agents');
 const SKILLS_DIR = path.join(PROJECT_ROOT, 'skills');
 const require = createRequire(import.meta.url);
 const HLJS_LANGUAGE_FILE_RE = /^[a-z0-9][a-z0-9-]{0,63}\.min\.js$/;
+// Primaries plus the sub-language grammars their instances register
+// (hljs-loader.mjs); a shipped but unmapped grammar stays a plain 404.
 const HLJS_LANGUAGE_FILES = new Set(
-  SUPPORTED_LANGUAGE_IDS.map((id) => `${id}.min.js`),
+  HLJS_GRAMMAR_IDS.map((id) => `${id}.min.js`),
 );
 
 function resolveHljsAssets(resolve = require.resolve, warn = (msg) => console.warn(msg)) {

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -13,6 +13,7 @@ import os from 'node:os';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import process from 'node:process';
+import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
 
@@ -94,6 +95,7 @@ import { readPluginsLock, pluginCurrentDir } from '../src/core/plugins-lock.mjs'
 import { normalizeManifest, PLUGIN_NAME_RE as MANIFEST_PLUGIN_NAME_RE } from '../src/core/plugin-manifest.mjs';
 import { listTaskSources, retryWriteback } from '../src/core/sources.mjs';
 import { callSource, PluginOpError } from '../src/core/plugin-shim.mjs';
+import { SUPPORTED_LANGUAGE_IDS } from './public/syntax-highlight.mjs';
 
 // ── node:sqlite runtime guard + warning filter ──────────────────────────────────
 // Drop ONLY the one-time ExperimentalWarning emitted by node:sqlite (the module is
@@ -117,6 +119,23 @@ const PROJECT_ROOT = path.resolve(__dirname, '..');
 const PUBLIC_DIR = path.join(__dirname, 'public');
 const AGENTS_DIR = path.join(PROJECT_ROOT, 'agents');
 const SKILLS_DIR = path.join(PROJECT_ROOT, 'skills');
+const require = createRequire(import.meta.url);
+const HLJS_LANGUAGE_FILE_RE = /^[a-z0-9][a-z0-9-]{0,63}\.min\.js$/;
+const HLJS_LANGUAGE_FILES = new Set(
+  SUPPORTED_LANGUAGE_IDS.map((id) => `${id}.min.js`),
+);
+
+function resolveHljsAssets(resolve = require.resolve, warn = (msg) => console.warn(msg)) {
+  try {
+    const core = resolve('@highlightjs/cdn-assets/es/core.min.js');
+    return { core, languages: path.join(path.dirname(core), 'languages') };
+  } catch (err) {
+    warn(`[worca-ui] syntax-highlighter assets unavailable: ${err?.message || err}`);
+    return null;
+  }
+}
+
+const HLJS_ASSETS = resolveHljsAssets();
 const PORT = Number(process.env.PORT) || 4317;
 // Bind to loopback by default (S1). Power users who knowingly want LAN exposure
 // can set WORCA_HOST=0.0.0.0, but the localhost-only Host/Origin guard still
@@ -589,6 +608,41 @@ app.use((req, res, next) => {
     return res.status(403).json({ error: 'forbidden: worca-cc is a localhost-only tool' });
   }
   next();
+});
+
+if (HLJS_ASSETS) {
+  const sendHljsModule = (file) => (_req, res, next) => {
+    res.type('text/javascript');
+    res.set('X-Content-Type-Options', 'nosniff');
+    res.sendFile(file, (err) => {
+      if (!err) return;
+      if (res.headersSent) return next(err);
+      next();
+    });
+  };
+  app.get('/vendor/hljs/core.min.js', sendHljsModule(HLJS_ASSETS.core));
+  app.get('/vendor/hljs/languages/:file', (req, res, next) => {
+    const file = String(req.params.file || '');
+    if (!HLJS_LANGUAGE_FILE_RE.test(file) || !HLJS_LANGUAGE_FILES.has(file)) return next();
+    const candidate = path.join(HLJS_ASSETS.languages, file);
+    try {
+      if (!fs.statSync(candidate).isFile()) return next();
+    } catch {
+      return next();
+    }
+    return sendHljsModule(candidate)(req, res, next);
+  });
+}
+
+app.use('/vendor', (err, _req, res, next) => {
+  if (res.headersSent) return next(err);
+  res.set('Cache-Control', 'no-store');
+  const status = err?.status === 400 ? 400 : 404;
+  res.status(status).type('text/plain').send(status === 400 ? 'Bad request' : 'Not found');
+});
+app.use('/vendor', (_req, res) => {
+  res.set('Cache-Control', 'no-store');
+  res.status(404).type('text/plain').send('Not found');
 });
 
 app.use(express.static(PUBLIC_DIR, { extensions: ['html'] }));
@@ -3475,6 +3529,7 @@ app.post('/api/chat/test', async (req, res) => {
 app.use((req, res, next) => {
   if (req.method !== 'GET') return next();
   if (req.path.startsWith('/api/') || req.path.startsWith('/ws')) return next();
+  if (req.path === '/vendor' || req.path.startsWith('/vendor/')) return next();
   res.sendFile(path.join(PUBLIC_DIR, 'index.html'), (err) => {
     if (err) next();
   });
@@ -3606,4 +3661,8 @@ if (isMain) {
 }
 
 export { app, server, runs };
-export const _testing = { wireRun, wireScan, summarizeRuns, startScan, wireAgentGen, startAgentGen, chatActions, chatRouter, channelHost, handleChatInbound, enqueueChatWork, chatNotifier, resumeRun };
+export const _testing = {
+  wireRun, wireScan, summarizeRuns, startScan, wireAgentGen, startAgentGen,
+  chatActions, chatRouter, channelHost, handleChatInbound, enqueueChatWork,
+  chatNotifier, resumeRun, resolveHljsAssets,
+};


### PR DESCRIPTION
## Summary

- Add syntax highlighting and old/new line-number gutters to history diffs.
- Replace the flat changed-file list with an accessible hierarchical file tree.
- Add custom folder, modified-file, added-file, and deleted-file icons.
- Keep filenames neutral and readable, without striking through deleted files.
- Improve diff-view density with a smaller filename heading and synchronized 860px file/code panes.
- Lazily load highlight.js language modules with safe plain-text fallbacks.
- Add rendering limits and validation for large or malformed diffs.
- Serve the required highlight.js browser assets from the UI server.

## Testing

- Added coverage for file-tree construction, ordering, statuses, icons, accessibility, and collapsing folders.
- Added coverage for syntax highlighting, lazy language loading, line numbering, truncation, and fallback behavior.
- Updated history-detail integration and Diff styling tests.