### PR TITLE
worca: Add `worca ui start|stop|restart|status` and a graceful port-in-use path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ Run from source:
 
 ```bash
 npm start                                 # web UI (default http://localhost:4317)
+npm run cli -- ui stop                    # stop it (also: status | restart | --port <n>)
 npm run cli -- --project <dir> --prompt "<task>"   # CLI pipeline run
 ```
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Requirements:
 ### Web UI
 
 ```bash
-worca --ui
+worca ui            # start it (worca --ui does the same)
 ```
 
 Open the printed URL (default `http://localhost:4317`), add a project, and
@@ -185,6 +185,20 @@ click **New pipeline**: describe the task (or paste a markdown brief, or pull
 a task from a plugin source like GitHub Issues), pick a workflow and
 guardrails, and run. Answer clarify questions and loop gates as they come —
 in the browser or from chat.
+
+The UI is one process per machine. Starting it while it is already up is not
+an error — Worca prints the URL and how to restart it, and exits 0:
+
+```bash
+worca ui status                 # is it running? (exit 0 = yes, 1 = no)
+worca ui restart                # stop the running one, start it again
+worca ui stop                   # stop it gracefully
+worca ui --port 4318 --open     # another port; open the browser when up
+```
+
+`--port` (or the `PORT` env var) picks the port; `stop`, `restart` and
+`status` remember the port of the last started UI, so they usually need no
+flag. See `worca ui help`.
 
 ### CLI
 

--- a/src/cli/worca-cc.mjs
+++ b/src/cli/worca-cc.mjs
@@ -4,7 +4,8 @@
 // CLI entry point. Parses flags, creates a core orchestrator, subscribes to its events,
 // renders a phase tracker + streamed agent logs to the terminal, and drives interactive
 // Q&A (clarify) and loop gates via node:readline. Supports --yes (auto), --mock,
-// --install <dir> (delegates to scripts/install.mjs), --ui (spawns ui/server.mjs),
+// --install <dir> (delegates to scripts/install.mjs), ui start|stop|restart|status
+// (--ui is an alias of `ui start`; see cmdUi),
 // and -v/-V/--version (also the bare word `version`).
 //
 // ESM, no external dependencies.
