### PR TITLE
worca: Make HTTP 500 Errors Recoverable

### DIFF
--- a/src/core/recoverable-error.mjs
+++ b/src/core/recoverable-error.mjs
@@ -33,7 +33,7 @@ export function classifyError(err) {
   if (/\bsession limit\b|hit your[^.]*\blimit\b|reached your[^.]*\blimit\b|\blimit\b[^.]*\bresets?\b/i.test(msg)) return 'usage_limit';
   if (/\b429\b|\b529\b|rate.?limit|overloaded/i.test(msg)) return 'rate_limit';
   if (/credit balance|usage limit|quota|insufficient_quota|billing/i.test(msg)) return 'quota';
-  if (/ECONNRESET|ETIMEDOUT|ENOTFOUND|ECONNREFUSED|EAI_AGAIN|EPIPE|socket hang up|fetch failed|network|connection (refused|reset|closed|error)|closed mid-response|response above may be incomplete|\btimed?[ -]?out\b|\btimeout\b/i.test(msg)) return 'network';
+  if (/ECONNRESET|ETIMEDOUT|ENOTFOUND|ECONNREFUSED|EAI_AGAIN|EPIPE|socket hang up|fetch failed|network|connection (refused|reset|closed|error)|closed mid-response|response above may be incomplete|\btimed?[ -]?out\b|\btimeout\b|\b500\b|Internal Server Error/i.test(msg)) return 'network';
   return null;
 }
 

--- a/test/recoverable-error.test.mjs
+++ b/test/recoverable-error.test.mjs
@@ -58,6 +58,12 @@ test('classifies the Claude CLI API timeout as network', () => {
   assert.equal(classifyError(new Error('the request timed-out after 60000ms')), 'network');
 });
 
+test('classifies HTTP 500 errors as network', () => {
+  assert.equal(classifyError(new Error('API Error: 500 Internal Server Error')), 'network');
+  assert.equal(classifyError(new Error('HTTP request failed with status 500')), 'network');
+  assert.equal(classifyError(new Error('Error: Request failed: Internal Server Error')), 'network');
+});
+
 test('returns null for a plain bug and accepts a raw string / nullish', () => {
   assert.equal(classifyError(new Error('TypeError: x is not a function')), null);
   assert.equal(classifyError('401 Invalid authentication credentials'), 'auth');


### PR DESCRIPTION
Make HTTP 500 errors recoverable (retryable) in the same way as ENOTFOUND and other network errors.

**File:** `src/core/recoverable-error.mjs`

**Change:** At line 36, extend the `network` class regex to also match 500 errors. The current line is:

```js
if (/ECONNRESET|ETIMEDOUT|ENOTFOUND|ECONNREFUSED|EAI_AGAIN|EPIPE|socket hang up|fetch failed|network|connection (refused|reset|closed|error)|closed mid-response|response above may be incomplete|\btimed?[ -]?out\b|\btimeout\b/i.test(msg)) return 'network';
```

Add `|\b500\b|Internal Server Error|HTTP 500|status 500` to the regex so that 500 errors are classified as `network` and retried by the orchestrator's recovery loop (`orchestrator.mjs:2437-2462`, up to 3 retries with exponential backoff in auto mode).

This is a one-line change. No new tests are strictly required since the existing unit tests in `test/recoverable-error.test.mjs` cover the classifier — but if the implementer adds a test case for the 500 pattern, that's fine too.