### PR TITLE
fix: keep the claude command line under the OS limit — prompt via stdin, system prompt/settings as files (#380)

### DIFF
--- a/src/core/claude-runner.mjs
+++ b/src/core/claude-runner.mjs
@@ -38,10 +38,56 @@ import { prepareModelEnv } from './model-env.mjs';
 import { classifyError, strongestClass } from './recoverable-error.mjs';
 import { explainUnspawnableClaude } from './preflight.mjs';
 import { writeFile, mkdir, appendFile, readFile, access } from 'node:fs/promises';
-import { constants as FS } from 'node:fs';
+import { constants as FS, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const DEFAULT_BIN = process.env.WORCA_CLAUDE_BIN || process.env.ORCH_CLAUDE_BIN || 'claude';
+
+/** What `--settings` carries, or null when there is nothing to carry (no hook
+ *  telemetry, no permission rules) — then the flag is omitted entirely. */
+export function buildSettingsPayload(permissionRules) {
+  const hook = buildHookSettings();
+  const hasRules = !!permissionRules && Object.values(permissionRules).some((a) => Array.isArray(a) && a.length);
+  // Present-but-malformed rules (e.g. `{deny: 'Bash(curl:*)'}`) make the object
+  // truthy while hasRules stays false, so the whole policy would drop out of
+  // argv silently. Say it once, then take the same no-rules path (fail-open,
+  // matching the guardrail-set read path) — the empty/absent cases ({}, {deny: []}, null)
+  // are normal and stay quiet.
+  if (!hasRules && permissionRules && typeof permissionRules === 'object'
+      && Object.values(permissionRules).some((a) => a != null && !Array.isArray(a))) {
+    console.warn('[worca] guardrails: permissionRules is malformed (deny/allow/ask must be arrays of strings) — ignoring it; this spawn carries NO permission rules');
+  }
+  if (!hook && !hasRules) return null;
+  const settings = {};
+  if (hook) settings.hooks = hook.hooks;
+  if (hasRules) settings.permissions = permissionRules;
+  return { hook: !!hook, settings };
+}
+
+/**
+ * Largest command line we hand to spawn() inline (GH #380). Windows caps the
+ * whole CreateProcess command line at 32,767 chars and Linux caps a single
+ * argument at 128 KiB, and a real task prompt (a 1000-line markdown plus the
+ * rendered channel artifacts) sails past both — `spawn ENAMETOOLONG` / E2BIG at
+ * the first node. Above this limit the prompt travels on stdin and the system
+ * prompt / settings as files (planClaudeInvocation); below it the argv is
+ * byte-identical to what it always was. The figure leaves ~12K of headroom
+ * under the Windows cap for the exe path, quoting, and flags this measure
+ * cannot see, and is deliberately platform-independent so the offload path is
+ * exercised (and testable) everywhere, not only on Windows.
+ *
+ * Inline JSON, or the path of a file holding that same JSON when the invocation
+ * is staged (GH #380 — the CLI accepts either).
+ */
+export const ARGV_INLINE_LIMIT = 20000;
+
+/** Conservative size of the command line spawn() would build: every argument
+ *  quoted and space-separated, after the binary. Over-counts slightly on
+ *  purpose (a prompt with embedded quotes grows under Windows escaping). */
+export function argvLength(bin, args) {
+  return String(bin || '').length + args.reduce((n, a) => n + String(a).length + 3, 0);
+}
 
 /** The spawn-failure Error for `bin`: the OS message, plus the Windows npm-shim
  *  explanation when that is what actually went wrong (ENOENT on a bare name
@@ -118,27 +164,15 @@ export function buildHookSettings() {
  * flags would be last-wins at the CLI, silently dropping one payload.
  * [] when there is nothing to say, so the baseline argv is byte-identical.
  * @param {{deny?:string[],allow?:string[],ask?:string[]}|null|undefined} permissionRules
+ * @param {string|null} [settingsFile] staged path (GH #380): `--settings <path>` carries the same JSON
  * @returns {string[]}
  */
-export function buildSettingsArgs(permissionRules) {
-  const hook = buildHookSettings();
-  const hasRules = !!permissionRules && Object.values(permissionRules).some((a) => Array.isArray(a) && a.length);
-  // Present-but-malformed rules (e.g. `{deny: 'Bash(curl:*)'}`) make the object
-  // truthy while hasRules stays false, so the whole policy would drop out of
-  // argv silently. Say it once, then take the same no-rules path (fail-open,
-  // matching the guardrail-set read path) — the empty/absent cases ({}, {deny: []}, null)
-  // are normal and stay quiet.
-  if (!hasRules && permissionRules && typeof permissionRules === 'object'
-      && Object.values(permissionRules).some((a) => a != null && !Array.isArray(a))) {
-    console.warn('[worca] guardrails: permissionRules is malformed (deny/allow/ask must be arrays of strings) — ignoring it; this spawn carries NO permission rules');
-  }
-  if (!hook && !hasRules) return [];
-  const settings = {};
-  if (hook) settings.hooks = hook.hooks;
-  if (hasRules) settings.permissions = permissionRules;
+export function buildSettingsArgs(permissionRules, settingsFile = null) {
+  const payload = buildSettingsPayload(permissionRules);
+  if (!payload) return [];
   const args = [];
-  if (hook) args.push('--include-hook-events');
-  args.push('--settings', JSON.stringify(settings));
+  if (payload.hook) args.push('--include-hook-events');
+  args.push('--settings', settingsFile || JSON.stringify(payload.settings));
   return args;
 }
 
@@ -243,6 +277,7 @@ export function mockEnabled(opts) {
  * @param {number|null} [o.maxBudgetUsd]    --max-budget-usd <n> (finite > 0; null/else omitted)
  * @param {string} [o.appendSubagentSystemPrompt] --append-subagent-system-prompt <text> (Task children only)
  *   All eight are Ask Worca sandbox options (ask-worca-design.md §6.3) and default-off.
+ * @param {number} [o.argvInlineLimit]     override ARGV_INLINE_LIMIT (GH #380; tests force the staged path)
  * @returns {Promise<{text:string, exitCode:number}>}
  */
 export async function runClaude(o = {}) {
@@ -279,6 +314,7 @@ export async function runClaude(o = {}) {
     maxTurns,
     maxBudgetUsd,
     appendSubagentSystemPrompt,
+    argvInlineLimit,
     bin = DEFAULT_BIN,
   } = o;
 
@@ -322,6 +358,7 @@ export async function runClaude(o = {}) {
     maxTurns,
     maxBudgetUsd,
     appendSubagentSystemPrompt,
+    argvInlineLimit,
   });
 }
 
@@ -353,11 +390,18 @@ export function buildClaudeArgs({
   // --allowedTools union).
   tools: builtinTools, strictMcpConfig, settingSources, disableSlashCommands, includePartialMessages,
   maxTurns, maxBudgetUsd, appendSubagentSystemPrompt,
-}) {
-  const args = ['-p', prompt, '--output-format', 'stream-json', '--verbose', '--permission-mode', permissionMode];
+}, delivery = {}) {
+  // delivery (GH #380, set only by planClaudeInvocation's staged branch):
+  //   promptViaStdin   -> bare `-p`; the prompt is written to the child's stdin
+  //   systemPromptFile -> `--append-system-prompt-file <path>` instead of the text
+  //   settingsFile     -> `--settings <path>` instead of the inline JSON
+  const { promptViaStdin = false, systemPromptFile = null, settingsFile = null } = delivery;
+  const args = promptViaStdin ? ['-p'] : ['-p', prompt];
+  args.push('--output-format', 'stream-json', '--verbose', '--permission-mode', permissionMode);
   if (resumeSessionId) args.push('--resume', resumeSessionId);
   if (systemPrompt) {
-    args.push('--append-system-prompt', systemPrompt);
+    if (systemPromptFile) args.push('--append-system-prompt-file', systemPromptFile);
+    else args.push('--append-system-prompt', systemPrompt);
   }
   if (model) {
     args.push('--model', model);
@@ -368,7 +412,7 @@ export function buildClaudeArgs({
   // SINGLE inline JSON (two --settings flags would be last-wins at the CLI). [] when
   // there is neither, so the baseline argv is unchanged; a CLI that rejects these
   // flags would only ever fail when the operator opted in.
-  for (const a of buildSettingsArgs(permissionRules)) args.push(a);
+  for (const a of buildSettingsArgs(permissionRules, settingsFile)) args.push(a);
   if (mcpConfigPath) args.push('--mcp-config', mcpConfigPath);
   const tools = Array.isArray(allowedTools) ? allowedTools.slice() : [];
   for (const s of (Array.isArray(mcpServerGrants) ? mcpServerGrants : [])) {
@@ -409,7 +453,56 @@ export function buildClaudeArgs({
   return args;
 }
 
-function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, model, effort, onEvent, signal, bin, resumeSessionId, mcpConfigPath, mcpServerGrants, permissionRules, envScrub, envAllowlist, modelEnv, tools, strictMcpConfig, settingSources, disableSlashCommands, includePartialMessages, maxTurns, maxBudgetUsd, appendSubagentSystemPrompt }) {
+/**
+ * Decide how ONE invocation reaches the CLI (GH #380). Pure: no I/O.
+ *  - inline (the common case): `args` is exactly buildClaudeArgs(opts); `stdin`
+ *    null; `files` empty.
+ *  - staged (argv over `limit`): the prompt goes on stdin (`-p` reads it — the
+ *    model sees the exact text, unlike a "read this file" instruction), the
+ *    system prompt and the settings JSON become files under `dir`, and no
+ *    argument carries free text any more, so the argv is short by construction.
+ * @param {object} opts  the buildClaudeArgs options
+ * @param {{bin?:string, dir?:string|(() => string), limit?:number}} [o]  `dir` may be a
+ *   factory, called only when staging is actually needed (so the caller creates
+ *   a temp dir exactly when one will be used)
+ * @returns {{args:string[], stdin:string|null, files:{path:string,content:string}[], staged:boolean, inlineLength:number}}
+ */
+export function planClaudeInvocation(opts, { bin = DEFAULT_BIN, dir = null, limit = ARGV_INLINE_LIMIT } = {}) {
+  const inline = buildClaudeArgs(opts);
+  const inlineLength = argvLength(bin, inline);
+  if (inlineLength <= limit) return { args: inline, stdin: null, files: [], staged: false, inlineLength };
+  if (!dir) throw new Error('planClaudeInvocation: a staging dir is required when the argv is over the limit');
+  if (typeof dir === 'function') dir = dir();
+  const files = [];
+  const prompt = typeof opts.prompt === 'string' ? opts.prompt : '';
+  const promptViaStdin = prompt.length > 0;             // an empty prompt stays `-p ''` — nothing to pipe
+  let systemPromptFile = null;
+  if (opts.systemPrompt) {
+    systemPromptFile = join(dir, 'system-prompt.md');
+    files.push({ path: systemPromptFile, content: opts.systemPrompt });
+  }
+  let settingsFile = null;
+  const payload = buildSettingsPayload(opts.permissionRules);
+  if (payload) {
+    settingsFile = join(dir, 'settings.json');
+    files.push({ path: settingsFile, content: JSON.stringify(payload.settings) });
+  }
+  const args = buildClaudeArgs(opts, { promptViaStdin, systemPromptFile, settingsFile });
+  return { args, stdin: promptViaStdin ? prompt : null, files, staged: true, inlineLength };
+}
+
+/** planClaudeInvocation + the I/O: a private temp dir is created and the files
+ *  written ONLY on the staged branch (`dir` is null otherwise, so the caller has
+ *  nothing to clean up). Synchronous on purpose — a few hundred KB once per
+ *  spawn, and it keeps the spawn sequence in runReal linear. */
+export function stageClaudeInvocation(opts, { bin = DEFAULT_BIN, limit = ARGV_INLINE_LIMIT } = {}) {
+  let dir = null;
+  const plan = planClaudeInvocation(opts, { bin, limit, dir: () => (dir = mkdtempSync(join(tmpdir(), 'worca-claude-'))) });
+  for (const file of plan.files) writeFileSync(file.path, file.content, 'utf8');
+  return { ...plan, dir };
+}
+
+function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, model, effort, onEvent, signal, bin, resumeSessionId, mcpConfigPath, mcpServerGrants, permissionRules, envScrub, envAllowlist, modelEnv, tools, strictMcpConfig, settingSources, disableSlashCommands, includePartialMessages, maxTurns, maxBudgetUsd, appendSubagentSystemPrompt, argvInlineLimit }) {
   return new Promise((resolveP, rejectP) => {
     // Per-model routing env (design §4.4), prepared BEFORE argv: reserved keys
     // are re-dropped here defensively — the write path already rejects them, so
@@ -441,12 +534,30 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
       console.warn(`[worca] model ${JSON.stringify(model ?? '')}: wire model ${JSON.stringify(wireModel)}`);
     }
 
-    const args = buildClaudeArgs({
-      prompt, systemPrompt, permissionMode, model: wireModel, effort, allowedTools, resumeSessionId,
-      mcpConfigPath, mcpServerGrants, permissionRules,
-      tools, strictMcpConfig, settingSources, disableSlashCommands, includePartialMessages,
-      maxTurns, maxBudgetUsd, appendSubagentSystemPrompt,
-    });
+    // GH #380: inline argv when it fits, else prompt on stdin + files (see
+    // ARGV_INLINE_LIMIT). The staging dir, when any, is removed on every
+    // terminal path below (finish) and on a failed spawn.
+    const limit = Number.isFinite(argvInlineLimit) && argvInlineLimit > 0 ? argvInlineLimit : ARGV_INLINE_LIMIT;
+    let plan;
+    try {
+      plan = stageClaudeInvocation({
+        prompt, systemPrompt, permissionMode, model: wireModel, effort, allowedTools, resumeSessionId,
+        mcpConfigPath, mcpServerGrants, permissionRules,
+        tools, strictMcpConfig, settingSources, disableSlashCommands, includePartialMessages,
+        maxTurns, maxBudgetUsd, appendSubagentSystemPrompt,
+      }, { bin, limit });
+    } catch (err) {
+      rejectP(new Error(`Failed to stage the claude prompt files: ${err.message}`));
+      return;
+    }
+    const { args } = plan;
+    const cleanupStaged = () => {
+      if (!plan.dir) return;
+      try { rmSync(plan.dir, { recursive: true, force: true }); } catch { /* best effort */ }
+    };
+    if (plan.staged) {
+      console.warn(`[worca] claude argv would be ${plan.inlineLength} chars (limit ${limit}): prompt on stdin, system prompt/settings as files`);
+    }
 
     // undefined when the guardrail is off, and the spread then adds NO `env` key —
     // spawn inherits process.env exactly as it did before guardrails existed.
@@ -461,10 +572,19 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
 
     let child;
     try {
-      child = spawn(bin, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'], ...(spawnEnv ? { env: spawnEnv } : {}) });
+      child = spawn(bin, args, {
+        cwd, stdio: [plan.stdin != null ? 'pipe' : 'ignore', 'pipe', 'pipe'], ...(spawnEnv ? { env: spawnEnv } : {}),
+      });
     } catch (err) {
+      cleanupStaged();
       rejectP(spawnFailure(bin, err, `Failed to spawn ${bin}`));
       return;
+    }
+    if (plan.stdin != null) {
+      // A child that dies before draining stdin (bad flag, ENOENT surfaced
+      // late) raises EPIPE here; the 'error'/'close' handlers own the real cause.
+      child.stdin.on('error', () => {});
+      child.stdin.end(plan.stdin, 'utf8');
     }
 
     let resultText = '';
@@ -504,6 +624,7 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
       if (settled) return;
       settled = true;
       if (signal) signal.removeEventListener?.('abort', onAbort);
+      cleanupStaged();
       fn(arg);
     };
 

--- a/test/spawn-argv-limit.test.mjs
+++ b/test/spawn-argv-limit.test.mjs
@@ -1,0 +1,163 @@
+// test/spawn-argv-limit.test.mjs — GH #380: `spawn claude: ENAMETOOLONG` on
+// Windows (32K command line) / E2BIG on Linux (128 KiB per argument) when the
+// task prompt rode in `-p`. Over ARGV_INLINE_LIMIT the prompt goes on stdin and
+// the system prompt / settings become files; under it the argv is unchanged.
+import { test, after, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile, chmod, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ARGV_INLINE_LIMIT, argvLength, buildClaudeArgs, buildSettingsArgs, buildSettingsPayload,
+  planClaudeInvocation, stageClaudeInvocation, runClaude,
+} from '../src/core/claude-runner.mjs';
+
+const tmp = [];
+async function tmpDir() { const d = await mkdtemp(join(tmpdir(), 'worca-cc-argv-')); tmp.push(d); return d; }
+after(async () => { await Promise.all(tmp.map((d) => rm(d, { recursive: true, force: true }))); });
+
+let prevMock, prevOrch, prevHooks;
+beforeEach(() => {
+  prevMock = process.env.WORCA_MOCK; prevOrch = process.env.ORCH_MOCK; prevHooks = process.env.WORCA_SUBAGENT_HOOKS;
+  delete process.env.WORCA_MOCK; delete process.env.ORCH_MOCK; delete process.env.WORCA_SUBAGENT_HOOKS;
+});
+afterEach(() => {
+  for (const [k, v] of [['WORCA_MOCK', prevMock], ['ORCH_MOCK', prevOrch], ['WORCA_SUBAGENT_HOOKS', prevHooks]]) {
+    if (v === undefined) delete process.env[k]; else process.env[k] = v;
+  }
+});
+
+const RULES = { deny: ['Bash(curl:*)'], allow: [], ask: [] };
+const BIG = 'x'.repeat(50_000);
+const OPTS = { prompt: BIG, systemPrompt: 'be terse', permissionMode: 'acceptEdits', permissionRules: RULES,
+  model: 'claude-sonnet-4-6', allowedTools: ['Read'], resumeSessionId: 'sess-9' };
+
+test('ARGV_INLINE_LIMIT leaves real headroom under the Windows 32,767-char command line', () => {
+  assert.ok(ARGV_INLINE_LIMIT <= 24_000 && ARGV_INLINE_LIMIT >= 8_000, String(ARGV_INLINE_LIMIT));
+  assert.equal(argvLength('claude', ['-p', 'abc']), 6 + (2 + 3) + (3 + 3));
+});
+
+test('under the limit: plan is byte-identical to buildClaudeArgs, nothing on stdin, no files', () => {
+  const opts = { ...OPTS, prompt: 'p' };
+  const plan = planClaudeInvocation(opts, { bin: 'claude' });
+  assert.deepEqual(plan.args, buildClaudeArgs(opts));
+  assert.equal(plan.stdin, null);
+  assert.deepEqual(plan.files, []);
+  assert.equal(plan.staged, false);
+  assert.deepEqual(plan.args.slice(0, 2), ['-p', 'p']);
+  assert.ok(plan.args.includes('--append-system-prompt') && plan.args.includes('--settings'));
+});
+
+test('over the limit: bare -p + stdin, --append-system-prompt-file, --settings <file>; no free text in argv', () => {
+  const plan = planClaudeInvocation(OPTS, { bin: 'claude', dir: '/stage' });
+  assert.equal(plan.staged, true);
+  assert.equal(plan.stdin, BIG);
+  assert.deepEqual(plan.args.slice(0, 3), ['-p', '--output-format', 'stream-json']);
+  assert.equal(plan.args[plan.args.indexOf('--append-system-prompt-file') + 1], join('/stage', 'system-prompt.md'));
+  assert.ok(!plan.args.includes('--append-system-prompt'));
+  assert.equal(plan.args[plan.args.indexOf('--settings') + 1], join('/stage', 'settings.json'));
+  assert.equal(plan.args[plan.args.indexOf('--resume') + 1], 'sess-9', 'resume survives staging');
+  assert.equal(plan.args[plan.args.indexOf('--model') + 1], 'claude-sonnet-4-6');
+  assert.ok(!plan.args.some((a) => a.includes('be terse') || a.length > 200), JSON.stringify(plan.args));
+  assert.ok(argvLength('claude', plan.args) < 1000);
+  assert.deepEqual(plan.files.map((f) => f.path), [join('/stage', 'system-prompt.md'), join('/stage', 'settings.json')]);
+  assert.equal(plan.files[0].content, 'be terse');
+  assert.deepEqual(JSON.parse(plan.files[1].content), { permissions: RULES });
+  assert.ok(plan.inlineLength > ARGV_INLINE_LIMIT);
+});
+
+test('over the limit with nothing to file: only the prompt moves (no system prompt, no settings)', () => {
+  const plan = planClaudeInvocation({ prompt: BIG, permissionMode: 'acceptEdits' }, { bin: 'claude', dir: '/stage' });
+  assert.equal(plan.stdin, BIG);
+  assert.deepEqual(plan.files, []);
+  assert.ok(!plan.args.includes('--settings') && !plan.args.includes('--append-system-prompt-file'));
+});
+
+test('a huge SYSTEM prompt alone also stages (Windows counts the whole line)', () => {
+  const plan = planClaudeInvocation({ prompt: 'p', systemPrompt: BIG, permissionMode: 'acceptEdits' }, { bin: 'claude', dir: '/stage' });
+  assert.equal(plan.staged, true);
+  assert.equal(plan.stdin, 'p', 'the (small) prompt still goes on stdin — one delivery shape for the staged path');
+  assert.equal(plan.files[0].content, BIG);
+});
+
+test('an explicit limit forces staging for a small prompt; a missing dir is an error, not a silent inline', () => {
+  const opts = { prompt: 'hello', permissionMode: 'acceptEdits' };
+  assert.equal(planClaudeInvocation(opts, { bin: 'claude', dir: '/s', limit: 10 }).staged, true);
+  assert.throws(() => planClaudeInvocation(opts, { bin: 'claude', limit: 10 }), /staging dir/);
+});
+
+test('buildSettingsArgs: inline JSON by default, a path when a settings file is given; null payload when nothing to carry', () => {
+  assert.deepEqual(buildSettingsArgs(RULES), ['--settings', JSON.stringify({ permissions: RULES })]);
+  assert.deepEqual(buildSettingsArgs(RULES, '/s/settings.json'), ['--settings', '/s/settings.json']);
+  assert.deepEqual(buildSettingsArgs(null), []);
+  assert.equal(buildSettingsPayload({ deny: [] }), null);
+});
+
+test('stageClaudeInvocation writes the files only on the staged branch', async () => {
+  const inline = stageClaudeInvocation({ prompt: 'p', permissionMode: 'acceptEdits' }, { bin: 'claude' });
+  assert.equal(inline.dir, null);
+  const staged = stageClaudeInvocation(OPTS, { bin: 'claude' });
+  tmp.push(staged.dir);
+  assert.ok(existsSync(join(staged.dir, 'system-prompt.md')) && existsSync(join(staged.dir, 'settings.json')));
+  assert.equal(await readFile(join(staged.dir, 'system-prompt.md'), 'utf8'), 'be terse');
+});
+
+/** A fake `claude` that records argv (NUL-separated), its stdin, and the
+ *  content of the --append-system-prompt-file it was given. */
+async function fakeBin(dir) {
+  const bin = join(dir, 'fake-claude.sh');
+  await writeFile(bin,
+    '#!/bin/sh\n' +
+    `prev=""; for a in "$@"; do printf '%s\\0' "$a" >> ${JSON.stringify(join(dir, 'argv.txt'))}; ` +
+    `if [ "$prev" = "--append-system-prompt-file" ]; then cp "$a" ${JSON.stringify(join(dir, 'sp.txt'))}; echo "$a" > ${JSON.stringify(join(dir, 'sp-path.txt'))}; fi; prev="$a"; done\n` +
+    `cat > ${JSON.stringify(join(dir, 'stdin.txt'))}\n` +
+    `printf '%s\\n' '{"type":"result","result":"ok"}'\nexit 0\n`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+test('runClaude end to end: over the limit the CLI receives the prompt on stdin and the files, then the staging dir is gone', async () => {
+  const dir = await tmpDir();
+  const bin = await fakeBin(dir);
+  const prompt = 'task prompt\nline two — ünïcödé';
+  await runClaude({ cwd: dir, bin, prompt, systemPrompt: 'agent body', permissionRules: RULES, argvInlineLimit: 50 });
+  const argv = (await readFile(join(dir, 'argv.txt'), 'utf8')).split('\0').filter(Boolean);
+  assert.equal(argv[0], '-p');
+  assert.equal(argv[1], '--output-format', 'no prompt positional');
+  assert.ok(!argv.includes(prompt) && !argv.includes('agent body'));
+  assert.equal(await readFile(join(dir, 'stdin.txt'), 'utf8'), prompt, 'exact prompt bytes on stdin');
+  assert.equal(await readFile(join(dir, 'sp.txt'), 'utf8'), 'agent body');
+  const spPath = (await readFile(join(dir, 'sp-path.txt'), 'utf8')).trim();
+  assert.ok(!existsSync(spPath), `staging dir cleaned up after close: ${spPath}`);
+});
+
+test('runClaude end to end: under the limit nothing changes — prompt positional, stdin closed', async () => {
+  const dir = await tmpDir();
+  const bin = await fakeBin(dir);
+  await runClaude({ cwd: dir, bin, prompt: 'small', systemPrompt: 'agent body' });
+  const argv = (await readFile(join(dir, 'argv.txt'), 'utf8')).split('\0').filter(Boolean);
+  assert.deepEqual(argv.slice(0, 2), ['-p', 'small']);
+  assert.equal(argv[argv.indexOf('--append-system-prompt') + 1], 'agent body');
+  assert.equal(await readFile(join(dir, 'stdin.txt'), 'utf8'), '', 'stdin is /dev/null on the inline path');
+  assert.ok(!existsSync(join(dir, 'sp-path.txt')));
+});
+
+test('runClaude: a real ~1000-line markdown prompt (the #380 report) stages by default', async () => {
+  const dir = await tmpDir();
+  const bin = await fakeBin(dir);
+  const prompt = Array.from({ length: 1000 }, (_, i) => `- [ ] requirement ${i}: the system shall do something specific and measurable`).join('\n');
+  assert.ok(prompt.length > ARGV_INLINE_LIMIT);
+  await runClaude({ cwd: dir, bin, prompt, systemPrompt: 'agent body' });
+  assert.equal(await readFile(join(dir, 'stdin.txt'), 'utf8'), prompt);
+});
+
+test('planClaudeInvocation: a dir factory is invoked only when staging is needed', () => {
+  let calls = 0;
+  const dir = () => { calls++; return '/lazy'; };
+  planClaudeInvocation({ prompt: 'p', permissionMode: 'acceptEdits' }, { bin: 'claude', dir });
+  assert.equal(calls, 0, 'inline: no dir');
+  const plan = planClaudeInvocation({ prompt: BIG, systemPrompt: 's', permissionMode: 'acceptEdits' }, { bin: 'claude', dir });
+  assert.equal(calls, 1);
+  assert.equal(plan.files[0].path, join('/lazy', 'system-prompt.md'));
+});


### PR DESCRIPTION
Fixes #380. Stacked on #383 (`fix/windows-npm-claude-hint`) → #382 → `dev`; retarget after each merge. The whole stack is current with `dev` (merged, per the repo's merge-commit convention), so the three PRs merge sequentially without further conflict resolution.

## Why

On Windows a real task prompt (the reporter's ~1000-line markdown) fails the very first node with `Failed to spawn claude: spawn ENAMETOOLONG`. The runner put **everything** in argv — `-p <entire prompt>`, `--append-system-prompt <entire agent .md>`, `--settings <inline JSON>` — and `CreateProcess` caps the command line at **32,767 chars**. Linux caps a single argument at **128 KiB** (`E2BIG`), which is why worca 0.x (`claude_cli.py`) offloaded prompts over 128 KiB to a temp file; the Node rewrite lost that and Windows' far lower ceiling exposed it immediately.

## What

`claude-runner.mjs` now **plans** each invocation (`planClaudeInvocation`, pure):

| argv size | delivery |
|---|---|
| ≤ `ARGV_INLINE_LIMIT` (20,000 chars) | **unchanged** — byte-identical argv; every existing argv test still passes |
| over it | bare `-p` with the prompt written to the child's **stdin** (the CLI reads it there — the model sees the *exact* text, unlike master's "read the file at …" instruction), `--append-system-prompt-file <tmp>/system-prompt.md`, `--settings <tmp>/settings.json` (the flag accepts a path or JSON) |

No argument carries free text on the staged path, so the line is short by construction; `--resume`, `--model`, `--allowedTools`, the MCP flags and the Ask Worca hardening flags are untouched. The limit is deliberately platform-independent (and ~12K under the Windows cap for the exe path, quoting and flags the measure can't see) so the offload path is exercised — and tested — on every platform, not just Windows.

`stageClaudeInvocation` creates a private temp dir and writes the files **only** when staging; `runReal` removes it on every terminal path (`finish`) and on a failed spawn, pipes stdin only when staged, and swallows the `EPIPE` a fast-dying child raises on it. `argvInlineLimit` is threaded through the `runClaude` gate for tests. `--append-system-prompt-file` verified on CLI 2.1.246 (fails fast on a missing file).

## Tests

`test/spawn-argv-limit.test.mjs` — limit headroom; inline plan `===` `buildClaudeArgs`; staged argv shape, files, stdin (with `--resume`); huge *system* prompt alone stages; lazy dir factory; `buildSettingsArgs` file form; and end-to-end `runClaude` against a fake `claude` that records argv, stdin and the system-prompt file — staged, inline, and the #380 1000-line prompt at the **default** limit — including staging-dir cleanup. Existing `spawn-args`, `claude-runner-session`, `ask-spawn`, `ask-runner-options`, `overview-agent` suites unchanged and green. Full suite green on all three branches of the stack after the `dev` merge (3687 / 3695 / 3707).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
