### PR TITLE
feat: Test button for catalog models in the Models view

### DIFF
--- a/src/core/model-test.mjs
+++ b/src/core/model-test.mjs
@@ -1,0 +1,79 @@
+// src/core/model-test.mjs
+// One minimal live claude spawn to verify a catalog model actually works —
+// the Models-view Test button (POST /api/models/:id/test). Mirrors the cheap
+// aux-run pattern of title.mjs: the model's catalog routing env travels with
+// the id via resolveModelEnv, no tools, low effort, hard timeout. Never
+// throws — the outcome is a result object either way.
+
+import { runClaude } from './claude-runner.mjs';
+import { resolveModelEnv } from './config.mjs';
+import { classifyError } from './recoverable-error.mjs';
+
+const TEST_TIMEOUT_MS = 60_000;
+const REPLY_CAP = 100;
+
+const SYSTEM = 'You are a connectivity check. Reply with exactly OK.';
+
+/** Actionable hint for a recovery class ('' when there is nothing to add —
+ *  the raw runner message already carries the detail). Pure, for tests. */
+export function hintFor(errorClass) {
+  switch (errorClass) {
+    case 'auth': return 'authentication failed — check the token/secret for this model';
+    case 'network': return 'endpoint unreachable — check ANTHROPIC_BASE_URL';
+    case 'rate_limit': return 'the endpoint is rate-limiting or overloaded — try again shortly';
+    case 'quota': return 'quota/billing problem — check the account behind this endpoint';
+    case 'usage_limit': return 'usage limit reached on the account behind this endpoint';
+    case 'timeout': return `no reply — the test timed out after ${TEST_TIMEOUT_MS / 1000}s`;
+    default: return '';
+  }
+}
+
+/**
+ * Live connectivity check for a catalog model id (global or plugin — the
+ * resolution precedence is resolveModelEnv's). Explicit user action only.
+ * @param {string} id catalog model id
+ * @param {{signal?:AbortSignal, bin?:string, run?:typeof runClaude}} [opts]
+ *   `run` is injectable for unit tests.
+ * @returns {Promise<{ok:true, text:string}|{ok:false, errorClass:(string|null), message:string, hint?:string}>}
+ */
+export async function testModel(id, { signal, bin, run = runClaude } = {}) {
+  const ctrl = new AbortController();
+  const onOuterAbort = () => ctrl.abort();
+  if (signal) {
+    if (signal.aborted) ctrl.abort();
+    else signal.addEventListener('abort', onOuterAbort, { once: true });
+  }
+  const timer = setTimeout(() => ctrl.abort(), TEST_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    const { text } = await run({
+      cwd: process.cwd(),
+      systemPrompt: SYSTEM,
+      prompt: 'Reply with exactly OK.',
+      model: id,
+      modelEnv: resolveModelEnv(id),
+      effort: 'low',
+      permissionMode: 'acceptEdits',
+      allowedTools: [],          // empty → no --allowedTools flag; pure text gen
+      signal: ctrl.signal,
+      bin,
+      onEvent: () => {},
+    });
+    const reply = String(text || '').split(/\r?\n/).map((l) => l.trim()).find((l) => l) || '';
+    if (!reply) {
+      return { ok: false, errorClass: null, message: 'the model returned an empty reply' };
+    }
+    return { ok: true, text: reply.slice(0, REPLY_CAP) };
+  } catch (err) {
+    if (err && err.name === 'AbortError') {
+      return { ok: false, errorClass: 'timeout', message: `Timed out after ${TEST_TIMEOUT_MS / 1000}s`, hint: hintFor('timeout') };
+    }
+    const message = err && err.message ? err.message : String(err);
+    const errorClass = (err && err.errorClass) || classifyError(message);
+    const hint = hintFor(errorClass);
+    return { ok: false, errorClass, message, ...(hint ? { hint } : {}) };
+  } finally {
+    clearTimeout(timer);
+    if (signal) signal.removeEventListener?.('abort', onOuterAbort);
+  }
+}

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -302,3 +302,31 @@ test('GET /api/plugins/:name/model-env: raw literals/refs for Edit-a-copy; secre
   assert.equal((await jfetch(`/api/plugins/ds-models/model-env?${q({ id: 'nope' })}`)).status, 400);
   assert.equal((await jfetch(`/api/plugins/ghost/model-env?${q({ id: 'x' })}`)).status, 404);
 });
