### PR TITLE
feat: skin the last of the browser's own controls — checkbox, radio, switch, rows and the system dialogs

### DIFF
--- a/docs/ui-primitives/mockup.html
+++ b/docs/ui-primitives/mockup.html
@@ -1,0 +1,1041 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Worca CC — native control skins (design mockup)</title>
+
+<!-- ==========================================================================
+     DESIGN MOCKUP — docs/ui-primitives/mockup.html
+     Proposal for skinning every remaining browser-default control in the
+     Worca CC UI. Open straight from disk (file://) — no server needed.
+
+     Three kinds of CSS live in this file:
+       #tokens  — copied verbatim from ui/public/style.css (do not edit here)
+       #patch   — THE PROPOSAL. This block is the diff for style.css.
+       #mockup  — page chrome for this document only. Never ships.
+     ========================================================================== -->
+
+<style id="tokens">
+/* ---- verbatim from ui/public/style.css :1-49 ---------------------------- */
+@font-face{font-family:'Poppins';font-style:normal;font-weight:400;font-display:swap;src:url('../../ui/public/fonts/poppins-latin-400-normal.woff2') format('woff2');}
+@font-face{font-family:'Poppins';font-style:normal;font-weight:500;font-display:swap;src:url('../../ui/public/fonts/poppins-latin-500-normal.woff2') format('woff2');}
+@font-face{font-family:'Poppins';font-style:normal;font-weight:600;font-display:swap;src:url('../../ui/public/fonts/poppins-latin-600-normal.woff2') format('woff2');}
+@font-face{font-family:'Poppins';font-style:normal;font-weight:700;font-display:swap;src:url('../../ui/public/fonts/poppins-latin-700-normal.woff2') format('woff2');}
+@font-face{font-family:'JetBrains Mono';font-style:normal;font-weight:400;font-display:swap;src:url('../../ui/public/fonts/jetbrains-mono-latin-400-normal.woff2') format('woff2');}
+:root{
+  --bg:#F1F1EF; --panel:#FFFFFF;
+  --ink:#19191B; --ink-2:#5C5C63; --ink-3:#9A9AA1;
+  --line:#ECECEA; --line-2:#E3E3E0; --field:#F6F6F4;
+  --green-bg:#E2F3DF; --green:#5BAE5B; --green-ink:#2F7A38;
+  --peach-bg:#FCEEDA; --peach:#EFA63C; --peach-ink:#B5751A;
+  --red-bg:#FBE3E0;  --red:#E76A5A;  --red-ink:#C5483A;
+  --blue-bg:#DEEFF7; --blue:#5BA6CC; --blue-ink:#3782A8;
+  --violet-bg:#EAE6F8; --violet:#8C7FD6; --violet-ink:#6353B8;
+  --amber-bg:#FCE8C8; --amber:#E6962A; --amber-ink:#A66510;
+  --seq:#B7B7BC; --amber-wash:#FEF7EC;
+  --amber-wash-2:#FEFAF3; --amber-line:#F5D9A8; --radio-ring:#D6D6D2;
+  --r-card:24px; --r-ctrl:14px;
+  --shadow:0 6px 28px rgba(25,25,27,.05), 0 1px 2px rgba(25,25,27,.04);
+  --shadow-soft:0 2px 12px rgba(25,25,27,.04);
+  --sans:'Poppins',system-ui,-apple-system,BlinkMacSystemFont,sans-serif;
+  --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+}
+*{box-sizing:border-box;}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:14px;line-height:1.5;
+  -webkit-font-smoothing:antialiased;}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:var(--r-card);
+  box-shadow:var(--shadow);padding:24px;}
+.card h2{font-size:17px;font-weight:700;letter-spacing:-.015em;margin:0 0 18px;}
+.hint{display:block;color:var(--ink-3);font-size:12px;margin-top:7px;line-height:1.45;}
+.field{margin-bottom:18px;}
+.field > label,.field .label{display:block;font-weight:600;font-size:13px;margin-bottom:8px;}
+.label-row{display:flex;align-items:center;gap:7px;margin-bottom:8px;}
+.label-row > label{display:inline-block;font-weight:600;font-size:13px;margin-bottom:0;}
+.input,.select,.textarea,input[type="text"],input[type="number"],textarea,select{
+  width:100%;font-family:inherit;font-size:14px;color:var(--ink);background:var(--field);
+  border:1.5px solid transparent;border-radius:var(--r-ctrl);padding:13px 15px;
+  transition:border-color .15s,background .15s;}
+.input::placeholder,input[type="text"]::placeholder,input[type="number"]::placeholder{color:var(--ink-3);}
+.input:focus,.select:focus,input[type="text"]:focus,input[type="number"]:focus,select:focus{
+  outline:none;background:#fff;border-color:var(--ink);}
+.select-wrap{position:relative;}
+.select,select{appearance:none;-webkit-appearance:none;padding-right:40px;cursor:pointer;}
+.select-wrap::after{content:"";position:absolute;right:15px;top:50%;width:9px;height:9px;
+  border-right:2px solid var(--ink-2);border-bottom:2px solid var(--ink-2);
+  transform:translateY(-65%) rotate(45deg);pointer-events:none;}
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;background:#fff;
+  border:1.5px solid var(--line-2);color:var(--ink);font-family:inherit;font-weight:600;font-size:13.5px;
+  padding:13px 20px;border-radius:999px;cursor:pointer;
+  transition:background .15s,filter .15s,transform .15s,border-color .15s;}
+.btn:hover:not(:disabled){background:var(--field);}
+.btn:disabled{opacity:.45;cursor:not-allowed;}
+.btn:focus-visible{outline:2px solid var(--ink);outline-offset:2px;}
+.btn-primary{background:var(--ink);border-color:var(--ink);color:#fff;}
+.btn-primary:hover:not(:disabled){background:var(--ink);transform:translateY(-1px);filter:brightness(1.08);}
+.btn-mini{padding:8px 14px;font-size:12.5px;}
+.btn-ghost{background:#fff;border:1.5px solid var(--line-2);color:var(--ink);font-family:inherit;
+  font-weight:600;font-size:13.5px;padding:13px 20px;border-radius:999px;cursor:pointer;transition:.15s;}
+.badge{display:inline-flex;align-items:center;font-size:10.5px;font-weight:700;letter-spacing:.06em;
+  text-transform:uppercase;padding:5px 10px;border-radius:8px;flex:0 0 auto;white-space:nowrap;
+  background:var(--field);color:var(--ink-3);}
+.badge.green{background:var(--green-bg);color:var(--green-ink);}
+.badge.waiting{background:var(--amber-bg);color:var(--amber-ink);}
+.badge.red{background:var(--red-bg);color:var(--red-ink);}
+.badge.violet{background:var(--violet-bg);color:var(--violet-ink);}
+.switch-row{display:flex;align-items:center;gap:12px;}
+.switch{width:44px;height:26px;border-radius:999px;background:var(--line-2);position:relative;
+  cursor:pointer;flex:0 0 auto;transition:background .18s;}
+.switch::after{content:"";position:absolute;top:3px;left:3px;width:20px;height:20px;border-radius:50%;
+  background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.18);transition:left .18s;}
+.switch.on{background:var(--green);}
+.switch.on::after{left:21px;}
+.switch-row .txt{font-weight:500;}
+.viewer-modal{position:fixed;inset:0;z-index:50;display:grid;place-items:center;padding:24px;
+  background:rgba(25,25,27,.42);}
+.viewer-modal.hidden{display:none;}
+.viewer-modal .card{width:min(860px,100%);max-height:86vh;overflow:auto;}
+.confirm-modal .card{width:min(440px,100%);}
+.confirm-message{margin:4px 0 18px;color:var(--ink-2);font-size:14px;line-height:1.5;white-space:pre-line;}
+.confirm-actions{display:flex;gap:9px;justify-content:flex-end;margin-top:14px;}
+.card-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:18px;}
+.card-head h2{font-size:17px;font-weight:700;letter-spacing:-.015em;margin:0;}
+#confirm-ok.danger{background:var(--red-ink);border-color:var(--red-ink);color:#fff;}
+.chip-select{display:flex;flex-wrap:wrap;gap:8px;}
+.chip-select label{display:inline-flex;gap:6px;align-items:center;font-size:12.5px;border:1px solid var(--line);
+  border-radius:999px;padding:4px 10px;cursor:pointer;}
+.fanout-toggle{display:inline-flex;align-items:center;gap:7px;font-size:12px;color:var(--ink-2);
+  cursor:pointer;user-select:none;font-weight:500;}
+.fanout-toggle input{margin:0;cursor:pointer;}
+.pl-enable{margin-left:auto;display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--ink-3);cursor:pointer;}
+.mv-efforts{display:flex;gap:14px;flex-wrap:wrap;}
+.mv-effort{display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;}
+.chat-event-row{display:flex;gap:8px;align-items:center;margin:4px 0;cursor:pointer;}
+.chat-channel-row{display:flex;gap:10px;align-items:center;margin:6px 0;}
+.chat-channel-toggle{display:flex;gap:8px;align-items:center;cursor:pointer;}
+.grv-source-row{display:flex;align-items:center;gap:10px;padding:10px 12px;border:1px solid var(--line);
+  border-radius:10px;cursor:pointer;}
+.wiz-proj{display:flex;align-items:center;gap:10px;padding:9px 11px;border-radius:10px;cursor:pointer;
+  font-size:13.5px;color:var(--ink);}
+.mono{font-family:var(--mono);}
+</style>
+
+<style id="patch">
+/* ==========================================================================
+   THE PROPOSAL — this block is the patch for ui/public/style.css.
+   Everything here is additive; no existing rule is removed.
+   ========================================================================== */
+
+/* --- 0. Global safety net -------------------------------------------------
+   Anything we do NOT hand-skin (a future <progress>, a date input, the OS
+   spell-check UI) picks up the brand green instead of the OS accent. */
+:root{ accent-color:var(--green); }
+
+/* --- 1. Checkbox + radio --------------------------------------------------
+   The mark is the one the app already draws for .qopt (style.css:761): a
+   1.5px --radio-ring hairline on --panel that fills --green and shows a white
+   glyph when selected. Styling the REAL input (appearance:none) means every
+   one of the ~15 existing sites is fixed with no markup change: :checked,
+   :disabled, :indeterminate, label-click and keyboard all keep working. */
+input[type="checkbox"],
+input[type="radio"]{
+  appearance:none;-webkit-appearance:none;
+  flex:0 0 auto;width:18px;height:18px;margin:0;padding:0;
+  border:1.5px solid var(--radio-ring);border-radius:6px;
+  background:var(--panel);cursor:pointer;vertical-align:middle;
+  transition:background-color .14s,border-color .14s,box-shadow .14s;
+}
+input[type="radio"]{border-radius:50%;}
+input[type="checkbox"]:hover:not(:disabled),
+input[type="radio"]:hover:not(:disabled){border-color:var(--ink-3);}
+
+/* checked — the identical white tick used by .qopt.sel */
+input[type="checkbox"]:checked{
+  border-color:var(--green);
+  background:var(--green) center/11px 11px no-repeat url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3.6' stroke-linecap='round' stroke-linejoin='round'><path d='M5 13l4 4L19 7'/></svg>");
+}
+/* mixed — "some of these are on" (model export picker, agent tool chips) */
+input[type="checkbox"]:indeterminate{
+  border-color:var(--green);
+  background:var(--green) center/11px 11px no-repeat url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3.6' stroke-linecap='round'><path d='M6 12h12'/></svg>");
+}
+/* radio — green ring, white gap, green dot, all from one box-shadow */
+input[type="radio"]:checked{
+  border-color:var(--green);background:var(--green);
+  box-shadow:inset 0 0 0 3.5px var(--panel);
+}
+
+/* disabled reads as "fixed", not as "broken": grey, never red, still legible */
+input[type="checkbox"]:disabled,
+input[type="radio"]:disabled{background:var(--field);border-color:var(--line-2);cursor:not-allowed;}
+/* re-state the glyph: the :disabled rule above uses the `background` shorthand,
+   which drops the tick that :checked painted. */
+input[type="checkbox"]:disabled:checked{
+  border-color:var(--seq);
+  background:var(--seq) center/11px 11px no-repeat url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3.6' stroke-linecap='round' stroke-linejoin='round'><path d='M5 13l4 4L19 7'/></svg>");
+}
+input[type="radio"]:disabled:checked{background:var(--seq);border-color:var(--seq);
+  box-shadow:inset 0 0 0 3.5px var(--panel);}
+
+/* same focus ring as every other control in the app */
+input[type="checkbox"]:focus-visible,
+input[type="radio"]:focus-visible{outline:2px solid var(--ink);outline-offset:2px;}
+
+@media (prefers-contrast:more),(forced-colors:active){
+  input[type="checkbox"],input[type="radio"]{border-color:CanvasText;}
+  input[type="checkbox"]:checked,input[type="radio"]:checked{background-color:Highlight;border-color:Highlight;}
+}
+
+/* --- 2. Switch, driven by a real checkbox ---------------------------------
+   The existing .switch is a <div role="switch"> mirrored to a hidden input by
+   hand (app.js:5007). One sibling selector lets the SAME pixels be driven by a
+   real <input type=checkbox>, so a switch needs no JS at all. Both spellings
+   are supported; nothing that exists today changes. */
+.sw-input{position:absolute;width:1px;height:1px;opacity:0;margin:0;pointer-events:none;}
+.switch.on,
+.sw-input:checked + .switch{background:var(--green);}
+.switch.on::after,
+.sw-input:checked + .switch::after{left:21px;}
+.sw-input:focus-visible + .switch{outline:2px solid var(--ink);outline-offset:2px;}
+.sw-input:disabled + .switch{opacity:.5;cursor:not-allowed;}
+/* compact variant for card headers and dense rows */
+.switch.switch-sm{width:34px;height:20px;}
+.switch.switch-sm::after{width:15px;height:15px;top:2.5px;left:2.5px;}
+.sw-input:checked + .switch.switch-sm::after{left:16.5px;}
+
+/* --- 3. Selectable rows ---------------------------------------------------
+   .qopt generalised: when a choice needs a whole row (a name, a badge, a
+   path), the row itself is the hit target and turns --green-bg when picked. */
+.opt-row{display:flex;align-items:center;gap:11px;width:100%;
+  padding:12px 15px;background:var(--panel);border:1.5px solid var(--line);
+  border-radius:13px;cursor:pointer;font-size:13.5px;font-weight:500;
+  color:var(--ink);transition:background .14s,border-color .14s;}
+.opt-row:hover{border-color:var(--ink-3);}
+.opt-row:has(input:checked){background:var(--green-bg);border-color:var(--green);}
+.opt-row:has(input:disabled){opacity:.55;cursor:not-allowed;background:var(--field);}
+.opt-row:has(input:focus-visible){outline:2px solid var(--ink);outline-offset:2px;}
+.opt-row .opt-name{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.opt-row .opt-sub{font:400 11.5px var(--mono);color:var(--ink-3);}
+.opt-list{display:flex;flex-direction:column;gap:8px;}
+
+/* --- 3b. Checkbox rows inside a .field -----------------------------------
+   `.check-row` has NO rule in style.css today, so `.field > label` (style.css:304)
+   claims it: display:block, 600 weight, 13px, 8px bottom margin. That is why
+   "No cap" (index.html:1240) renders as a bold heading welded to its box. Same
+   specificity as `.field > label`, so the qualified selector is what wins. */
+.check-row{display:inline-flex;align-items:center;gap:9px;cursor:pointer;user-select:none;
+  font-weight:500;font-size:12.5px;color:var(--ink-2);}
+.field > label.check-row,
+.field > label.fanout-toggle{display:inline-flex;margin-bottom:0;font-weight:500;}
+.check-row + .check-row{margin-left:16px;}
+
+/* --- 4. Chips ------------------------------------------------------------
+   .chip-select already draws the pill (style.css:1400). It only ever lacked a
+   selected state, so the box inside was doing the work alone. */
+.chip-select label{transition:background .14s,border-color .14s;}
+.chip-select label:hover{border-color:var(--ink-3);}
+.chip-select label:has(input:checked){background:var(--green-bg);border-color:var(--green);}
+.chip-select label:has(input:disabled){opacity:.55;cursor:not-allowed;}
+.chip-select input{width:14px;height:14px;border-radius:5px;}
+
+/* --- 5. Dialog fields (for promptModal) ----------------------------------
+   window.prompt replaced in the shell the confirm modal already owns. */
+.confirm-field{margin-bottom:14px;}
+.confirm-field > label{display:block;font-weight:600;font-size:12.5px;margin-bottom:6px;}
+.confirm-field .input{font-size:13.5px;padding:11px 14px;}
+.confirm-field .hint.err{color:var(--red-ink);}
+.confirm-checkbox{display:flex;align-items:flex-start;gap:10px;margin:0 0 4px;padding:12px 14px;
+  background:var(--field);border-radius:12px;font-size:12.5px;color:var(--ink-2);cursor:pointer;line-height:1.45;}
+.confirm-checkbox.hidden{display:none;}
+.confirm-modal .card h2.danger{color:var(--red-ink);}
+
+/* --- 6. Remaining UA chrome ---------------------------------------------- */
+/* number steppers: the app has min/max/step for validation, not for clicking */
+input[type="number"]{-moz-appearance:textfield;}
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button{-webkit-appearance:none;margin:0;}
+/* the WebKit search "x" is grey-on-grey and off-grid; .field-clear replaces it */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration{-webkit-appearance:none;}
+.field-clear{position:absolute;right:10px;top:50%;transform:translateY(-50%);width:18px;height:18px;
+  border:none;border-radius:50%;background:var(--line-2);color:var(--ink-2);font:600 11px/1 var(--sans);
+  cursor:pointer;display:grid;place-items:center;padding:0;}
+.field-clear:hover{background:var(--ink-3);color:#fff;}
+.field-clear[hidden]{display:none;}
+/* the OS disclosure triangle, everywhere — .advanced already did this locally */
+.disclosure > summary{list-style:none;cursor:pointer;display:flex;align-items:center;gap:8px;}
+.disclosure > summary::-webkit-details-marker{display:none;}
+.disclosure > summary::before{content:"";width:0;height:0;flex:0 0 auto;
+  border:4.5px solid transparent;border-left-color:var(--ink-3);
+  transition:transform .16s;transform-origin:2px 50%;}
+.disclosure[open] > summary::before{transform:rotate(90deg);}
+/* Firefox has no ::-webkit-scrollbar; style.css:899 leaves it on the OS default */
+html{scrollbar-color:var(--line-2) transparent;scrollbar-width:thin;}
+
+/* --- 7. Tooltip ----------------------------------------------------------
+   data-tip reuses the .info-bubble the app already creates once (style.css:346),
+   so a hint looks the same whether it hangs off a label or an icon button. */
+[data-tip]{position:relative;}
+</style>
+
+<style id="mockup">
+/* ---- this document only; never ships ------------------------------------ */
+body{padding:0 0 80px;}
+.wrap{max-width:1180px;margin:0 auto;padding:0 28px;}
+.masthead{padding:56px 0 30px;}
+.masthead .eyebrow{font:600 11px/1 var(--sans);letter-spacing:.14em;text-transform:uppercase;color:var(--ink-3);}
+.masthead h1{font-size:36px;font-weight:700;letter-spacing:-.03em;margin:14px 0 12px;}
+.masthead p{max-width:70ch;color:var(--ink-2);font-size:15px;margin:0 0 8px;}
+.masthead .principle{max-width:70ch;margin-top:22px;padding:16px 20px;background:var(--panel);
+  border:1px solid var(--line);border-left:3px solid var(--green);border-radius:0 14px 14px 0;
+  font-size:14px;color:var(--ink);}
+.toc{position:sticky;top:0;z-index:20;background:rgba(241,241,239,.88);backdrop-filter:blur(10px);
+  border-bottom:1px solid var(--line-2);margin-bottom:34px;}
+.toc ol{display:flex;flex-wrap:wrap;gap:2px;list-style:none;margin:0 auto;padding:9px 28px;max-width:1180px;
+  font-size:12px;counter-reset:s;}
+.toc a{display:block;padding:6px 11px;border-radius:999px;color:var(--ink-2);text-decoration:none;font-weight:500;}
+.toc a:hover{background:var(--panel);color:var(--ink);}
+section{margin-bottom:34px;scroll-margin-top:60px;}
+section > h2{font-size:13px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-3);
+  margin:0 0 14px;display:flex;align-items:baseline;gap:10px;}
+section > h2 .num{font-family:var(--mono);font-size:11px;color:var(--ink-3);}
+h3{font-size:15px;font-weight:600;margin:0 0 4px;letter-spacing:-.01em;}
+.lede{color:var(--ink-2);font-size:13.5px;margin:0 0 20px;max-width:82ch;}
+.lede code,.n{font-family:var(--mono);font-size:12px;background:var(--field);border-radius:5px;padding:1.5px 5px;}
+
+/* two-column before/after */
+.cmp{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--line);
+  border:1px solid var(--line);border-radius:16px;overflow:hidden;}
+.cmp > div{background:var(--panel);padding:20px 22px;}
+.cmp > div.before{background:#FBFBFA;}
+.tag{display:inline-flex;align-items:center;gap:6px;font:700 10px/1 var(--sans);letter-spacing:.08em;
+  text-transform:uppercase;padding:5px 9px;border-radius:7px;margin-bottom:16px;}
+.tag.now{background:var(--red-bg);color:var(--red-ink);}
+.tag.new{background:var(--green-bg);color:var(--green-ink);}
+
+/* state matrix */
+.states{display:flex;flex-wrap:wrap;gap:10px;}
+.state{flex:0 0 auto;width:92px;display:flex;flex-direction:column;align-items:center;gap:9px;
+  padding:15px 6px 11px;background:var(--field);border-radius:13px;text-align:center;}
+.before .state{background:#F2F2F0;}
+.state .cap{font:500 10.5px/1.3 var(--mono);color:var(--ink-3);}
+
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:20px;}
+.grid2 > .card{padding:20px 22px;}
+@media (max-width:900px){.cmp,.grid2{grid-template-columns:1fr;}}
+
+/* faux app surfaces */
+.surface{background:var(--bg);border:1px solid var(--line-2);border-radius:18px;padding:18px;}
+.surface.on-card{background:var(--panel);border-color:var(--line);}
+.agent-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;background:var(--panel);
+  border:1.5px solid var(--line-2);border-radius:14px;padding:12px 14px;box-shadow:var(--shadow-soft);}
+.agent-row .dot{width:9px;height:9px;border-radius:50%;background:var(--violet);flex:0 0 auto;}
+.agent-row .nm{font-weight:600;font-size:13px;width:88px;flex:0 0 auto;}
+.agent-row .select-wrap{width:118px;}
+.agent-row select{padding:9px 32px 9px 12px;font-size:12.5px;border-radius:11px;background:#fff;
+  border-color:var(--line-2);}
+.pl-card{background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:16px 18px;}
+.pl-head{display:flex;align-items:center;gap:9px;}
+.pl-name{font-size:14px;}
+.pl-version{font-size:11px;color:var(--ink-3);}
+
+.tbl{width:100%;border-collapse:collapse;font-size:12.5px;}
+.tbl th{text-align:left;font:700 10px/1 var(--sans);letter-spacing:.08em;text-transform:uppercase;
+  color:var(--ink-3);padding:0 12px 10px 0;border-bottom:1px solid var(--line-2);}
+.tbl td{padding:9px 12px 9px 0;border-bottom:1px solid var(--line);vertical-align:top;}
+.tbl tr:last-child td{border-bottom:none;}
+.tbl td.loc{font-family:var(--mono);font-size:11px;color:var(--ink-2);white-space:nowrap;}
+.tbl td.to{font-family:var(--mono);font-size:11px;color:var(--green-ink);white-space:nowrap;}
+
+.rule{display:flex;gap:14px;align-items:flex-start;padding:14px 16px;border-radius:13px;background:var(--field);}
+.rule .k{flex:0 0 auto;width:78px;font:700 10px/1.6 var(--sans);letter-spacing:.08em;text-transform:uppercase;color:var(--ink-3);}
+.rule .v{font-size:13px;color:var(--ink-2);}
+.rule .v b{color:var(--ink);font-weight:600;}
+.stack{display:flex;flex-direction:column;gap:10px;}
+.row{display:flex;gap:10px;align-items:center;flex-wrap:wrap;}
+
+/* DEMO ONLY: forces genuine UA rendering in the "today" column */
+.native input[type="checkbox"],.native input[type="radio"]{
+  appearance:auto;-webkit-appearance:auto;width:auto;height:auto;border:initial;background:initial;
+  border-radius:initial;box-shadow:none;accent-color:auto;}
+.native input[type="number"]{-moz-appearance:number-input;}
+.native input[type="number"]::-webkit-inner-spin-button{-webkit-appearance:inner-spin-button;}
+.native input[type="search"]::-webkit-search-cancel-button{-webkit-appearance:searchfield-cancel-button;}
+.native .check-row{display:block;font-weight:600;font-size:13px;color:var(--ink);margin-bottom:8px;}
+.native summary{list-style:revert;}
+.native summary::-webkit-details-marker{display:revert;}
+.native summary::before{display:none;}
+.native .opt-row:has(input:checked){background:var(--panel);border-color:var(--line);}
+.native .chip-select label:has(input:checked){background:transparent;border-color:var(--line);}
+</style>
+</head>
+
+<body>
+
+<div class="wrap">
+  <header class="masthead">
+    <div class="eyebrow">Worca CC · design mockup</div>
+    <h1>Skinning the last of the browser</h1>
+    <p>Thirteen checkbox sites, one radio group, eight blocking system dialogs and a handful of UA
+       widgets still render in the operating system's voice instead of Worca's. This page proposes
+       the whole set, side by side with what ships today.</p>
+    <div class="principle">
+      <b>The mark already exists.</b> <span class="n">.qopt</span> (style.css:761) draws a
+      1.5px&nbsp;<span class="n">--radio-ring</span> hairline on <span class="n">--panel</span> that fills
+      <span class="n">--green</span> behind a white tick. Every control below inherits that one mark, so
+      "chosen" looks identical whether it is a question option, a checkbox, a chip or a whole row.
+    </div>
+  </header>
+</div>
+
+<nav class="toc">
+  <ol>
+    <li><a href="#s1">1 · Checkbox</a></li>
+    <li><a href="#s2">2 · Radio</a></li>
+    <li><a href="#s3">3 · Switch</a></li>
+    <li><a href="#s4">4 · Rows &amp; chips</a></li>
+    <li><a href="#s5">5 · In situ</a></li>
+    <li><a href="#s6">6 · Select</a></li>
+    <li><a href="#s7">7 · Dialogs</a></li>
+    <li><a href="#s8">8 · UA chrome</a></li>
+    <li><a href="#s9">9 · Migration map</a></li>
+  </ol>
+</nav>
+
+<div class="wrap">
+
+<!-- ============================== 1 · CHECKBOX ============================ -->
+<section id="s1">
+  <h2><span class="num">01</span> Checkbox</h2>
+  <p class="lede">An 18px rounded square, <span class="n">--radio-ring</span> hairline on
+     <span class="n">--panel</span>, filling <span class="n">--green</span> with the same white tick
+     <span class="n">.qopt.sel</span> uses. Styled on the real <span class="n">&lt;input&gt;</span> via
+     <span class="n">appearance:none</span> — so <em>the rule reaches all thirteen existing
+     sites with no markup change</em>, and for eight of them that is the whole job. With <span class="n">:checked</span>, <span class="n">:disabled</span>,
+     <span class="n">:indeterminate</span>, label-clicks and keyboard all still free.</p>
+
+  <div class="cmp">
+    <div class="before native">
+      <span class="tag now">Today · OS control</span>
+      <div class="states">
+        <div class="state"><input type="checkbox" /><span class="cap">off</span></div>
+        <div class="state"><input type="checkbox" checked /><span class="cap">on</span></div>
+        <div class="state"><input type="checkbox" class="mixed-n" /><span class="cap">mixed</span></div>
+        <div class="state"><input type="checkbox" disabled /><span class="cap">disabled</span></div>
+        <div class="state"><input type="checkbox" checked disabled /><span class="cap">locked&nbsp;on</span></div>
+      </div>
+      <span class="hint">System accent (blue on stock macOS, whatever the user set on Windows),
+        13px, baseline-misaligned against 12px Poppins labels, and it changes shape per OS.</span>
+    </div>
+    <div>
+      <span class="tag new">Proposed</span>
+      <div class="states">
+        <div class="state"><input type="checkbox" /><span class="cap">off</span></div>
+        <div class="state"><input type="checkbox" checked /><span class="cap">on</span></div>
+        <div class="state"><input type="checkbox" class="mixed" /><span class="cap">mixed</span></div>
+        <div class="state"><input type="checkbox" disabled /><span class="cap">disabled</span></div>
+        <div class="state"><input type="checkbox" checked disabled /><span class="cap">locked&nbsp;on</span></div>
+      </div>
+      <span class="hint">Locked-on is <span class="n">--seq</span> grey, never red: the agent manifest
+        fixed it, nothing is wrong. Focus is the app's usual 2px <span class="n">--ink</span> ring —
+        tab into one to see it.</span>
+    </div>
+  </div>
+</section>
+
+<!-- =============================== 2 · RADIO ============================= -->
+<section id="s2">
+  <h2><span class="num">02</span> Radio</h2>
+  <p class="lede">Same hairline, circular, and the dot is a single
+     <span class="n">inset box-shadow</span> — no pseudo-element, so it works on a replaced element in
+     every engine. One visible group uses it today: guardrails wizard step 1
+     (<span class="n">guardrails-view.mjs:76</span>).</p>
+
+  <div class="cmp">
+    <div class="before native">
+      <span class="tag now">Today · OS control</span>
+      <div class="states">
+        <div class="state"><input type="radio" name="n1" /><span class="cap">off</span></div>
+        <div class="state"><input type="radio" name="n1" checked /><span class="cap">on</span></div>
+        <div class="state"><input type="radio" disabled /><span class="cap">disabled</span></div>
+        <div class="state"><input type="radio" checked disabled /><span class="cap">locked&nbsp;on</span></div>
+      </div>
+    </div>
+    <div>
+      <span class="tag new">Proposed</span>
+      <div class="states">
+        <div class="state"><input type="radio" name="p1" /><span class="cap">off</span></div>
+        <div class="state"><input type="radio" name="p1" checked /><span class="cap">on</span></div>
+        <div class="state"><input type="radio" disabled /><span class="cap">disabled</span></div>
+        <div class="state"><input type="radio" checked disabled /><span class="cap">locked&nbsp;on</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================== 3 · SWITCH ============================= -->
+<section id="s3">
+  <h2><span class="num">03</span> Switch</h2>
+  <p class="lede">Worca already has a switch (<span class="n">.switch</span>, style.css:470) — but it is a
+     <span class="n">&lt;div role="switch"&gt;</span> hand-mirrored to a hidden input in JS
+     (app.js:5007). Adding one sibling selector lets the <em>same pixels</em> be driven by a real
+     checkbox, so a new switch costs zero JavaScript and stays accessible for free.</p>
+
+  <div class="grid2">
+    <div class="card">
+      <h3>The control</h3>
+      <span class="hint" style="margin-bottom:16px">Existing size, plus a
+        <span class="n">.switch-sm</span> for dense rows like a plugin card header.</span>
+      <div class="stack" style="margin-top:14px">
+        <label class="switch-row"><input type="checkbox" class="sw-input" checked /><span class="switch"></span><span class="txt">Enabled</span></label>
+        <label class="switch-row"><input type="checkbox" class="sw-input" /><span class="switch"></span><span class="txt">Disabled state</span></label>
+        <label class="switch-row"><input type="checkbox" class="sw-input" checked /><span class="switch switch-sm"></span><span class="txt" style="font-size:12.5px">Compact</span></label>
+        <label class="switch-row"><input type="checkbox" class="sw-input" checked disabled /><span class="switch"></span><span class="txt">Locked on</span></label>
+      </div>
+    </div>
+    <div class="card">
+      <h3>When it is a switch, when it is a checkbox</h3>
+      <span class="hint" style="margin-bottom:16px">The single rule that decides all thirteen sites.</span>
+      <div class="stack" style="margin-top:14px">
+        <div class="rule"><span class="k">Switch</span><span class="v"><b>Acts on a live system the moment you flip it.</b>
+          Plugin enabled, chat channel on, notify-on events, mock mode, auto-scroll.</span></div>
+        <div class="rule"><span class="k">Checkbox</span><span class="v"><b>Part of a form you then Save or Next.</b>
+          Supported efforts, models to export, projects to scan, fan-out and questions flags,
+          "No cap", the purge opt-in inside a confirm.</span></div>
+      </div>
+      <span class="hint">Under this rule four sites become switches (<span class="n">plugins-view.mjs:63</span>,
+        <span class="n">chat-settings-view.mjs:36,58</span>) and the other nine keep the box.</span>
+    </div>
+  </div>
+</section>
+
+<!-- ========================== 4 · ROWS AND CHIPS ========================= -->
+<section id="s4">
+  <h2><span class="num">04</span> Selectable rows &amp; chips</h2>
+  <p class="lede">When a choice carries more than a word — a name plus a badge, a path, a model id — the
+     box alone cannot show selection at a glance. <span class="n">.opt-row</span> lifts
+     <span class="n">.qopt</span> out of the question panel and makes the whole row the target;
+     the existing <span class="n">.chip-select</span> pill finally gets a checked state.</p>
+
+  <div class="cmp">
+    <div class="before native">
+      <span class="tag now">Today</span>
+      <h3 style="font-size:13px;margin-bottom:10px">Guardrails · starting point</h3>
+      <div class="stack">
+        <label class="grv-source-row"><input type="radio" name="gn" checked /><span>Blank (custom)</span></label>
+        <label class="grv-source-row"><input type="radio" name="gn" /><span>Strict review</span><span class="badge waiting">built-in</span></label>
+      </div>
+      <h3 style="font-size:13px;margin:20px 0 10px">Agent tools</h3>
+      <div class="chip-select">
+        <label><input type="checkbox" checked /><span>Read</span></label>
+        <label><input type="checkbox" checked /><span>Edit</span></label>
+        <label><input type="checkbox" /><span>Bash</span></label>
+        <label><input type="checkbox" /><span>WebFetch</span></label>
+      </div>
+      <span class="hint">Selection is carried by a 13px OS glyph. At a glance the two lists look
+        uniform — you have to read each box.</span>
+    </div>
+    <div>
+      <span class="tag new">Proposed</span>
+      <h3 style="font-size:13px;margin-bottom:10px">Guardrails · starting point</h3>
+      <div class="opt-list">
+        <label class="opt-row"><input type="radio" name="gp" checked /><span class="opt-name">Blank (custom)</span></label>
+        <label class="opt-row"><input type="radio" name="gp" /><span class="opt-name">Strict review</span><span class="badge waiting">built-in</span></label>
+        <label class="opt-row"><input type="radio" name="gp" /><span class="opt-name">Ship guard</span><span class="badge violet">saved</span></label>
+      </div>
+      <h3 style="font-size:13px;margin:20px 0 10px">Agent tools</h3>
+      <div class="chip-select">
+        <label><input type="checkbox" checked /><span>Read</span></label>
+        <label><input type="checkbox" checked /><span>Edit</span></label>
+        <label><input type="checkbox" /><span>Bash</span></label>
+        <label><input type="checkbox" /><span>WebFetch</span></label>
+      </div>
+      <span class="hint">The chosen row and the chosen chips read from across the screen, in the same
+        <span class="n">--green-bg</span> the question panel already uses for a picked answer.</span>
+    </div>
+  </div>
+</section>
+
+<!-- ============================== 5 · IN SITU ============================ -->
+<section id="s5">
+  <h2><span class="num">05</span> In situ</h2>
+  <p class="lede">The six real surfaces, rebuilt. Nothing here needs new markup except the four
+     switch conversions.</p>
+
+  <div class="grid2">
+
+    <div class="card">
+      <h3>New Pipeline · Agents accordion</h3>
+      <span class="hint" style="margin-bottom:16px">app.js:3384 &amp; 3401 — the most-seen checkboxes in
+        the product. "Asks questions" is locked by the agent manifest on the second row.</span>
+      <div class="surface stack">
+        <div class="agent-row">
+          <span class="dot"></span><span class="nm">Planner</span>
+          <div class="select-wrap"><select><option>Opus 5</option></select></div>
+          <label class="fanout-toggle"><input type="checkbox" /><span>Fan-out</span></label>
+          <label class="fanout-toggle"><input type="checkbox" checked /><span>Asks questions</span></label>
+        </div>
+        <div class="agent-row">
+          <span class="dot" style="background:var(--green)"></span><span class="nm">Implementer</span>
+          <div class="select-wrap"><select><option>Sonnet 5</option></select></div>
+          <label class="fanout-toggle"><input type="checkbox" checked /><span>Fan-out</span></label>
+          <label class="fanout-toggle" title="Always off for this agent"><input type="checkbox" disabled /><span>Asks questions</span></label>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>Plugins · enable</h3>
+      <span class="hint" style="margin-bottom:16px">plugins-view.mjs:63 — flips a live system, so it
+        becomes a compact switch. The word beside it already changes; now the control agrees.</span>
+      <div class="surface stack">
+        <div class="pl-card">
+          <div class="pl-head">
+            <b class="pl-name">telegram-chat</b><span class="pl-version mono">1.4.0</span>
+            <span class="badge waiting">linked</span>
+            <label class="pl-enable"><input type="checkbox" class="sw-input" checked /><span class="switch switch-sm"></span><span>enabled</span></label>
+          </div>
+          <span class="hint">1 chat channel · 2 agents</span>
+        </div>
+        <div class="pl-card">
+          <div class="pl-head">
+            <b class="pl-name">linear-tasks</b><span class="pl-version mono">0.9.2</span>
+            <label class="pl-enable"><input type="checkbox" class="sw-input" /><span class="switch switch-sm"></span><span>disabled</span></label>
+          </div>
+          <span class="hint">1 task source</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>Chat settings</h3>
+      <span class="hint" style="margin-bottom:16px">chat-settings-view.mjs:36 &amp; 58 — both are live
+        toggles, so both become switches.</span>
+      <div class="surface">
+        <div class="label" style="font-weight:600;font-size:12.5px;margin-bottom:10px">Notify on</div>
+        <div class="stack">
+          <label class="chat-event-row"><input type="checkbox" class="sw-input" checked /><span class="switch switch-sm"></span><span>Pipeline finished</span></label>
+          <label class="chat-event-row"><input type="checkbox" class="sw-input" checked /><span class="switch switch-sm"></span><span>Question asked</span></label>
+          <label class="chat-event-row"><input type="checkbox" class="sw-input" /><span class="switch switch-sm"></span><span>Every step</span></label>
+        </div>
+        <div class="label" style="font-weight:600;font-size:12.5px;margin:18px 0 10px">Channels</div>
+        <div class="chat-channel-row">
+          <label class="chat-channel-toggle"><input type="checkbox" class="sw-input" checked /><span class="switch switch-sm"></span><span>Team (telegram)</span></label>
+          <span class="badge green">connected</span>
+          <button type="button" class="btn btn-mini" style="margin-left:auto">Test</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>Models · supported efforts &amp; export</h3>
+      <span class="hint" style="margin-bottom:16px">models-view.mjs:222 &amp; 336 — form state, so
+        boxes stay boxes. The export list gains <span class="n">.opt-row</span> because each option
+        carries a model id.</span>
+      <div class="surface">
+        <div class="label" style="font-weight:600;font-size:12.5px;margin-bottom:10px">Supported efforts</div>
+        <div class="mv-efforts">
+          <label class="mv-effort"><input type="checkbox" checked /><span>low</span></label>
+          <label class="mv-effort"><input type="checkbox" checked /><span>medium</span></label>
+          <label class="mv-effort"><input type="checkbox" checked /><span>high</span></label>
+          <label class="mv-effort"><input type="checkbox" /><span>max</span></label>
+        </div>
+        <div class="label" style="font-weight:600;font-size:12.5px;margin:18px 0 10px">Models to include</div>
+        <div class="opt-list">
+          <label class="opt-row"><input type="checkbox" checked /><span class="opt-name">Opus 5</span><span class="opt-sub">claude-opus-5</span></label>
+          <label class="opt-row"><input type="checkbox" /><span class="opt-name">Haiku 4.5</span><span class="opt-sub">claude-haiku-4-5</span></label>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>Workspace wizard · projects</h3>
+      <span class="hint" style="margin-bottom:16px">app.js:6329 — a missing project is disabled today
+        but looks almost identical to an unchecked one. As a row, "missing" is unmistakable.</span>
+      <div class="surface">
+        <div class="opt-list">
+          <label class="opt-row"><input type="checkbox" checked /><span class="opt-name">worca-cc</span><span class="opt-sub">~/dev/worca-cc</span></label>
+          <label class="opt-row"><input type="checkbox" /><span class="opt-name">atlas-red</span><span class="opt-sub">~/dev/atlas-red</span></label>
+          <label class="opt-row"><input type="checkbox" disabled /><span class="opt-name">old-api</span><span class="badge red">missing</span></label>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>Ask limits · "No cap"</h3>
+      <span class="hint" style="margin-bottom:16px">index.html:1240 — <b>the only site with a live layout bug.</b>
+        <span class="n">.check-row</span> has no rule at all, so <span class="n">.field &gt; label</span>
+        makes it a bold 13px block and the label welds itself to the box. §3b adds the missing rule;
+        the stepper arrows go with §8.</span>
+      <div class="surface on-card native">
+        <span class="tag now" style="margin-bottom:12px">Today</span>
+        <div class="field" style="margin-bottom:0">
+          <div class="label-row"><label for="nc-a">Per-turn cost cap (USD)</label></div>
+          <input class="input" type="number" min="0.1" max="100" step="0.1" placeholder="2" />
+          <label class="check-row" for="nc-a"><input id="nc-a" type="checkbox" /> No cap</label>
+        </div>
+      </div>
+      <div class="surface on-card" style="margin-top:12px">
+        <span class="tag new" style="margin-bottom:12px">Proposed</span>
+        <div class="field" style="margin-bottom:0">
+          <div class="label-row"><label for="nc-b">Per-turn cost cap (USD)</label></div>
+          <input class="input" type="number" min="0.1" max="100" step="0.1" placeholder="2" />
+          <label class="check-row" for="nc-b"><input id="nc-b" type="checkbox" /> No cap</label>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- ============================== 6 · SELECT ============================= -->
+<section id="s6">
+  <h2><span class="num">06</span> Select</h2>
+  <p class="lede">The closed state is already ours (<span class="n">appearance:none</span> +
+     <span class="n">.select-wrap::after</span>). The open popup belongs to the OS and cannot be styled —
+     the only fix is to stop using <span class="n">&lt;select&gt;</span>. <b>Recommendation: keep it for
+     the ten plain-text lists.</b> The OS popup is faster, keyboard-complete, screen-reader-correct and
+     far better on a phone; replacing it buys paint and costs behaviour. Reach for
+     <span class="n">.listbox</span> only where an option needs more than a word.</p>
+
+  <div class="cmp">
+    <div>
+      <span class="tag new">Keep · plain lists</span>
+      <span class="hint" style="margin-bottom:14px">Project, workspace, workflow, branch, guardrails,
+        the four log filters, budget period.</span>
+      <div class="select-wrap"><select>
+        <option>worca-cc</option><option>atlas-red</option><option>opendeck</option>
+      </select></div>
+      <span class="hint">Unchanged. The popup is native and that is the right trade.</span>
+    </div>
+    <div>
+      <span class="tag new">Promote · rich options</span>
+      <span class="hint" style="margin-bottom:14px">Agent colour (needs a swatch) and the model picker
+        (needs the id under the label) — the two that today flatten real information into one line.</span>
+      <div class="opt-list">
+        <label class="opt-row" style="padding:9px 13px"><input type="radio" name="clr" checked /><span style="width:13px;height:13px;border-radius:4px;background:var(--violet);flex:0 0 auto"></span><span class="opt-name">violet</span></label>
+        <label class="opt-row" style="padding:9px 13px"><input type="radio" name="clr" /><span style="width:13px;height:13px;border-radius:4px;background:var(--green);flex:0 0 auto"></span><span class="opt-name">green</span></label>
+        <label class="opt-row" style="padding:9px 13px"><input type="radio" name="clr" /><span style="width:13px;height:13px;border-radius:4px;background:var(--peach);flex:0 0 auto"></span><span class="opt-name">peach</span></label>
+      </div>
+      <span class="hint">Same <span class="n">.opt-row</span> as §4 — no new component.</span>
+    </div>
+  </div>
+</section>
+
+<!-- ============================== 7 · DIALOGS ============================ -->
+<section id="s7">
+  <h2><span class="num">07</span> Dialogs</h2>
+  <p class="lede"><span class="n">confirmModal()</span> already exists and eleven callers use it — but
+     eight sites still call <span class="n">window.confirm</span> / <span class="n">window.prompt</span>,
+     including all four destructive deletes. A system alert can't show the app's red, wraps a long
+     warning into an OS paragraph, blocks the event loop, and on Chrome offers "prevent this page from
+     creating more dialogs" — which silently breaks the next one. Two changes finish the job:
+     migrate the eight, and add <span class="n">promptModal()</span> so the two double-prompts become
+     one dialog. <b>The buttons below are live.</b></p>
+
+  <div class="grid2">
+    <div class="card">
+      <h3>Destructive confirm</h3>
+      <span class="hint" style="margin-bottom:16px">app.js:2604, 6245, 6663, 8020 — currently
+        <span class="n">window.confirm</span>. <span class="n">danger:true</span> and the red OK button
+        already exist (style.css:1869); nobody is passing them.</span>
+      <div class="row">
+        <button class="btn btn-mini" onclick="demoDelete()">Delete pipeline</button>
+        <button class="btn btn-mini" onclick="demoPurge()">Delete project (with purge)</button>
+        <button class="btn btn-mini" onclick="demoWorktree()">Discard worktree</button>
+      </div>
+      <span class="hint">The worktree one is the clearest win: three paragraphs of consequence
+        (app.js:9932) currently rendered as an OS alert.</span>
+    </div>
+    <div class="card">
+      <h3>promptModal() — new</h3>
+      <span class="hint" style="margin-bottom:16px">Same <span class="n">.confirm-modal</span> shell,
+        plus <span class="n">.confirm-field</span>. Takes an array of fields, so
+        <span class="n">app.js:2464+2467</span> and <span class="n">app.js:8007+8009</span> —
+        two blocking prompts back to back — collapse into one dialog with live validation.</span>
+      <div class="row">
+        <button class="btn btn-mini" onclick="demoSavePipeline()">Save pipeline (2 prompts → 1)</button>
+        <button class="btn btn-mini" onclick="demoProfile()">New plugin profile</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================= 8 · UA CHROME =========================== -->
+<section id="s8">
+  <h2><span class="num">08</span> The rest of the browser</h2>
+  <p class="lede">Small, cheap, and each one is a place where the OS speaks over the app.</p>
+
+  <div class="cmp">
+    <div class="before native">
+      <span class="tag now">Today</span>
+      <div class="stack">
+        <div><span class="hint" style="margin:0 0 6px">Number stepper · 7 fields</span>
+          <input class="input" type="number" value="40" /></div>
+        <div><span class="hint" style="margin:10px 0 6px">Search clear · 2 fields</span>
+          <input class="input" type="search" value="error" /></div>
+        <div><span class="hint" style="margin:10px 0 6px">Disclosure · ask-panel.mjs:1149</span>
+          <details><summary style="font-weight:600;font-size:11px;color:var(--ink-3)">MEMBERS</summary>
+            <div class="hint">Planner, Implementer, Reviewer</div></details></div>
+        <div><span class="hint" style="margin:10px 0 6px">Tooltip · ~97 <span class="n">title=</span></span>
+          <button class="btn btn-mini" title="Copy the visible log lines">copy</button>
+          <span class="hint">Hover and wait — OS bubble, ~1s delay, no styling, invisible on touch.</span></div>
+      </div>
+    </div>
+    <div>
+      <span class="tag new">Proposed</span>
+      <div class="stack">
+        <div><span class="hint" style="margin:0 0 6px">Steppers removed; min/max/step still validate</span>
+          <input class="input" type="number" value="40" /></div>
+        <div><span class="hint" style="margin:10px 0 6px"><span class="n">.field-clear</span> on the app's grid</span>
+          <div style="position:relative"><input class="input" id="dsearch" type="search" value="error" style="padding-right:38px" />
+            <button type="button" class="field-clear" onclick="document.getElementById('dsearch').value=''">&#10005;</button></div></div>
+        <div><span class="hint" style="margin:10px 0 6px"><span class="n">.disclosure</span> — the chevron <span class="n">.advanced</span> already uses</span>
+          <details class="disclosure"><summary style="font-weight:600;font-size:11px;color:var(--ink-3)">MEMBERS</summary>
+            <div class="hint">Planner, Implementer, Reviewer</div></details></div>
+        <div><span class="hint" style="margin:10px 0 6px"><span class="n">data-tip</span> reuses <span class="n">.info-bubble</span></span>
+          <button class="btn btn-mini" data-tip="Copy the visible log lines">copy</button>
+          <span class="hint">Instant, on-brand, and one delegated listener for all ~97.</span></div>
+      </div>
+    </div>
+  </div>
+  <span class="hint" style="margin-top:14px">Also in the patch: <span class="n">accent-color:var(--green)</span>
+    on <span class="n">:root</span> so anything never hand-skinned still lands in brand, and
+    <span class="n">scrollbar-color</span> so Firefox stops falling back to the OS bar that
+    <span class="n">::-webkit-scrollbar</span> (style.css:899) never reaches.</span>
+</section>
+
+<!-- =========================== 9 · MIGRATION MAP ========================= -->
+<section id="s9">
+  <h2><span class="num">09</span> Migration map</h2>
+  <p class="lede">What each site becomes. <b>Everything in the first group is CSS-only</b> — the global
+     <span class="n">input[type=checkbox]</span> rule reaches it with no code change at all.</p>
+
+  <div class="card">
+    <h3 style="margin-bottom:14px">CSS only — no code touched <span class="badge green" style="margin-left:8px">8 sites</span></h3>
+    <table class="tbl">
+      <tr><th>Site</th><th>Control</th><th>Class</th></tr>
+      <tr><td class="loc">index.html:861,867–871</td><td>Composer agent flags (6)</td><td class="to">.fanout-toggle</td></tr>
+      <tr><td class="loc">index.html:1035,1040–1044</td><td>Agent row flags (6)</td><td class="to">.fanout-toggle</td></tr>
+      <tr><td class="loc">index.html:1240</td><td>Ask limits · No cap <span class="badge red">layout bug</span></td><td class="to">.check-row (new)</td></tr>
+      <tr><td class="loc">index.html:1306</td><td>Confirm modal opt-in</td><td class="to">.confirm-checkbox</td></tr>
+      <tr><td class="loc">app.js:3384 / 3401</td><td>Fan-out / Asks questions</td><td class="to">.fanout-toggle</td></tr>
+      <tr><td class="loc">app.js:6707</td><td>Agent tool chips</td><td class="to">.chip-select</td></tr>
+      <tr><td class="loc">models-view.mjs:222</td><td>Supported efforts</td><td class="to">.mv-effort</td></tr>
+    </table>
+  </div>
+
+  <div class="card" style="margin-top:16px">
+    <h3 style="margin-bottom:14px">Better pattern — one-line markup change <span class="badge waiting" style="margin-left:8px">7 sites</span></h3>
+    <table class="tbl">
+      <tr><th>Site</th><th>Becomes</th><th>Class</th></tr>
+      <tr><td class="loc">plugins-view.mjs:63</td><td>Plugin enable → switch</td><td class="to">.sw-input + .switch-sm</td></tr>
+      <tr><td class="loc">chat-settings-view.mjs:36</td><td>Notify-on → switch</td><td class="to">.sw-input + .switch-sm</td></tr>
+      <tr><td class="loc">chat-settings-view.mjs:58</td><td>Channel enable → switch</td><td class="to">.sw-input + .switch-sm</td></tr>
+      <tr><td class="loc">guardrails-view.mjs:76</td><td>Starting point → row</td><td class="to">.opt-row</td></tr>
+      <tr><td class="loc">app.js:6329</td><td>Wizard projects → row</td><td class="to">.opt-row</td></tr>
+      <tr><td class="loc">models-view.mjs:336</td><td>Export picker → row</td><td class="to">.opt-row</td></tr>
+      <tr><td class="loc">ask-panel.mjs:1149</td><td>Members disclosure</td><td class="to">.disclosure</td></tr>
+    </table>
+  </div>
+
+  <div class="card" style="margin-top:16px">
+    <h3 style="margin-bottom:14px">Dialogs <span class="badge red" style="margin-left:8px">8 sites + 1 new fn</span></h3>
+    <table class="tbl">
+      <tr><th>Site</th><th>Today</th><th>Becomes</th></tr>
+      <tr><td class="loc">app.js:2464 + 2467</td><td>window.prompt &times;2</td><td class="to">promptModal(2 fields)</td></tr>
+      <tr><td class="loc">app.js:2604</td><td>window.confirm</td><td class="to">confirmModal danger</td></tr>
+      <tr><td class="loc">app.js:6245</td><td>window.confirm</td><td class="to">confirmModal danger</td></tr>
+      <tr><td class="loc">app.js:6663</td><td>window.confirm</td><td class="to">confirmModal danger</td></tr>
+      <tr><td class="loc">app.js:8007 + 8009</td><td>window.prompt &times;2</td><td class="to">promptModal(2 fields)</td></tr>
+      <tr><td class="loc">app.js:8020</td><td>window.confirm</td><td class="to">confirmModal danger</td></tr>
+      <tr><td class="loc">app.js:8100</td><td>window.confirm</td><td class="to">confirmModal</td></tr>
+      <tr><td class="loc">app.js:9932</td><td>window.confirm</td><td class="to">confirmModal danger</td></tr>
+    </table>
+    <span class="hint">After this, <span class="n">window.confirm|prompt|alert</span> has zero call
+      sites — worth a test that keeps it that way.</span>
+  </div>
+</section>
+
+</div><!-- /wrap -->
+
+<!-- ===== live demo modal (mirrors index.html:1299 + the proposed field slot) ===== -->
+<div id="confirm-modal" class="viewer-modal confirm-modal hidden" role="dialog" aria-modal="true" aria-labelledby="confirm-title">
+  <div class="card">
+    <div class="card-head"><h2 id="confirm-title">Confirm</h2></div>
+    <p id="confirm-message" class="confirm-message"></p>
+    <div id="confirm-fields"></div>
+    <label id="confirm-checkbox-wrap" class="confirm-checkbox hidden">
+      <input type="checkbox" id="confirm-checkbox" />
+      <span id="confirm-checkbox-label"></span>
+    </label>
+    <div class="confirm-actions">
+      <button type="button" id="confirm-cancel" class="btn btn-ghost btn-mini">Cancel</button>
+      <button type="button" id="confirm-ok" class="btn btn-primary btn-mini">Confirm</button>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ---- indeterminate can only be set in JS ---- */
+document.querySelectorAll('.mixed,.mixed-n').forEach(function (c) { c.indeterminate = true; });
+
+/* ---- confirmModal + promptModal, close to the shape app.js would get ---- */
+var M = {
+  modal: document.getElementById('confirm-modal'),
+  title: document.getElementById('confirm-title'),
+  msg: document.getElementById('confirm-message'),
+  fields: document.getElementById('confirm-fields'),
+  cbWrap: document.getElementById('confirm-checkbox-wrap'),
+  cb: document.getElementById('confirm-checkbox'),
+  cbLabel: document.getElementById('confirm-checkbox-label'),
+  ok: document.getElementById('confirm-ok'),
+  cancel: document.getElementById('confirm-cancel')
+};
+
+function openModal(opts) {
+  return new Promise(function (resolve) {
+    var o = opts || {};
+    M.title.textContent = o.title || 'Confirm';
+    M.title.classList.toggle('danger', !!o.danger);
+    M.msg.textContent = o.message || '';
+    M.msg.style.display = o.message ? '' : 'none';
+    M.ok.textContent = o.confirmLabel || 'Confirm';
+    M.cancel.textContent = o.cancelLabel || 'Cancel';
+    M.ok.classList.toggle('danger', !!o.danger);
+
+    M.fields.innerHTML = '';
+    var inputs = [];
+    (o.fields || []).forEach(function (f) {
+      var wrap = document.createElement('div'); wrap.className = 'confirm-field';
+      var lab = document.createElement('label'); lab.textContent = f.label; wrap.appendChild(lab);
+      var inp = document.createElement('input');
+      inp.className = 'input'; inp.type = 'text';
+      inp.placeholder = f.placeholder || ''; inp.value = f.value || '';
+      if (f.mono) inp.style.fontFamily = 'var(--mono)';
+      inp.dataset.id = f.id; wrap.appendChild(inp);
+      if (f.hint) { var h = document.createElement('small'); h.className = 'hint'; h.textContent = f.hint; wrap.appendChild(h); }
+      M.fields.appendChild(wrap); inputs.push(inp);
+      if (f.required) inp.addEventListener('input', validate);
+    });
+    function validate() {
+      var bad = (o.fields || []).some(function (f, i) { return f.required && !inputs[i].value.trim(); });
+      M.ok.disabled = bad;
+    }
+    validate();
+
+    M.cbWrap.classList.toggle('hidden', !o.checkbox);
+    M.cb.checked = false;
+    M.cbLabel.textContent = o.checkbox ? o.checkbox.label : '';
+    M.modal.classList.remove('hidden');
+    (inputs[0] || M.ok).focus();
+
+    function done(val) {
+      var out = null;
+      if (val) {
+        if (o.fields) { out = {}; inputs.forEach(function (i) { out[i.dataset.id] = i.value.trim(); }); }
+        else if (o.checkbox) out = { ok: true, checked: M.cb.checked };
+        else out = true;
+      } else if (o.checkbox && !o.fields) out = { ok: false, checked: false };
+      M.ok.classList.remove('danger'); M.title.classList.remove('danger');
+      M.ok.disabled = false;
+      M.modal.classList.add('hidden');
+      M.ok.removeEventListener('click', onOk);
+      M.cancel.removeEventListener('click', onCancel);
+      M.modal.removeEventListener('click', onBackdrop);
+      document.removeEventListener('keydown', onKey);
+      resolve(out);
+    }
+    function onOk() { if (!M.ok.disabled) done(true); }
+    function onCancel() { done(false); }
+    function onBackdrop(e) { if (e.target === M.modal) done(false); }
+    function onKey(e) {
+      if (e.key === 'Escape') done(false);
+      if (e.key === 'Enter' && o.fields && !M.ok.disabled) done(true);
+    }
+    M.ok.addEventListener('click', onOk);
+    M.cancel.addEventListener('click', onCancel);
+    M.modal.addEventListener('click', onBackdrop);
+    document.addEventListener('keydown', onKey);
+  });
+}
+function confirmModal(o) { return openModal(o); }
+function promptModal(o) { return openModal(Object.assign({ confirmLabel: 'Save' }, o)); }
+
+/* ---- the eight real call sites, as they would read after the change ---- */
+function demoDelete() {
+  confirmModal({
+    title: 'Delete pipeline', danger: true, confirmLabel: 'Delete',
+    message: 'Delete "nightly-refactor"?\n\nThis cannot be undone.'
+  });
+}
+function demoPurge() {
+  confirmModal({
+    title: 'Remove project', danger: true, confirmLabel: 'Remove',
+    message: 'Remove "worca-cc" from Worca?\n\nThe working tree on disk is left alone.',
+    checkbox: { label: 'Also delete config, secrets and state (purge — cannot be undone)' }
+  });
+}
+function demoWorktree() {
+  confirmModal({
+    title: 'Discard the retained worktree?', danger: true, confirmLabel: 'Discard',
+    message: 'Any work NOT yet committed exists only in the retained worktree; a recovery patch of '
+      + 'uncommitted changes will be saved in the pipeline directory before anything is removed.\n\n'
+      + 'If you already committed the work manually, discarding just removes the now-redundant '
+      + 'checkout and clears the warning. The pipeline history and feature branch are kept.'
+  });
+}
+function demoSavePipeline() {
+  promptModal({
+    title: 'Save pipeline',
+    message: 'Give it a name, and a domain so the picker can group it.',
+    fields: [
+      { id: 'name', label: 'Name', placeholder: 'e.g. nightly refactor', required: true },
+      { id: 'domain', label: 'Domain', value: 'coding', hint: 'Organizes the picker — e.g. coding, marketing.' }
+    ]
+  });
+}
+function demoProfile() {
+  promptModal({
+    title: 'New profile',
+    fields: [
+      { id: 'id', label: 'Profile id', placeholder: 'work', mono: true, required: true,
+        hint: 'Lowercase letters, digits and dashes.' },
+      { id: 'label', label: 'Display name', placeholder: 'optional' }
+    ]
+  });
+}
+
+/* ---- data-tip, reusing the app's single floating bubble ---- */
+(function () {
+  var bubble;
+  function show(t) {
+    if (!bubble) {
+      bubble = document.createElement('div');
+      bubble.className = 'info-bubble';
+      bubble.style.cssText = 'position:fixed;z-index:70;background:var(--ink);color:#fff;'
+        + 'border-radius:10px;padding:10px 13px;font-size:12px;line-height:1.5;max-width:340px;'
+        + 'box-shadow:var(--shadow);pointer-events:none;';
+      document.body.appendChild(bubble);
+    }
+    var r = t.getBoundingClientRect();
+    bubble.textContent = t.dataset.tip;
+    bubble.style.display = 'block';
+    bubble.style.left = r.left + 'px';
+    bubble.style.top = (r.bottom + 8) + 'px';
+  }
+  function hide() { if (bubble) bubble.style.display = 'none'; }
+  document.addEventListener('pointerover', function (e) {
+    var t = e.target.closest && e.target.closest('[data-tip]');
+    if (t) show(t); else hide();
+  });
+  document.addEventListener('focusin', function (e) {
+    var t = e.target.closest && e.target.closest('[data-tip]');
+    if (t) show(t);
+  });
+  document.addEventListener('focusout', hide);
+  window.addEventListener('scroll', hide, true);
+})();
+</script>
+</body>
+</html>

