### PR TITLE
Host process guard: agents can no longer kill the worca server

### DIFF
--- a/src/core/claude-runner.mjs
+++ b/src/core/claude-runner.mjs
@@ -37,6 +37,7 @@ import { createInterface } from 'node:readline';
 import { prepareModelEnv } from './model-env.mjs';
 import { classifyError, strongestClass } from './recoverable-error.mjs';
 import { explainUnspawnableClaude, resolveClaudeBin } from './preflight.mjs';
+import { hostGuardEnabled, hostGuardHookEntry, hostGuardSystemPrompt } from './host-guard.mjs';
 import { writeFile, mkdir, appendFile, readFile, access } from 'node:fs/promises';
 import { constants as FS, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -56,9 +57,14 @@ export function sigkillGraceMs() {
 }
 
 /** What `--settings` carries, or null when there is nothing to carry (no hook
- *  telemetry, no permission rules) — then the flag is omitted entirely. */
-export function buildSettingsPayload(permissionRules) {
+ *  telemetry, no permission rules, no host guard) — then the flag is omitted
+ *  entirely. `hostGuard` (set by runReal, gated by hostGuardEnabled) merges the
+ *  host-process-protection PreToolUse hook into the SAME single payload; the
+ *  returned `hook` flag stays telemetry-only (it drives --include-hook-events,
+ *  which the guard does not need). */
+export function buildSettingsPayload(permissionRules, { hostGuard = false } = {}) {
   const hook = buildHookSettings();
+  const guard = hostGuard && hostGuardEnabled() ? hostGuardHookEntry() : null;
   const hasRules = !!permissionRules && Object.values(permissionRules).some((a) => Array.isArray(a) && a.length);
   // Present-but-malformed rules (e.g. `{deny: 'Bash(curl:*)'}`) make the object
   // truthy while hasRules stays false, so the whole policy would drop out of
@@ -69,9 +75,13 @@ export function buildSettingsPayload(permissionRules) {
       && Object.values(permissionRules).some((a) => a != null && !Array.isArray(a))) {
     console.warn('[worca] guardrails: permissionRules is malformed (deny/allow/ask must be arrays of strings) — ignoring it; this spawn carries NO permission rules');
   }
-  if (!hook && !hasRules) return null;
+  if (!hook && !hasRules && !guard) return null;
   const settings = {};
-  if (hook) settings.hooks = hook.hooks;
+  if (hook) settings.hooks = { ...hook.hooks };
+  if (guard) {
+    settings.hooks = settings.hooks ?? {};
+    settings.hooks.PreToolUse = [...(settings.hooks.PreToolUse ?? []), guard];
+  }
   if (hasRules) settings.permissions = permissionRules;
   return { hook: !!hook, settings };
 }
@@ -179,10 +189,11 @@ export function buildHookSettings() {
  * [] when there is nothing to say, so the baseline argv is byte-identical.
  * @param {{deny?:string[],allow?:string[],ask?:string[]}|null|undefined} permissionRules
  * @param {string|null} [settingsFile] staged path (GH #380): `--settings <path>` carries the same JSON
+ * @param {{hostGuard?:boolean}} [opts] host-process guard (runReal sets it; see buildSettingsPayload)
  * @returns {string[]}
  */
-export function buildSettingsArgs(permissionRules, settingsFile = null) {
-  const payload = buildSettingsPayload(permissionRules);
+export function buildSettingsArgs(permissionRules, settingsFile = null, { hostGuard = false } = {}) {
+  const payload = buildSettingsPayload(permissionRules, { hostGuard });
   if (!payload) return [];
   const args = [];
   if (payload.hook) args.push('--include-hook-events');
@@ -403,7 +414,7 @@ export function buildClaudeArgs({
   // way in because the legacy body below already owns a local `tools` (the
   // --allowedTools union).
   tools: builtinTools, strictMcpConfig, settingSources, disableSlashCommands, includePartialMessages,
-  maxTurns, maxBudgetUsd, appendSubagentSystemPrompt,
+  maxTurns, maxBudgetUsd, appendSubagentSystemPrompt, hostGuard,
 }, delivery = {}) {
   // delivery (GH #380, set only by planClaudeInvocation's staged branch):
   //   promptViaStdin   -> bare `-p`; the prompt is written to the child's stdin
@@ -426,7 +437,7 @@ export function buildClaudeArgs({
   // SINGLE inline JSON (two --settings flags would be last-wins at the CLI). [] when
   // there is neither, so the baseline argv is unchanged; a CLI that rejects these
   // flags would only ever fail when the operator opted in.
-  for (const a of buildSettingsArgs(permissionRules, settingsFile)) args.push(a);
+  for (const a of buildSettingsArgs(permissionRules, settingsFile, { hostGuard })) args.push(a);
   if (mcpConfigPath) args.push('--mcp-config', mcpConfigPath);
   const tools = Array.isArray(allowedTools) ? allowedTools.slice() : [];
   for (const s of (Array.isArray(mcpServerGrants) ? mcpServerGrants : [])) {
@@ -496,7 +507,7 @@ export function planClaudeInvocation(opts, { bin = DEFAULT_BIN, dir = null, limi
     files.push({ path: systemPromptFile, content: opts.systemPrompt });
   }
   let settingsFile = null;
-  const payload = buildSettingsPayload(opts.permissionRules);
+  const payload = buildSettingsPayload(opts.permissionRules, { hostGuard: opts.hostGuard });
   if (payload) {
     settingsFile = join(dir, 'settings.json');
     files.push({ path: settingsFile, content: JSON.stringify(payload.settings) });
@@ -562,10 +573,20 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
     // ARGV_INLINE_LIMIT). The staging dir, when any, is removed on every
     // terminal path below (finish) and on a failed spawn.
     const limit = Number.isFinite(argvInlineLimit) && argvInlineLimit > 0 ? argvInlineLimit : ARGV_INLINE_LIMIT;
+    // Host guard (host-guard.mjs, 2026-08-31 incident): every REAL spawn — any
+    // role, custom agent, plugin agent, ask chat — carries the protection
+    // preamble, the PreToolUse hook (hostGuard -> the --settings payload), and
+    // WORCA_HOST_PID (below). One kill-switch: WORCA_HOST_GUARD=0. Mock spawns
+    // nothing, so runMock stays untouched.
+    const guardOn = hostGuardEnabled();
+    const guardedSystemPrompt = guardOn
+      ? [hostGuardSystemPrompt(process.pid), systemPrompt].filter(Boolean).join('\n\n')
+      : systemPrompt;
     let plan;
     try {
       plan = stageClaudeInvocation({
-        prompt, systemPrompt, permissionMode, model: wireModel, effort, allowedTools, resumeSessionId,
+        prompt, systemPrompt: guardedSystemPrompt, hostGuard: guardOn,
+        permissionMode, model: wireModel, effort, allowedTools, resumeSessionId,
         mcpConfigPath, mcpServerGrants, permissionRules,
         tools, strictMcpConfig, settingSources, disableSlashCommands, includePartialMessages,
         maxTurns, maxBudgetUsd, appendSubagentSystemPrompt,
@@ -593,6 +614,10 @@ function runReal({ cwd, systemPrompt, prompt, allowedTools, permissionMode, mode
     // pre-feature behavior, including the undefined -> inherit-process.env case.
     let spawnEnv = guardrailEnv;
     if (safeModelEnv) spawnEnv = { ...(guardrailEnv ?? process.env), ...safeModelEnv };
+
+    // WORCA_HOST_PID rides every guarded spawn (the hook reads it; scrub would
+    // drop it — WORCA_ is not an allowlisted prefix — so it is added AFTER).
+    if (guardOn) spawnEnv = { ...(spawnEnv ?? process.env), WORCA_HOST_PID: String(process.pid) };
 
     let child;
     try {

--- a/src/core/host-guard.mjs
+++ b/src/core/host-guard.mjs
@@ -68,16 +68,24 @@ const NESTED_SHELLS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh', 'powershell',
 /** Any killer, POSIX or Windows, appearing anywhere in a nested-shell payload. */
 const KILLER_WORD_RE = /\b(?:p?kill|killall|taskkill|stop-process|spps|wmic)\b/i;
 
+/** Killers that xargs / find -exec can hand targets to. */
+const KILLER_CMDS = new Set(['kill', 'pkill', 'killall', 'taskkill']);
+const isKillerToken = (t) => KILLER_CMDS.has(basename(t).toLowerCase().replace(/\.exe$/, ''));
+
 /** Replace quoted spans so quoted data ("fix; killall handling") never looks
  *  like a command, and substitutions so `kill $(…)` / `kill \`…\`` surface as a
  *  non-literal target instead of vanishing into the segment split; the RAW
- *  text is still consulted for nested-shell payloads. */
+ *  text is still consulted for nested-shell payloads. The `{}` placeholder
+ *  (xargs -I{}, find -exec … {}) becomes a token BEFORE the split eats the
+ *  braces — otherwise `xargs -I{} kill {}` splits into an xargs segment with
+ *  no kill word and a kill segment with no targets, and both pass. */
 function stripQuotes(s) {
   return s
     .replace(/'[^']*'/g, ' __q__ ')
     .replace(/"(?:[^"\\]|\\.)*"/g, ' __q__ ')
     .replace(/\$\([^()]*\)/g, ' __sub__ ')
-    .replace(/`[^`]*`/g, ' __sub__ ');
+    .replace(/`[^`]*`/g, ' __sub__ ')
+    .replace(/\{\}/g, ' __ph__ ');
 }
 
 const basename = (w) => w.slice(w.lastIndexOf('/') + 1);
@@ -139,9 +147,16 @@ export function evaluateKillCommand(command, hostPid) {
     if (cmd === 'pkill' || cmd === 'killall') {
       return `host guard: blocked \`${cmd}\` — pattern kills are forbidden.${pidNote}${advice}`;
     }
-    if (cmd === 'xargs'
-        && rest.some((t) => ['kill', 'pkill', 'killall', 'taskkill'].includes(basename(t).toLowerCase().replace(/\.exe$/, '')))) {
+    if (cmd === 'xargs' && rest.some(isKillerToken)) {
       return `host guard: blocked \`xargs kill\` — kill may only take literal numeric PIDs you name yourself.${pidNote}${advice}`;
+    }
+    // find spawns its -exec/-ok payload itself, so the kill never surfaces as
+    // a command word of its own segment; a killer anywhere in find's arguments
+    // alongside an -exec-family flag is the same unbounded fan-out as xargs.
+    if (cmd === 'find'
+        && rest.some((t) => /^-(?:exec|ok)(?:dir)?$/.test(t))
+        && rest.some(isKillerToken)) {
+      return `host guard: blocked \`find -exec kill\` — kill may only take literal numeric PIDs you name yourself.${pidNote}${advice}`;
     }
     // A nested shell is suspicious only when it carries an INLINE payload
     // (-c / /c / -Command); `bash scripts/kill-dev-server.sh` is a script FILE

--- a/src/core/host-guard.mjs
+++ b/src/core/host-guard.mjs
@@ -1,0 +1,256 @@
+// src/core/host-guard.mjs
+// The host-process guard. Every agent worca spawns carries this file as a
+// PreToolUse hook on Bash (see buildSettingsPayload in claude-runner.mjs), so
+// no agent — predefined role, custom agent, plugin agent, or their in-process
+// sub-agents — can kill the worca server that runs it.
+//
+// Born of the 2026-08-31 incident: an implementer cleaning up stray test
+// servers ran `ps aux | grep '[n]ode --disable' | awk '{print $2}' | while
+// read p; do kill $p; done` and took down its own host mid-run (the pattern
+// matches the production server argv exactly).
+//
+// Policy — deny when the command:
+//   - invokes `pkill` or `killall` (pattern kills, unbounded blast radius);
+//   - invokes `kill` with anything but literal numeric PIDs or `%N` jobspecs
+//     (variables, substitutions, piped/xargs input, `-PGID` group targets —
+//     all of these are how a kill reaches processes nobody named);
+//   - names the host PID (WORCA_HOST_PID) as a literal kill target;
+//   - wraps a kill in a nested `sh -c` / `bash -c` payload.
+// Everything else is allowed, so an agent can still stop processes it spawned:
+// look PIDs up first (ps is read-only and always allowed), then kill the
+// literal numbers. Forcing literal PIDs is the point — every literal target
+// passes through the host-PID check.
+//
+// The hook CLI is deliberately fail-open on malformed input: a broken payload
+// must not brick every Bash call of every agent. The DECISION is fail-closed.
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/** ON unless WORCA_HOST_GUARD is "0"/"false" — the one kill-switch for the
+ *  hook, the WORCA_HOST_PID env var, and the system-prompt preamble alike. */
+export function hostGuardEnabled() {
+  const v = process.env.WORCA_HOST_GUARD;
+  return !(v === '0' || String(v ?? '').toLowerCase() === 'false');
+}
+
+/** The PreToolUse hook entry buildSettingsPayload merges into --settings.
+ *  Runs THIS file with the server's own node; JSON.stringify double-quotes
+ *  both paths for the shell. */
+export function hostGuardHookEntry() {
+  // Forward slashes on purpose: JSON.stringify would double every Windows
+  // backslash and the hook shell's unescaping is unverified there, while
+  // CreateProcess and Git Bash both accept forward-slash paths. POSIX node
+  // paths never contain backslashes, so the replace is a no-op off Windows.
+  const q = (s) => JSON.stringify(String(s).replaceAll('\\', '/'));
+  return {
+    matcher: 'Bash',
+    hooks: [{ type: 'command', command: `${q(process.execPath)} ${q(fileURLToPath(import.meta.url))}` }],
+  };
+}
+
+/** The system-prompt preamble every real spawn carries (runReal prepends it). */
+export function hostGuardSystemPrompt(pid) {
+  return [
+    '## Host process protection',
+    `You run under the worca app server (PID ${pid}, \`node ui/server.mjs\`). Never kill it, and never kill any process you did not spawn yourself.`,
+    'Pattern kills are forbidden and a PreToolUse hook blocks them on every OS: `pkill`, `killall`, `xargs kill`, `taskkill /IM`, `Stop-Process -Name`, `wmic process … delete`, and any `kill` fed from a pipe, variable, or substitution (e.g. `ps aux | grep … | while read p; do kill $p; done`).',
+    'To stop a process you started: record its PID when you spawn it (or list PIDs with `ps`, which is always allowed), then run `kill <literal pid>`.',
+  ].join('\n');
+}
+
+/** Command words that may prefix the one we care about. */
+const SKIP_WORDS = new Set([
+  'do', 'then', 'else', 'elif', 'if', 'while', 'until',
+  'exec', 'command', 'builtin', 'nohup', 'time', 'sudo', 'env',
+]);
+
+const NESTED_SHELLS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh', 'powershell', 'pwsh', 'cmd']);
+
+/** Any killer, POSIX or Windows, appearing anywhere in a nested-shell payload. */
+const KILLER_WORD_RE = /\b(?:p?kill|killall|taskkill|stop-process|spps|wmic)\b/i;
+
+/** Replace quoted spans so quoted data ("fix; killall handling") never looks
+ *  like a command, and substitutions so `kill $(…)` / `kill \`…\`` surface as a
+ *  non-literal target instead of vanishing into the segment split; the RAW
+ *  text is still consulted for nested-shell payloads. */
+function stripQuotes(s) {
+  return s
+    .replace(/'[^']*'/g, ' __q__ ')
+    .replace(/"(?:[^"\\]|\\.)*"/g, ' __q__ ')
+    .replace(/\$\([^()]*\)/g, ' __sub__ ')
+    .replace(/`[^`]*`/g, ' __sub__ ');
+}
+
+const basename = (w) => w.slice(w.lastIndexOf('/') + 1);
+
+/** Leading env assignments and wrapper words stripped off a token list. */
+function commandWord(tokens) {
+  let i = 0;
+  while (i < tokens.length && (SKIP_WORDS.has(tokens[i]) || /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i]))) i++;
+  return { cmd: basename(tokens[i] ?? ''), rest: tokens.slice(i + 1) };
+}
+
+/** kill's targets: signal options consumed, redirections ignored. */
+function killTargets(rest) {
+  const targets = [];
+  let sawSignal = false;
+  let afterDashDash = false;
+  for (let i = 0; i < rest.length; i++) {
+    const t = rest[i];
+    if (t.startsWith('#')) break;                                  // trailing comment
+    if (/^\d*(?:>>?|<<?|>&|&>>?)$/.test(t)) { i++; continue; }     // spaced redirect: skip its operand too
+    if (/^\d*[<>]/.test(t) || t.includes('>') || t.includes('<')) continue; // attached redirection
+    if (!afterDashDash && t === '--') { afterDashDash = true; continue; }
+    if (!afterDashDash && t.startsWith('-')) {
+      if (t === '-s' || t === '-n') { i++; sawSignal = true; continue; }   // -s TERM / -n 15
+      if (!sawSignal && /^-(?:\d+|[A-Za-z]+\d*)$/.test(t)) { sawSignal = true; continue; } // first -9/-TERM
+      targets.push(t);                                                     // second dash token = a target
+      continue;
+    }
+    targets.push(t);
+  }
+  return targets;
+}
+
+/**
+ * The pure decision. `null` = allow; a non-empty string = deny, with the reason
+ * the agent will read (hook exit 2 feeds stderr back to the model).
+ * @param {string} command   the Bash tool's command text
+ * @param {number} [hostPid] the protected server PID (WORCA_HOST_PID); pattern
+ *   bans apply even without it
+ * @returns {string|null}
+ */
+export function evaluateKillCommand(command, hostPid) {
+  const raw = String(command ?? '');
+  if (!raw.trim()) return null;
+  const pidNote = Number.isFinite(hostPid)
+    ? ` The worca app server (PID ${hostPid}) runs this agent and must survive.`
+    : ' The worca app server runs this agent and must survive.';
+  const advice = ' To stop a process you spawned: list PIDs first (ps is always allowed), then `kill <literal pid>`.';
+
+  const segments = stripQuotes(raw).split(/(?:\|\||&&|;|\||&|\n|\$\(|`|[(){}])+/);
+  for (const seg of segments) {
+    const tokens = seg.trim().split(/\s+/).filter(Boolean);
+    if (!tokens.length) continue;
+    const { cmd: cmdRaw, rest } = commandWord(tokens);
+    // Windows commands are case-insensitive and may carry .exe (`TASKKILL`,
+    // `taskkill.exe`) — normalize once; POSIX names pass through unchanged.
+    const cmd = cmdRaw.toLowerCase().replace(/\.exe$/, '');
+
+    if (cmd === 'pkill' || cmd === 'killall') {
+      return `host guard: blocked \`${cmd}\` — pattern kills are forbidden.${pidNote}${advice}`;
+    }
+    if (cmd === 'xargs'
+        && rest.some((t) => ['kill', 'pkill', 'killall', 'taskkill'].includes(basename(t).toLowerCase().replace(/\.exe$/, '')))) {
+      return `host guard: blocked \`xargs kill\` — kill may only take literal numeric PIDs you name yourself.${pidNote}${advice}`;
+    }
+    // A nested shell is suspicious only when it carries an INLINE payload
+    // (-c / /c / -Command); `bash scripts/kill-dev-server.sh` is a script FILE
+    // and stays allowed (deliberate evasion via files is out of the threat
+    // model). PowerShell is the exception: its bare argument IS an inline
+    // command (`powershell "Stop-Process -Name node"`), so it is always scanned.
+    if (NESTED_SHELLS.has(cmd)
+        && (cmd === 'powershell' || cmd === 'pwsh' || rest.some((t) => /^(?:-c|\/c|-command|--command)$/i.test(t)))
+        && KILLER_WORD_RE.test(raw)) {
+      return `host guard: blocked a kill inside a nested \`${cmd}\` invocation — run the kill directly with literal PIDs so it can be checked.${pidNote}${advice}`;
+    }
+
+    // ── Windows-native killers (reachable from Git Bash on Windows) ──────────
+    if (cmd === 'taskkill') {
+      for (let i = 0; i < rest.length; i++) {
+        const flag = rest[i].toLowerCase().replace(/^[/-]+/, '');
+        if (flag === 'im') {
+          return `host guard: blocked \`taskkill /IM\` — killing by image name is a pattern kill.${pidNote}${advice}`;
+        }
+        if (flag === 'pid') {
+          const target = rest[++i] ?? '';
+          if (!/^\d+$/.test(target)) {
+            return `host guard: blocked \`taskkill /PID ${target}\` — only literal numeric PIDs are allowed.${pidNote}${advice}`;
+          }
+          if (Number.isFinite(hostPid) && Number(target) === hostPid) {
+            return `host guard: blocked taskkill of PID ${hostPid} — that is the worca app server this agent runs under. Kill only processes you spawned yourself.`;
+          }
+        }
+      }
+      continue;
+    }
+    if (cmd === 'stop-process' || cmd === 'spps') {
+      let sawId = false;
+      for (let i = 0; i < rest.length; i++) {
+        const t = rest[i].toLowerCase();
+        if (t === '-name' || t.startsWith('-name:')) {
+          return `host guard: blocked \`Stop-Process -Name\` — killing by process name is a pattern kill.${pidNote}${advice}`;
+        }
+        if (t === '-id' || t.startsWith('-id:')) {
+          sawId = true;
+          const value = t.includes(':') ? t.split(':')[1] : (rest[++i] ?? '');
+          for (const part of value.split(',')) {
+            if (!/^\d+$/.test(part)) {
+              return `host guard: blocked \`Stop-Process -Id ${part}\` — only literal numeric PIDs are allowed.${pidNote}${advice}`;
+            }
+            if (Number.isFinite(hostPid) && Number(part) === hostPid) {
+              return `host guard: blocked Stop-Process of PID ${hostPid} — that is the worca app server this agent runs under. Kill only processes you spawned yourself.`;
+            }
+          }
+        }
+      }
+      if (!sawId) {
+        return `host guard: blocked \`Stop-Process\` with no literal -Id — pipeline-fed or bare Stop-Process is a pattern kill.${pidNote}${advice}`;
+      }
+      continue;
+    }
+    if (cmd === 'wmic') {
+      // Checked against the RAW command: a parenthesized WHERE clause splits
+      // the segment (`where (name="node.exe") delete`), hiding the verb from
+      // this segment's tokens. A kill-verb elsewhere in a compound command can
+      // false-positive here — acceptable, the reason explains itself.
+      if (/\bprocess\b/i.test(raw) && /\b(?:delete|terminate)\b/i.test(raw)) {
+        return `host guard: blocked \`wmic process … delete\` — pattern kills are forbidden.${pidNote}${advice}`;
+      }
+      continue; // read-only wmic queries stay allowed
+    }
+
+    if (cmd !== 'kill') continue;
+
+    for (const t of killTargets(rest)) {
+      if (/^\d+$/.test(t)) {
+        if (Number.isFinite(hostPid) && Number(t) === hostPid) {
+          return `host guard: blocked kill of PID ${hostPid} — that is the worca app server this agent runs under. Kill only processes you spawned yourself.`;
+        }
+        continue;
+      }
+      if (/^%\d+$/.test(t)) continue; // this shell's own job
+      if (t.startsWith('-')) {
+        return `host guard: blocked \`kill ${t}\` — process-group/broadcast kills are forbidden.${pidNote}${advice}`;
+      }
+      return `host guard: blocked \`kill ${t}\` — kill accepts only literal numeric PIDs (no variables, substitutions, or piped input).${pidNote}${advice}`;
+    }
+  }
+  return null;
+}
+
+// ── hook CLI ─────────────────────────────────────────────────────────────────
+// stdin: the PreToolUse payload ({ tool_name, tool_input: { command } }).
+// exit 0 = allow; exit 2 = block, stderr is shown to the agent.
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (d) => { raw += d; });
+  process.stdin.on('end', () => {
+    let command = '';
+    try {
+      const payload = JSON.parse(raw);
+      if (payload?.tool_name !== 'Bash') process.exit(0);
+      command = String(payload?.tool_input?.command ?? '');
+    } catch {
+      process.exit(0); // fail-open: a malformed payload must not brick Bash
+    }
+    const pid = Number(process.env.WORCA_HOST_PID);
+    const reason = evaluateKillCommand(command, Number.isFinite(pid) && pid > 0 ? pid : undefined);
+    if (reason) {
+      process.stderr.write(`${reason}\n`);
+      process.exit(2);
+    }
+    process.exit(0);
+  });
+}

--- a/test/ask-runner-options.test.mjs
+++ b/test/ask-runner-options.test.mjs
@@ -11,6 +11,11 @@ import { buildClaudeArgs, runClaude } from '../src/core/claude-runner.mjs';
 
 const POSIX_SHIM = { skip: process.platform === 'win32' ? 'fake claude shim is a POSIX shell script (no .exe stand-in on Windows)' : false };
 
+// The host guard (see host-guard-wiring.test.mjs for its own coverage) adds
+// --settings / --append-system-prompt / WORCA_HOST_PID to every real spawn;
+// the parity assertions here isolate THIS file's feature, so pin it off.
+process.env.WORCA_HOST_GUARD = '0';
+
 const BASE = { prompt: 'p', permissionMode: 'acceptEdits' };
 const BASELINE = [
   '-p', 'p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'acceptEdits',

--- a/test/ask-spawn.test.mjs
+++ b/test/ask-spawn.test.mjs
@@ -216,6 +216,8 @@ test('fake bin env dump: the sandbox var reaches the SPAWNED env and every WORCA
   const env = (await readFile(out, 'utf8')).split('\n').filter(Boolean);
   assert.ok(env.includes('CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1'), 'survives buildSpawnEnv + prepareModelEnv and wins over a caller value');
   assert.ok(env.includes('ANTHROPIC_BASE_URL=http://proxy'), 'caller routing env still merged');
-  assert.ok(!env.some((l) => l.startsWith('WORCA_')), `WORCA_* scrubbed: ${env.filter((l) => l.startsWith('WORCA_'))}`);
+  const worcaLeaks = env.filter((l) => l.startsWith('WORCA_') && !l.startsWith('WORCA_HOST_PID='));
+  assert.equal(worcaLeaks.length, 0, `WORCA_* scrubbed (host-guard PID excepted): ${worcaLeaks}`);
+  assert.ok(env.includes(`WORCA_HOST_PID=${process.pid}`), 'the host-guard PID deliberately rides scrubbed spawns (host-guard.mjs)');
   assert.ok(env.some((l) => l.startsWith('PATH=')) && env.some((l) => l.startsWith('HOME=')), 'base vars kept');
 });

--- a/test/host-guard-wiring.test.mjs
+++ b/test/host-guard-wiring.test.mjs
@@ -1,0 +1,140 @@
+// test/host-guard-wiring.test.mjs
+// The host guard reaches every real spawn through the ONE --settings seam
+// (buildSettingsPayload), plus the WORCA_HOST_PID env var and a system-prompt
+// preamble — all injected at the runReal boundary so the pure builders stay
+// byte-identical without the `hostGuard` opt (spawn-args.test.mjs baselines).
+// Kill-switch: WORCA_HOST_GUARD=0/false disables all three.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile, readFile, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildClaudeArgs, buildSettingsPayload, planClaudeInvocation, runClaude,
+} from '../src/core/claude-runner.mjs';
+import { hostGuardEnabled, hostGuardHookEntry, hostGuardSystemPrompt } from '../src/core/host-guard.mjs';
+
+const POSIX_SHIM = { skip: process.platform === 'win32' ? 'fake claude shim is a POSIX shell script' : false };
+const BASE = { prompt: 'p', permissionMode: 'acceptEdits' };
+
+const dirs = [];
+const tmp = async () => { const d = await mkdtemp(join(tmpdir(), 'worca-cc-hostguard-')); dirs.push(d); return d; };
+after(async () => { await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true }))); });
+
+const withEnv = (kv, fn) => {
+  const prev = {};
+  for (const [k, v] of Object.entries(kv)) { prev[k] = process.env[k]; if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+  const restore = () => { for (const [k, v] of Object.entries(prev)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; } };
+  try { const r = fn(); if (r && typeof r.finally === 'function') return r.finally(restore); restore(); return r; } catch (e) { restore(); throw e; }
+};
+
+// ── the payload ──────────────────────────────────────────────────────────────
+
+test('buildSettingsPayload: hostGuard adds a PreToolUse Bash hook running host-guard.mjs', () => {
+  const payload = buildSettingsPayload(null, { hostGuard: true });
+  assert.ok(payload, 'payload present with the guard alone');
+  const entries = payload.settings.hooks?.PreToolUse ?? [];
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].matcher, 'Bash');
+  assert.match(entries[0].hooks[0].command, /host-guard\.mjs/);
+  assert.equal(payload.hook, false, 'the guard must NOT switch on --include-hook-events (telemetry-only flag)');
+});
+
+test('buildSettingsPayload: guard coexists with permission rules and telemetry hooks', () => {
+  const rules = { deny: ['Bash(curl:*)'] };
+  const both = buildSettingsPayload(rules, { hostGuard: true });
+  assert.deepEqual(both.settings.permissions, rules);
+  assert.match(both.settings.hooks.PreToolUse[0].hooks[0].command, /host-guard\.mjs/);
+
+  withEnv({ WORCA_SUBAGENT_HOOKS: '1' }, () => {
+    const merged = buildSettingsPayload(null, { hostGuard: true });
+    assert.equal(merged.hook, true, 'telemetry still drives --include-hook-events');
+    assert.equal(merged.settings.hooks.PostToolUse[0].matcher, 'Agent', 'telemetry PostToolUse survives');
+    assert.match(merged.settings.hooks.PreToolUse[0].hooks[0].command, /host-guard\.mjs/);
+  });
+});
+
+test('buildSettingsPayload: WORCA_HOST_GUARD=0 disables the guard (payload back to null)', () => {
+  withEnv({ WORCA_HOST_GUARD: '0' }, () => {
+    assert.equal(hostGuardEnabled(), false);
+    assert.equal(buildSettingsPayload(null, { hostGuard: true }), null);
+  });
+  assert.equal(hostGuardEnabled(), true, 'default is ON');
+});
+
+test('buildClaudeArgs: hostGuard emits exactly ONE --settings carrying the hook; without it argv is byte-identical', () => {
+  const guarded = buildClaudeArgs({ ...BASE, hostGuard: true });
+  const i = guarded.indexOf('--settings');
+  assert.ok(i > -1);
+  assert.equal(guarded.indexOf('--settings', i + 1), -1, 'exactly one --settings');
+  assert.match(guarded[i + 1], /host-guard\.mjs/);
+  assert.deepEqual(buildClaudeArgs({ ...BASE }), [
+    '-p', 'p', '--output-format', 'stream-json', '--verbose', '--permission-mode', 'acceptEdits',
+  ], 'no hostGuard opt => legacy argv untouched');
+});
+
+test('planClaudeInvocation: the staged settings.json carries the guard hook', () => {
+  const plan = planClaudeInvocation(
+    { ...BASE, prompt: 'x'.repeat(200), hostGuard: true },
+    { dir: () => '/staged', limit: 10 },
+  );
+  const settings = plan.files.find((f) => f.path.endsWith('settings.json'));
+  assert.ok(settings, 'settings.json staged');
+  assert.match(settings.content, /host-guard\.mjs/);
+});
+
+// ── the spawn: env var + system-prompt preamble, end to end ──────────────────
+
+test('hostGuardSystemPrompt names the PID and the banned patterns', () => {
+  const text = hostGuardSystemPrompt(4242);
+  assert.match(text, /4242/);
+  assert.match(text, /pkill/);
+});
+
+test('hostGuardHookEntry points node at this repo\'s host-guard.mjs', () => {
+  const entry = hostGuardHookEntry();
+  assert.equal(entry.matcher, 'Bash');
+  assert.match(entry.hooks[0].command, /host-guard\.mjs/);
+});
+
+/** Fake claude recording argv (NUL-separated) and WORCA_HOST_PID to files. */
+async function fakeBin(dir, argvFile, envFile) {
+  const bin = join(dir, 'fake-claude.sh');
+  await writeFile(
+    bin,
+    '#!/bin/sh\n' +
+    `for a in "$@"; do printf '%s\\0' "$a" >> ${JSON.stringify(argvFile)}; done\n` +
+    `printf '%s' "\${WORCA_HOST_PID-unset}" > ${JSON.stringify(envFile)}\n` +
+    'exit 0\n',
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+test('runClaude spawns with the guard settings, the preamble, and WORCA_HOST_PID', POSIX_SHIM, async () => {
+  const dir = await tmp();
+  const argvFile = join(dir, 'argv.txt');
+  const envFile = join(dir, 'env.txt');
+  const bin = await fakeBin(dir, argvFile, envFile);
+  await runClaude({ cwd: dir, prompt: 'hi', systemPrompt: 'ROLE PROMPT', bin });
+  const argv = (await readFile(argvFile, 'utf8')).split('\0');
+  const settings = argv[argv.indexOf('--settings') + 1];
+  assert.match(settings, /host-guard\.mjs/, 'guard hook in --settings');
+  const sys = argv[argv.indexOf('--append-system-prompt') + 1];
+  assert.match(sys, new RegExp(String(process.pid)), 'preamble names the host PID');
+  assert.ok(sys.endsWith('ROLE PROMPT'), 'role prompt survives after the preamble');
+  assert.equal(await readFile(envFile, 'utf8'), String(process.pid), 'child sees WORCA_HOST_PID');
+});
+
+test('runClaude with WORCA_HOST_GUARD=0 spawns the legacy argv and no env var', POSIX_SHIM, async () => {
+  const dir = await tmp();
+  const argvFile = join(dir, 'argv.txt');
+  const envFile = join(dir, 'env.txt');
+  const bin = await fakeBin(dir, argvFile, envFile);
+  await withEnv({ WORCA_HOST_GUARD: '0' }, () => runClaude({ cwd: dir, prompt: 'hi', bin }));
+  const argv = (await readFile(argvFile, 'utf8')).split('\0');
+  assert.ok(!argv.includes('--settings'), 'no settings payload');
+  assert.ok(!argv.includes('--append-system-prompt'), 'no preamble when systemPrompt is empty');
+  assert.equal(await readFile(envFile, 'utf8'), 'unset', 'no WORCA_HOST_PID');
+});

--- a/test/host-guard.test.mjs
+++ b/test/host-guard.test.mjs
@@ -1,0 +1,224 @@
+// test/host-guard.test.mjs
+// The host-process guard: a PreToolUse hook every spawned agent carries so it
+// can never kill the worca server that runs it (the 2026-08-31 incident: an
+// implementer's stray-server cleanup `ps aux | grep '[n]ode --disable' | … kill`
+// took down its own host mid-run).
+//
+// Two layers:
+//   1. evaluateKillCommand — the pure decision (null = allow, string = deny reason).
+//   2. the hook CLI — stdin PreToolUse JSON in, exit 0 (allow) / exit 2 + stderr
+//      reason (block), fail-open on garbage input.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { evaluateKillCommand } from '../src/core/host-guard.mjs';
+
+const HOST = 88275;
+
+const deny = (cmd, why, hostPid = HOST) => {
+  const reason = evaluateKillCommand(cmd, hostPid);
+  assert.ok(typeof reason === 'string' && reason.length, `${why}: expected deny for ${JSON.stringify(cmd)}, got allow`);
+  return reason;
+};
+const allow = (cmd, why, hostPid = HOST) => {
+  const reason = evaluateKillCommand(cmd, hostPid);
+  assert.equal(reason, null, `${why}: expected allow for ${JSON.stringify(cmd)}, got: ${reason}`);
+};
+
+// ── pattern kills are banned outright ────────────────────────────────────────
+
+test('host-guard denies the verbatim incident loop (piped kill)', () => {
+  deny("ps aux | grep '[n]ode --disable' | awk '{print $2}' | while read p; do kill $p; done",
+    'the exact command that killed the server');
+  deny("ps aux | grep '[n]ode --disable' | awk '{print $2}' | while read p; do kill $p 2>/dev/null; done",
+    'the mop-up variant');
+});
+
+test('host-guard denies pkill / killall in any position', () => {
+  deny('pkill -f node', 'pkill');
+  deny('killall node', 'killall');
+  deny('sudo pkill node', 'sudo prefix must not hide pkill');
+  deny('ls; pkill -f server', 'pkill after ;');
+  deny('true && killall -9 node', 'killall after &&');
+});
+
+test('host-guard denies kill fed by substitution, variables, or xargs', () => {
+  deny('kill $SERVER_PID', 'variable arg');
+  deny('kill $(cat server.pid)', 'command substitution');
+  deny('kill `cat server.pid`', 'backtick substitution');
+  deny("ps aux | grep node | awk '{print $2}' | xargs kill", 'xargs kill');
+  deny('for p in $(pgrep node); do kill -9 $p; done', 'loop over pgrep');
+  deny('FOO=1 kill $p', 'env-assignment prefix must not hide kill');
+  deny('/bin/kill $p', 'absolute path kill');
+});
+
+test('host-guard denies kill wrapped in a nested shell', () => {
+  deny("sh -c 'kill $p'", 'sh -c payload');
+  deny('bash -c "pkill node"', 'bash -c payload');
+});
+
+test('host-guard denies group / broadcast targets', () => {
+  deny('kill -- -123', 'process-group target');
+  deny('kill -9 -1', 'kill everything');
+});
+
+// ── the host PID itself ──────────────────────────────────────────────────────
+
+test('host-guard denies literal kill naming the host PID and says which PID', () => {
+  const reason = deny('kill 84049 88275 84064', 'the incident\'s literal kill (one PID was the server)');
+  assert.match(reason, /88275/, 'reason names the protected PID');
+});
+
+test('host-guard denies the host PID under signal flags', () => {
+  deny(`kill -9 ${HOST}`, '-9 host');
+  deny(`kill -TERM ${HOST}`, '-TERM host');
+  deny(`kill -s TERM ${HOST}`, '-s TERM host');
+  deny(`kill -- ${HOST}`, '-- host');
+});
+
+// ── legitimate kills stay allowed ────────────────────────────────────────────
+
+test('host-guard allows literal kills of other PIDs', () => {
+  allow('kill 12345', 'plain literal');
+  allow('kill 12345 67890', 'several literals');
+  allow('kill -9 12345', 'signal number');
+  allow('kill -TERM 12345', 'signal name');
+  allow('kill -s TERM 12345', '-s consumes the signal name');
+  allow('kill -- 12345', 'after --');
+  allow('kill %1', 'own jobspec');
+  allow('kill -0 12345', 'liveness probe');
+});
+
+test('host-guard allows non-kill commands, including kill-looking text in data', () => {
+  allow('', 'empty command');
+  allow('npm test', 'ordinary command');
+  allow("ps aux | grep '[n]ode --disable' | awk '{print $2}' | head -5", 'listing PIDs is read-only');
+  allow("git commit -m 'fix; killall handling'", 'kill words inside a quoted argument');
+  allow('echo kill', 'kill as data');
+  allow('grep -rn pkill src/', 'kill as a search term');
+});
+
+test('host-guard without a host PID still bans pattern kills but allows literals', () => {
+  allow('kill 12345', 'literal with no host pid', undefined);
+  deny('pkill -f node', 'pkill with no host pid', undefined);
+  deny('kill $p', 'non-literal with no host pid', undefined);
+});
+
+// ── Windows-native killers (agents on Windows reach taskkill / PowerShell /
+// wmic through Git Bash just as easily as `kill`) ────────────────────────────
+
+test('host-guard denies taskkill by image name (the Windows pattern kill)', () => {
+  deny('taskkill /IM node.exe /F', 'taskkill /IM');
+  deny('taskkill /F /IM node.exe', 'flag order must not matter');
+  deny('taskkill.exe /IM node.exe', '.exe suffix');
+  deny('cmd /c "taskkill /IM node.exe"', 'nested cmd /c payload');
+});
+
+test('host-guard checks literal taskkill /PID targets against the host PID', () => {
+  deny(`TASKKILL /PID ${HOST} /F`, 'host PID, case-insensitive command');
+  deny('taskkill /PID %SERVER_PID% /F', 'cmd-style variable is non-literal');
+  allow('taskkill /PID 12345 /F', 'literal other PID');
+  allow('taskkill /PID 12345 /T /F', 'tree+force flags on a literal PID');
+});
+
+test('host-guard denies PowerShell Stop-Process by name, bare (pipeline-fed), or nested', () => {
+  deny('Stop-Process -Name node', 'Stop-Process -Name');
+  deny('spps -Name node', 'spps alias');
+  deny('Get-Process node | Stop-Process', 'pipeline-fed Stop-Process');
+  deny('Stop-Process -Force', 'bare Stop-Process (input must come from a pipe)');
+  deny('powershell -Command "Stop-Process -Name node"', 'nested powershell payload');
+  deny('pwsh -c "taskkill /IM node.exe"', 'nested pwsh payload');
+});
+
+test('host-guard checks literal Stop-Process -Id targets against the host PID', () => {
+  deny(`stop-process -id ${HOST}`, 'host PID, lowercase');
+  deny(`Stop-Process -Id 12345,${HOST}`, 'host PID inside a comma list');
+  allow('Stop-Process -Id 12345', 'literal other PID');
+  allow('Stop-Process -Id 12345,67890', 'comma list of other PIDs');
+});
+
+test('host-guard denies wmic process deletion but allows read-only process listing', () => {
+  deny('wmic process where "name=\'node.exe\'" delete', 'wmic delete');
+  deny('wmic process where "name=\'node.exe\'" call terminate', 'wmic terminate');
+  allow('Get-Process node', 'read-only Get-Process');
+  allow('tasklist | findstr node', 'read-only tasklist');
+});
+
+// ── review fixes (2026-09-01 host-guard review: MAJ-1, MAJ-2, 2 minors) ──────
+
+test('host-guard denies xargs feeding Windows killers (MAJ-1)', () => {
+  deny("ps aux | grep node | awk '{print $2}' | xargs taskkill /F /PID", 'the incident transposed to Git Bash on Windows');
+  deny('pgrep node | xargs -I% taskkill /F /PID %', 'xargs -I placeholder spelling');
+  deny('pgrep node | xargs TASKKILL.EXE /F /PID', 'case + .exe');
+});
+
+test('host-guard allows literal kills with spaced redirects and trailing comments (MAJ-2)', () => {
+  allow('kill 12345 > /dev/null 2>&1', 'spaced redirect operand is not a target');
+  allow('kill 12345 >> kill.log', 'spaced append redirect');
+  allow('kill 12345 # stop the dev server', 'trailing comment');
+  deny(`kill ${HOST} > /dev/null`, 'host PID still caught in front of a redirect');
+  deny('kill $p # cleanup', 'a comment must not launder a variable target');
+});
+
+test('host-guard catches wmic delete across parentheses (minor)', () => {
+  deny('wmic process where (name="node.exe") delete', 'parenthesized WHERE splits segments');
+  allow('wmic process where (name="node.exe") get processid', 'parenthesized read-only query');
+  allow('wmic process list brief', 'plain listing');
+});
+
+test('host-guard allows running script FILES whose name contains kill words (minor)', () => {
+  allow('bash scripts/kill-dev-server.sh', 'bash script-file arg, no -c');
+  allow('sh ./killall-strays.sh', 'sh script-file arg');
+  deny("bash -c 'kill $p'", 'inline -c payloads stay denied');
+  deny('powershell "Stop-Process -Name node"', 'powershell bare argument IS an inline command');
+});
+
+// ── the hook CLI ─────────────────────────────────────────────────────────────
+
+const SCRIPT = fileURLToPath(new URL('../src/core/host-guard.mjs', import.meta.url));
+
+function runHook(stdin, env = {}) {
+  return new Promise((resolve) => {
+    const child = execFile(process.execPath, [SCRIPT], { env: { ...process.env, ...env } }, (err, stdout, stderr) => {
+      resolve({ code: err ? err.code : 0, stdout, stderr });
+    });
+    child.stdin.end(stdin);
+  });
+}
+
+test('hook CLI blocks a banned Bash command with exit 2 and a reason on stderr', async () => {
+  const { code, stderr } = await runHook(
+    JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'pkill -f node' } }),
+    { WORCA_HOST_PID: String(HOST) },
+  );
+  assert.equal(code, 2);
+  assert.match(stderr, /pkill/i);
+});
+
+test('hook CLI blocks the host PID kill with exit 2', async () => {
+  const { code, stderr } = await runHook(
+    JSON.stringify({ tool_name: 'Bash', tool_input: { command: `kill ${HOST}` } }),
+    { WORCA_HOST_PID: String(HOST) },
+  );
+  assert.equal(code, 2);
+  assert.match(stderr, new RegExp(String(HOST)));
+});
+
+test('hook CLI allows a safe kill and other tools', async () => {
+  const ok = await runHook(
+    JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'kill 12345' } }),
+    { WORCA_HOST_PID: String(HOST) },
+  );
+  assert.equal(ok.code, 0);
+  const read = await runHook(
+    JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/tmp/x' } }),
+    { WORCA_HOST_PID: String(HOST) },
+  );
+  assert.equal(read.code, 0);
+});
+
+test('hook CLI fails open on garbage input', async () => {
+  const { code } = await runHook('not json at all', { WORCA_HOST_PID: String(HOST) });
+  assert.equal(code, 0);
+});

--- a/test/host-guard.test.mjs
+++ b/test/host-guard.test.mjs
@@ -174,6 +174,30 @@ test('host-guard allows running script FILES whose name contains kill words (min
   deny('powershell "Stop-Process -Name node"', 'powershell bare argument IS an inline command');
 });
 
+// ── review fixes (2026-09-02 PR #408 review: {} placeholder bypass) ──────────
+// `{`/`}` are segment separators, so without the __ph__ replacement in
+// stripQuotes the braces of `-I{}` / `-exec … {}` vanish before the checks run:
+// the xargs segment loses its kill word and the kill segment loses its targets.
+
+test('host-guard denies xargs -I{} kill (the brace placeholder spelling)', () => {
+  deny('pgrep node | xargs -I{} kill {}', 'attached -I{}');
+  deny('pgrep node | xargs -I {} kill -9 {}', 'spaced -I {}');
+  deny("ps aux | grep '[n]ode --disable' | awk '{print $2}' | xargs -I{} kill {}",
+    'the incident transposed to -I{}');
+});
+
+test('host-guard denies find -exec kill', () => {
+  deny('find . -name "*.pid" -exec kill {} \\;', 'find -exec kill');
+  deny("find /tmp -name 'server*.pid' -execdir kill -9 '{}' +", 'find -execdir, quoted braces');
+  deny('find . -name node.pid -ok kill {} \\;', 'find -ok still fans out');
+  allow('find . -name "*.log" -exec rm {} \\;', 'find -exec of a non-killer stays allowed');
+  allow('find . -name kill.txt', 'kill-looking find pattern without -exec');
+});
+
+test('host-guard treats a bare {} kill target as non-literal', () => {
+  deny('kill {}', 'a placeholder is not a literal PID');
+});
+
 // ── the hook CLI ─────────────────────────────────────────────────────────────
 
 const SCRIPT = fileURLToPath(new URL('../src/core/host-guard.mjs', import.meta.url));

--- a/test/spawn-args.test.mjs
+++ b/test/spawn-args.test.mjs
@@ -20,6 +20,11 @@ import { buildClaudeArgs, runClaude } from '../src/core/claude-runner.mjs';
 
 const POSIX_SHIM = { skip: process.platform === 'win32' ? 'fake claude shim is a POSIX shell script (no .exe stand-in on Windows)' : false };
 
+// The host guard (see host-guard-wiring.test.mjs for its own coverage) adds
+// --settings / --append-system-prompt / WORCA_HOST_PID to every real spawn;
+// the parity assertions here isolate THIS file's feature, so pin it off.
+process.env.WORCA_HOST_GUARD = '0';
+
 const dirs = [];
 const tmp = async () => {
   const d = await mkdtemp(join(tmpdir(), 'worca-cc-argv-'));

--- a/test/spawn-argv-limit.test.mjs
+++ b/test/spawn-argv-limit.test.mjs
@@ -10,6 +10,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const POSIX_SHIM = { skip: process.platform === 'win32' ? 'fake claude shim is a POSIX shell script (no .exe stand-in on Windows)' : false };
+
+// The host guard (see host-guard-wiring.test.mjs for its own coverage) adds
+// --settings / --append-system-prompt / WORCA_HOST_PID to every real spawn;
+// the parity assertions here isolate THIS file's feature, so pin it off.
+process.env.WORCA_HOST_GUARD = '0';
 import {
   ARGV_INLINE_LIMIT, argvLength, buildClaudeArgs, buildSettingsArgs, buildSettingsPayload,
   planClaudeInvocation, stageClaudeInvocation, runClaude,


### PR DESCRIPTION
## Problem

On Aug 31 a pipeline implementer, cleaning up stray test servers, ran `ps aux | grep '[n]ode --disable' | awk '{print $2}' | while read p; do kill $p; done`. That pattern matches the production server argv (`node --disable-warning=ExperimentalWarning ui/server.mjs`) exactly — the agent killed the server orchestrating it. The app went down, both live runs were interrupted, and the orphaned agent kept working for another hour with nobody listening.

## Fix — three layers through one seam

Every real spawn (pipeline roles, custom and plugin agents, ask chat, and their in-process sub-agents) now carries:

1. **Enforcement** — `src/core/host-guard.mjs`, a PreToolUse hook on Bash injected via the existing single `--settings` payload (merges with telemetry hooks and guardrails permission rules, in both inline and staged delivery). Denied: `pkill`/`killall`, `xargs kill`/`xargs taskkill`, `kill` fed by pipes/variables/substitutions, group/broadcast targets, nested `sh -c` / `powershell` payloads, `taskkill /IM`, `Stop-Process -Name` (or pipeline-fed), `wmic process … delete`, and any literal kill naming the host PID. Literal-PID kills of the agent's own processes stay allowed — the guard forces literal PIDs precisely so every target passes the host check.
2. **Identity** — `WORCA_HOST_PID` in every spawn env (the one `WORCA_*` var that deliberately survives env scrub).
3. **Awareness** — a system-prompt preamble naming the protected PID and the banned patterns, so honest agents comply before the hook ever fires.

Kill-switch: `WORCA_HOST_GUARD=0`. The mock runner is untouched and the pure argv builders stay byte-identical without the `hostGuard` opt.

## Cross-OS

Covers macOS/Linux (POSIX kills) and Windows (Git Bash agents reaching `taskkill`/PowerShell/`wmic`; `%VAR%` args, case + `.exe` folding, forward-slash-normalized hook path).

## Verification

- 32 guard/wiring tests, including both incident commands verbatim; 137 tests green across the touched and adjacent suites.
- Live probe against the installed CLI: hook accepted, `pkill` blocked, reason surfaced to the model, no retry attempted.
- Max-effort review of the whole implementation: 0 critical / 2 major / 11 minor — both majors and 2 minors fixed in this branch (xargs-taskkill gap, spaced-redirect/trailing-comment false positives, wmic parenthesized-WHERE bypass, script-file false positive).

## Known limits (accepted)

Deliberate evasion (`node -e "process.kill(…)"`, running a script file) is outside the threat model — the guard targets accidental footguns, which is what took the server down. The hook fails open on malformed input by design (a broken payload must not brick every Bash call). Windows hook execution deserves one confirmation probe on a real Windows box. `kill 0` passes as a literal (contained today by the CLI giving tool shells their own process group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