+
+// ── model connectivity test (Models-view Test button) ────────────────────────
+
+test('POST /api/models/:id/test: 404 unknown id; 400 for a plugin model with an unset secret', async () => {
+  const r404 = await post('/api/models/no-such-model/test', {});
+  assert.equal(r404.status, 404);
+  assert.match(r404.body.error, /unknown model id/);
+
+  // A fresh plugin whose model references a secret nobody has set yet — the
+  // route must refuse before spawning anything.
+  const { writePluginsLock, readPluginsLock, pluginCurrentDir } = await import('../src/core/plugins-lock.mjs');
+  const { mkdirSync, writeFileSync } = await import('node:fs');
+  const cur = pluginCurrentDir('unset-plug');
+  mkdirSync(cur, { recursive: true });
+  writeFileSync(join(cur, 'worca-cc-plugin.json'), JSON.stringify({
+    name: 'unset-plug',
+    modelSecrets: [{ key: 'up-token', label: 'UP token' }],
+    models: [{ id: 'up-model', label: 'UP', env: { ANTHROPIC_AUTH_TOKEN: { secret: 'up-token' } } }],
+  }));
+  writePluginsLock({
+    ...readPluginsLock(),
+    'unset-plug': { repo: 'https://example.com/r', subdir: '', pinnedSha: 'x'.repeat(40), version: '1', enabled: true },
+  });
+
+  const r400 = await post('/api/models/up-model/test', {});
+  assert.equal(r400.status, 400);
+  assert.match(r400.body.error, /up-token.*not set/);
+});

--- a/test/model-test.test.mjs
+++ b/test/model-test.test.mjs
@@ -1,0 +1,80 @@
+// test/model-test.test.mjs — unit tests for the model connectivity check
+// (Models-view Test button). testModel takes an injectable `run` so no claude
+// binary is ever spawned; hintFor is pure.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { testModel, hintFor } from '../src/core/model-test.mjs';
+
+test('testModel: success returns ok + first-line capped reply and forwards the minimal run shape', async () => {
+  let seen = null;
+  const run = async (o) => { seen = o; return { text: '  OK\nsecond line ignored', exitCode: 0 }; };
+  const res = await testModel('glm-4.7', { run });
+  assert.deepEqual(res, { ok: true, text: 'OK' });
+  assert.equal(seen.model, 'glm-4.7');
+  assert.equal(seen.effort, 'low');
+  assert.deepEqual(seen.allowedTools, []);
+  assert.ok(seen.signal instanceof AbortSignal, 'timeout signal is wired');
+  assert.ok(seen.prompt.length > 0);
+  // modelEnv is whatever resolveModelEnv says for this id (undefined in the
+  // sandboxed test env) — the key must be NAMED in the call either way.
+  assert.ok('modelEnv' in seen);
+});
+
+test('testModel: long replies are capped', async () => {
+  const run = async () => ({ text: 'x'.repeat(500), exitCode: 0 });
+  const res = await testModel('m', { run });
+  assert.equal(res.ok, true);
+  assert.equal(res.text.length, 100);
+});
+
+test('testModel: run failure returns ok:false with the runner errorClass', async () => {
+  const run = async () => {
+    const err = new Error('claude exited with code 1: 401 authentication_error');
+    err.errorClass = 'auth';
+    throw err;
+  };
+  const res = await testModel('m', { run });
+  assert.equal(res.ok, false);
+  assert.equal(res.errorClass, 'auth');
+  assert.match(res.message, /authentication_error/);
+});
+
+test('testModel: errorClass falls back to classifyError on unstamped errors', async () => {
+  const run = async () => { throw new Error('ECONNREFUSED 127.0.0.1:9999'); };
+  const res = await testModel('m', { run });
+  assert.equal(res.ok, false);
+  assert.equal(res.errorClass, 'network');
+});
+
+test('testModel: abort surfaces as timeout', async () => {
+  const run = async ({ signal }) => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    if (signal?.aborted) throw err;
+    throw err; // caller-aborted before the spawn behaves the same
+  };
+  const ctrl = new AbortController();
+  ctrl.abort();
+  const res = await testModel('m', { signal: ctrl.signal, run });
+  assert.equal(res.ok, false);
+  assert.equal(res.errorClass, 'timeout');
+  assert.match(res.message, /[Tt]imed out|aborted/);
+});
+
+test('testModel: empty reply is a failure, not a silent pass', async () => {
+  const run = async () => ({ text: '   ', exitCode: 0 });
+  const res = await testModel('m', { run });
+  assert.equal(res.ok, false);
+  assert.match(res.message, /empty reply/i);
+});
+
+test('hintFor maps recovery classes to actionable text', () => {
+  assert.match(hintFor('auth'), /token|secret|authentication/i);
+  assert.match(hintFor('network'), /ANTHROPIC_BASE_URL|unreachable/i);
+  assert.match(hintFor('rate_limit'), /rate|overloaded/i);
+  assert.match(hintFor('quota'), /quota|billing|credit/i);
+  assert.match(hintFor('usage_limit'), /limit/i);
+  assert.match(hintFor('timeout'), /timed out/i);
+  assert.equal(hintFor(null), '');
+  assert.equal(hintFor('unknown-class'), '');
+});

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -239,3 +239,32 @@ test('export wizard: token LIMITS are not credentials (MAX_OUTPUT_TOKENS default
   assert.equal(mode('ANTHROPIC_AUTH_TOKEN'), 'secret');
   assert.equal(mode('API_KEY'), 'secret');
 });
