### PR TITLE
feat: opt-in per-model cost override for endpoints that report no cost

### DIFF
--- a/configurable-models-design.md
+++ b/configurable-models-design.md
@@ -157,6 +157,26 @@ No destructive auto-migration. Transition plan:
 
 **UI:** a dedicated **Models view** in the sidebar (precedent: Guardrails and Plugins are full views with their own stores — `guardrail-store.mjs`, `plugins-view.mjs`). Per entry: label, id, effort checkboxes, env editor with masked values and reserved-key errors inline, cost-unreliable badge, delete with dangling-ref confirmation. The `+ Add model…` dropdown item in `renderModelEffortPair()` (`app.js:2547-2570`) navigates to this view; the `window.prompt()` flow (`app.js:2997-3120`) is deleted.
 
+### 4.11 Pricing override (opt-in)
+
+§4.6 flags an endpoint that reports *no* cost, but the harder case is the endpoint that reports none and gets one **invented** for it: the Claude CLI computes `total_cost_usd` from its own price table keyed on the model **name**, so an on-prem or proxied model named like a public one is billed as that public model. worca has no price table of its own, so a free on-prem run was priced at the public rate — and `costUnreliable` cannot see it, because a fabricated positive cost is indistinguishable from a real one.
+
+A catalog entry may therefore carry an optional `cost`:
+
+```json
+{ "id": "discreetstack", "env": { "ANTHROPIC_BASE_URL": "…" },
+  "cost": { "perMtok": { "input": 0.5, "output": 1.5, "cacheRead": 0.05, "cacheWrite": 0.6, "cacheWrite1h": 1.2 } } }
+```
+
+- `{"free": true}` — recorded spend is always $0.
+- `{"perMtok": {...}}` — the CLI figure is **discarded** and the cost recomputed from the run's reported token usage (USD per million tokens; the ephemeral 1h/5m cache-write buckets are priced separately, 1h falling back to the `cacheWrite` rate when unset).
+
+**Opt-in**: with no `cost`, the CLI value stands exactly as before. Ported from worca 0.x's `cost_alias` / `worca.pricing.models`.
+
+`resolveModelCost` is the single chokepoint, applied at **every** surface that books spend — they share one windowed budget (`cost-budget.mjs` `combinedWindowedSpendUsd`), so re-pricing only some would leave the phantom spend inflating it from the others: the orchestrator's result intake and sub-agent telemetry, an Ask Worca turn (via a `resolveCost` hook injected into the reducer, keeping `ask/events.mjs` free of config/DB deps), and the overview agent's telemetry row. Two rules keep it honest: only a genuinely cost-bearing terminal `result` may be re-priced (a `{free}` override answers $0 for *any* input, so an ungated call would book a real $0 per stream frame), and a `{perMtok}` model whose result carried **no usage at all** is *unpriceable* — reported, never silently booked at $0. A model with an override is never `costUnreliable`-flagged, and a stale flag is lifted.
+
+**UI**: a *Pricing* section in the model editor — *Trust the CLI* (default) / *Free ($0)* / *Per million tokens* with the five rate inputs — plus a free/priced badge and rate summary on catalog cards. Validation lives server-side only (`assertModelCost`); the form surfaces the API's message. Plugin models carry the same field (§9.1).
+
 ## 5. Testing
 
 - **settings.mjs**: catalog reader sanitization (malformed entries dropped loudly), setter rejections (dup id, reserved env key, non-string env value), unknown-key survival on write.
@@ -211,7 +231,8 @@ A team member configures a custom model locally, adapts pipelines to it, and wan
         "ANTHROPIC_BASE_URL": "https://api.discretestack.com",
         "API_TIMEOUT_MS": "3000000",
         "ANTHROPIC_AUTH_TOKEN": { "secret": "discretestack-token" }