@@ -28,6 +29,10 @@ import {
 import { projectKey } from '../core/store.mjs';
 import { formatExecLine, formatGateHeader, formatRunSummary } from './render.mjs';
 import { pauseExitCode, describePauseReason, promptOptions, REASON } from '../core/failure-policy.mjs';
+import { effectiveDebugSpawn } from '../core/settings.mjs';
+import {
+  DEFAULT_UI_HOST, DEFAULT_UI_PORT, probeUi, stopUi, readUiInstance, uiUrl, waitForUiState,
+} from '../core/ui-instance.mjs';
 
 // ── node:sqlite runtime guard + warning filter ──────────────────────────────────
 // Drop ONLY the one-time ExperimentalWarning emitted by node:sqlite (the module is
@@ -204,7 +209,7 @@ Usage:
   worca --prompt "<task>" [--project <dir>] [options]
   worca --file <task.md> [--project <dir>] [options]
   worca "<task>" [--project <dir>] [options]   (bare prompt; quote it)
-  worca --ui
+  worca ui [start|stop|restart|status] [--port <n>] [--open]
   worca --install <targetDir> [--force]
 
 Subcommands:
@@ -218,6 +223,8 @@ Subcommands:
                               disable|doctor|link|reimport|init|validate|exec. See: worca plugin help
   marketplace <cmd> [...]     Manage plugin marketplaces: add|list|refresh|remove. See: worca marketplace help
   config [get|set|unset]      Budget & cost-limit settings
+  ui [start|stop|restart|status]
+                              Run the web UI (default http://localhost:4317). See: worca ui help
   help                        Print this help (same as --help).
   version                     Print the version (same as --version).
 
@@ -236,7 +243,7 @@ Options:
   --branch <name>          Feature branch name (default: claude proposes one)
   --mock                   Offline mock mode (no claude, no tokens)
   --yes, --non-interactive Auto-answer clarify (first option) and gates (continue)
-  --ui                     Launch the web UI (ui/server.mjs) and exit
+  --ui                     Same as "worca ui start" (accepts --port, --open, --mock)
   --install <targetDir>    Copy agents + /worca skill into <targetDir>/.claude
   -h, --help               Show this help
   -v, -V, --version        Print the version (worca <semver>) and exit
@@ -629,11 +636,97 @@ async function attachAndDrive(orch, flags, start) {
 
 // ── subcommands ──────────────────────────────────────────────────────────────────
 
-/** Spawn the web UI server and inherit its stdio. Resolves when it exits. */
-function launchUi() {
+// ── web UI lifecycle ─────────────────────────────────────────────────────────────
+//
+// The UI is a singleton over the machine-wide store, so `worca ui` never blindly
+// binds: it probes the port first (src/core/ui-instance.mjs). A Worca UI already
+// answering there is the EXPECTED state — print where it is and how to restart
+// it, exit 0. Only a port held by some other program is an error (exit 1).
+
+const UI_HELP = `worca ui — the web UI server
+
+Usage:
+  worca ui [start] [--port <n>] [--open] [--mock]   Start the UI (default http://localhost:${DEFAULT_UI_PORT})
+  worca ui stop [--port <n>]                        Stop the running UI gracefully
+  worca ui restart [--port <n>] [--open] [--mock]   Stop it if running, then start it again
+  worca ui status [--port <n>]                      Report whether it is running (exit 0 = running, 1 = not)
+  worca ui help                                     Show this help
+
+Options:
+  --port <n>   Port to bind (start) or to look at (stop/restart/status).
+               Default: the PORT env var, then ${DEFAULT_UI_PORT}. stop/restart/status
+               also read the port of the last started UI (<worca home>/ui.json).
+  --open       Open the UI in your browser once it is up
+  --mock       Start in offline mock mode (same as WORCA_MOCK=1)
+
+\`worca --ui\` is an alias of \`worca ui start\`.
+`;
+
+/** Bind/probe port for a `worca ui` verb: --port > (instance file) > PORT env > default. */
+function resolveUiPort(a, { preferInstanceFile = false } = {}) {
+  if (a.port !== undefined) {
+    const n = Number(a.port);
+    if (!Number.isInteger(n) || n < 1 || n > 65535) fail(`--port must be an integer between 1 and 65535, got: ${a.port}`);
+    return { port: n, host: process.env.WORCA_HOST || DEFAULT_UI_HOST };
+  }
+  if (preferInstanceFile) {
+    const inst = readUiInstance();
+    if (inst) return { port: inst.port, host: inst.host || process.env.WORCA_HOST || DEFAULT_UI_HOST };
+  }
+  const env = Number(process.env.PORT);
+  const port = Number.isInteger(env) && env > 0 ? env : DEFAULT_UI_PORT;
+  return { port, host: process.env.WORCA_HOST || DEFAULT_UI_HOST };
+}
+
+/** Best-effort `open`/`start`/`xdg-open`; never throws, never keeps the CLI alive. */
+function openBrowser(url) {
+  const [cmd, args] = process.platform === 'darwin' ? ['open', [url]]
+    : process.platform === 'win32' ? ['cmd', ['/c', 'start', '', url]]
+    : ['xdg-open', [url]];
+  try {
+    const p = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    p.on('error', () => {});
+    p.unref();
+  } catch { /* no browser opener on this box — the URL is printed anyway */ }
+}
+
+/** Spawn ui/server.mjs on `port` and inherit its stdio. Resolves with its exit code. */
+async function uiStart(a) {
+  const { port, host } = resolveUiPort(a);
+  const url = uiUrl({ host, port });
+  const probe = await probeUi({ host, port });
+  if (probe.state === 'worca') {
+    out(`Worca UI is already running at ${c('bold', url)}`);
+    out('');
+    out(`  Open it:       ${url}`);
+    out(`  Restart it:    ${c('bold', 'worca ui restart')}`);
+    out(`  Another port:  ${c('bold', `worca ui --port ${port + 1}`)}`);
+    if (a.open) openBrowser(url);
+    return 0;
+  }
+  if (probe.state === 'busy') {
+    process.stderr.write(`worca: port ${port} is in use by another program, so the Worca UI cannot start.\n\n`
+      + `  Pick a free port:  worca ui --port ${port + 1}   (or set PORT)\n`);
+    return 1;
+  }
+  // A UI started earlier on some OTHER port is worth a note, not a refusal.
+  const inst = readUiInstance();
+  if (inst && inst.port !== port) {
+    const other = await probeUi({ host: inst.host, port: inst.port });
+    if (other.state === 'worca') out(c('gray', `Note: another Worca UI is running at ${uiUrl({ host: inst.host, port: inst.port })}`));
+  }
+
   const server = join(REPO_ROOT, 'ui', 'server.mjs');
-  out(c('cyan', `Launching web UI: node ${server}`));
-  const child = spawn(process.execPath, [server], { stdio: 'inherit' });
+  out(c('cyan', `Starting Worca UI on ${url}`));
+  if (effectiveDebugSpawn().enabled) out(c('gray', `  node ${server}`));
+  const env = { ...process.env, PORT: String(port) };
+  if (a.mock) env.WORCA_MOCK = '1';
+  const child = spawn(process.execPath, [server], { stdio: 'inherit', env });
+  if (a.open) {
+    waitForUiState({ host, port, states: ['worca'], timeoutMs: 20000 })
+      .then((r) => { if (r) openBrowser(url); })
+      .catch(() => {});
+  }
   return new Promise((res) => {
     child.on('exit', (code) => res(code ?? 0));
     child.on('error', (err) => {
@@ -641,6 +734,75 @@ function launchUi() {
       res(1);
     });
   });
+}
+
+/** Stop the UI on the resolved port. Idempotent: "not running" exits 0. */
+async function uiStop(a, { quiet = false } = {}) {
+  const { port, host } = resolveUiPort(a, { preferInstanceFile: true });
+  const r = await stopUi({ host, port });
+  switch (r.status) {
+    case 'stopped':
+      out(`Stopped Worca UI on port ${port}${r.pid ? ` (pid ${r.pid})` : ''}.`);
+      return 0;
+    case 'not-running':
+      if (!quiet) out(`Worca UI is not running on port ${port}.`);
+      return 0;
+    case 'busy':
+      process.stderr.write(`worca: port ${port} is in use by another program, not a Worca UI — nothing to stop.\n`);
+      return 1;
+    case 'timeout':
+      process.stderr.write(`worca: the Worca UI on port ${port}${r.pid ? ` (pid ${r.pid})` : ''} did not exit in time.\n`);
+      return 1;
+    default:
+      process.stderr.write(`worca: could not stop the Worca UI on port ${port}: ${r.reason || r.status}\n`);
+      return 1;
+  }
+}
+
+async function uiStatus(a) {
+  const { port, host } = resolveUiPort(a, { preferInstanceFile: true });
+  const probe = await probeUi({ host, port });
+  if (probe.state === 'worca') {
+    const info = probe.info || {};
+    const detail = [info.pid ? `pid ${info.pid}` : null, info.version ? `v${info.version}` : null].filter(Boolean).join(', ');
+    out(`Worca UI is running at ${c('bold', uiUrl({ host, port }))}${detail ? ` (${detail})` : ''}`);
+    return 0;
+  }
+  if (probe.state === 'busy') {
+    out(`Worca UI is not running on port ${port} (the port is in use by another program).`);
+    return 1;
+  }
+  out(`Worca UI is not running on port ${port}.`);
+  return 1;
+}
+
+/** `worca ui [start|stop|restart|status|help] [--port <n>] [--open] [--mock]` */
+async function cmdUi(argv) {
+  const verbs = new Set(['start', 'stop', 'restart', 'status']);
+  let verb = 'start';
+  let rest = argv;
+  if (argv[0] === 'help' || argv[0] === '--help' || argv[0] === '-h') {
+    process.stdout.write(UI_HELP);
+    return 0;
+  }
+  if (argv[0] && !argv[0].startsWith('-')) {
+    if (!verbs.has(argv[0])) fail(`unknown ui command "${argv[0]}" — expected one of: start, stop, restart, status (see: worca ui help)`);
+    verb = argv[0];
+    rest = argv.slice(1);
+  }
+  const a = pluginArgs(rest, ['--port'], ['--open', '--mock']);
+  if (a._.length) fail(`unexpected argument: ${a._[0]} (see: worca ui help)`);
+  if (verb === 'stop') return uiStop(a);
+  if (verb === 'status') return uiStatus(a);
+  if (verb === 'restart') {
+    // Pin the port stop resolved (possibly from the instance file) so start reuses it.
+    const { port } = resolveUiPort(a, { preferInstanceFile: true });
+    a.port = String(port);
+    const code = await uiStop(a, { quiet: true });
+    if (code !== 0) return code;
+    return uiStart(a);
+  }
+  return uiStart(a);
 }
 
 /** Delegate to scripts/install.mjs, forwarding the target dir and any passthrough args. */
@@ -1678,7 +1840,7 @@ async function cmdMarketplace(argv) {
 
 // ── main ──────────────────────────────────────────────────────────────────────────
 
-const SUBCOMMANDS = new Set(['add', 'list', 'remove', 'resume', 'doctor', 'plugin', 'marketplace', 'config']);
+const SUBCOMMANDS = new Set(['add', 'list', 'remove', 'resume', 'doctor', 'plugin', 'marketplace', 'config', 'ui']);
 
 /** Levenshtein distance, two-row. Only ever called on short argv tokens. */
 function editDistance(a, b) {
@@ -1736,6 +1898,12 @@ async function main() {
     if (sub === 'plugin') return cmdPlugin(rest);
     if (sub === 'marketplace') return cmdMarketplace(rest);
     if (sub === 'config') return cmdConfig(rest);
+    if (sub === 'ui') return cmdUi(rest);
+  }
+  // `worca --ui [...]` is the historical spelling of `worca ui start [...]`; hand the
+  // remaining tokens to the ui parser so --port/--open/--mock work with either.
+  if (process.argv.slice(2).includes('--ui')) {
+    return cmdUi(process.argv.slice(2).filter((t) => t !== '--ui'));
   }
 
   const flags = parseArgs(process.argv.slice(2));
@@ -1750,10 +1918,6 @@ async function main() {
     const passthrough = [];
     if (process.argv.includes('--force')) passthrough.push('--force');
     return runInstall(flags.install, passthrough);
-  }
-
-  if (flags.ui) {
-    return launchUi();
   }
 
   if (flags.mock) {

--- a/src/core/ui-instance.mjs
+++ b/src/core/ui-instance.mjs
@@ -1,0 +1,235 @@
+// src/core/ui-instance.mjs
+// The web UI is a singleton over the machine-wide store, so `worca ui` needs to
+// know whether one is already up before it spawns another — and needs a way to
+// stop the one that is. This module is the CLI side of that lifecycle; the server
+// side (GET /api/health, POST /api/shutdown, the instance file) lives in
+// ui/server.mjs.
+//
+// Discovery is the Jupyter runtime-file pattern: the server writes
+// <worcaHome>/ui.json ({ pid, host, port, token, version, startedAt }) once it is
+// listening and removes it on exit. The file is a HINT, never the truth — a
+// crashed server leaves it behind, so every decision re-probes the port:
+//
+//   probeUi({ port })  -> { state: 'worca', info }   a Worca UI answered /api/health
+//                      -> { state: 'busy' }          something else owns the port
+//                      -> { state: 'free' }          nothing is listening
+//
+// Stopping goes through POST /api/shutdown with the file's bearer token so the
+// server runs its graceful path (chat channel workers die cleanly) on every
+// platform — a bare signal is a hard kill on Windows. The signal is the fallback
+// when the token is unavailable (file missing, or a server too old to have one).
+
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import process from 'node:process';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+import { worcaHome } from './projects.mjs';
+
+export const DEFAULT_UI_PORT = 4317;
+export const DEFAULT_UI_HOST = '127.0.0.1';
+/** What GET /api/health must report as `name` for the occupant to count as a Worca UI. */
+export const UI_HEALTH_NAME = '@worca/app';
+
+/** Absolute path of the instance file for the current worcaHome. */
+export function uiInstanceFile() {
+  return join(worcaHome(), 'ui.json');
+}
+
+/** A fresh shutdown token (hex, 32 bytes of entropy). */
+export function newUiToken() {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * Persist the running instance's coordinates. Atomic (tmp + rename) and 0600:
+ * the token authorizes a shutdown, so it must not be world-readable.
+ */
+export async function writeUiInstance({ pid, host, port, token, version, startedAt }) {
+  const file = uiInstanceFile();
+  await fsp.mkdir(join(file, '..'), { recursive: true });
+  const tmp = `${file}.${pid}.tmp`;
+  const body = JSON.stringify({ pid, host, port, token, version, startedAt }, null, 2) + '\n';
+  await fsp.writeFile(tmp, body, { mode: 0o600 });
+  await fsp.rename(tmp, file);
+  return file;
+}
+
+/** The instance file's contents, or null when missing/corrupt/not an object. */
+export function readUiInstance() {
+  try {
+    const data = JSON.parse(fs.readFileSync(uiInstanceFile(), 'utf8'));
+    if (!data || typeof data !== 'object' || Array.isArray(data)) return null;
+    const port = Number(data.port);
+    if (!Number.isInteger(port) || port <= 0) return null;
+    return { ...data, port, pid: Number(data.pid) || null };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove the instance file. With `ifPid`, only when the file still belongs to
+ * that process — an old server exiting late must not delete the file a newer
+ * one just wrote. Synchronous so it is usable from a process 'exit' handler.
+ */
+export function removeUiInstance({ ifPid } = {}) {
+  const file = uiInstanceFile();
+  try {
+    if (ifPid !== undefined) {
+      const cur = readUiInstance();
+      if (cur && cur.pid && cur.pid !== ifPid) return false;
+    }
+    fs.unlinkSync(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Host as it appears inside a URL (IPv6 literals need brackets). */
+export function urlHost(host) {
+  if (!host) return 'localhost';
+  if (host === '127.0.0.1' || host === '::1' || host === '[::1]' || host === 'localhost') return 'localhost';
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
+/** The URL a browser should open for a UI bound to host:port. */
+export function uiUrl({ host = DEFAULT_UI_HOST, port = DEFAULT_UI_PORT } = {}) {
+  return `http://${urlHost(host)}:${port}`;
+}
+
+/** Host to CONNECT to (bind-any addresses are not dialable). */
+function dialHost(host) {
+  if (!host || host === '0.0.0.0' || host === '::') return DEFAULT_UI_HOST;
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
+/** Every error code nested in a fetch failure (Node wraps them in `cause`, sometimes an AggregateError). */
+function errorCodes(err) {
+  const out = new Set();
+  const walk = (e, depth) => {
+    if (!e || depth > 4) return;
+    if (typeof e.code === 'string') out.add(e.code);
+    if (e.cause) walk(e.cause, depth + 1);
+    if (Array.isArray(e.errors)) for (const inner of e.errors) walk(inner, depth + 1);
+  };
+  walk(err, 0);
+  return out;
+}
+
+/** GET a JSON object from the UI, or null (non-2xx, non-JSON, non-object). Network errors propagate. */
+async function getJson(url, signal) {
+  const res = await fetch(url, { signal, headers: { accept: 'application/json' } });
+  if (!res.ok) return null;
+  try {
+    const data = await res.json();
+    return data && typeof data === 'object' && !Array.isArray(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ask host:port whether a Worca UI is listening there.
+ *
+ * @returns {Promise<{state:'worca', info:object} | {state:'busy'} | {state:'free'}>}
+ *   'busy' covers every occupant that is not a Worca UI: a non-JSON answer, a
+ *   different `name`, a hang (timeout) or a reset. Only a clean connection
+ *   refusal is 'free'. A Worca UI from before /api/health existed is recognised
+ *   by its settings route and reported with `info.legacy = true` (no pid, no
+ *   token — it cannot be stopped from here, only from its own terminal).
+ */
+export async function probeUi({ host = DEFAULT_UI_HOST, port = DEFAULT_UI_PORT, timeoutMs = 1500 } = {}) {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), timeoutMs);
+  const base = `http://${dialHost(host)}:${port}`;
+  try {
+    const info = await getJson(`${base}/api/health`, ctl.signal);
+    if (info) return info.name === UI_HEALTH_NAME ? { state: 'worca', info } : { state: 'busy' };
+    const legacy = await getJson(`${base}/api/settings`, ctl.signal);
+    if (legacy && typeof legacy.projectsRootDefault === 'string' && 'askMaxTurns' in legacy) {
+      return { state: 'worca', info: { name: UI_HEALTH_NAME, legacy: true } };
+    }
+    return { state: 'busy' };
+  } catch (err) {
+    const codes = errorCodes(err);
+    if (codes.has('ECONNREFUSED')) return { state: 'free' };
+    return { state: 'busy' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll until probeUi reports `state` (or any of `states`), or give up after timeoutMs. */
+export async function waitForUiState({ host, port, states, timeoutMs = 10000, intervalMs = 100 } = {}) {
+  const want = new Set(Array.isArray(states) ? states : [states]);
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const r = await probeUi({ host, port, timeoutMs: Math.min(1500, Math.max(200, deadline - Date.now())) });
+    if (want.has(r.state)) return r;
+    if (Date.now() >= deadline) return null;
+    await sleep(intervalMs);
+  }
+}
+
+/** True when a process with that pid exists (signal 0 probes without killing). */
+export function processAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try { process.kill(pid, 0); return true; } catch (err) { return err && err.code === 'EPERM'; }
+}
+
+/**
+ * Stop the Worca UI on host:port, gracefully when possible.
+ *
+ * Order: (1) POST /api/shutdown with the instance file's token — the server
+ * answers 202 and exits through its signal path; (2) if that is refused or no
+ * token is known, SIGTERM the pid the health probe reported; (3) wait for the
+ * port to free up. Idempotent: a port with no Worca UI is `notRunning`, not an
+ * error. The instance file is cleaned up whenever the port ends up free.
+ *
+ * @returns {Promise<{status:'stopped', method:'request'|'signal', pid:number|null}
+ *                  |{status:'not-running'}
+ *                  |{status:'busy'}
+ *                  |{status:'failed', pid:number|null, reason:string}
+ *                  |{status:'timeout', pid:number|null}>}
+ */
+export async function stopUi({ host = DEFAULT_UI_HOST, port = DEFAULT_UI_PORT, token, timeoutMs = 10000 } = {}) {
+  const probe = await probeUi({ host, port });
+  if (probe.state === 'free') { removeUiInstance(); return { status: 'not-running' }; }
+  if (probe.state === 'busy') return { status: 'busy' };
+  if (probe.info.legacy) {
+    return { status: 'failed', pid: null, reason: 'it is an older Worca UI without shutdown support — stop it from its own terminal (Ctrl+C) and start again' };
+  }
+  const pid = Number(probe.info.pid) || null;
+
+  const file = readUiInstance();
+  const bearer = token || (file && file.port === port ? file.token : null);
+  let method = null;
+
+  if (bearer) {
+    try {
+      const res = await fetch(`http://${dialHost(host)}:${port}/api/shutdown`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${bearer}`, accept: 'application/json' },
+        signal: AbortSignal.timeout(3000),
+      });
+      if (res.status === 202 || res.status === 200) method = 'request';
+    } catch {
+      // The server may drop the connection while exiting — the wait below decides.
+      method = 'request';
+    }
+  }
+  if (!method && pid) {
+    try { process.kill(pid, 'SIGTERM'); method = 'signal'; } catch { /* already gone, or not ours */ }
+  }
+  if (!method) return { status: 'failed', pid, reason: 'no shutdown token in the instance file and no pid to signal' };
+
+  const freed = await waitForUiState({ host, port, states: ['free'], timeoutMs });
+  if (!freed) return { status: 'timeout', pid };
+  removeUiInstance();
+  return { status: 'stopped', method, pid };
+}

--- a/test/cli-ui.test.mjs
+++ b/test/cli-ui.test.mjs
@@ -1,0 +1,215 @@
+// test/cli-ui.test.mjs
+// `worca ui start|stop|restart|status` and the `--ui` alias. The probe-only arms
+// run against fake occupants (a Worca-shaped health server, a foreign server, a
+// free port); the lifecycle arm boots the REAL ui/server.mjs on a free port in
+// mock mode and drives start -> restart -> stop through the CLI.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { useTempHome } from './helpers/temp-home.mjs';
+import { UI_HEALTH_NAME, probeUi, waitForUiState } from '../src/core/ui-instance.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, '..', 'src', 'cli', 'worca-cc.mjs');
+
+useTempHome(after);
+
+const created = [];
+async function freshHome() {
+  const dir = await mkdtemp(join(tmpdir(), 'worca-cc-cli-ui-'));
+  created.push(dir);
+  return dir;
+}
+after(() => Promise.all(created.map((d) => rm(d, { recursive: true, force: true }))));
+
+function run(args, { home, extraEnv } = {}) {
+  return new Promise((res) => {
+    const env = { ...process.env, ...(extraEnv || {}) };
+    if (home) env.WORCA_HOME = home;
+    const child = spawn(process.execPath, [CLI, ...args], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '', stderr = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('exit', (code) => res({ code, stdout, stderr }));
+  });
+}
+
+/** Start the CLI and keep it running (a `ui start` that spawns the real server). */
+function runDetachedCli(args, { home, extraEnv } = {}) {
+  const env = { ...process.env, ...(extraEnv || {}) };
+  if (home) env.WORCA_HOME = home;
+  const child = spawn(process.execPath, [CLI, ...args], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '', stderr = '';
+  child.stdout.on('data', (d) => { stdout += d; });
+  child.stderr.on('data', (d) => { stderr += d; });
+  const exited = new Promise((res) => child.on('exit', (code) => res(code)));
+  return { child, exited, out: () => stdout, err: () => stderr };
+}
+
+async function serve(handler) {
+  const srv = http.createServer(handler);
+  await new Promise((r) => srv.listen(0, '127.0.0.1', r));
+  return { srv, port: srv.address().port, close: () => new Promise((r) => srv.close(r)) };
+}
+const json = (res, code, body) => { res.writeHead(code, { 'content-type': 'application/json' }); res.end(JSON.stringify(body)); };
+async function freePort() { const { port, close } = await serve(() => {}); await close(); return port; }
+
+test('ui help / bad verb / bad port', async () => {
+  let r = await run(['ui', 'help']);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /worca ui stop/);
+  assert.match(r.stdout, /--open/);
+
+  r = await run(['ui', 'bogus']);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /unknown ui command "bogus"/);
+
+  r = await run(['ui', 'status', '--port', 'abc']);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /--port must be an integer/);
+
+  r = await run(['ui', '--nope']);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /Unknown flag: --nope/);
+
+  r = await run(['--help']);
+  assert.match(r.stdout, /worca ui \[start\|stop\|restart\|status\]/, 'top-level help advertises the subcommand');
+});
+
+test('ui status: free port -> "not running", exit 1; stop there is idempotent (exit 0)', async () => {
+  const port = await freePort();
+  const home = await freshHome();
+  let r = await run(['ui', 'status', '--port', String(port)], { home });
+  assert.equal(r.code, 1);
+  assert.match(r.stdout, new RegExp(`not running on port ${port}\\.`));
+  r = await run(['ui', 'stop', '--port', String(port)], { home });
+  assert.equal(r.code, 0, 'stopping a stopped UI is not an error');
+  assert.match(r.stdout, /not running/);
+});
+
+test('ui start against a running Worca: friendly block, exit 0, no server spawned', async () => {
+  const { port, close } = await serve((req, res) => {
+    if (req.url === '/api/health') return json(res, 200, { name: UI_HEALTH_NAME, version: '1.0.0', pid: 4242 });
+    json(res, 404, {});
+  });
+  try {
+    const home = await freshHome();
+    let r = await run(['ui', '--port', String(port)], { home });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, new RegExp(`already running at http://localhost:${port}`));
+    assert.match(r.stdout, /Restart it:\s+worca ui restart/);
+    assert.match(r.stdout, new RegExp(`Another port:\\s+worca ui --port ${port + 1}`));
+    assert.equal(r.stderr, '', 'an expected state prints nothing on stderr');
+    assert.doesNotMatch(r.stdout, /Starting Worca UI/, 'no second instance');
+
+    r = await run(['--ui', '--port', String(port)], { home });
+    assert.equal(r.code, 0, '--ui is an alias of ui start');
+    assert.match(r.stdout, /already running/);
+
+    r = await run(['ui', 'status', '--port', String(port)], { home });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /running at http:\/\/localhost:\d+ \(pid 4242, v1\.0\.0\)/);
+
+    // PORT env is honoured when --port is absent.
+    r = await run(['ui', 'status'], { home, extraEnv: { PORT: String(port) } });
+    assert.equal(r.code, 0);
+  } finally { await close(); }
+});
+
+test('ui start against another program: three-line conflict on stderr, exit 1', async () => {
+  const { port, close } = await serve((_req, res) => { res.writeHead(200, { 'content-type': 'text/html' }); res.end('<h1>not worca</h1>'); });
+  try {
+    const home = await freshHome();
+    let r = await run(['ui', 'start', '--port', String(port)], { home });
+    assert.equal(r.code, 1);
+    assert.match(r.stderr, new RegExp(`port ${port} is in use by another program`));
+    assert.match(r.stderr, new RegExp(`worca ui --port ${port + 1}`));
+    assert.doesNotMatch(r.stderr, /at .*\.mjs:\d+/, 'no stack trace');
+    assert.ok(r.stderr.trim().split('\n').length <= 3, `short: ${JSON.stringify(r.stderr)}`);
+
+    r = await run(['ui', 'stop', '--port', String(port)], { home });
+    assert.equal(r.code, 1);
+    assert.match(r.stderr, /not a Worca UI — nothing to stop/);
+    r = await run(['ui', 'status', '--port', String(port)], { home });
+    assert.equal(r.code, 1);
+    assert.match(r.stdout, /in use by another program/);
+  } finally { await close(); }
+});
+
+test('lifecycle: real server start -> instance file -> restart (new pid) -> stop (graceful, exit 0)', { timeout: 90000 }, async () => {
+  const home = await freshHome();
+  const port = await freePort();
+  const env = { WORCA_MOCK: '1' };
+
+  const first = runDetachedCli(['ui', 'start', '--port', String(port)], { home, extraEnv: env });
+  try {
+    const up = await waitForUiState({ port, states: ['worca'], timeoutMs: 45000 });
+    assert.ok(up, `server did not come up: ${first.err()}`);
+    assert.match(first.out(), new RegExp(`Starting Worca UI on http://localhost:${port}`));
+    assert.doesNotMatch(first.out(), /server\.mjs/, 'the script path stays behind the debug-spawn toggle');
+    const pid1 = up.info.pid;
+
+    const file = join(home, '.worca-cc', 'ui.json');
+    for (let i = 0; i < 50 && !existsSync(file); i++) await new Promise((r) => setTimeout(r, 100));
+    const inst = JSON.parse(await readFile(file, 'utf8'));
+    assert.equal(inst.pid, pid1);
+    assert.equal(inst.port, port);
+    assert.match(inst.token, /^[0-9a-f]{64}$/);
+
+    // stop/status/restart find the port from the instance file — no --port needed.
+    let r = await run(['ui', 'status'], { home });
+    assert.equal(r.code, 0, r.stdout + r.stderr);
+    assert.match(r.stdout, new RegExp(`localhost:${port} \\(pid ${pid1}`));
+
+    const second = runDetachedCli(['ui', 'restart'], { home, extraEnv: env });
+    try {
+      assert.equal(await first.exited, 0, `stopped server exits 0 (graceful), got stderr: ${first.err()}`);
+      let pid2 = null;
+      const deadline = Date.now() + 45000;
+      while (Date.now() < deadline) {
+        const p = await probeUi({ port });
+        if (p.state === 'worca' && p.info.pid && p.info.pid !== pid1) { pid2 = p.info.pid; break; }
+        await new Promise((res) => setTimeout(res, 150));
+      }
+      assert.ok(pid2, `restart did not bring up a new server: ${second.out()} ${second.err()}`);
+      assert.match(second.out(), /Starting Worca UI/);
+      assert.doesNotMatch(second.out(), /not running/, 'restart is quiet about the stop it just did');
+
+      r = await run(['ui', 'stop'], { home });
+      assert.equal(r.code, 0, r.stdout + r.stderr);
+      assert.match(r.stdout, new RegExp(`Stopped Worca UI on port ${port} \\(pid ${pid2}\\)`));
+      assert.equal(await second.exited, 0, `stopped server exits 0, stderr: ${second.err()}`);
+      assert.ok(!existsSync(file), 'instance file removed on exit');
+      assert.deepEqual(await probeUi({ port }), { state: 'free' });
+    } finally { try { second.child.kill('SIGKILL'); } catch { /* gone */ } }
+  } finally { try { first.child.kill('SIGKILL'); } catch { /* gone */ } }
+});
+
+test('node ui/server.mjs on a taken port: two lines, no stack, exit 1', { timeout: 60000 }, async () => {
+  const { port, close } = await serve((_req, res) => { res.end('x'); });
+  const home = await freshHome();
+  try {
+    const server = resolve(__dirname, '..', 'ui', 'server.mjs');
+    const r = await new Promise((res) => {
+      const child = spawn(process.execPath, [server], {
+        env: { ...process.env, WORCA_HOME: home, WORCA_MOCK: '1', PORT: String(port) },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '', stderr = '';
+      child.stdout.on('data', (d) => { stdout += d; });
+      child.stderr.on('data', (d) => { stderr += d; });
+      child.on('exit', (code) => res({ code, stdout, stderr }));
+    });
+    assert.equal(r.code, 1);
+    assert.match(r.stderr, new RegExp(`port ${port} is already in use`));
+    assert.match(r.stderr, /worca ui restart/);
+    assert.doesNotMatch(r.stderr, /EADDRINUSE|Unhandled 'error' event|at Server\./, `stack leaked: ${r.stderr}`);
+  } finally { await close(); }
+});

--- a/test/server-health-shutdown.test.mjs
+++ b/test/server-health-shutdown.test.mjs
@@ -1,0 +1,97 @@
+// test/server-health-shutdown.test.mjs
+// GET /api/health and POST /api/shutdown (the server side of `worca ui
+// status|stop`). App imported (no port bind) on an ephemeral http server, temp
+// WORCA_HOME — the api-guardrails pattern. uiControl is reached through _testing
+// so the shutdown branch can be exercised without exiting the test runner.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { createRequire } from 'node:module';
+
+import { useTempHome } from './helpers/temp-home.mjs';
+import { UI_HEALTH_NAME } from '../src/core/ui-instance.mjs';
+
+useTempHome(after);
+
+const PKG_VERSION = createRequire(import.meta.url)('../package.json').version;
+
+let srv, base, uiControl, bearerMatches;
+
+before(async () => {
+  process.env.WORCA_MOCK = '1';
+  const mod = await import('../ui/server.mjs'); // imported => no port bind, uiControl empty
+  ({ uiControl, bearerMatches } = mod._testing);
+  srv = http.createServer(mod.app);
+  await new Promise((r) => srv.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${srv.address().port}`;
+});
+
+after(async () => {
+  if (srv) await new Promise((r) => srv.close(r));
+  delete process.env.WORCA_MOCK;
+});
+
+test('GET /api/health identifies the process: name, version, pid, port', async () => {
+  const r = await fetch(`${base}/api/health`);
+  assert.equal(r.status, 200);
+  const body = await r.json();
+  assert.equal(body.name, UI_HEALTH_NAME);
+  assert.equal(body.version, PKG_VERSION);
+  assert.equal(body.pid, process.pid);
+  assert.equal(body.port, srv.address().port, 'reports the port it was reached on');
+  assert.equal(body.startedAt, null, 'not booted via isMain — no start time');
+});
+
+test('GET /api/health honours the localhost-only guard like every other route', async () => {
+  // fetch() drops a caller-set Host header (forbidden header name) — go raw.
+  const status = await new Promise((res, rej) => {
+    const req = http.request({ host: '127.0.0.1', port: srv.address().port, path: '/api/health', headers: { host: 'evil.example:80' } }, (r) => { r.resume(); res(r.statusCode); });
+    req.on('error', rej);
+    req.end();
+  });
+  assert.equal(status, 403);
+});
+
+test('POST /api/shutdown is 503 when the server did not boot as a process (no token)', async () => {
+  assert.equal(uiControl.token, null);
+  const r = await fetch(`${base}/api/shutdown`, { method: 'POST', headers: { authorization: 'Bearer anything' } });
+  assert.equal(r.status, 503);
+});
+
+test('POST /api/shutdown: 401 without/with a wrong token, 202 + onShutdown with the right one', async () => {
+  const calls = [];
+  uiControl.token = 'a'.repeat(64);
+  uiControl.onShutdown = (why) => calls.push(why);
+  try {
+    let r = await fetch(`${base}/api/shutdown`, { method: 'POST' });
+    assert.equal(r.status, 401, 'no header');
+    r = await fetch(`${base}/api/shutdown`, { method: 'POST', headers: { authorization: `Bearer ${'b'.repeat(64)}` } });
+    assert.equal(r.status, 401, 'wrong token');
+    r = await fetch(`${base}/api/shutdown`, { method: 'POST', headers: { authorization: `Bearer ${'a'.repeat(63)}` } });
+    assert.equal(r.status, 401, 'length mismatch never reaches timingSafeEqual');
+    assert.deepEqual(calls, [], 'refusals never trigger shutdown');
+
+    r = await fetch(`${base}/api/shutdown`, { method: 'POST', headers: { authorization: `Bearer ${'a'.repeat(64)}` } });
+    assert.equal(r.status, 202);
+    const body = await r.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.pid, process.pid);
+    await new Promise((res) => setImmediate(res));
+    await new Promise((res) => setImmediate(res));
+    assert.deepEqual(calls, ['request'], 'shutdown runs AFTER the 202 is answered');
+  } finally {
+    uiControl.token = null;
+    uiControl.onShutdown = null;
+  }
+});
+
+test('bearerMatches: scheme is case-insensitive, whitespace tolerant, never matches empty', () => {
+  assert.equal(bearerMatches('Bearer abc', 'abc'), true);
+  assert.equal(bearerMatches('bearer abc', 'abc'), true);
+  assert.equal(bearerMatches('  Bearer   abc  ', 'abc'), true);
+  assert.equal(bearerMatches('Basic abc', 'abc'), false);
+  assert.equal(bearerMatches('Bearer abd', 'abc'), false);
+  assert.equal(bearerMatches('Bearer ', ''), false);
+  assert.equal(bearerMatches(undefined, 'abc'), false);
+  assert.equal(bearerMatches('Bearer abc', null), false);
+});

--- a/test/ui-instance.test.mjs
+++ b/test/ui-instance.test.mjs
@@ -1,0 +1,188 @@
+// test/ui-instance.test.mjs
+// src/core/ui-instance.mjs: the instance file, the /api/health probe's three
+// states (+ the legacy fallback), and stopUi's request path and signal fallback.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { statSync, existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { useTempHome } from './helpers/temp-home.mjs';
+import {
+  DEFAULT_UI_PORT, UI_HEALTH_NAME, uiInstanceFile, writeUiInstance, readUiInstance, removeUiInstance,
+  probeUi, stopUi, uiUrl, urlHost, waitForUiState, newUiToken,
+} from '../src/core/ui-instance.mjs';
+
+useTempHome(after);
+
+/** An ephemeral http server on 127.0.0.1; `handler(req, res)` answers everything. */
+async function serve(handler) {
+  const srv = http.createServer(handler);
+  await new Promise((r) => srv.listen(0, '127.0.0.1', r));
+  const port = srv.address().port;
+  const close = () => new Promise((r) => srv.close(r));
+  return { srv, port, close };
+}
+const json = (res, code, body) => { res.writeHead(code, { 'content-type': 'application/json' }); res.end(JSON.stringify(body)); };
+
+/** A port nothing listens on (bind 0, read, release). */
+async function freePort() {
+  const { port, close } = await serve(() => {});
+  await close();
+  return port;
+}
+
+test('uiUrl/urlHost: loopback binds print as localhost, IPv6 literals get brackets', () => {
+  assert.equal(uiUrl(), `http://localhost:${DEFAULT_UI_PORT}`);
+  assert.equal(uiUrl({ host: '::1', port: 5 }), 'http://localhost:5');
+  assert.equal(uiUrl({ host: '0.0.0.0', port: 5 }), 'http://0.0.0.0:5');
+  assert.equal(urlHost('fe80::1'), '[fe80::1]');
+});
+
+test('instance file: write is 0600 + atomic, read normalises, remove honours ifPid', async () => {
+  const file = uiInstanceFile();
+  assert.equal(readUiInstance(), null, 'missing file reads as null');
+  const token = newUiToken();
+  await writeUiInstance({ pid: 4242, host: '127.0.0.1', port: '4317', token, version: '1.2.3', startedAt: 't' });
+  assert.ok(existsSync(file));
+  assert.ok(!existsSync(`${file}.4242.tmp`), 'tmp file renamed away');
+  if (process.platform !== 'win32') assert.equal(statSync(file).mode & 0o777, 0o600);
+  const inst = readUiInstance();
+  assert.equal(inst.port, 4317, 'port is coerced to a number');
+  assert.equal(inst.pid, 4242);
+  assert.equal(inst.token, token);
+
+  assert.equal(removeUiInstance({ ifPid: 9999 }), false, 'another pid must not delete it');
+  assert.ok(existsSync(file));
+  assert.equal(removeUiInstance({ ifPid: 4242 }), true);
+  assert.ok(!existsSync(file));
+  assert.equal(removeUiInstance(), false, 'already gone');
+
+  await writeFile(file, '{not json');
+  assert.equal(readUiInstance(), null, 'corrupt file reads as null');
+  await writeFile(file, JSON.stringify({ pid: 1, port: 'nope' }));
+  assert.equal(readUiInstance(), null, 'bad port reads as null');
+  removeUiInstance();
+});
+
+test('probeUi: free port -> free', async () => {
+  const port = await freePort();
+  assert.deepEqual(await probeUi({ port }), { state: 'free' });
+});
+
+test('probeUi: a Worca /api/health -> worca with its info', async () => {
+  const { port, close } = await serve((req, res) => {
+    if (req.url === '/api/health') return json(res, 200, { name: UI_HEALTH_NAME, version: '9.9.9', pid: 77 });
+    json(res, 404, { error: 'nope' });
+  });
+  try {
+    const r = await probeUi({ port });
+    assert.equal(r.state, 'worca');
+    assert.equal(r.info.pid, 77);
+    assert.equal(r.info.version, '9.9.9');
+  } finally { await close(); }
+});
+
+test('probeUi: a different program (HTML, other JSON name, 500) -> busy', async () => {
+  const cases = [
+    (_req, res) => { res.writeHead(200, { 'content-type': 'text/html' }); res.end('<html>hi</html>'); },
+    (_req, res) => json(res, 200, { name: 'something-else' }),
+    (_req, res) => json(res, 500, { error: 'boom' }),
+  ];
+  for (const handler of cases) {
+    const { port, close } = await serve(handler);
+    try { assert.deepEqual(await probeUi({ port }), { state: 'busy' }); } finally { await close(); }
+  }
+});
+
+test('probeUi: a hang is busy, not free (timeout)', async () => {
+  const { port, close, srv } = await serve(() => { /* never answers */ });
+  srv.on('connection', (s) => s.setTimeout(0));
+  try {
+    const r = await probeUi({ port, timeoutMs: 200 });
+    assert.equal(r.state, 'busy');
+  } finally { srv.closeAllConnections?.(); await close(); }
+});
+
+test('probeUi: an older Worca UI (no /api/health, but /api/settings) -> worca + legacy', async () => {
+  const { port, close } = await serve((req, res) => {
+    if (req.url === '/api/settings') return json(res, 200, { projectsRootDefault: '/home/x', askMaxTurns: 40, chat: {} });
+    json(res, 404, { error: 'not found' });
+  });
+  try {
+    const r = await probeUi({ port });
+    assert.equal(r.state, 'worca');
+    assert.equal(r.info.legacy, true);
+    const s = await stopUi({ port });
+    assert.equal(s.status, 'failed');
+    assert.match(s.reason, /older Worca UI/);
+  } finally { await close(); }
+});
+
+test('stopUi: free port -> not-running (idempotent) and clears a stale instance file', async () => {
+  const port = await freePort();
+  await writeUiInstance({ pid: 1, host: '127.0.0.1', port, token: 'x', version: '0', startedAt: 't' });
+  assert.deepEqual(await stopUi({ port }), { status: 'not-running' });
+  assert.equal(readUiInstance(), null, 'stale file removed');
+});
+
+test('stopUi: busy port -> busy, nothing signalled', async () => {
+  const { port, close } = await serve((_req, res) => json(res, 200, { name: 'other' }));
+  try { assert.deepEqual(await stopUi({ port }), { status: 'busy' }); } finally { await close(); }
+});
+
+test('stopUi: request path — bearer token from the instance file, server closes, port frees', async () => {
+  const token = newUiToken();
+  let seenAuth = null;
+  const { port, close, srv } = await serve((req, res) => {
+    if (req.url === '/api/health') return json(res, 200, { name: UI_HEALTH_NAME, pid: process.pid });
+    if (req.method === 'POST' && req.url === '/api/shutdown') {
+      seenAuth = req.headers.authorization;
+      json(res, 202, { ok: true });
+      setImmediate(() => { srv.closeAllConnections?.(); srv.close(); });
+      return;
+    }
+    json(res, 404, {});
+  });
+  await writeUiInstance({ pid: process.pid, host: '127.0.0.1', port, token, version: '0', startedAt: 't' });
+  try {
+    const r = await stopUi({ port, timeoutMs: 5000 });
+    assert.equal(r.status, 'stopped');
+    assert.equal(r.method, 'request');
+    assert.equal(seenAuth, `Bearer ${token}`);
+    assert.equal(readUiInstance(), null, 'instance file cleaned up');
+  } finally { await close().catch(() => {}); }
+});
+
+test('stopUi: signal fallback — no token, shutdown refused, SIGTERM on the health pid', { skip: process.platform === 'win32' && 'signal semantics differ on Windows' }, async () => {
+  const port = await freePort();
+  // A child that serves /api/health with ITS pid and refuses /api/shutdown (401).
+  const script = `
+    const http = require('node:http');
+    http.createServer((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      if (req.url === '/api/health') return res.end(JSON.stringify({ name: ${JSON.stringify(UI_HEALTH_NAME)}, pid: process.pid }));
+      res.statusCode = 401; res.end('{}');
+    }).listen(${port}, '127.0.0.1', () => process.stdout.write('up\\n'));
+  `;
+  const child = spawn(process.execPath, ['-e', script], { stdio: ['ignore', 'pipe', 'inherit'] });
+  await new Promise((r) => child.stdout.on('data', (d) => { if (String(d).includes('up')) r(); }));
+  const exited = new Promise((r) => child.on('exit', (code, signal) => r({ code, signal })));
+  try {
+    const r = await stopUi({ port, timeoutMs: 5000 });
+    assert.equal(r.status, 'stopped');
+    assert.equal(r.method, 'signal');
+    assert.equal(r.pid, child.pid);
+    const { signal } = await exited;
+    assert.equal(signal, 'SIGTERM');
+    assert.deepEqual(await probeUi({ port }), { state: 'free' });
+  } finally { try { child.kill('SIGKILL'); } catch { /* gone */ } }
+});
+
+test('waitForUiState: resolves when the state appears, null on deadline', async () => {
+  const port = await freePort();
+  assert.equal((await waitForUiState({ port, states: ['free'], timeoutMs: 1000 }))?.state, 'free');
+  assert.equal(await waitForUiState({ port, states: ['worca'], timeoutMs: 300 }), null);
+});

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -93,6 +93,9 @@ import { listGlobalModels, addGlobalModel, updateGlobalModel } from '../src/core
 import { modelEnvRef, maskModelEnvValue, SUBAGENT_MODEL_VALUES, subagentModelIssue } from '../src/core/model-env.mjs';
 import { listPluginModels, modelSecretsSchema, pluginModelSecretStatus } from '../src/core/plugin-models.mjs';
 import { testModel } from '../src/core/model-test.mjs';
+import {
+  DEFAULT_UI_PORT, UI_HEALTH_NAME, newUiToken, writeUiInstance, removeUiInstance, uiUrl,
+} from '../src/core/ui-instance.mjs';
 import { validateGuardrails } from '../src/core/guardrails.mjs';
 import {
   listBuiltinGuardrailSets, listGuardrailSets, readGuardrailSet,
@@ -174,6 +177,7 @@ const PUBLIC_DIR = path.join(__dirname, 'public');
 const AGENTS_DIR = path.join(PROJECT_ROOT, 'agents');
 const SKILLS_DIR = path.join(PROJECT_ROOT, 'skills');
 const require = createRequire(import.meta.url);
+const PKG_VERSION = require('../package.json').version;
 const HLJS_LANGUAGE_FILE_RE = /^[a-z0-9][a-z0-9-]{0,63}\.min\.js$/;
 // Primaries plus the sub-language grammars their instances register
 // (hljs-loader.mjs); a shipped but unmapped grammar stays a plain 404.
@@ -212,7 +216,7 @@ const ASK_VENDOR_ASSETS = {
   dompurify: resolveEsmAsset('dompurify'),
 };
 
-const PORT = Number(process.env.PORT) || 4317;
+const PORT = Number(process.env.PORT) || DEFAULT_UI_PORT;
 // Bind to loopback by default (S1). Power users who knowingly want LAN exposure
 // can set WORCA_HOST=0.0.0.0, but the localhost-only Host/Origin guard still
 // applies unless they also front it with auth.
@@ -275,6 +279,11 @@ const MAX_BUFFER = 5000;
 const app = express();
 const server = http.createServer(app);
 const wss = new WebSocketServer({ server, path: '/ws' });
+// ws re-emits the http server's 'error' on the WebSocketServer. With no listener
+// here, an EADDRINUSE on listen() became an unhandled 'error' event and a full
+// stack trace; the http server's own handler (isMain below) is the one that
+// reports it, so this side of the pair only has to not throw.
+wss.on('error', () => {});
 
 /** All currently connected sockets. */
 const sockets = new Set();
@@ -2779,6 +2788,49 @@ const settingsState = () => ({
   askMaxBudgetUsd: askMaxBudgetUsd(),
   debugSpawnEnabled: storedDebugSpawnEnabled(),          // what is STORED (the checkbox)
   debugSpawnEffective: effectiveDebugSpawn(),             // what the next spawn will DO, and why
+});
+
+// ---------------------------------------------------------------------------
+// Instance lifecycle (`worca ui status|stop|restart`, src/core/ui-instance.mjs)
+// ---------------------------------------------------------------------------
+// `uiControl` is set by the boot block below when the server owns a port. Under
+// test (app imported, no bind) it stays empty: /api/health still answers, and
+// /api/shutdown refuses with 503 rather than exiting the test runner.
+const uiControl = { token: null, onShutdown: null, startedAt: null };
+const startedAtIso = () => uiControl.startedAt || null;
+
+app.get('/api/health', (req, res) => {
+  const addr = req.socket && req.socket.localPort;
+  res.json({
+    name: UI_HEALTH_NAME,
+    version: PKG_VERSION,
+    pid: process.pid,
+    host: HOST,
+    port: addr || PORT,
+    startedAt: startedAtIso(),
+  });
+});
+
+/** Constant-time bearer check; `expected` is the boot-time token from ui.json. */
+function bearerMatches(header, expected) {
+  if (!expected || typeof header !== 'string') return false;
+  const m = /^Bearer\s+(\S+)$/i.exec(header.trim());
+  if (!m) return false;
+  const a = Buffer.from(m[1]);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+app.post('/api/shutdown', (req, res) => {
+  if (!uiControl.token || typeof uiControl.onShutdown !== 'function') {
+    return res.status(503).json({ error: 'shutdown is only available on a server started with `worca ui`' });
+  }
+  if (!bearerMatches(req.headers.authorization, uiControl.token)) {
+    return res.status(401).json({ error: 'shutdown requires the bearer token from the instance file' });
+  }
+  res.status(202).json({ ok: true, pid: process.pid });
+  // Answer first, exit on the next tick so the 202 actually leaves the socket.
+  setImmediate(() => uiControl.onShutdown('request'));
 });
 
 app.get('/api/settings', (_req, res) => {
@@ -5364,30 +5416,53 @@ if (isMain) {
     console.error(`[worca-ui] boot maintenance failed: ${err && err.message ? err.message : err}`);
   });
 
+  // A port that is already taken is an EXPECTED state (the UI is usually already
+  // up), not a crash: one line, no stack, exit 1. `worca ui` probes the port
+  // before spawning this process and prints the friendlier "already running"
+  // block itself; this branch is for `node ui/server.mjs` run by hand or a race.
   server.on('error', (err) => {
+    if (err && err.code === 'EADDRINUSE') {
+      console.error(`[worca-ui] port ${PORT} is already in use — is the UI already running?`);
+      console.error(`[worca-ui] check with \`worca ui status\`, restart with \`worca ui restart\`, or pick a port: \`worca ui --port <n>\``);
+      process.exit(1);
+    }
     console.error(`[worca-ui] server error: ${err && err.message ? err.message : err}`);
   });
 
+  // Channel workers must die with the server (design §9: persistent-process
+  // hygiene). Graceful shutdown frame -> 5s grace -> SIGKILL, then exit. The
+  // same path serves POST /api/shutdown (`worca ui stop`), which exits 0.
+  let shuttingDown = false;
+  let wroteInstanceFile = false;
+  const exitCodeFor = (signal) => (signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 0);
+  const shutdown = (signal) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    channelHost.stop().finally(() => process.exit(exitCodeFor(signal)));
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  // 'exit' handlers must be synchronous; removeUiInstance is. `ifPid` keeps an
+  // old server exiting late from deleting the file a newer one just wrote.
+  process.on('exit', () => { if (wroteInstanceFile) removeUiInstance({ ifPid: process.pid }); });
+
   server.listen(PORT, HOST, () => {
-    const shown = HOST === '127.0.0.1' || HOST === '::1' ? 'localhost' : HOST;
-    const url = `http://${shown}:${PORT}`;
+    const port = server.address().port;
+    const url = uiUrl({ host: HOST, port });
     console.log(`[worca-ui] listening on ${url} (bound to ${HOST})`);
-    console.log(`[worca-ui] WebSocket on ws://${shown}:${PORT}/ws`);
+    uiControl.token = newUiToken();
+    uiControl.onShutdown = shutdown;
+    uiControl.startedAt = new Date().toISOString();
+    writeUiInstance({
+      pid: process.pid, host: HOST, port, token: uiControl.token,
+      version: PKG_VERSION, startedAt: uiControl.startedAt,
+    }).then(() => { wroteInstanceFile = true; }, (err) => {
+      console.error(`[worca-ui] could not write the instance file (\`worca ui stop\` will fall back to a signal): ${err && err.message ? err.message : err}`);
+    });
     try { channelHost.start(); } catch (err) {
       console.error(`[worca-ui] chat channel host failed to start: ${err && err.message ? err.message : err}`);
     }
   });
-
-  // Channel workers must die with the server (design §9: persistent-process
-  // hygiene). Graceful shutdown frame -> 5s grace -> SIGKILL, then exit.
-  let shuttingDown = false;
-  const shutdownChat = (signal) => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    channelHost.stop().finally(() => process.exit(signal === 'SIGINT' ? 130 : 143));
-  };
-  process.on('SIGINT', () => shutdownChat('SIGINT'));
-  process.on('SIGTERM', () => shutdownChat('SIGTERM'));
 }
 
 export { app, server, runs };
@@ -5396,4 +5471,5 @@ export const _testing = {
   chatActions, chatRouter, channelHost, handleChatInbound, enqueueChatWork,
   chatNotifier, resumeRun, resolveHljsAssets, resolveEsmAsset, askJobs, askFollowers, askDeleting, resolveAskContext, flipCard,
   emitDiffCommentsChanged, emitAskWorktrees, askWorktreesEnvelope, deleteAskThreadFully,
+  uiControl, bearerMatches,
 };


### PR DESCRIPTION
## Why

`worca --ui` while the UI was already up printed a 20-line unhandled-`'error'` stack trace:

```
node:events:497
      throw er; // Unhandled 'error' event
Error: listen EADDRINUSE: address already in use 127.0.0.1:4317
    at Server.setupListenHandle [as _listen2] (node:net:1940:16)
    ...
```

`ws` re-emits the http server's listen error on the `WebSocketServer`, which had no listener. And "already running" is the *expected* state for a singleton UI, not an error.

## What

**`worca ui [start|stop|restart|status|help] [--port <n>] [--open] [--mock]`** — `--ui` stays as an alias of `ui start`.

Already running (exit 0, stdout):

```
Worca UI is already running at http://localhost:4317

  Open it:       http://localhost:4317
  Restart it:    worca ui restart
  Another port:  worca ui --port 4318
```

Another program on the port (exit 1, stderr):

```
worca: port 4317 is in use by another program, so the Worca UI cannot start.

  Pick a free port:  worca ui --port 4318   (or set PORT)
```

- `src/core/ui-instance.mjs` (new): `probeUi` (`GET /api/health` → `worca | busy | free`; pre-health servers recognised via `/api/settings` as `legacy`), `stopUi` (`POST /api/shutdown` with the bearer token from `<worcaHome>/ui.json`, SIGTERM on the health pid as fallback, then wait for the port to free), the instance file (0600, atomic, pid-guarded removal — Jupyter's runtime-file pattern).
- `ui/server.mjs`: `GET /api/health`, `POST /api/shutdown` (202 → existing graceful path, exit 0; 401 bad token; 503 when imported rather than booted), EADDRINUSE → two lines + exit 1, `wss` error absorbed, `[worca-ui] WebSocket on …` boot line dropped.
- CLI: port = `--port` > `PORT` env > 4317; `stop`/`restart`/`status` also read the last-started port from the instance file. `--open` launches the browser once `/api/health` answers. The `node …/server.mjs` path now prints only under the debug-spawn toggle.
- README + CONTRIBUTING document the lifecycle commands.

Why not Vite-style auto-pick-next-port: the UI is a singleton over the machine-wide DB — two instances would each spawn chat workers and fight over runs.

## Tests

- `test/ui-instance.test.mjs` — file semantics, the three probe states + legacy + hang, stop via request and via signal.
- `test/server-health-shutdown.test.mjs` — routes, host guard, constant-time token check, shutdown runs after the 202.
- `test/cli-ui.test.mjs` — fake occupants, `--ui` alias, a real `start → restart → stop` lifecycle on a free port (instance file, new pid, exit 0), and bare `node ui/server.mjs` on a taken port (no stack).

`npm test`: 4581/4581 locally (macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQb6cqdWxX1Hk7LAq9cHNu