+
+test('list: Test button on global + plugin cards (disabled while a secret is unset); built-ins get none', () => {
+  const el = renderModelsList({
+    globals: [GLOBAL],
+    plugins: PLUGINS,
+    predefined: PREDEFINED,
+    efforts: EFFORTS,
+  }, { doc });
+
+  const globalCard = el.querySelector('.mv-card:not(.mv-plugin):not(.mv-legacy)');
+  const gt = globalCard.querySelector('.mv-test');
+  assert.equal(gt.dataset.id, 'glm-4.7');
+  assert.equal(gt.disabled, false);
+  assert.ok(globalCard.querySelector('.mv-test-result'), 'result line present');
+
+  const cards = [...el.querySelectorAll('.mv-plugin')];
+  const unsetBtn = cards[0].querySelector('.mv-test');
+  assert.equal(unsetBtn.dataset.id, 'ds-stable');
+  assert.equal(unsetBtn.dataset.plugin, 'team-models');
+  assert.equal(unsetBtn.disabled, true, 'unset secret disables Test');
+  assert.match(unsetBtn.title, /secret/);
+  const okBtn = cards[1].querySelector('.mv-test');
+  assert.equal(okBtn.disabled, false, 'no secrets → enabled');
+  assert.ok(cards[0].querySelector('.mv-test-result'), 'result line present');
+
+  for (const row of el.querySelectorAll('.mv-builtin')) {
+    assert.equal(row.querySelector('.mv-test'), null, 'no Test on built-ins');
+  }
+});

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -8815,6 +8815,32 @@ async function promoteModelFlow(id) {
   }
 }
 
