### PR TITLE
fix: classify the CLI's "Request timed out" as a recoverable network error

### DIFF
--- a/src/core/recoverable-error.mjs
+++ b/src/core/recoverable-error.mjs
@@ -33,7 +33,7 @@ export function classifyError(err) {
   if (/\bsession limit\b|hit your[^.]*\blimit\b|reached your[^.]*\blimit\b|\blimit\b[^.]*\bresets?\b/i.test(msg)) return 'usage_limit';
   if (/\b429\b|\b529\b|rate.?limit|overloaded/i.test(msg)) return 'rate_limit';
   if (/credit balance|usage limit|quota|insufficient_quota|billing/i.test(msg)) return 'quota';
-  if (/ECONNRESET|ETIMEDOUT|ENOTFOUND|ECONNREFUSED|EAI_AGAIN|EPIPE|socket hang up|fetch failed|network|connection (refused|reset|closed|error)|closed mid-response|response above may be incomplete/i.test(msg)) return 'network';
+  if (/ECONNRESET|ETIMEDOUT|ENOTFOUND|ECONNREFUSED|EAI_AGAIN|EPIPE|socket hang up|fetch failed|network|connection (refused|reset|closed|error)|closed mid-response|response above may be incomplete|\btimed?[ -]?out\b|\btimeout\b/i.test(msg)) return 'network';
   return null;
 }
 

--- a/test/recoverable-error.test.mjs
+++ b/test/recoverable-error.test.mjs
@@ -49,6 +49,15 @@ test('classifies the Claude CLI mid-response disconnect as network', () => {
   assert.equal(classifyError(new Error('Connection error.')), 'network');
 });
 
+test('classifies the Claude CLI API timeout as network', () => {
+  // The exact string the headless CLI folds into its reject when an API request
+  // times out (the reported refine-step failure: a ~1h stall, then exit 1).
+  assert.equal(classifyError(new Error('claude exited with code 1: Request timed out')), 'network');
+  assert.equal(classifyError(new Error('Request timed out')), 'network');
+  assert.equal(classifyError(new Error('API Error: Request timeout')), 'network');
+  assert.equal(classifyError(new Error('the request timed-out after 60000ms')), 'network');
+});
+
 test('returns null for a plain bug and accepts a raw string / nullish', () => {
   assert.equal(classifyError(new Error('TypeError: x is not a function')), null);
   assert.equal(classifyError('401 Invalid authentication credentials'), 'auth');


### PR DESCRIPTION
## Problem

The headless claude CLI reports an API timeout as `Request timed out`, which matched none of the patterns in `classifyError` (`src/core/recoverable-error.mjs`). The orchestrator therefore treated it as a genuine bug and terminally failed the run (status `error`, not resumable) instead of entering the recovery gate.

Observed on a real refine step: the review artifact was already written, then a ~1h API stall ended in `claude exited with code 1: Request timed out` and killed the whole pipeline.

## Fix

Add timeout phrasings (`timed out` / `timed-out` / `timeout`) to the `network` class regex. Such failures now retry with exponential backoff in auto mode (up to `WORCA_RECOVERY_MAX_ATTEMPTS`, default 3) or open the retry/abort recovery prompt interactively. This also flows through claude-runner's line-by-line stderr classification, so the stamped `errorClass` is `network`.

`network` is the last class checked, so no higher-precedence class (auth / usage_limit / rate_limit / quota) is shadowed. The over-match risk of message sniffing is the file header's accepted YAGNI caveat.

## Tests

New regression test with the exact reported string plus variants (`test/recoverable-error.test.mjs`). Classifier + orchestrator-recovery suites: 18/18 pass. Full suite: 3000 pass; the 12 failures are pre-existing and unrelated (missing `@highlightjs/cdn-assets` dev dep, db/plugin-store env issues) — verified identical on a clean stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rn8LqwaeF4FBTV9VoCSeMA