### PR TITLE
Honor ANTHROPIC_MODEL in a model entry's env as the wire model id

### DIFF
--- a/configurable-models-design.md
+++ b/configurable-models-design.md
@@ -36,10 +36,15 @@ The catalog lives in `~/.worca-cc/settings.json` under a new `models` key, read/
 {
   "models": [
     {
-      "id": "glm-4.7",                       // what is passed to `claude --model`
+      "id": "glm-4.7",                       // worca's handle: config refs, cost
+                                             // flags, event attribution — and the
+                                             // wire id sent to `claude --model`
+                                             // UNLESS env.ANTHROPIC_MODEL overrides it (#374)
       "label": "GLM 4.7 (proxy)",            // display name; defaults to id
       "efforts": ["medium", "high"],         // subset of EFFORTS; defaults to all
-      "env": {                                // optional; merged into the spawn env
+      "env": {                                // optional; merged into the spawn env.
+                                              // ANTHROPIC_MODEL here becomes the wire id
+                                              // passed to `--model` (the id stays the handle)
         "ANTHROPIC_BASE_URL": "https://proxy.example/v1",
         "ANTHROPIC_AUTH_TOKEN": "sk-…"
       }
@@ -47,6 +52,19 @@ The catalog lives in `~/.worca-cc/settings.json` under a new `models` key, read/
   ]
 }
 ```
+
+> **Upgrade behavior (#374):** an entry's `env.ANTHROPIC_MODEL` was previously
+> stored-but-inert (the spawned `--model <id>` outranked the env var in the CLI).
+> As of #374 it is the **wire id** passed to `--model`, so a legal-but-dead stored
+> value now changes which model the endpoint runs. An unresolvable/empty value
+> falls back to the catalog id with a warning.
+>
+> **Cost-honesty caveat (§4.6):** the cost-unreliable watchdog gates on the
+> `ANTHROPIC_BASE_URL` key only. A base-URL-less routing shape — e.g.
+> `CLAUDE_CODE_USE_VERTEX=1` + `ANTHROPIC_MODEL` — is the config #374 makes
+> functional, but it is currently invisible to `observeModelCost`: no
+> cost-unreliable badge, and USD budget may record $0 for real spend. Widening
+> the gate is a follow-up.
 
 Reader contract mirrors the module's house style: missing/corrupt → `[]`, per-entry sanitization is loud-and-lenient (drop malformed entries with a `console.warn` naming them), setters throw on invalid input. Sanitization rules:
 

--- a/src/core/claude-runner.mjs
+++ b/src/core/claude-runner.mjs
@@ -217,7 +217,9 @@ function mockEnabled(opts) {
  * @param {string[]} [o.envAllowlist]    guardrail: extra env var names to keep under scrub
  * @param {Record<string,string>} [o.modelEnv] per-model routing env (design §4.4), merged
  *   LAST over the spawn env (it survives scrub and wins collisions — explicit operator
- *   config outranks ambient-env hygiene); reserved keys are re-dropped here defensively
+ *   config outranks ambient-env hygiene); reserved keys are re-dropped here defensively.
+ *   An ANTHROPIC_MODEL key is the WIRE id (#374): it replaces `model` in the spawned
+ *   `--model` flag, while `model` (the catalog id) stays worca's handle everywhere else
  * @param {string[]} [o.workspaceWriteTargets] §8.10 MOCK-ONLY member checkouts the mock
  *   implementer writes into instead of `cwd` (empty/absent => today's cwd behavior).
  *   Never reaches argv: `runReal` ignores it by construction.
@@ -337,8 +339,30 @@ export function buildClaudeArgs({
 
 function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, model, effort, onEvent, signal, bin, resumeSessionId, mcpConfigPath, mcpServerGrants, permissionRules, envScrub, envAllowlist, modelEnv }) {
   return new Promise((resolveP, rejectP) => {
+    // Per-model routing env (design §4.4), prepared BEFORE argv: reserved keys
+    // are re-dropped here defensively — the write path already rejects them, so
+    // a drop means a hand-edited settings file — and the surviving map is also
+    // where the wire id (below) is read from.
+    let safeModelEnv = null;
+    if (modelEnv && Object.keys(modelEnv).length) {
+      const { env: safe, dropped } = prepareModelEnv(modelEnv);
+      for (const k of dropped) {
+        console.warn(`[worca] modelEnv: dropping reserved/invalid key ${JSON.stringify(k)}`);
+      }
+      if (Object.keys(safe).length) safeModelEnv = safe;
+    }
+
+    // Wire id (#374): ANTHROPIC_MODEL in the resolved model env names the id the
+    // ENDPOINT should see; the catalog id stays worca's handle (config refs, cost
+    // flags). Passed as an explicit --model — self-documenting in logs and immune
+    // to CLI flag/env precedence — so the env var alone would otherwise be dead.
+    const wireModel = safeModelEnv?.ANTHROPIC_MODEL || model;
+    if (wireModel !== model) {
+      console.warn(`[worca] model ${JSON.stringify(model ?? '')}: wire model ${JSON.stringify(wireModel)}`);
+    }
+
     const args = buildClaudeArgs({
-      prompt, systemPrompt, permissionMode, model, effort, allowedTools, resumeSessionId,
+      prompt, systemPrompt, permissionMode, model: wireModel, effort, allowedTools, resumeSessionId,
       mcpConfigPath, mcpServerGrants, permissionRules,
     });
 
@@ -346,21 +370,12 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
     // spawn inherits process.env exactly as it did before guardrails existed.
     const guardrailEnv = buildSpawnEnv(envScrub, envAllowlist);
 
-    // Per-model routing env (design §4.4) merges LAST: it survives scrub and
-    // wins collisions (explicit operator config outranks ambient-env hygiene),
-    // except reserved keys, which are re-dropped here defensively — the write
-    // path already rejects them, so a drop means a hand-edited settings file.
-    // With no modelEnv (or nothing surviving the filter) the spawn env is
-    // byte-identical to the pre-feature behavior, including the undefined
-    // -> inherit-process.env case.
+    // Model env merges LAST: it survives scrub and wins collisions (explicit
+    // operator config outranks ambient-env hygiene). With no modelEnv (or
+    // nothing surviving the filter) the spawn env is byte-identical to the
+    // pre-feature behavior, including the undefined -> inherit-process.env case.
     let spawnEnv = guardrailEnv;
-    if (modelEnv && Object.keys(modelEnv).length) {
-      const { env: safe, dropped } = prepareModelEnv(modelEnv);
-      for (const k of dropped) {
-        console.warn(`[worca] modelEnv: dropping reserved/invalid key ${JSON.stringify(k)}`);
-      }
-      if (Object.keys(safe).length) spawnEnv = { ...(guardrailEnv ?? process.env), ...safe };
-    }
+    if (safeModelEnv) spawnEnv = { ...(guardrailEnv ?? process.env), ...safeModelEnv };
 
     let child;
     try {

--- a/src/core/claude-runner.mjs
+++ b/src/core/claude-runner.mjs
@@ -344,11 +344,17 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
     // a drop means a hand-edited settings file — and the surviving map is also
     // where the wire id (below) is read from.
     let safeModelEnv = null;
+    let wireModelDropped = false;
     if (modelEnv && Object.keys(modelEnv).length) {
       const { env: safe, dropped } = prepareModelEnv(modelEnv);
       for (const k of dropped) {
         console.warn(`[worca] modelEnv: dropping reserved/invalid key ${JSON.stringify(k)}`);
       }
+      // A configured wire id that didn't survive (unresolvable ${VAR}, empty, or
+      // whitespace-only) fell into `dropped`: we silently fall back to the catalog
+      // id below, so warn specifically — the generic drop line above doesn't say
+      // the argv model changed, and the wire-model line never fires (ids match).
+      wireModelDropped = 'ANTHROPIC_MODEL' in modelEnv && dropped.includes('ANTHROPIC_MODEL');
       if (Object.keys(safe).length) safeModelEnv = safe;
     }
 
@@ -357,7 +363,9 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
     // flags). Passed as an explicit --model — self-documenting in logs and immune
     // to CLI flag/env precedence — so the env var alone would otherwise be dead.
     const wireModel = safeModelEnv?.ANTHROPIC_MODEL || model;
-    if (wireModel !== model) {
+    if (wireModelDropped && wireModel === model) {
+      console.warn(`[worca] model ${JSON.stringify(model ?? '')}: configured wire model was dropped (unresolved/empty) — using the catalog id`);
+    } else if (wireModel !== model) {
       console.warn(`[worca] model ${JSON.stringify(model ?? '')}: wire model ${JSON.stringify(wireModel)}`);
     }
 

--- a/src/core/model-env.mjs
+++ b/src/core/model-env.mjs
@@ -49,9 +49,12 @@ export function modelEnvRef(value) {
 /**
  * Defensive spawn-time pass over a model entry's env (§4.4): drops reserved
  * keys and non-string values, and expands whole-value ${VAR} refs from
- * `sourceEnv` (an unset or empty var drops the key). Write-time validation
- * already rejects reserved keys, so a drop here means a hand-edited settings
- * file — the caller owns warning about `dropped`.
+ * `sourceEnv` (an unset or empty var drops the key). Values are trimmed and a
+ * value that is empty after trimming drops the key — an ANTHROPIC_MODEL wire id
+ * (#374) reaches `--model` verbatim, so a stray-whitespace or empty value must
+ * not survive. Write-time validation already rejects reserved keys, so a drop
+ * here means a hand-edited settings file — the caller owns warning about
+ * `dropped`.
  * @param {Record<string,*>|undefined} modelEnv
  * @param {Record<string,string|undefined>} [sourceEnv]
  * @returns {{env: Record<string,string>, dropped: string[]}}
@@ -64,10 +67,13 @@ export function prepareModelEnv(modelEnv, sourceEnv = process.env) {
     const ref = modelEnvRef(v);
     if (ref !== null) {
       const resolved = sourceEnv ? sourceEnv[ref] : undefined;
-      if (resolved === undefined || resolved === '') { dropped.push(k); continue; }
-      env[k] = resolved;
+      const t = typeof resolved === 'string' ? resolved.trim() : '';
+      if (!t) { dropped.push(k); continue; }
+      env[k] = t;
     } else {
-      env[k] = v;
+      const t = v.trim();
+      if (!t) { dropped.push(k); continue; }
+      env[k] = t;
     }
   }
   return { env, dropped };

--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -486,11 +486,15 @@ function sanitizeGlobalModel(raw) {
   const env = {};
   const rawEnv = raw.env && typeof raw.env === 'object' && !Array.isArray(raw.env) ? raw.env : {};
   for (const [k, v] of Object.entries(rawEnv)) {
-    if (isReservedModelEnvKey(k) || typeof v !== 'string' || !v) {
+    // Trim before storing: an ANTHROPIC_MODEL wire id (#374) reaches `--model`
+    // verbatim, so a pasted ' claude-opus-4-8' or whitespace-only value must not
+    // land on disk. Whitespace-only (truthy but empty after trim) is dropped.
+    const t = typeof v === 'string' ? v.trim() : '';
+    if (isReservedModelEnvKey(k) || typeof v !== 'string' || !t) {
       console.warn(`[worca] models entry ${JSON.stringify(id)}: dropping env key ${JSON.stringify(k)} (reserved or not a non-empty string)`);
       continue;
     }
-    env[k] = v;
+    env[k] = t;
   }
   return {
     id,

--- a/test/spawn-args.test.mjs
+++ b/test/spawn-args.test.mjs
@@ -516,7 +516,9 @@ test('ANTHROPIC_MODEL as ${VAR}: set -> expanded wire id; unset -> falls back to
   assert.equal(argv[argv.indexOf('--model') + 1], 'claude-opus-4-8', 'expanded ${VAR} is the wire id');
 
   const realWarn = console.warn;
-  console.warn = () => {}; // dropped-key warning is asserted elsewhere
+  const warnings = [];
+  console.warn = (...a) => warnings.push(a.join(' '));
+  delete process.env.WORCA_TEST_WIRE_MODEL_UNSET; // defensively: this var must be unset
   let argv2;
   try {
     argv2 = await runWithArgvDump({
@@ -527,6 +529,49 @@ test('ANTHROPIC_MODEL as ${VAR}: set -> expanded wire id; unset -> falls back to
     console.warn = realWarn;
   }
   assert.equal(argv2[argv2.indexOf('--model') + 1], 'opus-4-8-vertex', 'unresolvable ref -> catalog id');
+  assert.equal(
+    warnings.filter((w) => w.includes('configured wire model was dropped')).length, 1,
+    `dropped-wire-model warning fires: ${JSON.stringify(warnings)}`,
+  );
+  assert.equal(
+    warnings.filter((w) => w.includes('wire model "')).length, 0,
+    'the plain wire-model line does NOT fire on fallback',
+  );
+});
+
+test('whitespace-only ANTHROPIC_MODEL is dropped -> catalog id, with the dropped-wire-model warning', async () => {
+  const realWarn = console.warn;
+  const warnings = [];
+  console.warn = (...a) => warnings.push(a.join(' '));
+  let argv;
+  try {
+    argv = await runWithArgvDump({
+      model: 'opus-4-8-vertex',
+      modelEnv: { ANTHROPIC_MODEL: '   ' },
+    });
+  } finally {
+    console.warn = realWarn;
+  }
+  assert.equal(argv[argv.indexOf('--model') + 1], 'opus-4-8-vertex', 'whitespace-only -> catalog id');
+  assert.equal(
+    warnings.filter((w) => w.includes('configured wire model was dropped')).length, 1,
+    `dropped-wire-model warning fires: ${JSON.stringify(warnings)}`,
+  );
+});
+
+test('a pasted-with-spaces ANTHROPIC_MODEL is trimmed before reaching --model', async () => {
+  const realWarn = console.warn;
+  console.warn = () => {};
+  let argv;
+  try {
+    argv = await runWithArgvDump({
+      model: 'opus-4-8-vertex',
+      modelEnv: { ANTHROPIC_MODEL: '  claude-opus-4-8  ' },
+    });
+  } finally {
+    console.warn = realWarn;
+  }
+  assert.equal(argv[argv.indexOf('--model') + 1], 'claude-opus-4-8', 'trimmed wire id in argv');
 });
 
 test('wire id also lands in the spawn env (harmless: the explicit flag wins in the CLI)', async () => {

--- a/test/spawn-args.test.mjs
+++ b/test/spawn-args.test.mjs
@@ -449,3 +449,97 @@ test('runClaude mock path is unaffected by modelEnv (no spawn, no error)', async
   });
   assert.equal(r.exitCode, 0);
 });
+
+// ── wire model: ANTHROPIC_MODEL in modelEnv names the id the endpoint sees (#374)
+// Without this the key was legal-but-dead: the spawned `--model <catalog-id>`
+// always outranked the env var inside the CLI. The rule: the resolved model
+// env's ANTHROPIC_MODEL replaces the catalog id in argv (with one warning);
+// the catalog id remains worca's handle everywhere else.
+
+/** Run against the argv-dumping fake bin with WORCA_MOCK cleared; returns argv[]. */
+async function runWithArgvDump(extraOpts) {
+  const dir = await tmp();
+  const out = join(dir, 'argv.txt');
+  const bin = await fakeBin(dir, out);
+  const prevMock = process.env.WORCA_MOCK;
+  delete process.env.WORCA_MOCK;
+  try {
+    await runClaude({ cwd: dir, bin, prompt: 'p', ...extraOpts });
+  } finally {
+    if (prevMock === undefined) delete process.env.WORCA_MOCK; else process.env.WORCA_MOCK = prevMock;
+  }
+  return (await readFile(out, 'utf8')).split('\0').filter(Boolean);
+}
+
+test('modelEnv.ANTHROPIC_MODEL replaces the catalog id in --model (wire id), with one warning', async () => {
+  const realWarn = console.warn;
+  const warnings = [];
+  console.warn = (...a) => warnings.push(a.join(' '));
+  let argv;
+  try {
+    argv = await runWithArgvDump({
+      model: 'opus-4-8-vertex',
+      modelEnv: { CLAUDE_CODE_USE_VERTEX: '1', ANTHROPIC_MODEL: 'claude-opus-4-8' },
+    });
+  } finally {
+    console.warn = realWarn;
+  }
+  assert.equal(argv[argv.indexOf('--model') + 1], 'claude-opus-4-8', 'wire id reached argv');
+  assert.ok(!argv.includes('opus-4-8-vertex'), 'catalog id is not in argv');
+  assert.equal(
+    warnings.filter((w) => w.includes('wire model')).length, 1,
+    `one wire-model warning: ${JSON.stringify(warnings)}`,
+  );
+});
+
+test('modelEnv without ANTHROPIC_MODEL keeps --model = catalog id (regression guard)', async () => {
+  const argv = await runWithArgvDump({
+    model: 'claude-opus-4-8',
+    modelEnv: { ANTHROPIC_BASE_URL: 'https://proxy.test/v1' },
+  });
+  assert.equal(argv[argv.indexOf('--model') + 1], 'claude-opus-4-8');
+});
+
+test('ANTHROPIC_MODEL as ${VAR}: set -> expanded wire id; unset -> falls back to catalog id', async () => {
+  const prev = process.env.WORCA_TEST_WIRE_MODEL;
+  process.env.WORCA_TEST_WIRE_MODEL = 'claude-opus-4-8';
+  let argv;
+  try {
+    argv = await runWithArgvDump({
+      model: 'opus-4-8-vertex',
+      modelEnv: { ANTHROPIC_MODEL: '${WORCA_TEST_WIRE_MODEL}' },
+    });
+  } finally {
+    if (prev === undefined) delete process.env.WORCA_TEST_WIRE_MODEL;
+    else process.env.WORCA_TEST_WIRE_MODEL = prev;
+  }
+  assert.equal(argv[argv.indexOf('--model') + 1], 'claude-opus-4-8', 'expanded ${VAR} is the wire id');
+
+  const realWarn = console.warn;
+  console.warn = () => {}; // dropped-key warning is asserted elsewhere
+  let argv2;
+  try {
+    argv2 = await runWithArgvDump({
+      model: 'opus-4-8-vertex',
+      modelEnv: { ANTHROPIC_MODEL: '${WORCA_TEST_WIRE_MODEL_UNSET}' },
+    });
+  } finally {
+    console.warn = realWarn;
+  }
+  assert.equal(argv2[argv2.indexOf('--model') + 1], 'opus-4-8-vertex', 'unresolvable ref -> catalog id');
+});
+
+test('wire id also lands in the spawn env (harmless: the explicit flag wins in the CLI)', async () => {
+  const realWarn = console.warn;
+  console.warn = () => {};
+  let dump;
+  try {
+    dump = await runWithEnvDump({
+      model: 'opus-4-8-vertex',
+      modelEnv: { ANTHROPIC_MODEL: 'claude-opus-4-8' },
+    });
+  } finally {
+    console.warn = realWarn;
+  }
+  assert.ok(dump.includes('ANTHROPIC_MODEL=claude-opus-4-8'));
+});

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -205,7 +205,7 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
   idInput.placeholder = 'claude-opus-4-8, glm-4.7, a fine-tune id…';
   idInput.value = editing ? model.id : '';
   idInput.disabled = editing; // the id IS the reference — delete + re-add to rename
-  grid.appendChild(field('Model id (passed to claude --model)', idInput,
+  grid.appendChild(field('Model id (worca’s handle; sent to claude --model unless ANTHROPIC_MODEL overrides)', idInput,
     editing ? '' : 'Use a built-in id to override that built-in.'));
 
   const labelInput = h(doc, 'input', 'input mv-label');
@@ -232,7 +232,7 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
   const add = h(doc, 'button', 'btn-ghost mv-env-add', '+ env var');
   add.type = 'button';
   grid.appendChild(field('Routing env (merged into the claude spawn for this model)', envWrap,
-    'e.g. ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN. Stored values show masked; leave masked to keep. WORCA_* and process keys are reserved.'));
+    'e.g. ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN. ANTHROPIC_MODEL sets the wire id sent to --model (the id above stays worca’s handle). Stored values show masked; leave masked to keep. WORCA_* and process keys are reserved.'));
   const envBtns = h(doc, 'div', 'mv-env-btns');
   envBtns.appendChild(add);
   if (rows.length) {


### PR DESCRIPTION
Closes #374.

A catalog entry's `env` could legally carry `ANTHROPIC_MODEL` (the reserved-key policy allows all `ANTHROPIC_*`), but the key was silently dead: the runner always spawned `--model <catalog-id>`, and the CLI gives the flag precedence over the env var. No error, no warning, no effect.

## What changed

- `runReal` (`src/core/claude-runner.mjs`) now runs the `prepareModelEnv` pass **before** building argv and reads the wire id from its output: `wireModel = safeModelEnv?.ANTHROPIC_MODEL || model`. That value goes into `--model`; the catalog id remains worca's handle everywhere else (config refs, cost flags, event attribution — the init-event actual-model stamping, design §4.7, is untouched).
- One warning line when the two differ: `[worca] model "opus-4-8-vertex": wire model "claude-opus-4-8"`.
- `${VAR}` indirection works for free (the wire id is read post-filter); an unresolvable ref falls back to the catalog id via the existing dropped-key path.
- The spawn-env merge is unchanged — `ANTHROPIC_MODEL` still reaches the child env, harmlessly, since the explicit flag wins.
- No call-site changes: all five dispatch sites already forward `modelEnv` from `resolveModelEnv`.

This enables the same underlying model served by two providers side by side, e.g. `claude-opus-4-8` (direct) and a Vertex entry with `CLAUDE_CODE_USE_VERTEX=1` + `ANTHROPIC_MODEL=claude-opus-4-8`, selectable per pipeline node. Verified locally against a Vertex-routed catalog.

## Tests

Four new cases in `test/spawn-args.test.mjs` (all 31 pass):
- wire id reaches argv, catalog id absent, exactly one warning;
- `modelEnv` without `ANTHROPIC_MODEL` → `--model` = catalog id (regression guard);
- `${VAR}` set → expanded wire id; unset → catalog-id fallback;
- wire id also present in the spawn env.

Full suite: 2871/2876 — the remaining failures (plugin-store `rmSync` EISDIR, boot sweep, db path, symlink export) also fail on a clean tree, so they pre-exist this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)