### PR TITLE
worca: Keep the serialized-gate stub timer ref'd so the recovery test file survives

### DIFF
--- a/test/orchestrator-recovery.test.mjs
+++ b/test/orchestrator-recovery.test.mjs
@@ -151,7 +151,13 @@ test('serialized gate: two DISTINCT classes never open two prompts at once', asy
   // Stubbed _ask holds the "prompt" open briefly; record the peak concurrency.
   orch._ask = async () => {
     asks++; open++; maxOpen = Math.max(maxOpen, open);
-    await new Promise((r) => { const t = setTimeout(r, 5); t.unref?.(); });
+    // NOTE: the timer must stay REF'd. Every runtime timer in the harness is
+    // unref'd ("never hold the CLI open"), so during this 5ms hold the stub's
+    // timer is the only thing keeping the event loop alive; an unref'd timer
+    // here lets the loop drain mid-test and node:test cancels the run
+    // ("Promise resolution is still pending but the event loop has already
+    // resolved"), taking every later test in this file down with it.
+    await new Promise((r) => { setTimeout(r, 5); });
     open--;
     return { decision: 'retry' };
   };


### PR DESCRIPTION
## Problem

`npm test` exits 1 on `dev`: 4311 pass / 0 fail / **3 cancelled**, deterministically, all in `test/orchestrator-recovery.test.mjs`:

- `serialized gate: two DISTINCT classes never open two prompts at once` (:144)
- `done row has NULL resume_point (incremental writes cleared by done arm)` (:172)
- `crash -> reconcile -> resume continues from saved boundary to done` (:184)

Each dies with `failureType: 'cancelledByParent'`, error *"Promise resolution is still pending but the event loop has already resolved"*. This blocks the release workflow (it gates on `npm test`).

## Root cause

The serialized-gate test stubs `orch._ask` to hold the "prompt" open for 5 ms via `setTimeout(r, 5)` followed by `t.unref?.()`. Every runtime timer in the harness is deliberately unref'd ("never hold the CLI open"), so during that hold the stub's timer was the **only candidate ref on the event loop**. With it unref'd, the loop drained mid-test; node:test cancelled the pending test and the two tests after it in the file (both pass in isolation — pure collateral).

The test only ever passed by riding incidental ref'd handles left alive by earlier code paths; the P8 engine promotion (1dac9f5f, "delete the v1 orchestrator, promote the graph engine") removed those. The gate logic itself did not regress — `_recover` / `_enqueueRecoveryPrompt` / `_enqueueAsk` in `run-harness.mjs` are byte-identical to the v1 orchestrator's.

## Fix

Test-only: drop the `unref` so the stub's timer keeps the loop alive for its own 5 ms hold, with a comment explaining why it must stay ref'd. No product change.

## Verification

- `node --test test/orchestrator-recovery.test.mjs` → 9/9 pass, 0 cancelled
- Full `npm test` → **4314/4314 pass, 0 cancelled, exit 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)