+// Live connectivity check — explicit user action -> POST /api/models/:id/test
+// (mirrors the chat-test handler). Paints the card's own result line instead
+// of repainting the view, so an open editor survives the round trip.
+async function testModelFlow(btn) {
+  const id = btn.dataset.id;
+  const out = btn.closest('.mv-card')?.querySelector('.mv-test-result');
+  const paint = (text, err) => {
+    if (!out) return;
+    out.textContent = text;
+    out.className = `mv-test-result hint${err ? ' err' : ''}`;
+  };
+  btn.disabled = true;
+  paint('Testing…');
+  try {
+    const res = await fetch(`/api/models/${encodeURIComponent(id)}/test`, { method: 'POST' });
+    const data = await safeJson(res);
+    if (!res.ok) return paint(`✗ ${data.error || `HTTP ${res.status}`}`, true);
+    if (data.ok) return paint(`✓ replied: ${data.text}`);
+    paint(`✗ ${data.hint || data.message}`, true);
+  } catch (e) {
+    paint(`✗ ${e.message}`, true);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
 if (el.modelsList) {
   el.modelsList.addEventListener('click', (ev) => {
     const t = ev.target.closest('button');
@@ -8831,6 +8857,8 @@ if (el.modelsList) {
       promoteModelFlow(t.dataset.id);
     } else if (t.classList.contains('mv-copy')) {
       editPluginCopyFlow(t.dataset.plugin, t.dataset.id);
+    } else if (t.classList.contains('mv-test')) {
+      testModelFlow(t);
     } else if (t.classList.contains('mvx-export')) {
       exportPluginFlow();
     } else if (t.classList.contains('mvx-cancel')) {

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -64,6 +64,7 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
     body.appendChild(head);
     const bits = [m.id, effortsSummary(m.efforts, efforts), envSummary(m.env)].filter(Boolean);
     body.appendChild(h(doc, 'small', 'mv-summary hint', bits.join(' — ')));
+    body.appendChild(h(doc, 'small', 'mv-test-result hint')); // app.js paints the Test outcome here
     card.appendChild(body);
     const del = h(doc, 'button', 'btn-ghost mv-delete', 'Delete');
     del.type = 'button'; del.dataset.id = m.id;
@@ -71,6 +72,9 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
     const edit = h(doc, 'button', 'btn-ghost mv-edit', 'Edit');
     edit.type = 'button'; edit.dataset.id = m.id;
     card.appendChild(edit);
+    const tst = h(doc, 'button', 'btn-ghost mv-test', 'Test');
+    tst.type = 'button'; tst.dataset.id = m.id;
+    card.appendChild(tst);
     yours.appendChild(card);
   }
   root.appendChild(yours);
@@ -121,10 +125,19 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
         body.appendChild(h(doc, 'small', `mv-secret hint${s.set ? '' : ' err'}`,
           s.set ? `secret ${s.key}: set` : `secret ${s.key}: NOT SET — configure it in the plugin's settings`));
       }
+      body.appendChild(h(doc, 'small', 'mv-test-result hint')); // app.js paints the Test outcome here
       card.appendChild(body);
       const copy = h(doc, 'button', 'btn-ghost mv-copy', 'Edit a copy');
       copy.type = 'button'; copy.dataset.id = m.id; copy.dataset.plugin = m.plugin;
       card.appendChild(copy);
+      const tst = h(doc, 'button', 'btn-ghost mv-test', 'Test');
+      tst.type = 'button'; tst.dataset.id = m.id; tst.dataset.plugin = m.plugin;
+      if ((m.secrets || []).some((s) => !s.set)) {
+        // A test would only prove what the NOT SET line already says.
+        tst.disabled = true;
+        tst.title = 'set the plugin secret first';
+      }
+      card.appendChild(tst);
       plug.appendChild(card);
     }
     root.appendChild(plug);

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -85,6 +85,7 @@ import {
 import { listGlobalModels, addGlobalModel, updateGlobalModel } from '../src/core/settings.mjs';
 import { modelEnvRef } from '../src/core/model-env.mjs';
 import { listPluginModels, modelSecretsSchema, pluginModelSecretStatus } from '../src/core/plugin-models.mjs';
+import { testModel } from '../src/core/model-test.mjs';
 import { validateGuardrails } from '../src/core/guardrails.mjs';
 import {
   listBuiltinGuardrailSets, listGuardrailSets, readGuardrailSet,
@@ -3057,6 +3058,35 @@ app.delete('/api/models/:id', async (req, res) => {
   } catch (err) {
     // Throws only on an unknown id -> client error.
     return badRequest(res, err && err.message ? err.message : String(err));
+  }
+});
+
+// Live connectivity check for a catalog model — the Models-view Test button.
+// Explicit user action only (one real, tiny API call against wherever the
+// model routes). Caller mistakes get an HTTP status; the test OUTCOME rides a
+// 200 envelope, same convention as POST /api/chat/test. Ids resolve global
+// first, then plugin — resolveModelEnv's precedence.
+const modelTestsInFlight = new Set();
+app.post('/api/models/:id/test', async (req, res) => {
+  const id = String(req.params.id);
+  const lc = id.toLowerCase();
+  const global = listGlobalModels().find((m) => m.id.toLowerCase() === lc);
+  const plugin = global ? null : listPluginModels().find((m) => m.id.toLowerCase() === lc);
+  if (!global && !plugin) return res.status(404).json({ error: `unknown model id ${JSON.stringify(id)}` });
+  if (plugin && plugin.secrets.length) {
+    // Don't burn a spawn guaranteed to fail — resolveModelEnv drops unset secrets.
+    const unset = pluginModelSecretStatus(plugin.plugin)
+      .filter((s) => plugin.secrets.includes(s.key) && !s.set).map((s) => s.key);
+    if (unset.length) {
+      return badRequest(res, `secret ${unset.join(', ')} is not set — configure it in the plugin's settings`);
+    }
+  }
+  if (modelTestsInFlight.has(lc)) return badRequest(res, 'test already running for this model');
+  modelTestsInFlight.add(lc);
+  try {
+    res.json(await testModel(id));
+  } finally {
+    modelTestsInFlight.delete(lc);
   }
 });
 


### PR DESCRIPTION
## Why

Models installed from plugins (and global entries with custom routing env) are the entries most likely to silently not work — wrong base URL in the manifest, expired or mistyped secret, unreachable endpoint — and the only way to find out was to wire the model into a pipeline and watch the run fail.

## What

A **Test** button on plugin and global model cards in the Models view. One click does a single minimal live `claude` spawn with the model's resolved routing env and paints an actionable outcome into the card. Built-in cards get no button (ambient login; nothing to verify). Explicit user action only — nothing triggers a test automatically.

- **`src/core/model-test.mjs`** — `testModel(id)`: mirrors `title.mjs`'s cheap aux-run pattern (`resolveModelEnv`, no tools, `effort: 'low'`, 60s hard timeout). Never throws; returns `{ok, text}` or `{ok, errorClass, message, hint}`. `hintFor` maps the runner's recovery classes to hints (`auth` → check the token/secret, `network` → check `ANTHROPIC_BASE_URL`, …). An empty reply is a failure, not a silent pass. The runner is injectable, so tests never spawn.
- **`POST /api/models/:id/test`** — id resolves global-first then plugin (same precedence as `resolveModelEnv`); 404 unknown id; 400 while a plugin secret is unset (never burns a spawn guaranteed to fail) or while a test for the same id is already in flight; the outcome rides a 200 envelope, same convention as `POST /api/chat/test`.
- **`models-view.mjs`** — `mv-test` button + `mv-test-result` line on global and plugin cards; disabled with a tooltip while a plugin secret is unset. Renderers stay pure/detached.
- **`app.js`** — one delegated `mv-test` branch; paints the card's own result line so an open editor survives the round trip.

Cost note: a test is a real (tiny) API call against wherever the model routes; a direct `runClaude` call records nothing into cost tracking, so no budget bypass is needed.

## Tests

- `test/model-test.test.mjs` (new): success/cap/error-class/timeout/empty-reply via an injected runner; `hintFor`.
- `test/api-models.test.mjs`: 404 unknown id; 400 for a plugin model with an unset secret (plugin fixture).
- `test/models-view.test.mjs`: button on global + plugin cards, disabled-on-unset-secret, result line, no button on built-ins.

Tested manually in the UI: success reply, network-hint on a wrong base URL, disabled button on unset secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oqrCweC7rCUabA2AgLdGs