--- a/test/helpers/confirm-modal.mjs
+++ b/test/helpers/confirm-modal.mjs
@@ -1,0 +1,55 @@
+// Answer the app's own confirm/prompt modal.
+//
+// The destructive deletes and the two "name this thing" flows used to call
+// window.confirm / window.prompt, which a test answered by stubbing the global.
+// They now go through confirmModal() / promptModal() in the page, so a test has
+// to drive the real dialog instead: wait for it to open, fill any prompt fields,
+// then click OK (or Cancel).
+//
+//   await confirmDialog(window);                       // plain confirm -> OK
+//   await confirmDialog(window, { name: 'My Flow' });  // promptModal fields
+//   await cancelDialog(window);                        // -> Cancel
+import assert from 'node:assert/strict';
+
+const tick = (ms = 10) => new Promise((r) => setTimeout(r, ms));
+
+// Values are keyed by field id, matching promptModal's `fields[].id` (the input
+// carries id="confirm-f-<id>"). The synthetic 'input' event is what re-runs the
+// required-field check that gates the OK button.
+export async function confirmDialog(window, values = {}) {
+  const doc = window.document;
+  await tick();
+  const modal = doc.getElementById('confirm-modal');
+  assert.ok(modal, 'no #confirm-modal in the page');
+  assert.equal(modal.classList.contains('hidden'), false, 'the confirm modal did not open');
+  for (const [id, value] of Object.entries(values)) {
+    const input = doc.getElementById(`confirm-f-${id}`);
+    assert.ok(input, `the dialog has no field "${id}"`);
+    input.value = value;
+    input.dispatchEvent(new window.Event('input', { bubbles: true }));
+  }
+  const ok = doc.getElementById('confirm-ok');
+  assert.equal(ok.disabled, false, 'OK is still disabled — a required field is empty');
+  // captured BEFORE the click, for tests that assert on the copy
+  const message = doc.getElementById('confirm-message').textContent;
+  ok.click();
+  await tick();
+  return message;
+}
+
+export async function cancelDialog(window) {
+  const doc = window.document;
+  await tick();
+  doc.getElementById('confirm-cancel').click();
+  await tick();
+}
+
+// The message the dialog is currently showing, for tests that assert the copy.
+export function dialogText(window) {
+  const doc = window.document;
+  return {
+    title: doc.getElementById('confirm-title').textContent,
+    message: doc.getElementById('confirm-message').textContent,
+    confirmLabel: doc.getElementById('confirm-ok').textContent,
+  };
+}

