### PR TITLE
worca ui: probe over a one-shot http request so the CLI exits cleanly on Windows

### DIFF
--- a/src/core/ui-instance.mjs
+++ b/src/core/ui-instance.mjs
@@ -20,6 +20,7 @@
 // when the token is unavailable (file missing, or a server too old to have one).
 
 import fs from 'node:fs';
+import http from 'node:http';
 import fsp from 'node:fs/promises';
 import process from 'node:process';
 import { join } from 'node:path';
@@ -106,7 +107,7 @@ function dialHost(host) {
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
 }
 
-/** Every error code nested in a fetch failure (Node wraps them in `cause`, sometimes an AggregateError). */
+/** Every error code nested in a request failure (Node wraps them in `cause`, sometimes an AggregateError). */
 function errorCodes(err) {
   const out = new Set();
   const walk = (e, depth) => {
@@ -119,12 +120,38 @@ function errorCodes(err) {
   return out;
 }
 
+/**
+ * One-shot HTTP call on a throwaway connection. NOT fetch(): the lifecycle verbs
+ * call process.exit() right after a probe, and undici's pooled keep-alive socket is
+ * still closing at that moment — on Windows libuv asserts on it
+ * (`!(handle->flags & UV_HANDLE_CLOSING)`, src/win/async.c) and the CLI dies with
+ * 0xC0000409 instead of its exit code, after printing the right message. A bare
+ * `agent: false` + `Connection: close` request leaves nothing behind to tear down.
+ * Rejects with the socket error (its `code` intact, e.g. ECONNREFUSED) or the
+ * signal's AbortError.
+ */
+function request(url, { method = 'GET', headers = {}, signal } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, { method, agent: false, signal, headers: { ...headers, connection: 'close' } }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('error', reject);
+      res.on('end', () => resolve({
+        status: res.statusCode, ok: res.statusCode >= 200 && res.statusCode < 300,
+        text: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
 /** GET a JSON object from the UI, or null (non-2xx, non-JSON, non-object). Network errors propagate. */
 async function getJson(url, signal) {
-  const res = await fetch(url, { signal, headers: { accept: 'application/json' } });
+  const res = await request(url, { signal, headers: { accept: 'application/json' } });
   if (!res.ok) return null;
   try {
-    const data = await res.json();
+    const data = JSON.parse(res.text);
     return data && typeof data === 'object' && !Array.isArray(data) ? data : null;
   } catch {
     return null;
@@ -212,7 +239,7 @@ export async function stopUi({ host = DEFAULT_UI_HOST, port = DEFAULT_UI_PORT, t
 
   if (bearer) {
     try {
-      const res = await fetch(`http://${dialHost(host)}:${port}/api/shutdown`, {
+      const res = await request(`http://${dialHost(host)}:${port}/api/shutdown`, {
         method: 'POST',
         headers: { authorization: `Bearer ${bearer}`, accept: 'application/json' },
         signal: AbortSignal.timeout(3000),


### PR DESCRIPTION
## What

`worca ui start|status|stop` (from #420) crash on Windows with exit code 3221226505 (0xC0000409) instead of their real exit code, after printing the correct message. Found by the full Windows VM run after #403 landed: `test/cli-ui.test.mjs` "ui start against another program … exit 1" fails there.

## Why

The port probe in `src/core/ui-instance.mjs` used `fetch()`. Undici keeps a pooled keep-alive socket; the lifecycle verbs call `process.exit()` right after the probe while that socket is still closing, and on Windows libuv asserts:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
```

Reproduced in the Win11 VM (Node 24) on every busy-port path for `start` and `status`.

## Fix

Replace both `fetch()` calls (the health/settings probe and the `POST /api/shutdown`) with a minimal `node:http` request using `agent: false` + `Connection: close`, so nothing pooled is left to tear down at exit. Error semantics unchanged: socket errors keep their `code` (ECONNREFUSED → `free`), an aborted timeout signal → `busy`.

## Verification

- Win11 VM, direct repro: `ui start` / `ui status` against a non-Worca server now exit 1 cleanly, no assertion on stderr.
- Win11 VM: `test/ui-instance.test.mjs`, `test/cli-ui.test.mjs`, `test/server-health-shutdown.test.mjs` → 22 pass, 1 intentional skip, 0 fail (was 1 fail).
- macOS: same three suites 23/23; full `npm test` run on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQb6cqdWxX1Hk7LAq9cHNu
