### PR TITLE
Add Spawn-Debug Logging Toggle

### DIFF
--- a/src/core/claude-runner.mjs
+++ b/src/core/claude-runner.mjs
@@ -35,6 +35,7 @@
 import { spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import { prepareModelEnv, envFlag, describeModelEnv } from './model-env.mjs';
+import { effectiveDebugSpawn } from './settings.mjs';
 import { classifyError, strongestClass } from './recoverable-error.mjs';
 import { explainUnspawnableClaude, resolveClaudeBin } from './preflight.mjs';
 import { writeFile, mkdir, appendFile, readFile, access } from 'node:fs/promises';
@@ -175,17 +176,21 @@ export function subagentHooksEnabled() {
 }
 
 /**
- * Opt-in spawn diagnostics (WORCA_DEBUG_SPAWN), DEFAULT OFF (envFlag rule: any
- * value but "", "0", "false" turns it on). OFF ⇒ runReal emits NO spawn-debug
- * event and does not touch argv/env, so the spawn path is byte-identical to
- * today. (The once-per-process "routing env applied" confirmation below is a
- * separate, always-on line: it fires only for a model env that carries an
- * ANTHROPIC_* routing key, once per distinct model + env, never per spawn.)
- * Read directly in runReal (not a runClaude option) so it bypasses the
- * runClaude→runReal gate by construction.
+ * Opt-in spawn diagnostics, DEFAULT OFF. A NON-EMPTY WORCA_DEBUG_SPAWN in the
+ * environment wins (envFlag rule: any value but "0"/"false" turns it on, so an
+ * exported "0" is an explicit OFF); otherwise the stored `debugSpawnEnabled`
+ * setting applies — read fresh per spawn (settings.mjs#effectiveDebugSpawn, the
+ * one precedence rule the settings API also reports), so the UI checkbox reaches
+ * the next spawn in this process AND in a CLI run with no restart and no env
+ * mutation. OFF ⇒ runReal emits NO spawn-debug event and does not touch
+ * argv/env, so the spawn path is byte-identical to today. (The once-per-process
+ * "routing env applied" confirmation below is a separate, always-on line: it
+ * fires only for a model env that carries an ANTHROPIC_* routing key, once per
+ * distinct model + env, never per spawn.) Read directly in runReal (not a
+ * runClaude option) so it bypasses the runClaude→runReal gate by construction.
  */
 export function debugSpawnEnabled() {
-  return envFlag('WORCA_DEBUG_SPAWN');
+  return effectiveDebugSpawn().enabled;
 }
 
 /** Once per process per distinct (model, described env): see runReal. */

--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -11,6 +11,14 @@
 //   contextMaxBytesPerFile — §5.4 per-source-file inlining cap.
 //   contextMaxBytesTotal   — §5.4 total memory budget.
 //   skillMount             — §5.6 'copy' (default) | 'symlink' (opt-in).
+//   debugSpawnEnabled      — mirrors WORCA_DEBUG_SPAWN into a UI checkbox. Setting it
+//                            writes process.env.WORCA_DEBUG_SPAWN directly so
+//                            claude-runner.mjs's live env read picks it up on the very
+//                            next spawn — no restart, no import of this module by
+//                            claude-runner.mjs. An env var already set at worca launch
+//                            wins over the stored value at boot (see
+//                            applyDebugSpawnEnvFromSettings below); an explicit UI save
+//                            always overwrites process.env regardless.
 //   pipelineCostLimitUsd   — per-pipeline lifetime USD spend cap; unset = no limit.
 //   totalCostLimitUsd      — windowed all-pipelines USD spend cap; unset = no limit.
 //   costLimitResetPeriod   — total-budget window, 'weekly' | 'monthly' (default).
@@ -524,6 +532,55 @@ export async function setCostLimitResetPeriod(input) {
   else settings.costLimitResetPeriod = input;
   await persistSettings(settings);
   return { costLimitResetPeriod: costLimitResetPeriod() };
+}
+
+// ── Spawn-debug diagnostics toggle (UI-settable mirror of WORCA_DEBUG_SPAWN) ─
+// claude-runner.mjs's debugSpawnEnabled() reads process.env.WORCA_DEBUG_SPAWN fresh on
+// every spawn (not memoized), so this module does not need to be imported by
+// claude-runner.mjs at all — it only needs to WRITE that one env var. Reading it back
+// here (this debugSpawnEnabled()) is for the settings/UI layer only: "what's stored",
+// not "what's effective right now" (an env var exported before worca started can
+// diverge from the stored value — see applyDebugSpawnEnvFromSettings).
+export const DEFAULT_DEBUG_SPAWN_ENABLED = false;
+
+const isBool = (v) => typeof v === 'boolean';
+
+/** Stored spawn-debug preference: boolean, default OFF. Invalid stored value ⇒ OFF (loudly). */
+export function debugSpawnEnabled() {
+  const v = readSettings().debugSpawnEnabled;
+  if (v === undefined) return DEFAULT_DEBUG_SPAWN_ENABLED;
+  if (isBool(v)) return v;
+  console.warn(`[worca] invalid debugSpawnEnabled ${JSON.stringify(v)} — using the default (${DEFAULT_DEBUG_SPAWN_ENABLED})`);
+  return DEFAULT_DEBUG_SPAWN_ENABLED;
+}
+
+/**
+ * Persist the preference AND flip process.env.WORCA_DEBUG_SPAWN to match, in this
+ * process, right now — that's what makes the change take effect on the very next
+ * spawn with no restart. Always overwrites process.env, even if a launch-time env var
+ * was already present: an explicit UI save is a later, more specific instruction than
+ * whatever was exported before worca started.
+ * @throws {Error} unless `input` is a boolean.
+ */
+export async function setDebugSpawnEnabled(input) {
+  if (!isBool(input)) throw new Error('debugSpawnEnabled must be true or false');
+  const settings = readSettings();
+  if (input === DEFAULT_DEBUG_SPAWN_ENABLED) delete settings.debugSpawnEnabled;
+  else settings.debugSpawnEnabled = input;
+  await persistSettings(settings);
+  process.env.WORCA_DEBUG_SPAWN = input ? '1' : '0';
+  return { debugSpawnEnabled: debugSpawnEnabled() };
+}
+
+/**
+ * Boot-time only: apply the stored preference to process.env.WORCA_DEBUG_SPAWN UNLESS
+ * an explicit value is already present in the environment (power-user override at
+ * launch wins — the stored setting must not clobber it). Call once, before the server
+ * starts accepting spawns.
+ */
+export function applyDebugSpawnEnvFromSettings() {
+  if (process.env.WORCA_DEBUG_SPAWN !== undefined) return;
+  process.env.WORCA_DEBUG_SPAWN = debugSpawnEnabled() ? '1' : '0';
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -11,14 +11,12 @@
 //   contextMaxBytesPerFile — §5.4 per-source-file inlining cap.
 //   contextMaxBytesTotal   — §5.4 total memory budget.
 //   skillMount             — §5.6 'copy' (default) | 'symlink' (opt-in).
-//   debugSpawnEnabled      — mirrors WORCA_DEBUG_SPAWN into a UI checkbox. Setting it
-//                            writes process.env.WORCA_DEBUG_SPAWN directly so
-//                            claude-runner.mjs's live env read picks it up on the very
-//                            next spawn — no restart, no import of this module by
-//                            claude-runner.mjs. An env var already set at worca launch
-//                            wins over the stored value at boot (see
-//                            applyDebugSpawnEnvFromSettings below); an explicit UI save
-//                            always overwrites process.env regardless.
+//   debugSpawnEnabled      — the stored spawn-diagnostics preference (a UI checkbox).
+//                            claude-runner.mjs reads it fresh on every spawn through
+//                            effectiveDebugSpawn(), so it applies to the UI server AND
+//                            to CLI runs with no restart. A NON-EMPTY WORCA_DEBUG_SPAWN
+//                            in the process environment overrides it (power-user
+//                            override); this module never writes process.env.
 //   pipelineCostLimitUsd   — per-pipeline lifetime USD spend cap; unset = no limit.
 //   totalCostLimitUsd      — windowed all-pipelines USD spend cap; unset = no limit.
 //   costLimitResetPeriod   — total-budget window, 'weekly' | 'monthly' (default).
@@ -50,7 +48,7 @@ import { readFileSync, existsSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-import { EFFORTS, isReservedModelEnvKey, assertModelCost } from './model-env.mjs';
+import { EFFORTS, isReservedModelEnvKey, assertModelCost, envFlag } from './model-env.mjs';
 
 /**
  * The real OS home base, honoring HOME/USERPROFILE so tests can sandbox it.
@@ -534,18 +532,37 @@ export async function setCostLimitResetPeriod(input) {
   return { costLimitResetPeriod: costLimitResetPeriod() };
 }
 
-// ── Spawn-debug diagnostics toggle (UI-settable mirror of WORCA_DEBUG_SPAWN) ─
-// claude-runner.mjs's debugSpawnEnabled() reads process.env.WORCA_DEBUG_SPAWN fresh on
-// every spawn (not memoized), so this module does not need to be imported by
-// claude-runner.mjs at all — it only needs to WRITE that one env var. Reading it back
-// here (this debugSpawnEnabled()) is for the settings/UI layer only: "what's stored",
-// not "what's effective right now" (an env var exported before worca started can
-// diverge from the stored value — see applyDebugSpawnEnvFromSettings).
+// ── The keys POST /api/settings understands ──────────────────────────────────
+// The route keeps a legacy contract: a body naming NONE of these clears root
+// (test/settings-projects-root.test.mjs "a bodyless POST resets root"). Every
+// setter's key is listed HERE, beside the setters, so a new key cannot forget
+// to join a hand-maintained exclusion list in the route and wipe the root on
+// its first save.
+export const SETTINGS_POST_KEYS = Object.freeze([
+  'root', 'projectsRoot', 'chat',
+  'pipelineCostLimitUsd', 'totalCostLimitUsd', 'costLimitResetPeriod',
+  'askMaxTurns', 'askMaxBudgetUsd',
+  'debugSpawnEnabled',
+]);
+
+// ── Spawn-debug diagnostics toggle (the stored side of WORCA_DEBUG_SPAWN) ────
+// Like every other stored setting (skillMount, the cost caps, the ask caps) this
+// is READ AT USE TIME: claude-runner.mjs#debugSpawnEnabled calls
+// effectiveDebugSpawn() on every spawn, so a UI save reaches the very next spawn
+// in this process and in any CLI process with no restart, and nothing here ever
+// mutates process.env (a runtime env write would leak an explicit
+// WORCA_DEBUG_SPAWN=0 into every inherited child env and break the runner's
+// "OFF ⇒ byte-identical spawn env" invariant).
 export const DEFAULT_DEBUG_SPAWN_ENABLED = false;
 
 const isBool = (v) => typeof v === 'boolean';
 
-/** Stored spawn-debug preference: boolean, default OFF. Invalid stored value ⇒ OFF (loudly). */
+/** @throws {Error} unless `input` is a boolean (the route and the setter share this). */
+export function assertDebugSpawnInput(input) {
+  if (!isBool(input)) throw new Error('debugSpawnEnabled must be true or false');
+}
+
+/** STORED spawn-debug preference: boolean, default OFF. Invalid stored value ⇒ OFF (loudly). */
 export function debugSpawnEnabled() {
   const v = readSettings().debugSpawnEnabled;
   if (v === undefined) return DEFAULT_DEBUG_SPAWN_ENABLED;
@@ -555,32 +572,33 @@ export function debugSpawnEnabled() {
 }
 
 /**
- * Persist the preference AND flip process.env.WORCA_DEBUG_SPAWN to match, in this
- * process, right now — that's what makes the change take effect on the very next
- * spawn with no restart. Always overwrites process.env, even if a launch-time env var
- * was already present: an explicit UI save is a later, more specific instruction than
- * whatever was exported before worca started.
+ * What the runner will actually do on the next spawn, and why. ONE precedence
+ * rule, shared by the runner gate and the settings API: a NON-EMPTY
+ * WORCA_DEBUG_SPAWN in the environment wins (parsed with the envFlag rule, so an
+ * exported "0"/"false" is an explicit OFF override), otherwise the stored
+ * preference applies. An empty export (`export WORCA_DEBUG_SPAWN=` in a profile
+ * or a dotenv template) is NOT an override — the runner would read it as OFF
+ * while the UI showed the stored value checked, with nothing explaining why.
+ * @returns {{enabled: boolean, source: 'env'|'settings'}}
+ */
+export function effectiveDebugSpawn() {
+  const v = process.env.WORCA_DEBUG_SPAWN;
+  if (v !== undefined && v !== '') return { enabled: envFlag('WORCA_DEBUG_SPAWN'), source: 'env' };
+  return { enabled: debugSpawnEnabled(), source: 'settings' };
+}
+
+/**
+ * Persist the preference. Nothing else: the runner reads it back per spawn, so
+ * the change is live everywhere without touching this process's environment.
  * @throws {Error} unless `input` is a boolean.
  */
 export async function setDebugSpawnEnabled(input) {
-  if (!isBool(input)) throw new Error('debugSpawnEnabled must be true or false');
+  assertDebugSpawnInput(input);
   const settings = readSettings();
   if (input === DEFAULT_DEBUG_SPAWN_ENABLED) delete settings.debugSpawnEnabled;
   else settings.debugSpawnEnabled = input;
   await persistSettings(settings);
-  process.env.WORCA_DEBUG_SPAWN = input ? '1' : '0';
   return { debugSpawnEnabled: debugSpawnEnabled() };
-}
-
-/**
- * Boot-time only: apply the stored preference to process.env.WORCA_DEBUG_SPAWN UNLESS
- * an explicit value is already present in the environment (power-user override at
- * launch wins — the stored setting must not clobber it). Call once, before the server
- * starts accepting spawns.
- */
-export function applyDebugSpawnEnvFromSettings() {
-  if (process.env.WORCA_DEBUG_SPAWN !== undefined) return;
-  process.env.WORCA_DEBUG_SPAWN = debugSpawnEnabled() ? '1' : '0';
 }
 
 // ---------------------------------------------------------------------------

--- a/test/debug-spawn-settings.test.mjs
+++ b/test/debug-spawn-settings.test.mjs
@@ -1,0 +1,108 @@
+// test/debug-spawn-settings.test.mjs
+import { test, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  settingsFile, debugSpawnEnabled, setDebugSpawnEnabled,
+  applyDebugSpawnEnvFromSettings, DEFAULT_DEBUG_SPAWN_ENABLED,
+} from '../src/core/settings.mjs';
+import { debugSpawnEnabled as gateEnabled } from '../src/core/claude-runner.mjs';
+
+let home, prevHome, prevProfile, prevGate;
+
+before(async () => {
+  home = await mkdtemp(join(tmpdir(), 'worca-debug-spawn-'));
+  prevHome = process.env.HOME; prevProfile = process.env.USERPROFILE;
+  process.env.HOME = home; process.env.USERPROFILE = home;
+});
+beforeEach(async () => {
+  await mkdir(join(home, '.worca-cc'), { recursive: true });
+  await writeFile(settingsFile(), '{}\n', 'utf8');
+});
+after(async () => {
+  if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+  if (prevProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevProfile;
+  await rm(home, { recursive: true, force: true });
+});
+
+test('missing setting reads as OFF (default)', () => {
+  assert.equal(debugSpawnEnabled(), false);
+  assert.equal(DEFAULT_DEBUG_SPAWN_ENABLED, false);
+});
+
+test('corrupt settings.json falls back to OFF, never throws', async () => {
+  await writeFile(settingsFile(), '{ not json', 'utf8');
+  assert.equal(debugSpawnEnabled(), false);
+});
+
+test('corrupt stored value (non-boolean) falls back to OFF loudly', async () => {
+  await writeFile(settingsFile(), JSON.stringify({ debugSpawnEnabled: 'yes' }), 'utf8');
+  const realWarn = console.warn; const warnings = [];
+  console.warn = (...a) => warnings.push(a.join(' '));
+  try { assert.equal(debugSpawnEnabled(), false); } finally { console.warn = realWarn; }
+  assert.ok(warnings.some((w) => /debugSpawnEnabled/.test(w)));
+});
+
+test('setter round-trips true/false and returns the effective value', async () => {
+  assert.deepEqual(await setDebugSpawnEnabled(true), { debugSpawnEnabled: true });
+  assert.equal(debugSpawnEnabled(), true);
+  assert.deepEqual(await setDebugSpawnEnabled(false), { debugSpawnEnabled: false });
+  assert.equal(debugSpawnEnabled(), false);
+});
+
+test('setter rejects non-boolean input and persists nothing', async () => {
+  await assert.rejects(() => setDebugSpawnEnabled('true'), /must be true or false/);
+  const raw = JSON.parse(await readFile(settingsFile(), 'utf8'));
+  assert.equal('debugSpawnEnabled' in raw, false);
+});
+
+test('unknown keys survive a setter write (read-modify-write)', async () => {
+  await writeFile(settingsFile(), JSON.stringify({ someFutureKey: 42 }), 'utf8');
+  await setDebugSpawnEnabled(true);
+  const raw = JSON.parse(await readFile(settingsFile(), 'utf8'));
+  assert.equal(raw.someFutureKey, 42);
+  assert.equal(raw.debugSpawnEnabled, true);
+});
+
+test('saving the setting flips process.env so claude-runner\'s live gate changes with no restart', async () => {
+  prevGate = process.env.WORCA_DEBUG_SPAWN;
+  try {
+    delete process.env.WORCA_DEBUG_SPAWN;
+    assert.equal(gateEnabled(), false, 'sanity: unset env is off');
+    await setDebugSpawnEnabled(true);
+    assert.equal(gateEnabled(), true, 'flips on with no restart');
+    await setDebugSpawnEnabled(false);
+    assert.equal(gateEnabled(), false, 'flips back off with no restart');
+  } finally {
+    if (prevGate === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prevGate;
+  }
+});
+
+test('applyDebugSpawnEnvFromSettings: an env var already set at launch is NOT overwritten', async () => {
+  prevGate = process.env.WORCA_DEBUG_SPAWN;
+  try {
+    process.env.WORCA_DEBUG_SPAWN = '1'; // "set at launch"
+    await setDebugSpawnEnabled(false);   // stored preference disagrees
+    // Simulate a fresh process by re-reading only the stored value's effect:
+    process.env.WORCA_DEBUG_SPAWN = '1'; // re-assert the launch-time value the real boot would see
+    applyDebugSpawnEnvFromSettings();
+    assert.equal(process.env.WORCA_DEBUG_SPAWN, '1', 'launch override wins, stored OFF is not applied');
+  } finally {
+    if (prevGate === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prevGate;
+  }
+});
+
+test('applyDebugSpawnEnvFromSettings: applies the stored setting when no launch env is present', async () => {
+  prevGate = process.env.WORCA_DEBUG_SPAWN;
+  try {
+    delete process.env.WORCA_DEBUG_SPAWN;
+    await setDebugSpawnEnabled(true);
+    delete process.env.WORCA_DEBUG_SPAWN; // undo the setter's own env write to isolate the boot helper
+    applyDebugSpawnEnvFromSettings();
+    assert.equal(process.env.WORCA_DEBUG_SPAWN, '1');
+  } finally {
+    if (prevGate === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prevGate;
+  }
+});

--- a/test/debug-spawn-settings.test.mjs
+++ b/test/debug-spawn-settings.test.mjs
@@ -1,12 +1,16 @@
 // test/debug-spawn-settings.test.mjs
+// The stored spawn-diagnostics preference and the ONE precedence rule the runner
+// gate and the settings API share (settings.mjs#effectiveDebugSpawn): a non-empty
+// WORCA_DEBUG_SPAWN wins, otherwise the stored value applies. The setter persists
+// only — it never writes process.env.
 import { test, before, beforeEach, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  settingsFile, debugSpawnEnabled, setDebugSpawnEnabled,
-  applyDebugSpawnEnvFromSettings, DEFAULT_DEBUG_SPAWN_ENABLED,
+  settingsFile, debugSpawnEnabled, setDebugSpawnEnabled, effectiveDebugSpawn,
+  assertDebugSpawnInput, DEFAULT_DEBUG_SPAWN_ENABLED,
 } from '../src/core/settings.mjs';
 import { debugSpawnEnabled as gateEnabled } from '../src/core/claude-runner.mjs';
 
@@ -14,18 +18,28 @@ let home, prevHome, prevProfile, prevGate;
 
 before(async () => {
   home = await mkdtemp(join(tmpdir(), 'worca-debug-spawn-'));
-  prevHome = process.env.HOME; prevProfile = process.env.USERPROFILE;
+  prevHome = process.env.HOME; prevProfile = process.env.USERPROFILE; prevGate = process.env.WORCA_DEBUG_SPAWN;
   process.env.HOME = home; process.env.USERPROFILE = home;
 });
 beforeEach(async () => {
+  delete process.env.WORCA_DEBUG_SPAWN;            // every test starts with no env override
   await mkdir(join(home, '.worca-cc'), { recursive: true });
   await writeFile(settingsFile(), '{}\n', 'utf8');
 });
 after(async () => {
   if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
   if (prevProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevProfile;
+  if (prevGate === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prevGate;
   await rm(home, { recursive: true, force: true });
 });
+
+/** Run `fn` with WORCA_DEBUG_SPAWN set to `value` (undefined = unset), restoring after. */
+async function withGate(value, fn) {
+  const prev = process.env.WORCA_DEBUG_SPAWN;
+  if (value === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = value;
+  try { return await fn(); }
+  finally { if (prev === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prev; }
+}
 
 test('missing setting reads as OFF (default)', () => {
   assert.equal(debugSpawnEnabled(), false);
@@ -45,17 +59,25 @@ test('corrupt stored value (non-boolean) falls back to OFF loudly', async () => 
   assert.ok(warnings.some((w) => /debugSpawnEnabled/.test(w)));
 });
 
-test('setter round-trips true/false and returns the effective value', async () => {
+test('setter round-trips true/false, returns the stored value, and never touches process.env', async () => {
   assert.deepEqual(await setDebugSpawnEnabled(true), { debugSpawnEnabled: true });
   assert.equal(debugSpawnEnabled(), true);
+  assert.equal(process.env.WORCA_DEBUG_SPAWN, undefined, 'no env write on true');
   assert.deepEqual(await setDebugSpawnEnabled(false), { debugSpawnEnabled: false });
   assert.equal(debugSpawnEnabled(), false);
+  assert.equal(process.env.WORCA_DEBUG_SPAWN, undefined, 'no env write on false (no leaked "0" into child envs)');
+  const raw = JSON.parse(await readFile(settingsFile(), 'utf8'));
+  assert.equal('debugSpawnEnabled' in raw, false, 'the default is stored as absence');
 });
 
-test('setter rejects non-boolean input and persists nothing', async () => {
+test('setter rejects non-boolean input and persists nothing; assertDebugSpawnInput is the same rule', async () => {
   await assert.rejects(() => setDebugSpawnEnabled('true'), /must be true or false/);
   const raw = JSON.parse(await readFile(settingsFile(), 'utf8'));
   assert.equal('debugSpawnEnabled' in raw, false);
+  assert.throws(() => assertDebugSpawnInput('on'), /debugSpawnEnabled must be true or false/);
+  assert.throws(() => assertDebugSpawnInput(1), /must be true or false/);
+  assert.doesNotThrow(() => assertDebugSpawnInput(true));
+  assert.doesNotThrow(() => assertDebugSpawnInput(false));
 });
 
 test('unknown keys survive a setter write (read-modify-write)', async () => {
@@ -66,43 +88,44 @@ test('unknown keys survive a setter write (read-modify-write)', async () => {
   assert.equal(raw.debugSpawnEnabled, true);
 });
 
-test('saving the setting flips process.env so claude-runner\'s live gate changes with no restart', async () => {
-  prevGate = process.env.WORCA_DEBUG_SPAWN;
-  try {
-    delete process.env.WORCA_DEBUG_SPAWN;
-    assert.equal(gateEnabled(), false, 'sanity: unset env is off');
-    await setDebugSpawnEnabled(true);
-    assert.equal(gateEnabled(), true, 'flips on with no restart');
+test('effectiveDebugSpawn: env unset ⇒ the stored value, source "settings"; the runner gate follows with no restart', async () => {
+  assert.deepEqual(effectiveDebugSpawn(), { enabled: false, source: 'settings' });
+  assert.equal(gateEnabled(), false, 'sanity: unset env + default setting is off');
+  await setDebugSpawnEnabled(true);
+  assert.deepEqual(effectiveDebugSpawn(), { enabled: true, source: 'settings' });
+  assert.equal(gateEnabled(), true, 'the runner sees the saved setting on its next read');
+  await setDebugSpawnEnabled(false);
+  assert.equal(gateEnabled(), false, 'and flips back');
+});
+
+test('effectiveDebugSpawn: a NON-EMPTY env value wins over the stored value, in both directions', async () => {
+  await setDebugSpawnEnabled(false);
+  await withGate('1', () => {
+    assert.deepEqual(effectiveDebugSpawn(), { enabled: true, source: 'env' });
+    assert.equal(gateEnabled(), true);
+  });
+  await setDebugSpawnEnabled(true);
+  for (const off of ['0', 'false']) {
+    await withGate(off, () => {
+      assert.deepEqual(effectiveDebugSpawn(), { enabled: false, source: 'env' }, `an exported ${JSON.stringify(off)} is an explicit OFF override`);
+      assert.equal(gateEnabled(), false);
+    });
+  }
+});
+
+test('effectiveDebugSpawn: an EMPTY env export is not an override — the stored value still applies', async () => {
+  await setDebugSpawnEnabled(true);
+  await withGate('', () => {
+    assert.deepEqual(effectiveDebugSpawn(), { enabled: true, source: 'settings' });
+    assert.equal(gateEnabled(), true);
+  });
+});
+
+test('a UI save while the env overrides: stored changes, effective does not, env untouched', async () => {
+  await withGate('1', async () => {
     await setDebugSpawnEnabled(false);
-    assert.equal(gateEnabled(), false, 'flips back off with no restart');
-  } finally {
-    if (prevGate === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prevGate;
-  }
-});
-
-test('applyDebugSpawnEnvFromSettings: an env var already set at launch is NOT overwritten', async () => {
-  prevGate = process.env.WORCA_DEBUG_SPAWN;
-  try {
-    process.env.WORCA_DEBUG_SPAWN = '1'; // "set at launch"
-    await setDebugSpawnEnabled(false);   // stored preference disagrees
-    // Simulate a fresh process by re-reading only the stored value's effect:
-    process.env.WORCA_DEBUG_SPAWN = '1'; // re-assert the launch-time value the real boot would see
-    applyDebugSpawnEnvFromSettings();
-    assert.equal(process.env.WORCA_DEBUG_SPAWN, '1', 'launch override wins, stored OFF is not applied');
-  } finally {
-    if (prevGate === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prevGate;
-  }
-});
-
-test('applyDebugSpawnEnvFromSettings: applies the stored setting when no launch env is present', async () => {
-  prevGate = process.env.WORCA_DEBUG_SPAWN;
-  try {
-    delete process.env.WORCA_DEBUG_SPAWN;
-    await setDebugSpawnEnabled(true);
-    delete process.env.WORCA_DEBUG_SPAWN; // undo the setter's own env write to isolate the boot helper
-    applyDebugSpawnEnvFromSettings();
-    assert.equal(process.env.WORCA_DEBUG_SPAWN, '1');
-  } finally {
-    if (prevGate === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prevGate;
-  }
+    assert.equal(debugSpawnEnabled(), false, 'stored');
+    assert.deepEqual(effectiveDebugSpawn(), { enabled: true, source: 'env' }, 'launch override still in force');
+    assert.equal(process.env.WORCA_DEBUG_SPAWN, '1', 'the env var is untouched');
+  });
 });

--- a/test/settings-api.test.mjs
+++ b/test/settings-api.test.mjs
@@ -51,3 +51,37 @@ test('POST rejects a file path -> 400', async () => {
   const filePath = fileURLToPath(import.meta.url); // this test file: a file, not a dir
   assert.equal((await post(filePath)).status, 400);
 });
+
+const postJson = (body) => fetch(`${base}/api/settings`, {
+  method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+});
+
+test('GET /api/settings: debugSpawnEnabled defaults to false', async () => {
+  const j = await (await fetch(`${base}/api/settings`)).json();
+  assert.equal(j.debugSpawnEnabled, false);
+});
+
+test('POST sets debugSpawnEnabled; GET reflects it; does not touch root', async () => {
+  const target = await mkdtemp(join(tmpdir(), 'worca-cc-setapi-dbgroot-'));
+  try {
+    const before = await (await post(target)).json();
+    assert.equal(before.root, target); // sanity: root is genuinely non-empty going in
+    const after = await (await postJson({ debugSpawnEnabled: true })).json();
+    assert.equal(after.debugSpawnEnabled, true);
+    assert.equal(after.root, target, 'a debug-spawn-only POST must not clear root');
+    const refetched = await (await fetch(`${base}/api/settings`)).json();
+    assert.equal(refetched.debugSpawnEnabled, true);
+    assert.equal(refetched.root, target);
+  } finally {
+    await postJson({ debugSpawnEnabled: false }); // leave it clean for other tests
+    await post(''); // reset root
+    await rm(target, { recursive: true, force: true });
+  }
+});
+
+test('POST rejects a non-boolean debugSpawnEnabled -> 400', async () => {
+  const r = await postJson({ debugSpawnEnabled: 'on' });
+  assert.equal(r.status, 400);
+  const j = await r.json();
+  assert.match(j.error, /must be true or false/);
+});

--- a/test/settings-api.test.mjs
+++ b/test/settings-api.test.mjs
@@ -56,9 +56,22 @@ const postJson = (body) => fetch(`${base}/api/settings`, {
   method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
 });
 
-test('GET /api/settings: debugSpawnEnabled defaults to false', async () => {
+test('GET /api/settings: debugSpawnEnabled defaults to false, with the effective state and its source', async () => {
   const j = await (await fetch(`${base}/api/settings`)).json();
   assert.equal(j.debugSpawnEnabled, false);
+  assert.deepEqual(j.debugSpawnEffective, { enabled: false, source: 'settings' });
+});
+
+test('GET /api/settings: a non-empty WORCA_DEBUG_SPAWN reports source "env" while the stored value stays false', async () => {
+  const prev = process.env.WORCA_DEBUG_SPAWN;
+  process.env.WORCA_DEBUG_SPAWN = '1';
+  try {
+    const j = await (await fetch(`${base}/api/settings`)).json();
+    assert.equal(j.debugSpawnEnabled, false, 'stored');
+    assert.deepEqual(j.debugSpawnEffective, { enabled: true, source: 'env' });
+  } finally {
+    if (prev === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prev;
+  }
 });
 
 test('POST sets debugSpawnEnabled; GET reflects it; does not touch root', async () => {
@@ -84,4 +97,50 @@ test('POST rejects a non-boolean debugSpawnEnabled -> 400', async () => {
   assert.equal(r.status, 400);
   const j = await r.json();
   assert.match(j.error, /must be true or false/);
+});
+
+test('POST does not write process.env (the runner reads the setting itself)', async () => {
+  const prev = process.env.WORCA_DEBUG_SPAWN;
+  delete process.env.WORCA_DEBUG_SPAWN;
+  try {
+    await postJson({ debugSpawnEnabled: true });
+    assert.equal(process.env.WORCA_DEBUG_SPAWN, undefined);
+    await postJson({ debugSpawnEnabled: false });
+    assert.equal(process.env.WORCA_DEBUG_SPAWN, undefined);
+  } finally {
+    if (prev === undefined) delete process.env.WORCA_DEBUG_SPAWN; else process.env.WORCA_DEBUG_SPAWN = prev;
+  }
+});
+
+test('a mixed POST whose root is unusable answers 400 with the debug toggle NOT applied', async () => {
+  const filePath = fileURLToPath(import.meta.url); // a file, not a dir → setWorcaRoot throws
+  const r = await postJson({ debugSpawnEnabled: true, root: filePath });
+  assert.equal(r.status, 400);
+  const j = await (await fetch(`${base}/api/settings`)).json();
+  assert.equal(j.debugSpawnEnabled, false, 'nothing half-applied');
+});
+
+test('every SETTINGS_POST_KEYS key is exempt from the legacy "no known key clears root" fallback', async () => {
+  const { SETTINGS_POST_KEYS } = await import('../src/core/settings.mjs');
+  assert.ok(SETTINGS_POST_KEYS.includes('debugSpawnEnabled'), 'the new key is registered beside its setter');
+  const target = await mkdtemp(join(tmpdir(), 'worca-cc-setapi-keys-'));
+  try {
+    assert.equal((await (await post(target)).json()).root, target);
+    // A body carrying only a non-root known key must not clear root — one probe per
+    // key, each with a value its setter accepts as "no change / default".
+    const probes = {
+      projectsRoot: '', chat: {}, pipelineCostLimitUsd: '', totalCostLimitUsd: '', costLimitResetPeriod: '',
+      askMaxTurns: '', askMaxBudgetUsd: '', debugSpawnEnabled: false,
+    };
+    for (const k of SETTINGS_POST_KEYS) {
+      if (k === 'root') continue;
+      assert.ok(k in probes, `test probe missing for new key ${k}`);
+      const j = await (await postJson({ [k]: probes[k] })).json();
+      assert.equal(j.root, target, `a ${k}-only POST must not clear root`);
+    }
+    assert.equal((await (await postJson({})).json()).root, '', 'the legacy contract itself still holds');
+  } finally {
+    await post('');
+    await rm(target, { recursive: true, force: true });
+  }
 });

--- a/test/settings-projects-root.test.mjs
+++ b/test/settings-projects-root.test.mjs
@@ -310,7 +310,7 @@ test('GET /api/settings returns {root, projectsRoot, projectsRootDefault, defaul
   await withEnv(undefined, async () => {
     const j = await getApi();
     assert.deepEqual(Object.keys(j).sort(), ['askMaxBudgetUsd', 'askMaxTurns', 'chat', 'costLimitResetPeriod',
-      'default', 'pipelineCostLimitUsd', 'projectsRoot', 'projectsRootDefault', 'root', 'totalCostLimitUsd']);
+      'debugSpawnEnabled', 'default', 'pipelineCostLimitUsd', 'projectsRoot', 'projectsRootDefault', 'root', 'totalCostLimitUsd']);
     assert.equal(j.root, '', 'nothing set yet');
     assert.equal(j.projectsRoot, '', 'the RAW setting — "" when unset, exactly like root');
     assert.equal(j.projectsRootDefault, defaultRoot(), 'what applies while it is blank');

--- a/test/settings-projects-root.test.mjs
+++ b/test/settings-projects-root.test.mjs
@@ -310,7 +310,7 @@ test('GET /api/settings returns {root, projectsRoot, projectsRootDefault, defaul
   await withEnv(undefined, async () => {
     const j = await getApi();
     assert.deepEqual(Object.keys(j).sort(), ['askMaxBudgetUsd', 'askMaxTurns', 'chat', 'costLimitResetPeriod',
-      'debugSpawnEnabled', 'default', 'pipelineCostLimitUsd', 'projectsRoot', 'projectsRootDefault', 'root', 'totalCostLimitUsd']);
+      'debugSpawnEffective', 'debugSpawnEnabled', 'default', 'pipelineCostLimitUsd', 'projectsRoot', 'projectsRootDefault', 'root', 'totalCostLimitUsd']);
     assert.equal(j.root, '', 'nothing set yet');
     assert.equal(j.projectsRoot, '', 'the RAW setting — "" when unset, exactly like root');
     assert.equal(j.projectsRootDefault, defaultRoot(), 'what applies while it is blank');

--- a/test/spawn-args.test.mjs
+++ b/test/spawn-args.test.mjs
@@ -609,6 +609,24 @@ test('debugSpawnEnabled: off by default; truthy values enable; 0/false disable',
   }
 });
 
+test('debugSpawnEnabled: with the env unset or EMPTY the stored settings.json value applies (CLI runs honour the UI checkbox)', async () => {
+  const home = await tmp();
+  await mkdir(join(home, '.worca-cc'), { recursive: true });
+  const prev = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_DEBUG_SPAWN: process.env.WORCA_DEBUG_SPAWN };
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  try {
+    await writeFile(join(home, '.worca-cc', 'settings.json'), JSON.stringify({ debugSpawnEnabled: true }), 'utf8');
+    delete process.env.WORCA_DEBUG_SPAWN; assert.equal(debugSpawnEnabled(), true, 'unset env → stored true');
+    process.env.WORCA_DEBUG_SPAWN = '';    assert.equal(debugSpawnEnabled(), true, 'empty env is not an override');
+    process.env.WORCA_DEBUG_SPAWN = '0';   assert.equal(debugSpawnEnabled(), false, 'an exported 0 is an explicit OFF');
+    await writeFile(join(home, '.worca-cc', 'settings.json'), '{}', 'utf8');
+    delete process.env.WORCA_DEBUG_SPAWN;  assert.equal(debugSpawnEnabled(), false, 'default stored → off');
+    process.env.WORCA_DEBUG_SPAWN = '1';   assert.equal(debugSpawnEnabled(), true, 'env on wins over default');
+  } finally {
+    for (const [k, v] of Object.entries(prev)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+  }
+});
+
 test('redactArgvForLog: truncates ANY long token (prompt, --settings JSON, tool lists); flags & short values verbatim', () => {
   const big = 'x'.repeat(500);
   const settings = JSON.stringify({ permissions: { deny: Array.from({ length: 40 }, (_, i) => `Bash(rm -rf /${i})`) } });

--- a/test/ui-settings-debug-spawn.test.mjs
+++ b/test/ui-settings-debug-spawn.test.mjs
@@ -1,0 +1,99 @@
+// test/ui-settings-debug-spawn.test.mjs
+// Settings "Spawn diagnostics" card: GET paints the checkbox, Save posts exactly
+// { debugSpawnEnabled }, Reset posts { debugSpawnEnabled: false }, server 400 surfaces.
+// Boot copied from test/ui-settings-ask.test.mjs. Fetch-stubbed only — no disk.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
+const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
+
+const GET_BODY = (debugSpawnEnabled = false) => ({
+  root: '/w', projectsRoot: '/p', projectsRootDefault: '/p', default: {}, chat: {},
+  pipelineCostLimitUsd: null, totalCostLimitUsd: null, costLimitResetPeriod: 'monthly',
+  askMaxTurns: 40, askMaxBudgetUsd: 2, debugSpawnEnabled,
+});
+
+async function boot({ postResponse, initialDebugSpawnEnabled = false } = {}) {
+  const dom = new JSDOM(readFileSync(htmlPath, 'utf8'), { url: 'http://localhost:4317/' });
+  const { window } = dom;
+  window.Element.prototype.scrollIntoView = function () {};
+  window.WebSocket = class { constructor() { this.readyState = 1; } send() {} close() {} addEventListener() {} };
+  const posts = [];
+  window.fetch = (url, opts = {}) => {
+    const u = String(url);
+    if (u.includes('/api/settings')) {
+      if ((opts.method || 'GET').toUpperCase() === 'POST') {
+        const body = JSON.parse(opts.body);
+        posts.push(body);
+        return Promise.resolve(postResponse
+          || { ok: true, status: 200, json: async () => GET_BODY(body.debugSpawnEnabled) });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => GET_BODY(initialDebugSpawnEnabled) });
+    }
+    if (u.includes('/api/budget'))
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ pipelineLimitUsd: null, totalLimitUsd: null, resetPeriod: 'monthly', windowStartMs: 0, windowEndMs: 0, msUntilReset: 0, windowSpendUsd: 0, allTimeSpendUsd: 0, remainingUsd: null, blocked: false }) });
+    if (u.includes('/api/projects'))
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ projects: [] }) });
+    return Promise.resolve({ ok: true, status: 200, json: async () => ({ config: { steps: {}, customModels: [] }, models: [], efforts: [] }) });
+  };
+  for (const k of ['window', 'document', 'location', 'localStorage', 'WebSocket', 'fetch', 'navigator']) {
+    try { Object.defineProperty(globalThis, k, { value: window[k], configurable: true, writable: true }); } catch { /* keep */ }
+  }
+  globalThis.window = window; globalThis.document = window.document;
+  await import(pathToFileURL(appPath).href + `?b=${Date.now()}_${Math.random()}`);
+  await new Promise((r) => setTimeout(r, 0));
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+  const $ = (sel) => window.document.querySelector(sel);
+  const openSettings = async () => {
+    window.location.hash = 'settings';
+    window.dispatchEvent(new window.Event('hashchange'));
+    await tick();
+  };
+  return { window, posts, tick, $, openSettings };
+}
+
+test('ui-settings-debug-spawn: GET paints the checkbox unchecked by default', async () => {
+  const { $, openSettings } = await boot();
+  await openSettings();
+  assert.equal($('#debugSpawnEnabled').checked, false);
+});
+
+test('ui-settings-debug-spawn: GET paints a stored true value as checked', async () => {
+  const { $, openSettings } = await boot({ initialDebugSpawnEnabled: true });
+  await openSettings();
+  assert.equal($('#debugSpawnEnabled').checked, true);
+});
+
+test('ui-settings-debug-spawn: Save posts exactly { debugSpawnEnabled: true }', async () => {
+  const { $, posts, tick, openSettings } = await boot();
+  await openSettings();
+  $('#debugSpawnEnabled').checked = true;
+  $('#debugSpawnSave').click();
+  await tick();
+  assert.equal(posts.length, 1, 'exactly one POST');
+  assert.deepEqual(posts[0], { debugSpawnEnabled: true });
+  assert.match($('#debugSpawnMsg').textContent, /Saved/);
+});
+
+test('ui-settings-debug-spawn: Reset posts { debugSpawnEnabled: false }', async () => {
+  const { $, posts, tick, openSettings } = await boot({ initialDebugSpawnEnabled: true });
+  await openSettings();
+  $('#debugSpawnReset').click();
+  await tick();
+  assert.deepEqual(posts[0], { debugSpawnEnabled: false });
+  assert.equal($('#debugSpawnEnabled').checked, false, 'painted back from the response');
+});
+
+test('ui-settings-debug-spawn: a server 400 lands verbatim', async () => {
+  const { $, tick, openSettings } = await boot({
+    postResponse: { ok: false, status: 400, json: async () => ({ error: 'debugSpawnEnabled must be true or false' }) },
+  });
+  await openSettings();
+  $('#debugSpawnSave').click();
+  await tick();
+  assert.equal($('#debugSpawnMsg').textContent, 'debugSpawnEnabled must be true or false');
+});

--- a/test/ui-settings-debug-spawn.test.mjs
+++ b/test/ui-settings-debug-spawn.test.mjs
@@ -11,13 +11,13 @@ import { JSDOM } from 'jsdom';
 const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
 const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
 
-const GET_BODY = (debugSpawnEnabled = false) => ({
+const GET_BODY = (debugSpawnEnabled = false, debugSpawnEffective = { enabled: debugSpawnEnabled, source: 'settings' }) => ({
   root: '/w', projectsRoot: '/p', projectsRootDefault: '/p', default: {}, chat: {},
   pipelineCostLimitUsd: null, totalCostLimitUsd: null, costLimitResetPeriod: 'monthly',
-  askMaxTurns: 40, askMaxBudgetUsd: 2, debugSpawnEnabled,
+  askMaxTurns: 40, askMaxBudgetUsd: 2, debugSpawnEnabled, debugSpawnEffective,
 });
 
-async function boot({ postResponse, initialDebugSpawnEnabled = false } = {}) {
+async function boot({ postResponse, initialDebugSpawnEnabled = false, initialEffective } = {}) {
   const dom = new JSDOM(readFileSync(htmlPath, 'utf8'), { url: 'http://localhost:4317/' });
   const { window } = dom;
   window.Element.prototype.scrollIntoView = function () {};
@@ -32,7 +32,7 @@ async function boot({ postResponse, initialDebugSpawnEnabled = false } = {}) {
         return Promise.resolve(postResponse
           || { ok: true, status: 200, json: async () => GET_BODY(body.debugSpawnEnabled) });
       }
-      return Promise.resolve({ ok: true, status: 200, json: async () => GET_BODY(initialDebugSpawnEnabled) });
+      return Promise.resolve({ ok: true, status: 200, json: async () => GET_BODY(initialDebugSpawnEnabled, initialEffective) });
     }
     if (u.includes('/api/budget'))
       return Promise.resolve({ ok: true, status: 200, json: async () => ({ pipelineLimitUsd: null, totalLimitUsd: null, resetPeriod: 'monthly', windowStartMs: 0, windowEndMs: 0, msUntilReset: 0, windowSpendUsd: 0, allTimeSpendUsd: 0, remainingUsd: null, blocked: false }) });
@@ -96,4 +96,37 @@ test('ui-settings-debug-spawn: a server 400 lands verbatim', async () => {
   $('#debugSpawnSave').click();
   await tick();
   assert.equal($('#debugSpawnMsg').textContent, 'debugSpawnEnabled must be true or false');
+});
+
+test('ui-settings-debug-spawn: no env override ⇒ the env note is empty', async () => {
+  const { $, openSettings } = await boot();
+  await openSettings();
+  assert.equal($('#debugSpawnEnvNote').textContent, '');
+});
+
+test('ui-settings-debug-spawn: a launch-time env override is SAID, with the effective state, over an unchecked box', async () => {
+  const { $, openSettings } = await boot({ initialDebugSpawnEnabled: false, initialEffective: { enabled: true, source: 'env' } });
+  await openSettings();
+  assert.equal($('#debugSpawnEnabled').checked, false, 'the checkbox is the STORED value');
+  assert.match($('#debugSpawnEnvNote').textContent, /WORCA_DEBUG_SPAWN is set in the environment: diagnostics are ON/);
+  assert.ok($('#debugSpawnEnvNote').classList.contains('warn'));
+});
+
+test('ui-settings-debug-spawn: the mirror case — stored true, env forces OFF', async () => {
+  const { $, openSettings } = await boot({ initialDebugSpawnEnabled: true, initialEffective: { enabled: false, source: 'env' } });
+  await openSettings();
+  assert.equal($('#debugSpawnEnabled').checked, true);
+  assert.match($('#debugSpawnEnvNote').textContent, /diagnostics are OFF regardless/);
+});
+
+test('ui-settings-debug-spawn: a 2xx with an unparsable body leaves the checkbox as the user set it', async () => {
+  const { $, tick, openSettings } = await boot({
+    postResponse: { ok: true, status: 200, json: async () => { throw new Error('bad json'); } },
+  });
+  await openSettings();
+  $('#debugSpawnEnabled').checked = true;
+  $('#debugSpawnSave').click();
+  await tick();
+  assert.equal($('#debugSpawnEnabled').checked, true, 'not repainted as unset from an empty body');
+  assert.match($('#debugSpawnMsg').textContent, /Saved/);
 });

--- a/test/ui-settings-tooltips.test.mjs
+++ b/test/ui-settings-tooltips.test.mjs
@@ -17,10 +17,10 @@ const settingsView = () => {
   return dom.window.document.querySelector('.view[data-view="settings"]');
 };
 
-test('settings: nine info-tip icons, each with non-empty tip content', () => {
+test('settings: ten info-tip icons, each with non-empty tip content', () => {
   const view = settingsView();
   const tips = [...view.querySelectorAll('button.info-tip')];
-  assert.equal(tips.length, 9, 'nine ⓘ icons (2 folder fields, budget heading, 3 budget fields, ask heading, 2 ask fields)');
+  assert.equal(tips.length, 10, 'ten ⓘ icons (2 folder fields, budget heading, 3 budget fields, ask heading, 2 ask fields, spawn diagnostics)');
   for (const tip of tips) {
     assert.equal(tip.getAttribute('type'), 'button', 'icon must not submit anything');
     assert.match(tip.getAttribute('aria-label') || '', /^About /, 'icon names its setting');

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -626,6 +626,12 @@ function handleServerMessage(msg) {
     refreshBudget();
     return;
   }
+  // Another tab saved a Settings card: repaint ours from the server so a stale
+  // checkbox/field cannot be "saved" back over the change.
+  if (msg.type === 'settings-changed') {
+    loadSettings();
+    return;
+  }
   if (msg.type === 'projects-changed') {
     refreshAllCounts();
     if (currentView() === 'projects') loadProjectsView();
@@ -7963,10 +7969,27 @@ if (el.budgetReset) {
 }
 
 // ---- Ask Worca limits card (budget-card pattern above) ---------------------
-function setAskLimitsMsg(text, kind) {
-  const n = document.getElementById('askLimitsMsg');
+// Shared by the small Settings cards (Ask Worca, Spawn diagnostics): one hint
+// setter and one "POST /api/settings → parse → paint or show the error" routine,
+// so a fix to the fetch/parse/error path lands in every card at once.
+function setHintMsg(id, text, kind) {
+  const n = document.getElementById(id);
   if (n) { n.textContent = text || ''; n.className = `hint${kind ? ` ${kind}` : ''}`; }
 }
+async function postSettingsCard(body, { setMsg, paint, savedText = 'Saved.' }) {
+  setMsg('');
+  let res;
+  try {
+    res = await fetch('/api/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  } catch (e) { setMsg(e.message || 'network error', 'err'); return; }
+  const data = await safeJson(res);
+  if (!res.ok) { setMsg(data.error || `HTTP ${res.status}`, 'err'); return; }
+  // A 2xx with an unparsable body yields {} — leave the card as the user set it
+  // rather than painting every field as "unset".
+  if (Object.keys(data).length) paint(data);
+  setMsg(savedText);
+}
+function setAskLimitsMsg(text, kind) { setHintMsg('askLimitsMsg', text, kind); }
 function paintAskSettings(data) {
   const turns = document.getElementById('askMaxTurns');
   const budget = document.getElementById('askMaxBudgetUsd');
@@ -7977,17 +8000,8 @@ function paintAskSettings(data) {
   budget.disabled = noCap.checked;
   budget.value = data.askMaxBudgetUsd == null ? '' : String(data.askMaxBudgetUsd);
 }
-async function postAskLimits(body) {
-  setAskLimitsMsg('');
-  let res = null;
-  try {
-    res = await fetch('/api/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-  } catch { setAskLimitsMsg('network error', 'err'); return; }
-  let data = null;
-  try { data = await res.json(); } catch { data = null; }
-  if (!res.ok) { setAskLimitsMsg((data && data.error) || `save failed (${res.status})`, 'err'); return; }
-  paintAskSettings(data || {});
-  setAskLimitsMsg('Saved.');
+function postAskLimits(body) {
+  return postSettingsCard(body, { setMsg: setAskLimitsMsg, paint: paintAskSettings });
 }
 function saveAskLimits() {
   const turnsRaw = document.getElementById('askMaxTurns').value.trim();
@@ -8015,31 +8029,29 @@ document.getElementById('askNoCap')?.addEventListener('change', () => {
   if (budget) budget.disabled = document.getElementById('askNoCap').checked;
 });
 
-// ---- Spawn-debug diagnostics card (Ask Worca card pattern above) -----------
-function setDebugSpawnMsg(text, kind) {
-  const n = document.getElementById('debugSpawnMsg');
-  if (n) { n.textContent = text || ''; n.className = `hint${kind ? ` ${kind}` : ''}`; }
-}
+// ---- Spawn-debug diagnostics card (shares the Ask card's helpers above) ----
+function setDebugSpawnMsg(text, kind) { setHintMsg('debugSpawnMsg', text, kind); }
+// The checkbox is the STORED preference; the note says when the environment
+// overrides it (a non-empty WORCA_DEBUG_SPAWN at launch), so an operator never
+// sees an unchecked box while diagnostics are flowing — or the reverse.
 function paintDebugSpawnSettings(data) {
   const cb = document.getElementById('debugSpawnEnabled');
   if (!cb) return;
   cb.checked = !!data.debugSpawnEnabled;
+  const eff = data.debugSpawnEffective;
+  const envOverride = !!eff && eff.source === 'env';
+  setHintMsg('debugSpawnEnvNote', envOverride
+    ? `WORCA_DEBUG_SPAWN is set in the environment: diagnostics are ${eff.enabled ? 'ON' : 'OFF'} regardless of this setting.`
+    : '', envOverride ? 'warn' : '');
 }
-async function postDebugSpawn(body) {
-  setDebugSpawnMsg('');
-  let res = null;
-  try {
-    res = await fetch('/api/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-  } catch { setDebugSpawnMsg('network error', 'err'); return; }
-  let data = null;
-  try { data = await res.json(); } catch { data = null; }
-  if (!res.ok) { setDebugSpawnMsg((data && data.error) || `save failed (${res.status})`, 'err'); return; }
-  paintDebugSpawnSettings(data || {});
-  setDebugSpawnMsg('Saved. Applies to the next spawn — no restart needed.');
+function postDebugSpawn(body) {
+  return postSettingsCard(body, {
+    setMsg: setDebugSpawnMsg, paint: paintDebugSpawnSettings,
+    savedText: 'Saved. Applies to the next spawn — no restart needed.',
+  });
 }
 function saveDebugSpawn() {
-  const checked = document.getElementById('debugSpawnEnabled').checked;
-  postDebugSpawn({ debugSpawnEnabled: checked });
+  postDebugSpawn({ debugSpawnEnabled: document.getElementById('debugSpawnEnabled').checked });
 }
 document.getElementById('debugSpawnSave')?.addEventListener('click', saveDebugSpawn);
 document.getElementById('debugSpawnReset')?.addEventListener('click', () => postDebugSpawn({ debugSpawnEnabled: false }));

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -7682,6 +7682,7 @@ async function loadSettings() {
     paintSettings(data);
     paintBudgetSettings(data);
     paintAskSettings(data);
+    paintDebugSpawnSettings(data);
     paintBudgetReadout();
     refreshBudget();
     paintChatSettings(data.chat);
@@ -8013,6 +8014,35 @@ document.getElementById('askNoCap')?.addEventListener('change', () => {
   const budget = document.getElementById('askMaxBudgetUsd');
   if (budget) budget.disabled = document.getElementById('askNoCap').checked;
 });
+
+// ---- Spawn-debug diagnostics card (Ask Worca card pattern above) -----------
+function setDebugSpawnMsg(text, kind) {
+  const n = document.getElementById('debugSpawnMsg');
+  if (n) { n.textContent = text || ''; n.className = `hint${kind ? ` ${kind}` : ''}`; }
+}
+function paintDebugSpawnSettings(data) {
+  const cb = document.getElementById('debugSpawnEnabled');
+  if (!cb) return;
+  cb.checked = !!data.debugSpawnEnabled;
+}
+async function postDebugSpawn(body) {
+  setDebugSpawnMsg('');
+  let res = null;
+  try {
+    res = await fetch('/api/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  } catch { setDebugSpawnMsg('network error', 'err'); return; }
+  let data = null;
+  try { data = await res.json(); } catch { data = null; }
+  if (!res.ok) { setDebugSpawnMsg((data && data.error) || `save failed (${res.status})`, 'err'); return; }
+  paintDebugSpawnSettings(data || {});
+  setDebugSpawnMsg('Saved. Applies to the next spawn — no restart needed.');
+}
+function saveDebugSpawn() {
+  const checked = document.getElementById('debugSpawnEnabled').checked;
+  postDebugSpawn({ debugSpawnEnabled: checked });
+}
+document.getElementById('debugSpawnSave')?.addEventListener('click', saveDebugSpawn);
+document.getElementById('debugSpawnReset')?.addEventListener('click', () => postDebugSpawn({ debugSpawnEnabled: false }));
 
 // Browse… for the projects root: native OS dialog, in-app modal fallback —
 // the same two endpoints the add-project Browse button uses (app.js:3793).

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1133,6 +1133,30 @@
               <small class="hint" id="askLimitsMsg"></small>
             </section>
 
+            <!-- Spawn-debug diagnostics: UI mirror of WORCA_DEBUG_SPAWN
+                 (worca: Add Opt-in Debug Spawn Logging). Values are masked at spawn
+                 time by claude-runner.mjs; this card only flips the gate. -->
+            <section class="card settings-card" id="debug-spawn-settings-card">
+              <div class="card-head">
+                <div class="label-row">
+                  <h2>Spawn diagnostics</h2>
+                  <button type="button" class="info-tip" aria-label="About spawn diagnostics">i<span class="tip-content hidden">
+                    Values are masked; output appears in the run log and the console. Applies to all runs.
+                    If <code>WORCA_DEBUG_SPAWN</code> is set in the environment when Worca CC starts, that
+                    value overrides this checkbox.
+                  </span></button>
+                </div>
+              </div>
+              <div class="field">
+                <label class="check-row" for="debugSpawnEnabled"><input id="debugSpawnEnabled" type="checkbox" /> Log claude spawn details (argv + env key names)</label>
+              </div>
+              <div class="add-project-actions" style="margin-top:14px">
+                <button type="button" id="debugSpawnReset" class="btn btn-ghost btn-mini">Reset to default</button>
+                <button type="button" id="debugSpawnSave" class="btn btn-primary btn-mini">Save</button>
+              </div>
+              <small class="hint" id="debugSpawnMsg"></small>
+            </section>
+
             <!-- Chat notifications (chat-connectivity-design.md §4.8): which run
                  events ping which chat channels. Body rendered by
                  chat-settings-view.mjs; app.js owns fetch/save/Test wiring. -->

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1133,23 +1133,28 @@
               <small class="hint" id="askLimitsMsg"></small>
             </section>
 
-            <!-- Spawn-debug diagnostics: UI mirror of WORCA_DEBUG_SPAWN
-                 (worca: Add Opt-in Debug Spawn Logging). Values are masked at spawn
-                 time by claude-runner.mjs; this card only flips the gate. -->
+            <!-- Spawn-debug diagnostics: the stored side of WORCA_DEBUG_SPAWN.
+                 claude-runner.mjs reads the setting per spawn (UI server AND CLI);
+                 a non-empty env var overrides it. This card only flips the gate —
+                 the runner decides what is printable (routing keys readable,
+                 credentials as "<set, N chars>"). -->
             <section class="card settings-card" id="debug-spawn-settings-card">
               <div class="card-head">
                 <div class="label-row">
                   <h2>Spawn diagnostics</h2>
                   <button type="button" class="info-tip" aria-label="About spawn diagnostics">i<span class="tip-content hidden">
-                    Values are masked; output appears in the run log and the console. Applies to all runs.
-                    If <code>WORCA_DEBUG_SPAWN</code> is set in the environment when Worca CC starts, that
-                    value overrides this checkbox.
+                    Logs the exact claude binary, argv and routing env handed to every spawn, in the run
+                    log. Credentials never appear: routing keys (endpoint, wire model) print readable,
+                    every other value as <code>&lt;set, N chars&gt;</code>. Applies to runs started here
+                    and from the CLI, with no restart. A non-empty <code>WORCA_DEBUG_SPAWN</code> in the
+                    environment overrides this setting.
                   </span></button>
                 </div>
               </div>
               <div class="field">
-                <label class="check-row" for="debugSpawnEnabled"><input id="debugSpawnEnabled" type="checkbox" /> Log claude spawn details (argv + env key names)</label>
+                <label class="check-row" for="debugSpawnEnabled"><input id="debugSpawnEnabled" type="checkbox" /> Log claude spawn details (binary, argv, routing env)</label>
               </div>
+              <small class="hint" id="debugSpawnEnvNote"></small>
               <div class="add-project-actions" style="margin-top:14px">
                 <button type="button" id="debugSpawnReset" class="btn btn-ghost btn-mini">Reset to default</button>
                 <button type="button" id="debugSpawnSave" class="btn btn-primary btn-mini">Save</button>

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -305,6 +305,7 @@ body.view-history .topnav{margin:12px 32px 0;flex:0 0 auto;}
 .field > label .opt,.field .opt{color:var(--ink-3);font-weight:500;font-style:normal;}
 .hint{display:block;color:var(--ink-3);font-size:12px;margin-top:7px;line-height:1.45;}
 .hint.err{color:var(--red-ink);}
+.hint.warn{color:var(--amber-ink);}
 
 .input,.select,.textarea,.ta-hl-back,
 input[type="text"],input[type="number"],textarea,select{

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -41,6 +41,7 @@ import {
   setPipelineCostLimitUsd, setTotalCostLimitUsd, setCostLimitResetPeriod, assertCostLimitInputs,
   askMaxTurns, askMaxBudgetUsd, setAskMaxTurns, setAskMaxBudgetUsd, assertAskLimitInputs,
   chatPrefs, setChatPrefs,
+  debugSpawnEnabled as storedDebugSpawnEnabled, setDebugSpawnEnabled, applyDebugSpawnEnvFromSettings,
 } from '../src/core/settings.mjs';
 import {
   ASK_ID_RE, createThread as askCreateThread, getThread as askGetThread,
@@ -2752,6 +2753,7 @@ const settingsState = () => ({
   costLimitResetPeriod: costLimitResetPeriod(),
   askMaxTurns: askMaxTurns(),
   askMaxBudgetUsd: askMaxBudgetUsd(),
+  debugSpawnEnabled: storedDebugSpawnEnabled(),
 });
 
 app.get('/api/settings', (_req, res) => {
@@ -2767,6 +2769,7 @@ app.post('/api/settings', async (req, res) => {
   const has = (k) => Object.prototype.hasOwnProperty.call(body, k);
   const hasBudgetKey = has('pipelineCostLimitUsd') || has('totalCostLimitUsd') || has('costLimitResetPeriod');
   const hasAskKey = has('askMaxTurns') || has('askMaxBudgetUsd');
+  const hasDebugSpawnKey = has('debugSpawnEnabled');
   // Normalize the budget keys first, then validate them as a SET before ANY write.
   // Each setter persists on its own, so a two-key POST whose second key is invalid
   // used to answer 400 with the first key already on disk, no budget-changed
@@ -2787,6 +2790,9 @@ app.post('/api/settings', async (req, res) => {
   try {
     assertCostLimitInputs(budget);
     assertAskLimitInputs(ask);
+    if (hasDebugSpawnKey && typeof body.debugSpawnEnabled !== 'boolean') {
+      throw new Error('debugSpawnEnabled must be true or false');
+    }
     if (has('chat')) await setChatPrefs(body.chat);
     if (has('projectsRoot')) {
       await setProjectsRoot(typeof body.projectsRoot === 'string' ? body.projectsRoot : '');
@@ -2796,9 +2802,10 @@ app.post('/api/settings', async (req, res) => {
     if (has('costLimitResetPeriod')) await setCostLimitResetPeriod(budget.costLimitResetPeriod);
     if (has('askMaxTurns')) await setAskMaxTurns(ask.askMaxTurns);
     if (has('askMaxBudgetUsd')) await setAskMaxBudgetUsd(ask.askMaxBudgetUsd);
-    // Legacy contract: a POST that names no known key clears root. Budget and ask
-    // keys must not trip it — a budget-only or ask-only save would otherwise wipe the root.
-    if (has('root') || !(has('projectsRoot') || hasBudgetKey || hasAskKey || has('chat'))) {
+    if (hasDebugSpawnKey) await setDebugSpawnEnabled(body.debugSpawnEnabled);
+    // Legacy contract: a POST that names no known key clears root. Budget, ask, and
+    // debug-spawn keys must not trip it — a debug-spawn-only save would otherwise wipe root.
+    if (has('root') || !(has('projectsRoot') || hasBudgetKey || hasAskKey || has('chat') || hasDebugSpawnKey)) {
       await setWorcaRoot(typeof body.root === 'string' ? body.root : '');
     }
     if (hasBudgetKey) emitChanged('budget-changed');
@@ -5138,6 +5145,11 @@ if (isMain) {
   } catch (err) {
     console.error(`[worca-ui] builtin marketplace seed skipped: ${err && err.message ? err.message : err}`);
   }
+
+  // Apply the stored spawn-debug preference to this process's env, unless an operator
+  // already exported WORCA_DEBUG_SPAWN before launching worca (that wins — see
+  // applyDebugSpawnEnvFromSettings's doc comment in settings.mjs).
+  applyDebugSpawnEnvFromSettings();
 
   bootMaintenance().catch((err) => {
     console.error(`[worca-ui] boot maintenance failed: ${err && err.message ? err.message : err}`);

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -41,7 +41,7 @@ import {
   setPipelineCostLimitUsd, setTotalCostLimitUsd, setCostLimitResetPeriod, assertCostLimitInputs,
   askMaxTurns, askMaxBudgetUsd, setAskMaxTurns, setAskMaxBudgetUsd, assertAskLimitInputs,
   chatPrefs, setChatPrefs,
-  debugSpawnEnabled as storedDebugSpawnEnabled, setDebugSpawnEnabled, applyDebugSpawnEnvFromSettings,
+  debugSpawnEnabled as storedDebugSpawnEnabled, effectiveDebugSpawn, setDebugSpawnEnabled, assertDebugSpawnInput, SETTINGS_POST_KEYS,
 } from '../src/core/settings.mjs';
 import {
   ASK_ID_RE, createThread as askCreateThread, getThread as askGetThread,
@@ -2765,7 +2765,8 @@ const settingsState = () => ({
   costLimitResetPeriod: costLimitResetPeriod(),
   askMaxTurns: askMaxTurns(),
   askMaxBudgetUsd: askMaxBudgetUsd(),
-  debugSpawnEnabled: storedDebugSpawnEnabled(),
+  debugSpawnEnabled: storedDebugSpawnEnabled(),          // what is STORED (the checkbox)
+  debugSpawnEffective: effectiveDebugSpawn(),             // what the next spawn will DO, and why
 });
 
 app.get('/api/settings', (_req, res) => {
@@ -2802,8 +2803,14 @@ app.post('/api/settings', async (req, res) => {
   try {
     assertCostLimitInputs(budget);
     assertAskLimitInputs(ask);
-    if (hasDebugSpawnKey && typeof body.debugSpawnEnabled !== 'boolean') {
-      throw new Error('debugSpawnEnabled must be true or false');
+    if (hasDebugSpawnKey) assertDebugSpawnInput(body.debugSpawnEnabled);
+    // Root first: it is the one key whose setter can still fail AFTER the asserts
+    // above (an unusable path), so every other key's write must come after it or
+    // a mixed POST would answer 400 with those keys already applied on disk.
+    // Legacy contract: a POST that names NO known key clears root; the known
+    // keys live beside their setters (SETTINGS_POST_KEYS), not in a list here.
+    if (has('root') || !SETTINGS_POST_KEYS.some(has)) {
+      await setWorcaRoot(typeof body.root === 'string' ? body.root : '');
     }
     if (has('chat')) await setChatPrefs(body.chat);
     if (has('projectsRoot')) {
@@ -2815,12 +2822,10 @@ app.post('/api/settings', async (req, res) => {
     if (has('askMaxTurns')) await setAskMaxTurns(ask.askMaxTurns);
     if (has('askMaxBudgetUsd')) await setAskMaxBudgetUsd(ask.askMaxBudgetUsd);
     if (hasDebugSpawnKey) await setDebugSpawnEnabled(body.debugSpawnEnabled);
-    // Legacy contract: a POST that names no known key clears root. Budget, ask, and
-    // debug-spawn keys must not trip it — a debug-spawn-only save would otherwise wipe root.
-    if (has('root') || !(has('projectsRoot') || hasBudgetKey || hasAskKey || has('chat') || hasDebugSpawnKey)) {
-      await setWorcaRoot(typeof body.root === 'string' ? body.root : '');
-    }
     if (hasBudgetKey) emitChanged('budget-changed');
+    // Other open tabs repaint their Settings cards (a stale tab could otherwise
+    // "save" its old checkbox state over this one with no feedback to either).
+    if (hasAskKey || hasDebugSpawnKey) emitChanged('settings-changed');
     res.json({ ...settingsState(), chat: chatPrefs() });
   } catch (err) {
     // The setters throw only on an unusable path -> client error (400).
@@ -5268,11 +5273,6 @@ if (isMain) {
   } catch (err) {
     console.error(`[worca-ui] builtin marketplace seed skipped: ${err && err.message ? err.message : err}`);
   }
-
-  // Apply the stored spawn-debug preference to this process's env, unless an operator
-  // already exported WORCA_DEBUG_SPAWN before launching worca (that wins — see
-  // applyDebugSpawnEnvFromSettings's doc comment in settings.mjs).
-  applyDebugSpawnEnvFromSettings();
 
   bootMaintenance().catch((err) => {
     console.error(`[worca-ui] boot maintenance failed: ${err && err.message ? err.message : err}`);


### PR DESCRIPTION
## Summary

Adds a **Spawn diagnostics** card to Settings that stores the `WORCA_DEBUG_SPAWN` preference introduced in #416, so an operator can turn spawn logging on and off from the UI instead of restarting the server with an env var.

The stored setting is read by the runner **on every spawn**, so a save applies to the next spawn in the UI server *and* to CLI runs, on every OS, with no restart and no `process.env` mutation.

## Behaviour

**One precedence rule** — `settings.mjs#effectiveDebugSpawn()` — shared by the runner gate and the settings API:

| `WORCA_DEBUG_SPAWN` in the environment | Effective | Source |
|---|---|---|
| unset | stored `debugSpawnEnabled` (default `false`) | `settings` |
| `""` (empty export) | stored value — an empty export is **not** an override | `settings` |
| non-empty, e.g. `1` | ON | `env` |
| `0` / `false` | OFF — an explicit override in the OFF direction | `env` |

- `claude-runner.mjs#debugSpawnEnabled()` now returns `effectiveDebugSpawn().enabled`, read fresh per spawn. OFF ⇒ no spawn-debug event, argv/env untouched, spawn path byte-identical to today.
- **Nothing writes `process.env`.** A runtime env write would leak an explicit `WORCA_DEBUG_SPAWN=0` into every inherited child env and break the runner's "OFF ⇒ byte-identical spawn env" invariant.
- The card shows the **stored** value in the checkbox and an amber note when the environment overrides it (`WORCA_DEBUG_SPAWN is set in the environment: diagnostics are ON regardless of this setting`), so an unchecked box never hides flowing diagnostics, or the reverse.

## API

- `GET /api/settings` gains `debugSpawnEnabled` (stored boolean) and `debugSpawnEffective: { enabled, source: 'env' | 'settings' }`.
- `POST /api/settings { debugSpawnEnabled: boolean }` persists it; a non-boolean answers 400 with nothing written. Default (`false`) is stored as an absent key.
- **`SETTINGS_POST_KEYS`** (in `settings.mjs`, beside the setters) now feeds the route's legacy "a POST naming no known key clears root" contract. Previously that exclusion list was hand-maintained in the route, so a new key could wipe the root on its first save.
- **Root is written first** in the POST route: it is the only setter that can still fail after the asserts (unusable path), so a mixed POST with a bad root now answers 400 with the other keys *not* applied.
- A save of the Ask or Spawn-diagnostics card broadcasts `settings-changed`; other open tabs repaint their Settings cards so a stale tab cannot save its old checkbox state back over the change.

## UI

- `index.html`: new `#debug-spawn-settings-card` with an ⓘ tooltip (tooltip count 9 → 10).
- `app.js`: the Ask card's fetch/parse/error routine is extracted into shared `setHintMsg` / `postSettingsCard` helpers and reused by the new card; a 2xx with an unparsable body leaves the card as the user set it rather than painting every field as unset.
- `style.css`: `.hint.warn` (amber) for the env-override note.

## Tests

- `test/debug-spawn-settings.test.mjs` (new): defaults, corrupt file / corrupt value fallback, setter round-trip, non-boolean rejection, read-modify-write, the full env-precedence matrix, and "a UI save while the env overrides changes stored but not effective, env untouched".
- `test/settings-api.test.mjs`: GET shape, env-override reporting, POST/GET round-trip, 400 on non-boolean, no `process.env` write, mixed-POST-with-unusable-root rollback, and every `SETTINGS_POST_KEYS` key exempt from the clear-root fallback.
- `test/spawn-args.test.mjs`: the runner gate honours the stored value with the env unset or empty, and an exported `0` is an explicit OFF.
- `test/ui-settings-debug-spawn.test.mjs` (new, jsdom): paint, Save/Reset payloads, verbatim 400, env-override note in both directions, unparsable-2xx behaviour. Imports `app.js` via `pathToFileURL` so it runs on Windows.
- `test/settings-projects-root.test.mjs`, `test/ui-settings-tooltips.test.mjs`: updated for the new keys / tooltip.

CI: `npm test` and the headless-Chrome UI proofs are green. Windows 11 VM run: the remaining failures are all pre-existing on `dev` and untouched by this PR.

## Not in this PR (follow-ups)

- `worca config` has no key for `debugSpawnEnabled` yet (it only registers the budget keys, same as the Ask caps today) — a CLI-only user still uses the env var.
- `WORCA_DEBUG_SPAWN` and this toggle are not yet documented in the README / docs; the tooltip is the only user-facing documentation.

Builds on #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxExPpCSCs6j5JnPzD5v6g