--- a/test/ui-agents-view.test.mjs
+++ b/test/ui-agents-view.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
+import { confirmDialog } from './helpers/confirm-modal.mjs';
 
 const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
 const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
@@ -29,7 +30,6 @@ async function boot({ fetchHandler } = {}) {
   const { window } = dom;
   window.Element.prototype.scrollIntoView = function () {};
   window.WebSocket = WSStub;
-  window.confirm = () => true;
   window.requestAnimationFrame = (fn) => setTimeout(fn, 0); // composer paints via rAF (same stub as ui-composer.test.mjs)
   window.fetch = (url, opts) => {
     const u = String(url);
@@ -94,13 +94,13 @@ test('Delete issues DELETE /api/agents/:key; a 409 keeps the card + surfaces the
   const doc = window.document;
   const card = doc.querySelector('.agent-card[data-agent-key="docsWriter"]');
   click(window, card.querySelector('.agent-delete'));
-  await new Promise((r) => setTimeout(r, 0));
+  await confirmDialog(window);
   assert.equal(calls.length, 1);
   assert.ok(doc.querySelector('.agent-card[data-agent-key="docsWriter"]'), '409 keeps the card');
   assert.match(doc.querySelector('#agents-msg').textContent, /Uses Docs/);
   mode = 200;
   click(window, doc.querySelector('.agent-card[data-agent-key="docsWriter"] .agent-delete'));
-  await new Promise((r) => setTimeout(r, 0));
+  await confirmDialog(window);
   assert.equal(doc.querySelector('.agent-card[data-agent-key="docsWriter"]'), null, '200 removes the card');
 });
 
@@ -146,7 +146,6 @@ test('composer save surfaces server warnings via the link-banner toast', async (
       return null;
     },
   });
