### PR TITLE
Implement pause-on-error recovery policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ worca --project /path/to/your/project --prompt "demo task" --mock --yes
 Run `worca --help` for all subcommands (projects, plugins, marketplaces,
 config, doctor) and flags.
 
+Exit codes, for scripts and CI wrappers: `0` the run finished (or an
+interactive run paused and you can resume it); `1` a hard error, a stop, or an
+interactive pause an error forced; `2` a usage error; `3` a `--yes` run that
+parked itself — auth, quota, a usage or cost limit, exhausted retries, or a
+step error — with nobody attached to resume it. Nothing is discarded on a
+pause: `worca resume <pipelineId>` picks the run up where it stopped, and the
+cause is printed with the pause block on stdout.
+
 ### `/worca` skill (inside Claude Code)
 
 ```bash

--- a/scripts/verify-composer-cdp.mjs
+++ b/scripts/verify-composer-cdp.mjs
@@ -179,6 +179,16 @@ const mup = (x, y, button = 'left') => pumped(cdp('Input.dispatchMouseEvent', { 
 // check (6) fails while reporting delivery as trusted. The run-monitor proof
 // gates on `cancelable` for the same reason; this one now matches it.
 let wheelTrusted = null;        // null = not probed yet
+// Two probe wheels, not one: Chrome latches a wheel SEQUENCE — when the first
+// wheel of a sequence is not cancelled, every later wheel in it is dispatched
+// non-cancelable (preventDefault() becomes a no-op and `defaultPrevented` never
+// reads true), and a sequence outlives the settle() between two of our
+// dispatches. Linux CI Chrome 152 reports the FIRST wheel cancelable, so a
+// one-wheel probe picked the trusted path and then watched every real wheel
+// arrive non-cancelable (the run-monitor proof split on it).
+// Only a runner whose SECOND consecutive wheel is still cancelable can measure
+// `defaultPrevented` through trusted events; everything else runs the same
+// listener over the same layout through the synthetic path.
 async function probeWheel(x, y) {   // x,y come from the caller and are already inside the stage
   await ev('window.__wp=[];window.__wpH=(e)=>{window.__wp.push(e.cancelable);};window.addEventListener("wheel",window.__wpH,{passive:true});0');
   await mmove(x, y, 0);
@@ -187,9 +197,11 @@ async function probeWheel(x, y) {   // x,y come from the caller and are already 
   // very next invariance measurement read as broken.
   await wheelRaw(x, y, 0, 0, 0);
   await settle('wheel-probe');
+  await wheelRaw(x, y, 0, 0, 0);        // the second wheel of the sequence is the one that tells
+  await settle('wheel-probe');
   const seen = await ev('(()=>{const n=window.__wp;window.removeEventListener("wheel",window.__wpH);return n;})()');
-  wheelTrusted = seen.length > 0 && seen[seen.length - 1] === true;
-  log(`wheel delivery: ${wheelTrusted ? 'trusted CDP events' : 'SYNTHETIC'} (CDP wheels seen: ${seen.length}, cancelable: ${seen.length ? seen[seen.length - 1] : 'n/a'})`);
+  wheelTrusted = seen.length >= 2 && seen.every((c) => c === true);
+  log(`wheel delivery: ${wheelTrusted ? 'trusted CDP events' : 'SYNTHETIC'} (CDP wheels seen: ${seen.length}, cancelable: ${seen.join(',') || 'n/a'})`);
 }
 async function wheel(x, y, dx, dy, modifiers = 0) {
   if (wheelTrusted === null) await probeWheel(x, y);

--- a/scripts/verify-composer-cdp.mjs
+++ b/scripts/verify-composer-cdp.mjs
@@ -82,17 +82,32 @@ chrome = spawn(CHROME, ['--headless=new', ...SANDBOX, `--remote-debugging-port=$
   '--window-size=1280,900', '--hide-scrollbars', '--no-first-run', '--no-default-browser-check',
   '--disable-background-timer-throttling', '--disable-renderer-backgrounding', 'about:blank'],
 { stdio: ['ignore', 'pipe', 'pipe'] });
