### PR TITLE
worca: Set git identity in the submodule clone so the smuggle test survives CI

### DIFF
--- a/test/git-info-diff.test.mjs
+++ b/test/git-info-diff.test.mjs
@@ -149,6 +149,11 @@ test('diffPatch pins --submodule=short: an external diff tool cannot smuggle a s
     const base = g(['rev-parse', 'HEAD']).stdout.trim();
     await writeFile(join(dir, 'aaa.txt'), 'a\ntop changed\n');
     const gi = (args) => spawnSync('git', args, { cwd: join(dir, 'sub'), encoding: 'utf8' });
+    // The submodule working copy is a fresh clone — it inherits NO user identity
+    // from `subsrc`. Without these, the inner commit fails on a machine with no
+    // global git identity (CI), the submodule stays dirty, and the patch reads
+    // "+Subproject commit <same-hash>-dirty" instead of the new recorded commit.
+    gi(['config', 'user.email', 't@t']); gi(['config', 'user.name', 't']);
     await writeFile(join(dir, 'sub', '.env'), 'A=SK-LIVE-REALSECRET-0001\n');
     gi(['add', '-A']); gi(['commit', '-qm', 'secret']);
 


### PR DESCRIPTION
## Problem

The **worca-app-v1.1.0 release run failed at the test gate** (run 33509084175, before publish — nothing shipped, the tag is burned):

`diffPatch pins --submodule=short: an external diff tool cannot smuggle a submodule file into the previous section` — AssertionError: expected `/^\+Subproject commit [0-9a-f]{40}$/m`, actual ended in `+Subproject commit <same-hash>-dirty`.

## Root cause

The test commits **inside the submodule working copy** (`dir/sub`) — a fresh clone that inherits no `user.email`/`user.name` from its source repo. The CI runner has no global git identity, so that inner commit dies with *Author identity unknown*; the submodule stays dirty at the recorded commit and the patch reads `-dirty` instead of a new recorded commit. Locally the developer's global identity papered over it — the test only ever passed by accident of environment.

Every other test repo sets local identity right after `git init`; the cloned submodule was the one gap (confirmed by CI: 4313/4314 passed on the identity-less runner).

## Fix

Test-only: `gi(['config','user.email','t@t']); gi(['config','user.name','t'])` in the submodule clone before the inner commit, with a comment explaining why.

## Verification

- Reproduced the CI failure locally with `HOME=<empty> GIT_CONFIG_GLOBAL=<absent> GIT_CONFIG_NOSYSTEM=1` → same `-dirty` assertion failure
- Same environment with the fix → **pass**
- Whole file: 12/12 · full `npm test`: **4314/4314, exit 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)