-  window.prompt = () => 'Warny';
   window.location.hash = 'composer';
   window.dispatchEvent(new window.Event('hashchange'));
   await new Promise((r) => setTimeout(r, 0));
@@ -154,8 +153,7 @@ test('composer save surfaces server warnings via the link-banner toast', async (
   const doc = window.document;
   assert.ok(window.__composer.steps.length >= 1, 'canvas seeded from default');
   click(window, doc.querySelector('#composer-save'));
-  await new Promise((r) => setTimeout(r, 0));
-  await new Promise((r) => setTimeout(r, 0));
+  await confirmDialog(window, { name: 'Warny' });
   assert.match(doc.querySelector('#composer-link-text').textContent, /consumes "checklist"/, 'warning toasted');
   assert.equal(doc.querySelector('#composer-link-banner').hidden, false);
 });

--- a/test/ui-composer.test.mjs
+++ b/test/ui-composer.test.mjs
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
+import { confirmDialog } from './helpers/confirm-modal.mjs';
 
 const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
 const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
@@ -79,7 +80,6 @@ test('Save serializes the canvas to contract topology and POSTs {name,steps,feed
   window.Element.prototype.scrollIntoView = function () {};
   Object.defineProperty(window.HTMLElement.prototype, 'offsetParent', { get() { return window.document.body; }, configurable: true });
   window.requestAnimationFrame = (fn) => setTimeout(fn, 0);
-  window.prompt = () => 'My Flow';
   window.WebSocket = class { constructor() { this.readyState = 1; } send() {} close() {} addEventListener() {} };
   window.fetch = (url, opts) => {
     const u = String(url);
@@ -107,7 +107,8 @@ test('Save serializes the canvas to contract topology and POSTs {name,steps,feed
   assert.equal(cols.length, 5, 'default = 5 steps');
 
   window.document.getElementById('composer-save').dispatchEvent(new window.Event('click', { bubbles: true }));
-  await new Promise((r) => setTimeout(r, 10));
+  // Save now asks for name + domain in ONE promptModal instead of two window.prompts.
+  await confirmDialog(window, { name: 'My Flow' });
   assert.equal(posted.length, 1, 'one POST');
   assert.equal(posted[0].name, 'My Flow');
   assert.deepEqual(posted[0].steps.map((c) => c.map((x) => x.key)),
@@ -135,7 +136,6 @@ test('saved list renders rows with meta line + chips; expand builds a read-only 
   window.Element.prototype.scrollIntoView = function () {};
   Object.defineProperty(window.HTMLElement.prototype, 'offsetParent', { get() { return window.document.body; }, configurable: true });
   window.requestAnimationFrame = (fn) => setTimeout(fn, 0);
-  window.confirm = () => true;
   window.WebSocket = class { constructor() { this.readyState = 1; } send() {} close() {} addEventListener() {} };
   window.fetch = (url, opts) => {
     const u = String(url);
@@ -172,7 +172,7 @@ test('saved list renders rows with meta line + chips; expand builds a read-only 
   assert.equal(quick.querySelectorAll('.pl-body .ro-flow .node').length, 3, 'preview has 3 nodes');
 
   quick.querySelector('.pl-del').dispatchEvent(new window.Event('click', { bubbles: true }));
-  await new Promise((r) => setTimeout(r, 10));
+  await confirmDialog(window);
   assert.deepEqual(deleted, ['wf_quickfix'], 'DELETE called for the workflow id');
   assert.equal(window.document.querySelectorAll('#composer-saved-list .pl-item').length, 1, 'row removed after reload');
 });

--- a/test/ui-control-skins.test.mjs
+++ b/test/ui-control-skins.test.mjs
@@ -1,0 +1,174 @@
+// test/ui-control-skins.test.mjs — the browser's own controls, skinned.
+//
+// Covers the three halves of the change:
+//   1. style.css skins the REAL <input> (appearance:none), which is what lets
+//      every existing emitter keep its markup;
+//   2. the four live toggles render as switches and the three lists as rows;
+//   3. window.confirm / window.prompt have no call sites left — every dialog
+//      goes through confirmModal() / promptModal().
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+import { renderPluginList } from '../ui/public/plugins-view.mjs';
+import { renderChatSettings } from '../ui/public/chat-settings-view.mjs';
+import { renderStartStep } from '../ui/public/guardrails-view.mjs';
+
+const read = (p) => readFileSync(fileURLToPath(new URL(p, import.meta.url)), 'utf8');
+const css = read('../ui/public/style.css');
+const html = read('../ui/public/index.html');
+const appjs = read('../ui/public/app.js');
+
+// ---------------------------------------------------------------- stylesheet
+
+test('checkbox and radio are skinned on the real input, not a stand-in span', () => {
+  const rule = css.match(/input\[type="checkbox"\],\s*\ninput\[type="radio"\]\{[^}]+\}/);
+  assert.ok(rule, 'no shared checkbox/radio base rule');
+  assert.match(rule[0], /appearance:none/, 'still letting the UA draw it');
+  assert.match(rule[0], /-webkit-appearance:none/, 'Safari needs the prefix too');
+  assert.match(rule[0], /border:1\.5px solid var\(--radio-ring\)/, 'not the .qopt hairline');
+  // NOTHING may set display here: #mock and the two segmented radio groups are
+  // [hidden], and a display declaration would override the UA rule and show them.
+  assert.ok(!/display\s*:/.test(rule[0]), 'the base rule must not set display');
+});
+
+test('checked / indeterminate / locked-on all paint a glyph', () => {
+  assert.match(css, /input\[type="checkbox"\]:checked\{[^}]*var\(--green\)[^}]*data:image\/svg\+xml/,
+    'checked has no green fill + tick');
+  assert.match(css, /input\[type="checkbox"\]:indeterminate\{[^}]*data:image\/svg\+xml/,
+    'no mixed state');
+  assert.match(css, /input\[type="radio"\]:checked\{[^}]*box-shadow:inset/,
+    'radio dot should come from an inset shadow, not a pseudo-element');
+  // :disabled uses the `background` shorthand, which drops the image :checked
+  // painted — a locked-on box has to restate it or it renders blank.
+  const locked = css.match(/input\[type="checkbox"\]:disabled:checked\{[^}]+\}/);
+  assert.ok(locked, 'no locked-on rule');
+  assert.match(locked[0], /data:image\/svg\+xml/, 'locked-on lost its tick');
+  assert.match(locked[0], /var\(--seq\)/, 'locked-on should read as fixed (grey), not broken');
+});
+
+test('focus ring matches the rest of the app', () => {
+  assert.match(css, /input\[type="checkbox"\]:focus-visible,\s*\ninput\[type="radio"\]:focus-visible\{outline:2px solid var\(--ink\)/);
+});
+
+test('accent-color nets anything never hand-skinned', () => {
+  assert.match(css, /:root\{accent-color:var\(--green\);\}/);
+});
+
+test('markdown task lists keep their gap', () => {
+  // the blanket margin:0 in the base rule would otherwise win on source order
+  const base = css.indexOf('input[type="checkbox"],\ninput[type="radio"]{');
+  const askMd = css.lastIndexOf('.ask-md input[type="checkbox"]{margin-right:6px;}');
+  assert.ok(askMd > base, '.ask-md gap must be restated after the base rule');
+});
+
+test('a switch can be driven by a real checkbox', () => {
+  assert.match(css, /\.sw-input:checked \+ \.switch\{background:var\(--green\)/);
+  assert.match(css, /\.sw-input:checked \+ \.switch::after\{left:21px/);
+  assert.match(css, /\.sw-input:focus-visible \+ \.switch\{outline:2px solid var\(--ink\)/);
+  assert.match(css, /\.switch\.switch-sm\{/, 'no compact variant for dense rows');
+  // the hand-mirrored .on emitters (#mock, autoscroll) must keep working
+  assert.match(css, /\.switch\.on,\s*\n\.sw-input:checked \+ \.switch\{/);
+});
+
+test('.check-row beats `.field > label`, which used to claim it', () => {
+  assert.match(css, /\.check-row\{[^}]*display:inline-flex/);
+  assert.match(css, /\.field > label\.check-row,\s*\n\.field > label\.fanout-toggle\{[^}]*margin-bottom:0/);
+  const fieldLabel = css.indexOf('.field > label,.field .label{');
+  const override = css.indexOf('.field > label.check-row,');
+  assert.ok(override > fieldLabel, 'equal specificity — the override must come later');
+});
+
+test('selectable rows and chips carry the selection themselves', () => {
+  assert.match(css, /\.opt-row:has\(input:checked\)\{background:var\(--green-bg\)/);
+  assert.match(css, /\.opt-row:has\(input:disabled\)/);
+  assert.match(css, /\.chip-select label:has\(input:checked\)\{background:var\(--green-bg\)/);
+  // .opt-row is appended AFTER .wiz-proj / .grv-source-row / .mvx-model, which it
+  // ties with on specificity — source order is what lets it win.
+  for (const base of ['.wiz-proj{', '.grv-source-row{', '.mvx-model{']) {
+    assert.ok(css.indexOf('.opt-row{') > css.indexOf(base), `.opt-row must come after ${base}`);
+  }
+});
+
+test('the last of the UA chrome is reset', () => {
+  assert.match(css, /input\[type="number"\]::-webkit-inner-spin-button\{-webkit-appearance:none/);
+  assert.match(css, /input\[type="number"\]\{-moz-appearance:textfield;\}/);
+  assert.match(css, /input\[type="search"\]::-webkit-search-cancel-button/);
+  assert.match(css, /\.disclosure > summary::-webkit-details-marker\{display:none/);
+  assert.match(css, /\.disclosure\[open\] > summary::before\{transform:rotate\(90deg\)/);
+  assert.match(css, /html\{scrollbar-color:/, 'Firefox never sees ::-webkit-scrollbar');
+});
+
+test('the reduced-motion block is still the last one in the file', () => {
+  // style.css:3180 documents why; appending after it would silently break it.
+  const last = css.lastIndexOf('@media (prefers-reduced-motion: reduce){');
+  assert.ok(css.indexOf('.opt-row{') < last, 'the new section jumped the reduced-motion block');
+});
+
+// ------------------------------------------------------------------- markup
+
+test('the confirm modal has a slot for prompt fields', () => {
+  assert.ok(html.includes('id="confirm-fields"'), 'no #confirm-fields');
+  // ...between the message and the opt-in checkbox
+  assert.ok(html.indexOf('id="confirm-fields"') > html.indexOf('id="confirm-message"'));
+  assert.ok(html.indexOf('id="confirm-fields"') < html.indexOf('id="confirm-checkbox-wrap"'));
+});
+
+test('plugin enable renders as a switch', () => {
+  const doc = new JSDOM('<div></div>').window.document;
+  const el = renderPluginList([{ name: 'telegram-chat', version: '1.0.0', enabled: true }], { doc });
+  const cb = el.querySelector('input.pl-toggle');
+  assert.ok(cb, 'the .pl-toggle hook app.js delegates on is gone');
+  assert.ok(cb.classList.contains('sw-input'), 'not wired to the switch');
+  // `+` only reaches the IMMEDIATE next sibling — the track must sit right after
+  assert.ok(cb.nextElementSibling?.classList.contains('switch'), 'no .switch track after the input');
+  assert.ok(cb.nextElementSibling.classList.contains('switch-sm'), 'card headers use the compact track');
+  assert.ok(cb.getAttribute('aria-label'), 'a bare switch needs its own name');
+});
+
+test('chat notify + channel toggles render as switches', () => {
+  const doc = new JSDOM('<div></div>').window.document;
+  const el = renderChatSettings({
+    prefs: { notify: {}, channels: {} },
+    channels: [{ plugin: 'telegram-chat', channelId: 'team', platform: 'telegram', state: 'connected' }],
+  }, { doc });
+  for (const sel of ['input.chat-ev', 'input.chat-ch']) {
+    const cb = el.querySelector(sel);
+    assert.ok(cb, `${sel} missing`);
+    assert.ok(cb.classList.contains('sw-input'), `${sel} not wired to the switch`);
+    assert.ok(cb.nextElementSibling?.classList.contains('switch'), `${sel} has no track`);
+  }
+});
+
+test('guardrails starting point renders as selectable rows', () => {
+  const doc = new JSDOM('<div></div>').window.document;
+  const el = renderStartStep([{ id: 'g1', name: 'Strict', origin: 'builtin' }], { doc });
+  const row = el.querySelector('.grv-source-row');
+  assert.ok(row, 'the .grv-source-row hook is gone');
+  assert.ok(row.classList.contains('opt-row'), 'row does not carry the selection');
+  assert.ok(row.querySelector('.opt-name'), 'the name needs .opt-name to truncate');
+});
+
+// ------------------------------------------------------------------ dialogs
+
+test('no window.confirm / window.prompt call sites remain', () => {
+  // Comments may still mention them; a CALL is what must be gone.
+  const calls = appjs.match(/window\.(confirm|prompt)\s*\(/g) || [];
+  assert.deepEqual(calls, [], `still calling ${calls.join(', ')}`);
+});
+
+test('promptModal exists and shares the confirm shell', () => {
+  assert.match(appjs, /function promptModal\(/, 'no promptModal');
+  assert.match(appjs, /function confirmModal\(/, 'confirmModal must keep its name — 11 callers');
+  assert.match(appjs, /function modalShell\(/, 'the two should share one shell');
+});
+
+test('the destructive deletes ask in red', () => {
+  // every confirmModal that deletes something passes danger:true
+  for (const title of ['Delete pipeline', 'Delete workspace', 'Delete agent', 'Delete profile']) {
+    const m = appjs.match(new RegExp(`title: '${title}',([\\s\\S]{0,120})`));
+    assert.ok(m, `no confirmModal titled "${title}"`);
+    assert.match(m[1], /danger: true/, `"${title}" is not tinted red`);
+  }
+});

--- a/test/ui-control-skins.test.mjs
+++ b/test/ui-control-skins.test.mjs
@@ -72,6 +72,12 @@ test('a switch can be driven by a real checkbox', () => {
   assert.match(css, /\.switch\.on,\s*\n\.sw-input:checked \+ \.switch\{/);
 });
 
+test('the switch checkbox row is a positioning context (no viewport jump on click)', () => {
+  // .sw-input is position:absolute; its wrapper must be positioned so focusing
+  // the input on click does not scroll the page to the top.
+  assert.match(css, /:has\(> \.sw-input\)\{position:relative/);
+});
+
 test('.check-row beats `.field > label`, which used to claim it', () => {
   assert.match(css, /\.check-row\{[^}]*display:inline-flex/);
   assert.match(css, /\.field > label\.check-row,\s*\n\.field > label\.fanout-toggle\{[^}]*margin-bottom:0/);

--- a/test/ui-history-detail.test.mjs
+++ b/test/ui-history-detail.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
+import { confirmDialog } from './helpers/confirm-modal.mjs';
 import { MAX_FILE_SECTION_CODE_UNITS } from '../ui/public/diff-view.mjs';
 import { MAX_HIGHLIGHT_INPUT_BYTES } from '../ui/public/syntax-highlight.mjs';
 
@@ -519,11 +520,9 @@ test('discarding the retained worktree clears the banner and re-enables Archive'
       : null),
   });
   await openDetail(ctx);
-  // setupDiscardWorktreeButton still uses window.confirm — D2's confirmModal change
-  // covers Archive only.
-  ctx.window.confirm = () => true;
   const doc = ctx.window.document;
   click(ctx.window, doc.querySelector('#hist-detail .hist-discard'));
+  await confirmDialog(ctx.window);
   await settle(ctx.window, 5);
 
   assert.equal(doc.querySelector('#hist-detail .retained-banner').hidden, true);
@@ -559,8 +558,8 @@ test('deep-linked discard still clears the banner after the real row lands', asy
     'the action arrives with the authoritative row');
 
   // (3) discard acts on THAT row, so the repaint really clears
-  ctx.window.confirm = () => true;
   click(ctx.window, doc.querySelector('#hist-detail .hist-discard'));
+  await confirmDialog(ctx.window);
   await settle(ctx.window, 6);
   assert.equal(doc.querySelector('#hist-detail .retained-banner').hidden, true);
   assert.equal(doc.querySelector('#hist-detail .hd-archive').disabled, false);
@@ -2154,10 +2153,9 @@ test('discard confirms honestly, POSTs the keyed route, and shows the saved reco
     },
   });
   await openDetail(ctx);
-  let confirmText = '';
-  ctx.window.confirm = (text) => { confirmText = text; return true; };
   const doc = ctx.window.document;
   click(ctx.window, doc.querySelector('#hist-detail .hist-discard'));
+  const confirmText = await confirmDialog(ctx.window);
   await settle(ctx.window, 5);
 
   assert.equal(request.method, 'POST');
@@ -2180,9 +2178,9 @@ test('a failed discard keeps the banner, the badge and the Archive block — and
       : null),
   });
   await openDetail(ctx);
-  ctx.window.confirm = () => true;
   const doc = ctx.window.document;
   click(ctx.window, doc.querySelector('#hist-detail .hist-discard'));
+  await confirmDialog(ctx.window);
   await settle(ctx.window, 5);
 
   assert.equal(doc.querySelector('#hist-detail .hist-retained-badge').hidden, false, 'badge stays');

--- a/test/ui-running-detail.test.mjs
+++ b/test/ui-running-detail.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
+import { confirmDialog } from './helpers/confirm-modal.mjs';
 
 // The Running detail screen's body: live pipeline graph, banners, question panel.
 //
@@ -313,7 +314,6 @@ test('retained work renders from branch.commitFailed and binds Discard exactly o
     },
   });
   const { window, recv } = ctx;
-  window.confirm = () => true;   // setupDiscardWorktreeButton uses window.confirm, not confirmModal
   window.__np.getRun(ID).pipelineId = 'p1';
   const RETAINED = {
     type: 'state', runId: ID, status: 'running', steps: [],
@@ -338,6 +338,7 @@ test('retained work renders from branch.commitFailed and binds Discard exactly o
   const btn = window.document.querySelector('#run-detail .hist-discard');
   assert.equal(btn.hidden, false);
   btn.dispatchEvent(new window.Event('click', { bubbles: true }));
+  await confirmDialog(window);
   await settle(window, 5);
   assert.equal(posts.length, 1, 'exactly one POST per click, after three paints');
 });
@@ -356,7 +357,6 @@ test('a successful discard clears the Running banner for good and re-arms the bu
     },
   });
   const { window, recv } = ctx;
-  window.confirm = () => true;
   window.__np.getRun(ID).pipelineId = 'p1';
   const RETAINED = {
     type: 'state', runId: ID, status: 'running', steps: [],
@@ -369,6 +369,7 @@ test('a successful discard clears the Running banner for good and re-arms the bu
   const btn = window.document.querySelector('#run-detail .hist-discard');
   const before = btn.textContent;
   btn.dispatchEvent(new window.Event('click', { bubbles: true }));
+  await confirmDialog(window);
   await settle(window, 6);
 
   assert.equal(window.document.querySelector('#run-detail .retained-banner').hidden, true,

--- a/test/ui-workspaces.test.mjs
+++ b/test/ui-workspaces.test.mjs
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { JSDOM } from 'jsdom';
+import { confirmDialog } from './helpers/confirm-modal.mjs';
 
 const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
 const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
@@ -20,7 +21,6 @@ async function boot({ fetchHandler, workspaces = WS } = {}) {
   const { window } = dom;
   window.Element.prototype.scrollIntoView = function () {};
   window.WebSocket = class { constructor() { this.readyState = 1; } send() {} close() {} addEventListener() {} };
-  window.confirm = () => true;
   window.fetch = (url, opts) => {
     const u = String(url);
     if (fetchHandler) { const r = fetchHandler(u, opts || {}); if (r) return r; }
@@ -130,7 +130,7 @@ test('delete 200 removes the card + decrements the count', async () => {
   const doc = window.document;
   const beta = [...doc.querySelectorAll('#ws-list .ws-card')].find((c) => c.dataset.workspaceId === 'wks-beta-00000002');
   click(window, beta.querySelector('.ws-delete'));
-  await new Promise((r) => setTimeout(r, 0));
+  await confirmDialog(window);
   assert.equal(doc.querySelectorAll('#ws-list .ws-card').length, 1, 'Beta removed');
   assert.equal(doc.querySelector('#nav-workspaces-count').textContent, '1');
 });
@@ -145,7 +145,7 @@ test('delete 409 (live run) keeps the card + surfaces the error', async () => {
   const doc = window.document;
   const alpha = [...doc.querySelectorAll('#ws-list .ws-card')].find((c) => c.dataset.workspaceId === 'wks-alpha-00000001');
   click(window, alpha.querySelector('.ws-delete'));
-  await new Promise((r) => setTimeout(r, 0));
+  await confirmDialog(window);
   assert.equal(doc.querySelectorAll('#ws-list .ws-card').length, 2, 'card kept on 409');
   assert.match(doc.querySelector('#ws-msg').textContent, /run is in progress/, 'verbatim 409 error');
 });

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -236,6 +236,7 @@ const el = {
   confirmMessage: $('#confirm-message'),
   confirmOk: $('#confirm-ok'),
   confirmCancel: $('#confirm-cancel'),
+  confirmFields: $('#confirm-fields'),
   confirmCheckboxWrap: $('#confirm-checkbox-wrap'),
   confirmCheckbox: $('#confirm-checkbox'),
   confirmCheckboxLabel: $('#confirm-checkbox-label'),
@@ -2461,10 +2462,20 @@ function suggestWorkflowDomain(steps) {
 async function composerSave() {
   if (!composer.steps.length) return;
   composerExitLink();
-  const name = (window.prompt('Name this pipeline:', '') || '').trim();
-  if (!name) return;
   const suggested = suggestWorkflowDomain(composer.steps);
-  const domain = (window.prompt('Domain (organizes the picker — e.g. coding, marketing):', suggested) || '').trim() || suggested;
+  const answers = await promptModal({
+    title: 'Save pipeline',
+    message: 'Give it a name, and a domain so the picker can group it.',
+    confirmLabel: 'Save',
+    fields: [
+      { id: 'name', label: 'Name', placeholder: 'e.g. nightly refactor', required: true },
+      { id: 'domain', label: 'Domain', value: suggested,
+        hint: 'Organizes the picker — e.g. coding, marketing.' },
+    ],
+  });
+  if (!answers) return;
+  const name = answers.name;
+  const domain = answers.domain || suggested;
   const body = topology(composer.steps, composer.feedbacks); // {steps,feedbacks} with contract ids
   const saveBtn = document.getElementById('composer-save');
   let saved, warnings;
@@ -2601,7 +2612,11 @@ function composerRenderList() {
     const body = wrap.querySelector('.pl-body');
     if (del) del.addEventListener('click', async (e) => {
       e.stopPropagation();
-      if (!window.confirm(`Delete "${item.name}"? This cannot be undone.`)) return;
+      const ok = await confirmModal({
+        title: 'Delete pipeline', danger: true, confirmLabel: 'Delete',
+        message: `Delete "${item.name}"?\n\nThis cannot be undone.`,
+      });
+      if (!ok) return;
       try { await deleteWorkflow(item.id); } catch (err) {
         appendLog({ source: 'ui', level: 'error', text: `delete pipeline: ${err.message}`, ts: Date.now() }); return;
       }
@@ -6242,7 +6257,11 @@ async function rescanWorkspace(w) {
 // (live run/scan) keeps the card + surfaces data.error.
 async function deleteWorkspaceCard(card, w) {
   if (!card || !w) return;
-  if (!window.confirm(`Delete workspace "${w.name || w.id}"?\n\nThis removes its history store and best-effort branch cleanup. This cannot be undone.`)) return;
+  const ok = await confirmModal({
+    title: 'Delete workspace', danger: true, confirmLabel: 'Delete',
+    message: `Delete workspace "${w.name || w.id}"?\n\nThis removes its history store and best-effort branch cleanup. This cannot be undone.`,
+  });
+  if (!ok) return;
   const btn = card.querySelector('.ws-delete');
   if (btn) btn.disabled = true;
   try {
@@ -6324,7 +6343,9 @@ function renderWizardProjects() {
   projects.forEach((p) => {
     if (!p || !p.path) return;
     const row = document.createElement('label');
-    row.className = 'wiz-proj' + (p.exists ? '' : ' missing');
+    // .opt-row puts the selection on the whole row, so a picked project reads
+    // from across the list and "missing" stops looking like "just unchecked".
+    row.className = 'wiz-proj opt-row' + (p.exists ? '' : ' missing');
     const cb = document.createElement('input');
     cb.type = 'checkbox';
     cb.className = 'wiz-proj-cb';
@@ -6338,8 +6359,22 @@ function renderWizardProjects() {
       syncWizardStartEnabled();
     });
     const txt = document.createElement('span');
-    txt.textContent = p.exists ? p.name : `${p.name} (missing)`;
+    txt.className = 'opt-name';
+    txt.textContent = p.name;
     row.append(cb, txt);
+    if (p.path) {
+      const sub = document.createElement('span');
+      sub.className = 'opt-sub';
+      sub.textContent = p.path;
+      row.appendChild(sub);
+    }
+    // the parenthetical became a badge: same word, but it now reads as state
+    if (!p.exists) {
+      const badge = document.createElement('span');
+      badge.className = 'badge red';
+      badge.textContent = 'missing';
+      row.appendChild(badge);
+    }
     host.appendChild(row);
   });
   syncWizardStartEnabled();
@@ -6660,7 +6695,11 @@ async function fetchAgentFull(key) {
 }
 
 async function deleteAgentCard(card, a) {
-  if (!window.confirm(`Delete agent "${a.displayName || a.key}"?\n\nThis removes its markdown + metadata pair. This cannot be undone.`)) return;
+  const ok = await confirmModal({
+    title: 'Delete agent', danger: true, confirmLabel: 'Delete',
+    message: `Delete agent "${a.displayName || a.key}"?\n\nThis removes its markdown + metadata pair. This cannot be undone.`,
+  });
+  if (!ok) return;
   try {
     const res = await fetch(`/api/agents/${encodeURIComponent(a.key)}`, { method: 'DELETE' });
     const data = await safeJson(res);
@@ -6964,46 +7003,114 @@ function renderProjectsList() {
   host.appendChild(card);
 }
 
-// ---- Reusable confirmation modal -> Promise<boolean> ------------------------
-// With opts.checkbox: { label } it resolves { ok, checked } instead.
-// opts.danger tints the OK button red for a destructive action (opt-in, so no
-// existing caller changes). `done` always removes it again — the modal is shared,
-// and the tint must never leak into the next, harmless confirmation.
-function confirmModal({ title = 'Confirm', message = '', confirmLabel = 'Confirm', cancelLabel = 'Cancel', checkbox = null, danger = false } = {}) {
+// ---- Reusable confirm / prompt modal ---------------------------------------
+// One shell, two public entry points:
+//   confirmModal(opts) -> Promise<boolean>, or Promise<{ok, checked}> when
+//     opts.checkbox is given. Contract unchanged from before promptModal existed.
+//   promptModal(opts)  -> Promise<object|null> keyed by field id. This is what
+//     replaced window.prompt: it takes an ARRAY of fields, so the two places
+//     that used to fire two blocking prompts back to back (name + domain,
+//     profile id + label) now ask once.
+// opts.danger tints the title and the OK button red for a destructive action
+// (opt-in). `done` always clears every opt-in again — the modal is shared, and
+// neither the tint nor a leftover field may leak into the next, harmless call.
+function modalShell({
+  title = 'Confirm', message = '', confirmLabel = 'Confirm', cancelLabel = 'Cancel',
+  checkbox = null, danger = false, fields = null,
+} = {}) {
   return new Promise((resolve) => {
     el.confirmTitle.textContent = title;
+    el.confirmTitle.classList.toggle('danger', !!danger);
     el.confirmMessage.textContent = message;
+    el.confirmMessage.hidden = !message;
     el.confirmOk.textContent = confirmLabel;
     el.confirmCancel.textContent = cancelLabel;
     el.confirmOk.classList.toggle('danger', !!danger);
+
+    // prompt fields: built fresh each time, values bound via .value (never innerHTML)
+    const inputs = [];
+    el.confirmFields.replaceChildren();
+    for (const f of fields || []) {
+      const wrap = document.createElement('div');
+      wrap.className = 'confirm-field';
+      const lab = document.createElement('label');
+      lab.textContent = f.label;
+      lab.htmlFor = `confirm-f-${f.id}`;
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.className = 'input';
+      inp.id = `confirm-f-${f.id}`;
+      inp.dataset.fieldId = f.id;
+      inp.value = f.value || '';
+      inp.placeholder = f.placeholder || '';
+      inp.autocomplete = 'off';
+      if (f.mono) inp.style.fontFamily = 'var(--mono)';
+      wrap.append(lab, inp);
+      if (f.hint) {
+        const hint = document.createElement('small');
+        hint.className = 'hint';
+        hint.textContent = f.hint;
+        wrap.appendChild(hint);
+      }
+      el.confirmFields.appendChild(wrap);
+      inputs.push(inp);
+      if (f.required) inp.addEventListener('input', syncOk);
+    }
+    // A required field with nothing in it is the old `if (!name) return` guard,
+    // moved to where the user can see it.
+    function syncOk() {
+      el.confirmOk.disabled = (fields || []).some((f, i) => f.required && !inputs[i].value.trim());
+    }
+    syncOk();
+
     // opt-in checkbox: shown only when requested, always reset to unchecked
     el.confirmCheckboxWrap.classList.toggle('hidden', !checkbox);
     el.confirmCheckbox.checked = false;
     el.confirmCheckboxLabel.textContent = checkbox ? checkbox.label : '';
     el.confirmModal.classList.remove('hidden');
-    el.confirmOk.focus();
+    (inputs[0] || el.confirmOk).focus();
 
     const done = (val) => {
       const checked = el.confirmCheckbox.checked;
+      const values = {};
+      for (const i of inputs) values[i.dataset.fieldId] = i.value.trim();
       el.confirmOk.classList.remove('danger');   // never leak the tint to the next caller
+      el.confirmTitle.classList.remove('danger');
+      el.confirmOk.disabled = false;
+      el.confirmMessage.hidden = false;
+      el.confirmFields.replaceChildren();
       el.confirmModal.classList.add('hidden');
       el.confirmCheckboxWrap.classList.add('hidden');
       el.confirmOk.removeEventListener('click', onOk);
       el.confirmCancel.removeEventListener('click', onCancel);
       el.confirmModal.removeEventListener('click', onBackdrop);
       document.removeEventListener('keydown', onKey);
-      resolve(checkbox ? { ok: val, checked } : val);
+      if (fields) resolve(val ? values : null);
+      else resolve(checkbox ? { ok: val, checked } : val);
     };
-    const onOk = () => done(true);
+    const onOk = () => { if (!el.confirmOk.disabled) done(true); };
     const onCancel = () => done(false);
     const onBackdrop = (e) => { if (e.target === el.confirmModal) done(false); };
-    const onKey = (e) => { if (e.key === 'Escape') done(false); };
+    const onKey = (e) => {
+      if (e.key === 'Escape') done(false);
+      // Enter submits a filled-in prompt, the way the native one did
+      else if (e.key === 'Enter' && fields && !el.confirmOk.disabled) { e.preventDefault(); done(true); }
+    };
 
     el.confirmOk.addEventListener('click', onOk);
     el.confirmCancel.addEventListener('click', onCancel);
     el.confirmModal.addEventListener('click', onBackdrop);
     document.addEventListener('keydown', onKey);
   });
+}
+
+function confirmModal(opts = {}) {
+  return modalShell({ ...opts, fields: null });
+}
+
+// fields: [{ id, label, placeholder, value, hint, mono, required }]
+function promptModal({ confirmLabel = 'Save', fields = [], ...rest } = {}) {
+  return modalShell({ ...rest, confirmLabel, fields });
 }
 
 async function deleteProject(p) {
@@ -8004,9 +8111,18 @@ async function savePluginConfigForms(name, body) {
 // config form has anything to write into. Reopens on the NEW profile, which is
 // what the user wants to fill in next.
 async function addPluginProfile(name, sourceId) {
-  const id = (window.prompt('Profile id (lowercase letters, digits and dashes — e.g. "work"):') || '').trim();
-  if (!id) return;
-  const label = (window.prompt('Display name (optional):', id) || '').trim();
+  const answers = await promptModal({
+    title: 'New profile',
+    confirmLabel: 'Create',
+    fields: [
+      { id: 'id', label: 'Profile id', placeholder: 'work', mono: true, required: true,
+        hint: 'Lowercase letters, digits and dashes — e.g. "work".' },
+      { id: 'label', label: 'Display name', placeholder: 'optional' },
+    ],
+  });
+  if (!answers) return;
+  const id = answers.id;
+  const label = answers.label;
   const r = await pluginApi('POST', `/api/plugins/${encodeURIComponent(name)}/profiles`, { sourceId, id, label });
   if (!r.ok) return setPluginsMsg(r.data.error || 'could not create the profile', 'err');
   loadTaskSources();               // the New Pipeline profile bar lists this roster
@@ -8017,7 +8133,11 @@ async function deletePluginProfile(name, sourceId, profile) {
   if (!profile) return;
   // The server also drops every project binding that named it, so this is not
   // just a settings delete — say so before it happens, not after.
-  if (!window.confirm(`Delete profile "${profile}"? Its settings, token and any project bound to it are removed.`)) return;
+  const ok = await confirmModal({
+    title: 'Delete profile', danger: true, confirmLabel: 'Delete',
+    message: `Delete profile "${profile}"?\n\nIts settings, token and any project bound to it are removed.`,
+  });
+  if (!ok) return;
   const url = `/api/plugins/${encodeURIComponent(name)}/profiles/${encodeURIComponent(profile)}?sourceId=${encodeURIComponent(sourceId)}`;
   const r = await pluginApi('DELETE', url);
   if (!r.ok) return setPluginsMsg(r.data.error || 'could not delete the profile', 'err');
@@ -8096,12 +8216,21 @@ async function openPluginSettings(name, profile) {
   });
   body.querySelectorAll('.pl-profile-sel').forEach((sel) => {
     const prev = sel.value;
-    sel.addEventListener('change', () => {
-      if (dirty && !window.confirm('Discard unsaved changes and switch profiles?')) {
+    sel.addEventListener('change', async () => {
+      // The select has ALREADY moved by the time a non-blocking dialog opens, so
+      // snap it back first and only re-apply the choice once the answer is yes.
+      const wanted = sel.value;
+      if (dirty) {
         sel.value = prev;
-        return;
+        const ok = await confirmModal({
+          title: 'Discard unsaved changes?',
+          message: 'Switching profiles discards the edits you have not saved.',
+          confirmLabel: 'Discard and switch',
+        });
+        if (!ok) return;
+        sel.value = wanted;
       }
-      openPluginSettings(name, sel.value);
+      openPluginSettings(name, wanted);
     });
   });
   body.querySelectorAll('.pl-profile-add').forEach((btn) => {
@@ -9928,8 +10057,15 @@ function setupDiscardWorktreeButton(node, projectDir, p, onDiscarded) {
   if (!members.length) return;
   btn.addEventListener('click', async (e) => {
     e.stopPropagation();
-    const msg = 'Discard the retained worktree?\n\nAny work NOT yet committed exists only in the retained worktree; a recovery patch of uncommitted changes will be saved in the pipeline directory before anything is removed. If you already committed the work manually, discarding just removes the now-redundant checkout and clears the warning. The pipeline history and feature branch are kept.\n\nContinue?';
-    if (!window.confirm(msg)) return;
+    // The title carries the question and the OK button carries the verb, so the
+    // body no longer repeats either (it used to open "Discard the retained
+    // worktree?" and end "Continue?" because an OS alert has neither).
+    const msg = 'Any work NOT yet committed exists only in the retained worktree; a recovery patch of uncommitted changes will be saved in the pipeline directory before anything is removed.\n\nIf you already committed the work manually, discarding just removes the now-redundant checkout and clears the warning. The pipeline history and feature branch are kept.';
+    const ok = await confirmModal({
+      title: 'Discard the retained worktree?', danger: true, confirmLabel: 'Discard',
+      message: msg,
+    });
+    if (!ok) return;
     btn.disabled = true;
     const previous = btn.textContent;
     btn.textContent = 'Saving patch…';

--- a/ui/public/ask-panel.mjs
+++ b/ui/public/ask-panel.mjs
@@ -1147,7 +1147,8 @@ export function createAskPanel({ doc, win, fetch, sendWs, confirm, getPageContex
         srcInput.placeholder = 'auto';
         srcInput.value = card.sourceBranch || '';
         const details = doc.createElement('details');
-        details.className = 'ask-card-members-src';
+        // .disclosure swaps the OS triangle for the app's own chevron
+        details.className = 'ask-card-members-src disclosure';
         details.appendChild(make('summary', null, 'Per-member source branches'));
         const memberHost = make('div', 'ask-card-members-src-list');
         details.appendChild(memberHost);

--- a/ui/public/chat-settings-view.mjs
+++ b/ui/public/chat-settings-view.mjs
@@ -32,11 +32,13 @@ export function renderChatSettings({ prefs, channels } = {}, { doc = globalThis.
   evBox.appendChild(h(doc, 'div', 'label-row', 'Notify on'));
   for (const [key, label, hint] of EVENTS) {
     const row = h(doc, 'label', 'chat-event-row');
-    const cb = h(doc, 'input', 'chat-ev');
+    const cb = h(doc, 'input', 'sw-input chat-ev');
     cb.type = 'checkbox';
     cb.dataset.ev = key;
     cb.checked = p.notify?.[key] !== false;
+    cb.setAttribute('aria-label', label);
     row.appendChild(cb);
+    row.appendChild(h(doc, 'span', 'switch switch-sm'));
     row.appendChild(h(doc, 'span', '', label));
     if (hint) row.appendChild(h(doc, 'small', 'hint', hint));
     evBox.appendChild(row);
@@ -54,11 +56,13 @@ export function renderChatSettings({ prefs, channels } = {}, { doc = globalThis.
     const row = h(doc, 'div', 'chat-channel-row');
     row.dataset.channelKey = key;
     const toggle = h(doc, 'label', 'chat-channel-toggle');
-    const cb = h(doc, 'input', 'chat-ch');
+    const cb = h(doc, 'input', 'sw-input chat-ch');
     cb.type = 'checkbox';
     cb.dataset.channelKey = key;
     cb.checked = p.channels?.[key]?.enabled !== false;
+    cb.setAttribute('aria-label', `Enable ${c.displayName || c.channelId}`);
     toggle.appendChild(cb);
+    toggle.appendChild(h(doc, 'span', 'switch switch-sm'));
     toggle.appendChild(h(doc, 'span', '', `${c.displayName || c.channelId} (${c.platform})`));
     row.appendChild(toggle);
     const stateCls = { connected: 'green', degraded: 'waiting', connecting: 'waiting', unconfigured: 'waiting' }[c.state] || 'red';

--- a/ui/public/guardrails-view.mjs
+++ b/ui/public/guardrails-view.mjs
@@ -71,14 +71,16 @@ export function renderStartStep(sources, { doc = globalThis.document, selectedId
   list.setAttribute('role', 'radiogroup');
   list.setAttribute('aria-label', 'Starting point');
   const addRow = (id, label, builtin) => {
-    const row = h(doc, 'label', 'grv-source-row');
+    // .opt-row carries the selection on the WHOLE row (the name and its badge
+    // travel together); .grv-source-row stays for this view's own layout.
+    const row = h(doc, 'label', 'grv-source-row opt-row');
     const radio = h(doc, 'input', 'grv-source');
     radio.type = 'radio';
     radio.name = 'grv-source';
     radio.value = id;
     if (id === selectedId) radio.checked = true;
     row.appendChild(radio);
-    row.appendChild(h(doc, 'span', 'grv-source-name', label));
+    row.appendChild(h(doc, 'span', 'grv-source-name opt-name', label));
     if (builtin) row.appendChild(h(doc, 'span', 'badge waiting', 'built-in'));
     list.appendChild(row);
   };

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1302,6 +1302,8 @@
           <h2 id="confirm-title">Confirm</h2>
         </div>
         <p id="confirm-message" class="confirm-message"></p>
+        <!-- promptModal fills this with .confirm-field rows; empty for a plain confirm -->
+        <div id="confirm-fields"></div>
         <label id="confirm-checkbox-wrap" class="confirm-checkbox hidden">
           <input type="checkbox" id="confirm-checkbox" />
           <span id="confirm-checkbox-label"></span>

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -331,13 +331,13 @@ export function renderExportWizard(globals, { doc = globalThis.document } = {}) 
 
   const pick = step('1 — Models to include', 'Only your global models can be shared.');
   for (const m of globals) {
-    const lab = h(doc, 'label', 'mvx-model');
+    const lab = h(doc, 'label', 'mvx-model opt-row');
     const cb = h(doc, 'input', 'mvx-model-cb');
     cb.type = 'checkbox'; cb.value = m.id;
     cb.dataset.envKeys = Object.keys(m.env || {}).join('\n');
     lab.appendChild(cb);
-    lab.appendChild(h(doc, 'span', null, `${m.label || m.id} `));
-    lab.appendChild(h(doc, 'small', 'hint', m.id));
+    lab.appendChild(h(doc, 'span', 'opt-name', `${m.label || m.id} `));
+    lab.appendChild(h(doc, 'small', 'hint opt-sub', m.id));
     pick.appendChild(lab);
   }
   if (!globals.length) pick.appendChild(h(doc, 'div', 'hist-empty', 'No global models to share yet.'));

--- a/ui/public/plugins-view.mjs
+++ b/ui/public/plugins-view.mjs
@@ -58,12 +58,17 @@ export function renderPluginList(plugins, { doc = globalThis.document, channelSt
     head.appendChild(h(doc, 'span', 'pl-version mono', p.version || sha7(p.pinnedSha)));
     if (p.linked) head.appendChild(h(doc, 'span', 'badge waiting pl-linked', 'linked'));
     if (p.broken) head.appendChild(h(doc, 'span', 'badge red pl-broken', 'broken'));
+    // Enabling a plugin acts on a live system the moment it flips, so it reads
+    // as a switch. `.switch` MUST be the input's immediate next sibling — the
+    // `.sw-input:checked + .switch` rule is what paints the on state.
     const toggle = h(doc, 'label', 'pl-enable');
-    const cb = h(doc, 'input', 'pl-toggle');
+    const cb = h(doc, 'input', 'sw-input pl-toggle');
     cb.type = 'checkbox';
     cb.checked = p.enabled !== false;
     cb.dataset.name = p.name;
+    cb.setAttribute('aria-label', `Enable ${p.name}`);
     toggle.appendChild(cb);
+    toggle.appendChild(h(doc, 'span', 'switch switch-sm'));
     toggle.appendChild(h(doc, 'span', '', p.enabled !== false ? 'enabled' : 'disabled'));
     head.appendChild(toggle);
     card.appendChild(head);

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -3177,6 +3177,152 @@ body.rail-collapsed .ask-dock{left:76px;}
    instead; body.view-history/.view-running .main keep padding:0 by specificity. */
 .main,.run-screen-list,.hist-screen-list,.rd-body,.hd-body{padding-bottom:var(--ask-dock-clearance);}
 
+/* ---------- native control skins (checkbox / radio / switch / rows) -------- */
+/* Everything the browser used to draw for itself. The mark is the one .qopt
+   already draws (:761): a 1.5px --radio-ring hairline on --panel that fills
+   --green behind a white glyph, so "chosen" reads identically on a question
+   option, a checkbox, a chip and a whole row.
+   Styling the REAL <input> through appearance:none — rather than hiding it
+   behind a span — is what lets every existing emitter keep its markup:
+   :checked, :disabled, :indeterminate, label clicks and keyboard all keep
+   working with no JS. NOTHING here sets `display`, so the hidden inputs behind
+   the segmented controls (#mock, [name=target], [name=source]) stay hidden. */
+
+/* Net for anything never hand-skinned (a future <progress>, a date input, the
+   OS spell-check UI): brand green instead of the OS accent. */
+:root{accent-color:var(--green);}
+
+input[type="checkbox"],
+input[type="radio"]{
+  appearance:none;-webkit-appearance:none;
+  flex:0 0 auto;width:18px;height:18px;margin:0;padding:0;
+  border:1.5px solid var(--radio-ring);border-radius:6px;
+  background:var(--panel);cursor:pointer;vertical-align:middle;
+  transition:background-color .14s,border-color .14s;}
+input[type="radio"]{border-radius:50%;}
+input[type="checkbox"]:hover:not(:disabled),
+input[type="radio"]:hover:not(:disabled){border-color:var(--ink-3);}
+/* the identical white tick .qopt.sel uses */
+input[type="checkbox"]:checked{border-color:var(--green);
+  background:var(--green) center/11px 11px no-repeat url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3.6' stroke-linecap='round' stroke-linejoin='round'><path d='M5 13l4 4L19 7'/></svg>");}
+/* "some of these are on" — set from JS, there is no HTML attribute for it */
+input[type="checkbox"]:indeterminate{border-color:var(--green);
+  background:var(--green) center/11px 11px no-repeat url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3.6' stroke-linecap='round'><path d='M6 12h12'/></svg>");}
+/* ring, white gap and dot from one inset shadow — no pseudo-element, which a
+   replaced element cannot be relied on to render */
+input[type="radio"]:checked{border-color:var(--green);background:var(--green);
+  box-shadow:inset 0 0 0 3.5px var(--panel);}
+/* disabled reads as "fixed" (a manifest locked it), never as "broken" */
+input[type="checkbox"]:disabled,
+input[type="radio"]:disabled{background:var(--field);border-color:var(--line-2);cursor:not-allowed;}
+/* the :disabled rule above uses the `background` shorthand, which drops the
+   glyph :checked painted — so a locked-on box has to restate it */
+input[type="checkbox"]:disabled:checked{border-color:var(--seq);
+  background:var(--seq) center/11px 11px no-repeat url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23fff' stroke-width='3.6' stroke-linecap='round' stroke-linejoin='round'><path d='M5 13l4 4L19 7'/></svg>");}
+input[type="radio"]:disabled:checked{background:var(--seq);border-color:var(--seq);
+  box-shadow:inset 0 0 0 3.5px var(--panel);}
+input[type="checkbox"]:focus-visible,
+input[type="radio"]:focus-visible{outline:2px solid var(--ink);outline-offset:2px;}
+/* markdown task lists (:3019 sets the gap; the blanket margin:0 above would
+   otherwise win on source order) */
+.ask-md input[type="checkbox"]{margin-right:6px;}
+
+@media (prefers-contrast:more),(forced-colors:active){
+  input[type="checkbox"],input[type="radio"]{border-color:CanvasText;}
+  input[type="checkbox"]:checked,input[type="radio"]:checked{background-color:Highlight;border-color:Highlight;}
+}
+
+/* ---- switch driven by a real checkbox ----
+   .switch (:470) is a <div role="switch"> mirrored to a hidden input by hand
+   (app.js#wireMockSwitch). One sibling selector lets the SAME pixels be driven
+   by a real <input type=checkbox>, so a new switch needs no JS and keeps its
+   semantics for free. Both spellings work; the existing .on emitters are
+   untouched. */
+.sw-input{position:absolute;width:1px;height:1px;opacity:0;margin:0;pointer-events:none;}
+.switch.on,
+.sw-input:checked + .switch{background:var(--green);}
+.switch.on::after,
+.sw-input:checked + .switch::after{left:21px;}
+.sw-input:focus-visible + .switch{outline:2px solid var(--ink);outline-offset:2px;}
+.sw-input:disabled + .switch{opacity:.5;cursor:not-allowed;}
+/* A 20px track needs more room between rows than the 13px box it replaced. */
+.chat-event-row,.chat-channel-row{margin:8px 0;gap:10px;}
+.switch.switch-sm{width:34px;height:20px;}
+.switch.switch-sm::after{width:15px;height:15px;top:2.5px;left:2.5px;}
+.sw-input:checked + .switch.switch-sm::after{left:16.5px;}
+
+/* ---- checkbox rows inside a .field ----
+   .check-row carried NO rule, so `.field > label` (:304) claimed it: block,
+   600 weight, 13px, 8px bottom margin — which is why "No cap" rendered as a
+   heading welded to its box. Equal specificity class-count, so the qualified
+   selectors are what win. */
+.check-row{display:inline-flex;align-items:center;gap:9px;cursor:pointer;user-select:none;
+  font-weight:500;font-size:12.5px;color:var(--ink-2);}
+.field > label.check-row,
+.field > label.fanout-toggle{display:inline-flex;margin-bottom:0;font-weight:500;}
+
+/* ---- selectable rows ----
+   .qopt generalised: when a choice carries more than a word (a name plus a
+   badge, a path, a model id) the row itself is the target and the whole row
+   shows the selection. Appended here, so it wins the source-order tie against
+   the .grv-source-row / .wiz-proj / .mvx-model base rules those emitters keep
+   for their own layout; their qualified rules (.wiz-proj.missing) still win. */
+.opt-row{display:flex;align-items:center;gap:11px;width:100%;
+  padding:12px 15px;background:var(--panel);border:1.5px solid var(--line);
+  border-radius:13px;cursor:pointer;font-size:13.5px;font-weight:500;
+  color:var(--ink);transition:background .14s,border-color .14s;}
+.opt-row:hover{border-color:var(--ink-3);}
+.opt-row:has(input:checked){background:var(--green-bg);border-color:var(--green);}
+.opt-row:has(input:disabled){opacity:.55;cursor:not-allowed;background:var(--field);}
+.opt-row:has(input:focus-visible){outline:2px solid var(--ink);outline-offset:2px;}
+.opt-row .opt-name{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.opt-row .opt-sub{flex:0 0 auto;font:400 11.5px var(--mono);color:var(--ink-3);}
+.wiz-proj-list{gap:8px;}
+
+/* ---- chips ----
+   .chip-select (:1400) already drew the pill and never had a selected state,
+   so the box inside was carrying it alone. */
+.chip-select label{transition:background .14s,border-color .14s;}
+.chip-select label:hover{border-color:var(--ink-3);}
+.chip-select label:has(input:checked){background:var(--green-bg);border-color:var(--green);}
+.chip-select label:has(input:disabled){opacity:.55;cursor:not-allowed;}
+.chip-select input{width:14px;height:14px;border-radius:5px;}
+
+/* ---- confirm/prompt modal internals ---- */
+.confirm-field{margin-bottom:14px;}
+.confirm-field > label{display:block;font-weight:600;font-size:12.5px;margin-bottom:6px;}
+.confirm-field .input{font-size:13.5px;padding:11px 14px;}
+.confirm-field .hint.err{color:var(--red-ink);}
+.confirm-checkbox{display:flex;align-items:flex-start;gap:10px;margin:0 0 4px;padding:12px 14px;
+  background:var(--field);border-radius:12px;font-size:12.5px;color:var(--ink-2);
+  cursor:pointer;line-height:1.45;}
+.confirm-checkbox.hidden{display:none;}
+.confirm-modal .card h2.danger{color:var(--red-ink);}
+
+/* ---- the rest of the UA chrome ---- */
+/* min/max/step are there to validate, not to be clicked */
+input[type="number"]{-moz-appearance:textfield;}
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button{-webkit-appearance:none;margin:0;}
+/* the WebKit search "x" is grey-on-grey and off-grid; .field-clear replaces it */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration{-webkit-appearance:none;}
+.field-clear{position:absolute;right:10px;top:50%;transform:translateY(-50%);
+  width:18px;height:18px;border:none;border-radius:50%;background:var(--line-2);
+  color:var(--ink-2);font:600 11px/1 var(--sans);cursor:pointer;display:grid;
+  place-items:center;padding:0;}
+.field-clear:hover{background:var(--ink-3);color:#fff;}
+.field-clear[hidden]{display:none;}
+/* the OS disclosure triangle, everywhere — .advanced (:601) already did it locally */
+.disclosure > summary{list-style:none;cursor:pointer;display:flex;align-items:center;gap:8px;}
+.disclosure > summary::-webkit-details-marker{display:none;}
+.disclosure > summary::before{content:"";width:0;height:0;flex:0 0 auto;
+  border:4.5px solid transparent;border-left-color:var(--ink-3);
+  transition:transform .16s;transform-origin:2px 50%;}
+.disclosure[open] > summary::before{transform:rotate(90deg);}
+/* Firefox has no ::-webkit-scrollbar, so :899 never reaches it */
+html{scrollbar-color:var(--line-2) transparent;scrollbar-width:thin;}
+
 /* ---------- reduced motion for the Running redesign ---------- */
 /* MUST be the LAST block in the file: @media contributes no specificity, so a
    (0,1,0) `animation:none` here would LOSE the source-order tie against any

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -3239,6 +3239,11 @@ input[type="radio"]:focus-visible{outline:2px solid var(--ink);outline-offset:2p
    semantics for free. Both spellings work; the existing .on emitters are
    untouched. */
 .sw-input{position:absolute;width:1px;height:1px;opacity:0;margin:0;pointer-events:none;}
+/* The checkbox is position:absolute; without a positioned wrapper its
+   containing block is the viewport, so its static position sits near the top
+   of the page — clicking the switch focuses it and the browser scrolls that
+   into view, jerking the whole viewport up. Anchor it to its own row. */
+:where(label, div, span):has(> .sw-input){position:relative;}
 .switch.on,
 .sw-input:checked + .switch{background:var(--green);}
 .switch.on::after,


### PR DESCRIPTION
## The problem

`style.css` had **no rule for `input[type="checkbox"]` or `[type="radio"]`** and no `accent-color`, so 13 checkbox sites and one radio group rendered in the operating system's accent — sitting next to fully-skinned buttons, selects and the custom `.switch`. Eight flows still went through `window.confirm` / `window.prompt`, including all four destructive deletes, despite `confirmModal()` already existing with eleven callers.

## The idea

**The mark already exists.** `.qopt` (style.css:761) draws a 1.5px `--radio-ring` hairline on `--panel` that fills `--green` behind a white tick. Every control here inherits that one mark, so "chosen" reads identically whether it's a question option, a checkbox, a chip or a whole row. No new visual vocabulary.

Styling the **real `<input>`** through `appearance:none` — rather than hiding it behind a span — is what lets 8 of the 13 sites be fixed by CSS alone, with `:checked`, `:disabled`, `:indeterminate`, label clicks and keyboard all still free. Nothing in the base rule sets `display`, so the hidden inputs behind the segmented controls (`#mock`, `[name=target]`, `[name=source]`) stay hidden.

## What changed

**Checkbox / radio** — 18px rounded square (circle for radio), `--seq` grey when locked-on so a manifest-fixed toggle reads as *fixed*, never *broken*. The radio dot is one `inset box-shadow`, no pseudo-element on a replaced element.

**Switch** — `.sw-input:checked + .switch` lets the existing `.switch` pixels (a `<div role="switch">` hand-mirrored in JS at app.js#wireMockSwitch) be driven by a real checkbox, so a switch now costs zero JS. The rule for which sites convert: **switch = acts on a live system the moment you flip it** (plugin enable, chat notify-on, chat channel); **checkbox = form state you then Save** (efforts, export picker, wizard projects, fan-out/questions, No cap, the purge opt-in). Four convert, nine keep the box. The existing `.on` emitters are untouched.

**`.opt-row`** — `.qopt` generalised for choices carrying more than a word: guardrails starting point, workspace wizard projects, model export picker. A missing project now reads as missing instead of "unchecked-ish". Appended after the `.wiz-proj` / `.grv-source-row` / `.mvx-model` base rules, which it ties with on specificity — source order is what lets it win, and their qualified rules (`.wiz-proj.missing`) still do.

**`.check-row` was a live layout bug** — it carried no rule at all, so `.field > label` (style.css:304) claimed it: `display:block`, 600 weight, 13px. That is why "No cap" (index.html:1240) rendered as a bold heading welded to its box.

**Dialogs** — `promptModal()` joins `confirmModal()` on one `modalShell()`. The two flows that fired two blocking prompts back to back (pipeline name + domain, profile id + label) now ask once, with live validation on required fields. All four destructive deletes pass `danger: true`, which tints the title and OK button red — that option already existed and nobody was passing it. The retained-worktree warning stops repeating its own question and verb now that a title and a Discard button carry them.

**The rest** — number steppers, the WebKit search "x", the OS disclosure triangle (`.disclosure`), `scrollbar-color` for Firefox, and `accent-color: var(--green)` on `:root` as a net for anything never hand-skinned.

## Scope

| | |
|---|---|
| CSS only, no code touched | 8 sites |
| One-line markup change | 7 sites |
| Dialog call sites migrated | 8 (+ `promptModal`) |

`window.confirm` / `window.prompt` now have **zero call sites**; `ui-control-skins.test.mjs` asserts they stay that way.

## Design doc

`docs/ui-primitives/mockup.html` — a standalone before/after page (open it straight from disk). Its `#patch` block is literally the diff applied to `style.css`, and §9 is the migration map. Worth opening next to the diff when reviewing.

## Testing

**3735 pass, 0 fail** (3718 before; +17 new in `ui-control-skins.test.mjs`).

Tests that used to stub `window.confirm`/`prompt` now drive the real dialog through the new `test/helpers/confirm-modal.mjs`. Five test files updated; no assertion was weakened — `ui-history-detail` still asserts the discard copy, just read off the modal instead of the stub.

Also verified in Chrome against the running app (`WORCA_MOCK=1`): agents accordion (incl. the locked-on Questions box), plugins enable switch, chat settings, guardrails wizard, workspace wizard, model export picker, and all four dialog shapes — plain confirm, danger confirm, confirm-with-purge-checkbox, and the two-field promptModal.

Two things worth a reviewer's eye:
- `:has()` is used for the `.opt-row` / `.chip-select` selected states. Already in use at style.css:536, so no new baseline.
- The new section is inserted **before** the final `@media (prefers-reduced-motion)` block, which style.css:3180 documents must stay last. A test guards that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)