-      } }
+      },
+      "cost": { "perMtok": { "input": 0.5, "output": 1.5 } } }
   ],
   "modelSecrets": [
     { "key": "discretestack-token", "label": "DiscreteStack API token" }
@@ -221,7 +242,11 @@ A team member configures a custom model locally, adapts pipelines to it, and wan
 
 Env values take three forms: a **literal** string (travels verbatim — base URLs, timeouts, tier remaps), a whole-value **`${VAR}` ref** (travels as text, expanded from the teammate's process env at spawn resolution — existing `model-env.mjs` semantics), or a **secret placeholder** `{"secret": "<key>"}` referencing a plugin-level `modelSecrets` entry. Secrets are plugin-level, not per-model, so N models sharing one token prompt for it once.
 
-Validation (`plugin-manifest.mjs`, install fails on error): model ids non-empty + case-insensitively unique within the plugin, efforts a subset of `EFFORTS`, env keys pass `isReservedModelEnvKey` (the same write-time gate as `POST /api/models` — the spawn-time `prepareModelEnv` drop stays as the second gate), every `{"secret"}` ref names a declared `modelSecrets` key, `modelSecrets` keys match the config-field `KEY_RE` and are unique. Unknown fields warn (error under `--strict`), like everything else in the manifest.
+`cost` is the optional per-model **pricing override** (§4.11), in the same shape a global catalog entry uses: `{"free": true}` or `{"perMtok": {...}}` in USD per million tokens. A plugin distributing a model on its own endpoint is precisely the case the Claude CLI prices from its internal table keyed on the model **name**, so the price travels **with** the model rather than having to be re-pinned by hand on every machine that installs the plugin. It is configuration, never a credential: unlike env values it is surfaced unmasked and is carried verbatim by *Share as plugin*.
+
+Validation (`plugin-manifest.mjs`, install fails on error): model ids non-empty + case-insensitively unique within the plugin, efforts a subset of `EFFORTS`, env keys pass `isReservedModelEnvKey` (the same write-time gate as `POST /api/models` — the spawn-time `prepareModelEnv` drop stays as the second gate), every `{"secret"}` ref names a declared `modelSecrets` key, `modelSecrets` keys match the config-field `KEY_RE` and are unique, and `cost` passes `assertModelCost` — the SAME validator `settings.mjs` runs on a global entry, shared from the zero-import leaf `model-env.mjs` so neither catalog layer has to import the other. Unknown fields warn (error under `--strict`), like everything else in the manifest.
+
+Pricing follows the same precedence as the rest of a model's configuration (§9.3): `modelCostConfig` takes the user's **global** entry when one exists, else the winning **plugin** entry's manifest price. A global entry shadows the plugin's price even when it pins none — taking over a model id means owning its pricing too, so the two layers can never half-merge. *Edit a copy* therefore seeds the copy with the plugin's pricing.
 
 ### 9.2 Catalog composition: a fourth layer
 

--- a/src/core/ask/events.mjs
+++ b/src/core/ask/events.mjs
@@ -129,6 +129,11 @@ const resultText = (content) => {
  * @param {(p:{toolUseId:string, input:object, childOk:boolean|null})=>void} [o.onProposal]
  * @param {(p:{runId:string})=>void} [o.onCommentMutation]  a successful MCP-side comment write
  * @param {Record<string,string>} [o.attachmentNames]  id → display name (labels only)
+ * @param {(cliCostUsd:number, usage:object)=>number} [o.resolveCost]  re-price the
+ *   turn: given what the CLI reported and this turn's usage, return the
+ *   AUTHORITATIVE cost. Injected (rather than imported) to keep this reducer free
+ *   of config/DB dependencies. Default: trust the CLI. A non-finite return, or a
+ *   throw, falls back to the CLI figure.
  * @param {object} [o.limits]
  */
 export function createTurnReducer({
@@ -140,6 +145,7 @@ export function createTurnReducer({
   onProposal = null,
   onCommentMutation = null,
   attachmentNames = {},
+  resolveCost = null,
   limits = ASK_LIMITS,
 } = {}) {
   const startedAt = now();
@@ -194,7 +200,32 @@ export function createTurnReducer({
   // usage never feeds it — a result would report the whole turn, not one call.
   const ctxNow = () => { const e = lastMainUsageMsg ? usageByMsg.get(lastMainUsageMsg) : null; return e ? ctxOf(e.usage) : null; };
   const currentUsage = () => ({ ...(lastResult && lastResult.usage ? normalizeUsage(lastResult.usage) : usageSum()), ctx: ctxNow() });
-  const currentCost = () => (lastResult && typeof lastResult.total_cost_usd === 'number' && Number.isFinite(lastResult.total_cost_usd) ? lastResult.total_cost_usd : null);
+  /** What the CLI itself reported for this turn — null until the `result` frame lands. */
+  const cliCost = () => (lastResult && typeof lastResult.total_cost_usd === 'number' && Number.isFinite(lastResult.total_cost_usd) ? lastResult.total_cost_usd : null);
+  // The AUTHORITATIVE turn cost: cliCost() re-priced by the injected override, if
+  // any. Memoized on lastResult — resolveCost reads the model catalog off disk, and
+  // this is read by every ask-usage frame as well as finish()/snapshot(). null
+  // (no `result` frame seen) is NOT a price and is never re-priced: ask spec §6.2.8
+  // makes null mean "no cost observed", which the ledger writer no-ops on.
+  let costMemo = null;
+  const currentCost = () => {
+    const raw = cliCost();
+    if (raw === null || !resolveCost) return raw;
+    if (!costMemo || costMemo.src !== lastResult) {
+      let v = raw;
+      try { const r = resolveCost(raw, currentUsage()); if (Number.isFinite(r)) v = r; }
+      catch { /* a pricing override must never break a turn */ }
+      costMemo = { src: lastResult, value: v };
+    }
+    return costMemo.value;
+  };
+  /** authoritative ÷ CLI — the factor the per-agent cost split must ride (1 when no override applies). */
+  const costScale = () => {
+    const raw = cliCost();
+    if (raw === null || !(raw > 0)) return 1;
+    const resolved = currentCost();
+    return resolved === null ? 1 : resolved / raw;
+  };
   const emitUsage = () => emit('ask-usage', { usage: currentUsage(), costUsd: currentCost() });
   const flushDeltas = () => {
     if (timer !== null) { clearT(timer); timer = null; }
@@ -455,7 +486,14 @@ export function createTurnReducer({
       const agents = blocks.filter((b) => b.kind === 'agent');
       if (agents.length && lastResult) {
         const est = estimateAgentCosts(agents, lastResult);
-        agents.forEach((a, i) => { a.costUsd = est[i].costUsd; });
+        // §6.6 splits the CLI's OWN modelUsage costUSD across agents. When an
+        // override re-prices the turn, the shares must ride the same scale or the
+        // agent rows out-total the turn they belong to (a free endpoint would show
+        // $0.00 overall next to agents billing real dollars).
+        const scale = costScale();
+        agents.forEach((a, i) => {
+          a.costUsd = est[i].costUsd == null ? null : Math.round(est[i].costUsd * scale * 1e6) / 1e6;
+        });
       }
       const text = mainText() || (lastResult && typeof lastResult.result === 'string' ? lastResult.result : '');
       summary = {

--- a/src/core/ask/turn.mjs
+++ b/src/core/ask/turn.mjs
@@ -16,7 +16,7 @@ import { join, dirname, resolve as pathResolve } from 'node:path';
 import { mkdir, writeFile, unlink } from 'node:fs/promises';
 
 import { runClaude } from '../claude-runner.mjs';
-import { resolveModelEnv } from '../config.mjs';
+import { resolveModelEnv, resolveModelCost } from '../config.mjs';
 import { worcaHome } from '../projects.mjs';
 import { generateTitle } from '../title.mjs';
 import { createTurnReducer } from './events.mjs';
@@ -68,6 +68,7 @@ class AskTurn extends EventEmitter {
       askLimits: deps.askLimits ?? askLimits,
       limits: deps.limits ?? ASK_LIMITS,
       resolveModelEnv: deps.resolveModelEnv ?? resolveModelEnv,
+      resolveModelCost: deps.resolveModelCost ?? resolveModelCost,
       worcaHome: deps.worcaHome ?? worcaHome,
       buildMcpConfig: deps.buildMcpConfig ?? buildMcpConfig,
       serverPath: deps.serverPath ?? ASK_MCP_SERVER_PATH,
@@ -153,6 +154,12 @@ class AskTurn extends EventEmitter {
       setTimeout: d.setTimeout,
       clearTimeout: d.clearTimeout,
       attachmentNames: this.attachmentNames,
+      // Ask spend feeds the SAME windowed budget as pipeline spend
+      // (cost-budget.mjs combinedWindowedSpendUsd), so an on-prem model the CLI
+      // prices by name inflates it from here too — re-price the turn exactly as
+      // the orchestrator's result intake does. Trusts the CLI when the model
+      // carries no override, which is the default.
+      resolveCost: (cliCostUsd, usage) => d.resolveModelCost(this.model, cliCostUsd, usage),
       limits: d.limits,
       onProposal: ({ input }) => this._onProposal(input),
       // The MCP child cannot broadcast; the parent turns its comment writes into
@@ -190,6 +197,10 @@ class AskTurn extends EventEmitter {
     await this._settle();
     const summary = this.reducer.finish();
     const finalStatus = kind === 'error' ? 'error' : status;
+    // Already AUTHORITATIVE: the reducer applied this turn's per-model cost
+    // override (the `resolveCost` hook in _makeReducer), so this one value is
+    // correct for all four sinks below — the message row, the thread totals, the
+    // budget ledger, and the ask-done frame.
     const costUsd = summary.costUsd;
     // Persist BEFORE broadcasting: a client re-fetch on the terminal frame must
     // never see a still-streaming row. finishMessage gets the FULL patch (B-5).

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -265,6 +265,14 @@ export function costUnreliableModelIds() {
  */
 export function observeModelCost(modelId, costUsd, usage) {
   if (!modelHasBaseUrlRouting(modelId)) return null;
+  // An explicit per-model cost override GOVERNS this model's spend (resolveModelCost
+  // below) — the CLI's own figure is never trusted for it, so the "unreliable"
+  // badge is meaningless. Never flag it, and lift any flag left from before the
+  // override existed. Derived state: a DB hiccup here must never fail the run.
+  if (modelCostConfig(modelId)) {
+    try { prepare('DELETE FROM model_cost_flags WHERE model_id = ?').run(String(modelId).trim()); } catch { /* derived */ }
+    return null;
+  }
   const u = usage && typeof usage === 'object' ? usage : {};
   const tokens = ['input_tokens', 'output_tokens', 'cache_creation_input_tokens', 'cache_read_input_tokens']
     .reduce((n, k) => n + (Number(u[k]) || 0), 0);
@@ -284,6 +292,70 @@ export function observeModelCost(modelId, costUsd, usage) {
     return 'flagged';
   }
   return null; // no cost AND no tokens (e.g. an errored run) — no signal either way
+}
+
+// ── per-model cost override (opt-in) ──────────────────────────────────────────
+// The Claude CLI computes total_cost_usd from its OWN per-model price table keyed
+// on the model NAME — so an on-prem/proxied endpoint (even one that returns no
+// cost) still gets a fabricated dollar figure, which observeModelCost cannot
+// distinguish from a real one once it is positive. A user who KNOWS a model's
+// real price (or that it is free) can pin it in the GLOBAL catalog; that override
+// then wins over whatever the CLI reports. Inspired by worca 0.x's cost_alias /
+// worca.pricing.models mechanism. Opt-in: with no override the CLI value stands.
+
+/** The explicit cost override for a model from the user's GLOBAL catalog, or
+ *  null. Shape: {free:true} | {perMtok:{input?,output?,cacheRead?,cacheWrite?,
+ *  cacheWrite1h?}} (USD per million tokens). Predefined/plugin models carry none
+ *  — pinning a price is a user-catalog concern. Never throws. */
+export function modelCostConfig(modelId) {
+  const id = typeof modelId === 'string' ? modelId.trim() : '';
+  if (!id) return null;
+  const lc = id.toLowerCase();
+  const entry = listGlobalModels().find((m) => m.id.toLowerCase() === lc);
+  return entry?.cost ?? null;
+}
+
+/** Estimate USD from a Claude result `usage` object and a per-million-token rate
+ *  table (mirrors worca 0.x estimate_cost). Absent rates/fields count as 0. When
+ *  the CLI breaks cache-creation into ephemeral 1h/5m buckets they are priced
+ *  separately (1h falls back to the cacheWrite rate); otherwise the flat
+ *  cache_creation_input_tokens total is priced at cacheWrite. */
+export function estimateCost(usage, perMtok) {
+  if (!perMtok || typeof perMtok !== 'object') return 0;
+  const u = usage && typeof usage === 'object' ? usage : {};
+  const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
+  const rate = (k) => num(perMtok[k]);
+  const cc = u.cache_creation && typeof u.cache_creation === 'object' ? u.cache_creation : null;
+  const eph1h = cc ? num(cc.ephemeral_1h_input_tokens) : 0;
+  const eph5m = cc ? num(cc.ephemeral_5m_input_tokens) : 0;
+  const cacheWriteCost = (eph1h || eph5m)
+    ? (eph5m * rate('cacheWrite')
+        + eph1h * (perMtok.cacheWrite1h != null ? rate('cacheWrite1h') : rate('cacheWrite'))) / 1e6
+    : num(u.cache_creation_input_tokens) * rate('cacheWrite') / 1e6;
+  return (
+    num(u.input_tokens) * rate('input')
+    + num(u.output_tokens) * rate('output')
+    + num(u.cache_read_input_tokens) * rate('cacheRead')
+  ) / 1e6 + cacheWriteCost;
+}
+
+/**
+ * The AUTHORITATIVE cost for a dispatched model: the CLI's own figure unless the
+ * model carries an explicit override, which then wins. {free} → $0; {perMtok} →
+ * recomputed from `usage`. This is what stops a CLI that prices an on-prem model
+ * by name from inflating the ledger. With no override, `cliCostUsd` is returned
+ * verbatim (finite or not — the caller already gates on Number.isFinite).
+ * @param {string} modelId  the dispatched model id
+ * @param {number} cliCostUsd  the cost the CLI reported (may be NaN)
+ * @param {object} [usage]  the result event's usage object
+ * @returns {number}
+ */
+export function resolveModelCost(modelId, cliCostUsd, usage) {
+  const cost = modelCostConfig(modelId);
+  if (!cost) return cliCostUsd;
+  if (cost.free) return 0;
+  if (cost.perMtok) return estimateCost(usage, cost.perMtok);
+  return cliCostUsd;
 }
 
 /**

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -260,16 +260,21 @@ export function costUnreliableModelIds() {
  * @param {string} modelId
  * @param {number|null} costUsd  the reported cost (null when absent)
  * @param {object} [usage]
+ * @param {object|null} [costCfg]  this model's already-looked-up cost override
+ *   (modelCostConfig). Pass it when the caller has one in hand — every lookup is
+ *   a fresh settings.json read (settings.mjs is deliberately uncached), and the
+ *   result path needs the same answer for resolveModelCost. `undefined` = look
+ *   it up here; `null` = "checked, there is none".
  * @returns {'flagged'|'cleared'|null} what changed — 'flagged' asks the caller
  *   to surface its one-per-run warning; null = no observation recorded
  */
-export function observeModelCost(modelId, costUsd, usage) {
+export function observeModelCost(modelId, costUsd, usage, costCfg = undefined) {
   if (!modelHasBaseUrlRouting(modelId)) return null;
   // An explicit per-model cost override GOVERNS this model's spend (resolveModelCost
   // below) — the CLI's own figure is never trusted for it, so the "unreliable"
   // badge is meaningless. Never flag it, and lift any flag left from before the
   // override existed. Derived state: a DB hiccup here must never fail the run.
-  if (modelCostConfig(modelId)) {
+  if (costCfg !== undefined ? costCfg : modelCostConfig(modelId)) {
     try { prepare('DELETE FROM model_cost_flags WHERE model_id = ?').run(String(modelId).trim()); } catch { /* derived */ }
     return null;
   }
@@ -302,6 +307,13 @@ export function observeModelCost(modelId, costUsd, usage) {
 // real price (or that it is free) can pin it in the GLOBAL catalog; that override
 // then wins over whatever the CLI reports. Inspired by worca 0.x's cost_alias /
 // worca.pricing.models mechanism. Opt-in: with no override the CLI value stands.
+//
+// It governs EVERY surface that books spend, because they share one windowed
+// budget (cost-budget.mjs combinedWindowedSpendUsd): the orchestrator's result
+// intake and sub-agent telemetry (orchestrator.mjs), an Ask Worca turn (the
+// `resolveCost` hook ask/turn.mjs injects into the reducer), and the overview
+// agent's telemetry row. Re-pricing only some of them would leave the phantom
+// spend this exists to remove still inflating the budget from the others.
 
 /** The explicit cost override for a model from the user's GLOBAL catalog, or
  *  null. Shape: {free:true} | {perMtok:{input?,output?,cacheRead?,cacheWrite?,
@@ -315,27 +327,55 @@ export function modelCostConfig(modelId) {
   return entry?.cost ?? null;
 }
 
-/** Estimate USD from a Claude result `usage` object and a per-million-token rate
- *  table (mirrors worca 0.x estimate_cost). Absent rates/fields count as 0. When
- *  the CLI breaks cache-creation into ephemeral 1h/5m buckets they are priced
- *  separately (1h falls back to the cacheWrite rate); otherwise the flat
- *  cache_creation_input_tokens total is priced at cacheWrite. */
+/** The four token classes read off a usage object, accepting BOTH spellings in
+ *  play here: the RAW Claude result usage (`input_tokens`, …) that the pipeline
+ *  path carries, and Ask Worca's normalized persisted shape (`input`, `output`,
+ *  `cacheRead`, `cacheCreation` — ask/events.mjs normalizeUsage). Same tokens,
+ *  two names; a missing field counts as 0. Only the raw shape ever carries the
+ *  ephemeral cache-creation breakdown. */
+function usageTokens(u) {
+  const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
+  const pick = (snake, camel) => (u[snake] != null ? num(u[snake]) : num(u[camel]));
+  const cc = u.cache_creation && typeof u.cache_creation === 'object' ? u.cache_creation : null;
+  return {
+    input: pick('input_tokens', 'input'),
+    output: pick('output_tokens', 'output'),
+    cacheRead: pick('cache_read_input_tokens', 'cacheRead'),
+    cacheWrite: pick('cache_creation_input_tokens', 'cacheCreation'),
+    eph1h: cc ? num(cc.ephemeral_1h_input_tokens) : 0,
+    eph5m: cc ? num(cc.ephemeral_5m_input_tokens) : 0,
+  };
+}
+
+/** True when `usage` is an object that actually reports token counts — i.e. it
+ *  can be priced. A result event that carried NO usage at all is unpriceable and
+ *  must not be silently booked at $0 (resolveModelCost returns NaN for it); an
+ *  object whose counts are genuinely all zero IS priceable, at $0. */
+export function isPriceableUsage(usage) {
+  if (!usage || typeof usage !== 'object') return false;
+  return ['input_tokens', 'output_tokens', 'cache_read_input_tokens', 'cache_creation_input_tokens',
+    'cache_creation', 'input', 'output', 'cacheRead', 'cacheCreation'].some((k) => usage[k] != null);
+}
+
+/** Estimate USD from a `usage` object (either spelling, see usageTokens) and a
+ *  per-million-token rate table (mirrors worca 0.x estimate_cost). Absent rates/
+ *  fields count as 0. When the CLI breaks cache-creation into ephemeral 1h/5m
+ *  buckets they are priced separately (1h falls back to the cacheWrite rate);
+ *  otherwise the flat cache_creation_input_tokens total is priced at cacheWrite. */
 export function estimateCost(usage, perMtok) {
   if (!perMtok || typeof perMtok !== 'object') return 0;
   const u = usage && typeof usage === 'object' ? usage : {};
   const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
   const rate = (k) => num(perMtok[k]);
-  const cc = u.cache_creation && typeof u.cache_creation === 'object' ? u.cache_creation : null;
-  const eph1h = cc ? num(cc.ephemeral_1h_input_tokens) : 0;
-  const eph5m = cc ? num(cc.ephemeral_5m_input_tokens) : 0;
-  const cacheWriteCost = (eph1h || eph5m)
-    ? (eph5m * rate('cacheWrite')
-        + eph1h * (perMtok.cacheWrite1h != null ? rate('cacheWrite1h') : rate('cacheWrite'))) / 1e6
-    : num(u.cache_creation_input_tokens) * rate('cacheWrite') / 1e6;
+  const t = usageTokens(u);
+  const cacheWriteCost = (t.eph1h || t.eph5m)
+    ? (t.eph5m * rate('cacheWrite')
+        + t.eph1h * (perMtok.cacheWrite1h != null ? rate('cacheWrite1h') : rate('cacheWrite'))) / 1e6
+    : t.cacheWrite * rate('cacheWrite') / 1e6;
   return (
-    num(u.input_tokens) * rate('input')
-    + num(u.output_tokens) * rate('output')
-    + num(u.cache_read_input_tokens) * rate('cacheRead')
+    t.input * rate('input')
+    + t.output * rate('output')
+    + t.cacheRead * rate('cacheRead')
   ) / 1e6 + cacheWriteCost;
 }
 
@@ -345,16 +385,27 @@ export function estimateCost(usage, perMtok) {
  * recomputed from `usage`. This is what stops a CLI that prices an on-prem model
  * by name from inflating the ledger. With no override, `cliCostUsd` is returned
  * verbatim (finite or not — the caller already gates on Number.isFinite).
+ *
+ * ONLY call this on a genuinely cost-bearing event. A {free} model answers 0 for
+ * ANY input, so feeding it a non-result stream frame (whose `cliCostUsd` is NaN)
+ * would turn "nothing to record" into a real $0 the caller then books.
+ *
+ * A {perMtok} model is priced from tokens ALONE, so a result that carried no
+ * usage object at all is UNPRICEABLE: NaN comes back rather than a silent $0, so
+ * the caller's existing "no cost estimate" branch reports it instead of the
+ * operator quietly under-billing a model they explicitly asked to be priced.
  * @param {string} modelId  the dispatched model id
  * @param {number} cliCostUsd  the cost the CLI reported (may be NaN)
- * @param {object} [usage]  the result event's usage object
+ * @param {object} [usage]  the result event's usage object (either spelling)
+ * @param {object|null} [costCfg]  this model's already-looked-up cost override;
+ *   `undefined` = look it up here (see observeModelCost's note on sharing it)
  * @returns {number}
  */
-export function resolveModelCost(modelId, cliCostUsd, usage) {
-  const cost = modelCostConfig(modelId);
+export function resolveModelCost(modelId, cliCostUsd, usage, costCfg = undefined) {
+  const cost = costCfg !== undefined ? costCfg : modelCostConfig(modelId);
   if (!cost) return cliCostUsd;
   if (cost.free) return 0;
-  if (cost.perMtok) return estimateCost(usage, cost.perMtok);
+  if (cost.perMtok) return isPriceableUsage(usage) ? estimateCost(usage, cost.perMtok) : NaN;
   return cliCostUsd;
 }
 

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -315,16 +315,23 @@ export function observeModelCost(modelId, costUsd, usage, costCfg = undefined) {
 // agent's telemetry row. Re-pricing only some of them would leave the phantom
 // spend this exists to remove still inflating the budget from the others.
 
-/** The explicit cost override for a model from the user's GLOBAL catalog, or
- *  null. Shape: {free:true} | {perMtok:{input?,output?,cacheRead?,cacheWrite?,
- *  cacheWrite1h?}} (USD per million tokens). Predefined/plugin models carry none
- *  — pinning a price is a user-catalog concern. Never throws. */
+/** The explicit cost override governing a model, or null. Shape: {free:true} |
+ *  {perMtok:{input?,output?,cacheRead?,cacheWrite?,cacheWrite1h?}} (USD per
+ *  million tokens). Resolved with the SAME precedence as the rest of a model's
+ *  configuration (§9.3, mirroring modelHasBaseUrlRouting): the user's GLOBAL
+ *  entry wins outright, else the winning PLUGIN entry's manifest price — a
+ *  plugin shipping a model on its own endpoint is exactly the case that needs
+ *  one. Note a global entry shadows the plugin's price even when it pins none:
+ *  taking over a model id means owning its pricing too, so the two layers can
+ *  never half-merge. Built-ins carry none. Never throws. */
 export function modelCostConfig(modelId) {
   const id = typeof modelId === 'string' ? modelId.trim() : '';
   if (!id) return null;
   const lc = id.toLowerCase();
   const entry = listGlobalModels().find((m) => m.id.toLowerCase() === lc);
-  return entry?.cost ?? null;
+  if (entry) return entry.cost ?? null;
+  const pm = listPluginModels().find((m) => m.id.toLowerCase() === lc);
+  return pm?.cost ?? null;
 }
 
 /** The four token classes read off a usage object, accepting BOTH spellings in

--- a/src/core/model-env.mjs
+++ b/src/core/model-env.mjs
@@ -78,3 +78,49 @@ export function prepareModelEnv(modelEnv, sourceEnv = process.env) {
   }
   return { env, dropped };
 }
+
+// ── per-model cost override (opt-in pricing, config.mjs resolveModelCost) ─────
+// Lives HERE for the same reason the env policy does: BOTH catalog layers must
+// validate it against one rule. settings.mjs owns the user's global catalog and
+// plugin-manifest.mjs owns a plugin's models — neither may import the other, and
+// this leaf imports nothing. A plugin that ships a model routed at its own
+// endpoint is exactly the case that needs a price pinned, so its manifest
+// carries `cost` with the same shape and the same validation as a global entry.
+
+/** Allowed per-million-token rate keys for a model's `cost.perMtok` table. */
+export const COST_RATE_KEYS = ['input', 'output', 'cacheRead', 'cacheWrite', 'cacheWrite1h'];
+
+/**
+ * Validate a model `cost` override. Returns the normalized shape or undefined;
+ * THROWS on malformed input (callers that must not throw catch and drop).
+ *   { free: true }                               → recorded spend is always $0
+ *   { perMtok: { input, output, cacheRead, … } } → USD per million tokens, >= 0
+ * `{ free: false }` / `{}` mean "no override" → undefined.
+ * @param {*} cost
+ * @returns {{free:true}|{perMtok:Record<string,number>}|undefined}
+ * @throws {Error}
+ */
+export function assertModelCost(cost) {
+  if (cost === undefined || cost === null) return undefined;
+  if (typeof cost !== 'object' || Array.isArray(cost)) throw new Error('cost must be an object');
+  if (cost.free !== undefined && typeof cost.free !== 'boolean') throw new Error('cost.free must be a boolean');
+  if (cost.free === true) return { free: true };
+  if (cost.perMtok !== undefined) {
+    const p = cost.perMtok;
+    if (!p || typeof p !== 'object' || Array.isArray(p)) {
+      throw new Error('cost.perMtok must be an object of USD-per-million-token rates');
+    }
+    const rates = {};
+    for (const [k, v] of Object.entries(p)) {
+      if (!COST_RATE_KEYS.includes(k)) {
+        throw new Error(`unknown cost.perMtok rate ${JSON.stringify(k)} — allowed: ${COST_RATE_KEYS.join(', ')}`);
+      }
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 0) throw new Error(`cost.perMtok.${k} must be a finite number >= 0`);
+      rates[k] = n;
+    }
+    if (!Object.keys(rates).length) throw new Error('cost.perMtok must define at least one rate');
+    return { perMtok: rates };
+  }
+  return undefined; // { free: false } or {} — no override
+}

--- a/src/core/orchestrator.mjs
+++ b/src/core/orchestrator.mjs
@@ -75,7 +75,7 @@ import {
   probeClaudeCapabilities, explainUnspawnableClaude,
 } from './preflight.mjs';
 import { fanoutCap, mapWithCap } from './fanout.mjs';
-import { resolveStepModels, observeModelCost, resolveModelCost } from './config.mjs';
+import { resolveStepModels, observeModelCost, resolveModelCost, modelCostConfig } from './config.mjs';
 import { readGuardrailSet } from './guardrail-store.mjs';
 import { unionGuardrails, guardrailsToPermissionRules, mergePermissionRules } from './guardrails.mjs';
 import { hasBlocking, blockingIssues, readQuestionsFile } from './protocol.mjs';
@@ -3113,18 +3113,32 @@ class Orchestrator extends EventEmitter {
     // mock). Fall back to raw.total_cost_usd defensively. e.raw may be a string
     // (non-JSON line) — `.type` on it is just undefined, so this never throws.
     // `e.costUsd != null` keeps a genuine 0 (which `!= null` is true for).
+    const isResult = !!(e.raw && typeof e.raw === 'object' && e.raw.type === 'result');
     const rawCost = e.costUsd != null
       ? Number(e.costUsd)
-      : (e.raw && e.raw.type === 'result' ? Number(e.raw.total_cost_usd ?? e.raw.cost_usd) : NaN);
+      : (isResult ? Number(e.raw.total_cost_usd ?? e.raw.cost_usd) : NaN);
     // A per-model cost override (config.mjs) wins over the CLI's own figure — so a
     // CLI that prices an on-prem/proxied model by name can't inflate the ledger.
     // With no override this is `rawCost` unchanged (default behavior preserved).
-    const cost = attr?.model
-      ? resolveModelCost(attr.model, rawCost, e.raw && typeof e.raw === 'object' ? e.raw.usage : undefined)
+    //
+    // Gated on `isResult` — NOT merely on attr.model. Every stream frame reaches
+    // here, and only the terminal `result` carries cost; on the others rawCost is
+    // NaN and falls through untouched today. A {free} override answers 0 for any
+    // input, so resolving unconditionally would turn each of those into a real $0
+    // and fire _recordCost — a full writeState + 'state' broadcast — per FRAME
+    // instead of once per node. Looked up ONCE and shared with observeModelCost
+    // below: modelCostConfig re-reads settings.json on every call.
+    const costCfg = isResult && attr?.model ? modelCostConfig(attr.model) : null;
+    const cost = costCfg
+      ? resolveModelCost(attr.model, rawCost, e.raw.usage, costCfg)
       : rawCost;
     if (Number.isFinite(cost)) this._recordCost(cost, attr?.stepKey);
-    else if (e.raw && e.raw.type === 'result' && !this.claude.mock) {
-      this._log('orchestrator', 'warn', 'result event carried no cost estimate (total_cost_usd absent)', attr);
+    else if (isResult && !this.claude.mock) {
+      // A {perMtok} model prices from tokens alone, so a result with no usage is
+      // unpriceable (NaN) — say so plainly rather than blaming a missing cost field.
+      this._log('orchestrator', 'warn', costCfg?.perMtok
+        ? `model "${attr.model}" is priced per-Mtok but the result carried no token usage — this step's spend is unaccounted`
+        : 'result event carried no cost estimate (total_cost_usd absent)', attr);
     }
 
     // §4.6 cost-reliability observation: only terminal result events of REAL
@@ -3132,9 +3146,9 @@ class Orchestrator extends EventEmitter {
     // carries no attr and is skipped), and only env-routed models inside
     // observeModelCost. One warning per model per run; the observation itself
     // is derived state and must never fail the run.
-    if (e.raw && e.raw.type === 'result' && !this.claude.mock && attr?.model) {
+    if (isResult && !this.claude.mock && attr?.model) {
       try {
-        const verdict = observeModelCost(attr.model, Number.isFinite(cost) ? cost : null, e.raw.usage);
+        const verdict = observeModelCost(attr.model, Number.isFinite(cost) ? cost : null, e.raw.usage, costCfg);
         if (verdict === 'flagged' && !(this._costUnreliableWarned ||= new Set()).has(attr.model)) {
           this._costUnreliableWarned.add(attr.model);
           this._log('orchestrator', 'warn',
@@ -3253,7 +3267,13 @@ class Orchestrator extends EventEmitter {
         startedAt: new Date().toISOString(),
         finishedAt: null,
         subagentType: c.input?.subagent_type ?? null,
-        model: attr.model ?? null, // in-memory: lets telemetry apply the cost override
+        // In-memory only (no column): lets _recordSubAgentTelemetry price this
+        // child. A sub-agent runs on the PARENT node's endpoint, so the parent's
+        // model is the right price — UNLESS the Task input names a model that
+        // itself carries an explicit override, which then governs the child.
+        // A bare alias ('haiku') with no catalog entry is not one, so it keeps
+        // the parent's rather than silently reverting to the CLI's figure.
+        model: subAgentCostModel(c.input?.model, attr.model),
       };
       this.state.subAgents.push(rec);
       this._upsertSubAgent(rec);
@@ -3404,9 +3424,12 @@ class Orchestrator extends EventEmitter {
     if (Number.isFinite(Number(cost))) {
       // Apply the same per-model cost override as the node result path, so a
       // sub-agent of a free/priced model doesn't display the CLI's fabricated
-      // figure. rec.model is the parent node's dispatched model (the sub-agent
-      // shares its endpoint); absent (e.g. after resume) → the CLI value stands.
-      rec.costUsd = rec.model ? resolveModelCost(rec.model, Number(cost), tr.usage) : Number(cost);
+      // figure. rec.model is set at spawn (see subAgentCostModel); absent (e.g.
+      // after a resume, which rebuilds records from the table) → the CLI value
+      // stands. A {perMtok} model with unpriceable usage yields NaN — leave the
+      // row's cost UNSET rather than write a made-up figure into the display.
+      const resolved = rec.model ? resolveModelCost(rec.model, Number(cost), tr.usage) : Number(cost);
+      if (Number.isFinite(resolved)) rec.costUsd = resolved;
     }
     this._upsertSubAgent(rec);
     this._subAgentTransition('update', rec);
@@ -4101,6 +4124,22 @@ function rel(base, p) {
 // independent on purpose — a long description may render at ≤60 on the parent line
 // and ≤40 inside the child tag.
 const SUBAGENT_LABEL_MAX = 40;
+
+/**
+ * Which model id prices a sub-agent. The child runs inside the parent node's CLI
+ * invocation — same endpoint, same price — so the parent's dispatched model is the
+ * default. A Task input MAY name its own model; that only changes the price when
+ * the named model carries an explicit cost override of its own (a bare alias like
+ * 'haiku' resolves to nothing and must not drop the parent's override).
+ * @param {unknown} inputModel  the Task/Agent tool_use input's `model`, if any
+ * @param {string|undefined} parentModel  the parent node's dispatched model
+ * @returns {string|null}
+ */
+function subAgentCostModel(inputModel, parentModel) {
+  const own = typeof inputModel === 'string' && inputModel.trim() ? inputModel.trim() : null;
+  try { if (own && modelCostConfig(own)) return own; } catch { /* catalog read is best-effort */ }
+  return parentModel ?? null;
+}
 
 /**
  * Record id -> short description for every Task/Agent tool_use block in a

--- a/src/core/orchestrator.mjs
+++ b/src/core/orchestrator.mjs
@@ -75,7 +75,7 @@ import {
   probeClaudeCapabilities, explainUnspawnableClaude,
 } from './preflight.mjs';
 import { fanoutCap, mapWithCap } from './fanout.mjs';
-import { resolveStepModels, observeModelCost } from './config.mjs';
+import { resolveStepModels, observeModelCost, resolveModelCost } from './config.mjs';
 import { readGuardrailSet } from './guardrail-store.mjs';
 import { unionGuardrails, guardrailsToPermissionRules, mergePermissionRules } from './guardrails.mjs';
 import { hasBlocking, blockingIssues, readQuestionsFile } from './protocol.mjs';
@@ -3113,9 +3113,15 @@ class Orchestrator extends EventEmitter {
     // mock). Fall back to raw.total_cost_usd defensively. e.raw may be a string
     // (non-JSON line) — `.type` on it is just undefined, so this never throws.
     // `e.costUsd != null` keeps a genuine 0 (which `!= null` is true for).
-    const cost = e.costUsd != null
+    const rawCost = e.costUsd != null
       ? Number(e.costUsd)
       : (e.raw && e.raw.type === 'result' ? Number(e.raw.total_cost_usd ?? e.raw.cost_usd) : NaN);
+    // A per-model cost override (config.mjs) wins over the CLI's own figure — so a
+    // CLI that prices an on-prem/proxied model by name can't inflate the ledger.
+    // With no override this is `rawCost` unchanged (default behavior preserved).
+    const cost = attr?.model
+      ? resolveModelCost(attr.model, rawCost, e.raw && typeof e.raw === 'object' ? e.raw.usage : undefined)
+      : rawCost;
     if (Number.isFinite(cost)) this._recordCost(cost, attr?.stepKey);
     else if (e.raw && e.raw.type === 'result' && !this.claude.mock) {
       this._log('orchestrator', 'warn', 'result event carried no cost estimate (total_cost_usd absent)', attr);
@@ -3247,6 +3253,7 @@ class Orchestrator extends EventEmitter {
         startedAt: new Date().toISOString(),
         finishedAt: null,
         subagentType: c.input?.subagent_type ?? null,
+        model: attr.model ?? null, // in-memory: lets telemetry apply the cost override
       };
       this.state.subAgents.push(rec);
       this._upsertSubAgent(rec);
@@ -3394,7 +3401,13 @@ class Orchestrator extends EventEmitter {
     if (Number.isFinite(Number(tr.totalDurationMs))) rec.durationMs = Number(tr.totalDurationMs);
     if (Number.isFinite(Number(tr.totalTokens))) rec.tokens = Number(tr.totalTokens);
     const cost = tr.usage?.cost_usd ?? tr.usage?.total_cost_usd ?? tr.cost_usd;
-    if (Number.isFinite(Number(cost))) rec.costUsd = Number(cost);
+    if (Number.isFinite(Number(cost))) {
+      // Apply the same per-model cost override as the node result path, so a
+      // sub-agent of a free/priced model doesn't display the CLI's fabricated
+      // figure. rec.model is the parent node's dispatched model (the sub-agent
+      // shares its endpoint); absent (e.g. after resume) → the CLI value stands.
+      rec.costUsd = rec.model ? resolveModelCost(rec.model, Number(cost), tr.usage) : Number(cost);
+    }
     this._upsertSubAgent(rec);
     this._subAgentTransition('update', rec);
   }

--- a/src/core/overview-agent.mjs
+++ b/src/core/overview-agent.mjs
@@ -6,7 +6,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { runClaude } from './claude-runner.mjs';
-import { resolveModelEnv } from './config.mjs';
+import { resolveModelEnv, resolveModelCost } from './config.mjs';
 import { safeParseJson } from './protocol.mjs';
 import {
   lookupPipelineRow, runDirForRow, upsertSubAgent, readPipelineExtras,
@@ -94,6 +94,7 @@ export async function generateOverview(key, id, { model, signal, force = false, 
 
   const prompt = buildOverviewPrompt({ patch, results, reviews });
   let costUsd = null;
+  let usage = null;
   const startedAt = new Date().toISOString();
   const { text } = await runClaudeImpl({
     cwd: dir,
@@ -103,13 +104,24 @@ export async function generateOverview(key, id, { model, signal, force = false, 
     model,
     modelEnv: resolveModelEnv(model), // catalog routing env travels with the id (design §4.8)
     signal,
-    onEvent: (e) => { if (e.costUsd != null) costUsd = e.costUsd; },
+    onEvent: (e) => {
+      if (e.costUsd == null) return;
+      costUsd = e.costUsd;
+      usage = e.raw && typeof e.raw === 'object' ? e.raw.usage ?? null : null;
+    },
   });
 
   const overview = normalizeOverview(safeParseJson(text));
   await writeFile(join(dir, OVERVIEW_FILE), JSON.stringify(overview, null, 2));
 
-  // Record as a sub-agent for cost telemetry parity with pipeline nodes.
+  // Record as a sub-agent for cost telemetry parity with pipeline nodes — which
+  // includes the per-model cost override, so an overview run on a free/priced
+  // endpoint doesn't display the CLI's by-name figure. Unpriceable ({perMtok}
+  // with no usage) → NaN → leave it null rather than show a made-up number.
+  if (costUsd != null) {
+    const resolved = resolveModelCost(model, Number(costUsd), usage);
+    costUsd = Number.isFinite(resolved) ? resolved : null;
+  }
   upsertSubAgent(row.id, {
     id: `overview-${id}`,
     label: 'overview',

--- a/src/core/plugin-manifest.mjs
+++ b/src/core/plugin-manifest.mjs
@@ -6,7 +6,7 @@
 import { readFileSync, readdirSync, readlinkSync, existsSync } from 'node:fs';
 import { join, resolve, dirname, sep, isAbsolute } from 'node:path';
 import { WORCA_PLUGIN_APIS } from './plugin-api.mjs';
-import { EFFORTS, isReservedModelEnvKey } from './model-env.mjs';
+import { EFFORTS, isReservedModelEnvKey, assertModelCost } from './model-env.mjs';
 
 /** Plugin names are kebab-case, machine-unique, dir-name safe (spec §4.1). */
 export const PLUGIN_NAME_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
@@ -22,7 +22,7 @@ const KNOWN_CHANNEL = new Set(['id', 'displayName', 'platform', 'module', 'ingre
 const CHANNEL_INGRESS = new Set(['connect', 'webhook']);
 const KNOWN_FIELD = new Set(['key', 'type', 'label', 'secret', 'required', 'default', 'help', 'options']);
 const KNOWN_INPUT = new Set(['key', 'type', 'label', 'default', 'optionsFrom', 'options']);
-const KNOWN_MODEL = new Set(['id', 'label', 'efforts', 'env']);
+const KNOWN_MODEL = new Set(['id', 'label', 'efforts', 'env', 'cost']);
 const KNOWN_MODEL_SECRET = new Set(['key', 'label']);
 /** A manifest env value that defers to the plugin's secrets store (design §9.1). */
 const isSecretRef = (v) => !!v && typeof v === 'object' && !Array.isArray(v)
@@ -310,10 +310,23 @@ export function normalizeManifest(raw, { dir = '' } = {}) {
           errors.push(`${at} ("${id}"): env value for ${JSON.stringify(k)} must be a non-empty string or {"secret": "<key>"}`);
         }
       }
+      // A plugin that ships a model routed at its OWN endpoint is exactly the
+      // case that needs a price pinned (the CLI would price it by NAME), so a
+      // manifest may carry `cost` — same shape, same validator as a global
+      // catalog entry (model-env.mjs). A user's global entry for the same id
+      // still wins, as it does for label/efforts/env (§9.3).
+      let cost;
+      try {
+        cost = assertModelCost(m.cost);
+      } catch (e) {
+        errors.push(`${at} ("${id}"): ${e.message}`);
+        return;
+      }
       models.push({
         id, label: str(m.label) || id,
         efforts: efforts.length ? efforts : [...EFFORTS],
         ...(Object.keys(env).length ? { env } : {}),
+        ...(cost ? { cost } : {}),
       });
     });
     const mids = models.map((m) => m.id.toLowerCase());

--- a/src/core/plugin-models.mjs
+++ b/src/core/plugin-models.mjs
@@ -49,6 +49,7 @@ export function allPluginModels() {
       out.push({
         plugin: name, id: m.id, label: m.label, efforts: [...m.efforts],
         ...(m.env ? { env: m.env } : {}),
+        ...(m.cost ? { cost: m.cost } : {}),   // manifest-pinned pricing (config.mjs modelCostConfig)
         secrets: [...new Set(secrets)],
       });
     }

--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -42,7 +42,7 @@ import { readFileSync, existsSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-import { EFFORTS, isReservedModelEnvKey } from './model-env.mjs';
+import { EFFORTS, isReservedModelEnvKey, assertModelCost } from './model-env.mjs';
 
 /**
  * The real OS home base, honoring HOME/USERPROFILE so tests can sandbox it.
@@ -574,45 +574,9 @@ function sanitizeGlobalModel(raw) {
   };
 }
 
-/** Allowed per-million-token rate keys for a model's `cost.perMtok` table. */
-const COST_RATE_KEYS = ['input', 'output', 'cacheRead', 'cacheWrite', 'cacheWrite1h'];
-
-/**
- * Validate a model `cost` override (opt-in per-model pricing, config.mjs
- * resolveModelCost). Returns the normalized shape or undefined; THROWS on
- * malformed input (write path). Accepted:
- *   { free: true }                              → recorded spend is always $0
- *   { perMtok: { input, output, cacheRead, … } } → USD per million tokens, ≥ 0
- * `{ free: false }` / `{}` mean "no override" → undefined.
- * @throws {Error}
- */
-function assertModelCost(cost) {
-  if (cost === undefined || cost === null) return undefined;
-  if (typeof cost !== 'object' || Array.isArray(cost)) throw new Error('cost must be an object');
-  if (cost.free !== undefined && typeof cost.free !== 'boolean') throw new Error('cost.free must be a boolean');
-  if (cost.free === true) return { free: true };
-  if (cost.perMtok !== undefined) {
-    const p = cost.perMtok;
-    if (!p || typeof p !== 'object' || Array.isArray(p)) {
-      throw new Error('cost.perMtok must be an object of USD-per-million-token rates');
-    }
-    const rates = {};
-    for (const [k, v] of Object.entries(p)) {
-      if (!COST_RATE_KEYS.includes(k)) {
-        throw new Error(`unknown cost.perMtok rate ${JSON.stringify(k)} — allowed: ${COST_RATE_KEYS.join(', ')}`);
-      }
-      const n = Number(v);
-      if (!Number.isFinite(n) || n < 0) throw new Error(`cost.perMtok.${k} must be a finite number >= 0`);
-      rates[k] = n;
-    }
-    if (!Object.keys(rates).length) throw new Error('cost.perMtok must define at least one rate');
-    return { perMtok: rates };
-  }
-  return undefined; // { free: false } or {} — no override
-}
-
-/** Lenient read-side counterpart of assertModelCost: drops an invalid `cost`
- *  loudly instead of throwing (a corrupt settings.json must never break reads). */
+/** Lenient read-side counterpart of assertModelCost (model-env.mjs): drops an
+ *  invalid `cost` loudly instead of throwing (a corrupt settings.json must never
+ *  break reads). */
 function sanitizeModelCost(raw, id) {
   if (raw == null) return undefined;
   try {

--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -564,17 +564,68 @@ function sanitizeGlobalModel(raw) {
     }
     env[k] = t;
   }
+  const cost = sanitizeModelCost(raw.cost, id);
   return {
     id,
     label,
     efforts: efforts.length ? efforts : [...EFFORTS],
     ...(Object.keys(env).length ? { env } : {}),
+    ...(cost ? { cost } : {}),
   };
 }
 
+/** Allowed per-million-token rate keys for a model's `cost.perMtok` table. */
+const COST_RATE_KEYS = ['input', 'output', 'cacheRead', 'cacheWrite', 'cacheWrite1h'];
+
 /**
- * The sanitized global model catalog: [{id, label, efforts, env?}], effective
- * shape (label/efforts always present). Missing/corrupt -> []. Malformed and
+ * Validate a model `cost` override (opt-in per-model pricing, config.mjs
+ * resolveModelCost). Returns the normalized shape or undefined; THROWS on
+ * malformed input (write path). Accepted:
+ *   { free: true }                              → recorded spend is always $0
+ *   { perMtok: { input, output, cacheRead, … } } → USD per million tokens, ≥ 0
+ * `{ free: false }` / `{}` mean "no override" → undefined.
+ * @throws {Error}
+ */
+function assertModelCost(cost) {
+  if (cost === undefined || cost === null) return undefined;
+  if (typeof cost !== 'object' || Array.isArray(cost)) throw new Error('cost must be an object');
+  if (cost.free !== undefined && typeof cost.free !== 'boolean') throw new Error('cost.free must be a boolean');
+  if (cost.free === true) return { free: true };
+  if (cost.perMtok !== undefined) {
+    const p = cost.perMtok;
+    if (!p || typeof p !== 'object' || Array.isArray(p)) {
+      throw new Error('cost.perMtok must be an object of USD-per-million-token rates');
+    }
+    const rates = {};
+    for (const [k, v] of Object.entries(p)) {
+      if (!COST_RATE_KEYS.includes(k)) {
+        throw new Error(`unknown cost.perMtok rate ${JSON.stringify(k)} — allowed: ${COST_RATE_KEYS.join(', ')}`);
+      }
+      const n = Number(v);
+      if (!Number.isFinite(n) || n < 0) throw new Error(`cost.perMtok.${k} must be a finite number >= 0`);
+      rates[k] = n;
+    }
+    if (!Object.keys(rates).length) throw new Error('cost.perMtok must define at least one rate');
+    return { perMtok: rates };
+  }
+  return undefined; // { free: false } or {} — no override
+}
+
+/** Lenient read-side counterpart of assertModelCost: drops an invalid `cost`
+ *  loudly instead of throwing (a corrupt settings.json must never break reads). */
+function sanitizeModelCost(raw, id) {
+  if (raw == null) return undefined;
+  try {
+    return assertModelCost(raw);
+  } catch (e) {
+    console.warn(`[worca] models entry ${JSON.stringify(id)}: dropping invalid cost — ${e.message}`);
+    return undefined;
+  }
+}
+
+/**
+ * The sanitized global model catalog: [{id, label, efforts, env?, cost?}],
+ * effective shape (label/efforts always present). Missing/corrupt -> []. Malformed and
  * case-insensitively duplicate entries are dropped loudly (first wins). Never
  * throws.
  */
@@ -652,12 +703,13 @@ function assertTestSettingsAccess() {
 }
 
 /** The MINIMAL stored shape for validated parts (see section comment). */
-function storedModelShape(id, label, efforts, env) {
+function storedModelShape(id, label, efforts, env, cost) {
   return {
     id,
     ...(label && label !== id ? { label } : {}),
     ...(efforts.length && efforts.length !== EFFORTS.length ? { efforts } : {}),
     ...(Object.keys(env).length ? { env } : {}),
+    ...(cost ? { cost } : {}),
   };
 }
 
@@ -675,21 +727,23 @@ function rawModels(settings) {
 
 /**
  * Add a global catalog entry. `label` defaults to the id; `efforts` must be a
- * subset of EFFORTS (empty/absent = all); `env` keys must not be reserved.
- * @returns {Promise<{id:string,label:string,efforts:string[],env?:object}>} the effective entry
+ * subset of EFFORTS (empty/absent = all); `env` keys must not be reserved;
+ * `cost` is an optional per-model override ({free} | {perMtok}, see assertModelCost).
+ * @returns {Promise<{id:string,label:string,efforts:string[],env?:object,cost?:object}>} the effective entry
  * @throws {Error} on invalid input or a case-insensitively duplicate id
  */
-export async function addGlobalModel({ id, label, efforts, env } = {}) {
+export async function addGlobalModel({ id, label, efforts, env, cost } = {}) {
   assertTestSettingsAccess();
   const vid = assertModelId(id);
   if (!isClearInput(label) && typeof label !== 'string') throw new Error('label must be a string');
   const vefforts = assertEfforts(efforts);
   const venv = assertEnvPairs(env);
+  const vcost = assertModelCost(cost);
   const settings = readSettings();
   const models = rawModels(settings);
   if (findModelIndex(models, vid) !== -1) throw new Error(`a model with id ${JSON.stringify(vid)} already exists`);
   const vlabel = (typeof label === 'string' && label.trim()) || vid;
-  settings.models = [...models, storedModelShape(vid, vlabel, vefforts, venv)];
+  settings.models = [...models, storedModelShape(vid, vlabel, vefforts, venv, vcost)];
   await persistSettings(settings);
   return listGlobalModels().find((m) => m.id.toLowerCase() === vid.toLowerCase());
 }
@@ -698,11 +752,12 @@ export async function addGlobalModel({ id, label, efforts, env } = {}) {
  * Patch a global catalog entry. Omitted fields are kept. `label`: ''/null
  * resets to the id. `efforts`: []/null resets to all. `env`: null clears the
  * whole map; an object merges per key, where a null value DELETES that key and
- * a string sets it (write-only PATCH semantics, design §4.10).
+ * a string sets it (write-only PATCH semantics, design §4.10). `cost`: null/''
+ * removes the override; an object replaces it wholesale.
  * @returns {Promise<object>} the effective entry
  * @throws {Error} on an unknown id or invalid input
  */
-export async function updateGlobalModel(id, { label, efforts, env } = {}) {
+export async function updateGlobalModel(id, { label, efforts, env, cost } = {}) {
   assertTestSettingsAccess();
   const vid = assertModelId(id);
   const settings = readSettings();
@@ -730,8 +785,13 @@ export async function updateGlobalModel(id, { label, efforts, env } = {}) {
     }
   }
 
+  // cost: omitted keeps the current override; null/'' removes it; an object
+  // replaces it wholesale (not a per-key merge — the table is small).
+  let nextCost = current.cost;
+  if (cost !== undefined) nextCost = isClearInput(cost) ? undefined : assertModelCost(cost);
+
   settings.models = models.slice();
-  settings.models[idx] = storedModelShape(current.id, nextLabel, nextEfforts, nextEnv);
+  settings.models[idx] = storedModelShape(current.id, nextLabel, nextEfforts, nextEnv, nextCost);
   await persistSettings(settings);
   return listGlobalModels().find((m) => m.id.toLowerCase() === vid.toLowerCase());
 }

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -376,3 +376,69 @@ test('POST/PATCH /api/models reject a malformed `cost` with the message the form
   assert.equal(unknown.status, 400);
   assert.match(unknown.body.error, /unknown cost\.perMtok rate "bogus"/);
 });
+
+test('export-plugin carries `cost` into the generated manifest (pricing is config, not a credential)', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { normalizeManifest } = await import('../src/core/plugin-manifest.mjs');
+  await post('/api/models', {
+    id: 'exp-priced', label: 'Priced export',
+    env: { ANTHROPIC_BASE_URL: 'https://p.example', ANTHROPIC_AUTH_TOKEN: 'sk-live-never-export' },
+    cost: { perMtok: { input: 0.5, output: 1.5, cacheWrite1h: 1.2 } },
+  });
+  await post('/api/models', { id: 'exp-free', cost: { free: true } });
+  await post('/api/models', { id: 'exp-unpriced' });
+
+  const dest = join(proj, 'export', 'priced-models');
+  const r = await post('/api/models/export-plugin', {
+    name: 'priced-models', dest,
+    models: [
+      { id: 'exp-priced', env: { ANTHROPIC_BASE_URL: 'include', ANTHROPIC_AUTH_TOKEN: 'secret' } },
+      { id: 'exp-free' },
+      { id: 'exp-unpriced' },
+    ],
+  });
+  assert.equal(r.status, 200);
+
+  const manifest = JSON.parse(readFileSync(join(dest, 'worca-cc-plugin.json'), 'utf8'));
+  const byId = Object.fromEntries(manifest.models.map((m) => [m.id, m]));
+  assert.deepEqual(byId['exp-priced'].cost, { perMtok: { input: 0.5, output: 1.5, cacheWrite1h: 1.2 } },
+    'a shared on-prem model would otherwise be re-priced by NAME on every machine that installs this');
+  assert.deepEqual(byId['exp-free'].cost, { free: true });
+  assert.equal(byId['exp-unpriced'].cost, undefined, 'no override -> no key');
+
+  // The scaffold must install anywhere this host would, and the secret still never travels.
+  assert.equal(normalizeManifest(manifest).ok, true);
+  assert.doesNotMatch(readFileSync(join(dest, 'worca-cc-plugin.json'), 'utf8'), /sk-live-never-export/);
+});
+
+test('a plugin model\'s manifest price reaches GET /api/models and Edit-a-copy', async () => {
+  const { writePluginsLock, readPluginsLock, pluginCurrentDir } = await import('../src/core/plugins-lock.mjs');
+  const { mkdirSync, writeFileSync } = await import('node:fs');
+  const cur = pluginCurrentDir('priced-plug');
+  mkdirSync(cur, { recursive: true });
+  writeFileSync(join(cur, 'worca-cc-plugin.json'), JSON.stringify({
+    name: 'priced-plug',
+    models: [
+      { id: 'pp-rated', label: 'PP Rated', env: { ANTHROPIC_BASE_URL: 'https://pp.example' },
+        cost: { perMtok: { input: 1, output: 3 } } },
+      { id: 'pp-plain', label: 'PP Plain' },
+    ],
+  }));
+  writePluginsLock({
+    ...readPluginsLock(),
+    'priced-plug': { repo: 'https://example.com/r', subdir: '', pinnedSha: 'x'.repeat(40), version: '1', enabled: true },
+  });
+
+  const { body } = await jfetch('/api/models');
+  const priced = body.plugin.find((m) => m.id === 'pp-rated');
+  assert.deepEqual(priced.cost, { perMtok: { input: 1, output: 3 } }, 'pricing is config — surfaced, never masked');
+  assert.equal(body.plugin.find((m) => m.id === 'pp-plain').cost, undefined);
+
+  // Edit-a-copy seeds the global copy from the plugin's pricing: a copy that
+  // dropped it would revert to the CLI's by-name figure, since a global entry
+  // shadows the plugin price whether or not it pins one.
+  const copy = await jfetch(`/api/plugins/priced-plug/model-env?${q({ id: 'PP-Rated' })}`);
+  assert.equal(copy.status, 200);
+  assert.deepEqual(copy.body.cost, { perMtok: { input: 1, output: 3 } });
+  assert.equal((await jfetch(`/api/plugins/priced-plug/model-env?${q({ id: 'pp-plain' })}`)).body.cost, undefined);
+});

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -330,3 +330,49 @@ test('POST /api/models/:id/test: 404 unknown id; 400 for a plugin model with an 
   assert.equal(r400.status, 400);
   assert.match(r400.body.error, /up-token.*not set/);
 });
+
+// ── the pricing override over HTTP (what the editor form actually sends) ──────
+
+test('POST/PATCH /api/models carry `cost` end-to-end, and GET surfaces it unmasked', async () => {
+  const add = await post('/api/models', {
+    id: 'priced-api', label: 'Priced', efforts: [],
+    env: { ANTHROPIC_BASE_URL: 'https://p' },
+    cost: { perMtok: { input: 0.5, output: 1.5 } },
+  });
+  assert.equal(add.status, 200);
+  assert.deepEqual(add.body.model.cost, { perMtok: { input: 0.5, output: 1.5 } });
+  // Pricing is configuration, never a credential — it must NOT come back masked.
+  const got = (await jfetch('/api/models')).body.models.find((m) => m.id === 'priced-api');
+  assert.deepEqual(got.cost, { perMtok: { input: 0.5, output: 1.5 } });
+  assert.match(got.env.ANTHROPIC_BASE_URL, /^••/, 'env still masked alongside it');
+
+  // The editor replaces the table wholesale (it is small) rather than merging.
+  const toFree = await patch('/api/models/priced-api', { cost: { free: true } });
+  assert.deepEqual(toFree.body.model.cost, { free: true });
+
+  // 'Trust the CLI' sends null — an explicit clear, since the form shows the state.
+  const cleared = await patch('/api/models/priced-api', { cost: null });
+  assert.equal(cleared.body.model.cost, undefined);
+  assert.equal(listGlobalModels().find((m) => m.id === 'priced-api').cost, undefined);
+
+  // An unrelated edit omits `cost` entirely -> the stored override is kept.
+  await patch('/api/models/priced-api', { cost: { perMtok: { input: 2 } } });
+  const relabel = await patch('/api/models/priced-api', { label: 'Renamed' });
+  assert.equal(relabel.body.model.label, 'Renamed');
+  assert.deepEqual(relabel.body.model.cost, { perMtok: { input: 2 } }, 'omitted means keep');
+});
+
+test('POST/PATCH /api/models reject a malformed `cost` with the message the form shows', async () => {
+  const bad = await post('/api/models', { id: 'bad-cost', cost: { perMtok: {} } });
+  assert.equal(bad.status, 400);
+  assert.match(bad.body.error, /must define at least one rate/);
+  assert.equal(listGlobalModels().some((m) => m.id === 'bad-cost'), false, 'a rejected add leaves nothing behind');
+
+  const neg = await post('/api/models', { id: 'bad-cost', cost: { perMtok: { input: -1 } } });
+  assert.equal(neg.status, 400);
+  assert.match(neg.body.error, /finite number >= 0/);
+
+  const unknown = await patch('/api/models/priced-api', { cost: { perMtok: { bogus: 1 } } });
+  assert.equal(unknown.status, 400);
+  assert.match(unknown.body.error, /unknown cost\.perMtok rate "bogus"/);
+});

--- a/test/ask-events.test.mjs
+++ b/test/ask-events.test.mjs
@@ -429,3 +429,71 @@ test('context fill: a child message_delta sets the agent block ctx (last call wi
   assert.equal(agentFrames().at(-1).block.ctx, 11869, 'the last child call replaces');
   assert.equal(h.r.snapshot().usage.ctx, 11, 'main ctx comes from the main call (the spawn message), never the child');
 });
+
+// ── the injected cost override (config.mjs resolveModelCost) ─────────────────
+// The reducer never imports config/DB; the turn injects `resolveCost`, so these
+// pin the CONTRACT with hand-rolled overrides. Ask spend feeds the same windowed
+// budget as pipeline spend, which is why a re-priced turn matters here at all.
+
+test('resolveCost: the injected override replaces the CLI cost everywhere the turn reports it', () => {
+  const seen = [];
+  const h = harness({ resolveCost: (cli, usage) => { seen.push({ cli, usage }); return 0; } });
+  h.push(init(), mstart('msg_1'), mdelta({ output_tokens: 7 }), atext('msg_1', 'hi'));
+  assert.deepEqual(h.frames.filter((f) => f.type === 'ask-usage').map((f) => f.costUsd), [null],
+    'nothing to re-price before the result frame — the hook is not even called');
+  assert.equal(seen.length, 0);
+
+  h.push(result());
+  const usageFrames = h.frames.filter((f) => f.type === 'ask-usage');
+  assert.equal(usageFrames.at(-1).costUsd, 0, 'the ask-usage frame carries the OVERRIDE, not 0.0234');
+  assert.equal(h.r.snapshot().costUsd, 0);
+  assert.equal(h.r.finish().costUsd, 0);
+  assert.equal(seen.length, 1, 'memoized on the result — one catalog read per turn, not one per reader');
+  assert.equal(seen[0].cli, 0.0234, 'the hook sees what the CLI reported…');
+  assert.deepEqual(seen[0].usage, { ...normalizeUsage(RESULT_USAGE), ctx: 7 }, '…and this turn\'s usage');
+});
+
+test('resolveCost: absent, non-finite or throwing → the CLI figure stands (never a forged price)', () => {
+  assert.equal(harnessAfterResult({}).costUsd, 0.0234, 'no hook = default behavior');
+  assert.equal(harnessAfterResult({ resolveCost: () => NaN }).costUsd, 0.0234, 'unpriceable falls back');
+  assert.equal(harnessAfterResult({ resolveCost: () => { throw new Error('catalog on fire'); } }).costUsd, 0.0234,
+    'a pricing override must never break a turn');
+});
+
+function harnessAfterResult(opts) {
+  const h = harness(opts);
+  h.push(init(), atext('msg_1', 'hi'), result());
+  return h.r.finish();
+}
+
+test('resolveCost: a turn with NO result frame stays costUsd:null — §6.2.8 is not a price to re-price', () => {
+  const h = harness({ resolveCost: () => 0 });
+  h.push(init(), atext('msg_1', 'hi'));
+  assert.equal(h.r.finish().costUsd, null);
+});
+
+test('resolveCost: the §6.6 per-agent split is scaled so agent rows never out-total their turn', () => {
+  const MU = { 'claude-haiku-4-5': { inputTokens: 8032, outputTokens: 246, cacheReadInputTokens: 0, cacheCreationInputTokens: 0, costUSD: 0.02 } };
+  const runAgentTurn = (opts) => {
+    const h = harness(opts);
+    h.push(init(), atool('msg_1', 'toolu_agent', 'Agent', { subagent_type: 'general-purpose', description: 'count runs', prompt: 'P' }));
+    h.push(uresult('toolu_agent', [{ type: 'text', text: 'count: 1' }], { tur: AGENT_TUR }));
+    h.push(result({ modelUsage: MU }));
+    const s = h.r.finish();
+    return { agent: s.blocks.find((b) => b.kind === 'agent'), total: s.costUsd };
+  };
+  // Baseline (unchanged): w(agent)=4016+5·123=4631, w(total)=8032+5·246=9262 → 0.02 × 0.5.
+  const base = runAgentTurn({});
+  assert.equal(base.agent.costUsd, 0.01);
+
+  // {free}: the turn is $0, so its agents must be too.
+  const free = runAgentTurn({ resolveCost: () => 0 });
+  assert.equal(free.total, 0);
+  assert.equal(free.agent.costUsd, 0, 'a $0 turn cannot contain a billing agent');
+
+  // {perMtok}-style re-price: halve the turn, halve every share.
+  const half = runAgentTurn({ resolveCost: (cli) => cli / 2 });
+  assert.equal(half.total, 0.0117);
+  assert.equal(half.agent.costUsd, 0.005);
+  assert.equal(half.agent.estimated, true, 'still an estimate — scaling does not make it exact');
+});

--- a/test/model-cost-override-surfaces.test.mjs
+++ b/test/model-cost-override-surfaces.test.mjs
@@ -1,0 +1,316 @@
+// test/model-cost-override-surfaces.test.mjs
+// The per-model cost override (config.mjs) at every surface that books spend,
+// plus the invariants that keep it from misfiring:
+//   1. ONLY a cost-bearing `result` event may be re-priced. Every stream frame
+//      reaches the orchestrator's intake, and a {free} override answers $0 for
+//      any input — resolving unconditionally would book a real $0 per FRAME
+//      (each one a writeState + a 'state' broadcast) instead of once per node.
+//   2. A {perMtok} model is priced from tokens alone, so a result with NO usage
+//      is unpriceable and must be reported, never silently booked at $0.
+//   3. Ask Worca spend feeds the SAME windowed budget as pipeline spend
+//      (cost-budget.mjs combinedWindowedSpendUsd), so it must be re-priced too.
+//   4. The overview agent's sub-agent row is priced like any pipeline node.
+// Sandboxes HOME (settingsFile lives under it) + WORCA_HOME + the catalog
+// test-guard opt-in, exactly like model-cost-override.test.mjs.
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { addGlobalModel } from '../src/core/settings.mjs';
+import { createOrchestrator } from '../src/core/orchestrator.mjs';
+import { createAskTurn } from '../src/core/ask/turn.mjs';
+import { createThread, appendMessage, getMessage, getThread } from '../src/core/ask/store.mjs';
+import { generateOverview } from '../src/core/overview-agent.mjs';
+import { persistResults, persistDiffPatch } from '../src/core/results.mjs';
+import { listSubAgents } from '../src/core/artifacts.mjs';
+import { seedPipeline } from './helpers/db-seed.mjs';
+import { getDb, _resetForTests } from '../src/core/db.mjs';
+
+const dirs = [];
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
+let home;
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), 'worca-cc-mcos-home-'));
+  const whome = await mkdtemp(join(tmpdir(), 'worca-cc-mcos-whome-'));
+  dirs.push(home, whome);
+  _resetForTests();
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  process.env.WORCA_HOME = whome;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1';
+});
+after(async () => {
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+const USAGE = { input_tokens: 1_000_000, output_tokens: 1_000_000 };
+const FRAME = (i) => ({
+  type: 'assistant',
+  raw: { type: 'assistant', message: { id: `m${i}`, content: [{ type: 'text', text: `chunk ${i}` }] } },
+});
+
+/** An orchestrator parked mid-'plan', counting every state broadcast. */
+function pausedOrch(name) {
+  const orch = createOrchestrator({ projectDir: join(tmpdir(), name) });
+  orch._phase('plan', 0, 'start');
+  const seen = { states: 0, warns: [] };
+  orch.on('state', () => { seen.states += 1; });
+  const log = orch._log.bind(orch);
+  orch._log = (role, level, msg, attr) => { if (level === 'warn') seen.warns.push(msg); return log(role, level, msg, attr); };
+  return { orch, seen };
+}
+
+// ── 1. non-result frames are never re-priced ──────────────────────────────────
+
+test('orchestrator: an override never turns a NON-result frame into a booked $0', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  const { orch, seen } = pausedOrch('mcos-frames');
+  for (let i = 0; i < 25; i++) orch._onAgentEvent('planner', FRAME(i), { model: 'onprem', stepKey: 'plan' });
+
+  const step = orch.getState().steps.find((s) => s.key === 'plan');
+  assert.equal(step.costUsd, undefined, 'no result yet -> the step carries no cost figure at all');
+  assert.equal(seen.states, 0,
+    'not one state broadcast: _recordCost (writeState + broadcast) must fire once per NODE, never per frame');
+
+  // The terminal result IS re-priced — the whole point of the feature.
+  orch._onAgentEvent('planner',
+    { type: 'result', costUsd: 0.4625, raw: { type: 'result', total_cost_usd: 0.4625, usage: USAGE } },
+    { model: 'onprem', stepKey: 'plan' });
+  assert.equal(orch.getState().totalCostUsd, 0, 'the fabricated 0.4625 is discarded');
+  assert.equal(seen.states, 1, 'exactly one broadcast, from the result');
+});
+
+test('orchestrator: a {perMtok} override is likewise inert on non-result frames', async () => {
+  await addGlobalModel({ id: 'priced', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { perMtok: { input: 1 } } });
+  const { orch, seen } = pausedOrch('mcos-frames2');
+  for (let i = 0; i < 25; i++) orch._onAgentEvent('planner', FRAME(i), { model: 'priced', stepKey: 'plan' });
+  assert.equal(seen.states, 0);
+  assert.equal(orch.getState().steps.find((s) => s.key === 'plan').costUsd, undefined);
+});
+
+// ── 2. {perMtok} with nothing to price on ─────────────────────────────────────
+
+test('orchestrator: {perMtok} + a result with NO usage is reported, not silently booked at $0', async () => {
+  await addGlobalModel({ id: 'priced', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { perMtok: { input: 1, output: 3 } } });
+  const { orch, seen } = pausedOrch('mcos-nousage');
+  orch.claude.mock = false;
+  orch._onAgentEvent('planner',
+    { type: 'result', costUsd: 0.4625, raw: { type: 'result', total_cost_usd: 0.4625 } },
+    { model: 'priced', stepKey: 'plan' });
+
+  assert.equal(orch.getState().steps.find((s) => s.key === 'plan').costUsd, undefined,
+    'unpriceable -> nothing booked (and certainly not the CLI figure it was told to ignore)');
+  assert.equal(orch.getState().totalCostUsd, 0);
+  assert.ok(seen.warns.some((w) => /priced per-Mtok but the result carried no token usage/.test(w)),
+    `the operator is told their priced model went unaccounted; saw: ${JSON.stringify(seen.warns)}`);
+});
+
+test('orchestrator: {perMtok} + a usage object of genuine ZEROES prices at $0 (it IS priceable)', async () => {
+  await addGlobalModel({ id: 'priced', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { perMtok: { input: 1, output: 3 } } });
+  const { orch, seen } = pausedOrch('mcos-zerousage');
+  orch.claude.mock = false;
+  orch._onAgentEvent('planner',
+    { type: 'result', costUsd: 0.4625, raw: { type: 'result', total_cost_usd: 0.4625, usage: { input_tokens: 0, output_tokens: 0 } } },
+    { model: 'priced', stepKey: 'plan' });
+  assert.equal(orch.getState().steps.find((s) => s.key === 'plan').costUsd, 0, 'zero tokens is a price, not a gap');
+  assert.equal(seen.warns.length, 0, 'and no warning — nothing went unaccounted');
+});
+
+// ── 3. sub-agent attribution ──────────────────────────────────────────────────
+
+const spawnFrame = (id, input = {}) => ({
+  type: 'assistant',
+  raw: { type: 'assistant', message: { content: [{ type: 'tool_use', id, name: 'Agent', input: { description: 'd', ...input } }] } },
+});
+const hookFrame = (id, costUsd) => ({
+  type: 'hook-event',
+  raw: {
+    type: 'hook-event', hook_event_name: 'PostToolUse', tool_name: 'Agent', tool_use_id: id,
+    tool_response: { totalDurationMs: 100, totalTokens: 10, usage: { cost_usd: costUsd, input_tokens: 1_000_000 } },
+  },
+});
+
+test('sub-agent: inherits the PARENT node\'s price — the child shares its endpoint', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  const { orch } = pausedOrch('mcos-sub1');
+  const attr = { model: 'onprem', stepKey: 'plan', nodeId: 'n', stepIndex: 0, cycle: 1 };
+  orch._onAgentEvent('planner', spawnFrame('toolu_A'), attr);
+  orch._onAgentEvent('planner', hookFrame('toolu_A', 0.012), attr);
+  assert.equal(orch.state.subAgents.find((s) => s.id === 'toolu_A').costUsd, 0);
+});
+
+test('sub-agent: a bare Task `model` alias with no catalog entry keeps the parent\'s override', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  const { orch } = pausedOrch('mcos-sub2');
+  const attr = { model: 'onprem', stepKey: 'plan', nodeId: 'n', stepIndex: 0, cycle: 1 };
+  orch._onAgentEvent('planner', spawnFrame('toolu_B', { model: 'haiku' }), attr);
+  orch._onAgentEvent('planner', hookFrame('toolu_B', 0.012), attr);
+  assert.equal(orch.state.subAgents.find((s) => s.id === 'toolu_B').costUsd, 0,
+    "'haiku' resolves to nothing — falling back to the CLI figure would re-inflate a free endpoint");
+});
+
+test('sub-agent: a Task `model` that carries its OWN override is priced by it', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  await addGlobalModel({ id: 'sidecar', cost: { perMtok: { input: 2 } } });
+  const { orch } = pausedOrch('mcos-sub3');
+  const attr = { model: 'onprem', stepKey: 'plan', nodeId: 'n', stepIndex: 0, cycle: 1 };
+  orch._onAgentEvent('planner', spawnFrame('toolu_C', { model: 'sidecar' }), attr);
+  orch._onAgentEvent('planner', hookFrame('toolu_C', 0.012), attr);
+  assert.equal(orch.state.subAgents.find((s) => s.id === 'toolu_C').costUsd, 2, '1M input @ $2/Mtok');
+});
+
+test('sub-agent: an unpriceable {perMtok} child leaves the row\'s cost UNSET, not fabricated', async () => {
+  await addGlobalModel({ id: 'priced', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { perMtok: { input: 2 } } });
+  const { orch } = pausedOrch('mcos-sub4');
+  const attr = { model: 'priced', stepKey: 'plan', nodeId: 'n', stepIndex: 0, cycle: 1 };
+  orch._onAgentEvent('planner', spawnFrame('toolu_D'), attr);
+  orch._onAgentEvent('planner', {
+    type: 'hook-event',
+    raw: {
+      type: 'hook-event', hook_event_name: 'PostToolUse', tool_name: 'Agent', tool_use_id: 'toolu_D',
+      tool_response: { totalDurationMs: 100, totalTokens: 10, cost_usd: 0.012 }, // cost, but no usage
+    },
+  }, attr);
+  const rec = orch.state.subAgents.find((s) => s.id === 'toolu_D');
+  assert.equal(rec.costUsd, undefined);
+  assert.equal(rec.durationMs, 100, 'the rest of the telemetry still lands');
+});
+
+// ── 4. Ask Worca ──────────────────────────────────────────────────────────────
+
+const ASK_RESULT = (over = {}) => ({
+  type: 'result', subtype: 'success', is_error: false, total_cost_usd: 0.4625,
+  usage: { input_tokens: 1_000_000, output_tokens: 1_000_000, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+  modelUsage: {}, duration_ms: 40, num_turns: 1, session_id: 'sess-1', permission_denials: [], ...over,
+});
+
+function askTurn(model, runClaudeImpl) {
+  const thread = createThread();
+  const user = appendMessage(thread.id, { role: 'user', text: 'hello there' });
+  const asst = appendMessage(thread.id, { role: 'assistant', text: '', status: 'streaming' });
+  const frames = [];
+  const turn = createAskTurn({
+    threadId: thread.id, assistantMessageId: asst.id, userMessageId: user.id,
+    prompt: 'P', systemPrompt: 'SYS', restoredPrompt: 'R',
+    model, effort: 'high',
+    resumeSessionId: null, firstTurn: false, firstText: 'hello there', deterministicTitle: null,
+    mock: null, attachmentNames: {},
+    deps: { onFrame: (f) => frames.push(f), generateTitle: async () => '', runClaudeImpl },
+  });
+  return { turn, frames, thread, asst };
+}
+
+const askLedger = () => getDb().prepare('SELECT amount_usd FROM ask_cost_ledger ORDER BY id').all();
+
+test('ask: a {free} model books $0 in the row, the thread totals, the budget ledger AND the frame', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  const { turn, frames, thread, asst } = askTurn('onprem', async (opts) => {
+    opts.onEvent({ type: 'assistant', raw: { type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'hi' }] }, parent_tool_use_id: null } });
+    opts.onEvent({ type: 'result', raw: ASK_RESULT() });
+    return { text: 'hi', exitCode: 0 };
+  });
+  assert.equal((await turn.run()).status, 'done');
+
+  assert.equal(getMessage(asst.id).costUsd, 0, 'message row');
+  assert.equal(getThread(thread.id).totals.costUsd, 0, 'thread totals');
+  assert.deepEqual(askLedger(), [], 'ledger: a $0 turn leaves no row, so the windowed budget sees nothing');
+  assert.equal(frames.at(-1).costUsd, 0, 'ask-done frame');
+  // The live frames never showed the fabricated figure either.
+  assert.ok(frames.filter((f) => f.type === 'ask-usage').every((f) => f.costUsd === 0 || f.costUsd === null),
+    'no ask-usage frame leaked the CLI figure');
+});
+
+test('ask: a {perMtok} model books the recomputed cost into the budget ledger', async () => {
+  await addGlobalModel({ id: 'priced', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { perMtok: { input: 1, output: 3 } } });
+  const { turn, frames, thread, asst } = askTurn('priced', async (opts) => {
+    opts.onEvent({ type: 'assistant', raw: { type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'hi' }] }, parent_tool_use_id: null } });
+    opts.onEvent({ type: 'result', raw: ASK_RESULT() });
+    return { text: 'hi', exitCode: 0 };
+  });
+  await turn.run();
+  assert.equal(getMessage(asst.id).costUsd, 4, '1M input@1 + 1M output@3, not the CLI 0.4625');
+  assert.equal(getThread(thread.id).totals.costUsd, 4);
+  assert.deepEqual(askLedger().map((r) => r.amount_usd), [4]);
+  assert.equal(frames.at(-1).costUsd, 4);
+});
+
+test('ask: with NO override the CLI figure stands unchanged (default behavior)', async () => {
+  await addGlobalModel({ id: 'plain', env: { ANTHROPIC_BASE_URL: 'https://p' } });
+  const { turn, thread, asst } = askTurn('plain', async (opts) => {
+    opts.onEvent({ type: 'assistant', raw: { type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'hi' }] }, parent_tool_use_id: null } });
+    opts.onEvent({ type: 'result', raw: ASK_RESULT() });
+    return { text: 'hi', exitCode: 0 };
+  });
+  await turn.run();
+  assert.equal(getMessage(asst.id).costUsd, 0.4625);
+  assert.equal(getThread(thread.id).totals.costUsd, 0.4625);
+  assert.deepEqual(askLedger().map((r) => r.amount_usd), [0.4625]);
+});
+
+test('ask: §6.2.8 — no `result` frame still means costUsd NULL, an override does not forge a $0', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  const { turn, frames, asst } = askTurn('onprem', async (opts) => {
+    opts.onEvent({ type: 'assistant', raw: { type: 'assistant', message: { id: 'm1', content: [{ type: 'text', text: 'hi' }] }, parent_tool_use_id: null } });
+    return { text: 'hi', exitCode: 0 };   // no result event at all
+  });
+  await turn.run();
+  assert.equal(getMessage(asst.id).costUsd, null, 'null means "no cost observed" — not a price to re-price');
+  assert.equal(frames.at(-1).costUsd, null);
+  assert.deepEqual(askLedger(), []);
+});
+
+test('ask: a {free} turn\'s sub-agent rows are scaled to $0 too (agents never out-total their turn)', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  const AGENT_TUR = {
+    status: 'completed', agentId: 'a1', agentType: 'general-purpose', model: 'onprem',
+    totalDurationMs: 1000, totalTokens: 4139,
+    usage: { input_tokens: 4016, output_tokens: 123, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+  };
+  const { turn, asst } = askTurn('onprem', async (opts) => {
+    opts.onEvent({ type: 'assistant', raw: { type: 'assistant', parent_tool_use_id: null, session_id: 'sess-1',
+      message: { id: 'm1', role: 'assistant', content: [
+        { type: 'tool_use', id: 'toolu_1', name: 'Agent', input: { subagent_type: 'general-purpose', description: 'dig', prompt: 'P' } }] } } });
+    opts.onEvent({ type: 'user', raw: { type: 'user', parent_tool_use_id: null, session_id: 'sess-1',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: [{ type: 'text', text: 'ok' }] }] },
+      tool_use_result: AGENT_TUR } });
+    opts.onEvent({ type: 'result', raw: ASK_RESULT({
+      modelUsage: { onprem: { inputTokens: 8032, outputTokens: 246, cacheReadInputTokens: 0, cacheCreationInputTokens: 0, costUSD: 0.4625 } },
+    }) });
+    return { text: 'done', exitCode: 0 };
+  });
+  await turn.run();
+  const agents = (getMessage(asst.id).blocks || []).filter((b) => b.kind === 'agent');
+  assert.equal(agents.length, 1, 'the sub-agent block is there to price');
+  assert.equal(agents[0].costUsd, 0,
+    'the §6.6 share rides the override — a $0 turn cannot contain a billing agent');
+  assert.equal(getMessage(asst.id).costUsd, 0);
+});
+
+// ── 5. the overview agent ─────────────────────────────────────────────────────
+
+test('overview agent: its sub-agent row is priced by the override, like any pipeline node', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  const { id, dir, key } = await seedPipeline(join(home, 'proj'));
+  await mkdir(dir, { recursive: true });
+  await persistResults(dir, { summary: { filesNew: 1 } });
+  await persistDiffPatch(dir, 'diff --git a/x b/x\n+hi');
+
+  await generateOverview(key, id, {
+    model: 'onprem',
+    runClaudeImpl: async (opts) => {
+      opts.onEvent({ type: 'result', costUsd: 0.4625, raw: { type: 'result', total_cost_usd: 0.4625, usage: USAGE } });
+      return { text: '{"narrative":"did x","diffFindings":[],"diffCheckTruncated":false}' };
+    },
+  });
+  const row = listSubAgents(id).find((s) => s.id === `overview-${id}`);
+  assert.ok(row, 'the overview run is recorded as a sub-agent');
+  assert.equal(row.costUsd, 0, 'the CLI\'s by-name 0.4625 is discarded');
+});

--- a/test/model-cost-override.test.mjs
+++ b/test/model-cost-override.test.mjs
@@ -11,7 +11,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
-  modelCostConfig, estimateCost, resolveModelCost,
+  modelCostConfig, estimateCost, isPriceableUsage, resolveModelCost,
   observeModelCost, costUnreliableModelIds,
 } from '../src/core/config.mjs';
 import { addGlobalModel, updateGlobalModel } from '../src/core/settings.mjs';
@@ -87,6 +87,53 @@ test('resolveModelCost: {perMtok} → recomputed from tokens, ignoring the CLI v
   await addGlobalModel({ id: 'priced', cost: { perMtok: { input: 1, output: 3 } } });
   // 1M input @1 + 1M output @3 = 4, no matter what the CLI said.
   assert.equal(resolveModelCost('priced', 999, USAGE), 4);
+});
+
+test('estimateCost also reads Ask Worca\'s normalized usage shape (same tokens, other spelling)', () => {
+  const rates = { input: 1, output: 3, cacheRead: 0.1, cacheWrite: 1.25 };
+  const ask = { input: 1_000_000, output: 1_000_000, cacheRead: 1_000_000, cacheCreation: 1_000_000, ctx: 4_000_000 };
+  assert.equal(estimateCost(ask, rates), estimateCost(USAGE, rates), 'both spellings price identically');
+  assert.equal(estimateCost({ input: 500_000 }, { input: 3 }), 1.5);
+  // The raw spelling wins when (impossibly) both are present — it is the source shape.
+  assert.equal(estimateCost({ input_tokens: 1_000_000, input: 9_000_000 }, { input: 1 }), 1);
+  // A raw ZERO is a real count, not a gap: it must not fall through to the camel key.
+  assert.equal(estimateCost({ input_tokens: 0, input: 9_000_000 }, { input: 1 }), 0);
+});
+
+test('isPriceableUsage: an absent usage object is unpriceable; genuine zeroes are priceable', () => {
+  assert.equal(isPriceableUsage(undefined), false);
+  assert.equal(isPriceableUsage(null), false);
+  assert.equal(isPriceableUsage('nope'), false);
+  assert.equal(isPriceableUsage({}), false, 'an object with no token fields says nothing');
+  assert.equal(isPriceableUsage({ input_tokens: 0 }), true, 'zero tokens IS a count');
+  assert.equal(isPriceableUsage({ output: 0 }), true, 'the ask spelling counts too');
+  assert.equal(isPriceableUsage({ cache_creation: { ephemeral_1h_input_tokens: 5 } }), true);
+});
+
+test('resolveModelCost: {perMtok} with NO usage is NaN — never a silent $0, never the CLI figure', async () => {
+  await addGlobalModel({ id: 'priced', cost: { perMtok: { input: 1, output: 3 } } });
+  assert.ok(Number.isNaN(resolveModelCost('priced', 0.4625, undefined)),
+    'unpriceable: the caller reports it instead of booking a made-up number');
+  assert.ok(Number.isNaN(resolveModelCost('priced', 0.4625, null)));
+  assert.equal(resolveModelCost('priced', 0.4625, { input_tokens: 0, output_tokens: 0 }), 0,
+    'but a usage object of genuine zeroes prices at $0');
+  // {free} needs no usage at all — it is $0 by decree.
+  await addGlobalModel({ id: 'onprem', cost: { free: true } });
+  assert.equal(resolveModelCost('onprem', 0.4625, undefined), 0);
+});
+
+test('resolveModelCost / observeModelCost accept a pre-resolved override (one catalog read per event)', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  // An explicitly passed config is USED — including `null`, which means "checked,
+  // there is none" and must not trigger a second lookup that finds one.
+  assert.equal(resolveModelCost('onprem', 0.4625, USAGE, { free: true }), 0);
+  assert.equal(resolveModelCost('onprem', 0.4625, USAGE, null), 0.4625,
+    'null = the caller already established there is no override');
+  assert.equal(resolveModelCost('onprem', 0.4625, USAGE), 0, 'undefined = look it up');
+  // Same contract on the observer: a passed-in override suppresses the flag.
+  assert.equal(observeModelCost('onprem', 0, USAGE, { free: true }), null);
+  assert.equal(observeModelCost('onprem', 0, USAGE, null), 'flagged',
+    'told there is no override, it flags the zero-cost-with-tokens run as before');
 });
 
 test('observeModelCost: a model with an override is never flagged and its stale flag is lifted', async () => {

--- a/test/model-cost-override.test.mjs
+++ b/test/model-cost-override.test.mjs
@@ -1,0 +1,138 @@
+// test/model-cost-override.test.mjs
+// Opt-in per-model cost override (config.mjs): a user-pinned {free}/{perMtok}
+// entry in the GLOBAL catalog wins over whatever total_cost_usd the Claude CLI
+// fabricates for an on-prem/proxied model. Inspired by worca 0.x cost_alias.
+// Mirrors test/model-cost-flags.test.mjs sandboxing (sandboxed HOME + WORCA_HOME
+// + the catalog test-guard opt-in, plus a DB reset since observeModelCost writes).
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  modelCostConfig, estimateCost, resolveModelCost,
+  observeModelCost, costUnreliableModelIds,
+} from '../src/core/config.mjs';
+import { addGlobalModel, updateGlobalModel } from '../src/core/settings.mjs';
+import { createOrchestrator } from '../src/core/orchestrator.mjs';
+import { getDb, _resetForTests } from '../src/core/db.mjs';
+
+const dirs = [];
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
+beforeEach(async () => {
+  const home = await mkdtemp(join(tmpdir(), 'worca-cc-mco-home-'));
+  const whome = await mkdtemp(join(tmpdir(), 'worca-cc-mco-whome-'));
+  dirs.push(home, whome);
+  _resetForTests();
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  process.env.WORCA_HOME = whome;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1';
+});
+after(async () => {
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+const USAGE = { input_tokens: 1_000_000, output_tokens: 1_000_000, cache_read_input_tokens: 1_000_000, cache_creation_input_tokens: 1_000_000 };
+
+test('modelCostConfig: reads the GLOBAL catalog override, null when none / unknown', async () => {
+  await addGlobalModel({ id: 'onprem', cost: { free: true } });
+  await addGlobalModel({ id: 'plain' });
+  assert.deepEqual(modelCostConfig('ONPREM'), { free: true }, 'case-insensitive');
+  assert.equal(modelCostConfig('plain'), null);
+  assert.equal(modelCostConfig('claude-opus-5'), null, 'predefined carry none');
+  assert.equal(modelCostConfig(''), null);
+});
+
+test('estimateCost: rates are USD per MILLION tokens; missing rates/usage count as 0', () => {
+  // 1M of each class at 1.0/mtok = 1.0 apiece.
+  assert.equal(estimateCost(USAGE, { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 }), 4);
+  assert.equal(estimateCost(USAGE, { output: 2 }), 2, 'only output priced');
+  assert.equal(estimateCost({ input_tokens: 500_000 }, { input: 3 }), 1.5);
+  assert.equal(estimateCost({}, { input: 5 }), 0);
+  assert.equal(estimateCost(USAGE, {}), 0, 'no rates → $0');
+  assert.equal(estimateCost(USAGE, null), 0);
+});
+
+test('estimateCost: ephemeral 1h/5m cache buckets price separately, else flat cacheWrite', () => {
+  const u = { cache_creation: { ephemeral_5m_input_tokens: 1_000_000, ephemeral_1h_input_tokens: 1_000_000 } };
+  assert.equal(estimateCost(u, { cacheWrite: 1, cacheWrite1h: 2 }), 3, '5m@1 + 1h@2');
+  assert.equal(estimateCost(u, { cacheWrite: 1 }), 2, '1h falls back to cacheWrite when cacheWrite1h absent');
+  // No bucket breakdown → flat cache_creation_input_tokens at cacheWrite.
+  assert.equal(estimateCost({ cache_creation_input_tokens: 2_000_000 }, { cacheWrite: 1 }), 2);
+});
+
+test('resolveModelCost: no override → CLI value verbatim (incl. NaN passthrough)', async () => {
+  await addGlobalModel({ id: 'plain' });
+  assert.equal(resolveModelCost('plain', 0.4625, USAGE), 0.4625);
+  assert.equal(resolveModelCost('unknown-model', 1.23, USAGE), 1.23);
+  assert.ok(Number.isNaN(resolveModelCost('plain', NaN, USAGE)));
+});
+
+test('resolveModelCost: {free} → $0 regardless of what the CLI reported', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  assert.equal(resolveModelCost('onprem', 0.4625, USAGE), 0, 'the reported 0.46 is discarded');
+  assert.equal(resolveModelCost('ONPREM', 99, USAGE), 0, 'case-insensitive');
+  assert.equal(resolveModelCost('onprem', NaN, USAGE), 0, 'free is 0 even when CLI reported nothing');
+});
+
+test('resolveModelCost: {perMtok} → recomputed from tokens, ignoring the CLI value', async () => {
+  await addGlobalModel({ id: 'priced', cost: { perMtok: { input: 1, output: 3 } } });
+  // 1M input @1 + 1M output @3 = 4, no matter what the CLI said.
+  assert.equal(resolveModelCost('priced', 999, USAGE), 4);
+});
+
+test('observeModelCost: a model with an override is never flagged and its stale flag is lifted', async () => {
+  // A routed model with NO override reports zero cost with tokens → flagged.
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' } });
+  assert.equal(observeModelCost('onprem', 0, USAGE), 'flagged');
+  assert.deepEqual([...costUnreliableModelIds()], ['onprem']);
+
+  // Add an override to that SAME model, then observe again: never flags, and the
+  // stale flag from before the override existed is lifted.
+  await updateGlobalModel('onprem', { cost: { free: true } });
+  assert.equal(observeModelCost('onprem', 0, USAGE), null, 'never flagged with an override');
+  assert.equal(costUnreliableModelIds().size, 0, 'stale flag lifted');
+  assert.equal(getDb().prepare('SELECT COUNT(*) AS n FROM model_cost_flags').get().n, 0);
+});
+
+// ── end-to-end through the orchestrator's result-event intake ───────────────────
+
+test('orchestrator: a {free} model records $0 for the step and total, discarding the CLI figure', async () => {
+  await addGlobalModel({ id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } });
+  const orch = createOrchestrator({ projectDir: join(tmpdir(), 'mco-proj') });
+  orch._phase('plan', 0, 'start');
+  orch._onAgentEvent('planner',
+    { type: 'result', costUsd: 0.4625, raw: { type: 'result', total_cost_usd: 0.4625, usage: USAGE } },
+    { model: 'onprem', stepKey: 'plan' });
+  const st = orch.getState();
+  assert.equal(st.steps.find((s) => s.key === 'plan').costUsd, 0, 'the fabricated 0.4625 is discarded');
+  assert.equal(st.totalCostUsd, 0);
+});
+
+test('orchestrator: with no override the CLI figure is recorded unchanged', async () => {
+  await addGlobalModel({ id: 'plain', env: { ANTHROPIC_BASE_URL: 'https://p' } });
+  const orch = createOrchestrator({ projectDir: join(tmpdir(), 'mco-proj2') });
+  orch._phase('plan', 0, 'start');
+  orch._onAgentEvent('planner',
+    { type: 'result', costUsd: 0.4625, raw: { type: 'result', usage: USAGE } },
+    { model: 'plain', stepKey: 'plan' });
+  assert.equal(orch.getState().totalCostUsd, 0.4625);
+});
+
+test('orchestrator: a {perMtok} model records the recomputed cost, not the CLI figure', async () => {
+  await addGlobalModel({ id: 'priced', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { perMtok: { input: 1, output: 3 } } });
+  const orch = createOrchestrator({ projectDir: join(tmpdir(), 'mco-proj3') });
+  orch._phase('plan', 0, 'start');
+  orch._onAgentEvent('planner',
+    { type: 'result', costUsd: 999, raw: { type: 'result', usage: USAGE } },
+    { model: 'priced', stepKey: 'plan' });
+  assert.equal(orch.getState().totalCostUsd, 4, '1M input@1 + 1M output@3');
+});

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -5,8 +5,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { JSDOM } from 'jsdom';
 import {
-  effortsSummary, envSummary, renderModelsList, renderModelEditor,
-  collectModelEditor, makeEnvRow, deleteRefsSummary,
+  effortsSummary, envSummary, costSummary, renderModelsList, renderModelEditor,
+  collectModelEditor, makeEnvRow, applyCostMode, deleteRefsSummary,
   renderExportWizard, collectExportWizard,
 } from '../ui/public/models-view.mjs';
 
@@ -120,7 +120,7 @@ test('collect (create): id from input, partial efforts, env rows as typed; full 
 
   let { id, body } = collectModelEditor(el);
   assert.equal(id, null);
-  assert.deepEqual(body, { id: 'my-model', label: 'Mine', efforts: [], env: { ANTHROPIC_BASE_URL: 'https://x' } });
+  assert.deepEqual(body, { id: 'my-model', label: 'Mine', efforts: [], env: { ANTHROPIC_BASE_URL: 'https://x' }, cost: null });
 
   // Uncheck one effort -> the subset is sent.
   el.querySelector('.mv-effort-cb[value="max"]').checked = false;
@@ -267,4 +267,125 @@ test('list: Test button on global + plugin cards (disabled while a secret is uns
   for (const row of el.querySelectorAll('.mv-builtin')) {
     assert.equal(row.querySelector('.mv-test'), null, 'no Test on built-ins');
   }
+});
+
+// ── Pricing: the opt-in per-model cost override (config.mjs resolveModelCost) ──
+
+const PRICED = {
+  id: 'discreetstack', label: 'DiscreetStack', efforts: EFFORTS,
+  env: { ANTHROPIC_BASE_URL: '••••••e/v1' },
+  cost: { perMtok: { input: 0.5, output: 1.5 } },
+};
+const FREE = { id: 'onprem', label: 'On-prem', efforts: EFFORTS, cost: { free: true } };
+const mode = (el) => el.querySelector('.mv-cost-mode-rb:checked')?.value;
+const rate = (el, k) => el.querySelector(`.mv-cost-rate-in[data-rate="${k}"]`);
+
+test('costSummary: only a real override says anything', () => {
+  assert.equal(costSummary(undefined), '');
+  assert.equal(costSummary({}), '');
+  assert.equal(costSummary({ perMtok: {} }), '');
+  assert.equal(costSummary({ free: true }), 'priced free');
+  assert.equal(costSummary({ perMtok: { input: 0.5, output: 1.5 } }), 'input $0.5 · output $1.5 /Mtok');
+  assert.equal(costSummary({ perMtok: { cacheWrite1h: 1 } }), 'cache write (1h) $1 /Mtok');
+  assert.equal(costSummary({ perMtok: { input: 0 } }), 'input $0 /Mtok', 'a pinned ZERO rate is not "unset"');
+});
+
+test('editor (create): pricing defaults to Trust the CLI with the rate grid hidden', () => {
+  const el = renderModelEditor(null, EFFORTS, { doc });
+  assert.equal(mode(el), 'cli', 'default behavior is unchanged behavior');
+  assert.equal(el.querySelector('.mv-cost-rates').hidden, true);
+  assert.equal(el.querySelectorAll('.mv-cost-rate-in').length, 5, 'all five rate keys are offered');
+  assert.deepEqual([...el.querySelectorAll('.mv-cost-rate-in')].map((i) => i.dataset.rate),
+    ['input', 'output', 'cacheRead', 'cacheWrite', 'cacheWrite1h']);
+  assert.ok([...el.querySelectorAll('.mv-cost-rate-in')].every((i) => i.value === ''));
+});
+
+test('editor (edit): the STORED override is what the form shows', () => {
+  const free = renderModelEditor(FREE, EFFORTS, { doc });
+  assert.equal(mode(free), 'free');
+  assert.equal(free.querySelector('.mv-cost-rates').hidden, true, 'rates are irrelevant to free');
+
+  const priced = renderModelEditor(PRICED, EFFORTS, { doc });
+  assert.equal(mode(priced), 'perMtok');
+  assert.equal(priced.querySelector('.mv-cost-rates').hidden, false);
+  assert.equal(rate(priced, 'input').value, '0.5');
+  assert.equal(rate(priced, 'output').value, '1.5');
+  assert.equal(rate(priced, 'cacheRead').value, '', 'an unset rate stays blank, not "0"');
+
+  // A model with no override opens on Trust the CLI, like create.
+  assert.equal(mode(renderModelEditor(GLOBAL, EFFORTS, { doc })), 'cli');
+});
+
+test('applyCostMode: the rate grid follows the selected mode (app.js wires it to change)', () => {
+  const el = renderModelEditor(null, EFFORTS, { doc });
+  const rates = el.querySelector('.mv-cost-rates');
+  el.querySelector('.mv-cost-mode-rb[value="perMtok"]').checked = true;
+  applyCostMode(el);
+  assert.equal(rates.hidden, false);
+  el.querySelector('.mv-cost-mode-rb[value="free"]').checked = true;
+  applyCostMode(el);
+  assert.equal(rates.hidden, true);
+  // Never throws on an editor without the block (defensive: shared entry point).
+  applyCostMode(doc.createElement('div'));
+});
+
+test('collect: each mode emits its own cost shape; only filled rates are sent, as numbers', () => {
+  const el = renderModelEditor(null, EFFORTS, { doc });
+  el.querySelector('.mv-id').value = 'm';
+  assert.equal(collectModelEditor(el).body.cost, null, 'Trust the CLI = no override');
+
+  el.querySelector('.mv-cost-mode-rb[value="free"]').checked = true;
+  assert.deepEqual(collectModelEditor(el).body.cost, { free: true });
+
+  el.querySelector('.mv-cost-mode-rb[value="perMtok"]').checked = true;
+  rate(el, 'input').value = '0.5';
+  rate(el, 'cacheRead').value = '0.05';
+  rate(el, 'output').value = '';
+  assert.deepEqual(collectModelEditor(el).body.cost, { perMtok: { input: 0.5, cacheRead: 0.05 } },
+    'blank rates are omitted (cacheWrite1h then falls back to the 5m rate), values are numbers');
+
+  // A pinned ZERO is a rate, not a blank.
+  rate(el, 'output').value = '0';
+  assert.deepEqual(collectModelEditor(el).body.cost.perMtok.output, 0);
+});
+
+test('collect: per-Mtok with every rate blank is sent as-is for the server to reject by name', () => {
+  const el = renderModelEditor(null, EFFORTS, { doc });
+  el.querySelector('.mv-id').value = 'm';
+  el.querySelector('.mv-cost-mode-rb[value="perMtok"]').checked = true;
+  assert.deepEqual(collectModelEditor(el).body.cost, { perMtok: {} },
+    'settings.mjs owns the rules — duplicating them here would let them drift');
+});
+
+test('collect: the override ROUND-TRIPS, so editing a label never silently reprices a model', () => {
+  const el = renderModelEditor(PRICED, EFFORTS, { doc });
+  el.querySelector('.mv-label').value = 'Renamed';
+  const { body } = collectModelEditor(el);
+  assert.equal(body.label, 'Renamed');
+  assert.deepEqual(body.cost, { perMtok: { input: 0.5, output: 1.5 } }, 'untouched pricing survives');
+});
+
+test('list: a priced model shows its rates and drops the now-meaningless "cost not verified" badge', () => {
+  const el = renderModelsList({
+    globals: [
+      { ...PRICED, costUnreliable: true },
+      { ...FREE, costUnreliable: true },
+      { ...GLOBAL, costUnreliable: true },
+    ],
+    predefined: [], efforts: EFFORTS,
+  }, { doc });
+  const cards = [...el.querySelectorAll('.mv-card')];
+  const badges = (c) => [...c.querySelectorAll('.badge')].map((b) => b.textContent);
+
+  assert.ok(badges(cards[0]).includes('priced'));
+  assert.ok(!badges(cards[0]).includes('cost not verified'),
+    'an override GOVERNS the spend — the unreliable flag says nothing about it');
+  assert.match(cards[0].querySelector('.mv-summary').textContent, /input \$0\.5 · output \$1\.5 \/Mtok/);
+
+  assert.ok(badges(cards[1]).includes('free'));
+  assert.match(cards[1].querySelector('.mv-summary').textContent, /priced free/);
+
+  // A model with NO override still shows the flag — unchanged.
+  assert.ok(badges(cards[2]).includes('cost not verified'));
+  assert.ok(!badges(cards[2]).includes('priced'));
 });

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { JSDOM } from 'jsdom';
 import {
-  effortsSummary, envSummary, costSummary, renderModelsList, renderModelEditor,
+  effortsSummary, envSummary, costSummary, suggestDuplicateId, renderModelsList, renderModelEditor,
   collectModelEditor, makeEnvRow, applyCostMode, setModelCost, deleteRefsSummary,
   renderExportWizard, collectExportWizard,
 } from '../ui/public/models-view.mjs';
@@ -428,4 +428,36 @@ test('list: a plugin card shows its MANIFEST price, same rules as a global card'
   assert.match(cards[0].querySelector('.mv-summary').textContent, /input \$1 · output \$3 \/Mtok/);
   assert.ok(badges(cards[1]).includes('free'));
   assert.ok(badges(cards[2]).includes('cost not verified'), 'unpriced plugin model: flag unchanged');
+});
+
+// ── Duplicate ────────────────────────────────────────────────────────────────
+
+test('suggestDuplicateId: first free -copy, then numbered, case-insensitively', () => {
+  assert.equal(suggestDuplicateId('glm-4.7', []), 'glm-4.7-copy');
+  assert.equal(suggestDuplicateId('glm-4.7', ['glm-4.7']), 'glm-4.7-copy');
+  assert.equal(suggestDuplicateId('glm-4.7', ['glm-4.7', 'glm-4.7-copy']), 'glm-4.7-copy-2');
+  assert.equal(suggestDuplicateId('glm-4.7', ['GLM-4.7-COPY', 'glm-4.7-copy-2']), 'glm-4.7-copy-3',
+    'ids collide case-insensitively, so the suggestion must too');
+  // Duplicating a duplicate keeps stacking rather than fighting over one name.
+  assert.equal(suggestDuplicateId('glm-4.7-copy', ['glm-4.7-copy']), 'glm-4.7-copy-copy');
+});
+
+test('list: only global cards get Duplicate — plugin cards already have Edit a copy', () => {
+  const el = renderModelsList({
+    globals: [GLOBAL],
+    legacy: [{ id: 'old-local', label: 'Old Local' }],
+    plugins: [{ id: 'pp', label: 'PP', efforts: EFFORTS, plugin: 'p', secrets: [] }],
+    predefined: PREDEFINED,
+    efforts: EFFORTS,
+  }, { doc });
+
+  const globalCard = el.querySelector('.mv-card:not(.mv-plugin):not(.mv-legacy)');
+  const dup = globalCard.querySelector('.mv-duplicate');
+  assert.ok(dup, 'global card offers Duplicate');
+  assert.equal(dup.dataset.id, GLOBAL.id, 'carries the SOURCE id — the flow reads the raw env by it');
+  assert.equal(dup.type, 'button', 'never submits a form');
+
+  assert.equal(el.querySelector('.mv-plugin .mv-duplicate'), null);
+  assert.equal(el.querySelector('.mv-legacy .mv-duplicate'), null);
+  assert.equal(el.querySelector('.mv-builtin .mv-duplicate'), null);
 });

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import { JSDOM } from 'jsdom';
 import {
   effortsSummary, envSummary, costSummary, renderModelsList, renderModelEditor,
-  collectModelEditor, makeEnvRow, applyCostMode, deleteRefsSummary,
+  collectModelEditor, makeEnvRow, applyCostMode, setModelCost, deleteRefsSummary,
   renderExportWizard, collectExportWizard,
 } from '../ui/public/models-view.mjs';
 
@@ -388,4 +388,44 @@ test('list: a priced model shows its rates and drops the now-meaningless "cost n
   // A model with NO override still shows the flag — unchanged.
   assert.ok(badges(cards[2]).includes('cost not verified'));
   assert.ok(!badges(cards[2]).includes('priced'));
+});
+
+test('setModelCost: loads any override into an editor (the ONE cost -> form mapping)', () => {
+  const el = renderModelEditor(null, EFFORTS, { doc });
+  setModelCost(el, { perMtok: { input: 0.5, cacheWrite1h: 1.2 } });
+  assert.equal(mode(el), 'perMtok');
+  assert.equal(el.querySelector('.mv-cost-rates').hidden, false);
+  assert.equal(rate(el, 'input').value, '0.5');
+  assert.equal(rate(el, 'cacheWrite1h').value, '1.2');
+  assert.equal(rate(el, 'output').value, '');
+
+  setModelCost(el, { free: true });
+  assert.equal(mode(el), 'free');
+  assert.equal(rate(el, 'input').value, '', 'switching modes clears the stale rates');
+
+  setModelCost(el, null);
+  assert.equal(mode(el), 'cli');
+  assert.equal(el.querySelector('.mv-cost-rates').hidden, true);
+  setModelCost(doc.createElement('div'), { free: true }); // never throws without the block
+});
+
+test('list: a plugin card shows its MANIFEST price, same rules as a global card', () => {
+  const el = renderModelsList({
+    globals: [],
+    plugins: [
+      { id: 'pp-rated', label: 'PP Rated', efforts: EFFORTS, plugin: 'priced-plug', secrets: [],
+        env: { ANTHROPIC_BASE_URL: '••••••mple' }, cost: { perMtok: { input: 1, output: 3 } }, costUnreliable: true },
+      { id: 'pp-free', label: 'PP Free', efforts: EFFORTS, plugin: 'priced-plug', secrets: [], cost: { free: true } },
+      { id: 'pp-plain', label: 'PP Plain', efforts: EFFORTS, plugin: 'priced-plug', secrets: [], costUnreliable: true },
+    ],
+    predefined: [], efforts: EFFORTS,
+  }, { doc });
+  const cards = [...el.querySelectorAll('.mv-plugin')];
+  const badges = (c) => [...c.querySelectorAll('.badge')].map((b) => b.textContent);
+
+  assert.ok(badges(cards[0]).includes('priced'));
+  assert.ok(!badges(cards[0]).includes('cost not verified'), 'a pinned price governs the spend');
+  assert.match(cards[0].querySelector('.mv-summary').textContent, /input \$1 · output \$3 \/Mtok/);
+  assert.ok(badges(cards[1]).includes('free'));
+  assert.ok(badges(cards[2]).includes('cost not verified'), 'unpriced plugin model: flag unchanged');
 });

--- a/test/plugin-manifest.test.mjs
+++ b/test/plugin-manifest.test.mjs
@@ -427,3 +427,37 @@ test('models: unknown fields warn (strict promotes via validatePluginDir)', () =
   assert.match(r.warnings.join('\n'), /models\[0\]: unknown field "pricing" ignored/);
   assert.match(r.warnings.join('\n'), /modelSecrets\[0\]: unknown field "magic" ignored/);
 });
+
+test('models: `cost` is validated and normalized exactly like a global catalog entry', () => {
+  const r = normalizeManifest({
+    name: 'p',
+    models: [
+      { id: 'free-one', cost: { free: true } },
+      { id: 'rated', cost: { perMtok: { output: '3', input: 0.5 } } },   // numeric strings coerced
+      { id: 'free-wins', cost: { free: true, perMtok: { input: 9 } } },
+      { id: 'no-override', cost: { free: false } },
+      { id: 'plain' },
+    ],
+  });
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+  const byId = Object.fromEntries(r.manifest.models.map((m) => [m.id, m]));
+  assert.deepEqual(byId['free-one'].cost, { free: true });
+  assert.deepEqual(byId.rated.cost, { perMtok: { output: 3, input: 0.5 } });
+  assert.deepEqual(byId['free-wins'].cost, { free: true }, 'free wins over perMtok');
+  assert.equal(byId['no-override'].cost, undefined, '{free:false} is no override');
+  assert.equal(byId.plain.cost, undefined, 'no cost key when the manifest pins none');
+});
+
+test('models: a malformed `cost` is a manifest ERROR, named by model and rule', () => {
+  const fail = (cost, re) => {
+    const r = normalizeManifest({ name: 'p', models: [{ id: 'm', cost }] });
+    assert.equal(r.ok, false, `expected failure for ${JSON.stringify(cost)}`);
+    assert.ok(r.errors.some((e) => re.test(e)), `${re} not in ${JSON.stringify(r.errors)}`);
+  };
+  fail('nope', /models\[0\] \("m"\): cost must be an object/);
+  fail({ free: 'yes' }, /cost\.free must be a boolean/);
+  fail({ perMtok: 5 }, /cost\.perMtok must be an object/);
+  fail({ perMtok: { bogus: 1 } }, /unknown cost\.perMtok rate "bogus"/);
+  fail({ perMtok: { input: -1 } }, /cost\.perMtok\.input must be a finite number >= 0/);
+  fail({ perMtok: {} }, /must define at least one rate/);
+});

--- a/test/plugin-models.test.mjs
+++ b/test/plugin-models.test.mjs
@@ -18,7 +18,7 @@ import {
 } from '../src/core/plugin-models.mjs';
 import {
   listModels, resolveModelEnv, modelHasBaseUrlRouting, referencedPluginModels,
-  setNodeModel,
+  setNodeModel, modelCostConfig, resolveModelCost,
 } from '../src/core/config.mjs';
 import { addGlobalModel, removeGlobalModel } from '../src/core/settings.mjs';
 
@@ -201,4 +201,56 @@ test('referencedPluginModels: refs block; global-shadow and other-plugin carve-o
   await setNodeModel(proj, 'wf_x', 's1_0', { model: '', effort: '' });
   assert.deepEqual(referencedPluginModels('discretestack-models'), [], 'cleared selection unblocks');
   writePluginsLock({ ...readPluginsLock(), 'zz-other': zz });
+});
+
+// ── manifest-pinned pricing (config.mjs modelCostConfig) ─────────────────────
+// A plugin that ships a model on its OWN endpoint is exactly the case the CLI
+// prices by NAME, so the price must travel WITH the model rather than having to
+// be re-pinned by hand on every machine that installs the plugin.
+
+test('a manifest `cost` reaches the plugin layer and GOVERNS that model\'s spend', () => {
+  installFixture('priced-plug', {
+    models: [
+      { id: 'pp-free', label: 'PP Free', env: { ANTHROPIC_BASE_URL: 'https://pp.example' }, cost: { free: true } },
+      { id: 'pp-rated', label: 'PP Rated', env: { ANTHROPIC_BASE_URL: 'https://pp.example' }, cost: { perMtok: { input: 1, output: 3 } } },
+      { id: 'pp-plain', label: 'PP Plain' },
+    ],
+  });
+  const byId = Object.fromEntries(allPluginModels().map((m) => [m.id, m]));
+  assert.deepEqual(byId['pp-free'].cost, { free: true });
+  assert.deepEqual(byId['pp-rated'].cost, { perMtok: { input: 1, output: 3 } });
+  assert.equal(byId['pp-plain'].cost, undefined, 'no cost key when the manifest pins none');
+
+  // The whole point: it actually prices a run.
+  assert.deepEqual(modelCostConfig('pp-free'), { free: true });
+  assert.equal(modelCostConfig('PP-RATED').perMtok.output, 3, 'case-insensitive, like every other lookup');
+  assert.equal(modelCostConfig('pp-plain'), null);
+  const usage = { input_tokens: 1_000_000, output_tokens: 1_000_000 };
+  assert.equal(resolveModelCost('pp-free', 0.4625, usage), 0, 'the CLI\'s by-name figure is discarded');
+  assert.equal(resolveModelCost('pp-rated', 999, usage), 4, '1M input@1 + 1M output@3');
+  assert.equal(resolveModelCost('pp-plain', 0.4625, usage), 0.4625, 'unpriced plugin model: unchanged');
+});
+
+test('a user GLOBAL entry shadows the plugin price — even when it pins none (§9.3)', async () => {
+  // Taking over a model id means owning its pricing too: the two layers must
+  // never half-merge (a global label + a plugin price would be untraceable).
+  await addGlobalModel({ id: 'pp-rated', label: 'Mine', env: { ANTHROPIC_BASE_URL: 'https://mine' } });
+  assert.equal(modelCostConfig('pp-rated'), null, 'the global entry pins no price, so there is none');
+  assert.equal(resolveModelCost('pp-rated', 0.4625, {}), 0.4625);
+
+  await addGlobalModel({ id: 'pp-free', label: 'Mine too', cost: { perMtok: { input: 2 } } });
+  assert.deepEqual(modelCostConfig('pp-free'), { perMtok: { input: 2 } }, 'a global price wins outright');
+
+  await removeGlobalModel('pp-rated');
+  await removeGlobalModel('pp-free');
+  assert.deepEqual(modelCostConfig('pp-rated'), { perMtok: { input: 1, output: 3 } }, 'the plugin price returns');
+});
+
+test('a disabled plugin takes its pricing with it', () => {
+  installFixture('priced-plug', {
+    models: [{ id: 'pp-free', cost: { free: true } }],
+  }, { enabled: false });
+  assert.equal(modelCostConfig('pp-free'), null);
+  installFixture('priced-plug', { models: [{ id: 'pp-free', cost: { free: true } }] });
+  assert.deepEqual(modelCostConfig('pp-free'), { free: true });
 });

--- a/test/settings-models.test.mjs
+++ b/test/settings-models.test.mjs
@@ -157,3 +157,84 @@ test('read-modify-write: catalog writes never disturb other/unknown settings key
     assert.deepEqual(raw.futureKey, { a: 1 });
   });
 });
+
+// ── per-model cost override ────────────────────────────────────────────────────
+
+test('cost: {free:true} round-trips and is stored verbatim', async () => {
+  await withSandbox(async () => {
+    const added = await addGlobalModel({
+      id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true },
+    });
+    assert.deepEqual(added, {
+      id: 'onprem', label: 'onprem', efforts: [...EFFORTS],
+      env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true },
+    });
+    assert.deepEqual((await readRawSettings()).models, [
+      { id: 'onprem', env: { ANTHROPIC_BASE_URL: 'https://p' }, cost: { free: true } },
+    ]);
+  });
+});
+
+test('cost: {perMtok} keeps only known numeric rates', async () => {
+  await withSandbox(async () => {
+    const added = await addGlobalModel({
+      id: 'priced', cost: { perMtok: { input: 0.5, output: 1.5, cacheRead: 0.05, cacheWrite: 0.6 } },
+    });
+    assert.deepEqual(added.cost, { perMtok: { input: 0.5, output: 1.5, cacheRead: 0.05, cacheWrite: 0.6 } });
+  });
+});
+
+test('cost: free wins over perMtok; {free:false}/{} are no override', async () => {
+  await withSandbox(async () => {
+    const a = await addGlobalModel({ id: 'a', cost: { free: true, perMtok: { input: 9 } } });
+    assert.deepEqual(a.cost, { free: true });
+    const b = await addGlobalModel({ id: 'b', cost: { free: false } });
+    assert.equal(b.cost, undefined);
+    const c = await addGlobalModel({ id: 'c', cost: {} });
+    assert.equal(c.cost, undefined);
+    assert.deepEqual((await readRawSettings()).models.map((m) => m.id), ['a', 'b', 'c']);
+  });
+});
+
+test('cost: write-path rejections leak nothing', async () => {
+  await withSandbox(async () => {
+    await assert.rejects(addGlobalModel({ id: 'x', cost: 'nope' }), /cost must be an object/);
+    await assert.rejects(addGlobalModel({ id: 'x', cost: { free: 'yes' } }), /cost\.free must be a boolean/);
+    await assert.rejects(addGlobalModel({ id: 'x', cost: { perMtok: 5 } }), /cost\.perMtok must be an object/);
+    await assert.rejects(addGlobalModel({ id: 'x', cost: { perMtok: { bogus: 1 } } }), /unknown cost\.perMtok rate "bogus"/);
+    await assert.rejects(addGlobalModel({ id: 'x', cost: { perMtok: { input: -1 } } }), /must be a finite number >= 0/);
+    await assert.rejects(addGlobalModel({ id: 'x', cost: { perMtok: {} } }), /must define at least one rate/);
+    assert.deepEqual(listGlobalModels(), []);
+  });
+});
+
+test('cost: update adds, replaces wholesale, and clears with null', async () => {
+  await withSandbox(async () => {
+    await addGlobalModel({ id: 'm1', label: 'One' });
+    let m = await updateGlobalModel('m1', { cost: { free: true } });
+    assert.deepEqual(m.cost, { free: true });
+    // Object replaces wholesale (not a per-key merge).
+    m = await updateGlobalModel('m1', { cost: { perMtok: { input: 1, output: 2 } } });
+    assert.deepEqual(m.cost, { perMtok: { input: 1, output: 2 } });
+    // Untouched when omitted.
+    m = await updateGlobalModel('m1', { label: 'Two' });
+    assert.deepEqual(m.cost, { perMtok: { input: 1, output: 2 } });
+    // null removes the override; entry stores minimally again.
+    m = await updateGlobalModel('m1', { cost: null });
+    assert.equal(m.cost, undefined);
+    assert.deepEqual((await readRawSettings()).models, [{ id: 'm1', label: 'Two' }]);
+  });
+});
+
+test('cost reader: an invalid cost is dropped loudly, the rest of the entry survives', async () => {
+  await withSandbox(async (home) => {
+    await mkdir(join(home, '.worca-cc'), { recursive: true });
+    await writeFile(settingsFile(), JSON.stringify({
+      models: [{ id: 'bent', cost: { perMtok: { bogus: 1 } } }, { id: 'ok', cost: { free: true } }],
+    }));
+    assert.deepEqual(listGlobalModels(), [
+      { id: 'bent', label: 'bent', efforts: [...EFFORTS] },              // cost dropped, entry kept
+      { id: 'ok', label: 'ok', efforts: [...EFFORTS], cost: { free: true } },
+    ]);
+  });
+});

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -87,7 +87,8 @@ import {
   renderStartStep, collectStartStep, renderGuardrailReferences409,
 } from './guardrails-view.mjs';
 import {
-  renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, applyCostMode, setModelCost, deleteRefsSummary,
+  renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, applyCostMode, setModelCost,
+  suggestDuplicateId, deleteRefsSummary,
   renderExportWizard, collectExportWizard,
 } from './models-view.mjs';
 import {
@@ -8625,7 +8626,55 @@ function prefillModelEditor(editor, pre) {
   const msg = editor.querySelector('.mv-editor-msg');
   if (msg && (pre.secretKeys || []).length) {
     msg.textContent = `Fill in ${pre.secretKeys.join(', ')} — secret values never leave the plugin.`;
+  } else if (msg && pre.duplicatedFrom) {
+    msg.textContent = `Copy of ${pre.duplicatedFrom} — change what should differ, then Add model.`;
   }
+}
+
+/**
+ * Duplicate a global entry: a CREATE editor seeded from it, with a free id
+ * suggested. Deriving a sibling that differs in one parameter is the common way
+ * a catalog grows — same endpoint, a different wire id or effort set or price.
+ *
+ * The raw env values are fetched first (GET :id/env-value, the same deliberate
+ * reveal the editor's "Show values" uses). The card only ever holds MASKED ones,
+ * and create-mode values are stored literally — seeding from the masks would
+ * write a row of bullets into settings.json as if it were a token.
+ */
+async function duplicateModelFlow(id) {
+  const d = mvState.data || {};
+  const src = (d.models || []).find((m) => m.id === id);
+  if (!src) return;
+  let env = {};
+  if (src.env && Object.keys(src.env).length) {
+    try {
+      const res = await fetch(`/api/models/${encodeURIComponent(id)}/env-value`);
+      const data = await safeJson(res);
+      if (!res.ok || !data.env) return setModelsMsg(data.error || `HTTP ${res.status}`, 'err');
+      env = data.env;
+    } catch (e) {
+      return setModelsMsg(e.message, 'err');
+    }
+  }
+  // Every id the catalog knows — the add is rejected for colliding with ANY of
+  // them, so a suggestion has to clear all four layers, not just the global one.
+  const taken = [d.models, d.plugin, d.predefined].flatMap((xs) => (xs || []).map((m) => m.id));
+  const newId = suggestDuplicateId(src.id, taken);
+  mvState.editing = null;
+  mvState.openCreate = true;
+  mvState.openShare = false;
+  mvState.prefill = {
+    id: newId,
+    // Only suffix a label the user actually chose; an entry that never had one
+    // keeps none, so the copy's label defaults to its own new id.
+    label: src.label && src.label !== src.id ? `${src.label} copy` : '',
+    efforts: src.efforts,
+    env,
+    secretKeys: [],
+    ...(src.cost ? { cost: src.cost } : {}),
+    duplicatedFrom: src.id,
+  };
+  renderModelsViewBody();
 }
 
 async function editPluginCopyFlow(plugin, id) {
@@ -8859,6 +8908,8 @@ if (el.modelsList) {
       deleteModelFlow(t.dataset.id);
     } else if (t.classList.contains('mv-promote')) {
       promoteModelFlow(t.dataset.id);
+    } else if (t.classList.contains('mv-duplicate')) {
+      duplicateModelFlow(t.dataset.id);
     } else if (t.classList.contains('mv-copy')) {
       editPluginCopyFlow(t.dataset.plugin, t.dataset.id);
     } else if (t.classList.contains('mv-test')) {

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -87,7 +87,7 @@ import {
   renderStartStep, collectStartStep, renderGuardrailReferences409,
 } from './guardrails-view.mjs';
 import {
-  renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, deleteRefsSummary,
+  renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, applyCostMode, deleteRefsSummary,
   renderExportWizard, collectExportWizard,
 } from './models-view.mjs';
 import {
@@ -8880,6 +8880,13 @@ if (el.modelsList) {
     } else if (t.classList.contains('mv-save')) {
       saveModelEditorFlow();
     }
+  });
+  // Pricing mode. A `change` listener, not the click one above: arrow-key
+  // navigation within a radio group changes the selection without a click.
+  el.modelsList.addEventListener('change', (ev) => {
+    if (!ev.target.classList || !ev.target.classList.contains('mv-cost-mode-rb')) return;
+    const editorEl = ev.target.closest('.mv-editor');
+    if (editorEl) applyCostMode(editorEl);
   });
 }
 if (el.modelCreateBtn) {

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -87,7 +87,7 @@ import {
   renderStartStep, collectStartStep, renderGuardrailReferences409,
 } from './guardrails-view.mjs';
 import {
-  renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, applyCostMode, deleteRefsSummary,
+  renderModelsList, renderModelEditor, collectModelEditor, makeEnvRow, applyCostMode, setModelCost, deleteRefsSummary,
   renderExportWizard, collectExportWizard,
 } from './models-view.mjs';
 import {
@@ -8592,9 +8592,12 @@ function renderModelsViewBody() {
 }
 
 // "Edit a copy" prefill (design §9.6): create-mode editor seeded from a plugin
-// model — id/label/efforts plus its literal/${VAR} env values; each {secret}
-// key becomes an EMPTY row the user must fill (the plugin's secret is never
-// copied). Saving POSTs a global entry that shadows the plugin one.
+// model — id/label/efforts/pricing plus its literal/${VAR} env values; each
+// {secret} key becomes an EMPTY row the user must fill (the plugin's secret is
+// never copied). Saving POSTs a global entry that shadows the plugin one —
+// INCLUDING its pricing, since a global entry shadows the plugin's price too
+// (config.mjs modelCostConfig), so a copy that dropped it would silently go
+// back to being priced by the CLI.
 function prefillModelEditor(editor, pre) {
   const idInput = editor.querySelector('.mv-id');
   if (idInput) idInput.value = pre.id;
@@ -8604,6 +8607,7 @@ function prefillModelEditor(editor, pre) {
   if (efforts.size) {
     for (const cb of editor.querySelectorAll('.mv-effort-cb')) cb.checked = efforts.has(cb.value);
   }
+  setModelCost(editor, pre.cost || null);
   const wrap = editor.querySelector('.mv-env');
   if (!wrap) return;
   for (const [k, v] of Object.entries(pre.env || {})) {

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -29,6 +29,28 @@ export function envSummary(env) {
   return keys.includes('ANTHROPIC_BASE_URL') ? `${n} · routes via base URL` : n;
 }
 
+/** The per-Mtok rate keys, in editor order, with their display labels. Mirrors
+ *  settings.mjs COST_RATE_KEYS — the server is the validator, this is the form. */
+export const COST_RATES = [
+  ['input', 'Input'],
+  ['output', 'Output'],
+  ['cacheRead', 'Cache read'],
+  ['cacheWrite', 'Cache write (5m)'],
+  ['cacheWrite1h', 'Cache write (1h)'],
+];
+
+/** One-line pricing summary for a card, or '' when the model has no override
+ *  (the overwhelming default — the CLI's own figure is trusted). */
+export function costSummary(cost) {
+  if (!cost || typeof cost !== 'object') return '';
+  if (cost.free) return 'priced free';
+  const p = cost.perMtok;
+  if (!p || typeof p !== 'object') return '';
+  const set = COST_RATES.filter(([k]) => p[k] != null);
+  if (!set.length) return '';
+  return `${set.map(([k, lab]) => `${lab.toLowerCase()} $${p[k]}`).join(' · ')} /Mtok`;
+}
+
 /**
  * The Models view body: global entries (editable), the selected project's
  * legacy custom models (promotable), and the built-in catalog (read-only).
@@ -60,9 +82,13 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
     head.appendChild(h(doc, 'b', 'mv-name', m.label || m.id));
     if (predefLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadow', 'overrides built-in'));
     else if (pluginLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadow', 'overrides plugin'));
-    if (m.costUnreliable) head.appendChild(h(doc, 'span', 'badge waiting mv-cost', 'cost not verified'));
+    // The §4.6 "unreliable" badge is meaningless once an override GOVERNS this
+    // model's spend — and the backend only lifts the stored flag on the model's
+    // next result event, so suppress it here the moment pricing is pinned.
+    if (m.costUnreliable && !m.cost) head.appendChild(h(doc, 'span', 'badge waiting mv-cost', 'cost not verified'));
+    if (m.cost) head.appendChild(h(doc, 'span', 'badge violet mv-cost-pinned', m.cost.free ? 'free' : 'priced'));
     body.appendChild(head);
-    const bits = [m.id, effortsSummary(m.efforts, efforts), envSummary(m.env)].filter(Boolean);
+    const bits = [m.id, effortsSummary(m.efforts, efforts), envSummary(m.env), costSummary(m.cost)].filter(Boolean);
     body.appendChild(h(doc, 'small', 'mv-summary hint', bits.join(' — ')));
     body.appendChild(h(doc, 'small', 'mv-test-result hint')); // app.js paints the Test outcome here
     card.appendChild(body);
@@ -258,7 +284,52 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
   }
   grid.appendChild(envBtns);
 
+  // ── Pricing (opt-in per-model cost override, config.mjs resolveModelCost) ──
+  // The CLI computes total_cost_usd from its OWN table keyed on the model NAME,
+  // so an on-prem/proxied endpoint gets a fabricated figure worca cannot tell
+  // from a real one. Three mutually exclusive modes; the default is unchanged
+  // behavior. Rendered detached like everything else here — app.js wires the
+  // mode change to applyCostMode.
+  const cost = editing ? model.cost : null;
+  const mode = !cost ? 'cli' : (cost.free ? 'free' : 'perMtok');
+  const costWrap = h(doc, 'div', 'mv-cost-edit');
+  const modes = h(doc, 'div', 'mv-cost-modes');
+  const groupName = `mv-cost-mode-${editing ? model.id : 'new'}`;
+  for (const [value, text] of [
+    ['cli', 'Trust the CLI'],
+    ['free', 'Free ($0)'],
+    ['perMtok', 'Per million tokens'],
+  ]) {
+    const lab = h(doc, 'label', 'mv-cost-mode');
+    const rb = h(doc, 'input', 'mv-cost-mode-rb');
+    rb.type = 'radio'; rb.name = groupName; rb.value = value; rb.checked = value === mode;
+    lab.appendChild(rb);
+    lab.appendChild(h(doc, 'span', null, text));
+    modes.appendChild(lab);
+  }
+  costWrap.appendChild(modes);
+
+  const rates = h(doc, 'div', 'mv-cost-rates');
+  for (const [key, labelText] of COST_RATES) {
+    const lab = h(doc, 'label', 'mv-cost-rate');
+    lab.appendChild(h(doc, 'span', 'mv-cost-rate-label', labelText));
+    const inp = h(doc, 'input', 'input mv-cost-rate-in');
+    inp.type = 'number'; inp.min = '0'; inp.step = '0.01'; inp.placeholder = '0';
+    inp.dataset.rate = key;
+    const v = cost && cost.perMtok ? cost.perMtok[key] : undefined;
+    inp.value = v == null ? '' : String(v);
+    lab.appendChild(inp);
+    lab.appendChild(h(doc, 'span', 'mv-cost-rate-unit', '$/Mtok'));
+    rates.appendChild(lab);
+  }
+  costWrap.appendChild(rates);
+  grid.appendChild(field('Pricing', costWrap,
+    'Only for an endpoint the CLI prices by NAME rather than from what the endpoint reports — an on-prem or proxied model. '
+    + 'Trust the CLI is the default and leaves spend exactly as today. Blank rates count as $0, except Cache write (1h), '
+    + 'which falls back to the 5m rate when blank.'));
+
   root.appendChild(grid);
+  applyCostMode(root); // grid is attached now — the rate block is reachable from root
   const msg = h(doc, 'p', 'form-msg mv-editor-msg');
   msg.setAttribute('aria-live', 'polite');
   root.appendChild(msg);
@@ -271,6 +342,19 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
   btns.appendChild(save); btns.appendChild(cancel);
   root.appendChild(btns);
   return root;
+}
+
+/**
+ * Show the per-Mtok rate inputs only in that mode. The single place that knows
+ * the rule, so the initial render and the delegated `change` handler in app.js
+ * can never drift apart. Safe on an editor with no pricing block.
+ * @param {Element} rootEl  the .mv-editor root
+ */
+export function applyCostMode(rootEl) {
+  const rates = rootEl && rootEl.querySelector('.mv-cost-rates');
+  if (!rates) return;
+  const picked = rootEl.querySelector('.mv-cost-mode-rb:checked');
+  rates.hidden = (picked ? picked.value : 'cli') !== 'perMtok';
 }
 
 /** app.js exposes envRow creation to the delegated mv-env-add handler. */
@@ -307,12 +391,30 @@ export function collectModelEditor(rootEl) {
     }
   }
 
+  // Pricing. The editor renders the STORED override, so it round-trips: a user
+  // who came to change a label leaves it untouched. 'cli' is therefore an
+  // explicit CLEAR (null), not an omission — it is what the form now shows.
+  // Rate values are sent raw for the server to validate (settings.mjs
+  // assertModelCost owns the rules; duplicating them here would let them drift).
+  const mode = rootEl.querySelector('.mv-cost-mode-rb:checked')?.value || 'cli';
+  let cost = null;
+  if (mode === 'free') cost = { free: true };
+  else if (mode === 'perMtok') {
+    const perMtok = {};
+    for (const inp of rootEl.querySelectorAll('.mv-cost-rate-in')) {
+      const raw = (inp.value ?? '').trim();
+      if (raw !== '') perMtok[inp.dataset.rate] = Number(raw);
+    }
+    cost = { perMtok };   // empty -> the server rejects it by name, surfaced in the form
+  }
+
   const body = {
     ...(editing ? {} : { id }),
     label,
     // All boxes checked = the full set = store the default (empty).
     efforts: efforts.length === allCount ? [] : efforts,
     env,
+    cost,
   };
   return { id: editing ? id : null, body };
 }

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -52,6 +52,26 @@ export function costSummary(cost) {
 }
 
 /**
+ * A free id for a duplicate of `id`: `<id>-copy`, then `-copy-2`, `-copy-3`…
+ * Compared case-insensitively against EVERY id the catalog knows (global,
+ * plugin, built-in, legacy) — the add would be rejected for colliding with any
+ * of them, and a suggestion the server refuses is worse than no suggestion.
+ * @param {string} id  the source model's id
+ * @param {Iterable<string>} takenIds
+ * @returns {string}
+ */
+export function suggestDuplicateId(id, takenIds = []) {
+  const taken = new Set([...takenIds].map((t) => String(t).toLowerCase()));
+  const base = `${id}-copy`;
+  if (!taken.has(base.toLowerCase())) return base;
+  for (let n = 2; n < 1000; n += 1) {
+    const c = `${base}-${n}`;
+    if (!taken.has(c.toLowerCase())) return c;
+  }
+  return base; // 998 copies of one model: let the server reject the duplicate
+}
+
+/**
  * The Models view body: global entries (editable), the selected project's
  * legacy custom models (promotable), and the built-in catalog (read-only).
  * `globals` come MASKED from GET /api/models. `predefinedShadowedIds` marks
@@ -98,6 +118,12 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
     const edit = h(doc, 'button', 'btn-ghost mv-edit', 'Edit');
     edit.type = 'button'; edit.dataset.id = m.id;
     card.appendChild(edit);
+    // Duplicate opens a CREATE editor seeded from this entry (app.js fetches the
+    // raw env values first — the card only ever holds masked ones). The point is
+    // deriving a sibling: same routing, one parameter changed.
+    const dup = h(doc, 'button', 'btn-ghost mv-duplicate', 'Duplicate');
+    dup.type = 'button'; dup.dataset.id = m.id;
+    card.appendChild(dup);
     const tst = h(doc, 'button', 'btn-ghost mv-test', 'Test');
     tst.type = 'button'; tst.dataset.id = m.id;
     card.appendChild(tst);

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -143,9 +143,12 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
       head.appendChild(h(doc, 'b', 'mv-name', m.label || m.id));
       head.appendChild(h(doc, 'span', 'badge waiting mv-origin', `plugin: ${m.plugin}`));
       if (globalLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadowed', 'overridden by your copy'));
-      if (m.costUnreliable) head.appendChild(h(doc, 'span', 'badge waiting mv-cost', 'cost not verified'));
+      // Same rule as a global card: a manifest-pinned price governs the spend,
+      // so the §4.6 "unreliable" flag says nothing about it.
+      if (m.costUnreliable && !m.cost) head.appendChild(h(doc, 'span', 'badge waiting mv-cost', 'cost not verified'));
+      if (m.cost) head.appendChild(h(doc, 'span', 'badge violet mv-cost-pinned', m.cost.free ? 'free' : 'priced'));
       body.appendChild(head);
-      const bits = [m.id, effortsSummary(m.efforts, efforts), envSummary(m.env)].filter(Boolean);
+      const bits = [m.id, effortsSummary(m.efforts, efforts), envSummary(m.env), costSummary(m.cost)].filter(Boolean);
       body.appendChild(h(doc, 'small', 'mv-summary hint', bits.join(' — ')));
       for (const s of m.secrets || []) {
         body.appendChild(h(doc, 'small', `mv-secret hint${s.set ? '' : ' err'}`,
@@ -290,8 +293,6 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
   // from a real one. Three mutually exclusive modes; the default is unchanged
   // behavior. Rendered detached like everything else here — app.js wires the
   // mode change to applyCostMode.
-  const cost = editing ? model.cost : null;
-  const mode = !cost ? 'cli' : (cost.free ? 'free' : 'perMtok');
   const costWrap = h(doc, 'div', 'mv-cost-edit');
   const modes = h(doc, 'div', 'mv-cost-modes');
   const groupName = `mv-cost-mode-${editing ? model.id : 'new'}`;
@@ -302,7 +303,7 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
   ]) {
     const lab = h(doc, 'label', 'mv-cost-mode');
     const rb = h(doc, 'input', 'mv-cost-mode-rb');
-    rb.type = 'radio'; rb.name = groupName; rb.value = value; rb.checked = value === mode;
+    rb.type = 'radio'; rb.name = groupName; rb.value = value;
     lab.appendChild(rb);
     lab.appendChild(h(doc, 'span', null, text));
     modes.appendChild(lab);
@@ -316,8 +317,6 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
     const inp = h(doc, 'input', 'input mv-cost-rate-in');
     inp.type = 'number'; inp.min = '0'; inp.step = '0.01'; inp.placeholder = '0';
     inp.dataset.rate = key;
-    const v = cost && cost.perMtok ? cost.perMtok[key] : undefined;
-    inp.value = v == null ? '' : String(v);
     lab.appendChild(inp);
     lab.appendChild(h(doc, 'span', 'mv-cost-rate-unit', '$/Mtok'));
     rates.appendChild(lab);
@@ -329,7 +328,7 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
     + 'which falls back to the 5m rate when blank.'));
 
   root.appendChild(grid);
-  applyCostMode(root); // grid is attached now — the rate block is reachable from root
+  setModelCost(root, editing ? model.cost : null); // grid is attached now — the block is reachable from root
   const msg = h(doc, 'p', 'form-msg mv-editor-msg');
   msg.setAttribute('aria-live', 'polite');
   root.appendChild(msg);
@@ -342,6 +341,28 @@ export function renderModelEditor(model, efforts, { doc = globalThis.document } 
   btns.appendChild(save); btns.appendChild(cancel);
   root.appendChild(btns);
   return root;
+}
+
+/**
+ * Load a `cost` override into an editor: pick the matching mode and fill the
+ * rates. The ONE place that maps a stored cost onto the form, shared by the
+ * initial render and by "Edit a copy"'s prefill of a plugin model's pricing —
+ * a second implementation of this mapping is exactly how the two would drift.
+ * Safe on an editor with no pricing block. Pass null/undefined for no override.
+ * @param {Element} rootEl  the .mv-editor root
+ * @param {{free?:boolean, perMtok?:Record<string,number>}|null} [cost]
+ */
+export function setModelCost(rootEl, cost) {
+  const rates = rootEl && rootEl.querySelector('.mv-cost-rates');
+  if (!rates) return;
+  const mode = !cost ? 'cli' : (cost.free ? 'free' : 'perMtok');
+  for (const rb of rootEl.querySelectorAll('.mv-cost-mode-rb')) rb.checked = rb.value === mode;
+  const p = cost && cost.perMtok && typeof cost.perMtok === 'object' ? cost.perMtok : {};
+  for (const inp of rootEl.querySelectorAll('.mv-cost-rate-in')) {
+    const v = p[inp.dataset.rate];
+    inp.value = v == null ? '' : String(v);
+  }
+  applyCostMode(rootEl);
 }
 
 /**

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1716,6 +1716,20 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .mv-env-row .mv-env-copy{flex:0 0 auto;padding:6px 10px;}
 .mv-env-btns{display:flex;gap:10px;justify-content:flex-start;}
 .mv-env-btns .btn-ghost{padding:7px 12px;font-size:12px;}
+/* Pricing: the opt-in per-model cost override. Modes read like the effort row;
+   the rate grid is hidden outside per-Mtok mode (explicit — a reset elsewhere
+   must not be able to un-hide it). */
+.mv-cost-edit{display:grid;gap:10px;}
+.mv-cost-modes{display:flex;gap:14px;flex-wrap:wrap;}
+.mv-cost-mode{display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;}
+.mv-cost-rates{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px 14px;}
+.mv-cost-rates[hidden]{display:none;}
+/* Label on its own row spanning both columns, then input + unit — five rates
+   side by side leave a numeric input far too narrow to read its own value. */
+.mv-cost-rate{display:grid;grid-template-columns:1fr auto;align-items:center;gap:4px 8px;font-size:12.5px;}
+.mv-cost-rate-label{grid-column:1 / -1;}
+.mv-cost-rate .mv-cost-rate-in{min-width:0;font-family:var(--mono);font-size:12.5px;}
+.mv-cost-rate-unit{color:var(--muted,#6b7280);font-size:11.5px;white-space:nowrap;}
 
 /* ---- Model plugins (design §9.6): plugin cards + export wizard ---- */
 .mv-secret{display:block;margin:4px 0 0;}

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -2857,6 +2857,7 @@ const pluginModelsPayload = () => {
         k, typeof v === 'string' ? maskEnvValue(v) : `(secret: ${v.secret})`,
       ])),
       secrets: status.filter((s) => m.secrets.includes(s.key)),
+      ...(m.cost ? { cost: m.cost } : {}),   // manifest-pinned pricing — config, never a credential
       ...(flagged.has(m.id.toLowerCase()) ? { costUnreliable: true } : {}),
     };
   });
@@ -2952,6 +2953,10 @@ app.post('/api/models/export-plugin', async (req, res) => {
       ...(entry.label !== entry.id ? { label: entry.label } : {}),
       ...(entry.efforts.length && entry.efforts.length !== EFFORTS.length ? { efforts: entry.efforts } : {}),
       ...(Object.keys(env).length ? { env } : {}),
+      // Pricing travels with the model. It is configuration, not a credential —
+      // and a shared on-prem model is precisely one the CLI would otherwise
+      // price by NAME on every machine that installs the plugin.
+      ...(entry.cost ? { cost: entry.cost } : {}),
     });
   }
 
@@ -4494,7 +4499,12 @@ app.get('/api/plugins/:name/model-env', (req, res) => {
     if (typeof v === 'string') env[k] = v;
     else secretKeys.push(k);
   }
-  res.json({ id: model.id, label: model.label, efforts: model.efforts, env, secretKeys });
+  // `cost` rides along so "Edit a copy" starts from the plugin's pricing — a
+  // copy that silently dropped it would repay the CLI's by-name figure.
+  res.json({
+    id: model.id, label: model.label, efforts: model.efforts, env, secretKeys,
+    ...(model.cost ? { cost: model.cost } : {}),
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -2869,7 +2869,7 @@ app.get('/api/models', (req, res) => {
 app.post('/api/models', async (req, res) => {
   const b = req.body || {};
   try {
-    const model = await addGlobalModel({ id: b.id, label: b.label, efforts: b.efforts, env: b.env });
+    const model = await addGlobalModel({ id: b.id, label: b.label, efforts: b.efforts, env: b.env, cost: b.cost });
     res.json({ model: maskedGlobalModel(model), models: maskedGlobalModels() });
   } catch (err) {
     // addGlobalModel throws only on validation (empty/dup id, unknown effort,
@@ -3022,7 +3022,7 @@ app.patch('/api/models/:id', async (req, res) => {
     env = Object.fromEntries(Object.entries(env).filter(([, v]) => !isMaskedEcho(v)));
   }
   try {
-    const model = await updateGlobalModel(req.params.id, { label: b.label, efforts: b.efforts, env });
+    const model = await updateGlobalModel(req.params.id, { label: b.label, efforts: b.efforts, env, cost: b.cost });
     res.json({ model: maskedGlobalModel(model), models: maskedGlobalModels() });
   } catch (err) {
     // updateGlobalModel throws only on validation (unknown id, unknown effort,


### PR DESCRIPTION
## Problem

A small pipeline run against the on-prem **discreetstack** model — which is configured to return no cost value — was still billed **$0.46**. Root cause: the Claude Code CLI computes `total_cost_usd` itself from an internal per-model price table keyed on the **model name**, even when the endpoint returns no cost. worca-cc has no pricing table of its own and trusted the CLI value verbatim, so a free on-prem run was priced as if it were the public Anthropic model of the same name.

## Approach

Port the per-model cost mechanism from worca 0.x (`origin/master`, Python) as an **opt-in** override. Each GLOBAL catalog entry may carry a `cost` field:

- `{ "free": true }` — force the run to $0.
- `{ "perMtok": { "input", "output", "cacheRead", "cacheWrite", "cacheWrite1h" } }` — discard the CLI cost and recompute from reported usage (USD per million tokens; honors the ephemeral 1h/5m cache-write buckets).

Models **without** a `cost` entry keep trusting the CLI cost exactly as before — **default behavior is unchanged**.

The override governs **every surface that books spend**, because they all feed one windowed budget (`cost-budget.mjs combinedWindowedSpendUsd = windowedSpendUsd + askWindowedSpendUsd`). Re-pricing only the pipeline would leave the same phantom spend inflating the budget from the chat side.

| Surface | Where |
| --- | --- |
| Pipeline node result | `orchestrator.mjs` result intake |
| Pipeline sub-agent telemetry | `orchestrator.mjs` `_recordSubAgentTelemetry` |
| Ask Worca turn — message row, thread totals, budget ledger, `ask-done` frame | `ask/turn.mjs` → `resolveCost` hook in `ask/events.mjs` |
| Overview agent telemetry row | `overview-agent.mjs` |

Pricing is a property of the **model**, not of one machine's config, so it travels with a plugin's models too: a manifest may carry `cost`, *Share as plugin* exports it, and `modelCostConfig` resolves it with the same precedence as everything else about a model (§9.3) — the user's global entry first, else the winning plugin entry. A global entry shadows the plugin price even when it pins none: taking over a model id means owning its pricing too, so the layers never half-merge.

## Changes

- **`config.mjs`** — `modelCostConfig` / `estimateCost` / `isPriceableUsage` / `resolveModelCost`; `observeModelCost` short-circuits and clears the derived cost-reliability flag for configured models. `estimateCost` reads both usage spellings — the raw Claude shape (`input_tokens`, …) and Ask's normalized one (`input`, `output`, `cacheRead`, `cacheCreation`) — so both paths price identically. `resolveModelCost` and `observeModelCost` accept an already-looked-up override so a caller with one in hand doesn't pay for a second lookup.
- **`settings.mjs`** — validate + persist `cost` on add / update / read (invalid cost is dropped loudly, keeping the rest of the entry).
- **`orchestrator.mjs`** — apply the override at the result intake and the sub-agent telemetry chokepoints.
- **`ask/events.mjs`** — the reducer takes an injected `resolveCost` hook (injected, not imported, so it stays free of config/DB deps), memoized per turn; the §6.6 per-agent cost split is scaled by the same factor.
- **`ask/turn.mjs`** — wire the hook to `resolveModelCost(this.model, …)`; one authoritative value then feeds all four sinks.
- **`overview-agent.mjs`** — price its sub-agent row like any pipeline node.
- **`server.mjs`** — pass `cost` through the model add/update API.
- **`models-view.mjs` / `app.js` / `style.css`** — the **Pricing editor**: a section in the model editor with three mutually exclusive modes — *Trust the CLI* (the default), *Free ($0)*, and *Per million tokens*, which reveals the five rate inputs. List cards (global **and** plugin) gain a free/priced badge and a rate summary.
- **`model-env.mjs`** — `COST_RATE_KEYS` + `assertModelCost` live here so BOTH catalog layers validate `cost` against one rule: `settings.mjs` and `plugin-manifest.mjs` may not import each other, and this zero-import leaf already holds the env policy for exactly that reason.
- **`plugin-manifest.mjs` / `plugin-models.mjs`** — `cost` is a known model field, validated by that same `assertModelCost` (a malformed price fails the install, naming the model and the rule), and carried through the plugin layer.
- **`models-view.mjs` / `app.js`** — **Duplicate** on global cards: a create editor seeded from an existing entry (free id, label, efforts, env, pricing) so a sibling that differs in one parameter doesn't have to be retyped.
- **`configurable-models-design.md`** — new **§4.11** (the override, its two safety rules, and the surfaces it governs — previously undocumented) and **§9.1** extended with the manifest field, its validation, and the precedence rule.

### Rules that keep it from misfiring

- **Only a cost-bearing `result` event is ever re-priced.** Every stream frame reaches the orchestrator's intake and a `{free}` override answers $0 for *any* input, so resolving unconditionally would book a real $0 per **frame** — each one a full `writeState` plus a `state` broadcast — instead of once per node. Pinned by a test asserting zero broadcasts across 25 non-result frames, then exactly one from the result.
- **`{perMtok}` with a result that carried no usage is UNPRICEABLE**, not a silent $0: `NaN` comes back and the step is reported as unaccounted, because an operator who asked for per-Mtok pricing should not be quietly under-billed. A usage object of genuine zeroes still prices at $0 — `isPriceableUsage` draws that line.
- **Ask's §6.2.8 `costUsd: null` is preserved.** No `result` frame means "no cost observed", which is not a price to re-price; the ledger writer still no-ops on it.
- **A sub-agent inherits the parent node's price** (it shares the endpoint) unless the Task input names a model carrying its *own* override. A bare alias like `haiku` resolves to nothing and must not revert the child to the CLI's figure.

### Duplicate

Deriving a variant that differs in one parameter — same endpoint, a different wire id or effort set or price — was only possible by retyping the whole entry, token included.

- Raw env values are fetched first (`GET :id/env-value`, the same deliberate reveal *Show values* uses). The card holds only MASKED values and create-mode values are stored literally, so seeding from what the client has would write a row of bullets into `settings.json` as if it were a token.
- `suggestDuplicateId` picks the first free `<id>-copy`, `-copy-2`, … compared case-insensitively against every id the catalog knows — global, plugin **and** built-in. The add is rejected for colliding with any layer, and a suggestion the server refuses is worse than none.
- The label is suffixed only when the source chose one; an entry whose label was just its id keeps none, so the copy's label defaults to its own new id.
- Global cards only: plugin models already have *Edit a copy*, legacy ones have *Promote*, and duplicating a built-in to a new id would produce an entry with no routing.

### Editor notes

- The form renders the **stored** override, so it round-trips: opening the editor to rename a model leaves its pricing untouched. That is why *Trust the CLI* sends `cost: null` — an explicit clear rather than an omission, matching what the form shows.
- Blank rates are omitted rather than sent as `0`, so *Cache write (1h)* keeps falling back to the 5m rate.
- No client-side rate validation: `settings.mjs assertModelCost` owns those rules, and duplicating them would let the two drift. An empty rate table is sent as-is and the server's own message lands in the form's existing error line.
- The mode handler listens for `change`, not `click` — arrow-key navigation within a radio group changes the selection without a click.
- `setModelCost` is the ONE cost→form mapping, shared by the initial render and by *Edit a copy*'s prefill of a plugin model's pricing. Without that prefill a copy would silently revert to the CLI's by-name figure, since the global entry shadows the plugin price.

## Testing

- **`test/model-cost-override.test.mjs`** (14) — `modelCostConfig` / `estimateCost` / `isPriceableUsage` / `resolveModelCost` / `observeModelCost`, both usage spellings, the unpriceable-`{perMtok}` rule, the pre-resolved-config contract, plus 3 orchestrator end-to-end cost-ingestion tests.
- **`test/model-cost-override-surfaces.test.mjs`** (14, new) — all four spend surfaces end-to-end over the real catalog: the per-frame regression guard, `{perMtok}` with no usage vs. zero usage, sub-agent attribution, Ask (row + totals + ledger + frame + per-agent split + the null rule), and the overview agent.
- **`test/ask-events.test.mjs`** (+4) — the reducer's `resolveCost` contract: replacement, memoization, fallback on non-finite/throwing, and the scaled per-agent split.
- **`test/settings-models.test.mjs`** (+7) — round-trip, free-wins-over-perMtok, clear, and invalid-cost handling.
- **`test/models-view.test.mjs`** (+8, jsdom) — `costSummary`, the editor's default and stored-override states, `applyCostMode`, each mode's collected shape, the round-trip guard, and the list-card badges.
- **`test/api-models.test.mjs`** (+4) — `cost` over HTTP end-to-end: POST/PATCH/GET (unmasked), wholesale replace, `null` clear, omitted-means-keep, the three rejection messages the form surfaces, the export scaffold carrying `cost` (and still stripping the token), and the plugin payload + *Edit a copy* route.
- **`test/plugin-manifest.test.mjs`** (+2) — manifest `cost` normalization and every rejection, named by model and rule.
- **`test/models-view.test.mjs`** (+2 more) — the id suggestion (numbering, case-insensitive collisions, duplicate-of-a-duplicate) and Duplicate appearing on global cards only.
- **`test/plugin-models.test.mjs`** (+3) — a manifest price reaching the plugin layer and actually governing spend, global-shadows-plugin precedence (including a global that pins none), and a disabled plugin taking its pricing with it.

Also verified in the browser against a seeded catalog and a seeded plugin: modes toggle by mouse and keyboard, rate values survive hiding, a save round-trips to `settings.json` with masked env values intact, *Trust the CLI* clears the entry, a rejected empty-rate save keeps the editor open with the server's message, plugin cards show their manifest prices, *Edit a copy* prefills them, *Share as plugin* writes `cost` into the scaffold with the auth token still reduced to a `{secret}` placeholder, and *Duplicate* lands the source's RAW env values (not masks) in an independent new entry.

Full suite: **3819/3819 pass**. No model definition is seeded — the operator adds the `cost` entry manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
