### PR TITLE
fix: remove plugin symlinks with unlink, not rmSync

### DIFF
--- a/src/core/plugin-repo.mjs
+++ b/src/core/plugin-repo.mjs
@@ -10,7 +10,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createHash } from 'node:crypto';
-import { mkdirSync, existsSync, rmSync } from 'node:fs';
+import { mkdirSync, existsSync, rmSync, unlinkSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -302,7 +302,10 @@ export async function exportVersion(name, sha, { exec = defaultExec, repoUrl, su
   }
   const warnings = [];
   for (const rel of findEscapingSymlinks(versionDir)) {
-    rmSync(join(versionDir, rel), { force: true });
+    // unlink, not rmSync: rmSync stats THROUGH the link, so a link to a
+    // directory throws ERR_FS_EISDIR and a dangling one (the common escaping
+    // case) reads as "already gone" and survives force:true (Node 23).
+    unlinkSync(join(versionDir, rel));
     warnings.push(`removed symlink escaping the export dir: ${rel}`);
   }
   return { versionDir, warnings };

--- a/src/core/plugin-store.mjs
+++ b/src/core/plugin-store.mjs
@@ -11,7 +11,7 @@ import { promisify } from 'node:util';
 import { createHash } from 'node:crypto';
 import {
   existsSync, readdirSync, readFileSync, readlinkSync,
-  mkdirSync, rmSync, symlinkSync, renameSync,
+  mkdirSync, rmSync, symlinkSync, renameSync, unlinkSync,
 } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { WORCA_PLUGIN_APIS } from './plugin-api.mjs';
@@ -161,6 +161,18 @@ function currentTarget(name) {
   try { return readlinkSync(pluginCurrentDir(name)); } catch { return null; }
 }
 
+// rmSync is the wrong primitive for a POSIX path that may be a symlink: it
+// stats THROUGH the link, so a link to a directory throws ERR_FS_EISDIR and a
+// DANGLING link reads as "already gone" and survives force:true (Node 23).
+// unlink removes the link itself; the fallback covers a real directory
+// (test fixtures build `current` as a plain dir).
+const rmLink = (path) => {
+  try { unlinkSync(path); return; } catch (err) {
+    if (err.code === 'ENOENT') return;
+  }
+  rmSync(path, { recursive: true, force: true });
+};
+
 /** Atomic swap (§6.1 step 3): write current.tmp symlink, rename(2) over current.
  *  Windows can't create a plain symlink without elevated privileges/Developer
  *  Mode, and can't rename() a directory reparse point over an existing one
@@ -177,7 +189,7 @@ function swapCurrent(name, target) {
     return;
   }
   const tmp = `${current}.tmp`;
-  rmSync(tmp, { force: true });
+  rmLink(tmp);
   symlinkSync(target, tmp);
   renameSync(tmp, current);
 }
@@ -186,9 +198,9 @@ function swapCurrent(name, target) {
  *  dir, restore/remove current, tidy now-empty dirs. Prior state untouched. */
 function cleanupFailedVersion(name, versionDir, prevCurrent) {
   rmSync(versionDir, { recursive: true, force: true });
-  rmSync(`${pluginCurrentDir(name)}.tmp`, { force: true });
+  rmLink(`${pluginCurrentDir(name)}.tmp`);
   if (prevCurrent) { try { swapCurrent(name, prevCurrent); } catch { /* best effort */ } }
-  else rmSync(pluginCurrentDir(name), { force: true });
+  else rmLink(pluginCurrentDir(name));
   for (const d of [join(pluginDir(name), 'versions'), pluginDir(name)]) {
     try { if (readdirSync(d).length === 0) rmSync(d, { recursive: true, force: true }); } catch { /* absent */ }
   }
@@ -352,7 +364,7 @@ export async function uninstallPlugin(name, { purge = false } = {}) {
   // a different tracker. Cleared HERE (not only in the server's DELETE route)
   // so the CLI's `worca plugin remove` drops them too.
   clearBindingsForPlugin(name);
-  rmSync(pluginCurrentDir(name), { force: true });
+  rmLink(pluginCurrentDir(name)); // symlink in real installs, a plain dir in test fixtures
   rmSync(join(pluginDir(name), 'versions'), { recursive: true, force: true });
   delete lock[name];
   writePluginsLock(lock);


### PR DESCRIPTION
## Problem

`fs.rmSync` stats **through** a symlink, which breaks the plugin store in two ways on Node 23 (observed on v23.11.0, macOS):

1. **Every plugin uninstall fails.** `uninstallPlugin` removed the store's `current` link (a symlink to the versioned install, e.g. `current -> versions/cbdd092`) with `rmSync(path, { force: true })`. rmSync resolves the link, sees a directory, and throws `ERR_FS_EISDIR: Path is a directory: ~/.worca-cc/plugins/<name>/current`.
2. **Dangling symlinks silently survive.** For a link whose target doesn't exist — the common shape of an *escaping* symlink — rmSync's stat gets ENOENT and `force: true` turns that into a no-op. `exportVersion` warned "removed symlink escaping the export dir" while leaving the link in place.

## Fix

- `plugin-store.mjs`: an `rmLink` helper — `unlinkSync` first (removes the link itself; handles dangling links), falling back to recursive `rmSync` for the plain-directory shape test fixtures build — used at the four possibly-a-symlink sites: uninstall, the atomic-swap `current.tmp` link (twice), and failed-install cleanup.
- `plugin-repo.mjs`: `exportVersion` uses `unlinkSync` directly; `findEscapingSymlinks` guarantees the path is a symlink.

## Tests

No new tests: the bug was already covered by existing tests that fail on Node 23 before this change and pass after it — `uninstallPlugin keeps data/ by default; purge removes everything`, `doctor + uninstall guard for plugin models`, `DELETE /api/plugins/:name … (409 + references)`, and `exportVersion: escaping symlink deleted with warning; internal symlink kept`. Full suite failure count drops from 16 to 8; the remaining 8 are unrelated environment issues (missing `@highlightjs/cdn-assets` dev install, `DatabaseSync.location()` not present on Node 23.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oqrCweC7rCUabA2AgLdGs