-chrome.stderr.on('data', () => {});
+// Keep Chrome's last stderr lines: when no DevTools target ever appears, its own
+// words (a sandbox refusal, a profile lock, a crash) are the diagnosis.
+const chromeErr = [];
+chrome.stderr.on('data', (d) => { chromeErr.push(String(d)); if (chromeErr.length > 40) chromeErr.shift(); });
+let chromeExit = null;
+chrome.on('exit', (code, signal) => { chromeExit = { code, signal }; });
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 let wsUrl = null;
-for (let i = 0; i < 60 && !wsUrl; i += 1) {
+// Deadline-based, not iteration-based: a cold CI runner can take well over the
+// old ~15s (60 × 250ms) to bring the first page target up, and that budget was
+// the difference between a green and a red proofs job on the same commit.
+const targetDeadline = Date.now() + 60_000;
+while (!wsUrl && Date.now() < targetDeadline && !chromeExit) {
   try {
     const list = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
     const page = list.find((t) => t.type === 'page' && t.webSocketDebuggerUrl);
     if (page) wsUrl = page.webSocketDebuggerUrl; else await sleep(200);
   } catch { await sleep(250); }
 }
-if (!wsUrl) { console.error('no devtools target'); await shutdown(1); }
+if (!wsUrl) {
+  console.error(chromeExit
+    ? `no devtools target: chrome exited (code ${chromeExit.code}, signal ${chromeExit.signal})`
+    : 'no devtools target after 60s');
+  if (chromeErr.length) console.error(chromeErr.join('').trim().split('\n').slice(-15).join('\n'));
+  await shutdown(1);
+}
 const ws = new WebSocket(wsUrl);
 await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
 let msgId = 0; const pending = new Map(); const listeners = [];

--- a/scripts/verify-run-monitor-cdp.mjs
+++ b/scripts/verify-run-monitor-cdp.mjs
@@ -188,6 +188,16 @@ const wheelRaw = (x, y, dx, dy, modifiers = 0) => pumped(cdp('Input.dispatchMous
 // whenever the trusted event is not cancelable. `defaultPrevented` is what "the
 // page scrolls / the canvas takes the wheel" reduces to, and only the synthetic
 // path can report it.
+// Two probe wheels, not one: Chrome latches a wheel SEQUENCE — when the first
+// wheel of a sequence is not cancelled, every later wheel in it is dispatched
+// non-cancelable (preventDefault() becomes a no-op and `defaultPrevented` never
+// reads true), and a sequence outlives the settle() between two of our
+// dispatches. Linux CI Chrome 152 reports the FIRST wheel cancelable, so a
+// one-wheel probe picked the trusted path and then watched every real wheel
+// arrive non-cancelable (the pull_request/push runs of one commit split on it).
+// Only a runner whose SECOND consecutive wheel is still cancelable can measure
+// `defaultPrevented` through trusted events; everything else runs the same
+// listener over the same layout through the synthetic path.
 let wheelMode = null;                   // 'trusted' | 'synthetic'
 async function probeWheel(stageSel, x, y) {
   await ev(`window.__wheels=[];window.addEventListener('wheel',(e)=>{window.__wheels.push(
@@ -195,9 +205,11 @@ async function probeWheel(stageSel, x, y) {
   await mmove(x, y);
   await wheelRaw(x, y, 0, 0, 0);        // ZERO delta: the probe must not move anything
   await settle('wheel-probe');
+  await wheelRaw(x, y, 0, 0, 0);        // the second wheel of the sequence is the one that tells
+  await settle('wheel-probe');
   const seen = await ev('window.__wheels');
-  wheelMode = seen.length && seen[seen.length - 1].cancelable ? 'trusted' : 'synthetic';
-  log(`wheel delivery: ${wheelMode} (CDP wheels seen: ${seen.length}, cancelable: ${seen.length ? seen[seen.length - 1].cancelable : 'n/a'})`);
+  wheelMode = seen.length >= 2 && seen.every((w) => w.cancelable) ? 'trusted' : 'synthetic';
+  log(`wheel delivery: ${wheelMode} (CDP wheels seen: ${seen.length}, cancelable: ${seen.map((w) => w.cancelable).join(',') || 'n/a'})`);
   await ev('window.__wheels=[];0');
 }
 /** One wheel over `stageSel` at client (x,y). Returns the event's

--- a/scripts/verify-run-monitor-cdp.mjs
+++ b/scripts/verify-run-monitor-cdp.mjs
@@ -96,16 +96,31 @@ chrome = spawn(CHROME, ['--headless=new', ...SANDBOX, `--remote-debugging-port=$
   '--window-size=1280,900', '--hide-scrollbars', '--no-first-run', '--no-default-browser-check',
   '--disable-background-timer-throttling', '--disable-renderer-backgrounding', 'about:blank'],
 { stdio: ['ignore', 'pipe', 'pipe'] });
-chrome.stderr.on('data', () => {});
+// Keep Chrome's last stderr lines: when no DevTools target ever appears, its own
+// words (a sandbox refusal, a profile lock, a crash) are the diagnosis.
+const chromeErr = [];
+chrome.stderr.on('data', (d) => { chromeErr.push(String(d)); if (chromeErr.length > 40) chromeErr.shift(); });
+let chromeExit = null;
+chrome.on('exit', (code, signal) => { chromeExit = { code, signal }; });
 let wsUrl = null;
-for (let i = 0; i < 60 && !wsUrl; i += 1) {
+// Deadline-based, not iteration-based: a cold CI runner can take well over the
+// old ~15s (60 × 250ms) to bring the first page target up, and that budget was
+// the difference between a green and a red proofs job on the same commit.
+const targetDeadline = Date.now() + 60_000;
+while (!wsUrl && Date.now() < targetDeadline && !chromeExit) {
   try {
     const list = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
     const page = list.find((t) => t.type === 'page' && t.webSocketDebuggerUrl);
     if (page) wsUrl = page.webSocketDebuggerUrl; else await sleep(200);
   } catch { await sleep(250); }
 }
-if (!wsUrl) { console.error('no devtools target'); await shutdown(1); }
+if (!wsUrl) {
+  console.error(chromeExit
+    ? `no devtools target: chrome exited (code ${chromeExit.code}, signal ${chromeExit.signal})`
+    : 'no devtools target after 60s');
+  if (chromeErr.length) console.error(chromeErr.join('').trim().split('\n').slice(-15).join('\n'));
+  await shutdown(1);
+}
 const ws = new WebSocket(wsUrl);
 await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
 let msgId = 0; const pending = new Map(); const listeners = [];

--- a/src/cli/worca-cc.mjs
+++ b/src/cli/worca-cc.mjs
@@ -334,7 +334,7 @@ async function askGate(rl, issues, header) {
 
 /**
  * Ask the user how to handle a recoverable error (auth / rate-limit / quota /
- * network). Shows the cause and waits for retry / abort. Returns { decision }.
+ * network). Shows the cause and waits for retry / pause. Returns { decision }.
  */
 async function askRecovery(rl, recovery) {
   const rec = recovery || {};
@@ -344,12 +344,12 @@ async function askRecovery(rl, recovery) {
   if (rec.cls === 'auth') out(c('gray', '  Fix: re-authenticate (claude setup-token or /login) in another terminal, then retry.'));
   else out(c('gray', '  Fix: wait out the limit / restore connectivity / top up credit, then retry.'));
   out('  1) Retry');
-  out('  2) Abort the run');
+  out('  2) Pause the run (nothing is discarded — resume later)');
   let decision = '';
   while (!decision) {
     const raw = (await question(rl, c('cyan', 'Choose [1-2]: '))).trim();
     if (raw === '1' || /^retry/i.test(raw)) decision = 'retry';
-    else if (raw === '2' || /^abort/i.test(raw)) decision = 'abort';
+    else if (raw === '2' || /^(pause|abort)/i.test(raw)) decision = 'pause';
   }
   return { decision };
 }
@@ -557,7 +557,15 @@ async function attachAndDrive(orch, flags, start) {
       for (const line of summary.slice(1)) out(line);
     }
   } else if (result?.status === 'paused') {
-    out(c('yellow', result?.reason ? `Pipeline paused: ${result.reason}` : 'Pipeline paused.'));
+    // An error-pause reads as a failure the user can pick up again: the cause on
+    // its own line, then the reassurance that nothing was thrown away.
+    if (result.reason === 'error') {
+      out(c('red', c('bold', 'Pipeline paused after an error.')));
+      if (result.detail) out(c('red', `  ${result.detail}`));
+      out(c('yellow', 'Nothing was discarded: the worktree and the run position are kept.'));
+    } else {
+      out(c('yellow', result?.reason ? `Pipeline paused: ${result.reason}` : 'Pipeline paused.'));
+    }
     out(`Resume with: ${c('bold', `worca resume ${orch.state.id}`)}`);
   } else if (result?.status === 'stopped') {
     out(c('yellow', 'Pipeline stopped.'));
@@ -569,7 +577,11 @@ async function attachAndDrive(orch, flags, start) {
   }
   // An unanswered question is a failure even if the run somehow settled `done`.
   if (answerFailure) return 1;
-  return result?.status === 'done' || result?.status === 'paused' ? 0 : 1;
+  if (result?.status === 'done') return 0;
+  // D10: a pause the user asked for is a success (Ctrl+C, a budget hold); a pause
+  // an ERROR forced is a failure a script must be able to read off the exit code.
+  if (result?.status === 'paused') return result.reason === 'error' ? 1 : 0;
+  return 1;
 }
 
 // ── subcommands ──────────────────────────────────────────────────────────────────

--- a/src/cli/worca-cc.mjs
+++ b/src/cli/worca-cc.mjs
@@ -403,10 +403,16 @@ function stdinCanAnswer() {
 /**
  * Wire readline Q&A, log/phase rendering, and SIGINT pause/stop onto an
  * orchestrator, then drive it. `start` launches run() or resume(). Returns the
- * process exit code: 0 for done — and for a pause in an INTERACTIVE run (the
- * user chose or witnessed it and can resume); 3 for a pause under --yes (the
- * run parked itself on auth/quota/usage-limit/exhausted retries with nobody
- * attached to resume it, so a wrapper must not read success); 1 otherwise.
+ * process exit code (pauseExitCode, failure-policy.mjs):
+ *   0  done — and an INTERACTIVE pause the user chose or a limit/cap forced (they
+ *      witnessed it and can resume);
+ *   1  a terminal error (a launch failure, an unrecoverable resume, a stop) and an
+ *      INTERACTIVE pause an error forced;
+ *   2  a usage error (fail());
+ *   3  any pause under --yes — the run parked itself (auth/quota/usage limit,
+ *      exhausted retries, an error) with nobody attached to resume it, so a
+ *      wrapper must not read success. Under --yes a parked run's cause prints
+ *      on STDOUT with the pause block; only a terminal error reaches stderr.
  */
 async function attachAndDrive(orch, flags, start) {
   // Refuse an unanswerable interactive run BEFORE start(). The orchestrator
@@ -588,6 +594,10 @@ async function attachAndDrive(orch, flags, start) {
     if (result.reason === REASON.ERROR) {
       out(c('red', c('bold', 'Pipeline paused after an error.')));
       if (result.detail) out(c('red', `  ${result.detail}`));
+      out(c('yellow', 'Nothing was discarded: the worktree and the run position are kept.'));
+    } else if (result.reason === REASON.RECOVERABLE) {
+      out(c('yellow', c('bold', 'Pipeline paused on a recoverable error — resume once it clears.')));
+      if (result.detail) out(c('yellow', `  ${result.detail}`));
       out(c('yellow', 'Nothing was discarded: the worktree and the run position are kept.'));
     } else if (result?.reason) {
       const label = describePauseReason(result.reason) || result.reason;

--- a/src/cli/worca-cc.mjs
+++ b/src/cli/worca-cc.mjs
@@ -27,6 +27,7 @@ import {
 } from '../core/projects.mjs';
 import { projectKey } from '../core/store.mjs';
 import { formatExecLine, formatGateHeader, formatRunSummary } from './render.mjs';
+import { pauseExitCode, describePauseReason, promptOptions, REASON } from '../core/failure-policy.mjs';
 
 // ── node:sqlite runtime guard + warning filter ──────────────────────────────────
 // Drop ONLY the one-time ExperimentalWarning emitted by node:sqlite (the module is
@@ -351,22 +352,27 @@ async function askGate(rl, issues, header) {
 
 /**
  * Ask the user how to handle a recoverable error (auth / rate-limit / quota /
- * network). Shows the cause and waits for retry / pause. Returns { decision }.
+ * network). Shows the cause and the row's options (failure-policy.mjs: Retry, plus
+ * what giving up does — pause or abort). Returns { decision } with the chosen
+ * option's id as the wire value.
  */
 async function askRecovery(rl, recovery) {
   const rec = recovery || {};
+  const options = Array.isArray(rec.options) && rec.options.length ? rec.options : promptOptions({ outcome: 'pause' });
   out('');
   out(c('yellow', c('bold', `Recoverable ${String(rec.cls || 'error').replace('_', ' ')} error — the pipeline could not reach the model.`)));
   if (rec.message) out(c('gray', `  ${rec.message}`));
   if (rec.cls === 'auth') out(c('gray', '  Fix: re-authenticate (claude setup-token or /login) in another terminal, then retry.'));
   else out(c('gray', '  Fix: wait out the limit / restore connectivity / top up credit, then retry.'));
-  out('  1) Retry');
-  out('  2) Pause the run (nothing is discarded — resume later)');
+  options.forEach((o, i) => out(`  ${i + 1}) ${o.label}`));
   let decision = '';
   while (!decision) {
-    const raw = (await question(rl, c('cyan', 'Choose [1-2]: '))).trim();
-    if (raw === '1' || /^retry/i.test(raw)) decision = 'retry';
-    else if (raw === '2' || /^(pause|abort)/i.test(raw)) decision = 'pause';
+    const raw = (await question(rl, c('cyan', `Choose [1-${options.length}]: `))).trim();
+    const byNumber = options[Number(raw) - 1];
+    if (byNumber) decision = byNumber.id;
+    else if (/^retry/i.test(raw)) decision = 'retry';
+    // 'pause' and 'abort' both mean give up; the option offered names the verdict.
+    else if (/^(pause|abort)/i.test(raw)) decision = options.find((o) => o.id !== 'retry')?.id || 'pause';
   }
   return { decision };
 }
@@ -579,12 +585,15 @@ async function attachAndDrive(orch, flags, start) {
   } else if (result?.status === 'paused') {
     // An error-pause reads as a failure the user can pick up again: the cause on
     // its own line, then the reassurance that nothing was thrown away.
-    if (result.reason === 'error') {
+    if (result.reason === REASON.ERROR) {
       out(c('red', c('bold', 'Pipeline paused after an error.')));
       if (result.detail) out(c('red', `  ${result.detail}`));
       out(c('yellow', 'Nothing was discarded: the worktree and the run position are kept.'));
+    } else if (result?.reason) {
+      const label = describePauseReason(result.reason) || result.reason;
+      out(c('yellow', `Pipeline paused: ${label}${result.detail ? ` — ${result.detail}` : ''}`));
     } else {
-      out(c('yellow', result?.reason ? `Pipeline paused: ${result.reason}` : 'Pipeline paused.'));
+      out(c('yellow', 'Pipeline paused.'));
     }
     out(`Resume with: ${c('bold', `worca resume ${orch.state.id}`)}`);
   } else if (result?.status === 'stopped') {
@@ -598,15 +607,13 @@ async function attachAndDrive(orch, flags, start) {
   // An unanswered question is a failure even if the run somehow settled `done`.
   if (answerFailure) return 1;
   if (result?.status === 'done') return 0;
-  // A pause exits 0 only when someone is attached to resume it (interactive —
-  // pinned by the MAJ-7 Ctrl+C pitfall test) AND the user asked for it (Ctrl+C,
-  // a budget hold). Under --yes every pause is the run parking ITSELF
-  // (auth/quota/usage limit/exhausted recoverable retries/an error) with nobody
-  // left to resume: exit 0 here would let a CI job go green on a run that did no
-  // work. 3, not 1, so wrappers can tell "resumable pause" from a hard error
-  // (2 is fail()'s usage-error code). An interactive pause an ERROR forced is a
-  // failure a script must be able to read off the exit code: 1.
-  if (result?.status === 'paused') return flags.auto ? 3 : (result.reason === 'error' ? 1 : 0);
+  // The exit code for a pause is a consequence of its reason (failure-policy.mjs):
+  // 0 only when someone is attached to resume it (interactive — pinned by the
+  // MAJ-7 Ctrl+C pitfall test) and no error forced it; 1 for an interactive
+  // error-pause; 3 under --yes, where every pause is the run parking ITSELF with
+  // nobody left to resume (0 would let a CI job go green on a run that did no
+  // work; 2 is fail()'s usage-error code).
+  if (result?.status === 'paused') return pauseExitCode(result.reason, flags.auto);
   return 1;
 }
 

--- a/src/core/artifacts.mjs
+++ b/src/core/artifacts.mjs
@@ -1519,6 +1519,7 @@ async function rowToHistoryEntry(row, repoDir = null, opts = {}) {
     sourceBranch: source,
     guardrailsId: row.guardrails_id ?? null,
     pauseReason: row.pause_reason ?? null,
+    pauseDetail: row.pause_detail ?? null,
     retainedWork: retainedWorkFor(row),
     survived,
     added,
@@ -1574,7 +1575,8 @@ export async function listPipelines(projectDir, opts = {}, workspaceKey) {
   const rows = getDb().prepare(`
     SELECT id, project_key, target, title, status, started_at, updated_at, total_cost_usd, total_active_ms,
            branch, workspace_meta, guardrails_id,
-           json_extract(CASE WHEN json_valid(resume_point) THEN resume_point END, '$.pauseReason') AS pause_reason
+           json_extract(CASE WHEN json_valid(resume_point) THEN resume_point END, '$.pauseReason') AS pause_reason,
+           json_extract(CASE WHEN json_valid(resume_point) THEN resume_point END, '$.pauseDetail') AS pause_detail
     FROM pipelines
     WHERE ${workspaceKey ? 'workspace_key = ?' : 'project_key = ?'} AND archived_at IS NULL
     ORDER BY started_at DESC
@@ -1602,7 +1604,8 @@ export async function listAllPipelines(opts = {}, { batchSize = 16 } = {}) {
   const rows = getDb().prepare(`
     SELECT id, project_key, workspace_key, target, title, status, started_at, updated_at,
            total_cost_usd, total_active_ms, branch, workspace_meta, guardrails_id,
-           json_extract(CASE WHEN json_valid(resume_point) THEN resume_point END, '$.pauseReason') AS pause_reason
+           json_extract(CASE WHEN json_valid(resume_point) THEN resume_point END, '$.pauseReason') AS pause_reason,
+           json_extract(CASE WHEN json_valid(resume_point) THEN resume_point END, '$.pauseDetail') AS pause_detail
     FROM pipelines
     WHERE archived_at IS NULL
     ORDER BY COALESCE(updated_at, started_at) DESC, project_key, id
@@ -1785,6 +1788,11 @@ function rowToState(row) {
     `).all(row.id).map(stepRowToStep),
     subAgents: listSubAgents(row.id),
   };
+  // The pause cause rides resume_point (no column): expose it on the DETAIL payload
+  // too, so a deep-linked History detail no longer waits for the LIST row.
+  const rp = j(row.resume_point, null);
+  state.pauseReason = typeof rp?.pauseReason === 'string' ? rp.pauseReason : null;
+  state.pauseDetail = typeof rp?.pauseDetail === 'string' ? rp.pauseDetail : null;
   const outcome = j(row.outcome, null);
   if (outcome) {
     state.engine = 2;

--- a/src/core/ask/follow.mjs
+++ b/src/core/ask/follow.mjs
@@ -7,8 +7,9 @@
 //   post({kind, text, href})                     → a system message + notice
 //   updateStatus({pipelineId?, status?, phase?, cardFailed?}) → ask_run_links + ask-run-status
 // Message budget per run: ≤3 question notices (deduped by id) + exactly one of
-// failed/finished. done{status:'error'} posts nothing — the richer `error`
-// event already did (the orchestrator emits both for one failure).
+// failed/finished/paused; an error-pause rides the paused notice with its detail
+// (no `error` event precedes it). done{status:'error'} posts nothing — the richer
+// `error` event already did (the orchestrator emits both for one failure).
 // detach() removes the named listeners and latches; the follower self-detaches
 // on error/done. Core module: no Express, no orchestrator import — driven by a
 // bare EventEmitter in tests.
@@ -84,8 +85,13 @@ export function attachRunFollower(orch, {
       if (status === 'paused') {
         // Terminal for THIS orchestrator, not for the run: a resume builds a new
         // one (ui/server.mjs resumeRun), which re-attaches a fresh follower. So say
-        // "paused" — never "finished" — and let go (review of PR #376).
-        post({ kind: 'paused', text: `Run paused — "${runName()}" · resume it from Running`, href: `#running/${runId}` });
+        // "paused" — never "finished" — and let go (review of PR #376). An ERROR-
+        // pause (errors-pause policy: no `error` event precedes it) names the cause
+        // here, since this is the only line the thread will ever see for it.
+        const text = p.reason === 'error'
+          ? `Run paused after an error — "${runName()}": ${String(p.detail || 'unknown error')} · resume it from Running`
+          : `Run paused — "${runName()}" · resume it from Running`;
+        post({ kind: 'paused', text, href: `#running/${runId}` });
       } else if (status !== 'error') {
         post({ kind: 'done', text: finishLine(status), href: `#running/${runId}` });
       }

--- a/src/core/chat/command-router.mjs
+++ b/src/core/chat/command-router.mjs
@@ -14,7 +14,7 @@ import { parseCommand } from './parser.mjs';
 import { BOOKEND_EXECUTION_IDS } from '../../shared/graph/constants.mjs';
 import { createAllowlistGuard, parseIdList } from './allowlist.mjs';
 import { runRef, fmtUsd, fmtMs } from './renderers.mjs';
-import { giveUpOption } from '../failure-policy.mjs';
+import { giveUpOption, describePauseReason, pauseConsequences } from '../failure-policy.mjs';
 
 const md = (value) => ({ kind: 'markdown', value });
 const reply = (text, severity = 'info') => ({ title: null, body: [md(text)], severity });
@@ -175,8 +175,8 @@ export function createCommandRouter({ actions, chatContext, logger = () => {} })
         const r = t.row;
         return reply([runLine({ ...r, runId: r.id }),
           ...(fmtUsd(r.totalCostUsd) ? [`   **Cost:** ${fmtUsd(r.totalCostUsd)}`] : []),
-          ...(r.pauseReason ? [`   **Pause reason:** ${r.pauseReason}`] : []),
-          ...(r.pauseDetail ? [`   **Error:** ${r.pauseDetail}`] : []),
+          ...(r.pauseReason ? [`   **Pause reason:** ${describePauseReason(r.pauseReason) || r.pauseReason}`] : []),
+          ...(r.pauseDetail ? [`   **${pauseConsequences(r.pauseReason).severity === 'error' ? 'Error' : 'Cause'}:** ${r.pauseDetail}`] : []),
         ].join('\n'));
       }
       const r = t.run;

--- a/src/core/chat/command-router.mjs
+++ b/src/core/chat/command-router.mjs
@@ -14,6 +14,7 @@ import { parseCommand } from './parser.mjs';
 import { BOOKEND_EXECUTION_IDS } from '../../shared/graph/constants.mjs';
 import { createAllowlistGuard, parseIdList } from './allowlist.mjs';
 import { runRef, fmtUsd, fmtMs } from './renderers.mjs';
+import { giveUpOption } from '../failure-policy.mjs';
 
 const md = (value) => ({ kind: 'markdown', value });
 const reply = (text, severity = 'info') => ({ title: null, body: [md(text)], severity });
@@ -323,14 +324,16 @@ export function createCommandRouter({ actions, chatContext, logger = () => {} })
       if (verb === 'abort') return reply(`Gates have no abort — \`/approve ${ref}\`, \`/retry ${ref}\`, or \`/stop ${ref}\`.`, 'warning');
       payload = { decision: verb === 'approve' ? 'continue' : 'another' };
     } else if (pq.kind === 'recovery') {
-      payload = { decision: verb === 'abort' ? 'pause' : 'retry' };
+      // /abort is the give-up choice; what it does (pause or abort) is the row's
+      // option (failure-policy.mjs) — the option id is the wire decision.
+      payload = { decision: verb === 'abort' ? giveUpOption(pq.recovery?.options).id : 'retry' };
     } else {
       return reply(`\`${ref}\` is waiting on ${pq.kind} — use \`/answer ${ref} <n>\`.`, 'warning');
     }
     await actions.answer(t.run.runId, pq.id, payload);
     const what = pq.kind === 'gate'
       ? (payload.decision === 'continue' ? 'approved — continuing' : 'sent back for another cycle')
-      : (payload.decision === 'retry' ? 'retrying' : 'pausing the run');
+      : (payload.decision === 'retry' ? 'retrying' : payload.decision === 'abort' ? 'aborting the run' : 'pausing the run');
     return reply(`✅ \`${ref}\` ${what}.`, 'success');
   }
 

--- a/src/core/chat/command-router.mjs
+++ b/src/core/chat/command-router.mjs
@@ -44,7 +44,7 @@ const HELP_TEXT = [
   '`/status [*ref]` — run detail · `/cost [*ref]` — run cost',
   '`/pause [*ref]` · `/stop [*ref]` · `/resume [*ref]`',
   '`/approve [*ref]` — continue past a gate · `/retry [*ref]` — another cycle',
-  '`/abort [*ref]` — abort a recovery prompt',
+  '`/abort [*ref]` — give up on a recovery prompt (pauses the run; nothing is discarded)',
   '`/answer [*ref] <n|text> [| …]` — answer clarify questions (option number, or text for free-text)',
   '`/projects` · `/use <name>` — scope commands to one project',
   '`/mute 30m|2h|1d` · `/unmute` — silence notifications for this chat',
@@ -175,6 +175,7 @@ export function createCommandRouter({ actions, chatContext, logger = () => {} })
         return reply([runLine({ ...r, runId: r.id }),
           ...(fmtUsd(r.totalCostUsd) ? [`   **Cost:** ${fmtUsd(r.totalCostUsd)}`] : []),
           ...(r.pauseReason ? [`   **Pause reason:** ${r.pauseReason}`] : []),
+          ...(r.pauseDetail ? [`   **Error:** ${r.pauseDetail}`] : []),
         ].join('\n'));
       }
       const r = t.run;
@@ -322,14 +323,14 @@ export function createCommandRouter({ actions, chatContext, logger = () => {} })
       if (verb === 'abort') return reply(`Gates have no abort — \`/approve ${ref}\`, \`/retry ${ref}\`, or \`/stop ${ref}\`.`, 'warning');
       payload = { decision: verb === 'approve' ? 'continue' : 'another' };
     } else if (pq.kind === 'recovery') {
-      payload = { decision: verb === 'abort' ? 'abort' : 'retry' };
+      payload = { decision: verb === 'abort' ? 'pause' : 'retry' };
     } else {
       return reply(`\`${ref}\` is waiting on ${pq.kind} — use \`/answer ${ref} <n>\`.`, 'warning');
     }
     await actions.answer(t.run.runId, pq.id, payload);
     const what = pq.kind === 'gate'
       ? (payload.decision === 'continue' ? 'approved — continuing' : 'sent back for another cycle')
-      : (payload.decision === 'retry' ? 'retrying' : 'aborting');
+      : (payload.decision === 'retry' ? 'retrying' : 'pausing the run');
     return reply(`✅ \`${ref}\` ${what}.`, 'success');
   }
 

--- a/src/core/chat/notifier.mjs
+++ b/src/core/chat/notifier.mjs
@@ -89,7 +89,10 @@ export function createNotifier({ channelHost, getPrefs, chatContext, logger = ()
         const status = payload?.status || 'done';
         if (status === 'error') return; // the richer 'error' event already went out
         const prefs = getPrefsSafe().notify;
-        if (status === 'paused' ? prefs.paused === false : prefs.done === false) return;
+        // An error-pause IS the failure notification (no 'error' event
+        // precedes it): notify.error gates it, not notify.paused.
+        const gate = status === 'paused' ? (payload?.reason === 'error' ? prefs.error : prefs.paused) : prefs.done;
+        if (gate === false) return;
         deliver(renderDone(meta(), payload || {}));
       }));
 

--- a/src/core/chat/notifier.mjs
+++ b/src/core/chat/notifier.mjs
@@ -14,6 +14,7 @@ import { readPluginConfig } from '../plugin-config.mjs';
 import { parseIdList } from './allowlist.mjs';
 import { createRateLimiter } from './rate-limiter.mjs';
 import { renderDone, renderError, renderQuestion } from './renderers.mjs';
+import { pauseConsequences } from '../failure-policy.mjs';
 
 /**
  * @param {{channelHost: object, getPrefs: () => {notify:object, channels:object},
@@ -89,9 +90,10 @@ export function createNotifier({ channelHost, getPrefs, chatContext, logger = ()
         const status = payload?.status || 'done';
         if (status === 'error') return; // the richer 'error' event already went out
         const prefs = getPrefsSafe().notify;
-        // An error-pause IS the failure notification (no 'error' event
-        // precedes it): notify.error gates it, not notify.paused.
-        const gate = status === 'paused' ? (payload?.reason === 'error' ? prefs.error : prefs.paused) : prefs.done;
+        // Which preference gates a pause follows its reason (failure-policy.mjs):
+        // an error-pause IS the failure notification (no 'error' event precedes
+        // it), so notify.error gates it, not notify.paused.
+        const gate = status === 'paused' ? prefs[pauseConsequences(payload?.reason).notifyPref] : prefs.done;
         if (gate === false) return;
         deliver(renderDone(meta(), payload || {}));
       }));

--- a/src/core/chat/renderers.mjs
+++ b/src/core/chat/renderers.mjs
@@ -59,8 +59,9 @@ export function renderDone(meta, payload = {}) {
     const parts = head(isError ? '\u{1F534}' : '⏸', meta);
     parts.push(`   **Status:** paused${reason ? ` — ${reason}` : ''}`);
     if (payload.detail && payload.reason) {
-      const d = String(payload.detail);
-      parts.push(`   **${isError ? 'Error' : 'Cause'}:** ${d.length > 300 ? `${d.slice(0, 300)}…` : d}`);
+      // Already bounded (PAUSE_DETAIL_MAX, middle-clipped so the runner's trailing
+      // cause survives) — a head clip here would throw exactly that tail away.
+      parts.push(`   **${isError ? 'Error' : 'Cause'}:** ${String(payload.detail)}`);
     }
     parts.push(`   Resume from the worca-cc UI, or reply: /resume ${runRef(meta.runId)}`);
     return mdMsg(parts.join('\n'), isError ? 'error' : 'warning');

--- a/src/core/chat/renderers.mjs
+++ b/src/core/chat/renderers.mjs
@@ -44,6 +44,7 @@ function head(icon, meta) {
 const PAUSE_REASONS = {
   cost_pipeline: 'pipeline cost limit reached',
   cost_total: 'total cost limit reached',
+  error: 'a step failed',
 };
 
 /**
@@ -53,11 +54,18 @@ const PAUSE_REASONS = {
 export function renderDone(meta, payload = {}) {
   const status = payload.status || 'done';
   if (status === 'paused') {
+    // An error-pause IS the failure notification (no 'error' event precedes
+    // it), so it takes the failure icon/severity and carries the message.
+    const isError = payload.reason === 'error';
     const reason = payload.reason ? (PAUSE_REASONS[payload.reason] || payload.reason) : null;
-    const parts = head('⏸', meta);
+    const parts = head(isError ? '\u{1F534}' : '⏸', meta);
     parts.push(`   **Status:** paused${reason ? ` — ${reason}` : ''}`);
+    if (isError && payload.detail) {
+      const d = String(payload.detail);
+      parts.push(`   **Error:** ${d.length > 300 ? `${d.slice(0, 300)}…` : d}`);
+    }
     parts.push(`   Resume from the worca-cc UI, or reply: /resume ${runRef(meta.runId)}`);
-    return mdMsg(parts.join('\n'), 'warning');
+    return mdMsg(parts.join('\n'), isError ? 'error' : 'warning');
   }
   if (status === 'stopped') {
     const parts = head('⏹', meta);
@@ -109,7 +117,7 @@ export function renderQuestion(meta, payload = {}) {
     }
     parts.push(kind === 'gate'
       ? `   Reply: /approve ${ref} to continue · /retry ${ref} for another cycle`
-      : `   Reply: /approve ${ref} to retry · /abort ${ref} to abort`);
+      : `   Reply: /approve ${ref} to retry · /abort ${ref} to pause the run`);
     return mdMsg(parts.join('\n'), 'warning');
   }
 

--- a/src/core/chat/renderers.mjs
+++ b/src/core/chat/renderers.mjs
@@ -9,6 +9,8 @@
 // ordinals and embeds the exact reply commands (/approve, /retry, /answer n…)
 // using the run-id wildcard-suffix convention the command router resolves.
 
+import { pauseConsequences, describePauseReason, giveUpOption } from '../failure-policy.mjs';
+
 const md = (value) => ({ kind: 'markdown', value });
 
 export function fmtMs(ms) {
@@ -41,11 +43,6 @@ function head(icon, meta) {
   return parts;
 }
 
-const PAUSE_REASONS = {
-  cost_pipeline: 'pipeline cost limit reached',
-  cost_total: 'total cost limit reached',
-  error: 'a step failed',
-};
 
 /**
  * done event: status done|stopped|paused (+reason for limit pauses).
@@ -54,15 +51,16 @@ const PAUSE_REASONS = {
 export function renderDone(meta, payload = {}) {
   const status = payload.status || 'done';
   if (status === 'paused') {
-    // An error-pause IS the failure notification (no 'error' event precedes
-    // it), so it takes the failure icon/severity and carries the message.
-    const isError = payload.reason === 'error';
-    const reason = payload.reason ? (PAUSE_REASONS[payload.reason] || payload.reason) : null;
+    // The icon, severity and wording follow the pause's reason (failure-policy.mjs):
+    // an error-pause IS the failure notification (no 'error' event precedes it).
+    const { severity } = pauseConsequences(payload.reason);
+    const isError = severity === 'error';
+    const reason = payload.reason ? (describePauseReason(payload.reason) || payload.reason) : null;
     const parts = head(isError ? '\u{1F534}' : '⏸', meta);
     parts.push(`   **Status:** paused${reason ? ` — ${reason}` : ''}`);
-    if (isError && payload.detail) {
+    if (payload.detail && payload.reason) {
       const d = String(payload.detail);
-      parts.push(`   **Error:** ${d.length > 300 ? `${d.slice(0, 300)}…` : d}`);
+      parts.push(`   **${isError ? 'Error' : 'Cause'}:** ${d.length > 300 ? `${d.slice(0, 300)}…` : d}`);
     }
     parts.push(`   Resume from the worca-cc UI, or reply: /resume ${runRef(meta.runId)}`);
     return mdMsg(parts.join('\n'), isError ? 'error' : 'warning');
@@ -117,7 +115,7 @@ export function renderQuestion(meta, payload = {}) {
     }
     parts.push(kind === 'gate'
       ? `   Reply: /approve ${ref} to continue · /retry ${ref} for another cycle`
-      : `   Reply: /approve ${ref} to retry · /abort ${ref} to pause the run`);
+      : `   Reply: /approve ${ref} to retry · /abort ${ref} to ${giveUpOption(payload.recovery?.options).id === 'abort' ? 'abort the run' : 'pause the run'}`);
     return mdMsg(parts.join('\n'), 'warning');
   }
 

--- a/src/core/failure-policy.mjs
+++ b/src/core/failure-policy.mjs
@@ -1,0 +1,191 @@
+// failure-policy.mjs — the ONE place that decides what a failure does to a run.
+//
+// Every site in the engine that can see a failure — the per-node retry loop, the
+// flow-card dispatcher, the budget gate, run()/resume()'s setup and shell catch
+// blocks — asks `resolveFailure()` for a VERDICT and then enacts it with its own
+// mechanics (throwing the pause sentinel through the scheduler, picking a resume
+// point, stamping a setup replay). No site makes the decision itself, so shifting
+// a case from "terminal error" to "pause" (or back) is a one-cell edit in
+// FAILURE_POLICY below plus its row in test/failure-policy.test.mjs.
+//
+// Inputs (all plain values — this module is pure and imports nothing):
+//   site     where the failure surfaced (SITES)
+//   cls      classifyError()'s class, or null for an unclassified error; the
+//            budget gate passes its cost code
+//   auto     --yes / headless (true) or interactive (false)
+//   attempt  1-based attempt number, for bounded retries
+//   answer   the recovery prompt's answer once the user gave one ('retry'|'giveup')
+//
+// Verdicts:
+//   { outcome: 'retry' }                          try again (the site backs off)
+//   { outcome: 'prompt', options: [...] }         ask the user (interactive only)
+//   { outcome: 'pause', reason: ReasonCode }      park the run, resumable
+//   { outcome: 'error' }                          end the run as a terminal error
+//
+// Control-flow signals — a PauseError, an AbortError, a pause already requested,
+// the user's Stop — are NOT failures and never reach this table; every site guards
+// for them first. Stop is user-only and always ends the run as 'stopped'.
+//
+// A verdict is issued ONCE. When a site enacts 'error' it marks the error
+// terminal (markTerminal) so every enclosing catch — the flow dispatcher, the
+// shell — enacts that same verdict instead of re-deciding at its own site.
+
+/** Where a failure can surface. */
+export const SITES = Object.freeze(['node', 'flow', 'budget', 'setup', 'launch', 'shell']);
+
+/** Machine-readable pause reasons. The human text rides `pauseDetail`. */
+export const REASON = Object.freeze({
+  USAGE_LIMIT: 'usage_limit',     // a session/usage cap that clears after a multi-hour reset
+  ERROR: 'error',                 // a failure that would otherwise have ended the run
+  COST_PIPELINE: 'cost_pipeline', // the per-pipeline cost cap
+  COST_TOTAL: 'cost_total',       // the total (weekly/monthly) cost cap
+});
+export const REASON_CODES = Object.freeze(Object.values(REASON));
+
+/** Max auto-mode retries for a recoverable error before the row's `then` verdict. */
+export const RECOVERY_MAX_AUTO_ATTEMPTS = (() => {
+  const n = Number(process.env.WORCA_RECOVERY_MAX_ATTEMPTS);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 3;
+})();
+
+// ── verdict constructors ──────────────────────────────────────────────────────
+const pause = (reason) => Object.freeze({ outcome: 'pause', reason });
+const error = () => Object.freeze({ outcome: 'error' });
+/** Bounded retries (auto mode): `max` retries, then the `then` verdict. */
+const retry = (max, then) => Object.freeze({ outcome: 'retry', max, then });
+/** Interactive prompt: Retry re-runs in place; the give-up option enacts `giveUp`. */
+const prompt = (giveUp) => Object.freeze({ outcome: 'prompt', giveUp });
+
+/** One matrix cell: the verdict per run mode. */
+const cell = (auto, interactive) => Object.freeze({ auto, interactive });
+/** The same verdict in both modes. */
+const both = (v) => cell(v, v);
+
+// ── THE MATRIX ────────────────────────────────────────────────────────────────
+// Rows are keyed by site, then by error class; '*' is the row for any class the
+// site has no specific row for. Edit a cell to shift a case.
+//
+// A note on the two contested rows (PR #415 vs. the policy PR #412 shipped):
+//   node/'*'   an UNCLASSIFIED error (often a genuine bug) pauses instead of ending
+//              the run; resume retries the node in place. Flip to error() to
+//              restore "a bug ends the run".
+//   node/auth… an interactive recovery prompt's give-up option PAUSES (no Abort
+//              verdict). Flip prompt(error()) to offer Abort as a terminal error.
+export const FAILURE_POLICY = Object.freeze({
+  node: Object.freeze({
+    usage_limit: both(pause(REASON.USAGE_LIMIT)),
+    // auth/quota are user-fixable but never time-fixable — a 1s/2s/4s backoff
+    // cannot re-login or top up a balance — so auto mode pauses on the first hit.
+    auth:        cell(pause(REASON.ERROR), prompt(pause(REASON.ERROR))),
+    quota:       cell(pause(REASON.ERROR), prompt(pause(REASON.ERROR))),
+    rate_limit:  cell(retry(RECOVERY_MAX_AUTO_ATTEMPTS, pause(REASON.ERROR)), prompt(pause(REASON.ERROR))),
+    network:     cell(retry(RECOVERY_MAX_AUTO_ATTEMPTS, pause(REASON.ERROR)), prompt(pause(REASON.ERROR))),
+    '*':         both(pause(REASON.ERROR)),
+  }),
+  // A flow card, the questions loop, _afterExecution, a composite shell mode, an
+  // allocation failure — engine-side throws around an execution.
+  flow: Object.freeze({ '*': both(pause(REASON.ERROR)) }),
+  // The step-boundary budget gate (not an error: a cap was reached).
+  budget: Object.freeze({
+    cost_pipeline: both(pause(REASON.COST_PIPELINE)),
+    cost_total:    both(pause(REASON.COST_TOTAL)),
+  }),
+  // run()'s setup — checkout, graph build, skills gate — failed with the pipeline
+  // row already created. A pause here stamps `setupIncomplete`; resume replays it.
+  setup: Object.freeze({ '*': both(pause(REASON.ERROR)) }),
+  // Before the pipeline row exists (topology, preflight, tool detection) there is
+  // nothing to resume into: a launch error is the only enactable verdict.
+  launch: Object.freeze({ '*': both(error()) }),
+  // Anything that escaped the engine after setup (a scheduler throw, a persist
+  // failure, a bookkeeping bug).
+  shell: Object.freeze({ '*': both(pause(REASON.ERROR)) }),
+});
+
+/** The recovery prompt's options, derived from the row: what Retry does is fixed;
+ *  the give-up option's id is the wire `decision` value and names its verdict. */
+export function promptOptions(giveUp) {
+  const giveUpId = giveUp.outcome === 'pause' ? 'pause' : 'abort';
+  return Object.freeze([
+    Object.freeze({ id: 'retry', label: 'Retry' }),
+    giveUpId === 'pause'
+      ? Object.freeze({ id: 'pause', label: 'Pause the run (nothing is discarded — resume later)' })
+      : Object.freeze({ id: 'abort', label: 'Abort the run' }),
+  ]);
+}
+
+/** The give-up option of a prompt's options (the CLI/UI/chat render its label and
+ *  send its id back as the decision). Falls back to the pause option for a prompt
+ *  payload that predates options. */
+export function giveUpOption(options) {
+  const found = Array.isArray(options) ? options.find((o) => o && o.id !== 'retry') : null;
+  return found || promptOptions({ outcome: 'pause' })[1];
+}
+
+/** A recovery answer's `decision` wire value → the policy answer. 'abort' is the
+ *  pre-policy wire value (older UI tabs, chat /abort) and means give up too. */
+export function answerFromDecision(decision) {
+  return decision === 'retry' ? 'retry' : 'giveup';
+}
+
+/**
+ * Decide what a failure does. Pure.
+ * @param {{site:string, cls?:string|null, auto?:boolean, attempt?:number, answer?:'retry'|'giveup'}} f
+ * @returns {{outcome:'retry'|'prompt'|'pause'|'error', reason?:string, options?:readonly object[]}}
+ */
+export function resolveFailure({ site, cls = null, auto = false, attempt = 1, answer } = {}) {
+  const rows = FAILURE_POLICY[site];
+  if (!rows) throw new Error(`failure-policy: unknown site '${site}'`);
+  const row = (cls != null && rows[cls]) || rows['*'];
+  if (!row) throw new Error(`failure-policy: no row for ${site}/${cls}`);
+  let v = auto ? row.auto : row.interactive;
+  if (v.outcome === 'retry') {
+    v = attempt > v.max ? v.then : { outcome: 'retry' };
+  }
+  if (v.outcome === 'prompt') {
+    if (answer === undefined) return { outcome: 'prompt', options: promptOptions(v.giveUp) };
+    v = answer === 'retry' ? { outcome: 'retry' } : v.giveUp;
+  }
+  return v.outcome === 'pause' ? { outcome: 'pause', reason: v.reason } : { outcome: v.outcome };
+}
+
+// ── terminal-verdict stamp ────────────────────────────────────────────────────
+const TERMINAL = Symbol.for('worca.failure.terminal');
+/** Stamp an error whose verdict is 'error' so enclosing sites enact, not re-decide. */
+export function markTerminal(err) {
+  if (err && typeof err === 'object') { try { err[TERMINAL] = true; } catch { /* frozen */ } }
+  return err;
+}
+export function isTerminal(err) {
+  return !!(err && typeof err === 'object' && err[TERMINAL] === true);
+}
+
+// ── consequences of a pause, keyed on its reason ──────────────────────────────
+// What each surface does with a parked run is a function of the reason code, not
+// of ad hoc string checks. `null` is a manual pause (the user pressed Pause).
+const CONSEQUENCES = Object.freeze({
+  manual:                { reportsToSource: false, stagesResults: false, severity: 'info',    notifyPref: 'paused', exitInteractive: 0, label: null },
+  [REASON.USAGE_LIMIT]:  { reportsToSource: true,  stagesResults: false, severity: 'warning', notifyPref: 'paused', exitInteractive: 0, label: 'session/usage limit reached' },
+  [REASON.COST_PIPELINE]:{ reportsToSource: true,  stagesResults: false, severity: 'warning', notifyPref: 'paused', exitInteractive: 0, label: 'pipeline cost limit reached' },
+  [REASON.COST_TOTAL]:   { reportsToSource: true,  stagesResults: false, severity: 'warning', notifyPref: 'paused', exitInteractive: 0, label: 'total cost limit reached' },
+  [REASON.ERROR]:        { reportsToSource: true,  stagesResults: true,  severity: 'error',   notifyPref: 'error',  exitInteractive: 1, label: 'a step failed' },
+});
+
+/** The consequences row for a pause reason (unknown/legacy free-text reasons read
+ *  as a forced pause with a warning severity — every reasoned pause is forced). */
+export function pauseConsequences(reason) {
+  if (reason == null || reason === '') return CONSEQUENCES.manual;
+  return CONSEQUENCES[reason] || CONSEQUENCES[REASON.USAGE_LIMIT];
+}
+
+/** CLI exit code for a paused run. Under --yes every pause is the run parking
+ *  ITSELF with nobody left to resume: 3, so a wrapper can tell a resumable pause
+ *  from a hard error (1) and a usage error (2). Interactive: 0 when the user asked
+ *  for it or a cap/limit holds the run; 1 when an error forced it. */
+export function pauseExitCode(reason, auto) {
+  return auto ? 3 : pauseConsequences(reason).exitInteractive;
+}
+
+/** Human label for a reason code, or null for a manual pause / unknown code. */
+export function describePauseReason(reason) {
+  return pauseConsequences(reason).label;
+}

--- a/src/core/failure-policy.mjs
+++ b/src/core/failure-policy.mjs
@@ -31,11 +31,12 @@
 // shell — enacts that same verdict instead of re-deciding at its own site.
 
 /** Where a failure can surface. */
-export const SITES = Object.freeze(['node', 'flow', 'budget', 'setup', 'launch', 'shell']);
+export const SITES = Object.freeze(['node', 'flow', 'budget', 'setup', 'launch', 'shell', 'resume']);
 
 /** Machine-readable pause reasons. The human text rides `pauseDetail`. */
 export const REASON = Object.freeze({
   USAGE_LIMIT: 'usage_limit',     // a session/usage cap that clears after a multi-hour reset
+  RECOVERABLE: 'recoverable',     // a classified (auth/quota/rate_limit/network) error the run could not outwait
   ERROR: 'error',                 // a failure that would otherwise have ended the run
   COST_PIPELINE: 'cost_pipeline', // the per-pipeline cost cap
   COST_TOTAL: 'cost_total',       // the total (weekly/monthly) cost cap
@@ -76,10 +77,12 @@ export const FAILURE_POLICY = Object.freeze({
     usage_limit: both(pause(REASON.USAGE_LIMIT)),
     // auth/quota are user-fixable but never time-fixable — a 1s/2s/4s backoff
     // cannot re-login or top up a balance — so auto mode pauses on the first hit.
-    auth:        cell(pause(REASON.ERROR), prompt(pause(REASON.ERROR))),
-    quota:       cell(pause(REASON.ERROR), prompt(pause(REASON.ERROR))),
-    rate_limit:  cell(retry(RECOVERY_MAX_AUTO_ATTEMPTS, pause(REASON.ERROR)), prompt(pause(REASON.ERROR))),
-    network:     cell(retry(RECOVERY_MAX_AUTO_ATTEMPTS, pause(REASON.ERROR)), prompt(pause(REASON.ERROR))),
+    // A self-parked auto run pauses as RECOVERABLE (the class is kept: "resume when
+    // it clears"); a user who gives up on the prompt pauses as ERROR (a verdict).
+    auth:        cell(pause(REASON.RECOVERABLE), prompt(pause(REASON.ERROR))),
+    quota:       cell(pause(REASON.RECOVERABLE), prompt(pause(REASON.ERROR))),
+    rate_limit:  cell(retry(RECOVERY_MAX_AUTO_ATTEMPTS, pause(REASON.RECOVERABLE)), prompt(pause(REASON.ERROR))),
+    network:     cell(retry(RECOVERY_MAX_AUTO_ATTEMPTS, pause(REASON.RECOVERABLE)), prompt(pause(REASON.ERROR))),
     '*':         both(pause(REASON.ERROR)),
   }),
   // A flow card, the questions loop, _afterExecution, a composite shell mode, an
@@ -99,6 +102,12 @@ export const FAILURE_POLICY = Object.freeze({
   // Anything that escaped the engine after setup (a scheduler throw, a persist
   // failure, a bookkeeping bug).
   shell: Object.freeze({ '*': both(pause(REASON.ERROR)) }),
+  // resume() could not REHYDRATE the paused run — the checkout is gone, run.json
+  // is corrupt, a guardrail set or agent prompt no longer loads. The point on disk
+  // is already the best the run can offer: parking it again would re-persist the
+  // same point (and re-notify the task source) on every attempt, forever. A
+  // structurally unrecoverable resume ends the run.
+  resume: Object.freeze({ '*': both(error()) }),
 });
 
 /** The recovery prompt's options, derived from the row: what Retry does is fixed;
@@ -165,6 +174,7 @@ export function isTerminal(err) {
 const CONSEQUENCES = Object.freeze({
   manual:                { reportsToSource: false, stagesResults: false, severity: 'info',    notifyPref: 'paused', exitInteractive: 0, label: null },
   [REASON.USAGE_LIMIT]:  { reportsToSource: true,  stagesResults: false, severity: 'warning', notifyPref: 'paused', exitInteractive: 0, label: 'session/usage limit reached' },
+  [REASON.RECOVERABLE]:  { reportsToSource: true,  stagesResults: false, severity: 'warning', notifyPref: 'paused', exitInteractive: 0, label: 'recoverable error — resume to retry' },
   [REASON.COST_PIPELINE]:{ reportsToSource: true,  stagesResults: false, severity: 'warning', notifyPref: 'paused', exitInteractive: 0, label: 'pipeline cost limit reached' },
   [REASON.COST_TOTAL]:   { reportsToSource: true,  stagesResults: false, severity: 'warning', notifyPref: 'paused', exitInteractive: 0, label: 'total cost limit reached' },
   [REASON.ERROR]:        { reportsToSource: true,  stagesResults: true,  severity: 'error',   notifyPref: 'error',  exitInteractive: 1, label: 'a step failed' },

--- a/src/core/graph/scheduler.mjs
+++ b/src/core/graph/scheduler.mjs
@@ -393,6 +393,12 @@ export function createScheduler(opts) {
   async function runComposite(h) {
     const portId = h.entry.expandsPort;
     const expanded = await execute({ ...h.args, composite: 'expand', expandsPort: portId });
+    // A pause raised INSIDE the expansion (the adapter converted a throw) settles the
+    // shell row here, with its expands binding intact. Falling through to
+    // runUnexpanded would strip `expandsPort`/the binding from the very entry the
+    // resume re-invokes, so the node would re-run once as a plain execution and the
+    // decomposition would never be re-read.
+    if (expanded?.paused === true) return { paused: true };
     const phases = Array.isArray(expanded?.phases) ? expanded.phases : [];
     if (!phases.length) return runUnexpanded(h, portId);
 
@@ -444,7 +450,8 @@ export function createScheduler(opts) {
     const tasks = Array.isArray(ph.tasks) ? ph.tasks : [];
     const phaseAbort = new AbortController();
     let firstError = null;
-    await execute({ ...h.args, composite: 'phase', phase: ph.ordinal, phaseStatus: 'running' });
+    const opened = await execute({ ...h.args, composite: 'phase', phase: ph.ordinal, phaseStatus: 'running' });
+    if (opened?.paused === true) return { paused: true };   // the phase bookkeeping paused the run: no slice launches
 
     const results = await Promise.allSettled(tasks.map((task, index) =>
       runSlice(h, portId, ph, task, index, phaseAbort).catch((err) => {

--- a/src/core/orchestrator.mjs
+++ b/src/core/orchestrator.mjs
@@ -15,7 +15,7 @@ import { rm } from 'node:fs/promises';
 
 import {
   RunHarness, isAbort, isPause, pauseErr, firstLine, jsonClone,
-  clipMiddle, sumStepActive, normalizeClarifyAnswer, errorDetail,
+  clipMiddle, sumStepActive, normalizeClarifyAnswer,
 } from './run-harness.mjs';
 import { resolveGraph, loadAgentFile, GRAPH_DEFAULT_WORKFLOW } from './workflows.mjs';
 import { classifyLoops } from '../shared/graph/loops.mjs';
@@ -32,6 +32,7 @@ import {
 } from './artifacts.mjs';
 import { readQuestionsFile } from './protocol.mjs';
 import { classifyError } from './recoverable-error.mjs';
+import { resolveFailure, markTerminal, isTerminal } from './failure-policy.mjs';
 
 /** Max ask-then-resume question rounds per execution (mirrors v1's constant). */
 const MAX_QUESTION_ROUNDS = 3;
@@ -493,14 +494,34 @@ export class GraphOrchestrator extends RunHarness {
         this._logStepFailure(nc, ctx, err);
         throw err;
       }
-      // POLICY: no error ends the run. Anything that escaped _runNodeAttempts' own
-      // conversion — a flow card, the questions loop, _afterExecution, an unexpected
-      // throw — pauses the run with the error as its reason (D4). pause() rejects a
-      // sibling parked on a recovery prompt with the pause sentinel, so that slice
-      // unwinds as paused too (the old AbortError release is subsumed).
-      this._pauseForError(nc, ctx, err);
-      endMark = 'paused';
-      return { paused: true };
+      // The FLOW site (failure-policy.mjs): anything that escaped _runNodeAttempts'
+      // own verdict — a flow card, the questions loop, _afterExecution, an
+      // unexpected throw — is decided here. A verdict the node site already issued
+      // (a terminal error) is enacted, never re-decided.
+      const verdict = isTerminal(err) ? { outcome: 'error' }
+        : resolveFailure({ site: 'flow', cls: classifyError(err), auto: this.auto });
+      if (verdict.outcome === 'pause') {
+        // pause() rejects a sibling parked on a recovery prompt with the pause
+        // sentinel, so that slice unwinds as paused too.
+        this._pauseFor(verdict.reason, err, { nc, ctx });
+        endMark = 'paused';
+        return { paused: true };
+      }
+      // Terminal: the scheduler sees the failure (its row ends 'error', in-flight
+      // siblings 'skipped') and _engineRun rethrows it for the shell's error path.
+      endMark = 'error';
+      this._graphError ||= markTerminal(err);   // preserve identity for the base catch
+      this._logStepFailure(nc, ctx, err);
+      // A sibling slice parked on an interactive recovery prompt is not
+      // signal-reachable (_ask settles only via answer()/pause()/stop()), so a
+      // genuine slice failure rejects that prompt — the phase is failing and must
+      // not wait on a now-meaningless answer.
+      if (ctx.slice && this.pendingQuestion?.kind === 'recovery') {
+        const pq = this.pendingQuestion;
+        this.pendingQuestion = null;
+        pq.reject(abortError());
+      }
+      throw err;
     } finally {
       this._execStep(ctx, endMark);
       // A PAUSED slice stays 'running': the resume re-runs the whole composite,
@@ -512,9 +533,9 @@ export class GraphOrchestrator extends RunHarness {
   }
 
   /** A throw before the execution had a ledger row (the composite shell modes, or
-   *  _execCtx's allocation): the SAME three outcomes as _execute's catch, in the
-   *  same order and with the same conditions, just without a row to mark.
-   *  args.executionId / args.ordinal exist on every composite call (argsFor,
+   *  _execCtx's allocation): the SAME outcomes as _execute's catch, in the same
+   *  order and with the same conditions — the FLOW site — just without a row to
+   *  mark. args.executionId / args.ordinal exist on every composite call (argsFor,
    *  scheduler.mjs:333-342, is spread into each of them). */
   _settleUnstarted(nc, node, args, err) {
     if (isPause(err) || (this.pauseRequested && (isAbort(err) || this.pauseAbort.signal.aborted))) return { paused: true };
@@ -524,8 +545,15 @@ export class GraphOrchestrator extends RunHarness {
       this._logStepFailure(nc, ctx, err);
       throw err;
     }
-    this._pauseForError(nc, ctx, err);
-    return { paused: true };
+    const verdict = isTerminal(err) ? { outcome: 'error' }
+      : resolveFailure({ site: 'flow', cls: classifyError(err), auto: this.auto });
+    if (verdict.outcome === 'pause') {
+      this._pauseFor(verdict.reason, err, { nc, ctx });
+      return { paused: true };
+    }
+    this._graphError ||= markTerminal(err);
+    this._logStepFailure(nc, ctx, err);
+    throw err;
   }
 
   /** The five flow cards through P3's dispatcher. Engine-owned: instant, $0, no
@@ -745,11 +773,12 @@ export class GraphOrchestrator extends RunHarness {
     this._persist().catch(() => {});
   }
 
-  /** The recoverable-error retry loop around ONE execution. Every pause path throws
-   *  pauseErr() with pauseRequested already set (_pauseForLimit / _pauseForError call
-   *  pause()), so _execute's catch reproduces the 'paused' mark. Nothing here ends
-   *  the run: a non-recoverable error, and a recovery the user or auto mode gave up
-   *  on, PAUSE it (policy: errors pause; only the user's stop stops). */
+  /** The retry loop around ONE execution — the NODE site of failure-policy.mjs.
+   *  _recover() resolves the verdict (running the backoff or the recovery prompt
+   *  on the way); this loop enacts it. A pause throws pauseErr() with
+   *  pauseRequested already set (_pauseFor calls pause()), so _execute's catch
+   *  reproduces the 'paused' mark; a terminal error is stamped so _execute's
+   *  catch enacts it instead of re-deciding at the flow site. */
   async _runNodeAttempts(nc, ctx) {
     for (let attempt = 1; ; attempt++) {
       try {
@@ -759,17 +788,11 @@ export class GraphOrchestrator extends RunHarness {
         if (isAbort(err) || isPause(err)) throw err;
         if (this.abort.signal.aborted || this.state.status === 'stopped') throw err;  // a stop is in flight: _execute marks it 'stopped'
         const cls = classifyError(err);
-        if (!cls) { this._pauseForError(nc, ctx, err); throw pauseErr(); }            // not recoverable -> pause
-        if (cls === 'usage_limit') { this._pauseForLimit(nc, ctx, err); throw pauseErr(); }
-        // Auto mode: auth/quota are user-fixable but never time-fixable — a
-        // 1s/2s/4s backoff cannot re-login or top up a balance — so skip the
-        // futile retries and pause on the first hit. Interactive runs keep the
-        // recovery prompt: the user may fix the cause and hit Retry in place.
-        if (this.auto && (cls === 'auth' || cls === 'quota')) { this._pauseForError(nc, ctx, err); throw pauseErr(); }
-        const decision = await this._recover({ node: { key: nc.key || ctx.nodeId }, cls, err, attempt });
-        if (this.pauseRequested) throw pauseErr();                                    // a pause landed during backoff/prompt: its reason stands
-        if (decision === 'pause') { this._pauseForError(nc, ctx, err); throw pauseErr(); }  // user/auto gave up -> pause
-        this._execStep(ctx, 'start');           // back to running for the retry
+        const verdict = await this._recover({ node: { key: nc.key || ctx.nodeId }, cls, err, attempt });
+        if (this.pauseRequested) throw pauseErr();          // a pause landed during backoff/prompt: its reason stands
+        if (verdict.outcome === 'retry') { this._execStep(ctx, 'start'); continue; }   // back to running for the retry
+        if (verdict.outcome === 'pause') { this._pauseFor(verdict.reason, err, { nc, ctx }); throw pauseErr(); }
+        throw markTerminal(err);                           // terminal: _execute's catch ends the run
       }
     }
   }
@@ -801,43 +824,6 @@ export class GraphOrchestrator extends RunHarness {
       nodeId: ctx.nodeId, executionId: ctx.executionId, cycle: ctx.ordinal,
       ...(err?.stream ? { stream: err.stream } : {}),
     });
-  }
-
-  /** A session/usage cap that only clears after a multi-hour reset: pause the run
-   *  (v1's _pauseForLimit, orchestrator.mjs:756, re-keyed by execution). */
-  _pauseForLimit(nc, ctx, err) {
-    const label = nc.key || ctx.nodeId;
-    const reason = firstLine(err?.message || String(err));
-    this._setPauseReason(reason, null);
-    this._log(label, 'warn', `session/usage limit reached — pausing for manual resume: ${reason}`,
-      { nodeId: ctx.nodeId, executionId: ctx.executionId, cycle: ctx.ordinal });
-    appendAudit(this.pipeline.dir, `Pipeline **paused**: session/usage limit on ${label} — ${reason}. Resume after the reset.`).catch(() => {});
-    this.pause();
-  }
-
-  /**
-   * POLICY (errors pause; stop is user-only): a failure that used to end the run as
-   * 'error' — a non-recoverable runner error, a recovery the user or auto mode gave
-   * up on, a flow-card / questions-round / _afterExecution throw — pauses it instead,
-   * mirroring _pauseForLimit. Order matters: the ONE error-level log line FIRST
-   * (_logStepFailure skips the pause sentinel the caller throws next), then the
-   * machine-readable reason 'error' + the clipped error text, the audit line, and
-   * pause() — which sets pauseRequested BEFORE anything reaches the scheduler, so
-   * onSnapshot stays frozen at the last clean point, this row settles 'paused'
-   * (non-terminal) and reattach() re-invokes it on resume with its session.
-   * A pause already unwinding (the user's, or a sibling's) keeps its own reason; a
-   * stop in flight is never re-labelled (pause() would be a no-op on 'stopped' and
-   * the scheduler must keep seeing the stop, not a pause).
-   */
-  _pauseForError(nc, ctx, err) {
-    const label = nc.key || ctx.nodeId;
-    this._logStepFailure(nc, ctx, err);
-    if (this.pauseRequested || this.state.status === 'stopped' || this.abort.signal.aborted) return;
-    this._setPauseReason('error', errorDetail(err));
-    appendAudit(this.pipeline.dir,
-      `Pipeline **paused**: execution failed on ${label} — ${firstLine(err?.message || String(err)) || 'unknown error'}. Fix the cause, then resume.`,
-    ).catch(() => {});
-    this.pause();
   }
 
   /**

--- a/src/core/orchestrator.mjs
+++ b/src/core/orchestrator.mjs
@@ -15,7 +15,7 @@ import { rm } from 'node:fs/promises';
 
 import {
   RunHarness, isAbort, isPause, pauseErr, firstLine, jsonClone,
-  clipMiddle, sumStepActive, normalizeClarifyAnswer,
+  clipMiddle, sumStepActive, normalizeClarifyAnswer, errorDetail,
 } from './run-harness.mjs';
 import { resolveGraph, loadAgentFile, GRAPH_DEFAULT_WORKFLOW } from './workflows.mjs';
 import { classifyLoops } from '../shared/graph/loops.mjs';
@@ -145,14 +145,30 @@ export class GraphOrchestrator extends RunHarness {
     return this._buildResumePoint(null);
   }
 
+  /** hook: the last clean point (see run-harness.mjs). _graphSnapshot is never cleared
+   *  (onSnapshot, the resume restore), and the scheduler's finish() takes one final
+   *  snapshot, so after a clean 'done' this IS the all-terminal point. */
+  _engineLastPoint() {
+    return this._graphSnapshot ? this._buildResumePoint(this._graphSnapshot) : null;
+  }
+
+  /** hook: agent keys for a setup replay — from the frozen manifest, never the workflow row. */
+  _engineAgentKeys() {
+    if (this.resolved?.agentKeys) return new Set(this.resolved.agentKeys);
+    const manifest = this.state.stepper;
+    return manifest ? new Set(resolvedFromManifest(manifest, this.registry).agentKeys) : new Set();
+  }
+
   // ── hook 2: run the graph ──────────────────────────────────────────────────
   /**
    * The scheduler owns readiness, loop budgets, gates and End; this method owns
    * the process side: the resume-time restoration (Task 6), the pre-rendered
    * task document, the executor binding, the event fan-out and the resume-v2
-   * snapshot. Returns 'done' | 'paused'; a genuine execution failure is re-thrown
-   * VERBATIM (AbortError/pause identity intact) so the base run()/resume() catch
-   * classifies it exactly as v1 does.
+   * snapshot. Returns 'done' | 'paused'; only the user's STOP is re-thrown (its
+   * AbortError/plain-error identity intact) so the base run()/resume() catch
+   * classifies it exactly as v1 does. Every other failure pauses inside _execute
+   * (errors never end a run), and a pause that lands after the End card fired
+   * returns 'paused', never 'done'.
    * @param {{resume?:object|null, rehydrated?:object|null}} [o] the base passes
    *   `{ resume: rp, rehydrated }` on a resume and `{ resume: null }` on a fresh run.
    * @returns {Promise<'done'|'paused'>}
@@ -212,6 +228,16 @@ export class GraphOrchestrator extends RunHarness {
       // agent's error otherwise). A scheduler abort with nothing recorded yet is a stop.
       throw this._graphError || (this.abort.signal.aborted ? abortError('stopped') : new Error('a graph execution failed'));
     }
+    if (outcome === 'done' && this.pauseRequested) {
+      // D17: the scheduler resolves `ended` BEFORE it looks at pauseRequested
+      // (scheduler.mjs:1033-1034), so a pause that landed on a straggler after the
+      // End card fired — an error-pause, or the user's — came back as 'done'. It is
+      // a pause: the point was frozen by onSnapshot the moment pause() ran (the
+      // straggler's row is still non-terminal in it), reattach() re-invokes that
+      // row on resume and the restored `ended` then quiesces the run to done.
+      this.state.resumePoint = this._buildResumePoint(this._graphSnapshot);
+      return 'paused';
+    }
     if (outcome === 'paused') {
       this.state.resumePoint = this._buildResumePoint(this._graphSnapshot);
       return 'paused';
@@ -256,6 +282,7 @@ export class GraphOrchestrator extends RunHarness {
       checkpointRefs: { ...this.checkpointRefs },
       workspace: this.isWorkspace ? { projects: this._workspaceProjects() } : null,
       pauseReason: this.pauseReason || null,
+      pauseDetail: this.pauseDetail || null,
       // The EFFECTIVE instruction at dispatch time (post in-worktree graph
       // build), not the detect-time tools.instruction.
       toolInstruction: this.toolInstruction ?? '',
@@ -401,16 +428,35 @@ export class GraphOrchestrator extends RunHarness {
     const nc = (this.resolved.nodeCtx || {})[node.id] || { nodeId: node.id, kind: node.kind, key: null };
     // The composite protocol: these three modes are the process side of a
     // fan-out — they spawn nothing, record no ledger row and allocate nothing,
-    // so a composite shell never burns a plan version.
-    if (args.composite === 'expand') return await this._expandDecomposition(node, args);
-    if (args.composite === 'phase') return this._compositePhase(args);
-    if (args.composite === 'finish') return await this._finishComposite(nc, args);
+    // so a composite shell never burns a plan version. Same policy as below: a
+    // throw pauses the run. Only the `finish` answer is read as a settlement
+    // (settle -> pausedExecution); runComposite ignores an `expand` answer
+    // without `phases` (it falls to runUnexpanded) and runPhase ignores the
+    // `phase` answers (scheduler.mjs:447/:469), so for those two the pause lands
+    // one call later, at the next ordinary execute's _checkPause() — the shell
+    // row ends 'paused' either way and the whole fan-out re-runs on resume.
+    if (args.composite) {
+      try {
+        if (args.composite === 'expand') return await this._expandDecomposition(node, args);
+        if (args.composite === 'phase') return this._compositePhase(args);
+        return await this._finishComposite(nc, args);
+      } catch (err) {
+        return this._settleUnstarted(nc, node, args, err);
+      }
+    }
 
-    const ctx = this._execCtx(node, nc, args);
+    let ctx;
+    try {
+      ctx = this._execCtx(node, nc, args);
+    } catch (err) {
+      return this._settleUnstarted(nc, node, args, err);   // allocation failed: no row to mark
+    }
     this._execStep(ctx, 'start');
-    if (ctx.slice) updateTaskStatus(this.pipeline.id, ctx.slice.id, 'running', new Date().toISOString());
     let endMark = 'done';
     try {
+      // A real DB write — inside the try: a throw here pauses like anything
+      // else, and the finally skips updateTaskStatus for a 'paused' mark.
+      if (ctx.slice) updateTaskStatus(this.pipeline.id, ctx.slice.id, 'running', new Date().toISOString());
       // Exactly what v1's dispatcher loop does at every step boundary
       // (orchestrator.mjs:259-261): a stop or pause requested while nothing was
       // in flight (e.g. between executions, or during a flow card) must land
@@ -435,19 +481,26 @@ export class GraphOrchestrator extends RunHarness {
         endMark = 'paused';
         return { paused: true };
       }
-      endMark = (isAbort(err) && this.abort.signal.aborted) ? 'stopped' : 'error';
-      this._graphError ||= err;                 // preserve identity for the base catch
-      this._logStepFailure(nc, ctx, err);
-      // A sibling slice parked on an interactive recovery prompt is not
-      // signal-reachable (_ask settles only via answer()/pause()/stop()), so a
-      // genuine slice failure rejects that prompt exactly as v1's noteFailure
-      // does — the phase is failing and must not wait on a now-meaningless answer.
-      if (ctx.slice && this.pendingQuestion?.kind === 'recovery') {
-        const pq = this.pendingQuestion;
-        this.pendingQuestion = null;
-        pq.reject(abortError());
+      if (this.abort.signal.aborted || this.state.status === 'stopped') {
+        // The user's stop — the ONLY path that still lets the scheduler see a
+        // failure. Its identity is kept for _engineRun's rethrow; the shell's catch
+        // classifies the run 'stopped' (status/isAbort), never 'error'. This also
+        // covers a child that died with a PLAIN error after the stop landed — that
+        // error still gets today's one error-level line (_logStepFailure skips
+        // AbortErrors itself).
+        endMark = 'stopped';
+        this._graphError ||= err;               // preserve identity for the base catch
+        this._logStepFailure(nc, ctx, err);
+        throw err;
       }
-      throw err;
+      // POLICY: no error ends the run. Anything that escaped _runNodeAttempts' own
+      // conversion — a flow card, the questions loop, _afterExecution, an unexpected
+      // throw — pauses the run with the error as its reason (D4). pause() rejects a
+      // sibling parked on a recovery prompt with the pause sentinel, so that slice
+      // unwinds as paused too (the old AbortError release is subsumed).
+      this._pauseForError(nc, ctx, err);
+      endMark = 'paused';
+      return { paused: true };
     } finally {
       this._execStep(ctx, endMark);
       // A PAUSED slice stays 'running': the resume re-runs the whole composite,
@@ -456,6 +509,23 @@ export class GraphOrchestrator extends RunHarness {
         updateTaskStatus(this.pipeline.id, ctx.slice.id, endMark === 'stopped' ? 'error' : endMark, new Date().toISOString());
       }
     }
+  }
+
+  /** A throw before the execution had a ledger row (the composite shell modes, or
+   *  _execCtx's allocation): the SAME three outcomes as _execute's catch, in the
+   *  same order and with the same conditions, just without a row to mark.
+   *  args.executionId / args.ordinal exist on every composite call (argsFor,
+   *  scheduler.mjs:333-342, is spread into each of them). */
+  _settleUnstarted(nc, node, args, err) {
+    if (isPause(err) || (this.pauseRequested && (isAbort(err) || this.pauseAbort.signal.aborted))) return { paused: true };
+    const ctx = { nodeId: node.id, executionId: args.executionId, ordinal: args.ordinal || 1 };
+    if (this.abort.signal.aborted || this.state.status === 'stopped') {
+      this._graphError ||= err;                 // the stop keeps its identity for _engineRun's rethrow
+      this._logStepFailure(nc, ctx, err);
+      throw err;
+    }
+    this._pauseForError(nc, ctx, err);
+    return { paused: true };
   }
 
   /** The five flow cards through P3's dispatcher. Engine-owned: instant, $0, no
@@ -675,9 +745,11 @@ export class GraphOrchestrator extends RunHarness {
     this._persist().catch(() => {});
   }
 
-  /** The recoverable-error retry loop around ONE execution. The pause paths throw
-   *  pauseErr() with pauseRequested already set (_pauseForLimit calls pause()),
-   *  so _execute's catch reproduces the 'paused' mark. */
+  /** The recoverable-error retry loop around ONE execution. Every pause path throws
+   *  pauseErr() with pauseRequested already set (_pauseForLimit / _pauseForError call
+   *  pause()), so _execute's catch reproduces the 'paused' mark. Nothing here ends
+   *  the run: a non-recoverable error, and a recovery the user or auto mode gave up
+   *  on, PAUSE it (policy: errors pause; only the user's stop stops). */
   async _runNodeAttempts(nc, ctx) {
     for (let attempt = 1; ; attempt++) {
       try {
@@ -685,11 +757,13 @@ export class GraphOrchestrator extends RunHarness {
       } catch (err) {
         if (this.pauseRequested && (isAbort(err) || isPause(err) || this.pauseAbort.signal.aborted)) throw pauseErr();
         if (isAbort(err) || isPause(err)) throw err;
+        if (this.abort.signal.aborted || this.state.status === 'stopped') throw err;  // a stop is in flight: _execute marks it 'stopped'
         const cls = classifyError(err);
-        if (!cls) throw err;                    // not recoverable -> today's path
+        if (!cls) { this._pauseForError(nc, ctx, err); throw pauseErr(); }            // not recoverable -> pause
         if (cls === 'usage_limit') { this._pauseForLimit(nc, ctx, err); throw pauseErr(); }
         const decision = await this._recover({ node: { key: nc.key || ctx.nodeId }, cls, err, attempt });
-        if (decision === 'abort') throw err;    // user/auto gave up -> fail as today
+        if (this.pauseRequested) throw pauseErr();                                    // a pause landed during backoff/prompt: its reason stands
+        if (decision === 'pause') { this._pauseForError(nc, ctx, err); throw pauseErr(); }  // user/auto gave up -> pause
         this._execStep(ctx, 'start');           // back to running for the retry
       }
     }
@@ -729,10 +803,35 @@ export class GraphOrchestrator extends RunHarness {
   _pauseForLimit(nc, ctx, err) {
     const label = nc.key || ctx.nodeId;
     const reason = firstLine(err?.message || String(err));
-    if (!this.pauseReason) this.pauseReason = reason;
+    this._setPauseReason(reason, null);
     this._log(label, 'warn', `session/usage limit reached — pausing for manual resume: ${reason}`,
       { nodeId: ctx.nodeId, executionId: ctx.executionId, cycle: ctx.ordinal });
     appendAudit(this.pipeline.dir, `Pipeline **paused**: session/usage limit on ${label} — ${reason}. Resume after the reset.`).catch(() => {});
+    this.pause();
+  }
+
+  /**
+   * POLICY (errors pause; stop is user-only): a failure that used to end the run as
+   * 'error' — a non-recoverable runner error, a recovery the user or auto mode gave
+   * up on, a flow-card / questions-round / _afterExecution throw — pauses it instead,
+   * mirroring _pauseForLimit. Order matters: the ONE error-level log line FIRST
+   * (_logStepFailure skips the pause sentinel the caller throws next), then the
+   * machine-readable reason 'error' + the clipped error text, the audit line, and
+   * pause() — which sets pauseRequested BEFORE anything reaches the scheduler, so
+   * onSnapshot stays frozen at the last clean point, this row settles 'paused'
+   * (non-terminal) and reattach() re-invokes it on resume with its session.
+   * A pause already unwinding (the user's, or a sibling's) keeps its own reason; a
+   * stop in flight is never re-labelled (pause() would be a no-op on 'stopped' and
+   * the scheduler must keep seeing the stop, not a pause).
+   */
+  _pauseForError(nc, ctx, err) {
+    const label = nc.key || ctx.nodeId;
+    this._logStepFailure(nc, ctx, err);
+    if (this.pauseRequested || this.state.status === 'stopped' || this.abort.signal.aborted) return;
+    this._setPauseReason('error', errorDetail(err));
+    appendAudit(this.pipeline.dir,
+      `Pipeline **paused**: execution failed on ${label} — ${firstLine(err?.message || String(err)) || 'unknown error'}. Fix the cause, then resume.`,
+    ).catch(() => {});
     this.pause();
   }
 
@@ -978,7 +1077,7 @@ export class GraphOrchestrator extends RunHarness {
     this._resumeSnapshot = rp.snapshot || null;
     this._graphSnapshot = rp.snapshot || null;
     this._planVersion = Number.isFinite(rp.planVersion) ? rp.planVersion : 0;
-    this.pauseReason = null;
+    this._clearPauseReason();
     const manifest = rp.manifest || this.state.stepper;
     this.state.stepper = manifest;
     this._adoptResolvedGraph(resolvedFromManifest(manifest, this.registry));

--- a/src/core/orchestrator.mjs
+++ b/src/core/orchestrator.mjs
@@ -519,7 +519,10 @@ export class GraphOrchestrator extends RunHarness {
       if (ctx.slice && this.pendingQuestion?.kind === 'recovery') {
         const pq = this.pendingQuestion;
         this.pendingQuestion = null;
-        pq.reject(abortError());
+        // Stamped terminal: the released sibling's catch must ENACT this verdict
+        // (its row ends 'error' with the phase), never re-decide it at the flow site
+        // as a pause with the detail 'aborted'.
+        pq.reject(markTerminal(abortError()));
       }
       throw err;
     } finally {
@@ -791,7 +794,7 @@ export class GraphOrchestrator extends RunHarness {
         const verdict = await this._recover({ node: { key: nc.key || ctx.nodeId }, cls, err, attempt });
         if (this.pauseRequested) throw pauseErr();          // a pause landed during backoff/prompt: its reason stands
         if (verdict.outcome === 'retry') { this._execStep(ctx, 'start'); continue; }   // back to running for the retry
-        if (verdict.outcome === 'pause') { this._pauseFor(verdict.reason, err, { nc, ctx }); throw pauseErr(); }
+        if (verdict.outcome === 'pause') { this._pauseFor(verdict.reason, err, { nc, ctx, cls }); throw pauseErr(); }
         throw markTerminal(err);                           // terminal: _execute's catch ends the run
       }
     }

--- a/src/core/run-harness.mjs
+++ b/src/core/run-harness.mjs
@@ -62,6 +62,11 @@ import {
   isValidSourceRef, snapshotWorktreePatch,
 } from './worktree.mjs';
 import { readPluginsLock, pluginCurrentDir } from './plugins-lock.mjs'; // §9.4 disabled-plugin hint
+import { classifyError } from './recoverable-error.mjs';
+import {
+  resolveFailure, isTerminal, markTerminal, answerFromDecision,
+  REASON, pauseConsequences, describePauseReason,
+} from './failure-policy.mjs';
 
 // worca-cc repo root; holds skills/. fileURLToPath, never URL.pathname: the
 // latter is `/C:/…` on Windows and %-encoded everywhere (see DEFAULT_AGENTS_DIR
@@ -95,12 +100,6 @@ function findDisabledPluginFor(key) {
   } catch { /* no home / unreadable lock */ }
   return null;
 }
-
-/** Max auto-mode retries for a recoverable error before pausing the run. */
-const RECOVERY_MAX_AUTO_ATTEMPTS = (() => {
-  const n = Number(process.env.WORCA_RECOVERY_MAX_ATTEMPTS);
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 3;
-})();
 
 /**
  * `attr` marking a log line whose text came from a subprocess's stderr.
@@ -184,12 +183,6 @@ export function pauseErr() {
 
 export function isPause(err) {
   return !!err && err.name === 'PauseError';
-}
-
-/** The recovery prompt's "give up" answer. 'pause' is the vocabulary; 'abort' is
- *  the pre-policy wire value (older UI tabs, chat /abort) and means the same. */
-export function isPauseDecision(ans) {
-  return !!ans && (ans.decision === 'pause' || ans.decision === 'abort');
 }
 
 /** Fail-safe JSON.parse for nullable DB text columns; null on absent/bad JSON. */
@@ -804,7 +797,7 @@ export class RunHarness extends EventEmitter {
    * Record WHY the run is pausing: a machine-readable reason (the cost codes, 'error',
    * or the usage-limit first line) plus an optional human detail. FIRST WRITER WINS —
    * a pause kills its siblings and their unwinds must not overwrite the cause (the
-   * rule _pauseForLimit/_pauseForCost already follow). Mirrored onto state so every
+   * rule every _pauseFor site follows). Mirrored onto state so every
    * `state` event and getState() carry it. @returns {boolean} true when recorded
    */
   _setPauseReason(reason, detail = null) {
@@ -821,6 +814,51 @@ export class RunHarness extends EventEmitter {
     this.pauseDetail = null;
     this.state.pauseReason = null;
     this.state.pauseDetail = null;
+  }
+
+  /**
+   * Enact a 'pause' verdict (failure-policy.mjs) at ANY site — the one mechanism
+   * behind every forced pause: the ONE log line, the reason + detail (first writer
+   * wins), the audit line, then pause(). pause() sets pauseRequested BEFORE anything
+   * reaches the scheduler, so onSnapshot stays frozen at the last clean point, the
+   * failing row settles 'paused' (non-terminal) and reattach() re-invokes it on
+   * resume. Returns false — recording nothing — when a pause is already unwinding
+   * (the user's, or a sibling's: its reason stands) or a stop is in flight (never
+   * re-labelled: pause() would be a no-op on 'stopped' and the scheduler must keep
+   * seeing the stop). The caller throws pauseErr() itself where a throw is due.
+   * @param {string} reason a REASON code
+   * @param {Error|null} err the failure; null for a cap (`detail` carries the text)
+   * @param {{nc?:object|null, ctx?:object|null, label?:string, detail?:string|null}} [o]
+   *   nc/ctx: the execution (orchestrator sites); label: the log source otherwise
+   */
+  _pauseFor(reason, err, { nc = null, ctx = null, label = null, detail = null } = {}) {
+    const where = label || nc?.key || ctx?.nodeId || 'orchestrator';
+    const meta = ctx ? { nodeId: ctx.nodeId, executionId: ctx.executionId, cycle: ctx.ordinal } : {};
+    const line = firstLine(err?.message || (err == null ? '' : String(err))) || 'unknown error';
+    const text = detail ?? (reason === REASON.ERROR ? errorDetail(err) : line);
+    if (reason === REASON.ERROR) {
+      // The ONE error-level line, written BEFORE the pause sentinel the caller
+      // throws next (a pause/abort is never logged as a failure).
+      this._log(where, 'error', `${ctx ? 'execution' : 'run'} failed: ${clipMiddle(err?.message || err, 500)}`,
+        { ...meta, ...(err?.stream ? { stream: err.stream } : {}) });
+    }
+    if (this.pauseRequested || this.state.status === 'stopped' || this.abort.signal.aborted) return false;
+    this._setPauseReason(reason, text);
+    let audit;
+    if (reason === REASON.ERROR) {
+      audit = ctx
+        ? `Pipeline **paused**: execution failed on ${where} — ${line}. Fix the cause, then resume.`
+        : `Pipeline **paused**: ${line}. Fix the cause, then resume.`;
+    } else if (reason === REASON.USAGE_LIMIT) {
+      this._log(where, 'warn', `${describePauseReason(reason)} — pausing for manual resume: ${text}`, meta);
+      audit = `Pipeline **paused**: session/usage limit on ${where} — ${text}. Resume after the reset.`;
+    } else {
+      this._log(where, 'warn', `${text} — pausing for manual resume`, meta);
+      audit = `Pipeline **paused**: ${text}.`;
+    }
+    appendAudit(this.pipeline.dir, audit).catch(() => {});
+    this.pause();
+    return true;
   }
 
   /**
@@ -1115,9 +1153,10 @@ export class RunHarness extends EventEmitter {
         return { status: 'stopped', pipelineDir: this.pipeline?.dir || null };
       }
       if (this.pipeline) {
-        // POLICY: a failure once the row exists never ends the run (D6).
+        // The SETUP / SHELL site (failure-policy.mjs): a failure once the row exists.
         try {
-          return await this._pauseForFailure(err);
+          const paused = await this._pauseForFailure(err);
+          if (paused) return paused;
         } catch (err2) {
           // Last resort: the pause bookkeeping itself failed. Fall through to today's
           // error shape (persist/audit/results/write-back) rather than reject run().
@@ -1127,7 +1166,9 @@ export class RunHarness extends EventEmitter {
           this.state.resumePoint = null;
         }
       }
-      // No row yet (topology, preflight, tool detection) — a launch error, as today.
+      // No row yet (topology, preflight, tool detection): the LAUNCH site. Its only
+      // enactable verdict is a terminal error — there is nothing to resume into.
+      else this._launchVerdict(err);
       this._setStatus('error');
       const message = err?.message || String(err);
       this._emit('error', { message });
@@ -1412,10 +1453,11 @@ export class RunHarness extends EventEmitter {
         return { status: 'stopped', pipelineDir: this.pipeline?.dir || null };
       }
       if (this.pipeline) {
-        // POLICY: a failure once the row exists never ends the run (D6). `rp` is the
-        // point this resume consumed — the fallback when the engine holds none.
+        // The SETUP / SHELL site (failure-policy.mjs). `rp` is the point this resume
+        // consumed — the fallback when the engine holds none.
         try {
-          return await this._pauseForFailure(err, rp);
+          const paused = await this._pauseForFailure(err, rp);
+          if (paused) return paused;
         } catch (err2) {
           // Last resort: the pause bookkeeping itself failed. Fall through to today's
           // error shape (persist/audit/results/write-back) rather than reject resume().
@@ -2348,7 +2390,7 @@ export class RunHarness extends EventEmitter {
     const spentHere = Math.max(this.state.totalCostUsd || 0, sumStepCosts(this.state.steps));
     if (pipeLimit != null && spentHere >= pipeLimit
         && !readCostCapOverride(this.pipeline.id)) {
-      this._pauseForCost('cost_pipeline',
+      this._capReached(REASON.COST_PIPELINE,
         `pipeline cost limit reached ($${spentHere.toFixed(2)} >= $${pipeLimit.toFixed(2)})`);
     }
     const totalLimit = totalCostLimitUsd();
@@ -2356,69 +2398,71 @@ export class RunHarness extends EventEmitter {
       const period = costLimitResetPeriod();
       const spent = totalWindowSpendUsd(costWindowStart(new Date(), period).getTime());
       if (spent >= totalLimit) {
-        this._pauseForCost('cost_total',
+        this._capReached(REASON.COST_TOTAL,
           `total cost limit reached ($${spent.toFixed(2)} >= $${totalLimit.toFixed(2)} this ${period === 'weekly' ? 'week' : 'month'})`);
       }
     }
   }
 
-  /** Mirror of _pauseForLimit, but with a MACHINE-READABLE reason code
-   *  ('cost_pipeline' | 'cost_total') the UI switches on. Unlike _pauseForLimit
-   *  (whose caller throws), this throws itself — its caller is the boundary
-   *  gate, not a catch block. The audit line here is required: _completePaused
-   *  suppresses its generic audit whenever pauseReason is set. */
-  _pauseForCost(code, detail) {
-    this._setPauseReason(code, detail);
-    this._log('orchestrator', 'warn', `${detail} — pausing for manual resume`);
-    appendAudit(this.pipeline.dir, `Pipeline **paused**: ${detail}.`).catch(() => {});
-    this.pause();
-    throw pauseErr();
+  /** The BUDGET site (failure-policy.mjs): a cost cap was reached at a step
+   *  boundary. Unlike the catch-block sites this throws itself — its caller is
+   *  the boundary gate. The audit line is required: _completePaused suppresses
+   *  its generic audit whenever pauseReason is set. */
+  _capReached(code, detail) {
+    const verdict = resolveFailure({ site: 'budget', cls: code, auto: this.auto });
+    if (verdict.outcome === 'pause') {
+      this._pauseFor(verdict.reason, null, { detail });
+      throw pauseErr();
+    }
+    throw markTerminal(new Error(detail));
   }
 
-  /** Decide how to recover from a classified error. Auto mode: bounded backoff
-   *  then give up (and give up immediately if a pause fired during backoff, so a
-   *  pause is never followed by a wasted retry). Interactive: ONE shared prompt
-   *  per error class (same-class siblings await the same answer), and distinct
-   *  classes are serialized so only one recovery prompt is open at a time (the
-   *  gate holds a single pendingQuestion). Returns 'retry' | 'pause' ('pause' =
-   *  the user or auto mode gave up: the run PAUSES with the error as its reason —
-   *  nothing here can end a run). The per-class dedupe map shares ONE decision
-   *  across siblings; a sibling that receives 'pause' second finds pauseRequested
-   *  already set and unwinds as that same pause. */
+  /**
+   * Resolve the NODE-site verdict for a failed execution (failure-policy.mjs),
+   * running the recovery round it calls for on the way: auto mode backs off before
+   * a 'retry' (a pause fired DURING backoff still returns 'retry' — the caller
+   * checks pauseRequested first and unwinds as THAT pause, so a user pause is never
+   * followed by a wasted retry); interactive mode opens ONE shared prompt per error
+   * class (same-class siblings await the same answer), serialized so only one
+   * recovery prompt is open at a time (the gate holds a single pendingQuestion),
+   * and re-resolves with the answer. The per-class dedupe map shares ONE answer
+   * across siblings; a sibling that receives a pause verdict second finds
+   * pauseRequested already set and unwinds as that same pause.
+   * @returns {Promise<{outcome:'retry'|'pause'|'error', reason?:string}>}
+   */
   async _recover({ node, cls, err, attempt }) {
+    const verdict = resolveFailure({ site: 'node', cls, auto: this.auto, attempt });
+    if (verdict.outcome !== 'retry' && verdict.outcome !== 'prompt') return verdict;   // no recovery round
     this._log(node.key, 'warn', `recoverable ${cls} error: ${err.message}`, err?.stream ? ERR_STREAM : null);
     await appendAudit(this.pipeline.dir, `Recoverable **${cls}** error on ${node.key}: ${firstLine(err.message)}`).catch(() => {});
 
-    if (this.auto) {
-      if (attempt > RECOVERY_MAX_AUTO_ATTEMPTS) return 'pause';
+    if (verdict.outcome === 'retry') {
       await this._backoff(attempt, this.pauseAbort.signal);
-      // A pause during backoff must win: report 'pause' instead of retrying. The
-      // loop's outer catch re-classifies under pauseRequested and unwinds as THAT
-      // pause (its reason stands — _runNodeAttempts checks pauseRequested first).
-      if (this.pauseRequested || this.pauseAbort.signal.aborted) return 'pause';
-      return 'retry';
+      return verdict;
     }
 
     this._recovery ||= new Map();
     if (!this._recovery.has(cls)) {
-      const p = this._enqueueRecoveryPrompt(cls, firstLine(err.message))
+      const p = this._enqueueRecoveryPrompt(cls, firstLine(err.message), verdict.options)
         .finally(() => { if (this._recovery) this._recovery.delete(cls); });
       this._recovery.set(cls, p);
     }
-    return this._recovery.get(cls);
+    const answer = await this._recovery.get(cls);
+    return resolveFailure({ site: 'node', cls, auto: this.auto, attempt, answer });
   }
 
   /** Open a recovery prompt for one class, serialized behind any in-flight
    *  recovery prompt (the question gate has a single pendingQuestion slot, so
-   *  distinct classes must queue — see the clarify answer). Returns 'retry'|'pause';
-   *  the legacy `{ decision: 'abort' }` wire value still reads as 'pause'. */
-  _enqueueRecoveryPrompt(cls, message) {
+   *  distinct classes must queue — see the clarify answer). The prompt carries the
+   *  row's options (what the give-up choice does); resolves the policy answer
+   *  'retry' | 'giveup' (the legacy `{ decision: 'abort' }` wire value is a give-up). */
+  _enqueueRecoveryPrompt(cls, message, options) {
     const run = () =>
       this._ask({
         id: `recovery-${cls}-${this._recoveryNonce()}`,
         kind: 'recovery',
-        recovery: { cls, message },
-      }).then((ans) => (isPauseDecision(ans) ? 'pause' : 'retry'));
+        recovery: { cls, message, options },
+      }).then((ans) => answerFromDecision(ans && ans.decision));
     return this._enqueueAsk(run);
   }
 
@@ -3670,8 +3714,9 @@ export class RunHarness extends EventEmitter {
     // user is present and resuming shortly, and the resumed run's terminal path
     // reports the real outcome. An ERROR-pause additionally keeps the diff
     // artifact the retired error path produced. Never throws (spec §7.5).
-    if (this.pauseReason === 'error') await this._buildResults({ stage: true });
-    if (this.pauseReason) await this._reportToSource();
+    const consequences = pauseConsequences(this.pauseReason);
+    if (consequences.stagesResults) await this._buildResults({ stage: true });
+    if (consequences.reportsToSource) await this._reportToSource();
     const payload = {
       status: 'paused',
       pipelineDir: this.pipeline.dir,
@@ -3693,26 +3738,28 @@ export class RunHarness extends EventEmitter {
   _engineAgentKeys() { return new Set(); }
 
   /**
-   * POLICY (errors pause; stop is user-only): a failure the shell sees once the
-   * pipeline row exists never ends the run. Record the cause; kill anything still
-   * in flight (pause() is a no-op unless the run is 'running', and the status write
-   * below is unconditional); pick the resume point MOST-SPECIFIC FIRST —
-   * state.resumePoint (the engine's live point), the engine's LAST clean point (the
-   * final all-terminal snapshot when the failure came after the engine finished, D14),
-   * the consumed `fallbackPoint` (resume()'s rp), else the engine's pre-dispatch
-   * point; scrub any terminal error row (and the fail-fast's skipped collateral) out
-   * of its snapshot; then complete as a pause — _completePaused stamps/strips
-   * `setupIncomplete` from _setupDone (D7) for EVERY pause path. Emits NO 'error'
-   * event: the `done` payload carries reason 'error' + detail, the run log the line.
+   * The SETUP / SHELL site (failure-policy.mjs): a failure the shell sees once the
+   * pipeline row exists — before run()'s setup finished ('setup') or after it
+   * ('shell'). A verdict already issued downstream (a terminal error from the node
+   * or flow site) is enacted, never re-decided. Returns null when the verdict is a
+   * terminal error — the caller then falls through to the error path — else records
+   * the cause; kills anything still in flight (pause() is a no-op unless the run is
+   * 'running', and the status write below is unconditional); picks the resume
+   * point MOST-SPECIFIC FIRST — state.resumePoint (the engine's live point), the
+   * engine's LAST clean point (the final all-terminal snapshot when the failure
+   * came after the engine finished, D14), the consumed `fallbackPoint` (resume()'s
+   * rp), else the engine's pre-dispatch point; scrubs any terminal error row (and
+   * the fail-fast's skipped collateral) out of its snapshot; then completes as a
+   * pause — _completePaused stamps/strips `setupIncomplete` from _setupDone (D7)
+   * for EVERY pause path. Emits NO 'error' event: the `done` payload carries the
+   * reason + detail, the run log the line.
    */
   async _pauseForFailure(err, fallbackPoint = null) {
-    const message = err?.message || String(err);
-    this._log('orchestrator', 'error', `run failed: ${clipMiddle(message, 500)} — pausing for manual resume`,
-      err?.stream ? ERR_STREAM : null);
-    this._setPauseReason('error', errorDetail(err));
-    await appendAudit(this.pipeline.dir,
-      `Pipeline **paused**: ${firstLine(message) || 'unknown error'}. Fix the cause, then resume.`).catch(() => {});
-    this.pause();
+    const site = this._setupDone ? 'shell' : 'setup';
+    const verdict = isTerminal(err) ? { outcome: 'error' }
+      : resolveFailure({ site, cls: classifyError(err), auto: this.auto });
+    if (verdict.outcome !== 'pause') { markTerminal(err); return null; }
+    this._pauseFor(verdict.reason, err);
     const source = this.state.resumePoint || this._engineLastPoint() || fallbackPoint || this._enginePrePausePoint();
     this.state.resumePoint = {
       ...source,
@@ -3722,6 +3769,17 @@ export class RunHarness extends EventEmitter {
       pausedAt: new Date().toISOString(),
     };
     return await this._completePaused();
+  }
+
+  /** The LAUNCH site: no pipeline row yet, so a terminal error is the only verdict
+   *  the shell can enact. Consulted for completeness — a row flipped to 'pause'
+   *  cannot be honored here and says so in the run log. */
+  _launchVerdict(err) {
+    const verdict = resolveFailure({ site: 'launch', cls: classifyError(err), auto: this.auto });
+    if (verdict.outcome !== 'error') {
+      this._log('orchestrator', 'warn', `failure policy asks to ${verdict.outcome} a launch failure, but no pipeline row exists to resume into — ending the run as an error`);
+    }
+    markTerminal(err);
   }
 
   /**

--- a/src/core/run-harness.mjs
+++ b/src/core/run-harness.mjs
@@ -96,7 +96,7 @@ function findDisabledPluginFor(key) {
   return null;
 }
 
-/** Max auto-mode retries for a recoverable error before falling back to status error. */
+/** Max auto-mode retries for a recoverable error before pausing the run. */
 const RECOVERY_MAX_AUTO_ATTEMPTS = (() => {
   const n = Number(process.env.WORCA_RECOVERY_MAX_ATTEMPTS);
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : 3;
@@ -184,6 +184,12 @@ export function pauseErr() {
 
 export function isPause(err) {
   return !!err && err.name === 'PauseError';
+}
+
+/** The recovery prompt's "give up" answer. 'pause' is the vocabulary; 'abort' is
+ *  the pre-policy wire value (older UI tabs, chat /abort) and means the same. */
+export function isPauseDecision(ans) {
+  return !!ans && (ans.decision === 'pause' || ans.decision === 'abort');
 }
 
 /** Fail-safe JSON.parse for nullable DB text columns; null on absent/bad JSON. */
@@ -505,6 +511,36 @@ export function clipMiddle(text, n) {
   return s.slice(0, head) + '…' + s.slice(-(n - 1 - head));
 }
 
+/** Longest pause detail we persist/broadcast (the run log keeps the full text). */
+export const PAUSE_DETAIL_MAX = 400;
+
+/** The human detail a converted failure pauses with: the WHOLE message, whitespace-
+ *  collapsed and middle-clipped — the runner frames failures as "claude exited with
+ *  code N: <cause>" with the cause at the END, so a head-only clip would drop it.
+ *  Never empty: every consumer prints it verbatim. */
+export function errorDetail(err, max = PAUSE_DETAIL_MAX) {
+  const message = err == null ? '' : (err.message ?? String(err));
+  return clipMiddle(message, max) || 'unknown error';
+}
+
+/** A snapshot row the scheduler marked 'error' is TERMINAL to reattach() — the node
+ *  would never re-fire and a resumed run would quiesce to a false done. Under the
+ *  errors-pause policy such a row can only come from a failure that bypassed the
+ *  adapter's conversion. failExecution's fail-fast abort also settles every
+ *  in-flight sibling as 'skipped' (TERMINAL too), so when an error row is present the
+ *  skipped rows are its collateral and are re-armed with it; a snapshot WITHOUT an
+ *  error row is returned by identity (its skipped rows are legitimate). */
+export function scrubErrorRows(snapshot) {
+  if (!snapshot || !Array.isArray(snapshot.execs)) return snapshot ?? null;
+  if (!snapshot.execs.some((e) => e && e.status === 'error')) return snapshot;
+  const execs = snapshot.execs.map((e) => {
+    if (!e || (e.status !== 'error' && e.status !== 'skipped')) return e;
+    const { error: _dropped, ...rest } = e;
+    return { ...rest, status: 'paused' };
+  });
+  return { ...snapshot, execs };
+}
+
 /**
  * Normalize an answer payload from answer()/auto into [{id, choice}].
  * Accepts { answers:[{id,choice}] } or a bare array. Fills any missing
@@ -631,12 +667,15 @@ export class RunHarness extends EventEmitter {
     this.abort = new AbortController();
     this.pauseRequested = false;
     this.pauseAbort = new AbortController(); // aborts ONLY node children on pause
-    this.pauseReason = null;                 // set when a session/usage limit forces the pause
+    this.pauseReason = null;                 // WHY the run paused: 'cost_pipeline'|'cost_total'|'error'|<usage-limit line>|null
+    this.pauseDetail = null;                 // the human detail behind pauseReason ('error': the clipped message)
+    this._setupDone = false;                 // run()/resume() flip this right before _engineRun (setup replay)
+    this._modeRecorded = false;              // resume(): the row recorded a run-root mode (a setup-incomplete point may not)
     this._pauseGate = null;                  // gate context snapshot when paused at a gate
     this._resumeNodeSessions = null;         // nodeId -> sessionId map, set by resume() (Task 5)
     this.resumeOpts = this.opts.resume || null; // { row, resumePoint, steps } from readPipelineForResume
     this.pendingQuestion = null; // { id, resolve, reject, kind }
-    this._recovery = null;      // class -> in-flight Promise<'retry'|'abort'> (same-class dedupe)
+    this._recovery = null;      // class -> in-flight Promise<'retry'|'pause'> (same-class dedupe)
     this._askTail = null;       // serializes _ask: ONE prompt open at a time (recovery + step questions)
     this._recoverySeq = 0;      // monotonic id source for recovery prompts (determinism-safe)
     this.agentPrompts = null;
@@ -684,6 +723,8 @@ export class RunHarness extends EventEmitter {
       // detached run throws TypeError on the first this.state.branches[key] = … .
       branches: {},
       checkpointRefs: {},
+      pauseReason: null,   // mirrors this.pauseReason so getState() (a deep clone of state) carries it live
+      pauseDetail: null,   // mirrors this.pauseDetail
       // Sub-agent lifecycle records (rides the existing `state` snapshot; mirrored to
       // the sub_agents table). Each: { id, label, nodeId, stepIndex, cycle, stepKey,
       // status, startedAt, finishedAt, durationMs?, tokens?, costUsd? };
@@ -757,6 +798,29 @@ export class RunHarness extends EventEmitter {
 
   _checkPause() {
     if (this.pauseRequested) throw pauseErr();
+  }
+
+  /**
+   * Record WHY the run is pausing: a machine-readable reason (the cost codes, 'error',
+   * or the usage-limit first line) plus an optional human detail. FIRST WRITER WINS —
+   * a pause kills its siblings and their unwinds must not overwrite the cause (the
+   * rule _pauseForLimit/_pauseForCost already follow). Mirrored onto state so every
+   * `state` event and getState() carry it. @returns {boolean} true when recorded
+   */
+  _setPauseReason(reason, detail = null) {
+    if (this.pauseReason) return false;
+    this.pauseReason = String(reason);
+    this.pauseDetail = detail == null || detail === '' ? null : String(detail);
+    this.state.pauseReason = this.pauseReason;
+    this.state.pauseDetail = this.pauseDetail;
+    return true;
+  }
+
+  _clearPauseReason() {
+    this.pauseReason = null;
+    this.pauseDetail = null;
+    this.state.pauseReason = null;
+    this.state.pauseDetail = null;
   }
 
   /**
@@ -944,7 +1008,7 @@ export class RunHarness extends EventEmitter {
       let resolvedSkills = new Map();          // ← HOISTED; empty Map on the default workflow
       if (requiredSkills.length) {
         const skillCtx = { repoRoot: REPO_ROOT, projectDir: this.projectDir, pluginDirs: pluginSkillDirs() };
-        resolvedSkills = validateSkills(requiredSkills, skillCtx); // throws => caught => run ends 'error'
+        resolvedSkills = validateSkills(requiredSkills, skillCtx); // throws => caught => the run PAUSES (D6); the setup replay re-gates on resume
         if (this.runRootMode !== 'detached') {
           // LEGACY delivery, byte-identical to today: inject ONLY into real isolated
           // worktrees, never the main projectDir, so a copy can never pollute the
@@ -978,6 +1042,9 @@ export class RunHarness extends EventEmitter {
         await this._assembleContext(resolvedSkills);
       }
       this._checkAbort();
+      // D7: every setup step above is done — a pause from here on has nothing to
+      // replay, so _completePaused strips any `setupIncomplete` stamp instead.
+      this._setupDone = true;
 
       // 4) (Clarify now runs as the first graph node — see _runClarifyNode.)
 
@@ -1003,6 +1070,12 @@ export class RunHarness extends EventEmitter {
       return { status: 'done', pipelineDir: this.pipeline.dir };
     } catch (err) {
       if ((isPause(err) || this.state.status === 'pausing') && this.state.status !== 'stopped') {
+        // A plain error that landed while a user pause was unwinding (a setup step that
+        // failed under the pause): the user's pause keeps the reason, the run log keeps
+        // the failure. _completePaused stamps setupIncomplete when setup never finished.
+        if (!isPause(err) && !isAbort(err)) {
+          this._log('orchestrator', 'error', `failed while pausing: ${clipMiddle(err?.message || err, 500)}`, err?.stream ? ERR_STREAM : null);
+        }
         if (this.pipeline) {
           if (!this.state.resumePoint) {
             // Paused before the engine started (preflight/worktree): the engine
@@ -1041,6 +1114,20 @@ export class RunHarness extends EventEmitter {
         });
         return { status: 'stopped', pipelineDir: this.pipeline?.dir || null };
       }
+      if (this.pipeline) {
+        // POLICY: a failure once the row exists never ends the run (D6).
+        try {
+          return await this._pauseForFailure(err);
+        } catch (err2) {
+          // Last resort: the pause bookkeeping itself failed. Fall through to today's
+          // error shape (persist/audit/results/write-back) rather than reject run().
+          // The finally tears the checkout down on 'error' — never leave a
+          // point that names it (today's error branch does not clear it; the stop branch does).
+          this._log('orchestrator', 'error', `pause bookkeeping failed: ${err2?.message || err2} — ending the run as a launch error`);
+          this.state.resumePoint = null;
+        }
+      }
+      // No row yet (topology, preflight, tool detection) — a launch error, as today.
       this._setStatus('error');
       const message = err?.message || String(err);
       this._emit('error', { message });
@@ -1064,8 +1151,8 @@ export class RunHarness extends EventEmitter {
       });
       return { status: 'error', pipelineDir: this.pipeline?.dir || null, error: message };
     } finally {
-      this._stopHeartbeat(); // clear timer + NULL owner columns (done/stopped/error/paused)
-      // C1: tear the run root + worktree(s) down on done/stopped/error — the branch is
+      this._stopHeartbeat(); // clear timer + NULL owner columns (done/stopped/launch-error/paused)
+      // C1: tear the run root + worktree(s) down on done/stopped/launch-error — the branch is
       // always kept (every member's, on a workspace run), only the disposable checkout
       // is removed. But NEVER on a pause: the checkout (with any uncommitted agent
       // work) and the run root are the things we resume into (§8.13).
@@ -1079,7 +1166,9 @@ export class RunHarness extends EventEmitter {
   /**
    * Continue a paused pipeline from its persisted resume point. Mirrors run()'s
    * shell but skips createPipeline / checkpoint / worktree / graph setup — those
-   * artifacts exist from the original run. Resolves like run().
+   * artifacts exist from the original run, unless the point is stamped
+   * `setupIncomplete` (D7 replay), which re-runs whatever setup never finished.
+   * Resolves like run().
    */
   async resume() {
     const saved = this.resumeOpts;
@@ -1098,6 +1187,9 @@ export class RunHarness extends EventEmitter {
     // may be async; v1's synchronous return is awaited unchanged.
     const rehydrated = await this._engineRehydrate(rp);
     if (!rehydrated || typeof rehydrated.audit !== 'string' || !Array.isArray(rehydrated.memberWorktrees)) throw new Error('engine hook contract: _engineRehydrate must return { checkpointRef, memberWorktrees:[], audit }');
+    // D7: the point tells us whether run() ever finished its setup. Until the replay
+    // below re-runs it, a pause here must re-stamp the flag (_completePaused reads it).
+    this._setupDone = rp.setupIncomplete !== true;
     try {
       // ── rehydrate identity + state ──
       this.state.id = row.id;
@@ -1116,6 +1208,8 @@ export class RunHarness extends EventEmitter {
       recordArtifact(row.id, RUN_LOG_KIND, RUN_LOG_FILE);
       this.stepModels = rp.stepModels || null;
       this.workflowId = rp.workflowId || this.workflowId;
+      // The saved point carries the pause that produced it; a resumed run is running.
+      this._clearPauseReason();
       // Rehydrate the run's selection BEFORE re-resolving so resume enforces the
       // LATEST saved set definition (missing set -> warn + Permissive, inside
       // _resolveGuardrails). Legacy resume points without the field fall back to
@@ -1137,9 +1231,9 @@ export class RunHarness extends EventEmitter {
       // pre-change row. A run can therefore never be resumed into a mode it was not
       // started in, no matter when the default flips or rolls back.
       const meta = safeParse(row.workspace_meta);
-      const recordedMode = this.isWorkspace
-        ? (meta?.runRootMode || 'legacy')
-        : (this.state.branch?.runRootMode || 'legacy');
+      const recordedRaw = this.isWorkspace ? meta?.runRootMode : this.state.branch?.runRootMode;
+      this._modeRecorded = !!recordedRaw;                       // a setup-incomplete point may carry none
+      const recordedMode = recordedRaw || 'legacy';
       this.runRootMode = recordedMode === 'detached' ? 'detached' : 'legacy';
       // Re-stamp BEFORE the first persist so a resumed workspace run re-persists the
       // pin rather than dropping it (toPipelineRow reads it off state every persist).
@@ -1231,6 +1325,18 @@ export class RunHarness extends EventEmitter {
       await appendAudit(this.pipeline.dir, rehydrated.audit);
       this._emit('state', this.getState());
 
+      // ── setup replay (D7): a converted setup failure paused this run before its
+      //    checkout / graph / skills gate existed. Re-run exactly what run() never
+      //    finished. Placed HERE: _setupRunRoot persists, and the row must already
+      //    read 'running' (above), never the constructor's 'idle'.
+      let replayedSkills = null;
+      if (rp.setupIncomplete === true) {
+        replayedSkills = await this._replaySetup();
+        // The replay (re)wrote the run manifest; the re-assembly below reads it.
+        if (this.runRootMode === 'detached') resumeManifest = await readRunManifest(this.runRoot);
+      }
+      this._setupDone = true;
+
       // ── §5.2 detached resume: idempotent re-assembly (self-healing) ──
       // Only when the RECORDED mode is 'detached', and NEVER with a resolvedSkills
       // variable — that path does not exist here: resume never runs
@@ -1245,10 +1351,10 @@ export class RunHarness extends EventEmitter {
       // member. A member real dir deleted while paused degrades per §8.20 — a
       // missing SOURCE never throws (a missing worktree still hard-fails, above).
       if (this.runRootMode === 'detached') {
-        await this._assembleContext(resumeManifest?.skillResolutions ?? new Map());
+        await this._assembleContext(replayedSkills ?? (resumeManifest?.skillResolutions ?? new Map()));
         // AFTER the assembly: it rewrites run.json.warnings wholesale, so recording
         // this first would drop it from the durable ledger.
-        if (!resumeManifest) {
+        if (!resumeManifest && !replayedSkills) {
           await this._recordRunWarning(
             'run.json was missing or unparseable, so the bundle/plugin skills this run mounted ' +
             'could not be restored to the skill mount; real-dir and root skills were re-mounted ' +
@@ -1272,6 +1378,12 @@ export class RunHarness extends EventEmitter {
       return { status: 'done', pipelineDir: this.pipeline.dir };
     } catch (err) {
       if ((isPause(err) || this.state.status === 'pausing') && this.state.status !== 'stopped') {
+        // A plain error that landed while a user pause was unwinding (a replayed setup
+        // step that failed under the pause): the user's pause keeps the reason, the run
+        // log keeps the failure. _completePaused re-stamps setupIncomplete from _setupDone.
+        if (!isPause(err) && !isAbort(err)) {
+          this._log('orchestrator', 'error', `failed while pausing: ${clipMiddle(err?.message || err, 500)}`, err?.stream ? ERR_STREAM : null);
+        }
         if (this.pipeline) {
           if (!this.state.resumePoint) this.state.resumePoint = rp; // re-arm the consumed point: a paused row must stay resumable
           return await this._completePaused();
@@ -1299,6 +1411,20 @@ export class RunHarness extends EventEmitter {
         this._emit('done', { status: 'stopped', pipelineDir: this.pipeline?.dir || null });
         return { status: 'stopped', pipelineDir: this.pipeline?.dir || null };
       }
+      if (this.pipeline) {
+        // POLICY: a failure once the row exists never ends the run (D6). `rp` is the
+        // point this resume consumed — the fallback when the engine holds none.
+        try {
+          return await this._pauseForFailure(err, rp);
+        } catch (err2) {
+          // Last resort: the pause bookkeeping itself failed. Fall through to today's
+          // error shape (persist/audit/results/write-back) rather than reject resume().
+          // The finally tears the checkout down on 'error' — never leave a
+          // point that names it (today's error branch does not clear it; the stop branch does).
+          this._log('orchestrator', 'error', `pause bookkeeping failed: ${err2?.message || err2} — ending the run as a launch error`);
+          this.state.resumePoint = null;
+        }
+      }
       this._setStatus('error');
       const message = err?.message || String(err);
       this._emit('error', { message });
@@ -1319,7 +1445,7 @@ export class RunHarness extends EventEmitter {
       this._emit('done', { status: 'error', pipelineDir: this.pipeline?.dir || null });
       return { status: 'error', pipelineDir: this.pipeline?.dir || null, error: message };
     } finally {
-      this._stopHeartbeat(); // clear timer + NULL owner columns (done/stopped/error/paused)
+      this._stopHeartbeat(); // clear timer + NULL owner columns (done/stopped/launch-error/paused)
       // Same teardown as run()'s finally — wiring only run()'s would keep legacy
       // teardown on every detached run that finishes after a resume (including every
       // crash-interrupted run, §8.12's primary scenario): run root leaked until the
@@ -1358,9 +1484,11 @@ export class RunHarness extends EventEmitter {
    * resolution, workDirs/branchInfos/state.branches registration, the scalar
    * mirrors, the mode stamp, the persist + emit — runs identically in both modes.
    */
-  async _setupRunRoot() {
+  async _setupRunRoot({ replay = false } = {}) {
     this.state.branches = this.state.branches || {};      // belt-and-braces for resumed/legacy shapes
-    this.runRootMode = runRootMode();                     // §10 flag, read ONCE, here, per pipeline
+    // A resume REPLAY keeps the mode the row recorded — never the live flag — unless
+    // the paused run never got far enough to record one (then this IS run()'s read).
+    if (!replay || !this._modeRecorded) this.runRootMode = runRootMode(); // §10 flag, read ONCE, here, per pipeline
     this.state.runRootMode = this.runRootMode;            // top-level pin → workspace_meta (artifacts.mjs)
     const detached = this.runRootMode === 'detached';
     this.runRoot = detached ? join(worcaHome(), 'runs', this.pipeline.id) : null;
@@ -1377,6 +1505,15 @@ export class RunHarness extends EventEmitter {
     // (test/orchestrator-workspace.test.mjs) guards exactly this.
     const setupFailures = [];
     await mapWithCap(this.members, fanoutCap(), async (m) => {
+      // Replay: a member whose checkout survived the pause is already re-attached by
+      // resume() (workDirs/branchInfos/state.branches); `git worktree add` onto the
+      // live dir would fail. (This skips the per-member "Worktree `<key>`" audit line
+      // for kept members — say so in the run log instead.)
+      const kept = replay ? this.workDirs.get(m.projectKey) : null;
+      if (kept && existsSync(kept)) {
+        this._log('orchestrator', 'info', `setup replay: ${m.projectKey} keeps its checkout ${kept}`);
+        return;
+      }
       try {
         const { source, featureRaw } = this.isWorkspace
           ? await this._resolveMemberBranches(m)          // unchanged (member-suffixed names)
@@ -2231,7 +2368,7 @@ export class RunHarness extends EventEmitter {
    *  gate, not a catch block. The audit line here is required: _completePaused
    *  suppresses its generic audit whenever pauseReason is set. */
   _pauseForCost(code, detail) {
-    if (!this.pauseReason) this.pauseReason = code;
+    this._setPauseReason(code, detail);
     this._log('orchestrator', 'warn', `${detail} — pausing for manual resume`);
     appendAudit(this.pipeline.dir, `Pipeline **paused**: ${detail}.`).catch(() => {});
     this.pause();
@@ -2239,22 +2376,26 @@ export class RunHarness extends EventEmitter {
   }
 
   /** Decide how to recover from a classified error. Auto mode: bounded backoff
-   *  then give up (and abort immediately if a pause fired during backoff, so a
+   *  then give up (and give up immediately if a pause fired during backoff, so a
    *  pause is never followed by a wasted retry). Interactive: ONE shared prompt
    *  per error class (same-class siblings await the same answer), and distinct
    *  classes are serialized so only one recovery prompt is open at a time (the
-   *  gate holds a single pendingQuestion). Returns 'retry' | 'abort'. */
+   *  gate holds a single pendingQuestion). Returns 'retry' | 'pause' ('pause' =
+   *  the user or auto mode gave up: the run PAUSES with the error as its reason —
+   *  nothing here can end a run). The per-class dedupe map shares ONE decision
+   *  across siblings; a sibling that receives 'pause' second finds pauseRequested
+   *  already set and unwinds as that same pause. */
   async _recover({ node, cls, err, attempt }) {
     this._log(node.key, 'warn', `recoverable ${cls} error: ${err.message}`, err?.stream ? ERR_STREAM : null);
     await appendAudit(this.pipeline.dir, `Recoverable **${cls}** error on ${node.key}: ${firstLine(err.message)}`).catch(() => {});
 
     if (this.auto) {
-      if (attempt > RECOVERY_MAX_AUTO_ATTEMPTS) return 'abort';
+      if (attempt > RECOVERY_MAX_AUTO_ATTEMPTS) return 'pause';
       await this._backoff(attempt, this.pauseAbort.signal);
-      // A pause during backoff must win: abort instead of retrying. The loop's
-      // outer catch then re-classifies the thrown error under pauseRequested and
-      // unwinds as a pause (the pauseAbort signal is aborted).
-      if (this.pauseRequested || this.pauseAbort.signal.aborted) return 'abort';
+      // A pause during backoff must win: report 'pause' instead of retrying. The
+      // loop's outer catch re-classifies under pauseRequested and unwinds as THAT
+      // pause (its reason stands — _runNodeAttempts checks pauseRequested first).
+      if (this.pauseRequested || this.pauseAbort.signal.aborted) return 'pause';
       return 'retry';
     }
 
@@ -2269,14 +2410,15 @@ export class RunHarness extends EventEmitter {
 
   /** Open a recovery prompt for one class, serialized behind any in-flight
    *  recovery prompt (the question gate has a single pendingQuestion slot, so
-   *  distinct classes must queue — see the clarify answer). Returns 'retry'|'abort'. */
+   *  distinct classes must queue — see the clarify answer). Returns 'retry'|'pause';
+   *  the legacy `{ decision: 'abort' }` wire value still reads as 'pause'. */
   _enqueueRecoveryPrompt(cls, message) {
     const run = () =>
       this._ask({
         id: `recovery-${cls}-${this._recoveryNonce()}`,
         kind: 'recovery',
         recovery: { cls, message },
-      }).then((ans) => (ans && ans.decision === 'abort' ? 'abort' : 'retry'));
+      }).then((ans) => (isPauseDecision(ans) ? 'pause' : 'retry'));
     return this._enqueueAsk(run);
   }
 
@@ -2394,8 +2536,9 @@ export class RunHarness extends EventEmitter {
       if (this.auto) {
         if (kind === 'recovery') {
           // Auto mode handles recovery in _recover before ever calling _ask;
-          // this is a defensive fallback so an auto run can never hang.
-          return { decision: 'abort' };
+          // this is a defensive fallback so an auto run can never hang. Giving up
+          // pauses the run (errors never end one), so 'pause' is the answer.
+          return { decision: 'pause' };
         }
         if (kind === 'clarify' || kind === 'questions') {
           this._log('orchestrator', 'info', `auto-answering ${kind} ${id}`);
@@ -2581,8 +2724,9 @@ export class RunHarness extends EventEmitter {
   /**
    * Task-source write-back (spec §7.5): report the finished run to the plugin
    * source that produced it. Runs on EVERY terminal path and ALWAYS after
-   * _buildResults() — done (statusToResult -> 'completed') and stopped/error alike
-   * (-> 'failed'; chat-connectivity design PR12 closed the old success-only gap).
+   * _buildResults() — done (statusToResult -> 'completed'), stopped/launch-error
+   * (-> 'failed'; chat-connectivity design PR12 closed the old success-only gap),
+   * and error-pauses (-> 'needs-human', from _completePaused).
    * So the payload is the same SHAPE on all three: retryWriteback reads
    * results.json (sources.mjs:215), and a stopped/error run that persisted one now
    * carries the diffstat and "Key things to check" lines too. Only a run with
@@ -3497,15 +3641,127 @@ export class RunHarness extends EventEmitter {
     if (this.pipeline?.id) clearPipelineOwnership(this.pipeline.id);
   }
 
-  /** Terminal bookkeeping for a pause: persist the resume point + paused status. */
+  /** Terminal bookkeeping for a pause: persist the resume point + paused status.
+   *  An ERROR-pause additionally keeps what the retired error path produced — the
+   *  diff artifact and the task-source write-back (statusToResult('paused') ->
+   *  'needs-human'; retryWriteback re-reads the ROW, so this runs AFTER the persist).
+   *  Safe here and only here: the checkout and the checkpoint refs are live, and the
+   *  finally never tears a paused run down. Both helpers are no-ops with an empty
+   *  workDirs (a setup-phase pause). */
   async _completePaused() {
+    // D7: a pause that landed BEFORE run()'s setup finished (a converted setup failure,
+    // or a user pause racing one — run()'s pause branch catches a plain error while
+    // 'pausing') must replay that setup on resume; a completed setup never leaves a
+    // stale stamp behind (resume() re-arms the consumed point, which may carry one).
+    const rp = this.state.resumePoint;
+    if (rp && typeof rp === 'object') {
+      if (this._setupDone) delete rp.setupIncomplete;
+      else rp.setupIncomplete = true;
+    }
     this._setStatus('paused');
     await this._persist();
-    // A plain manual pause has no reason; only a limit-pause records one (audited
-    // already at the pause site, so don't double-log it here).
+    // A plain manual pause has no reason; every reasoned pause audited at its site.
     if (!this.pauseReason) await appendAudit(this.pipeline.dir, `Pipeline **paused**.`).catch(() => {});
-    this._emit('done', { status: 'paused', pipelineDir: this.pipeline.dir, reason: this.pauseReason || null });
-    return { status: 'paused', pipelineDir: this.pipeline.dir, reason: this.pauseReason || null };
+    if (this.pauseReason === 'error') {
+      await this._buildResults({ stage: true });
+      await this._reportToSource();
+    }
+    const payload = {
+      status: 'paused',
+      pipelineDir: this.pipeline.dir,
+      reason: this.pauseReason || null,
+      detail: this.pauseDetail || null,
+    };
+    this._emit('done', payload);
+    return { ...payload };
+  }
+
+  /** Engine hook (optional): the LAST clean graph point the engine holds — the final
+   *  all-terminal snapshot after a completed run, the last clean one mid-run. The
+   *  failure fallback prefers it over the pre-dispatch point so a failure AFTER the
+   *  engine finished never re-runs the graph (D14). Base engines: none. */
+  _engineLastPoint() { return null; }
+
+  /** Engine hook (optional): the run's distinct agent keys from the frozen manifest —
+   *  what the skills gate needs on a setup replay (D7). Base engines: none. */
+  _engineAgentKeys() { return new Set(); }
+
+  /**
+   * POLICY (errors pause; stop is user-only): a failure the shell sees once the
+   * pipeline row exists never ends the run. Record the cause; kill anything still
+   * in flight (pause() is a no-op unless the run is 'running', and the status write
+   * below is unconditional); pick the resume point MOST-SPECIFIC FIRST —
+   * state.resumePoint (the engine's live point), the engine's LAST clean point (the
+   * final all-terminal snapshot when the failure came after the engine finished, D14),
+   * the consumed `fallbackPoint` (resume()'s rp), else the engine's pre-dispatch
+   * point; scrub any terminal error row (and the fail-fast's skipped collateral) out
+   * of its snapshot; then complete as a pause — _completePaused stamps/strips
+   * `setupIncomplete` from _setupDone (D7) for EVERY pause path. Emits NO 'error'
+   * event: the `done` payload carries reason 'error' + detail, the run log the line.
+   */
+  async _pauseForFailure(err, fallbackPoint = null) {
+    const message = err?.message || String(err);
+    this._log('orchestrator', 'error', `run failed: ${clipMiddle(message, 500)} — pausing for manual resume`,
+      err?.stream ? ERR_STREAM : null);
+    this._setPauseReason('error', errorDetail(err));
+    await appendAudit(this.pipeline.dir,
+      `Pipeline **paused**: ${firstLine(message) || 'unknown error'}. Fix the cause, then resume.`).catch(() => {});
+    this.pause();
+    const source = this.state.resumePoint || this._engineLastPoint() || fallbackPoint || this._enginePrePausePoint();
+    this.state.resumePoint = {
+      ...source,
+      snapshot: scrubErrorRows(source.snapshot ?? null),
+      pauseReason: this.pauseReason,
+      pauseDetail: this.pauseDetail,
+      pausedAt: new Date().toISOString(),
+    };
+    return await this._completePaused();
+  }
+
+  /**
+   * resume() of a point whose run() never finished its setup (D7) — run()'s steps
+   * 3..3e in order, abort-checked, each guarded so a step that DID complete is not
+   * redone. Returns the resolved skill map for the detached assembly.
+   * @returns {Promise<Map>} resolvedSkills
+   */
+  async _replaySetup() {
+    // 3) checkpoint
+    if (!this.checkpointRef) {
+      if (this.isWorkspace) await this._ensureGitCheckpointAll(); else await this._ensureGitCheckpoint();
+    } else if (!this.isWorkspace) {
+      const onlyKey = this.members[0]?.projectKey;
+      if (onlyKey && !this.checkpointRefs[onlyKey]) {
+        this.checkpointRefs[onlyKey] = this.checkpointRef;
+        this.state.checkpointRefs = { ...this.checkpointRefs };
+      }
+    }
+    this._checkAbort();
+    // 3b) run root + worktrees — keyed on the per-member map, NEVER on this.workDir
+    //     (it defaults to projectDir and is never falsy).
+    const missing = this.members.some((m) => !this.workDirs.get(m.projectKey));
+    if (missing) await this._setupRunRoot({ replay: true });
+    this._checkAbort();
+    // 3c) graph build (fail-safe, idempotent)
+    if (this.isWorkspace) await this._buildWorktreeGraphAll(); else await this._buildWorktreeGraph();
+    this._checkAbort();
+    // 3d) the skills gate + legacy injection — run()'s block, agent keys from the frozen manifest
+    const requiredSkills = collectRequiredSkills(this.registry, this._engineAgentKeys());
+    let resolvedSkills = new Map();
+    if (requiredSkills.length) {
+      const skillCtx = { repoRoot: REPO_ROOT, projectDir: this.projectDir, pluginDirs: pluginSkillDirs() };
+      resolvedSkills = validateSkills(requiredSkills, skillCtx);   // throws => caught => the run PAUSES again
+      if (this.runRootMode !== 'detached') {
+        const candidates = this.isWorkspace ? [...this.workDirs.values()] : [this.workDir];
+        const worktrees = candidates.filter((d) => d && d !== this.projectDir);
+        const injected = await injectSkills(resolvedSkills, { targets: worktrees });
+        if (injected.length) {
+          await appendAudit(this.pipeline.dir, `Skills: injected ${injected.join(', ')} into ${worktrees.length} worktree(s).`);
+        }
+      }
+    }
+    this._checkAbort();
+    await appendAudit(this.pipeline.dir, 'Setup replayed on resume (the paused run never finished it).').catch(() => {});
+    return resolvedSkills;
   }
 
   // ── engine hooks ─────────────────────────────────────────────────────────────

--- a/src/core/run-harness.mjs
+++ b/src/core/run-harness.mjs
@@ -663,6 +663,7 @@ export class RunHarness extends EventEmitter {
     this.pauseReason = null;                 // WHY the run paused: 'cost_pipeline'|'cost_total'|'error'|<usage-limit line>|null
     this.pauseDetail = null;                 // the human detail behind pauseReason ('error': the clipped message)
     this._setupDone = false;                 // run()/resume() flip this right before _engineRun (setup replay)
+    this._rehydrated = true;                 // resume() clears this until the paused run is rehydrated (the 'resume' site)
     this._modeRecorded = false;              // resume(): the row recorded a run-root mode (a setup-incomplete point may not)
     this._pauseGate = null;                  // gate context snapshot when paused at a gate
     this._resumeNodeSessions = null;         // nodeId -> sessionId map, set by resume() (Task 5)
@@ -828,14 +829,16 @@ export class RunHarness extends EventEmitter {
    * seeing the stop). The caller throws pauseErr() itself where a throw is due.
    * @param {string} reason a REASON code
    * @param {Error|null} err the failure; null for a cap (`detail` carries the text)
-   * @param {{nc?:object|null, ctx?:object|null, label?:string, detail?:string|null}} [o]
-   *   nc/ctx: the execution (orchestrator sites); label: the log source otherwise
+   * @param {{nc?:object|null, ctx?:object|null, label?:string, detail?:string|null, cls?:string|null}} [o]
+   *   nc/ctx: the execution (orchestrator sites); label: the log source otherwise;
+   *   cls: the error class behind a RECOVERABLE pause (kept in the log, audit and detail)
    */
-  _pauseFor(reason, err, { nc = null, ctx = null, label = null, detail = null } = {}) {
+  _pauseFor(reason, err, { nc = null, ctx = null, label = null, detail = null, cls = null } = {}) {
     const where = label || nc?.key || ctx?.nodeId || 'orchestrator';
     const meta = ctx ? { nodeId: ctx.nodeId, executionId: ctx.executionId, cycle: ctx.ordinal } : {};
     const line = firstLine(err?.message || (err == null ? '' : String(err))) || 'unknown error';
-    const text = detail ?? (reason === REASON.ERROR ? errorDetail(err) : line);
+    const text = detail ?? (reason === REASON.ERROR ? errorDetail(err)
+      : reason === REASON.RECOVERABLE ? `${cls || 'recoverable'}: ${line}` : line);
     if (reason === REASON.ERROR) {
       // The ONE error-level line, written BEFORE the pause sentinel the caller
       // throws next (a pause/abort is never logged as a failure).
@@ -852,6 +855,10 @@ export class RunHarness extends EventEmitter {
     } else if (reason === REASON.USAGE_LIMIT) {
       this._log(where, 'warn', `${describePauseReason(reason)} — pausing for manual resume: ${text}`, meta);
       audit = `Pipeline **paused**: session/usage limit on ${where} — ${text}. Resume after the reset.`;
+    } else if (reason === REASON.RECOVERABLE) {
+      this._log(where, 'warn', `recoverable ${cls || 'error'} error — pausing for manual resume: ${line}`,
+        { ...meta, ...(err?.stream ? { stream: err.stream } : {}) });
+      audit = `Pipeline **paused**: recoverable ${cls || 'error'} error on ${where} — ${line}. Resume to retry.`;
     } else {
       this._log(where, 'warn', `${text} — pausing for manual resume`, meta);
       audit = `Pipeline **paused**: ${text}.`;
@@ -1231,6 +1238,10 @@ export class RunHarness extends EventEmitter {
     // D7: the point tells us whether run() ever finished its setup. Until the replay
     // below re-runs it, a pause here must re-stamp the flag (_completePaused reads it).
     this._setupDone = rp.setupIncomplete !== true;
+    // The 'resume' site (failure-policy.mjs): until the paused run is rehydrated —
+    // identity, worktrees, guardrails, prompts — a failure cannot be parked again
+    // (the point on disk is all there is) and ends the run.
+    this._rehydrated = false;
     try {
       // ── rehydrate identity + state ──
       this.state.id = row.id;
@@ -1365,6 +1376,7 @@ export class RunHarness extends EventEmitter {
       this._startHeartbeat();
       await appendAudit(this.pipeline.dir, rehydrated.audit);
       this._emit('state', this.getState());
+      this._rehydrated = true;
 
       // ── setup replay (D7): a converted setup failure paused this run before its
       //    checkout / graph / skills gate existed. Re-run exactly what run() never
@@ -1372,6 +1384,7 @@ export class RunHarness extends EventEmitter {
       //    read 'running' (above), never the constructor's 'idle'.
       let replayedSkills = null;
       if (rp.setupIncomplete === true) {
+        this.state.titleProvisional = rp.titleProvisional === true;
         replayedSkills = await this._replaySetup();
         // The replay (re)wrote the run manifest; the re-assembly below reads it.
         if (this.runRootMode === 'detached') resumeManifest = await readRunManifest(this.runRoot);
@@ -3699,8 +3712,14 @@ export class RunHarness extends EventEmitter {
     // stale stamp behind (resume() re-arms the consumed point, which may carry one).
     const rp = this.state.resumePoint;
     if (rp && typeof rp === 'object') {
-      if (this._setupDone) delete rp.setupIncomplete;
-      else rp.setupIncomplete = true;
+      if (this._setupDone) { delete rp.setupIncomplete; delete rp.titleProvisional; }
+      else {
+        rp.setupIncomplete = true;
+        // Whether run() ever kicked the LLM title off (it does so right after the run
+        // root exists): the replay reads this to finish the job, since the flag is
+        // not a row column.
+        rp.titleProvisional = this.state.titleProvisional === true;
+      }
     }
     this._setStatus('paused');
     await this._persist();
@@ -3738,9 +3757,11 @@ export class RunHarness extends EventEmitter {
   _engineAgentKeys() { return new Set(); }
 
   /**
-   * The SETUP / SHELL site (failure-policy.mjs): a failure the shell sees once the
-   * pipeline row exists — before run()'s setup finished ('setup') or after it
-   * ('shell'). A verdict already issued downstream (a terminal error from the node
+   * The SETUP / SHELL / RESUME site (failure-policy.mjs): a failure the shell sees
+   * once the pipeline row exists — before run()'s setup finished ('setup'), after it
+   * ('shell'), or before resume() rehydrated the paused run ('resume', where the
+   * only verdict that can be enacted is to end the run: the point on disk is
+   * already the best the run can offer). A verdict already issued downstream (a terminal error from the node
    * or flow site) is enacted, never re-decided. Returns null when the verdict is a
    * terminal error — the caller then falls through to the error path — else records
    * the cause; kills anything still in flight (pause() is a no-op unless the run is
@@ -3755,7 +3776,7 @@ export class RunHarness extends EventEmitter {
    * reason + detail, the run log the line.
    */
   async _pauseForFailure(err, fallbackPoint = null) {
-    const site = this._setupDone ? 'shell' : 'setup';
+    const site = !this._rehydrated ? 'resume' : this._setupDone ? 'shell' : 'setup';
     const verdict = isTerminal(err) ? { outcome: 'error' }
       : resolveFailure({ site, cls: classifyError(err), auto: this.auto });
     if (verdict.outcome !== 'pause') { markTerminal(err); return null; }
@@ -3799,11 +3820,19 @@ export class RunHarness extends EventEmitter {
         this.state.checkpointRefs = { ...this.checkpointRefs };
       }
     }
+    // run() closes the preflight bookend right after the checkpoint; the paused
+    // run's ledger still holds it at 'start' (the rehydrated steps), so close it
+    // here or a finished run keeps an open preflight row forever.
+    this._bookend('preflight', 'done');
     this._checkAbort();
     // 3b) run root + worktrees — keyed on the per-member map, NEVER on this.workDir
     //     (it defaults to projectDir and is never falsy).
     const missing = this.members.some((m) => !this.workDirs.get(m.projectKey));
     if (missing) await this._setupRunRoot({ replay: true });
+    // run() kicks the LLM title off once runCwd exists; a run that paused before
+    // that point still carries its provisional title, so kick it off now. A run
+    // that got past it already holds the generated row.title (loaded by resume()).
+    if (this.state.titleProvisional) this._kickoffTitleGeneration();
     this._checkAbort();
     // 3c) graph build (fail-safe, idempotent)
     if (this.isWorkspace) await this._buildWorktreeGraphAll(); else await this._buildWorktreeGraph();

--- a/test/ask-follow.test.mjs
+++ b/test/ask-follow.test.mjs
@@ -171,3 +171,16 @@ test('done{paused}: one "paused" notice (never "finished"), status paused, then 
   assert.equal(follower.detached, true, 'this orchestrator is done; the resume creates a new one');
   assert.equal(detached(), 1);
 });
+
+test('done{paused, reason:error}: the notice carries the error detail; the card stays paused (resumable), never failed', () => {
+  const { orch, posts, patches, follower, detached } = harness();
+  orch.state = { title: 'T' };
+  orch.emit('done', { status: 'paused', reason: 'error', detail: 'claude exited with code 1: disk full' });
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0].kind, 'paused');
+  assert.match(posts[0].text, /^Run paused after an error — "T": claude exited with code 1: disk full · resume it from Running$/);
+  assert.equal(posts[0].href, '#running/run-uuid-1');
+  assert.deepEqual(patches, [{ status: 'paused' }], 'no cardFailed: the run is parked, not dead');
+  assert.equal(follower.detached, true);
+  assert.equal(detached(), 1);
+});

--- a/test/chat-command-router.test.mjs
+++ b/test/chat-command-router.test.mjs
@@ -164,7 +164,16 @@ test('approvals: gate continue/another, recovery retry/abort, guardrails between
   await send('/approve');
   assert.deepEqual(calls.at(-1), ['answer', 'run-aaaa1111', 'rec-1', { decision: 'retry' }]);
   await send('/abort');
-  assert.deepEqual(calls.at(-1), ['answer', 'run-aaaa1111', 'rec-1', { decision: 'abort' }]);
+  assert.deepEqual(calls.at(-1), ['answer', 'run-aaaa1111', 'rec-1', { decision: 'pause' }]);
+});
+
+test('/status on an error-paused history row prints the error detail', async () => {
+  const { send, state } = fixture();
+  state.rows.push({ id: 'pipe-dddd4444', title: 'Blew up', status: 'paused', totalCostUsd: 0.5,
+    pauseReason: 'error', pauseDetail: 'claude exited with code 1: disk full' });
+  const out = text(await send('/status *4444'));
+  assert.match(out, /Pause reason:.*error/);
+  assert.match(out, /\*\*Error:\*\* claude exited with code 1: disk full/);
 });
 
 test('/answer: ordinal validation and clarify payload mapping', async () => {

--- a/test/chat-command-router.test.mjs
+++ b/test/chat-command-router.test.mjs
@@ -119,7 +119,7 @@ test('/status: no-arg single-active default, wildcard suffix, history fallback, 
   assert.match(hist, /✅ `\*2222` done — Old run/);
 
   const paused = text(await send('/status *3333'));
-  assert.match(paused, /Pause reason:.*cost_pipeline/);
+  assert.match(paused, /Pause reason:.*pipeline cost limit reached/);
 
   assert.match(text(await send('/status *zzzz')), /No run matches/);
 
@@ -172,8 +172,23 @@ test('/status on an error-paused history row prints the error detail', async () 
   state.rows.push({ id: 'pipe-dddd4444', title: 'Blew up', status: 'paused', totalCostUsd: 0.5,
     pauseReason: 'error', pauseDetail: 'claude exited with code 1: disk full' });
   const out = text(await send('/status *4444'));
-  assert.match(out, /Pause reason:.*error/);
+  assert.match(out, /Pause reason:.*a step failed/);
   assert.match(out, /\*\*Error:\*\* claude exited with code 1: disk full/);
+});
+
+test('/status on a recoverable- or limit-paused row labels the reason and calls the detail a cause', async () => {
+  const { send, state } = fixture();
+  state.rows.push({ id: 'pipe-eeee5555', title: 'Logged out', status: 'paused', totalCostUsd: 0.1,
+    pauseReason: 'recoverable', pauseDetail: 'auth: API Error: 401' });
+  state.rows.push({ id: 'pipe-ffff6666', title: 'Capped', status: 'paused', totalCostUsd: 0.1,
+    pauseReason: 'usage_limit', pauseDetail: "You've hit your session limit · resets 6pm" });
+  const rec = text(await send('/status *5555'));
+  assert.match(rec, /Pause reason:.*recoverable error/);
+  assert.match(rec, /\*\*Cause:\*\* auth: API Error: 401/);
+  assert.doesNotMatch(rec, /\*\*Error:\*\*/);
+  const lim = text(await send('/status *6666'));
+  assert.match(lim, /Pause reason:.*session\/usage limit reached/);
+  assert.match(lim, /\*\*Cause:\*\* You've hit your session limit/);
 });
 
 test('/answer: ordinal validation and clarify payload mapping', async () => {

--- a/test/chat-core.test.mjs
+++ b/test/chat-core.test.mjs
@@ -157,6 +157,18 @@ test('renderDone: done/stopped/paused(+reason) — valid messages, right severit
   assert.match(errored.body[0].value, /\*\*Status:\*\* paused — a step failed/);
   assert.match(errored.body[0].value, /\*\*Error:\*\* claude exited with code 1: disk full/);
   assert.match(errored.body[0].value, /\/resume \*2951/);
+
+  // A self-parked recoverable pause is a WARNING with a cause, not a failure.
+  const recoverable = renderDone(META, { status: 'paused', reason: 'recoverable', detail: 'auth: API Error: 401' });
+  assert.equal(recoverable.severity, 'warning');
+  assert.match(recoverable.body[0].value, /\*\*Status:\*\* paused — recoverable error/);
+  assert.match(recoverable.body[0].value, /\*\*Cause:\*\* auth: API Error: 401/);
+
+  // The detail is already bounded and MIDDLE-clipped upstream so the runner's
+  // trailing cause survives; the message must not head-clip it away again.
+  const long = `${'x'.repeat(133)}…${'y'.repeat(260)} THE CAUSE`;
+  const tail = renderDone(META, { status: 'paused', reason: 'error', detail: long });
+  assert.match(tail.body[0].value, /THE CAUSE/);
 });
 
 test('renderError truncates long messages', () => {

--- a/test/chat-core.test.mjs
+++ b/test/chat-core.test.mjs
@@ -151,6 +151,12 @@ test('renderDone: done/stopped/paused(+reason) — valid messages, right severit
   assert.match(paused.body[0].value, /\/resume \*2951/);
   const pausedFree = renderDone(META, { status: 'paused', reason: null });
   assert.doesNotMatch(pausedFree.body[0].value, / — /);
+
+  const errored = renderDone(META, { status: 'paused', reason: 'error', detail: 'claude exited with code 1: disk full' });
+  assert.equal(errored.severity, 'error');
+  assert.match(errored.body[0].value, /\*\*Status:\*\* paused — a step failed/);
+  assert.match(errored.body[0].value, /\*\*Error:\*\* claude exited with code 1: disk full/);
+  assert.match(errored.body[0].value, /\/resume \*2951/);
 });
 
 test('renderError truncates long messages', () => {
@@ -198,7 +204,7 @@ test('renderQuestion instructs the pipe form when a question is free-text', () =
   assert.match(msg.body[0].value, /\/answer \*ab12 <your answer>/);
 });
 
-test('renderQuestion recovery: cause + approve/retry; renderTest is valid', () => {
+test('renderQuestion recovery: cause + retry/pause reply line; renderTest is valid', () => {
   const msg = renderQuestion(META, {
     id: 'rec-1', kind: 'recovery',
     recovery: { message: 'claude exited 1: context canceled' },
@@ -207,4 +213,7 @@ test('renderQuestion recovery: cause + approve/retry; renderTest is valid', () =
   assert.match(msg.body[0].value, /recovery decision/);
   assert.match(msg.body[0].value, /\*\*Cause:\*\* claude exited 1/);
   assert.equal(isValidMessage(renderTest()), true);
+
+  const q = renderQuestion(META, { id: 'r1', kind: 'recovery', recovery: { cls: 'auth', message: 'x' } });
+  assert.match(q.body[0].value, /\/abort \*2951 to pause the run/);
 });

--- a/test/chat-notifier.test.mjs
+++ b/test/chat-notifier.test.mjs
@@ -81,6 +81,17 @@ test('prefs gate events; per-channel toggle disables a channel', async () => {
   orch.emit('done', { status: 'done' });
   await settle();
   assert.equal(sent.length, 0, 'channel toggle wins');
+
+  state.prefs = { notify: { done: true, paused: false, error: true }, channels: {} };
+  orch.emit('done', { status: 'paused', reason: 'error', detail: 'boom' });
+  await settle();
+  assert.equal(sent.length, 2, 'an error-pause follows notify.error, not notify.paused');
+  assert.match(sent[0].message.body[0].value, /\*\*Error:\*\* boom/);
+  sent.length = 0;
+  state.prefs = { notify: { done: true, paused: true, error: false }, channels: {} };
+  orch.emit('done', { status: 'paused', reason: 'error', detail: 'boom' });
+  await settle();
+  assert.equal(sent.length, 0, 'notify.error=false suppresses the error-pause');
 });
 
 test('muted chats are skipped and counted; unmuted keep receiving', async () => {

--- a/test/cli-interactive.test.mjs
+++ b/test/cli-interactive.test.mjs
@@ -347,7 +347,8 @@ test('recovery arm: a --yes run that pauses itself exits 3 — a wrapper must no
   });
   assert.equal(r.timedOut, false, r.stdout);
   assert.equal(r.code, 3, `expected the resumable-pause exit code (0=done, 1=error, 2=usage)\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
-  assert.match(r.stdout, /Pipeline paused after an error\./);
+  assert.match(r.stdout, /Pipeline paused on a recoverable error/);
+  assert.match(r.stdout, /auth: .*401/, 'the class and the cause print with the pause block');
   assert.match(r.stdout, /Resume with: /, 'the pause is resumable, and says how');
   const id = pipelineIdFrom(r.stdout);
   assert.ok(id, `no pipeline id in:\n${r.stdout}`);

--- a/test/cli-interactive.test.mjs
+++ b/test/cli-interactive.test.mjs
@@ -275,30 +275,37 @@ test('gate arm: "continue" spends no cycle — the loop body never re-runs', asy
 // Real runner + a stub bin that always fails with a 401, so every attempt is a
 // recoverable `auth` error and the interactive gate re-opens after each Retry.
 
-test('recovery arm: Abort ends the run with a non-zero exit', async () => {
+test('recovery arm: Pause parks the run (paused · error) and exits non-zero', async () => {
   const stub = failingClaudeBin('API Error: 401 Invalid authentication credentials');
   const repo = freshRepo();
-  const r = await driveCli(['--project', repo, '--prompt', 'recovery abort e2e'], {
+  const r = await driveCli(['--project', repo, '--prompt', 'recovery pause e2e'], {
     mock: false,
     // PATH prefix: run-harness passes claude.bin = undefined to the capabilities probe, which
     // then bare-PATH-looks-up `claude` — WORCA_CLAUDE_BIN alone would let the REAL one spawn.
     env: { WORCA_CLAUDE_BIN: stub.bin, WORCA_RECOVERY_BACKOFF_MS: '0',
            PATH: `${dirname(stub.bin)}:${process.env.PATH}` },
-    script: [{ cue: /Choose \[1-2\]/, send: '2\n' }],   // "Abort the run"
+    script: [{ cue: /Choose \[1-2\]/, send: '2\n' }],   // "Pause the run"
   });
   assert.equal(r.timedOut, false, r.stdout);
   assert.equal(r.sent, 1, `no recovery prompt rendered:\n${r.stdout}`);
-  assert.equal(r.code, 1, `expected a non-zero exit\n${r.stdout}`);
+  assert.equal(r.code, 1, `an error-pause exits non-zero\n${r.stdout}`);
 
   // Rendered by askRecovery.
   assert.match(r.stdout, /Recoverable auth error — the pipeline could not reach the model\./);
   assert.match(r.stdout, /Fix: re-authenticate \(claude setup-token or \/login\) in another terminal, then retry\./);
   assert.match(r.stdout, /^ {2}1\) Retry$/m);
-  assert.match(r.stdout, /^ {2}2\) Abort the run$/m);
-  assert.match(r.stdout, /Pipeline ended with status: error/);
+  assert.match(r.stdout, /^ {2}2\) Pause the run/m);
+  // Errors pause the run: the error text is kept, nothing is discarded, and the
+  // run is resumable — never the old `Pipeline ended with status: error`.
+  assert.match(r.stdout, /Pipeline paused after an error\./);
+  assert.match(r.stdout, /401 Invalid authentication credentials/);
+  assert.match(r.stdout, /Resume with: .*worca resume /);
+  assert.doesNotMatch(r.stdout, /Pipeline ended with status: error/);
 
-  // Behavioural consequence: aborting spawned the failing node exactly once.
+  // Behavioural consequence: pausing spawned the failing node exactly once.
   assert.equal(stub.spawnsMatching('# Task: Clarify'), 1);
+  const id = /worca resume ([A-Za-z0-9_-]+)/.exec(r.stdout)?.[1];
+  assert.equal(pipelineStatuses().find((p) => p.id === id)?.status, 'paused', 'the row is parked, resumable');
 });
 
 test('recovery arm: Retry re-runs the failing node before the next prompt', async () => {
@@ -312,13 +319,15 @@ test('recovery arm: Retry re-runs the failing node before the next prompt', asyn
            PATH: `${dirname(stub.bin)}:${process.env.PATH}` },
     script: [
       { cue: /Choose \[1-2\]/, send: '1\n' },   // Retry -> the node runs again
-      { cue: /Choose \[1-2\]/, send: '2\n' },   // ...fails again; Abort out
+      { cue: /Choose \[1-2\]/, send: '2\n' },   // ...fails again; Pause out
     ],
   });
   assert.equal(r.timedOut, false, r.stdout);
   assert.equal(r.sent, 2, `only ${r.sent} recovery prompt(s) rendered:\n${r.stdout}`);
   assert.equal(r.code, 1, `expected a non-zero exit\n${r.stdout}`);
-  // The decisive contrast with the Abort-first test: two spawns, not one.
+  assert.match(r.stdout, /Pipeline paused after an error\./);
+  assert.doesNotMatch(r.stdout, /Pipeline ended with status: error/);
+  // The decisive contrast with the Pause-first test: two spawns, not one.
   assert.equal(stub.spawnsMatching('# Task: Clarify'), 2);
 });
 

--- a/test/cli-resume.test.mjs
+++ b/test/cli-resume.test.mjs
@@ -286,13 +286,12 @@ test('resume an unregistered cwd project -> resolves past "not onboarded"', asyn
       resumePoint: graphResumePoint({ pipelineDir: projDir }),
     });
     const r = await run(['resume', id, '--mock', '--yes'], { cwd: projDir });
-    // The re-attach failure no longer emits an `error` event: it pauses the run
-    // (the shell site of failure-policy.mjs), so the cause prints with the pause
-    // block on stdout. Under --yes a pause exits 3 (pauseExitCode): the run parked
-    // itself with nobody attached to resume it — never 0, and distinct from 1.
-    assert.equal(r.code, 3, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
+    // A re-attach failure is the RESUME site of failure-policy.mjs: the run cannot
+    // be rehydrated, so it ENDS (exit 1, the cause on stderr) — re-parking it would
+    // re-persist the same dead point and re-notify the task source on every attempt.
+    assert.equal(r.code, 1, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
     assert.doesNotMatch(r.stderr, /not onboarded/i, `stderr: ${r.stderr}`);
-    assert.match(r.stdout, /worktree missing/i, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
+    assert.match(r.stderr, /worktree missing/i, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
   } finally {
     await rm(projDir, { recursive: true, force: true });
   }

--- a/test/cli-resume.test.mjs
+++ b/test/cli-resume.test.mjs
@@ -286,10 +286,12 @@ test('resume an unregistered cwd project -> resolves past "not onboarded"', asyn
       resumePoint: graphResumePoint({ pipelineDir: projDir }),
     });
     const r = await run(['resume', id, '--mock', '--yes'], { cwd: projDir });
-    assert.equal(r.code, 1, r.stderr);
+    // The re-attach failure no longer emits an `error` event: it pauses the run
+    // (the shell site of failure-policy.mjs), so the cause prints with the pause
+    // block on stdout. Under --yes a pause exits 3 (pauseExitCode): the run parked
+    // itself with nobody attached to resume it — never 0, and distinct from 1.
+    assert.equal(r.code, 3, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
     assert.doesNotMatch(r.stderr, /not onboarded/i, `stderr: ${r.stderr}`);
-    // The re-attach failure no longer emits an `error` event: it pauses the run,
-    // so the cause prints with the pause block on stdout (exit still 1, D10).
     assert.match(r.stdout, /worktree missing/i, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
   } finally {
     await rm(projDir, { recursive: true, force: true });

--- a/test/cli-resume.test.mjs
+++ b/test/cli-resume.test.mjs
@@ -288,7 +288,9 @@ test('resume an unregistered cwd project -> resolves past "not onboarded"', asyn
     const r = await run(['resume', id, '--mock', '--yes'], { cwd: projDir });
     assert.equal(r.code, 1, r.stderr);
     assert.doesNotMatch(r.stderr, /not onboarded/i, `stderr: ${r.stderr}`);
-    assert.match(r.stderr, /worktree missing/i, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
+    // The re-attach failure no longer emits an `error` event: it pauses the run,
+    // so the cause prints with the pause block on stdout (exit still 1, D10).
+    assert.match(r.stdout, /worktree missing/i, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
   } finally {
     await rm(projDir, { recursive: true, force: true });
   }

--- a/test/cost-enforcement.test.mjs
+++ b/test/cost-enforcement.test.mjs
@@ -13,7 +13,7 @@ import { getDb } from '../src/core/db.mjs';
 import { createOrchestrator } from '../src/core/orchestrator.mjs';
 import { setPipelineCostLimitUsd, setTotalCostLimitUsd } from '../src/core/settings.mjs';
 import { recordCostDelta, setCostCapOverride, recordAskCostDelta } from '../src/core/cost-budget.mjs';
-import { listAllPipelines, listPipelines } from '../src/core/artifacts.mjs';
+import { listAllPipelines, listPipelines, readPipelineByKey } from '../src/core/artifacts.mjs';
 
 useTempHome(after);
 
@@ -172,4 +172,24 @@ test('a malformed resume_point does not break the list queries', async () => {
   assert.equal(mine.pauseReason, null, 'unparseable resume points read as no reason');
   const perProject = await listPipelines('/tmp/proj-a');
   assert.ok(perProject.find((e) => e.id === id), 'the per-project list survives it too');
+});
+
+test('list wire rows AND the detail payload (rowToState) expose pauseReason + pauseDetail from resume_point', async () => {
+  const { id, key } = await seedPipeline('/tmp/proj-a', {
+    status: 'paused',
+    resumePoint: { version: 2, kind: 'boundary', pauseReason: 'error', pauseDetail: 'claude exited with code 1: disk full' },
+  });
+  const mine = (await listAllPipelines()).find((e) => e.id === id);
+  assert.equal(mine.pauseReason, 'error');
+  assert.equal(mine.pauseDetail, 'claude exited with code 1: disk full');
+  const perProject = (await listPipelines('/tmp/proj-a')).find((e) => e.id === id);
+  assert.equal(perProject.pauseDetail, 'claude exited with code 1: disk full');
+  // The DETAIL payload (GET /api/history/:key/:id serves readPipelineByKey) carries it too,
+  // so a deep-linked History detail no longer waits for the LIST row.
+  const detail = await readPipelineByKey(key, id);
+  assert.equal(detail.state.pauseReason, 'error');
+  assert.equal(detail.state.pauseDetail, 'claude exited with code 1: disk full');
+  // A reasonless / legacy point reads as null, never undefined.
+  const plain = await seedPipeline('/tmp/proj-a', { status: 'paused', resumePoint: { version: 2, kind: 'boundary' } });
+  assert.equal((await readPipelineByKey(plain.key, plain.id)).state.pauseDetail, null);
 });

--- a/test/failure-policy.test.mjs
+++ b/test/failure-policy.test.mjs
@@ -1,0 +1,197 @@
+// The failure-policy matrix, one test per cell. This file IS the review surface
+// for a policy shift: flipping a cell in src/core/failure-policy.mjs changes
+// exactly one row here. The engine tests (orchestrator-recovery,
+// orchestrator-error-pause, run-harness-hooks, skills-gate-wiring, …) prove the
+// sites ENACT the verdicts; this file pins WHAT the verdicts are.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveFailure, FAILURE_POLICY, SITES, REASON, REASON_CODES,
+  RECOVERY_MAX_AUTO_ATTEMPTS, promptOptions, giveUpOption, answerFromDecision,
+  markTerminal, isTerminal, pauseConsequences, pauseExitCode, describePauseReason,
+} from '../src/core/failure-policy.mjs';
+
+const MAX = RECOVERY_MAX_AUTO_ATTEMPTS;
+const PAUSE_ERR = { outcome: 'pause', reason: 'error' };
+
+// ── the matrix, cell by cell ────────────────────────────────────────────────────
+// [site, cls, auto, attempt, answer] -> expected verdict (options elided)
+const ROWS = [
+  // node / usage_limit: never retried, pauses with its own reason, both modes
+  ['node', 'usage_limit', true,  1, undefined, { outcome: 'pause', reason: 'usage_limit' }],
+  ['node', 'usage_limit', false, 1, undefined, { outcome: 'pause', reason: 'usage_limit' }],
+  // node / auth, quota: auto pauses on the FIRST hit (no futile backoff); interactive prompts
+  ['node', 'auth',  true,  1, undefined, PAUSE_ERR],
+  ['node', 'quota', true,  1, undefined, PAUSE_ERR],
+  ['node', 'auth',  false, 1, undefined, { outcome: 'prompt' }],
+  ['node', 'quota', false, 1, undefined, { outcome: 'prompt' }],
+  ['node', 'auth',  false, 1, 'retry',   { outcome: 'retry' }],
+  ['node', 'auth',  false, 1, 'giveup',  PAUSE_ERR],
+  // node / network, rate_limit: auto retries MAX times, then pauses; interactive prompts
+  ['node', 'network',    true, 1,       undefined, { outcome: 'retry' }],
+  ['node', 'network',    true, MAX,     undefined, { outcome: 'retry' }],
+  ['node', 'network',    true, MAX + 1, undefined, PAUSE_ERR],
+  ['node', 'rate_limit', true, 1,       undefined, { outcome: 'retry' }],
+  ['node', 'rate_limit', true, MAX + 1, undefined, PAUSE_ERR],
+  ['node', 'network',    false, 1, undefined, { outcome: 'prompt' }],
+  ['node', 'network',    false, 1, 'retry',   { outcome: 'retry' }],
+  ['node', 'network',    false, 1, 'giveup',  PAUSE_ERR],
+  ['node', 'rate_limit', false, 1, 'giveup',  PAUSE_ERR],
+  // node / unclassified (the contested row): pauses, both modes
+  ['node', null, true,  1, undefined, PAUSE_ERR],
+  ['node', null, false, 1, undefined, PAUSE_ERR],
+  // flow: a flow card / questions loop / _afterExecution / composite-shell throw pauses
+  ['flow', null,      true,  1, undefined, PAUSE_ERR],
+  ['flow', null,      false, 1, undefined, PAUSE_ERR],
+  ['flow', 'network', true,  1, undefined, PAUSE_ERR],
+  // budget: a cap pauses with its cost code
+  ['budget', 'cost_pipeline', true,  1, undefined, { outcome: 'pause', reason: 'cost_pipeline' }],
+  ['budget', 'cost_pipeline', false, 1, undefined, { outcome: 'pause', reason: 'cost_pipeline' }],
+  ['budget', 'cost_total',    true,  1, undefined, { outcome: 'pause', reason: 'cost_total' }],
+  ['budget', 'cost_total',    false, 1, undefined, { outcome: 'pause', reason: 'cost_total' }],
+  // setup: checkout / graph / skills gate failed with the row created -> pause (+ replay on resume)
+  ['setup', null,   true,  1, undefined, PAUSE_ERR],
+  ['setup', null,   false, 1, undefined, PAUSE_ERR],
+  ['setup', 'auth', false, 1, undefined, PAUSE_ERR],
+  // launch: no row yet -> the only enactable verdict
+  ['launch', null,      true,  1, undefined, { outcome: 'error' }],
+  ['launch', null,      false, 1, undefined, { outcome: 'error' }],
+  ['launch', 'network', true,  1, undefined, { outcome: 'error' }],
+  // shell: escaped the engine after setup -> pause
+  ['shell', null,  true,  1, undefined, PAUSE_ERR],
+  ['shell', null,  false, 1, undefined, PAUSE_ERR],
+  ['shell', 'quota', true, 1, undefined, PAUSE_ERR],
+];
+
+for (const [site, cls, auto, attempt, answer, want] of ROWS) {
+  const label = `${site}/${cls ?? '*'} ${auto ? 'auto' : 'interactive'} attempt=${attempt}${answer ? ` answer=${answer}` : ''}`;
+  test(`matrix: ${label} -> ${want.outcome}${want.reason ? `(${want.reason})` : ''}`, () => {
+    const got = resolveFailure({ site, cls, auto, attempt, answer });
+    assert.equal(got.outcome, want.outcome);
+    assert.equal(got.reason, want.reason);
+    if (want.outcome === 'prompt') assert.ok(Array.isArray(got.options) && got.options.length === 2, 'a prompt carries its two options');
+    else assert.equal(got.options, undefined);
+  });
+}
+
+// ── structural guarantees ──────────────────────────────────────────────────────
+
+test('every site has a row for every class the classifier can produce (or a * row)', () => {
+  const classes = ['auth', 'usage_limit', 'rate_limit', 'quota', 'network', null];
+  for (const site of SITES) {
+    assert.ok(FAILURE_POLICY[site], `site ${site} is in the matrix`);
+    for (const cls of classes) {
+      if (site === 'budget') continue;   // the budget site takes cost codes, not error classes
+      assert.doesNotThrow(() => resolveFailure({ site, cls, auto: true }), `${site}/${cls ?? '*'} auto`);
+      assert.doesNotThrow(() => resolveFailure({ site, cls, auto: false }), `${site}/${cls ?? '*'} interactive`);
+    }
+  }
+  assert.throws(() => resolveFailure({ site: 'nowhere' }), /unknown site/);
+});
+
+test('every pause verdict names a known reason code', () => {
+  for (const site of SITES) {
+    for (const cls of Object.keys(FAILURE_POLICY[site])) {
+      for (const auto of [true, false]) {
+        const v = resolveFailure({ site, cls: cls === '*' ? null : cls, auto, attempt: MAX + 1, answer: 'giveup' });
+        if (v.outcome === 'pause') assert.ok(REASON_CODES.includes(v.reason), `${site}/${cls}: ${v.reason}`);
+      }
+    }
+  }
+});
+
+test('the launch site can only end the run — nothing exists to resume into', () => {
+  for (const cls of ['auth', 'network', null]) {
+    for (const auto of [true, false]) assert.equal(resolveFailure({ site: 'launch', cls, auto }).outcome, 'error');
+  }
+});
+
+test('the matrix is frozen: a site cannot be edited at runtime', () => {
+  assert.ok(Object.isFrozen(FAILURE_POLICY));
+  assert.ok(Object.isFrozen(FAILURE_POLICY.node));
+  assert.throws(() => { FAILURE_POLICY.node.auth = null; }, TypeError);
+});
+
+// ── the recovery prompt's options ──────────────────────────────────────────────
+
+test('promptOptions: Retry is fixed; the give-up option names the verdict it enacts', () => {
+  const p = promptOptions({ outcome: 'pause', reason: 'error' });
+  assert.deepEqual(p.map((o) => o.id), ['retry', 'pause']);
+  const a = promptOptions({ outcome: 'error' });
+  assert.deepEqual(a.map((o) => o.id), ['retry', 'abort']);
+  assert.match(a[1].label, /Abort/);
+});
+
+test('the interactive rows carry their options through the prompt verdict', () => {
+  const v = resolveFailure({ site: 'node', cls: 'network', auto: false });
+  assert.equal(v.outcome, 'prompt');
+  assert.deepEqual(v.options.map((o) => o.id), ['retry', 'pause']);
+});
+
+test('giveUpOption: the non-retry option, or the pause option for a payload without options', () => {
+  assert.equal(giveUpOption([{ id: 'retry' }, { id: 'abort' }]).id, 'abort');
+  assert.equal(giveUpOption(undefined).id, 'pause');
+  assert.equal(giveUpOption([]).id, 'pause');
+});
+
+test("answerFromDecision: 'retry' retries; 'pause', 'abort' (legacy) and anything else give up", () => {
+  assert.equal(answerFromDecision('retry'), 'retry');
+  assert.equal(answerFromDecision('pause'), 'giveup');
+  assert.equal(answerFromDecision('abort'), 'giveup');
+  assert.equal(answerFromDecision(undefined), 'giveup');
+});
+
+// ── the terminal stamp ─────────────────────────────────────────────────────────
+
+test('markTerminal stamps an error in place (identity kept) and isTerminal reads it', () => {
+  const err = new Error('boom');
+  assert.equal(isTerminal(err), false);
+  assert.equal(markTerminal(err), err);
+  assert.equal(isTerminal(err), true);
+  assert.equal(isTerminal(null), false);
+  assert.equal(isTerminal('boom'), false);
+  assert.doesNotThrow(() => markTerminal(Object.freeze(new Error('frozen'))));
+});
+
+// ── consequences, keyed on the reason ──────────────────────────────────────────
+
+test('consequences: a manual pause is silent; every reasoned pause reports needs-human', () => {
+  assert.equal(pauseConsequences(null).reportsToSource, false);
+  assert.equal(pauseConsequences('').reportsToSource, false);
+  for (const r of REASON_CODES) assert.equal(pauseConsequences(r).reportsToSource, true, r);
+});
+
+test('consequences: only an error-pause stages the diff artifact and reads as an error', () => {
+  assert.equal(pauseConsequences(REASON.ERROR).stagesResults, true);
+  assert.equal(pauseConsequences(REASON.ERROR).severity, 'error');
+  assert.equal(pauseConsequences(REASON.ERROR).notifyPref, 'error');
+  for (const r of [REASON.USAGE_LIMIT, REASON.COST_PIPELINE, REASON.COST_TOTAL]) {
+    assert.equal(pauseConsequences(r).stagesResults, false, r);
+    assert.equal(pauseConsequences(r).severity, 'warning', r);
+    assert.equal(pauseConsequences(r).notifyPref, 'paused', r);
+  }
+  assert.equal(pauseConsequences(null).severity, 'info');
+});
+
+test('consequences: a legacy free-text reason (a pre-policy usage-limit line) reads as a forced pause', () => {
+  const c = pauseConsequences("You've hit your session limit · resets 6pm");
+  assert.equal(c.reportsToSource, true);
+  assert.equal(c.severity, 'warning');
+});
+
+test('exit codes: 3 under --yes for every pause; interactive 0 unless an error forced it', () => {
+  for (const r of [null, ...REASON_CODES]) assert.equal(pauseExitCode(r, true), 3, `auto ${r}`);
+  assert.equal(pauseExitCode(null, false), 0);
+  assert.equal(pauseExitCode(REASON.USAGE_LIMIT, false), 0);
+  assert.equal(pauseExitCode(REASON.COST_PIPELINE, false), 0);
+  assert.equal(pauseExitCode(REASON.COST_TOTAL, false), 0);
+  assert.equal(pauseExitCode(REASON.ERROR, false), 1);
+});
+
+test('describePauseReason: a label per code, none for a manual pause', () => {
+  assert.equal(describePauseReason(null), null);
+  assert.equal(describePauseReason(REASON.ERROR), 'a step failed');
+  assert.equal(describePauseReason(REASON.COST_TOTAL), 'total cost limit reached');
+  assert.equal(describePauseReason(REASON.USAGE_LIMIT), 'session/usage limit reached');
+});

--- a/test/failure-policy.test.mjs
+++ b/test/failure-policy.test.mjs
@@ -14,6 +14,7 @@ import {
 
 const MAX = RECOVERY_MAX_AUTO_ATTEMPTS;
 const PAUSE_ERR = { outcome: 'pause', reason: 'error' };
+const PAUSE_REC = { outcome: 'pause', reason: 'recoverable' };
 
 // ── the matrix, cell by cell ────────────────────────────────────────────────────
 // [site, cls, auto, attempt, answer] -> expected verdict (options elided)
@@ -21,9 +22,10 @@ const ROWS = [
   // node / usage_limit: never retried, pauses with its own reason, both modes
   ['node', 'usage_limit', true,  1, undefined, { outcome: 'pause', reason: 'usage_limit' }],
   ['node', 'usage_limit', false, 1, undefined, { outcome: 'pause', reason: 'usage_limit' }],
-  // node / auth, quota: auto pauses on the FIRST hit (no futile backoff); interactive prompts
-  ['node', 'auth',  true,  1, undefined, PAUSE_ERR],
-  ['node', 'quota', true,  1, undefined, PAUSE_ERR],
+  // node / auth, quota: auto pauses on the FIRST hit (no futile backoff) as RECOVERABLE
+  // (the class is kept: resume when it clears); interactive prompts, and giving up is ERROR
+  ['node', 'auth',  true,  1, undefined, PAUSE_REC],
+  ['node', 'quota', true,  1, undefined, PAUSE_REC],
   ['node', 'auth',  false, 1, undefined, { outcome: 'prompt' }],
   ['node', 'quota', false, 1, undefined, { outcome: 'prompt' }],
   ['node', 'auth',  false, 1, 'retry',   { outcome: 'retry' }],
@@ -31,9 +33,9 @@ const ROWS = [
   // node / network, rate_limit: auto retries MAX times, then pauses; interactive prompts
   ['node', 'network',    true, 1,       undefined, { outcome: 'retry' }],
   ['node', 'network',    true, MAX,     undefined, { outcome: 'retry' }],
-  ['node', 'network',    true, MAX + 1, undefined, PAUSE_ERR],
+  ['node', 'network',    true, MAX + 1, undefined, PAUSE_REC],
   ['node', 'rate_limit', true, 1,       undefined, { outcome: 'retry' }],
-  ['node', 'rate_limit', true, MAX + 1, undefined, PAUSE_ERR],
+  ['node', 'rate_limit', true, MAX + 1, undefined, PAUSE_REC],
   ['node', 'network',    false, 1, undefined, { outcome: 'prompt' }],
   ['node', 'network',    false, 1, 'retry',   { outcome: 'retry' }],
   ['node', 'network',    false, 1, 'giveup',  PAUSE_ERR],
@@ -62,6 +64,10 @@ const ROWS = [
   ['shell', null,  true,  1, undefined, PAUSE_ERR],
   ['shell', null,  false, 1, undefined, PAUSE_ERR],
   ['shell', 'quota', true, 1, undefined, PAUSE_ERR],
+  // resume: the paused run could not be rehydrated (checkout gone, run.json corrupt) -> the run ends
+  ['resume', null,      true,  1, undefined, { outcome: 'error' }],
+  ['resume', null,      false, 1, undefined, { outcome: 'error' }],
+  ['resume', 'network', true,  1, undefined, { outcome: 'error' }],
 ];
 
 for (const [site, cls, auto, attempt, answer, want] of ROWS) {
@@ -104,6 +110,12 @@ test('every pause verdict names a known reason code', () => {
 test('the launch site can only end the run — nothing exists to resume into', () => {
   for (const cls of ['auth', 'network', null]) {
     for (const auto of [true, false]) assert.equal(resolveFailure({ site: 'launch', cls, auto }).outcome, 'error');
+  }
+});
+
+test('the resume site ends the run — re-parking an un-rehydratable point would loop forever', () => {
+  for (const cls of ['auth', 'network', null]) {
+    for (const auto of [true, false]) assert.equal(resolveFailure({ site: 'resume', cls, auto }).outcome, 'error');
   }
 });
 
@@ -166,7 +178,7 @@ test('consequences: only an error-pause stages the diff artifact and reads as an
   assert.equal(pauseConsequences(REASON.ERROR).stagesResults, true);
   assert.equal(pauseConsequences(REASON.ERROR).severity, 'error');
   assert.equal(pauseConsequences(REASON.ERROR).notifyPref, 'error');
-  for (const r of [REASON.USAGE_LIMIT, REASON.COST_PIPELINE, REASON.COST_TOTAL]) {
+  for (const r of [REASON.USAGE_LIMIT, REASON.RECOVERABLE, REASON.COST_PIPELINE, REASON.COST_TOTAL]) {
     assert.equal(pauseConsequences(r).stagesResults, false, r);
     assert.equal(pauseConsequences(r).severity, 'warning', r);
     assert.equal(pauseConsequences(r).notifyPref, 'paused', r);
@@ -184,6 +196,7 @@ test('exit codes: 3 under --yes for every pause; interactive 0 unless an error f
   for (const r of [null, ...REASON_CODES]) assert.equal(pauseExitCode(r, true), 3, `auto ${r}`);
   assert.equal(pauseExitCode(null, false), 0);
   assert.equal(pauseExitCode(REASON.USAGE_LIMIT, false), 0);
+  assert.equal(pauseExitCode(REASON.RECOVERABLE, false), 0);
   assert.equal(pauseExitCode(REASON.COST_PIPELINE, false), 0);
   assert.equal(pauseExitCode(REASON.COST_TOTAL, false), 0);
   assert.equal(pauseExitCode(REASON.ERROR, false), 1);
@@ -194,4 +207,5 @@ test('describePauseReason: a label per code, none for a manual pause', () => {
   assert.equal(describePauseReason(REASON.ERROR), 'a step failed');
   assert.equal(describePauseReason(REASON.COST_TOTAL), 'total cost limit reached');
   assert.equal(describePauseReason(REASON.USAGE_LIMIT), 'session/usage limit reached');
+  assert.match(describePauseReason(REASON.RECOVERABLE), /recoverable/);
 });

--- a/test/graph-scheduler.test.mjs
+++ b/test/graph-scheduler.test.mjs
@@ -1117,3 +1117,38 @@ test('34 a composite cut short by the End drain is `skipped` and publishes nothi
   // `skipped` is TERMINAL, so a resume must not re-invoke the abandoned shell.
   assert.equal(h.last().execs.find((e) => e.executionId === 'x:n_work:1').status, 'skipped');
 });
+
+// ── a pause raised INSIDE the expansion settles the shell with its expands binding ──
+// The adapter converts an expand-time throw into `{ paused: true }`. runComposite
+// must settle the shell on that answer: falling through to runUnexpanded would
+// strip `expandsPort`/the binding from the very entry the resume re-invokes, so the
+// node would re-run ONCE as a plain execution and the decomposition never be re-read.
+test('35 a paused expand settles the shell in place — the resume re-runs the WHOLE fan-out', async () => {
+  const first = harness({
+    template: FANOUT,
+    script: {
+      n_make: () => md('/p/plan.md'),
+      n_split: manifest,
+      n_work: (a) => (a.composite === 'expand' ? { paused: true } : compositeWorker()(a)),
+      n_check: () => ({ verdict: CLEAN }),
+    },
+  });
+  assert.equal(await first.scheduler.run(), 'paused');
+  const calls = first.callsFor('n_work');
+  assert.equal(calls.length, 1, 'no plain execution ran after the paused expand');
+  assert.equal(calls[0].composite, 'expand');
+  const snap = first.last();
+  assert.equal(snap.execs.find((e) => e.executionId === 'x:n_work:1').status, 'paused', 'the shell is NON-terminal');
+  assert.deepEqual(first.callsFor('n_check'), [], 'nothing published');
+
+  const second = harness({
+    template: FANOUT,
+    script: { n_work: compositeWorker(), n_check: () => ({ verdict: CLEAN }) },
+  });
+  second.scheduler.reattach(snap);
+  assert.equal(await second.scheduler.run(), 'done');
+  const c = second.callsFor('n_work');
+  assert.equal(c[0].composite, 'expand', 'the resume re-expands: the expands binding survived the pause');
+  assert.ok(c.some((x) => x.slice?.id === 'p1t1'), 'the fan-out ran');
+  assert.equal(c.filter((x) => x.bindings?.task === undefined && !x.composite && !x.slice).length, 0, 'never a plain execution with the binding stripped');
+});

--- a/test/orchestrator-error-pause.test.mjs
+++ b/test/orchestrator-error-pause.test.mjs
@@ -3,7 +3,7 @@
 // point, and resume() replays whatever setup the paused run never finished.
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, existsSync } from 'node:fs';
+import { mkdtempSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
@@ -145,4 +145,49 @@ test('a failure BEFORE createPipeline is still a launch error (nothing to resume
   assert.match(res.error, /ghost/);
   assert.equal(errors.length, 1, "the launch-error channel still emits 'error'");
   assert.equal(getDb().prepare('SELECT COUNT(*) AS n FROM pipelines').get().n, rowsBefore, 'no row was created');
+});
+
+// ── the RESUME site: a paused run that cannot be rehydrated ENDS ──────────────
+// Re-parking it would re-persist the same dead point and re-notify the task source
+// on every attempt, forever (failure-policy.mjs: resume/* -> error).
+test('resume: a paused run whose checkout was deleted ENDS as an error — it is never re-parked', async () => {
+  const dir = gitDir();
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: runners() });
+  orch1._buildWorktreeGraph = async () => { throw new Error('graphify exploded'); };
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused', JSON.stringify(r1));
+  const wt = orch1.getState().branch.worktreeDir;
+  assert.ok(wt && existsSync(wt));
+  rmSync(wt, { recursive: true, force: true });            // the checkout is gone
+  const saved = readPipelineForResume(orch1.state.id);
+  assert.equal(saved.row.status, 'paused');
+
+  const orch2 = createOrchestrator({ projectDir: dir, auto: true, claude: { mock: true }, runners: runners(), resume: saved });
+  const r2 = await orch2.resume();
+  assert.equal(r2.status, 'error', JSON.stringify(r2));
+  assert.match(r2.error, /worktree missing/);
+  const row = getDb().prepare('SELECT status FROM pipelines WHERE id = ?').get(orch1.state.id);
+  assert.equal(row.status, 'error', 'the row is terminal — a second resume is refused, not repeated');
+});
+
+test('setup replay closes the preflight bookend and kicks the title off — a finished run keeps no open preflight row', async () => {
+  const dir = gitDir();
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: runners() });
+  // Throw INSIDE the checkpoint step — before run() closes the preflight bookend
+  // and before the title kickoff — so the paused run carries an open preflight
+  // row and its provisional title.
+  orch1._ensureGitCheckpoint = async () => { throw new Error('git checkpoint failed: index.lock held'); };
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused', JSON.stringify(r1));
+  assert.equal(orch1.getState().steps.find((s) => s.key === 'x:preflight:1')?.status, 'start', 'the pause left preflight open');
+  const saved = readPipelineForResume(orch1.state.id);
+
+  const orch2 = createOrchestrator({ projectDir: dir, auto: true, claude: { mock: true }, runners: runners(), resume: saved });
+  let kicked = 0;
+  const realKick = orch2._kickoffTitleGeneration.bind(orch2);
+  orch2._kickoffTitleGeneration = () => { kicked++; return realKick(); };
+  const r2 = await orch2.resume();
+  assert.equal(r2.status, 'done', JSON.stringify(r2));
+  assert.equal(orch2.getState().steps.find((s) => s.key === 'x:preflight:1')?.status, 'done', 'the replay closed the bookend');
+  assert.equal(kicked, 1, 'the replay kicked the title generation off (the original run never reached it)');
 });

--- a/test/orchestrator-error-pause.test.mjs
+++ b/test/orchestrator-error-pause.test.mjs
@@ -1,0 +1,148 @@
+// test/orchestrator-error-pause.test.mjs — POLICY: no error ends a run that has a row.
+// Setup-phase, harness-level and post-engine failures pause with a correct resume
+// point, and resume() replays whatever setup the paused run never finished.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { useTempHome } from './helpers/temp-home.mjs';
+import { createOrchestrator } from '../src/core/orchestrator.mjs';
+import { readPipelineForResume } from '../src/core/artifacts.mjs';
+import { getDb } from '../src/core/db.mjs';
+
+useTempHome(after);
+
+function gitDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'worca-cc-errpause-'));
+  execSync('git init -q && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init', { cwd: dir });
+  return dir;
+}
+const okProducer = async () => ({ status: 'ok', summary: 'ok' });
+const okVerifier = async () => ({ status: 'ok', issues: [], review: { issues: [] }, summary: '' });
+const runners = () => ({ producer: okProducer, verifier: okVerifier });
+
+test('setup throw AFTER the worktree exists (graph build) -> paused, pre-engine point, worktree kept; resume completes', async () => {
+  const dir = gitDir();
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: runners() });
+  // The mock guard lives INSIDE _buildWorktreeGraph (run-harness.mjs); an instance
+  // override replaces it, so this throw IS reached under claude.mock.
+  orch1._buildWorktreeGraph = async () => { throw new Error('graphify exploded'); };
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused', JSON.stringify(r1));
+  assert.equal(r1.reason, 'error');
+  assert.equal(r1.detail, 'graphify exploded');
+  assert.equal(orch1.getState().steps.filter((s) => String(s.key).startsWith('x:') && s.nodeId !== 'preflight').length, 0, 'no execution ever ran');
+  const saved = readPipelineForResume(orch1.state.id);
+  assert.equal(saved.row.status, 'paused');
+  assert.equal(saved.resumePoint.snapshot, null, 'pre-engine point');
+  assert.equal(saved.resumePoint.setupIncomplete, true);
+  const wt = orch1.getState().branch.worktreeDir;
+  assert.ok(wt && existsSync(wt), 'the checkout survives the pause');
+
+  const orch2 = createOrchestrator({ projectDir: dir, auto: true, claude: { mock: true }, runners: runners(), resume: saved });
+  const r2 = await orch2.resume();
+  assert.equal(r2.status, 'done', JSON.stringify(r2));
+  assert.equal(readPipelineForResume(orch1.state.id).row.status, 'done');
+  assert.ok(!existsSync(wt), 'done tears the checkout down as on any fresh run');
+});
+
+test('setup throw BEFORE the worktree exists (run root) -> paused with no checkout; resume replays the setup INTO a worktree', async () => {
+  const dir = gitDir();
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: runners() });
+  orch1._setupRunRoot = async () => { throw new Error('worktree add failed: disk full'); };
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused', JSON.stringify(r1));
+  assert.equal(r1.reason, 'error');
+  assert.equal(orch1.getState().branch, null, 'no checkout was ever created');
+  const saved = readPipelineForResume(orch1.state.id);
+  assert.equal(saved.resumePoint.setupIncomplete, true);
+  assert.ok(saved.resumePoint.checkpointRef, 'the checkpoint (which succeeded) rides the point');
+
+  const seen = [];
+  const orch2 = createOrchestrator({
+    projectDir: dir, auto: true, claude: { mock: true }, resume: saved,
+    runners: { producer: async (ctx) => { seen.push(ctx.projectDir); return okProducer(); }, verifier: okVerifier },
+  });
+  const r2 = await orch2.resume();
+  assert.equal(r2.status, 'done', JSON.stringify(r2));
+  const wt = orch2.getState().branch?.worktreeDir;
+  assert.ok(wt && wt !== dir, 'the replay created a real checkout');
+  assert.ok(seen.length && seen.every((cwd) => cwd === wt), `every agent ran INSIDE the replayed worktree, never the real dir: ${seen}`);
+  assert.ok(!seen.some((cwd) => cwd === dir), 'the user\'s live checkout was never an agent cwd');
+  const done = readPipelineForResume(orch1.state.id);
+  assert.equal(done.row.status, 'done');
+});
+
+test('a throw inside _engineRun before the scheduler (extras) -> paused; resume completes', async () => {
+  const dir = gitDir();
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: runners() });
+  orch1._collectExtras = async () => { throw new Error('extras unreadable'); };
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused', JSON.stringify(r1));
+  assert.equal(r1.reason, 'error');
+  const saved = readPipelineForResume(orch1.state.id);
+  assert.equal(saved.resumePoint.setupIncomplete, undefined, 'setup HAD finished — nothing to replay');
+  assert.equal(saved.resumePoint.snapshot, null, 'the engine never produced a snapshot: pre-engine point');
+  const orch2 = createOrchestrator({ projectDir: dir, auto: true, claude: { mock: true }, runners: runners(), resume: saved });
+  assert.equal((await orch2.resume()).status, 'done');
+});
+
+test('a throw AFTER the engine finished (post-processing) pauses on the FINAL snapshot; resume redoes only the post-processing', async () => {
+  const dir = gitDir();
+  let producerCalls = 0;
+  const mk = () => ({ producer: async () => { producerCalls++; return okProducer(); }, verifier: okVerifier });
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: mk() });
+  const realBookend = orch1._bookend.bind(orch1);
+  orch1._bookend = (name, status) => { if (name === 'done') throw new Error('ledger write failed'); return realBookend(name, status); };
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused', JSON.stringify(r1));
+  assert.equal(r1.reason, 'error');
+  assert.equal(r1.detail, 'ledger write failed');
+  assert.ok(producerCalls > 0, 'the graph ran to completion before the failure');
+  const saved = readPipelineForResume(orch1.state.id);
+  assert.equal(saved.row.status, 'paused');
+  assert.ok(saved.resumePoint.snapshot, 'the FINAL scheduler snapshot is the point (D14)');
+  assert.ok(saved.resumePoint.snapshot.ended, 'End was reached in that snapshot');
+  assert.ok(!saved.resumePoint.snapshot.execs.some((e) => e.status === 'start' || e.status === 'paused' || e.status === 'error'),
+    'nothing is left to re-invoke');
+  const before = producerCalls;
+  const orch2 = createOrchestrator({ projectDir: dir, auto: true, claude: { mock: true }, runners: mk(), resume: saved });
+  const r2 = await orch2.resume();
+  assert.equal(r2.status, 'done', JSON.stringify(r2));
+  assert.equal(producerCalls, before, 'no agent re-ran: the graph was already complete');
+  assert.equal(orch2.getState().endReached, true, 'the restored `ended` re-sets endReached (no quiescence warning)');
+  assert.equal(readPipelineForResume(orch1.state.id).row.status, 'done');
+});
+
+test('_afterExecution throwing pauses the run; the execution row is paused and re-runs on resume', async () => {
+  const dir = gitDir();
+  let once = true;
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: runners() });
+  const real = orch1._afterExecution.bind(orch1);
+  orch1._afterExecution = async (...a) => { if (once) { once = false; throw new Error('review write failed'); } return real(...a); };
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused', JSON.stringify(r1));
+  assert.equal(r1.detail, 'review write failed');
+  const saved = readPipelineForResume(orch1.state.id);
+  assert.ok(saved.steps.some((s) => s.status === 'paused'));
+  assert.ok(!saved.steps.some((s) => s.status === 'error'));
+  const orch2 = createOrchestrator({ projectDir: dir, auto: true, claude: { mock: true }, runners: runners(), resume: saved });
+  assert.equal((await orch2.resume()).status, 'done');
+});
+
+test('a failure BEFORE createPipeline is still a launch error (nothing to resume)', async () => {
+  const dir = gitDir();
+  const rowsBefore = getDb().prepare('SELECT COUNT(*) AS n FROM pipelines').get().n;
+  const orch = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: runners() });
+  orch._preflightAgentKeys = () => { throw new Error('agent "ghost" is not installed'); };
+  const errors = [];
+  orch.on('error', (e) => errors.push(e));
+  const res = await orch.run();
+  assert.equal(res.status, 'error');
+  assert.equal(res.pipelineDir, null);
+  assert.match(res.error, /ghost/);
+  assert.equal(errors.length, 1, "the launch-error channel still emits 'error'");
+  assert.equal(getDb().prepare('SELECT COUNT(*) AS n FROM pipelines').get().n, rowsBefore, 'no row was created');
+});

--- a/test/orchestrator-partial-diff.test.mjs
+++ b/test/orchestrator-partial-diff.test.mjs
@@ -1,9 +1,10 @@
 // test/orchestrator-partial-diff.test.mjs
 // The diff artifact must survive the NON-done terminal paths. A run that is
-// stopped (or that errors) mid-flight still commits its work onto the kept
-// feature branch, so History must be able to show that work: _buildResults()
-// runs on the stopped/error branches too, while the checkpoint refs and the
-// worktree are still live (the `finally` tears them down right after).
+// stopped (or that paused on a failure) mid-flight still commits its work onto
+// the kept feature branch, so History must be able to show that work:
+// _buildResults() runs on the stopped and error-paused branches too, while the
+// checkpoint refs and the worktree are still live (the `finally` tears them down
+// right after — except on a pause, where the checkout is KEPT for the resume).
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
@@ -81,7 +82,7 @@ test(`[${engine.id}] a run stopped mid-flight persists results.json + diff-patch
   assert.ok(arts.some((a) => a.kind === 'diff-patch'), 'the diff-patch artifact is indexed');
 });
 
-test(`[${engine.id}] a run that errors mid-flight persists results.json + diff-patch.patch`, async () => {
+test(`[${engine.id}] a run that pauses on a failure mid-flight persists results.json + diff-patch.patch`, async () => {
   const repo = await freshRepo();
   const orch = engine.create({
     projectDir: repo, prompt: 'x', auto: true, claude: { mock: true }, branch: { source: 'main' },
@@ -90,12 +91,14 @@ test(`[${engine.id}] a run that errors mid-flight persists results.json + diff-p
   const edit = editOnWorktree(orch, 'errored work\n');
 
   const res = await orch.run();
-  assert.equal(res.status, 'error', JSON.stringify(res));
+  assert.equal(res.status, 'paused', JSON.stringify(res));
+  assert.equal(res.reason, 'error');
   assert.ok(edit.done, 'precondition: the tracked file was edited inside the worktree');
 
-  assert.ok(existsSync(results(res.pipelineDir)), 'results.json is persisted on the error path');
+  assert.ok(existsSync(results(res.pipelineDir)), 'results.json is persisted on the error-pause path');
   const text = readFileSync(patch(res.pipelineDir), 'utf8');
   assert.match(text, /\+errored work/);
+  assert.ok(existsSync(orch.getState().branch.worktreeDir), 'the checkout is KEPT — the run is resumable');
 
   const arts = await listArtifacts(orch.getState().id);
   assert.ok(arts.some((a) => a.kind === 'diff-patch'), 'the diff-patch artifact is indexed');
@@ -157,7 +160,7 @@ test(`[${engine.id}] a stopped run keeps the files the agent CREATED (untracked)
   assert.match(fromBranch, /\+agent created this/, 'precondition: the kept branch carries the file');
 });
 
-test(`[${engine.id}] an errored run keeps the files the agent CREATED too`, async () => {
+test(`[${engine.id}] a failure-paused run keeps the files the agent CREATED too`, async () => {
   const repo = await freshRepo();
   const orch = engine.create({
     projectDir: repo, prompt: 'x', auto: true, claude: { mock: true }, branch: { source: 'main' },
@@ -166,9 +169,11 @@ test(`[${engine.id}] an errored run keeps the files the agent CREATED too`, asyn
   const made = editOnWorktree(orch, 'errored new file\n', 'brand-new.txt');
 
   const res = await orch.run();
-  assert.equal(res.status, 'error', JSON.stringify(res));
+  assert.equal(res.status, 'paused', JSON.stringify(res));
+  assert.equal(res.reason, 'error');
   assert.ok(made.done, 'precondition: an untracked file was created inside the worktree');
   assert.match(readFileSync(patch(res.pipelineDir), 'utf8'), /\+errored new file/);
+  assert.ok(existsSync(orch.getState().branch.worktreeDir), 'the checkout is KEPT — the run is resumable');
 });
 
 // A checkpoint existing is NOT the same as the run having a diff. Every downstream

--- a/test/orchestrator-recovery-release.test.mjs
+++ b/test/orchestrator-recovery-release.test.mjs
@@ -3,10 +3,17 @@
 // on an interactive recovery prompt is released — the doomed phase must not wait
 // on a human"), deleted by P8 commit 11c7b7ee with no replacement.
 //
-// The guard lives in GraphOrchestrator._execute's catch (orchestrator.mjs:444-448):
-// a recovery `_ask` settles ONLY through answer()/pause()/stop(), so no AbortSignal
-// can reach it. When a phase-mate slice fails for real, the doomed phase must reject
-// that prompt itself or the composite waits forever on an answer nobody will give.
+// Under the errors-pause policy the release is no longer a bespoke guard in
+// GraphOrchestrator._execute's catch: a recovery `_ask` settles ONLY through
+// answer()/pause()/stop() (no AbortSignal reaches it), and the phase-mate's genuine
+// failure now PAUSES the run — so pause() itself rejects the parked prompt with the
+// pause sentinel (run-harness.mjs#pause). Flow: p1t1's kaboom -> _runNodeAttempts
+// (classifyError -> null) -> _pauseForError -> pause() rejects p1t2's parked _ask
+// with PauseError -> that rejection escapes _recover and propagates STRAIGHT out of
+// _runNodeAttempts (the `await this._recover(…)` sits INSIDE its catch, so there is
+// no re-classification) -> p1t2's _execute catch takes the pause branch. Both slices
+// answer { paused: true }, runSlice marks them 'paused', runPhase returns
+// { paused: true }, runComposite bails and settle -> pausedExecution for x:n_impl:1.
 //
 // Everything below the injected runner is REAL: the scheduler's composite driver
 // (expand -> phase -> parallel slices -> finish), the semaphore, the recoverable-
@@ -130,22 +137,21 @@ test('a slice parked on a recovery prompt is released when a phase-mate fails', 
   assert.deepEqual(recovery[0].recovery,
     { cls: 'auth', message: 'claude exited with code 1: invalid authentication' });
 
-  // 2. The doomed phase REJECTED it rather than waiting on a human — an _ask is
-  //    not signal-reachable, so nothing else can settle it.
-  assert.equal(rejectedWith?.name, 'AbortError', 'the parked prompt was rejected with an AbortError');
+  // 2. pause() released the parked prompt with the pause sentinel — nothing waits on a human.
+  assert.equal(rejectedWith?.name, 'PauseError', 'the parked prompt was rejected by the pause');
   assert.equal(orch.pendingQuestion, null, 'and the single prompt slot was cleared');
 
-  // 3. The run terminated on the FIRST genuine failure, not on the abort.
-  assert.equal(res.status, 'error', `the composite failed the run: ${JSON.stringify(res)}`);
-  assert.equal(res.error, 'claude exited with code 1: kaboom');
-  assert.equal(orch.getState().status, 'error');
-  const composite = execs.find((e) => e.executionId === 'x:n_impl:1' && e.status === 'error');
-  assert.match(composite.error, /^composite execution failed in phase 1: task "Slice one": .*kaboom/);
+  // 3. The genuine failure PAUSED the run (errors never end a run); the reason names it.
+  assert.equal(res.status, 'paused', JSON.stringify(res));
+  assert.equal(res.reason, 'error');
+  assert.equal(res.detail, 'claude exited with code 1: kaboom');
+  assert.equal(orch.getState().status, 'paused');
+  const composite = execs.find((e) => e.executionId === 'x:n_impl:1' && e.status === 'paused');
+  assert.ok(composite, 'the composite shell row is paused (non-terminal), so resume re-runs the whole fan-out');
+  assert.ok(!execs.some((e) => e.status === 'error'), 'the scheduler never recorded an error row');
 
-  // 4. Both slices are CLOSED rows. Without the guard the released slice's
-  //    _execute never reaches its `finally`, so its ledger row (and its task row)
-  //    stay 'start' forever — a task that reads as running after the run failed.
+  // 4. Both slices are CLOSED rows — paused, not error.
   const slices = orch.getState().steps.filter((s) => s.kind === 'task');
   assert.deepEqual(slices.map((s) => s.taskId).sort(), ['p1t1', 'p1t2']);
-  for (const s of slices) assert.equal(s.status, 'error', `${s.taskId} closed`);
+  for (const s of slices) assert.equal(s.status, 'paused', `${s.taskId} closed as paused`);
 });

--- a/test/orchestrator-recovery-release.test.mjs
+++ b/test/orchestrator-recovery-release.test.mjs
@@ -8,7 +8,7 @@
 // answer()/pause()/stop() (no AbortSignal reaches it), and the phase-mate's genuine
 // failure now PAUSES the run — so pause() itself rejects the parked prompt with the
 // pause sentinel (run-harness.mjs#pause). Flow: p1t1's kaboom -> _runNodeAttempts
-// (classifyError -> null) -> _pauseForError -> pause() rejects p1t2's parked _ask
+// (classifyError -> null -> the node site's pause verdict) -> _pauseFor -> pause() rejects p1t2's parked _ask
 // with PauseError -> that rejection escapes _recover and propagates STRAIGHT out of
 // _runNodeAttempts (the `await this._recover(…)` sits INSIDE its catch, so there is
 // no re-classification) -> p1t2's _execute catch takes the pause branch. Both slices
@@ -134,7 +134,10 @@ test('a slice parked on a recovery prompt is released when a phase-mate fails', 
   const recovery = questions.filter((q) => q.kind === 'recovery');
   assert.equal(recovery.length, 1, `exactly one recovery prompt opened: ${JSON.stringify(questions.map((q) => q.kind))}`);
   assert.match(recovery[0].id, /^recovery-auth-/, 'the prompt is keyed by its error class');
-  assert.deepEqual(recovery[0].recovery,
+  // The prompt carries the failure policy's row options next to the cause.
+  assert.deepEqual(recovery[0].recovery.options.map((o) => o.id), ['retry', 'pause']);
+  const { options: _opts, ...recoveryCause } = recovery[0].recovery;
+  assert.deepEqual(recoveryCause,
     { cls: 'auth', message: 'claude exited with code 1: invalid authentication' });
 
   // 2. pause() released the parked prompt with the pause sentinel — nothing waits on a human.

--- a/test/orchestrator-recovery.test.mjs
+++ b/test/orchestrator-recovery.test.mjs
@@ -1,17 +1,23 @@
 // test/orchestrator-recovery.test.mjs — recoverable-error retry gate.
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, existsSync } from 'node:fs';
 import { tmpdir, hostname } from 'node:os';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 import { useTempHome } from './helpers/temp-home.mjs';
 import { createOrchestrator } from '../src/core/orchestrator.mjs';
 import { readPipelineForResume, reconcileStaleRunning } from '../src/core/artifacts.mjs';
+import { writeGraphWorkflow } from '../src/core/workflows.mjs';
 import { getDb } from '../src/core/db.mjs';
 
 useTempHome(after);
 process.env.WORCA_RECOVERY_BACKOFF_MS = '0'; // no real waiting in tests
+// The D17 straggler test needs BOTH branches of its graph in flight at once:
+// defaultMaxParallel() reads WORCA_MAX_PARALLEL FIRST (scheduler.mjs:45-48), and at
+// an ambient 1 n_side may take the only slot, End never fires and the run hangs.
+// Same pin as test/orchestrator-recovery-release.test.mjs:34-38.
+process.env.WORCA_MAX_PARALLEL = '4';
 
 function gitDir() {
   const dir = mkdtempSync(join(tmpdir(), 'worca-cc-recovery-'));
@@ -65,7 +71,36 @@ test('interactive: recoverable error -> Retry re-runs the node, run completes', 
   assert.equal(res.status, 'done');
 });
 
-test('interactive: recoverable error -> Abort fails the run as today', async () => {
+test('interactive: recoverable error -> Pause parks the run as paused (reason error), never error', async () => {
+  const dir = gitDir();
+  let orch;
+  const logs = [];
+  orch = createOrchestrator({
+    projectDir: dir, prompt: 'demo', auto: false, claude: { mock: true },
+    runners: { producer: authOnceProducer(), verifier: okVerifier },
+  });
+  orch.on('question', answerWith(() => orch, 'pause'));
+  orch.on('log', (l) => logs.push(l));
+  const res = await orch.run();
+  assert.equal(res.status, 'paused', JSON.stringify(res));
+  assert.equal(res.reason, 'error');
+  assert.match(res.detail, /401 Invalid authentication credentials/);
+  assert.equal(orch.getState().status, 'paused');
+  assert.equal(orch.getState().pauseReason, 'error', 'getState() carries the reason');
+  // The ONE error-level line is written BEFORE the error is converted into the pause sentinel.
+  assert.ok(logs.some((l) => l.level === 'error' && /execution failed: .*401/.test(l.text)), JSON.stringify(logs.filter((l) => l.level === 'error')));
+  const row = getDb().prepare('SELECT status, resume_point, branch FROM pipelines WHERE id = ?').get(orch.state.id);
+  assert.equal(row.status, 'paused');
+  const rp = JSON.parse(row.resume_point);
+  assert.equal(rp.pauseReason, 'error');
+  assert.match(rp.pauseDetail, /401/);
+  assert.ok(existsSync(JSON.parse(row.branch).worktreeDir), 'worktree kept for the resume');
+  // The failed execution is a PAUSED (non-terminal) row — what reattach re-invokes.
+  assert.ok(orch.getState().steps.some((s) => s.status === 'paused'), JSON.stringify(orch.getState().steps.map((s) => [s.key, s.status])));
+  assert.ok(!orch.getState().steps.some((s) => s.status === 'error'));
+});
+
+test("interactive: the legacy { decision: 'abort' } answer still means Pause", async () => {
   const dir = gitDir();
   let orch;
   orch = createOrchestrator({
@@ -74,10 +109,11 @@ test('interactive: recoverable error -> Abort fails the run as today', async () 
   });
   orch.on('question', answerWith(() => orch, 'abort'));
   const res = await orch.run();
-  assert.equal(res.status, 'error');
+  assert.equal(res.status, 'paused');
+  assert.equal(res.reason, 'error');
 });
 
-test('auto: bounded retry then fail when the error never clears', async () => {
+test('auto: bounded retry then PAUSE when the error never clears', async () => {
   const dir = gitDir();
   let calls = 0;
   const alwaysAuth = async () => { calls++; throw AUTH_ERR(); };
@@ -86,9 +122,136 @@ test('auto: bounded retry then fail when the error never clears', async () => {
     runners: { producer: alwaysAuth, verifier: okVerifier },
   });
   const res = await orch.run();
-  assert.equal(res.status, 'error');
+  assert.equal(res.status, 'paused', JSON.stringify(res));
+  assert.equal(res.reason, 'error');
   // First producer node: 1 initial + RECOVERY_MAX_AUTO_ATTEMPTS retries = 4 calls.
   assert.equal(calls, 4);
+});
+
+test('a NON-recoverable throw pauses the run with reason error + detail (was: status error)', async () => {
+  const dir = gitDir();
+  const orch = createOrchestrator({
+    projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true },
+    runners: { producer: async () => { throw new Error('claude exited with code 1: disk full'); }, verifier: okVerifier },
+  });
+  const res = await orch.run();
+  assert.equal(res.status, 'paused', JSON.stringify(res));
+  assert.equal(res.reason, 'error');
+  assert.equal(res.detail, 'claude exited with code 1: disk full');
+  assert.equal(res.error, undefined, 'a paused result has no error field');
+  const saved = readPipelineForResume(orch.state.id);
+  assert.equal(saved.row.status, 'paused');
+  assert.ok(saved.resumePoint?.snapshot, 'the frozen (clean) scheduler snapshot is persisted (the Task card completed before the agent fired)');
+  assert.ok(!saved.resumePoint.snapshot.execs.some((e) => e.status === 'error'), 'the scheduler never saw the error');
+});
+
+test('resume after an error-pause re-invokes the paused execution WITH its session and completes', async () => {
+  const dir = gitDir();
+  let boom = true;
+  const seen = [];
+  const mkRunners = () => ({
+    producer: async (ctx) => {
+      ctx.onEvent({ type: 'session', sessionId: `sess-${ctx.nodeId}` });
+      seen.push({ nodeId: ctx.nodeId, resume: ctx.resumeSessionId || null });
+      if (boom) { boom = false; throw new Error('claude exited with code 1: disk full'); }
+      return { status: 'ok', summary: 'ok' };
+    },
+    verifier: okVerifier,
+  });
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, runners: mkRunners() });
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused');
+  const failed = seen[0];
+  const saved = readPipelineForResume(orch1.state.id);
+  assert.equal(saved.steps.find((s) => s.nodeId === failed.nodeId)?.status, 'paused');
+
+  const orch2 = createOrchestrator({ projectDir: dir, auto: true, claude: { mock: true }, runners: mkRunners(), resume: saved });
+  const r2 = await orch2.resume();
+  assert.equal(r2.status, 'done', JSON.stringify(r2));
+  assert.ok(seen.some((s) => s.nodeId === failed.nodeId && s.resume === `sess-${failed.nodeId}`), 'the failed execution re-ran with its session re-attached');
+  assert.equal(orch2.pauseReason, null); assert.equal(orch2.getState().pauseDetail, null);
+  const after2 = readPipelineForResume(orch1.state.id);
+  assert.equal(after2.row.status, 'done');
+  assert.equal(after2.row.resume_point, null);
+});
+
+test('the user stop still ends the run STOPPED even when the child dies with a plain error', async () => {
+  const dir = gitDir();
+  let orch;
+  orch = createOrchestrator({
+    projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true },
+    runners: {
+      producer: async () => {
+        orch.stop();                                            // the user's stop lands mid-node…
+        await new Promise((r) => setTimeout(r, 5));
+        throw new Error('claude exited with code 143');         // …and the child reports a PLAIN error
+      },
+      verifier: okVerifier,
+    },
+  });
+  const res = await orch.run();
+  assert.equal(res.status, 'stopped', JSON.stringify(res));
+  const row = getDb().prepare('SELECT status, resume_point FROM pipelines WHERE id = ?').get(orch.state.id);
+  assert.equal(row.status, 'stopped');
+  assert.equal(row.resume_point, null, 'a stopped run is never resumable');
+});
+
+test('an error-pause that lands AFTER the End card fired still PAUSES the run (D17); resume re-invokes the straggler and completes', { timeout: 60_000 }, async () => {
+  const dir = gitDir();
+  // Two branches off the Task card: n_review (a verifier) reaches End at once;
+  // n_side (a producer, NOT wired to End) is still running when End fires and then
+  // fails. The scheduler prefers `ended` over `pauseRequested` (scheduler.mjs:1033-1034),
+  // so without _engineRun's D17 guard this run would end 'done' with the error swallowed.
+  // Needs BOTH branches in flight at once — the module-scope WORCA_MAX_PARALLEL pin
+  // (see the top of this file) guarantees the second slot; at 1 this would deadlock.
+  const wf = await writeGraphWorkflow({
+    id: 'wf_straggler', name: 'Straggler',
+    nodes: [
+      { id: 'n_task', kind: 'task', x: 0, y: 0, config: {} },
+      { id: 'n_review', kind: 'agent', key: 'reviewer', x: 240, y: 0, config: {} },
+      { id: 'n_side', kind: 'agent', key: 'planner', x: 240, y: 200, config: {} },
+      { id: 'n_end', kind: 'end', x: 480, y: 0, config: {} },
+    ],
+    wires: [
+      { id: 'w1', from: { node: 'n_task', port: 'task' }, to: { node: 'n_review', port: 'plan' } },
+      { id: 'w2', from: { node: 'n_task', port: 'task' }, to: { node: 'n_side', port: 'task' } },
+      { id: 'w3', from: { node: 'n_review', port: 'pass' }, to: { node: 'n_end', port: 'result' } },
+    ],
+  });
+  let sideCalls = 0;
+  let endFired;
+  const endReached = new Promise((r) => { endFired = r; });
+  const mk = () => ({
+    verifier: okVerifier,                                   // n_review: instant pass -> End fires
+    producer: async () => {                                 // n_side: the straggler
+      sideCalls++;
+      if (sideCalls === 1) {
+        await endReached;                                   // hold until End has settled…
+        await new Promise((r) => setTimeout(r, 10));
+        throw new Error('claude exited with code 1: side blew up');   // …then fail
+      }
+      return { status: 'ok', summary: 'ok' };
+    },
+  });
+  const orch1 = createOrchestrator({ projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true }, workflowId: wf.id, runners: mk() });
+  orch1.on('exec', (p) => { if (p.nodeId === 'n_end' && p.status === 'done') endFired(); });
+  const r1 = await orch1.run();
+  assert.equal(r1.status, 'paused', JSON.stringify(r1));
+  assert.equal(r1.reason, 'error');
+  assert.match(r1.detail, /side blew up/);
+  assert.equal(sideCalls, 1, 'the straggler DID run (both branches fire together: defaultMaxParallel is 4)');
+  const saved = readPipelineForResume(orch1.state.id);
+  assert.equal(saved.row.status, 'paused');
+  assert.ok(saved.resumePoint.snapshot?.ended, 'the frozen point already carries End');
+  assert.equal(saved.resumePoint.snapshot.execs.find((e) => e.executionId === 'x:n_side:1')?.status, 'start',
+    'the straggler is NON-terminal in the frozen point (onSnapshot froze when pause() ran)');
+
+  const orch2 = createOrchestrator({ projectDir: dir, auto: true, claude: { mock: true }, runners: mk(), resume: saved });
+  const r2 = await orch2.resume();
+  assert.equal(r2.status, 'done', JSON.stringify(r2));
+  assert.equal(sideCalls, 2, 'reattach re-invoked the straggler; nothing else re-ran');
+  assert.equal(orch2.getState().endReached, true);
+  assert.equal(readPipelineForResume(orch1.state.id).row.status, 'done');
 });
 
 test('auto: session-limit pauses the run (not error) and is resumable', async () => {

--- a/test/orchestrator-recovery.test.mjs
+++ b/test/orchestrator-recovery.test.mjs
@@ -325,7 +325,8 @@ test('auto: session-limit pauses the run (not error) and is resumable', async ()
   });
   const res = await orch.run();
   assert.equal(res.status, 'paused');
-  assert.match(res.reason || '', /session limit/i);
+  assert.equal(res.reason, 'usage_limit', 'a machine-readable reason code');
+  assert.match(res.detail || '', /session limit/i, 'the cause rides the detail');
   assert.equal(calls, 1, 'a usage cap is NOT retried — it pauses on the first hit');
 });
 
@@ -360,8 +361,8 @@ test('shared gate: two concurrent recoveries of one class open ONE prompt', asyn
     orch._recover({ node, cls: 'auth', err: AUTH_ERR(), attempt: 1 }),
     orch._recover({ node, cls: 'auth', err: AUTH_ERR(), attempt: 1 }),
   ]);
-  assert.equal(a, 'retry');
-  assert.equal(b, 'retry');
+  assert.equal(a.outcome, 'retry');
+  assert.equal(b.outcome, 'retry');
   assert.equal(asks, 1, 'one shared prompt for both same-class failures');
 });
 
@@ -389,8 +390,8 @@ test('serialized gate: two DISTINCT classes never open two prompts at once', asy
     orch._recover({ node: { key: 'n1', nodeId: 'a' }, cls: 'auth', err: AUTH_ERR(), attempt: 1 }),
     orch._recover({ node: { key: 'n2', nodeId: 'b' }, cls: 'network', err: NET_ERR(), attempt: 1 }),
   ]);
-  assert.equal(a, 'retry');
-  assert.equal(b, 'retry');
+  assert.equal(a.outcome, 'retry');
+  assert.equal(b.outcome, 'retry');
   assert.equal(asks, 2, 'one prompt per distinct class');
   assert.equal(maxOpen, 1, 'prompts are serialized — only one open at a time');
 });

--- a/test/orchestrator-recovery.test.mjs
+++ b/test/orchestrator-recovery.test.mjs
@@ -126,8 +126,10 @@ test('auto: bounded retry then PAUSE when a transient error never clears', async
   // An outage that outlasts the backoff budget is still outside the pipeline's
   // control: park the run as resumable instead of a terminal error.
   assert.equal(res.status, 'paused');
-  assert.equal(res.reason, 'error');
-  assert.match(res.detail || '', /ECONNRESET/);
+  // A self-parked auto run keeps its CLASS: 'recoverable' (resume when it clears),
+  // never the 'error' verdict a user's give-up or a genuine failure carries.
+  assert.equal(res.reason, 'recoverable');
+  assert.match(res.detail || '', /^network: .*ECONNRESET/);
   // First producer node: 1 initial + RECOVERY_MAX_AUTO_ATTEMPTS retries = 4 calls.
   assert.equal(calls, 4);
 });
@@ -135,16 +137,21 @@ test('auto: bounded retry then PAUSE when a transient error never clears', async
 test('auto: auth error pauses immediately — a 7s backoff cannot re-login', async () => {
   const dir = gitDir();
   let calls = 0;
+  const logs = [];
   const alwaysAuth = async () => { calls++; throw AUTH_ERR(); };
   const orch = createOrchestrator({
     projectDir: dir, prompt: 'demo', auto: true, claude: { mock: true },
     runners: { producer: alwaysAuth, verifier: okVerifier },
   });
+  orch.on('log', (l) => logs.push(l));
   const res = await orch.run();
   assert.equal(res.status, 'paused', JSON.stringify(res));
-  assert.equal(res.reason, 'error');
-  assert.match(res.detail || '', /401/);
+  assert.equal(res.reason, 'recoverable');
+  assert.match(res.detail || '', /^auth: .*401/);
   assert.equal(calls, 1, 'auth is NOT retried — it pauses on the first hit');
+  // The class survives into the run log (a warn, not the error-level failure line).
+  assert.ok(logs.some((l) => l.level === 'warn' && /recoverable auth error — pausing/.test(l.text)), JSON.stringify(logs.map((l) => [l.level, l.text])));
+  assert.ok(!logs.some((l) => l.level === 'error'), 'a recoverable pause is not logged as a failure');
 });
 
 test('auto: quota error pauses immediately — retrying cannot top up the balance', async () => {
@@ -157,8 +164,8 @@ test('auto: quota error pauses immediately — retrying cannot top up the balanc
   });
   const res = await orch.run();
   assert.equal(res.status, 'paused');
-  assert.equal(res.reason, 'error');
-  assert.match(res.detail || '', /credit balance/i);
+  assert.equal(res.reason, 'recoverable');
+  assert.match(res.detail || '', /^quota: .*credit balance/i);
   assert.equal(calls, 1, 'quota is NOT retried — it pauses on the first hit');
 });
 

--- a/test/orchestrator-workspace.test.mjs
+++ b/test/orchestrator-workspace.test.mjs
@@ -299,8 +299,8 @@ test('_stageWorkingTree stages EVERY member worktree (not just primary)', async 
   }
 });
 
-// ── partial worktree-setup failure is fully torn down (no leak; §5.10 edge 4) ──
-test('a member whose branch is already checked out errors the run and leaks no worktree', async () => {
+// ── partial worktree-setup failure PAUSES, keeping the sibling checkout (§5.10 edge 4) ──
+test('a member whose branch is already checked out PAUSES the run; the sibling\'s checkout is kept and the resume replays the setup', async () => {
   const a = await freshRepo();
   const b = await freshRepo();
   const ws = workspaceOpts([a, b], { branch: { source: 'main', feature: 'collide' } });
@@ -316,13 +316,23 @@ test('a member whose branch is already checked out errors the run and leaks no w
 
   const orch = createOrchestrator({ ...ws, prompt: 'x', auto: true, claude: { mock: true } });
   const res = await orch.run();
-  // The run errors (one member could not get its worktree); whichever member DID
-  // get a worktree must be torn down (no orphan checkout dir), branch kept.
-  assert.equal(res.status, 'error', JSON.stringify(res));
-  const wtBaseA = join(a, '.worca-cc', 'worktrees');
-  // a's pipeline-id worktree (if it was created before b threw) must be gone.
-  const orphan = existsSync(join(wtBaseA, orch.getState().id || ''));
-  assert.ok(!orphan, 'partial worktree for member a must be torn down on setup failure');
+  assert.equal(res.status, 'paused', JSON.stringify(res));
+  assert.equal(res.reason, 'error');
+  assert.match(res.detail, /already checked out/);
+  // _setupRunRoot settles EVERY member before throwing, so whichever member DID get a
+  // worktree is recorded AND kept — the paused run resumes into it.
+  const wtA = orch.getState().branches[projectKey(a)]?.worktreeDir;
+  assert.ok(wtA && existsSync(wtA), "member a's checkout is retained for the resume");
+  const saved = readPipelineForResume(orch.getState().id);
+  assert.equal(saved.resumePoint.setupIncomplete, true);
+  assert.equal(saved.resumePoint.workspace.projects.find((p) => p.projectKey === projectKey(a))?.worktreeDir, wtA, 'the point records the kept checkout');
+  // Free b's branch, then resume: the replay re-attaches a and creates b.
+  assert.equal(spawnSync('git', ['-C', b, 'worktree', 'remove', '--force', squatDir]).status, 0);
+  const orch2 = createOrchestrator({ ...ws, auto: true, claude: { mock: true }, resume: saved });
+  const res2 = await orch2.resume();
+  assert.equal(res2.status, 'done', JSON.stringify(res2));
+  assert.ok(orch2.getState().branches[bKey]?.worktreeDir, 'the replay created member b');
+  assert.ok(!existsSync(wtA), 'done tears every member checkout down');
 });
 
 // ── fan-out node forcing ──────────────────────────────────────────────────────

--- a/test/pause-reason-model.test.mjs
+++ b/test/pause-reason-model.test.mjs
@@ -1,0 +1,58 @@
+// test/pause-reason-model.test.mjs — the {reason, detail} pause model + pure helpers.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { useTempHome } from './helpers/temp-home.mjs';
+import { createOrchestrator } from '../src/core/orchestrator.mjs';
+import { errorDetail, scrubErrorRows, PAUSE_DETAIL_MAX } from '../src/core/run-harness.mjs';
+
+useTempHome(after);
+
+test('errorDetail: whole message, whitespace-collapsed, middle-clipped, never empty', () => {
+  assert.equal(errorDetail(new Error('claude exited with code 1:\n  disk full')), 'claude exited with code 1: disk full');
+  assert.equal(errorDetail('plain string'), 'plain string');
+  assert.equal(errorDetail(null), 'unknown error');
+  assert.equal(errorDetail(new Error('')), 'unknown error');
+  const long = errorDetail(new Error('x'.repeat(2000) + ' CAUSE'));
+  assert.ok(long.length <= PAUSE_DETAIL_MAX);
+  assert.match(long, /…/);
+  assert.match(long, /CAUSE$/, 'the tail (the cause) survives the clip');
+});
+
+test('scrubErrorRows: an error row and the fail-fast\'s skipped collateral become non-terminal paused rows', () => {
+  const snap = { version: 2, seq: 3, execs: [
+    { executionId: 'x:a:1', status: 'done' },
+    { executionId: 'x:b:1', status: 'error', error: 'boom' },
+    { executionId: 'x:c:1', status: 'start' },
+    { executionId: 'x:d:1', status: 'skipped' },   // aborted mid-flight by failExecution's controller.abort()
+  ] };
+  const out = scrubErrorRows(snap);
+  assert.deepEqual(out.execs.map((e) => e.status), ['done', 'paused', 'start', 'paused']);
+  assert.equal('error' in out.execs[1], false, 'the error text is dropped with the terminal mark');
+  assert.equal(out.seq, 3);
+  assert.equal(scrubErrorRows(null), null);
+  const clean = { version: 2, execs: [{ executionId: 'x:a:1', status: 'done' }, { executionId: 'x:e:1', status: 'skipped' }] };
+  assert.equal(scrubErrorRows(clean), clean, 'no error row => returned by identity (a legitimate skipped row stays skipped)');
+});
+
+test('_setPauseReason: first writer wins, state mirrors it, _clearPauseReason resets both', () => {
+  const orch = createOrchestrator({ projectDir: process.cwd(), prompt: 'x', claude: { mock: true } });
+  assert.equal(orch._setPauseReason('error', 'boom'), true);
+  assert.equal(orch._setPauseReason('cost_total', 'later'), false, 'a sibling unwind never overwrites the cause');
+  assert.equal(orch.pauseReason, 'error');
+  assert.equal(orch.pauseDetail, 'boom');
+  assert.equal(orch.getState().pauseReason, 'error');
+  assert.equal(orch.getState().pauseDetail, 'boom');
+  orch._clearPauseReason();
+  assert.equal(orch.pauseReason, null);
+  assert.equal(orch.getState().pauseDetail, null);
+});
+
+test('the resume point carries pauseDetail next to pauseReason', () => {
+  const orch = createOrchestrator({ projectDir: process.cwd(), prompt: 'x', claude: { mock: true } });
+  orch.pipeline = { id: 'p1', dir: '/tmp/p1', promptText: 'x' };   // _buildResumePoint reads pipeline.dir
+  orch._setPauseReason('error', 'disk full');
+  const rp = orch._buildResumePoint(null);
+  assert.equal(rp.pauseReason, 'error');
+  assert.equal(rp.pauseDetail, 'disk full');
+  assert.equal(rp.snapshot, null);
+});

--- a/test/run-harness-hooks.test.mjs
+++ b/test/run-harness-hooks.test.mjs
@@ -166,6 +166,32 @@ test('run(): a pause requested during preflight lands on _enginePrePausePoint an
   assert.equal(JSON.parse(row.resume_point).kind, 'stub-boundary', 'persisted through _completePaused');
 });
 
+test('run(): a throw AFTER createPipeline pauses on the pre-engine point with reason error (never status error)', async () => {
+  const dir = await makeRepo();
+  const orch = new StubEngine({ projectDir: dir, prompt: 'demo', claude: { mock: true }, auto: true });
+  orch._setupRunRoot = async () => { throw new Error('disk full'); };
+  const errors = [];
+  orch.on('error', (e) => errors.push(e));
+  const res = await orch.run();
+  assert.equal(res.status, 'paused', JSON.stringify(res));
+  assert.equal(res.reason, 'error');
+  assert.equal(res.detail, 'disk full');
+  assert.equal(errors.length, 0, "a converted failure emits no 'error' event");
+  assert.equal(orch.calls.prePause, 1, 'the engine decided the pre-engine resume point (the base hook default _engineLastPoint() is null)');
+  assert.equal(orch.calls.engineRun.length, 0, 'the engine never ran');
+  const rp = orch.state.resumePoint;
+  assert.equal(rp.kind, 'stub-boundary');
+  assert.equal(rp.snapshot, null);
+  assert.equal(rp.pauseReason, 'error');
+  assert.equal(rp.pauseDetail, 'disk full');
+  assert.equal(rp.setupIncomplete, true, 'resume() must replay the setup');
+  const row = getDb().prepare('SELECT status, resume_point FROM pipelines WHERE id = ?').get(orch.state.id);
+  assert.equal(row.status, 'paused');
+  assert.equal(JSON.parse(row.resume_point).pauseReason, 'error', 'persisted through _completePaused');
+  assert.match(auditOf(orch.state.id), /Pipeline \*\*paused\*\*: disk full/);
+  assert.doesNotMatch(auditOf(orch.state.id), /Pipeline \*\*error\*\*/);
+});
+
 test('resume(): the shell consumes the _engineRehydrate bag and never reads rp.bus', async () => {
   const dir = await makeRepo();
   const p = await createPipeline(dir, { promptText: 'demo', sourceType: 'prompt' });

--- a/test/run-root-teardown.test.mjs
+++ b/test/run-root-teardown.test.mjs
@@ -612,7 +612,7 @@ test('detached: §8.20 — an edit INSIDE the CLAUDE.md fence is rescued, never 
 
 // ── detached partial-setup containment ───────────────────────────────────────
 
-test('detached: one member failing createWorktree tears down the sibling — no orphan under runs/<id>/repos', async () => {
+test('detached: one member failing createWorktree PAUSES the run — the run root is KEPT, and the resume replays the setup', async () => {
   const a = await freshRepo('worca-cc-rrt-a-');
   const b = await freshRepo('worca-cc-rrt-b-');
   const ws = workspaceOpts([a, b], { branch: { source: 'main', feature: 'collide' } });
@@ -627,12 +627,26 @@ test('detached: one member failing createWorktree tears down the sibling — no 
   await withMode('detached', async () => {
     const orch = createOrchestrator({ ...ws, prompt: 'x', auto: true, claude: { mock: true } });
     const res = await orch.run();
-    assert.equal(res.status, 'error', JSON.stringify(res));
+    assert.equal(res.status, 'paused', JSON.stringify(res));
+    assert.equal(res.reason, 'error');
+    assert.match(res.detail, /already checked out/);
     const id = orch.getState().id;
     const reposBase = join(worcaHome(), 'runs', id, 'repos');
-    // Whichever member DID get a worktree must be torn down, and the run root with it.
-    assert.ok(!existsSync(reposBase), `no orphan checkout under ${reposBase}`);
-    assert.ok(!existsSync(join(worcaHome(), 'runs', id)), 'the run root is reclaimed too');
+    // A pause never tears down: whichever member DID get a checkout keeps it, and the
+    // run root with it — that is what the resume replays INTO.
+    assert.ok(existsSync(reposBase), `the checkout under ${reposBase} is kept for the resume`);
+    assert.ok(existsSync(join(worcaHome(), 'runs', id)), 'the run root is kept too');
+    const saved = readPipelineForResume(id);
+    assert.equal(saved.row.status, 'paused');
+    assert.equal(saved.resumePoint.setupIncomplete, true);
+
+    // Free b's branch, then resume: the replay re-attaches a and creates b, and the
+    // finished run reclaims the whole run root exactly as a fresh run would.
+    assert.equal(spawnSync('git', ['-C', b, 'worktree', 'remove', '--force', squatDir]).status, 0);
+    const orch2 = createOrchestrator({ ...ws, auto: true, claude: { mock: true }, resume: saved });
+    const res2 = await orch2.resume();
+    assert.equal(res2.status, 'done', JSON.stringify(res2));
+    assert.ok(!existsSync(join(worcaHome(), 'runs', id)), 'the run root is reclaimed on done');
     // a's branch is still KEPT (only the disposable checkout goes).
     assert.ok(branchList(a).some((x) => x.startsWith('collide-')), "member a's branch is kept");
   });

--- a/test/server-pause-reason.test.mjs
+++ b/test/server-pause-reason.test.mjs
@@ -81,3 +81,33 @@ test('end to end: wireRun done -> summarizeRuns is what a reloading client sees'
     runs.delete(entry.id);
   }
 });
+
+test('wireRun: an error-pause stores reason AND detail; a later stray error event never demotes it', () => {
+  const entry = makeEntry({ id: 'uuid-PR6' });
+  runs.set(entry.id, entry);
+  try {
+    _testing.wireRun(entry);
+    entry.orch.emit('done', { status: 'paused', reason: 'error', detail: 'claude exited with code 1: disk full' });
+    assert.equal(entry.status, 'paused');
+    assert.equal(entry.pauseReason, 'error');
+    assert.equal(entry.pauseDetail, 'claude exited with code 1: disk full');
+    entry.orch.emit('error', { message: 'late' });
+    assert.equal(entry.status, 'paused', "an 'error' event must not override a parked run");
+    const sum = _testing.summarizeRuns().find((r) => r.runId === 'uuid-PR6');
+    assert.equal(sum.pauseDetail, 'claude exited with code 1: disk full');
+  } finally {
+    runs.delete(entry.id);
+  }
+});
+
+test("wireRun: 'error' still marks a RUNNING entry error (the launch-error channel)", () => {
+  const entry = makeEntry({ id: 'uuid-PR7' });
+  runs.set(entry.id, entry);
+  try {
+    _testing.wireRun(entry);
+    entry.orch.emit('error', { message: 'agent "ghost" is not installed' });
+    assert.equal(entry.status, 'error');
+  } finally {
+    runs.delete(entry.id);
+  }
+});

--- a/test/skills-gate-wiring.test.mjs
+++ b/test/skills-gate-wiring.test.mjs
@@ -21,6 +21,7 @@ import { createOrchestrator } from '../src/core/orchestrator.mjs';
 import { worcaHome } from '../src/core/projects.mjs';
 import { projectKey } from '../src/core/store.mjs';
 import { readRunManifest } from '../src/core/run-manifest.mjs';
+import { readPipelineForResume } from '../src/core/artifacts.mjs';
 import { getDb } from '../src/core/db.mjs';
 import { useTempHome } from './helpers/temp-home.mjs';
 import { fileURLToPath } from 'node:url';
@@ -166,7 +167,7 @@ test('detached + declared skills forwards the validated resolutions and mounts t
   });
 });
 
-test('detached + an UNRESOLVABLE declared skill still hard-fails before any node', async () => {
+test('detached + an UNRESOLVABLE declared skill still gates before any node — PAUSES the run, and the gate holds on resume', async () => {
   const repo = await freshRepo();
   const agentsDir = await agentsDirRequiring(['no-such-skill-anywhere']);
   await withMode('detached', async () => {
@@ -178,12 +179,30 @@ test('detached + an UNRESOLVABLE declared skill still hard-fails before any node
     const real = orch._assembleContext.bind(orch);
     orch._assembleContext = async (r) => { assembled++; return real(r); };
     const res = await orch.run();
-    assert.equal(res.status, 'error', JSON.stringify(res));
-    assert.match(res.error, /no-such-skill-anywhere/);
+    assert.equal(res.status, 'paused', JSON.stringify(res));
+    assert.equal(res.reason, 'error');
+    assert.match(res.detail, /no-such-skill-anywhere/);
     assert.equal(assembled, 0, 'the gate throws BEFORE assembly, so no context is generated');
-    // No node ever ran.
+    assert.equal(orch.getState().resumePoint?.setupIncomplete, true, 'resume replays the setup — including this gate');
     assert.ok(!orch.getState().steps.some((s) => s.status === 'start' || s.status === 'ok'),
       JSON.stringify(orch.getState().steps));
+
+    // The gate HOLDS on resume: with the skill still missing the replay pauses again
+    // on the same cause, and still nothing is assembled or dispatched.
+    const saved = readPipelineForResume(orch.getState().id);
+    const orch2 = createOrchestrator({
+      projectDir: repo, auto: true, claude: { mock: true },
+      branch: { source: 'main' }, agentsDir, resume: saved,
+    });
+    let assembled2 = 0;
+    const real2 = orch2._assembleContext.bind(orch2);
+    orch2._assembleContext = async (r) => { assembled2++; return real2(r); };
+    const res2 = await orch2.resume();
+    assert.equal(res2.status, 'paused', JSON.stringify(res2));
+    assert.equal(res2.reason, 'error');
+    assert.match(res2.detail, /no-such-skill-anywhere/);
+    assert.equal(assembled2, 0, 'the replayed gate throws BEFORE the replayed assembly');
+    assert.equal(readPipelineForResume(orch.getState().id).row.status, 'paused');
   });
 });
 

--- a/test/ui-cost-paused.test.mjs
+++ b/test/ui-cost-paused.test.mjs
@@ -82,14 +82,14 @@ const historyList = (pipelines) =>
 // Seed one live run via `hello`, then drive it paused with a `done` frame that
 // carries the pause reason (the server's done broadcast really carries it —
 // orchestrator._completePaused emits it and wireRun spreads the payload).
-async function pausedRun(ctx, reason) {
+async function pausedRun(ctx, reason, detail = undefined) {
   ctx.showRunning();
   ctx.recv({
     type: 'hello',
     runs: [{ runId: 'r1', title: 'Feat', projectDir: PROJECT, status: 'running', startedAt: '00:00:00', pipelineId: 'pl_1' }],
   });
   await ctx.tick();
-  ctx.recv({ type: 'done', runId: 'r1', status: 'paused', reason });
+  ctx.recv({ type: 'done', runId: 'r1', status: 'paused', reason, ...(detail !== undefined ? { detail } : {}) });
   await ctx.tick();
   return ctx.window.document.querySelector('#run-list .run-card');
 }
@@ -183,6 +183,16 @@ test('a non-cost pause leaves the banner hidden and the pill plain', async () =>
   assert.equal(card.querySelector('.cost-banner').hidden, true);
   assert.equal(card.querySelector('.rc-status-word').textContent, 'Paused');
   assert.equal(card.querySelector('.btn-resume').disabled, false);
+});
+
+test('an error pause: pill "Paused · error", no cost banner, Resume enabled with the detail as tooltip', async () => {
+  const ctx = await boot();
+  const card = await pausedRun(ctx, 'error', 'claude exited with code 1: disk full');
+  assert.equal(card.querySelector('.rc-status-word').textContent, 'Paused · error');
+  assert.equal(card.querySelector('.cost-banner').hidden, true);
+  const resume = card.querySelector('.btn-resume');
+  assert.equal(resume.disabled, false, 'an error pause is always resumable');
+  assert.match(resume.title, /disk full/);
 });
 
 // Resume + the cost-pause banner moved to the History DETAIL screen; the card
@@ -291,4 +301,58 @@ test('reload parity: a hello-seeded paused run with pauseReason renders the bann
   assert.equal(ctx.window.__np.getRun('r9').pauseReason, 'cost_pipeline');
   assert.ok(card.querySelector('.cost-banner.cb-pipeline'), 'banner survives a reload');
   assert.equal(card.querySelector('.rc-status-word').textContent, 'Paused · cost limit');
+});
+
+// ---------------------------------------------------------------------------
+// Error pauses in History: the red card note, the detail banner, and the
+// deep-link fallback onto the DETAIL payload (rowToState now carries both keys).
+// ---------------------------------------------------------------------------
+const ERROR_ENTRIES = [
+  { id: 'h3', projectKey: 'k1', title: 'Blew up', status: 'paused', pauseReason: 'error',
+    pauseDetail: 'claude exited with code 1: disk full', startedAt: '2026-09-02T00:00:00Z' },
+];
+const errorDetailArm = (id) => Promise.resolve({
+  ok: true, status: 200,
+  json: async () => ({ state: { id, phase: 'implement', status: 'paused', totalCostUsd: 1.2, steps: [],
+                                pauseReason: 'error', pauseDetail: 'claude exited with code 1: disk full' } }),
+});
+const errorArms = (url) => {
+  if (url.endsWith('/api/history/k1/h3')) return errorDetailArm('h3');
+  if (url.endsWith('/api/history')) return historyList(ERROR_ENTRIES);
+  return null;
+};
+
+test('history: an error pause renders the red "paused · error" note; the detail screen shows the error banner and an enabled Resume', async () => {
+  const ctx = await boot({ fetchHandler: errorArms });
+  ctx.showHistory();
+  await ctx.tick();
+  const card = ctx.window.document.querySelector('#history .hist-card');
+  const note = card.querySelector('.hist-pausenote');
+  assert.equal(note.hidden, false);
+  assert.equal(note.textContent, 'paused · error');
+  assert.ok(note.classList.contains('error'), 'error note uses the red modifier');
+  assert.match(note.title, /disk full/);
+  assert.equal(card.dataset.pauseReason, 'error');
+
+  ctx.showDetail('k1', 'h3');
+  await ctx.settle();
+  const resume = ctx.window.document.querySelector('#hist-detail .hd-resume');
+  assert.equal(resume.disabled, false, 'an error pause never gates Resume');
+  assert.match(resume.title, /Paused after an error: claude exited with code 1: disk full/);
+  const banner = ctx.window.document.querySelector('#hist-detail .hd-banners .pause-error-banner');
+  assert.ok(banner, 'the detail screen shows the error-pause banner');
+  assert.match(banner.textContent, /Paused after an error/);
+  assert.match(banner.textContent, /disk full/);
+  assert.equal(ctx.window.document.querySelector('#hist-detail .hd-banners .cost-banner'), null, 'no cost banner for an error pause');
+});
+
+test('history deep link: the DETAIL payload alone (no list row yet) still shows the error banner', async () => {
+  // A list without the entry — only the detail arm knows the pause cause (rowToState).
+  const arms = (url) => (url.endsWith('/api/history/k1/h3') ? errorDetailArm('h3') : (url.endsWith('/api/history') ? historyList([]) : null));
+  const ctx = await boot({ fetchHandler: arms });
+  ctx.showDetail('k1', 'h3');
+  await ctx.settle();
+  const banner = ctx.window.document.querySelector('#hist-detail .hd-banners .pause-error-banner');
+  assert.ok(banner, 'the banner falls back to data.state.pauseReason/pauseDetail');
+  assert.match(banner.textContent, /disk full/);
 });

--- a/test/ui-history-detail.test.mjs
+++ b/test/ui-history-detail.test.mjs
@@ -596,7 +596,8 @@ test('deep link derives retained work from state.branch.commitFailed, then DEFER
 test('cost-paused run shows the banner; Continue-without-cap resumes with ignoreCostCap', async () => {
   const posts = [];
   const ctx = await bootDetail({
-    // 'cost_pipeline' and 'cost_total' are the only two reasons the product emits.
+    // Reasons the product emits: 'cost_pipeline', 'cost_total', 'error', or the
+    // usage-limit first line (free text).
     rows: [{ ...ROW, status: 'paused', pauseReason: 'cost_pipeline' }],
     detail: PAUSED_DETAIL,
     arms: (url, opts) => {
@@ -628,7 +629,7 @@ test('a deep-linked cost-paused run gains its banner exactly once when the row a
   await settle(ctx.window, 5);
   const doc = ctx.window.document;
   assert.equal(doc.querySelector('#hist-detail .hd-banners .cost-banner'), null,
-    'the stub carries no pauseReason (it lives on LIST rows only)');
+    'the stub carries no pauseReason and the detail payload none either');
 
   await deliverRows(ctx, [{ ...ROW, status: 'paused', pauseReason: 'cost_total' }]);
   assert.equal(doc.querySelectorAll('#hist-detail .hd-banners .cost-banner').length, 1);

--- a/test/ui-run-hosts.test.mjs
+++ b/test/ui-run-hosts.test.mjs
@@ -642,6 +642,13 @@ test('every label helper reads the graph; a run with no manifest reads plainly "
     steps: [{ key: 'x:n_a:1', executionId: 'x:n_a:1', nodeId: 'n_a', ordinal: 1, status: 'start', activeMs: 10, startedAt: '2026-08-26T10:00:00Z' }] });
   assert.equal(np.statusPill(r).text, '2 agents running');
   assert.equal(np.rdStateCopy(r, 'Planner'), '2 agents running.');
+  // An error pause names its cause; any OTHER reason is the orchestrator's own
+  // free text (a usage-limit line); a reasonless pause is still "Paused by you".
+  assert.match(np.rdStateCopy({ ...r, status: 'paused', pauseReason: 'error', pauseDetail: 'claude exited with code 1: disk full' }, 'Planner'),
+    /^Paused after an error: claude exited with code 1: disk full\. Fix the cause, then Resume/);
+  assert.match(np.rdStateCopy({ ...r, status: 'paused', pauseReason: "You've hit your session limit · resets 6pm" }, 'Planner'),
+    /^Paused — You've hit your session limit · resets 6pm\./);
+  assert.match(np.rdStateCopy({ ...r, status: 'paused', pauseReason: null }, 'Planner'), /^Paused by you\./);
   // A run whose manifest has not arrived yet: no active agent to name, and the
   // v1 phaseKey switch that used to name a phase is gone.
   const bare = np.makeRun({ runId: 'r2', title: 't', projectDir: '/p', status: 'running' });

--- a/test/ui-running-detail.test.mjs
+++ b/test/ui-running-detail.test.mjs
@@ -412,6 +412,10 @@ test('the gate and recovery bodies render on the detail page too (D6)', async ()
   const rpanel = rec.window.document.querySelector('#run-detail .rd-questions .qpanel');
   assert.ok(rpanel.querySelector('.recovery-retry'), 'the recovery body renders');
   assert.match(rpanel.textContent, /token expired/);
+  const pauseBtn = rpanel.querySelector('.recovery-pause');
+  assert.ok(pauseBtn, 'the give-up button is "Pause run"');
+  assert.equal(pauseBtn.textContent, 'Pause run');
+  assert.equal(rpanel.querySelector('.recovery-abort'), null, 'no Abort control remains');
 });
 
 test('answers posted from the DETAIL panel carry the detail panel\'s choices', async () => {

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -770,6 +770,7 @@ function onHello(msg) {
       kind: r0.kind || 'run',
       pipelineId: r0.pipelineId || null,
       pauseReason: r0.pauseReason || null,
+      pauseDetail: r0.pauseDetail || null,
       workspaceId: r0.workspaceId || undefined,
       projectNames: Array.isArray(r0.projectNames) && r0.projectNames.length ? r0.projectNames : undefined,
     });
@@ -898,6 +899,7 @@ function nowHMS() {
 function makeRun({
   runId, title, projectDir, status = 'running', startedAt, local = false,
   pendingQuestion = null, kind = 'run', pipelineId = null, pauseReason = null,
+  pauseDetail = null,
   workspaceId = undefined, workspaceName = undefined, projectNames = null,
 }) {
   return {
@@ -912,6 +914,7 @@ function makeRun({
     pipelineId,           // matches a History row id once persisted; used to hide lingerers from History
     pauseReason,          // why it paused, or null — ANY orchestrator pause code rides here
                           // (e.g. 'usage_limit'); only the cost pair renders a cost banner
+    pauseDetail,          // the human-readable cause behind an 'error' pause, or null
     workspaceId,
     workspaceName,
     // Stable ordering key: assigned once per runId, never bumped by activity
@@ -4054,7 +4057,8 @@ function renderGateBody(r, panel, pq) {
 }
 
 // Recovery prompt: a node hit a recoverable error (auth / rate-limit / quota /
-// network). Show the cause and let the user fix it then Retry, or Abort the run.
+// network). Show the cause and let the user fix it then Retry, or park the run
+// with Pause run — nothing here ends a run, only Stop does.
 function renderRecoveryBody(r, panel, pq) {
   const rec = pq.recovery || {};
   const intro = document.createElement('div');
@@ -4062,7 +4066,7 @@ function renderRecoveryBody(r, panel, pq) {
   const hint = rec.cls === 'auth'
     ? 'Re-authenticate (e.g. run `claude setup-token` or `/login`), then Retry.'
     : 'Fix the problem (wait out a limit, restore connectivity, top up credit), then Retry.';
-  intro.textContent = `This step could not reach the model. ${hint}`;
+  intro.textContent = `This step could not reach the model. ${hint} Or pause the run and come back later — only Stop ends it.`;
   panel.appendChild(intro);
 
   if (rec.message) {
@@ -4074,15 +4078,16 @@ function renderRecoveryBody(r, panel, pq) {
 
   const foot = document.createElement('div');
   foot.className = 'qpanel-foot gate-actions';
-  const abort = document.createElement('button');
-  abort.type = 'button';
-  abort.className = 'btn recovery-abort';
-  abort.textContent = 'Abort run';
+  const pause = document.createElement('button');
+  pause.type = 'button';
+  pause.className = 'btn recovery-pause';
+  pause.textContent = 'Pause run';
+  pause.title = 'Park the run here with this error as the reason. Nothing is discarded — Resume retries the step later.';
   const retry = document.createElement('button');
   retry.type = 'button';
   retry.className = 'btn btn-primary recovery-retry';
   retry.textContent = 'Retry';
-  foot.append(abort, retry);
+  foot.append(pause, retry);
   panel.appendChild(foot);
 }
 
@@ -4269,6 +4274,9 @@ function onDone(r, msg) {
   // unconditionally so a later reasonless done clears it, matching the server's
   // own entry.pauseReason reset in wireRun.
   r.pauseReason = msg.reason || null;
+  // An 'error' pause also carries the cause it parked on; assigned unconditionally
+  // for the same reason as the code above — a later reasonless done must clear it.
+  r.pauseDetail = msg.detail || null;
   finishRun(r, msg.status || 'done');
   // Nothing else picks up the FINAL spend delta: a non-cost `done` broadcasts no
   // budget-changed, and startBudgetTick refetches only while runs are live. Without
@@ -9435,7 +9443,7 @@ if (runListEl) {
 
     // qpanel actions. Resolve the run per-card via the enclosing .run-card so
     // delegation works for any dynamically-built card.
-    const qbtn = e.target.closest && e.target.closest('.qpanel .btn-go, .qpanel .gate-continue, .qpanel .gate-another, .qpanel .recovery-retry, .qpanel .recovery-abort');
+    const qbtn = e.target.closest && e.target.closest('.qpanel .btn-go, .qpanel .gate-continue, .qpanel .gate-another, .qpanel .recovery-retry, .qpanel .recovery-pause');
     if (qbtn) {
       const card = qbtn.closest('.run-card');
       const runId = card && card.dataset.runId;
@@ -9444,7 +9452,7 @@ if (runListEl) {
       if (qbtn.classList.contains('gate-continue')) postAnswer(r, { decision: 'continue' });
       else if (qbtn.classList.contains('gate-another')) postAnswer(r, { decision: 'another' });
       else if (qbtn.classList.contains('recovery-retry')) postAnswer(r, { decision: 'retry' });
-      else if (qbtn.classList.contains('recovery-abort')) postAnswer(r, { decision: 'abort' });
+      else if (qbtn.classList.contains('recovery-pause')) postAnswer(r, { decision: 'pause' });
       else submitAnswer(r, qbtn.closest('.qpanel'));
     }
   });
@@ -10288,12 +10296,17 @@ const PAUSED_STATUSES = ['paused', 'pausing', 'interrupted'];
 // Disable a history Resume button while a total-budget pause is still blocked by
 // the current window. Shared by setupHdActions (first paint) and
 // refreshHistResumeGating (every later budget change).
-function applyHistResumeGate(btn, pauseReason, budget) {
+function applyHistResumeGate(btn, pauseReason, budget, pauseDetail = '') {
   const totalBlocked = pauseReason === 'cost_total' && !!(budget && budget.blocked);
   btn.disabled = totalBlocked;
-  btn.title = totalBlocked
-    ? `Total budget reached — blocked until ${fmtResetAtLocal(budget.windowEndMs)} or a higher total limit`
-    : '';
+  if (totalBlocked) {
+    btn.title = `Total budget reached — blocked until ${fmtResetAtLocal(budget.windowEndMs)} or a higher total limit`;
+  } else if (pauseReason === 'error') {
+    // An error pause is never gated — the tooltip carries the cause instead.
+    btn.title = `Paused after an error${pauseDetail ? `: ${pauseDetail}` : ''} — fix the cause, then resume`;
+  } else {
+    btn.title = '';
+  }
 }
 
 // Re-gate the mounted history Resume button from the dataset.pauseReason stamp
@@ -10312,7 +10325,7 @@ function refreshHistResumeGating() {
     // otherwise a `cost_total` block that lands later leaves the button enabled and
     // the user clicks into a guaranteed 403. Re-gate, then restore the D3 error
     // title when gating did not take the button away.
-    applyHistResumeGate(btn, root.dataset.pauseReason || '', budgetState.budget);
+    applyHistResumeGate(btn, root.dataset.pauseReason || '', budgetState.budget, root.dataset.pauseDetail || '');
     if (btn.dataset.resumeState === 'error' && btn.dataset.resumeError && !btn.disabled) {
       btn.title = btn.dataset.resumeError;
     }
@@ -10434,14 +10447,21 @@ function buildHistCard(projectDir, p, ghAvailable = false) {
   // Pause note. Resume + its budget gating live on the detail page now; the
   // dataset stamp survives for parity/debugging.
   const pauseReason = typeof p.pauseReason === 'string' ? p.pauseReason : '';
+  const pauseDetail = typeof p.pauseDetail === 'string' ? p.pauseDetail : '';
   if (pauseReason) node.dataset.pauseReason = pauseReason;
+  if (pauseDetail) node.dataset.pauseDetail = pauseDetail;
   const noteEl = node.querySelector('.hist-pausenote');
-  const costPaused = PAUSED_STATUSES.includes(String(p.status || '').toLowerCase())
-    && pauseReason.startsWith('cost_');
-  noteEl.hidden = !costPaused;
+  const parked = PAUSED_STATUSES.includes(String(p.status || '').toLowerCase());
+  const costPaused = parked && pauseReason.startsWith('cost_');
+  const errorPaused = parked && pauseReason === 'error';
+  noteEl.hidden = !(costPaused || errorPaused);
   noteEl.textContent = costPaused
-    ? (pauseReason === 'cost_total' ? 'paused · total budget' : 'paused · cost limit') : '';
+    ? (pauseReason === 'cost_total' ? 'paused · total budget' : 'paused · cost limit')
+    : (errorPaused ? 'paused · error' : '');
+  // The cause is too long for the caption line — it rides as the tooltip.
+  noteEl.title = errorPaused ? pauseDetail : '';
   noteEl.classList.toggle('total', costPaused && pauseReason === 'cost_total');
+  noteEl.classList.toggle('error', errorPaused);
 
   renderRetainedWork(node, p);           // badge only — the card has no banner node
   setupPrButton(node, projectDir, p, ghAvailable);
@@ -11466,14 +11486,44 @@ function hdRetainedFor(record, st) {
   return { retained: derived, provisional: true };
 }
 
+// Error-pause banner (D11): the cause, and the promise that nothing was discarded.
+function renderErrorPauseBanner(detail) {
+  const el = document.createElement('div');
+  el.className = 'pause-error-banner';
+  const b = document.createElement('b');
+  b.textContent = 'Paused after an error';
+  const text = document.createElement('div');
+  text.className = 'peb-text';
+  text.textContent = detail || 'The run hit an error it could not recover from.';
+  const hint = document.createElement('div');
+  hint.className = 'peb-hint';
+  hint.textContent = 'Nothing was discarded: the worktree and the run position are kept. Fix the cause, then Resume.';
+  el.append(b, text, hint);
+  return el;
+}
+
 function paintHdBanners(screen, record, data) {
   const st = data.state;
   const banners = screen.querySelector('.hd-banners');
 
-  // Cost-pause banner. pauseReason lives on LIST rows only (rowToState has none),
-  // so a deep link gets it late — rebuild idempotently instead of once.
-  const pauseReason = typeof record.pauseReason === 'string' ? record.pauseReason : '';
+  // Pause banners. The LIST row is authoritative, but a deep link has only the
+  // stub until the row lands — so fall back to the DETAIL payload, which now
+  // carries both keys too. Rebuild idempotently instead of once.
+  const pauseReason = typeof record.pauseReason === 'string' ? record.pauseReason
+    : (typeof st.pauseReason === 'string' ? st.pauseReason : '');
   if (pauseReason) screen.dataset.pauseReason = pauseReason; else delete screen.dataset.pauseReason;
+  const pauseDetail = typeof record.pauseDetail === 'string' ? record.pauseDetail
+    : (typeof st.pauseDetail === 'string' ? st.pauseDetail : '');
+  if (pauseDetail) screen.dataset.pauseDetail = pauseDetail; else delete screen.dataset.pauseDetail;
+  // Keyed on the detail so a corrected cause replaces the banner instead of stacking.
+  const wantErr = pauseReason === 'error' && HD_RESUMABLE.has(String(st.status || '').toLowerCase());
+  const oldErr = banners.querySelector('.pause-error-banner');
+  if (oldErr && (!wantErr || oldErr.dataset.detail !== pauseDetail)) oldErr.remove();
+  if (wantErr && !banners.querySelector('.pause-error-banner')) {
+    const errBanner = renderErrorPauseBanner(pauseDetail);
+    errBanner.dataset.detail = pauseDetail;
+    banners.prepend(errBanner);
+  }
   // Rebuild the cost banner ONLY when the reason actually changed. An
   // unconditional remove+rebuild detaches the `.cb-override` button mid-flight:
   // that click awaits confirmModal then resumePipeline, and ANY paintHistory()
@@ -11585,7 +11635,7 @@ function setupHdActions(screen, record, data) {
   const resumeBtn = screen.querySelector('.hd-resume');
   if (HD_RESUMABLE.has(status) && st.resumable !== false) {
     resumeBtn.hidden = false;
-    applyHistResumeGate(resumeBtn, screen.dataset.pauseReason || '', budgetState.budget);
+    applyHistResumeGate(resumeBtn, screen.dataset.pauseReason || '', budgetState.budget, screen.dataset.pauseDetail || '');
     resumeBtn.addEventListener('click', () => {
       const r = hdCurrentRecord(record);              // never the load-time object
       resumePipeline(r, r.projectDir || null, resumeBtn);
@@ -13486,6 +13536,14 @@ function rdStateCopy(r, stepName) {
   // line and the banner above the graph never disagree.
   if (r.pauseReason === 'cost_pipeline') return 'Paused — pipeline cost limit reached.';
   if (r.pauseReason === 'cost_total') return 'Paused — total budget reached.';
+  if (r.pauseReason === 'error') {
+    const why = r.pauseDetail ? `: ${r.pauseDetail}` : '';
+    return `Paused after an error${why}. Fix the cause, then Resume — the worktree and progress are kept.`;
+  }
+  if (r.pauseReason && (r.status === 'paused' || r.status === 'pausing' || r.status === 'interrupted')) {
+    // Any other reason is the orchestrator's own text (a session/usage-limit line).
+    return `Paused — ${r.pauseReason}. Resume once it clears.`;
+  }
   if (r.status === 'paused' || r.status === 'pausing' || r.status === 'interrupted') {
     return 'Paused by you. Agents in flight finished their checkpoint; nothing new is dispatched.';
   }
@@ -14274,10 +14332,12 @@ function statusPill(r) {
     // A cost pause names its cause so the pill alone explains why the run parked.
     if (r.pauseReason === 'cost_pipeline') return { family: 'amber', text: 'Paused · cost limit' };
     if (r.pauseReason === 'cost_total') return { family: 'amber', text: 'Paused · total budget' };
+    // An error pause is parked and resumable (never dead), so it stays in the amber family.
+    if (r.pauseReason === 'error') return { family: 'amber', text: 'Paused · error' };
     return { family: 'amber', text: 'Paused' };
   }
   // Same family as `paused`: an interrupted run is parked and resumable, and
-  // PAUSED_STATUSES (app.js:8726) already treats it that way.
+  // PAUSED_STATUSES (app.js:10286) already treats it that way.
   if (r.status === 'interrupted') return { family: 'amber', text: 'Interrupted' };
   if (r.pendingQuestion != null) return { family: 'amber', text: 'Paused · awaiting answers' };
   if (r.status === 'starting') return { family: 'peach', text: 'Starting' };
@@ -14857,9 +14917,14 @@ function paintRunCard(r) {
   const totalBlocked = r.pauseReason === 'cost_total' && budgetState.budget?.blocked;
   if (resumeBtn) {
     resumeBtn.disabled = !!totalBlocked;
-    resumeBtn.title = totalBlocked
-      ? `Total budget reached — blocked until ${fmtResetAtLocal(budgetState.budget.windowEndMs)} or a higher total limit`
-      : stockResumeTitle();
+    if (totalBlocked) {
+      resumeBtn.title = `Total budget reached — blocked until ${fmtResetAtLocal(budgetState.budget.windowEndMs)} or a higher total limit`;
+    } else if (r.pauseReason === 'error') {
+      // The cause the run parked on, so the card alone explains what to fix.
+      resumeBtn.title = `Paused after an error${r.pauseDetail ? `: ${r.pauseDetail}` : ''} — fix the cause, then resume`;
+    } else {
+      resumeBtn.title = stockResumeTitle();
+    }
   }
 }
 
@@ -15273,6 +15338,19 @@ function paintRdBanners(screen, r) {
     banners.prepend(fresh);                      // above the retained-work banner
   }
 
+  // ---- error-pause banner (D11) ----
+  // Same conditional-rebuild shape as paintHdBanners': keyed on the detail so a
+  // repaint neither stacks a second banner nor freezes a corrected cause.
+  const errPaused = isPaused(r) && r.pauseReason === 'error';
+  const errDetail = r.pauseDetail || '';
+  const oldErr = banners.querySelector('.pause-error-banner');
+  if (oldErr && (!errPaused || oldErr.dataset.detail !== errDetail)) oldErr.remove();
+  if (errPaused && !banners.querySelector('.pause-error-banner')) {
+    const errBanner = renderErrorPauseBanner(errDetail);
+    errBanner.dataset.detail = errDetail;
+    banners.prepend(errBanner);
+  }
+
   // ---- retained work (D11) ----
   // renderRetainedWork only READS `p.retainedWork`, so a derived carrier is fine
   // for the paint; every MUTATING helper below gets the same carrier so the
@@ -15319,12 +15397,12 @@ el.runDetail?.addEventListener('click', (e) => {
   if (override) { confirmCostOverride(r.runId, override); return; }   // async, fire-and-forget
   if (e.target.closest && e.target.closest('.cb-settings')) { location.hash = 'settings'; return; }
   const qbtn = e.target.closest && e.target.closest(
-    '.qpanel .btn-go, .qpanel .gate-continue, .qpanel .gate-another, .qpanel .recovery-retry, .qpanel .recovery-abort');
+    '.qpanel .btn-go, .qpanel .gate-continue, .qpanel .gate-another, .qpanel .recovery-retry, .qpanel .recovery-pause');
   if (!qbtn) return;
   if (qbtn.classList.contains('gate-continue')) postAnswer(r, { decision: 'continue' });
   else if (qbtn.classList.contains('gate-another')) postAnswer(r, { decision: 'another' });
   else if (qbtn.classList.contains('recovery-retry')) postAnswer(r, { decision: 'retry' });
-  else if (qbtn.classList.contains('recovery-abort')) postAnswer(r, { decision: 'abort' });
+  else if (qbtn.classList.contains('recovery-pause')) postAnswer(r, { decision: 'pause' });
   else submitAnswer(r, qbtn.closest('.qpanel'));
 });
 

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -10307,9 +10307,11 @@ function applyHistResumeGate(btn, pauseReason, budget, pauseDetail = '') {
   btn.disabled = totalBlocked;
   if (totalBlocked) {
     btn.title = `Total budget reached — blocked until ${fmtResetAtLocal(budget.windowEndMs)} or a higher total limit`;
-  } else if (pauseReason === 'error') {
+  } else if (pauseReason === 'error' || pauseReason === 'recoverable') {
     // An error pause is never gated — the tooltip carries the cause instead.
-    btn.title = `Paused after an error${pauseDetail ? `: ${pauseDetail}` : ''} — fix the cause, then resume`;
+    btn.title = pauseReason === 'recoverable'
+      ? `Paused on a recoverable error${pauseDetail ? `: ${pauseDetail}` : ''} — resume once it clears`
+      : `Paused after an error${pauseDetail ? `: ${pauseDetail}` : ''} — fix the cause, then resume`;
   } else {
     btn.title = '';
   }
@@ -10459,11 +10461,11 @@ function buildHistCard(projectDir, p, ghAvailable = false) {
   const noteEl = node.querySelector('.hist-pausenote');
   const parked = PAUSED_STATUSES.includes(String(p.status || '').toLowerCase());
   const costPaused = parked && pauseReason.startsWith('cost_');
-  const errorPaused = parked && pauseReason === 'error';
+  const errorPaused = parked && (pauseReason === 'error' || pauseReason === 'recoverable');
   noteEl.hidden = !(costPaused || errorPaused);
   noteEl.textContent = costPaused
     ? (pauseReason === 'cost_total' ? 'paused · total budget' : 'paused · cost limit')
-    : (errorPaused ? 'paused · error' : '');
+    : (errorPaused ? (pauseReason === 'recoverable' ? 'paused · recoverable' : 'paused · error') : '');
   // The cause is too long for the caption line — it rides as the tooltip.
   noteEl.title = errorPaused ? pauseDetail : '';
   noteEl.classList.toggle('total', costPaused && pauseReason === 'cost_total');
@@ -11493,17 +11495,21 @@ function hdRetainedFor(record, st) {
 }
 
 // Error-pause banner (D11): the cause, and the promise that nothing was discarded.
-function renderErrorPauseBanner(detail) {
+function renderErrorPauseBanner(detail, reason = 'error') {
+  const recoverable = reason === 'recoverable';
   const el = document.createElement('div');
   el.className = 'pause-error-banner';
+  el.dataset.reason = reason;
   const b = document.createElement('b');
-  b.textContent = 'Paused after an error';
+  b.textContent = recoverable ? 'Paused on a recoverable error' : 'Paused after an error';
   const text = document.createElement('div');
   text.className = 'peb-text';
   text.textContent = detail || 'The run hit an error it could not recover from.';
   const hint = document.createElement('div');
   hint.className = 'peb-hint';
-  hint.textContent = 'Nothing was discarded: the worktree and the run position are kept. Fix the cause, then Resume.';
+  hint.textContent = recoverable
+    ? 'The run could not reach the model and parked itself. Nothing was discarded — once the cause clears (re-login, connectivity, credit, a rate limit), Resume retries the step.'
+    : 'Nothing was discarded: the worktree and the run position are kept. Fix the cause, then Resume.';
   el.append(b, text, hint);
   return el;
 }
@@ -11522,11 +11528,11 @@ function paintHdBanners(screen, record, data) {
     : (typeof st.pauseDetail === 'string' ? st.pauseDetail : '');
   if (pauseDetail) screen.dataset.pauseDetail = pauseDetail; else delete screen.dataset.pauseDetail;
   // Keyed on the detail so a corrected cause replaces the banner instead of stacking.
-  const wantErr = pauseReason === 'error' && HD_RESUMABLE.has(String(st.status || '').toLowerCase());
+  const wantErr = (pauseReason === 'error' || pauseReason === 'recoverable') && HD_RESUMABLE.has(String(st.status || '').toLowerCase());
   const oldErr = banners.querySelector('.pause-error-banner');
-  if (oldErr && (!wantErr || oldErr.dataset.detail !== pauseDetail)) oldErr.remove();
+  if (oldErr && (!wantErr || oldErr.dataset.detail !== pauseDetail || oldErr.dataset.reason !== pauseReason)) oldErr.remove();
   if (wantErr && !banners.querySelector('.pause-error-banner')) {
-    const errBanner = renderErrorPauseBanner(pauseDetail);
+    const errBanner = renderErrorPauseBanner(pauseDetail, pauseReason);
     errBanner.dataset.detail = pauseDetail;
     banners.prepend(errBanner);
   }
@@ -13546,6 +13552,10 @@ function rdStateCopy(r, stepName) {
     const why = r.pauseDetail ? `: ${r.pauseDetail}` : '';
     return `Paused after an error${why}. Fix the cause, then Resume — the worktree and progress are kept.`;
   }
+  if (r.pauseReason === 'recoverable') {
+    const why = r.pauseDetail ? ` (${r.pauseDetail})` : '';
+    return `Paused on a recoverable error${why}. Once it clears, Resume retries the step — the worktree and progress are kept.`;
+  }
   if (r.pauseReason === 'usage_limit') {
     return `Paused — session/usage limit reached${r.pauseDetail ? ` (${r.pauseDetail})` : ''}. Resume after the reset.`;
   }
@@ -14343,6 +14353,7 @@ function statusPill(r) {
     if (r.pauseReason === 'cost_total') return { family: 'amber', text: 'Paused · total budget' };
     // An error pause is parked and resumable (never dead), so it stays in the amber family.
     if (r.pauseReason === 'error') return { family: 'amber', text: 'Paused · error' };
+    if (r.pauseReason === 'recoverable') return { family: 'amber', text: 'Paused · recoverable' };
     if (r.pauseReason === 'usage_limit') return { family: 'amber', text: 'Paused · usage limit' };
     return { family: 'amber', text: 'Paused' };
   }
@@ -14929,9 +14940,11 @@ function paintRunCard(r) {
     resumeBtn.disabled = !!totalBlocked;
     if (totalBlocked) {
       resumeBtn.title = `Total budget reached — blocked until ${fmtResetAtLocal(budgetState.budget.windowEndMs)} or a higher total limit`;
-    } else if (r.pauseReason === 'error') {
+    } else if (r.pauseReason === 'error' || r.pauseReason === 'recoverable') {
       // The cause the run parked on, so the card alone explains what to fix.
-      resumeBtn.title = `Paused after an error${r.pauseDetail ? `: ${r.pauseDetail}` : ''} — fix the cause, then resume`;
+      resumeBtn.title = r.pauseReason === 'recoverable'
+        ? `Paused on a recoverable error${r.pauseDetail ? `: ${r.pauseDetail}` : ''} — resume once it clears`
+        : `Paused after an error${r.pauseDetail ? `: ${r.pauseDetail}` : ''} — fix the cause, then resume`;
     } else {
       resumeBtn.title = stockResumeTitle();
     }
@@ -15351,7 +15364,7 @@ function paintRdBanners(screen, r) {
   // ---- error-pause banner (D11) ----
   // Same conditional-rebuild shape as paintHdBanners': keyed on the detail so a
   // repaint neither stacks a second banner nor freezes a corrected cause.
-  const errPaused = isPaused(r) && r.pauseReason === 'error';
+  const errPaused = isPaused(r) && (r.pauseReason === 'error' || r.pauseReason === 'recoverable');
   const errDetail = r.pauseDetail || '';
   const oldErr = banners.querySelector('.pause-error-banner');
   if (oldErr && (!errPaused || oldErr.dataset.detail !== errDetail)) oldErr.remove();

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -4078,11 +4078,16 @@ function renderRecoveryBody(r, panel, pq) {
 
   const foot = document.createElement('div');
   foot.className = 'qpanel-foot gate-actions';
+  // The give-up option comes from the failure policy's row (options ride the
+  // prompt): 'pause' parks the run, 'abort' ends it. Older payloads carry none.
+  const giveUp = (Array.isArray(rec.options) && rec.options.find((o) => o && o.id !== 'retry')) || { id: 'pause' };
   const pause = document.createElement('button');
   pause.type = 'button';
-  pause.className = 'btn recovery-pause';
-  pause.textContent = 'Pause run';
-  pause.title = 'Park the run here with this error as the reason. Nothing is discarded — Resume retries the step later.';
+  pause.className = giveUp.id === 'abort' ? 'btn recovery-abort' : 'btn recovery-pause';
+  pause.textContent = giveUp.id === 'abort' ? 'Abort run' : 'Pause run';
+  pause.title = giveUp.id === 'abort'
+    ? 'End the run here with this error. The worktree is torn down.'
+    : 'Park the run here with this error as the reason. Nothing is discarded — Resume retries the step later.';
   const retry = document.createElement('button');
   retry.type = 'button';
   retry.className = 'btn btn-primary recovery-retry';
@@ -9443,7 +9448,7 @@ if (runListEl) {
 
     // qpanel actions. Resolve the run per-card via the enclosing .run-card so
     // delegation works for any dynamically-built card.
-    const qbtn = e.target.closest && e.target.closest('.qpanel .btn-go, .qpanel .gate-continue, .qpanel .gate-another, .qpanel .recovery-retry, .qpanel .recovery-pause');
+    const qbtn = e.target.closest && e.target.closest('.qpanel .btn-go, .qpanel .gate-continue, .qpanel .gate-another, .qpanel .recovery-retry, .qpanel .recovery-pause, .qpanel .recovery-abort');
     if (qbtn) {
       const card = qbtn.closest('.run-card');
       const runId = card && card.dataset.runId;
@@ -9453,6 +9458,7 @@ if (runListEl) {
       else if (qbtn.classList.contains('gate-another')) postAnswer(r, { decision: 'another' });
       else if (qbtn.classList.contains('recovery-retry')) postAnswer(r, { decision: 'retry' });
       else if (qbtn.classList.contains('recovery-pause')) postAnswer(r, { decision: 'pause' });
+      else if (qbtn.classList.contains('recovery-abort')) postAnswer(r, { decision: 'abort' });
       else submitAnswer(r, qbtn.closest('.qpanel'));
     }
   });
@@ -13540,8 +13546,11 @@ function rdStateCopy(r, stepName) {
     const why = r.pauseDetail ? `: ${r.pauseDetail}` : '';
     return `Paused after an error${why}. Fix the cause, then Resume — the worktree and progress are kept.`;
   }
+  if (r.pauseReason === 'usage_limit') {
+    return `Paused — session/usage limit reached${r.pauseDetail ? ` (${r.pauseDetail})` : ''}. Resume after the reset.`;
+  }
   if (r.pauseReason && (r.status === 'paused' || r.status === 'pausing' || r.status === 'interrupted')) {
-    // Any other reason is the orchestrator's own text (a session/usage-limit line).
+    // A legacy reason is the orchestrator's own text (a pre-policy session/usage-limit line).
     return `Paused — ${r.pauseReason}. Resume once it clears.`;
   }
   if (r.status === 'paused' || r.status === 'pausing' || r.status === 'interrupted') {
@@ -14334,6 +14343,7 @@ function statusPill(r) {
     if (r.pauseReason === 'cost_total') return { family: 'amber', text: 'Paused · total budget' };
     // An error pause is parked and resumable (never dead), so it stays in the amber family.
     if (r.pauseReason === 'error') return { family: 'amber', text: 'Paused · error' };
+    if (r.pauseReason === 'usage_limit') return { family: 'amber', text: 'Paused · usage limit' };
     return { family: 'amber', text: 'Paused' };
   }
   // Same family as `paused`: an interrupted run is parked and resumable, and
@@ -15397,12 +15407,13 @@ el.runDetail?.addEventListener('click', (e) => {
   if (override) { confirmCostOverride(r.runId, override); return; }   // async, fire-and-forget
   if (e.target.closest && e.target.closest('.cb-settings')) { location.hash = 'settings'; return; }
   const qbtn = e.target.closest && e.target.closest(
-    '.qpanel .btn-go, .qpanel .gate-continue, .qpanel .gate-another, .qpanel .recovery-retry, .qpanel .recovery-pause');
+    '.qpanel .btn-go, .qpanel .gate-continue, .qpanel .gate-another, .qpanel .recovery-retry, .qpanel .recovery-pause, .qpanel .recovery-abort');
   if (!qbtn) return;
   if (qbtn.classList.contains('gate-continue')) postAnswer(r, { decision: 'continue' });
   else if (qbtn.classList.contains('gate-another')) postAnswer(r, { decision: 'another' });
   else if (qbtn.classList.contains('recovery-retry')) postAnswer(r, { decision: 'retry' });
   else if (qbtn.classList.contains('recovery-pause')) postAnswer(r, { decision: 'pause' });
+  else if (qbtn.classList.contains('recovery-abort')) postAnswer(r, { decision: 'abort' });
   else submitAnswer(r, qbtn.closest('.qpanel'));
 });
 

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1551,6 +1551,12 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
    In the v2 card it is a direct child of .h-meta on its own line. */
 .hist-pausenote{font-size:11.5px;font-weight:600;color:var(--amber-ink);}
 .hist-pausenote.total{color:var(--red-ink);}
+.hist-pausenote.error{color:var(--red-ink);}
+.pause-error-banner{border-radius:var(--r-ctrl);padding:12px 14px;margin-top:12px;font-size:13px;background:var(--red-bg);color:var(--red-ink);}
+.pause-error-banner b{display:block;margin-bottom:4px;}
+.pause-error-banner .peb-text{color:var(--ink);font-family:var(--mono);font-size:12px;word-break:break-word;}
+.pause-error-banner .peb-hint{color:var(--ink-2);margin-top:6px;}
+.hd-banners .pause-error-banner,.rd-banners .pause-error-banner{align-self:stretch;margin:0;}
 
 @media (max-width:1080px){
   .stat-row{grid-template-columns:repeat(2,1fr);}

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -484,6 +484,9 @@ function summarizeRuns() {
     // 'cost_pipeline'/'cost_total') instead of showing a plain "Paused" card
     // until the next event.
     pauseReason: r.pauseReason || null,
+    // The clipped failure message behind reason 'error', or null — so a
+    // reload/reconnect restores the "Paused · error" detail, not a bare card.
+    pauseDetail: r.pauseDetail || null,
     startedAt: r.startedAt,
     pendingQuestion: r.pendingQuestion || null,
     // kind discriminator so the client routes runs vs scans vs agent generations
@@ -564,14 +567,21 @@ function wireRun(entry) {
         // Remember the pause reason for summarizeRuns (hello). Reset on every
         // done so a later reasonless finish cannot leave a stale cost banner.
         entry.pauseReason = (payload && payload.reason) || null;
+        // ...and WHAT went wrong for an error-pause, reset alongside it.
+        entry.pauseDetail = (payload && payload.detail) || null;
         resolvePending(entry, { reason: entry.status });
         if (payload?.reason === 'cost_pipeline' || payload?.reason === 'cost_total') {
           emitChanged('budget-changed');
         }
       }
       if (name === 'error') {
-        entry.status = 'error';
-        resolvePending(entry, { reason: 'error' });
+        // The launch-error channel (a failure BEFORE the pipeline row exists). A
+        // converted in-run failure pauses and emits no 'error'; never let a stray
+        // one demote a parked run.
+        if (entry.status !== 'paused' && entry.status !== 'pausing') {
+          entry.status = 'error';
+          resolvePending(entry, { reason: 'error' });
+        }
       }
       if (name === 'exec') {
         entry.status = 'running';


### PR DESCRIPTION
## What this PR does

Changes the run's error policy from **"errors end the run"** to **"errors pause the run; only the user's Stop ends it"** — and puts every pause-vs-error decision in ONE table so any case can be shifted later with a one-cell edit.

### The failure-policy matrix (`src/core/failure-policy.mjs`)

Every site that can see a failure — the per-node retry loop, the flow dispatcher, the budget gate, run()/resume()'s setup and shell catch blocks, resume()'s rehydration — asks `resolveFailure({ site, cls, auto, attempt, answer })` for a verdict (`retry` | `prompt` | `pause` + reason | `error`) and then only *enacts* it. No site decides on its own. `test/failure-policy.test.mjs` has one test per cell and is the review surface for a policy shift.

| Site | Class | Auto (`--yes`) | Interactive |
|---|---|---|---|
| node | usage_limit | pause `usage_limit` | pause `usage_limit` |
| node | auth, quota | pause `recoverable` on the first hit | prompt; Retry / give up → pause `error` |
| node | network, rate_limit | retry ×3 → pause `recoverable` | prompt; Retry / give up → pause `error` |
| node | unclassified | pause `error` | pause `error` |
| flow (flow cards, questions loop, composite shell) | any | pause `error` | pause `error` |
| budget | cost_pipeline / cost_total | pause with the cost code | same |
| setup (checkout, graph, skills gate) | any | pause `error` + setup replay on resume | same |
| launch (no pipeline row yet) | any | error | error |
| shell (escaped the engine) | any | pause `error` | pause `error` |
| resume (could not rehydrate: checkout gone, run.json corrupt) | any | error | error |

Two contested cells are documented in the module header for a one-line flip: unclassified node errors pause (flip to `error()` to make a bug end the run), and the interactive give-up option pauses (flip to `prompt(error())` to offer Abort as a terminal error).

A verdict is issued once: a terminal error is stamped (`markTerminal`) so enclosing catch blocks enact it instead of re-deciding at their own site.

### Reasons and their consequences

Pause reasons are a closed set — `usage_limit`, `recoverable`, `error`, `cost_pipeline`, `cost_total` — with the human text in a new `pauseDetail` (persisted in the resume point, exposed on list/detail/state payloads). `pauseConsequences(reason)` drives what each surface does with a parked run instead of ad hoc string checks: task-source write-back (`needs-human` for every forced pause), the staged diff artifact (error-pauses only), chat severity and notification preference, and the CLI exit code.

### Engine

- One mechanism, `RunHarness._pauseFor(reason, err, ctx)`, behind every forced pause (replaces `_pauseForLimit` / `_pauseForError` / `_pauseForCost` / `_pauseForRecoverable`). The worktree, checkpoint refs and run position are kept; Resume retries the failed step.
- Setup failures pause with a `setupIncomplete` stamp; resume replays whatever setup never finished, closes the preflight bookend and kicks off the title generation.
- A pause raised inside a composite expansion settles the shell with its expands binding intact, so the resume re-runs the whole fan-out.
- An un-rehydratable resume (the `resume` site) ends the run instead of re-parking the same dead point on every attempt.
- The recovery prompt carries the row's options; the give-up option's id is the wire decision (`pause` today; `abort` still accepted as a legacy value).

### Surfaces

- **CLI**: the recovery prompt renders the row's options; a pause prints its reason and cause. Exit codes: `0` done or an interactive user/limit pause; `1` a terminal error or an interactive error-pause; `2` usage error; `3` any `--yes` pause (the run parked itself with nobody attached). Documented in the README.
- **Web UI**: Pause/Abort button on the recovery panel from the row's option, error and recoverable banners on Running/History with the detail, `paused · error` / `paused · recoverable` / `paused · usage limit` badges, resume-button tooltips with the cause.
- **Chat/notifier**: pauses render with the reason's label, severity and gate; `/abort` on a recovery prompt gives up; `/status` shows the reason label and the cause.

### Relationship to #412

Merged dev (with #412) in and kept #412's decisions where the two disagreed: auth/quota pause on the first hit in auto mode, machine-readable reasons, exit 3 for a self-parked `--yes` run, every forced pause reports to the task source.

### CI

Two hardenings of the headless-Chrome proof scripts, both flaking on dev too: a 60s deadline for the first DevTools target, and a two-wheel probe (Chrome latches a wheel sequence non-cancelable after an uncancelled first wheel).

Design note: https://claude.ai/code/artifact/7b1b6fb6-73fe-45c0-9df7-598a54d3a824

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxExPpCSCs6j5JnPzD5v6g
