### PR TITLE
feat: run the npm-installed Claude Code on native Windows (resolve the .cmd shim to the package's claude.exe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,12 @@ Requirements:
 - **Node.js >= 22.13.0** (the built-in `node:sqlite` store)
 - The **[Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI**
   (`claude`) on your `PATH` — for real runs; mock mode needs nothing.
-  On **native Windows** use the [native installer](https://docs.anthropic.com/en/docs/claude-code/setup)
-  (`claude.exe`) or point `WORCA_CLAUDE_BIN` at it: the npm install only ships a
-  `claude.cmd` shim, which Windows won't resolve by name and Node won't spawn
-  without a shell — Worca reports this case explicitly rather than a bare `ENOENT`.
+  On **native Windows** both the [native installer](https://docs.anthropic.com/en/docs/claude-code/setup)
+  (`claude.exe`) and `npm install -g @anthropic-ai/claude-code` work: npm puts a
+  `claude.cmd` shim on `PATH` that Node cannot spawn, so Worca runs the package's
+  native `claude.exe` next to it instead. If that binary is missing (the package's
+  `postinstall` didn't run) or the layout isn't npm's, Worca says so rather than
+  a bare `ENOENT`; `WORCA_CLAUDE_BIN` can always point at a `claude.exe` directly.
 
 ## Quick start
 

--- a/src/core/claude-runner.mjs
+++ b/src/core/claude-runner.mjs
@@ -36,7 +36,7 @@ import { spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { prepareModelEnv } from './model-env.mjs';
 import { classifyError, strongestClass } from './recoverable-error.mjs';
-import { explainUnspawnableClaude } from './preflight.mjs';
+import { explainUnspawnableClaude, resolveClaudeBin } from './preflight.mjs';
 import { writeFile, mkdir, appendFile, readFile, access } from 'node:fs/promises';
 import { constants as FS, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -88,6 +88,9 @@ export const ARGV_INLINE_LIMIT = 20000;
 export function argvLength(bin, args) {
   return String(bin || '').length + args.reduce((n, a) => n + String(a).length + 3, 0);
 }
+
+/** Log each npm-shim resolution once per process, not once per spawn. */
+const _resolveNoted = new Set();
 
 /** The spawn-failure Error for `bin`: the OS message, plus the Windows npm-shim
  *  explanation when that is what actually went wrong (ENOENT on a bare name
@@ -534,6 +537,16 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
       console.warn(`[worca] model ${JSON.stringify(model ?? '')}: wire model ${JSON.stringify(wireModel)}`);
     }
 
+    // Windows + npm-installed Claude Code: the bare name is a .cmd shim Node
+    // cannot spawn; resolveClaudeBin swaps in the package's native claude.exe.
+    // Everywhere else this is `bin` unchanged. Resolved BEFORE the argv plan so
+    // the command-line measure below counts the path that is actually spawned.
+    const resolved = resolveClaudeBin(bin);
+    if (resolved.note && !_resolveNoted.has(resolved.bin)) {
+      _resolveNoted.add(resolved.bin);
+      console.warn(`[worca] ${resolved.note}`);
+    }
+
     // GH #380: inline argv when it fits, else prompt on stdin + files (see
     // ARGV_INLINE_LIMIT). The staging dir, when any, is removed on every
     // terminal path below (finish) and on a failed spawn.
@@ -545,7 +558,7 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
         mcpConfigPath, mcpServerGrants, permissionRules,
         tools, strictMcpConfig, settingSources, disableSlashCommands, includePartialMessages,
         maxTurns, maxBudgetUsd, appendSubagentSystemPrompt,
-      }, { bin, limit });
+      }, { bin: resolved.bin, limit });
     } catch (err) {
       rejectP(new Error(`Failed to stage the claude prompt files: ${err.message}`));
       return;
@@ -572,7 +585,7 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
 
     let child;
     try {
-      child = spawn(bin, args, {
+      child = spawn(resolved.bin, args, {
         cwd, stdio: [plan.stdin != null ? 'pipe' : 'ignore', 'pipe', 'pipe'], ...(spawnEnv ? { env: spawnEnv } : {}),
       });
     } catch (err) {

--- a/src/core/preflight.mjs
+++ b/src/core/preflight.mjs
@@ -11,9 +11,9 @@
 
 import { spawn } from 'node:child_process';
 import { access } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { constants as FS, existsSync } from 'node:fs';
+import { constants as FS, existsSync, statSync, openSync, readSync, closeSync } from 'node:fs';
 
 /**
  * Run a command and resolve to its trimmed stdout, or null on any failure.
@@ -332,48 +332,140 @@ export async function detectToolsPerProject(projectDirs) {
  * @param {string} [bin] the claude binary (defaults to `claude`)
  * @returns {Promise<{mcpConfig: boolean, version: string|null}>}
  */
+// ── Windows: the executable behind a bare `claude` ────────────────────────────
+// Native Windows resolves a bare name on PATH to `.exe` only, and Node refuses
+// to run .cmd/.bat shims without a shell (CVE-2024-27980). The npm install of
+// Claude Code (>= 2.1 — every version Worca supports) puts a `claude.cmd` shim
+// on PATH whose target is a REAL native binary at npm's fixed layout:
+//   <shim dir>\node_modules\@anthropic-ai\claude-code\bin\claude.exe
+// (the package's postinstall copies the platform binary over a ~500-byte text
+// placeholder there). resolveClaudeBin() spawns that .exe directly — no shell,
+// correct kill target, no quoting surface — and explainUnspawnableClaude()
+// covers the cases where that is not possible.
+
+export const NPM_CLAUDE_EXE_SEGMENTS = Object.freeze(['node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe']);
+
+/** A real PE executable (MZ header, bigger than npm's placeholder stub). */
+export function isNativeExe(p) {
+  try {
+    const st = statSync(p);
+    if (!st.isFile() || st.size < 4096) return false;
+    const fd = openSync(p, 'r');
+    try {
+      const head = Buffer.alloc(2);
+      readSync(fd, head, 0, 2, 0);
+      return head.toString('latin1') === 'MZ';
+    } finally { closeSync(fd); }
+  } catch { return false; }
+}
+
+const _ov = { isNativeExe: null };
+const _resolveCache = new Map();
+/** Test seam (mirrors folder-dialog.mjs): swap the PE check so an end-to-end
+ *  test on a POSIX host can stand in a shell script for claude.exe. */
+export const _testing = {
+  set({ isNativeExe: native = _ov.isNativeExe } = {}) { _ov.isNativeExe = native; _resolveCache.clear(); },
+  reset() { _ov.isNativeExe = null; _resolveCache.clear(); },
+};
+
+/** What `bin` reaches on a Windows PATH: a real .exe (spawn works as-is), the
+ *  shims found, and — next to the FIRST shim — the npm package's native binary
+ *  when present, with whether it is real or still the placeholder. */
+function probeWindowsClaude(bin, { pathEnv, exists, native }) {
+  const name = String(bin || 'claude').trim() || 'claude';
+  const ok = (p) => { try { return !!exists(p); } catch { return false; } }; // a probe error is "absent"
+  const out = { name, exe: null, shims: [], npm: null };
+  if (/\.exe$/i.test(name)) { out.exe = name; return out; }       // explicit .exe: nothing to resolve
+  const explicitPath = /[\\/]/.test(name);
+  const shimExt = /\.(cmd|bat|ps1)$/i.test(name);
+  const stems = explicitPath ? [name] : pathEnv.split(';').filter(Boolean).map((d) => join(d, name));
+  for (const stem of stems) {
+    if (!shimExt && ok(stem + '.exe')) { out.exe = stem + '.exe'; return out; }
+    for (const ext of shimExt ? [''] : ['.cmd', '.bat', '.ps1']) {
+      const shim = stem + ext;
+      if (!ok(shim)) continue;
+      out.shims.push(shim);
+      if (!out.npm) {
+        const candidate = join(dirname(shim), ...NPM_CLAUDE_EXE_SEGMENTS);
+        if (ok(candidate)) out.npm = { exe: candidate, native: !!native(candidate) };
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * The executable to spawn for `bin` on THIS host. Off Windows, and whenever a
+ * real .exe is reachable, that is `bin` unchanged (spawn's own PATH lookup is
+ * correct). When the only PATH hit is npm's .cmd shim and the package's native
+ * claude.exe sits next to it, that .exe is returned instead — with a one-line
+ * `note` for the log. Otherwise `bin` unchanged again, and the spawn's ENOENT
+ * is what explainUnspawnableClaude() turns into an actionable message.
+ *
+ * Pure with injected platform/pathEnv/exists/isNativeExe; the default
+ * (uninjected) resolution is memoised per bin+PATH — PATH does not change under
+ * a running process, and the probe is a handful of stat()s per spawn otherwise.
+ * @param {string} [bin]
+ * @param {{platform?:string, pathEnv?:string, exists?:(p:string)=>boolean, isNativeExe?:(p:string)=>boolean}} [opts]
+ * @returns {{bin:string, source:'as-is'|'exe'|'npm', note:string|null}}
+ */
+export function resolveClaudeBin(bin = 'claude', opts = {}) {
+  const platform = opts.platform ?? process.platform;
+  if (platform !== 'win32') return { bin, source: 'as-is', note: null };
+  const pathEnv = opts.pathEnv ?? (process.env.PATH ?? '');
+  const injected = Object.keys(opts).length > 0;
+  const key = `${bin}\0${pathEnv}`;
+  if (!injected && _resolveCache.has(key)) return _resolveCache.get(key);
+  const p = probeWindowsClaude(bin, {
+    pathEnv, exists: opts.exists ?? existsSync, native: opts.isNativeExe ?? _ov.isNativeExe ?? isNativeExe,
+  });
+  let out;
+  if (p.exe) out = { bin, source: 'exe', note: null };
+  else if (p.npm && p.npm.native) {
+    out = { bin: p.npm.exe, source: 'npm', note:
+      `using the npm-installed Claude Code binary ${p.npm.exe} ("${p.name}" on PATH is npm's .cmd shim, which Node cannot spawn directly)` };
+  } else out = { bin, source: 'as-is', note: null };
+  if (!injected) _resolveCache.set(key, out);
+  return out;
+}
+
 /**
  * Why a bare `claude` cannot be spawned on THIS host, or null when the generic
- * error is the whole story. Native Windows + npm-installed Claude Code: npm's
- * global install lays down `claude.cmd` / `claude.ps1` shims and no `.exe`,
- * but Windows resolves a bare name on PATH to `.exe` only, and Node refuses to
- * run .cmd/.bat without a shell (CVE-2024-27980) — so spawn('claude') is ENOENT
- * even though `where claude` finds it. The fix is the user's (native build, or
- * WORCA_CLAUDE_BIN → claude.exe); Worca's job is to SAY so instead of "ENOENT".
+ * error is the whole story (or when resolveClaudeBin() would have handled it).
+ * Two Windows cases get an actionable message: the npm shim with the package's
+ * binary still being the postinstall placeholder, and a shim with no native
+ * binary next to it at all (non-npm layout, or a pre-native package).
  *
- * Pure: platform / PATH / existence are injectable for tests. Never throws.
+ * Pure: platform / PATH / existence / PE check are injectable. Never throws.
  * @param {string} [bin] the configured claude binary (name or path)
- * @param {{platform?:string, pathEnv?:string, exists?:(p:string)=>boolean}} [o]
+ * @param {{platform?:string, pathEnv?:string, exists?:(p:string)=>boolean, isNativeExe?:(p:string)=>boolean}} [o]
  * @returns {string|null}
  */
 export function explainUnspawnableClaude(bin = 'claude', {
   platform = process.platform,
   pathEnv = process.env.PATH ?? '',
   exists = existsSync,
+  isNativeExe: native = _ov.isNativeExe ?? isNativeExe,
 } = {}) {
   if (platform !== 'win32') return null;
-  const name = String(bin || 'claude').trim() || 'claude';
-  if (/\.exe$/i.test(name)) return null; // an explicit .exe that fails is a real ENOENT
-  const explicitPath = /[\\/]/.test(name);
-  const shimExt = /\.(cmd|bat|ps1)$/i.test(name);
-  const stems = explicitPath ? [name] : pathEnv.split(';').filter(Boolean).map((d) => join(d, name));
-  const ok = (p) => { try { return !!exists(p); } catch { return false; } }; // a probe error is "absent"
-  const shims = [];
-  for (const stem of stems) {
-    if (!shimExt && ok(stem + '.exe')) return null; // a real exe is reachable — not this problem
-    for (const ext of shimExt ? [''] : ['.cmd', '.bat', '.ps1']) {
-      if (ok(stem + ext)) shims.push(stem + ext);
-    }
+  const p = probeWindowsClaude(bin, { pathEnv, exists, native });
+  if (p.exe || !p.shims.length) return null;           // a real exe, or a plain "not installed"
+  if (p.npm && p.npm.native) return null;               // resolveClaudeBin() spawns this one — not a failure
+  const base = `"${p.name}" resolves to a script shim (${p.shims[0]}) — the npm install of Claude Code. ` +
+    'Windows only launches a .exe by name and Node cannot run a .cmd/.bat shim without a shell. ';
+  if (p.npm) {
+    const installer = join(dirname(dirname(p.npm.exe)), 'install.cjs');
+    return base + `Worca would run the package's native binary instead, but ${p.npm.exe} is still npm's ` +
+      `placeholder — the package's postinstall did not run (--ignore-scripts / --omit=optional). Run: node ${installer}, ` +
+      'or reinstall Claude Code without those flags.';
   }
-  if (!shims.length) return null;
-  return `"${name}" resolves to a script shim (${shims[0]}) — the npm install of Claude Code. ` +
-    'Windows only launches a .exe by name and Node cannot run a .cmd/.bat shim without a shell, ' +
-    'so Worca cannot start it. Install the native Windows build (irm https://claude.ai/install.ps1 | iex) ' +
-    'or set WORCA_CLAUDE_BIN to the full path of claude.exe.';
+  return base + `No native binary was found next to it (${join(dirname(p.shims[0]), ...NPM_CLAUDE_EXE_SEGMENTS)}). ` +
+    'Install the native Windows build (irm https://claude.ai/install.ps1 | iex), or set WORCA_CLAUDE_BIN to the full path of claude.exe.';
 }
 
 export async function probeClaudeCapabilities(bin = 'claude') {
-  const exe = bin && String(bin).trim() ? String(bin).trim() : 'claude';
+  const name = bin && String(bin).trim() ? String(bin).trim() : 'claude';
+  const exe = resolveClaudeBin(name).bin; // same resolution as the runner's spawn (npm shim → native .exe)
   const help = await execSafe(exe, ['--help'], { timeout: 8000 });
   const raw = await execSafe(exe, ['--version'], { timeout: 8000 });
   const version = raw ? (/(\d+\.\d+\.\d+)/.exec(raw)?.[1] ?? raw.split(/\s+/)[0] ?? null) : null;

--- a/test/preflight-npm-claude-resolve.test.mjs
+++ b/test/preflight-npm-claude-resolve.test.mjs
@@ -1,0 +1,147 @@
+// test/preflight-npm-claude-resolve.test.mjs — npm-installed Claude Code on
+// native Windows: the `claude.cmd` shim on PATH is unspawnable by Node, but the
+// package's native claude.exe sits at npm's fixed layout next to it. Worca
+// resolves and spawns that .exe directly; the remaining unsupported cases get
+// an actionable explanation.
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  resolveClaudeBin, explainUnspawnableClaude, isNativeExe, NPM_CLAUDE_EXE_SEGMENTS, _testing,
+} from '../src/core/preflight.mjs';
+import { runClaude } from '../src/core/claude-runner.mjs';
+
+const NPM = 'C:\\Users\\u\\AppData\\Roaming\\npm';
+const SHIM = join(NPM, 'claude.cmd');
+const EXE = join(NPM, ...NPM_CLAUDE_EXE_SEGMENTS);
+const WIN = { platform: 'win32', pathEnv: `C:\\Windows;${NPM}` };
+const has = (...paths) => (p) => paths.includes(p);
+const nativeIf = (...paths) => (p) => paths.includes(p);
+
+test('NPM_CLAUDE_EXE_SEGMENTS is npm\'s global layout for the package', () => {
+  assert.equal(EXE, join(NPM, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe'));
+});
+
+test('off Windows: bin is returned unchanged, no note', () => {
+  assert.deepEqual(resolveClaudeBin('claude', { platform: 'darwin', exists: () => true, isNativeExe: () => true }),
+    { bin: 'claude', source: 'as-is', note: null });
+});
+
+test('win32 + a real .exe on PATH: unchanged (spawn\'s own lookup is right), even with a shim elsewhere', () => {
+  const exe = join('C:\\Users\\u\\.local\\bin', 'claude.exe');
+  const r = resolveClaudeBin('claude', { platform: 'win32', pathEnv: `C:\\Users\\u\\.local\\bin;${NPM}`, exists: has(exe, SHIM, EXE), isNativeExe: () => true });
+  assert.deepEqual(r, { bin: 'claude', source: 'exe', note: null });
+});
+
+test('win32 + only the npm shim, native binary next to it: resolves to that .exe with a note', () => {
+  const r = resolveClaudeBin('claude', { ...WIN, exists: has(SHIM, EXE), isNativeExe: nativeIf(EXE) });
+  assert.equal(r.bin, EXE);
+  assert.equal(r.source, 'npm');
+  assert.match(r.note, /npm-installed Claude Code binary/);
+  assert.ok(r.note.includes(EXE) && r.note.includes('"claude"'));
+  // …and there is nothing to explain: the spawn will succeed.
+  assert.equal(explainUnspawnableClaude('claude', { ...WIN, exists: has(SHIM, EXE), isNativeExe: nativeIf(EXE) }), null);
+});
+
+test('WORCA_CLAUDE_BIN pointing at the .cmd explicitly resolves relative to the shim\'s own dir', () => {
+  const r = resolveClaudeBin(SHIM, { ...WIN, pathEnv: '', exists: has(SHIM, EXE), isNativeExe: nativeIf(EXE) });
+  assert.equal(r.bin, EXE);
+});
+
+test('shim + placeholder binary (postinstall never ran): unchanged, and the explanation names install.cjs', () => {
+  const r = resolveClaudeBin('claude', { ...WIN, exists: has(SHIM, EXE), isNativeExe: () => false });
+  assert.deepEqual(r, { bin: 'claude', source: 'as-is', note: null });
+  const msg = explainUnspawnableClaude('claude', { ...WIN, exists: has(SHIM, EXE), isNativeExe: () => false });
+  assert.match(msg, /placeholder/);
+  assert.match(msg, /postinstall did not run/);
+  assert.ok(msg.includes(join(NPM, 'node_modules', '@anthropic-ai', 'claude-code', 'install.cjs')), msg);
+});
+
+test('shim with no native binary next to it (non-npm layout): unchanged, and the explanation says what was looked for', () => {
+  const r = resolveClaudeBin('claude', { ...WIN, exists: has(SHIM), isNativeExe: () => true });
+  assert.equal(r.source, 'as-is');
+  const msg = explainUnspawnableClaude('claude', { ...WIN, exists: has(SHIM), isNativeExe: () => true });
+  assert.ok(msg.includes(EXE), 'names the path it looked for');
+  assert.match(msg, /install\.ps1/);
+  assert.match(msg, /WORCA_CLAUDE_BIN/);
+});
+
+test('nothing on PATH at all: unchanged and no explanation (a plain ENOENT)', () => {
+  assert.equal(resolveClaudeBin('claude', { ...WIN, exists: () => false }).source, 'as-is');
+  assert.equal(explainUnspawnableClaude('claude', { ...WIN, exists: () => false }), null);
+});
+
+test('isNativeExe: MZ header and real size; the 500-byte text placeholder and a missing file are not', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'worca-cc-pe-'));
+  try {
+    const real = join(dir, 'real.exe');
+    writeFileSync(real, Buffer.concat([Buffer.from('MZ'), Buffer.alloc(8192)]));
+    const stub = join(dir, 'stub.exe');
+    writeFileSync(stub, 'echo "Error: claude native binary not installed." >&2\nexit 1\n');
+    const bigText = join(dir, 'big.exe');
+    writeFileSync(bigText, '#!/bin/sh\n' + 'x'.repeat(9000));
+    assert.equal(isNativeExe(real), true);
+    assert.equal(isNativeExe(stub), false);
+    assert.equal(isNativeExe(bigText), false);
+    assert.equal(isNativeExe(join(dir, 'missing.exe')), false);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ── end to end: the runner spawns the resolved binary ────────────────────────
+let prevMock, prevOrch, prevPath, platformDesc, dir;
+beforeEach(() => {
+  prevMock = process.env.WORCA_MOCK; prevOrch = process.env.ORCH_MOCK; prevPath = process.env.PATH;
+  delete process.env.WORCA_MOCK; delete process.env.ORCH_MOCK;
+  platformDesc = Object.getOwnPropertyDescriptor(process, 'platform');
+  dir = mkdtempSync(join(tmpdir(), 'worca-cc-npmshim-'));
+});
+afterEach(() => {
+  if (prevMock !== undefined) process.env.WORCA_MOCK = prevMock;
+  if (prevOrch !== undefined) process.env.ORCH_MOCK = prevOrch;
+  process.env.PATH = prevPath;
+  Object.defineProperty(process, 'platform', platformDesc);
+  _testing.reset();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** npm's global layout in a temp dir: <dir>/<bin>.cmd + the package's bin/claude.exe
+ *  (a shell script here — POSIX ignores the extension; the PE check is swapped out). */
+function layoutNpmInstall(bin) {
+  writeFileSync(join(dir, `${bin}.cmd`), '@echo off\r\n');
+  const exe = join(dir, ...NPM_CLAUDE_EXE_SEGMENTS);
+  mkdirSync(join(exe, '..'), { recursive: true });
+  writeFileSync(exe,
+    '#!/bin/sh\n' +
+    `printf '%s\\0' "$@" > ${JSON.stringify(join(dir, 'argv.txt'))}\n` +
+    `printf '%s\\n' '{"type":"result","result":"ok"}'\nexit 0\n`);
+  chmodSync(exe, 0o755);
+  return exe;
+}
+
+test('runClaude on a faked win32 host spawns the npm package\'s claude.exe instead of failing on the .cmd shim', async () => {
+  const bin = 'worca-fake-claude-npm';
+  const exe = layoutNpmInstall(bin);
+  process.env.PATH = dir;
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  _testing.set({ isNativeExe: (p) => p === exe });
+  const events = [];
+  const out = await runClaude({ bin, prompt: 'hi', cwd: dir, onEvent: (e) => events.push(e) });
+  assert.equal(out.exitCode, 0);
+  assert.ok(existsSync(join(dir, 'argv.txt')), 'the resolved binary ran');
+  const argv = readFileSync(join(dir, 'argv.txt'), 'utf8').split('\0').filter(Boolean);
+  assert.deepEqual(argv.slice(0, 2), ['-p', 'hi']);
+});
+
+test('runClaude on a faked win32 host with the placeholder binary: ENOENT carries the postinstall explanation', async () => {
+  const bin = 'worca-fake-claude-stub';
+  layoutNpmInstall(bin);
+  process.env.PATH = dir;
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+  _testing.set({ isNativeExe: () => false });        // "still the placeholder"
+  await assert.rejects(
+    runClaude({ bin, prompt: 'hi', cwd: dir, onEvent: () => {} }),
+    (err) => /ENOENT/.test(err.message) && /postinstall did not run/.test(err.message) && /install\.cjs/.test(err.message),
+  );
+});


### PR DESCRIPTION
Stacked on #384 (`fix/windows-argv-limit`) → #383 → #382 → `dev`; retarget after each merge. Turns #383's "here is why the npm install can't work" into "it works", keeping that message only for the genuinely unsupported cases.

## What changed in the npm package

`@anthropic-ai/claude-code` ≥ 2.1 (every version Worca supports — it needs ≥ 2.1.220 for `--mcp-config`) no longer ships `cli.js`. Its `bin` is `bin/claude.exe`: a **native binary** pulled from a platform `optionalDependency` and copied by `postinstall` over a ~500-byte text placeholder. The package's own comment says the `.exe` name is chosen so npm's `cmd-shim` "emits a direct exec on Windows" — the `claude.cmd` on `PATH` is just `"%dp0%\node_modules\@anthropic-ai\claude-code\bin\claude.exe" %*`.

So on native Windows an npm install gives Node an unspawnable `.cmd` on `PATH` **and a real `claude.exe` at npm's fixed layout next to it**. No shell, no shim parsing, no running `cli.js` under our own node is needed — just find that `.exe`.

## What

`preflight.mjs`
- `resolveClaudeBin(bin)` — off Windows, or when a real `.exe` is reachable on `PATH`, returns `bin` unchanged (spawn's own lookup is right). When the only hit is a `.cmd`/`.bat`/`.ps1` shim and `<shim dir>\node_modules\@anthropic-ai\claude-code\bin\claude.exe` is a **real PE binary** (`MZ` header, larger than the placeholder — `isNativeExe`), returns that path with a one-line note. Otherwise unchanged, and the spawn's `ENOENT` gets the explanation. Pure with injected `platform`/`pathEnv`/`exists`/`isNativeExe`; the default resolution is memoised per `bin`+`PATH`.
- `explainUnspawnableClaude` now shares the same probe and adds the case the resolver can't fix: shim present but the binary is **still the placeholder** (`postinstall` didn't run) → names the exact `node …\install.cjs` to run. The "no native binary next to it" case now says which path it looked for.
- `probeClaudeCapabilities` resolves the same way, so preflight and runs agree.
- `_testing.set({ isNativeExe })` seam (mirrors `folder-dialog.mjs`) so an end-to-end test on a POSIX host can stand a shell script in for `claude.exe`.

`claude-runner.mjs` — resolves before the argv plan (so #384's measure counts the path actually spawned) and spawns `resolved.bin`; the note is logged once per process.

README — Windows requirement updated: both installs work.

## Risks (small, and all fail *towards the message, never towards a wrong binary*)
- Layout assumption is npm's standard global layout; pnpm/Yarn/Volta miss → existing explanation.
- If Anthropic moves the binary again, the `MZ` check + path miss degrade to the explanation.
- Nothing changes off Windows or for the native installer: `resolveClaudeBin` returns `bin` unchanged there, so every existing spawn test is byte-identical.

## Tests
`test/preflight-npm-claude-resolve.test.mjs` — resolver matrix (POSIX, `.exe` on PATH beats a shim, shim + native → resolved with note and *no* explanation, explicit `WORCA_CLAUDE_BIN=…\claude.cmd`, shim + placeholder → unchanged + `install.cjs` message, shim without binary → unchanged + "looked for …" message, nothing → plain), `isNativeExe` against a real MZ file / the text placeholder / a big text file / a missing file, and **end to end**: `runClaude` on a faked `win32` host with npm's layout in a temp `PATH` spawns the package's `claude.exe` (argv recorded), and with the placeholder fails with the postinstall explanation. #383's tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
