### PR TITLE
docs: use the architecture diagram as the README hero image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It ships as a **web UI**, a **CLI**, and an installable **`/worca` skill** for
 Claude Code — all running the same engine. See the
 **[architecture in one picture](docs/ARCHITECTURE.md)**.
 
-![Running pipeline with live flow graph and streaming log](docs/screenshots/running.png)
+[![The Worca stack — clients, the engine, the headless Claude Code harness, and model endpoints](docs/screenshots/architecture.png)](docs/ARCHITECTURE.md)
 
 ## How a run works
 
@@ -62,6 +62,8 @@ and durations, the clarify Q&A, agent transcripts, and logs:
   pull request via `gh` from the History view.
 - **Mock mode** — the entire pipeline runs offline with a deterministic mock
   (no `claude`, no tokens) for demos, development, and CI.
+
+![Running pipeline with live flow graph and streaming log](docs/screenshots/running.png)
 
 ### Agents
 


### PR DESCRIPTION
The sentence "See the architecture in one picture" was followed by the running-pipeline screenshot, not the architecture. Now:

- The first README image is the architecture stack diagram, and clicking it opens `docs/ARCHITECTURE.md`.
- The running-pipeline screenshot moves down into **Features → Pipeline**, right under the bullets it illustrates (live cockpit, mock mode, etc.).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)