### PR TITLE
Workflow export/import as JSON and as a plugin (#421)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ and durations, the clarify Q&A, agent transcripts, and logs:
   runs out). Flow cards — **Task** (the run's request), **End** (the result),
   **AND**, **OR**, **Combine** — express joins, choices and merges without any
   code. Saved pipelines appear in the New Pipeline picker.
+- **Share a pipeline** — every saved pipeline can leave Worca three ways.
+  *Export to Claude Code* turns it into a runnable `/command` skill under
+  `.claude/` so it runs without Worca. *Download JSON* / *Import JSON* pass a
+  pipeline to another Worca user as a single file (a taken name gets a
+  ` (2)` suffix; nothing is ever overwritten). *Export to a plugin folder*
+  bundles the pipeline with your own agents it uses and the skills they need,
+  so the recipient runs `worca plugin link <folder>` and updates later with
+  `worca plugin reimport`. Built-in agents are never copied — a plugin
+  pipeline may reference them directly.
 
 ![Workflow Composer — drag agents into steps, groups, and feedback loops](docs/screenshots/composer.png)
 
@@ -214,10 +223,15 @@ worca resume <pipelineId>
 
 # offline demo — full pipeline, no tokens
 worca --project /path/to/your/project --prompt "demo task" --mock --yes
+
+# share a saved pipeline: as JSON, or as a plugin folder bundling your agents + skills
+worca workflow export wf_my-flow --format json --out my-flow.json
+worca workflow import my-flow.json
+worca workflow export wf_my-flow --format plugin --target ./my-flow-plugin
 ```
 
 Run `worca --help` for all subcommands (projects, plugins, marketplaces,
-config, doctor) and flags.
+workflows, config, doctor) and flags.
 
 Exit codes, for scripts and CI wrappers: `0` the run finished (or an
 interactive run paused and you can resume it); `1` a hard error, a stop, or an

--- a/README.md
+++ b/README.md
@@ -90,15 +90,15 @@ and durations, the clarify Q&A, agent transcripts, and logs:
   runs out). Flow cards — **Task** (the run's request), **End** (the result),
   **AND**, **OR**, **Combine** — express joins, choices and merges without any
   code. Saved pipelines appear in the New Pipeline picker.
-- **Share a pipeline** — every saved pipeline can leave Worca three ways.
-  *Export to Claude Code* turns it into a runnable `/command` skill under
-  `.claude/` so it runs without Worca. *Download JSON* / *Import JSON* pass a
-  pipeline to another Worca user as a single file (a taken name gets a
-  ` (2)` suffix; nothing is ever overwritten). *Export to a plugin folder*
-  bundles the pipeline with your own agents it uses and the skills they need,
-  so the recipient runs `worca plugin link <folder>` and updates later with
-  `worca plugin reimport`. Built-in agents are never copied — a plugin
-  pipeline may reference them directly.
+- **Share a pipeline** — *Export…* on a saved pipeline offers three formats.
+  A *JSON file* passes it to another Worca user, who picks it up with
+  *Import…* (a taken name gets a ` (2)` suffix; nothing is ever overwritten).
+  A *Claude Code skill* turns it into a runnable `/command` under `.claude/`
+  so it runs without Worca. A *Worca plugin* folder bundles the pipeline with
+  your own agents it uses and the skills they need, so the recipient runs
+  `worca plugin link <folder>` and updates later with `worca plugin reimport`.
+  Built-in agents are never copied — a plugin pipeline may reference them
+  directly. The saved list is tabbed by domain; click a card to open it.
 
 ![Workflow Composer — drag agents into steps, groups, and feedback loops](docs/screenshots/composer.png)
 

--- a/src/cli/worca-cc.mjs
+++ b/src/cli/worca-cc.mjs
@@ -225,7 +225,7 @@ Subcommands:
   config [get|set|unset]      Budget & cost-limit settings
   ui [start|stop|restart|status]
                               Run the web UI (default http://localhost:4317). See: worca ui help
-  workflow <cmd> [...]        Export a workflow as a Claude Code skill: list|export. See: worca workflow help
+  workflow <cmd> [...]        Export a workflow (Claude Code skill, JSON, or plugin) / import JSON: list|export|import. See: worca workflow help
   help                        Print this help (same as --help).
   version                     Print the version (same as --version).
 
@@ -1204,21 +1204,41 @@ working, including updates (install provenance lives in plugins.lock.json).
 Exit codes: 0 ok, 1 failure, 2 usage/validation errors.
 `;
 
-const WORKFLOW_HELP = `worca workflow — export a saved Composer workflow as a runnable Claude Code skill
+const WORKFLOW_HELP = `worca workflow — export a saved Composer workflow (as a Claude Code skill, as
+shareable JSON, or as a Worca plugin) and import one shared as JSON
 
 Usage:
   worca workflow list                                List workflows (id, name, domain)
-  worca workflow export <id> [options]               Export a workflow to <dest>/.claude/
+  worca workflow export <id> [options]               Export a workflow (see --format)
+  worca workflow import <file> [--name <name>]       Import a JSON export into your library ('-' = stdin)
 
-Export options:
+Export formats (--format):
+  claude (default)         A runnable Claude Code skill tree under <dest>/.claude/
+  json                     The shareable v2 graph, to stdout (or --out <file>)
+  plugin                   A Worca plugin folder (--target <dir>) bundling the workflow,
+                           your own agents it uses and the skills they require; the
+                           recipient runs: worca plugin link <dir>
+
+Options (claude):
   --global                 Export to the home dir (~/.claude), not a project
   --target <dir>           Export into <dir>/.claude (default: cwd)
   --slug <name>            Skill slug (default: slugified workflow name)
   --dry-run                Show the classification (create/update/no-op/conflict); write nothing
   --on-conflict <mode>     skip (default) | overwrite | namespace conflicting files
+Options (json):
+  --out <file>             Write to <file> instead of stdout
+Options (plugin):
+  --target <dir>           The plugin folder (created, or updated in place)
+  --name <plugin>          Plugin name (default: an existing manifest's name, else the folder name)
+  --keep-version           Do not patch-bump the manifest version on an update
+  --dry-run                Show the classification; write nothing
+
+Import: the id is minted from the name; a name already in use gets a " (2)" suffix —
+nothing is ever overwritten. A workflow that needs agents you do not have is refused;
+ask its author for the plugin export instead.
 
 Export always prints the plan first, then applies (unless --dry-run). A re-export
-of an unchanged workflow is an all-no-op. Exit codes: 0 ok, 1 failure, 2 usage errors.
+of an unchanged workflow is an all-no-op. Exit codes: 0 ok, 1 failure, 2 usage/validation errors.
 `;
 
 /** Tiny per-verb arg parser: positionals plus declared --value / --bool flags. */
@@ -1238,7 +1258,7 @@ function pluginArgs(argv, valueFlags = [], boolFlags = []) {
       out[a.slice(2)] = v;
     } else if (boolFlags.includes(a)) {
       out[a.slice(2)] = true;
-    } else if (a.startsWith('-')) {
+    } else if (a.startsWith('-') && a !== '-') {                 // a lone '-' is the stdin positional
       fail(`Unknown flag: ${a}`);
     } else {
       out._.push(a);
@@ -1323,9 +1343,8 @@ async function pluginInit(rest) {
   for (const part of withParts) {
     if (!INIT_PARTS.includes(part)) fail(`unknown --with part "${part}" (known: ${INIT_PARTS.join(', ')})`);
   }
-  if (withParts.includes('workflows') && !withParts.includes('agents')) {
-    fail('--with workflows requires agents (templates may only reference the plugin\'s own agent keys)');
-  }
+  // `--with workflows` no longer requires `agents`: a plugin template may reference
+  // built-in agents (#421), so a workflow-only plugin scaffolds a built-in chain.
   const target = resolve(process.cwd(), a.dir || name);
   const { mkdir, writeFile, chmod, readdir } = await import('node:fs/promises');
   try {
@@ -1434,19 +1453,24 @@ async function pluginInit(rest) {
   }
   if (withParts.includes('workflows')) {
     // A v2 graph: the Task and End cards are mandatory (V20/V21) and every input
-    // takes exactly one wire (V7). Ports come from the sidecar above.
+    // takes exactly one wire (V7). With agents, ports come from the sidecar above;
+    // without, the chain runs the built-in planner (a plugin template may
+    // reference built-ins — they are on every host).
+    const withAgent = withParts.includes('agents');
+    const key = withAgent ? agentKey : 'planner';
+    const outPort = withAgent ? 'notes' : 'plan';
     files.set('workflows/example-flow.json', JSON.stringify({
       name: `${name} example flow`,
       version: 2,
       domain: 'general',
       nodes: [
         { id: 'n_task', kind: 'task', x: 40, y: 200, config: {} },
-        { id: 'n_helper', kind: 'agent', key: agentKey, x: 320, y: 200, config: {} },
+        { id: 'n_helper', kind: 'agent', key, x: 320, y: 200, config: {} },
         { id: 'n_end', kind: 'end', x: 600, y: 200, config: {} },
       ],
       wires: [
         { id: 'w1', from: { node: 'n_task', port: 'task' }, to: { node: 'n_helper', port: 'task' } },
-        { id: 'w2', from: { node: 'n_helper', port: 'notes' }, to: { node: 'n_end', port: 'result' } },
+        { id: 'w2', from: { node: 'n_helper', port: outPort }, to: { node: 'n_end', port: 'result' } },
       ],
     }, null, 2) + '\n');
   }
@@ -1862,6 +1886,8 @@ async function cmdWorkflow(argv) {
   if (!verb || verb === 'help') { process.stdout.write(WORKFLOW_HELP); return 0; }
   const wf = await import('../core/workflows.mjs');
   const xp = await import('../core/workflow-export.mjs');
+  const share = await import('../core/workflow-share.mjs');
+  const { formatIssue } = await import('../shared/graph/validate.mjs');
   try {
     switch (verb) {
       case 'list': {
@@ -1871,10 +1897,80 @@ async function cmdWorkflow(argv) {
         for (const w of items) out(`${w.id}\t${w.name}\t${(w.domain || 'general')}`);
         return 0;
       }
+      case 'import': {
+        const a = pluginArgs(rest, ['--name'], []);
+        const file = a._[0];
+        if (!file) fail('Usage: worca workflow import <file> [--name <name>]');
+        const { readFile } = await import('node:fs/promises');
+        let text;
+        try {
+          text = file === '-'
+            ? await new Promise((res, rej) => { let s = ''; process.stdin.setEncoding('utf8'); process.stdin.on('data', (c) => (s += c)); process.stdin.on('end', () => res(s)); process.stdin.on('error', rej); })
+            : await readFile(resolve(process.cwd(), file), 'utf8');
+        } catch (e) { process.stderr.write(`worca workflow import: cannot read ${file}: ${e.message}\n`); return 1; }
+        let obj;
+        try { obj = JSON.parse(text); } catch (e) { process.stderr.write(`worca workflow import: ${file} is not valid JSON (${e.message})\n`); return 2; }
+        try {
+          const r = await share.importGraphWorkflow(obj, { name: a.name });
+          out(`imported\t${r.workflow.id}\t${r.workflow.name}`);
+          if (r.renamed) out(c('yellow', `renamed: "${r.requestedName}" was already taken — saved as "${r.workflow.name}"`));
+          for (const w of r.warnings || []) out(`${c('yellow', 'warn')}\t${formatIssue(w)}`);
+          return 0;
+        } catch (e) {
+          if (e && e.code === 'INVALID_GRAPH') {
+            process.stderr.write(`worca workflow import: ${e.summary || 'invalid graph'}\n`);
+            for (const issue of e.errors || []) process.stderr.write(`  - ${formatIssue(issue)}\n`);
+            return 2;
+          }
+          if (e && (e.code === 'BAD_REQUEST' || e.code === 'RESERVED_NAME')) { process.stderr.write(`worca workflow import: ${e.message}\n`); return 2; }
+          throw e;
+        }
+      }
       case 'export': {
-        const a = pluginArgs(rest, ['--target', '--slug', '--on-conflict'], ['--global', '--dry-run']);
+        const a = pluginArgs(rest, ['--target', '--slug', '--on-conflict', '--format', '--out', '--name'], ['--global', '--dry-run', '--keep-version']);
         const id = a._[0];
-        if (!id) fail('Usage: worca workflow export <id> [--global | --target <dir>] [--slug <name>] [--dry-run] [--on-conflict=skip|overwrite|namespace]');
+        if (!id) fail('Usage: worca workflow export <id> [--format claude|json|plugin] [--global | --target <dir>] [--slug <name>] [--out <file>] [--name <plugin>] [--keep-version] [--dry-run] [--on-conflict=skip|overwrite|namespace]');
+        const format = a.format || 'claude';
+        if (!['claude', 'json', 'plugin'].includes(format)) fail(`--format must be claude|json|plugin (got ${format})`);
+
+        if (format === 'json') {
+          const payload = await share.exportGraphJson(id);
+          const text = JSON.stringify(payload, null, 2) + '\n';
+          if (a.out) {
+            const { writeFile } = await import('node:fs/promises');
+            const dest = resolve(process.cwd(), a.out);
+            await writeFile(dest, text, 'utf8');
+            out(`${c('green', 'wrote')}\t${dest}`);
+          } else {
+            process.stdout.write(text);
+          }
+          return 0;
+        }
+
+        if (format === 'plugin') {
+          if (!a.target) fail('--format plugin requires --target <dir> (the plugin folder)');
+          if (a.global) fail('--global does not apply to --format plugin');
+          const r = await xp.exportWorkflowPlugin({
+            workflowId: id, targetDir: resolve(process.cwd(), a.target), pluginName: a.name,
+            keepVersion: !!a['keep-version'], dryRun: !!a['dry-run'],
+          });
+          for (const p of r.created) out(`${c('green', 'create')}\t${p}`);
+          for (const p of r.updated) out(`${c('cyan', 'update')}\t${p}`);
+          for (const p of r.noop) out(`${c('gray', 'no-op')}\t${p}`);
+          for (const s of r.skipped) out(`${c('gray', 'skip')}\t${s.path}\t(${s.reason})`);
+          for (const w of r.warnings || []) out(`${c('yellow', 'warn')}\t${w}`);
+          for (const p of r.written) out(`${c('green', 'wrote')}\t${p}`);
+          if (r.validation && !r.validation.ok) {
+            out(c('yellow', `\nthe plugin folder does not validate — fix the errors above before sharing it`));
+            return 1;
+          }
+          if (!a['dry-run']) {
+            out(`\nplugin "${r.name}" v${r.version} at ${r.dir}`);
+            out(`share the folder; the recipient runs: worca plugin link ${r.dir}`);
+          }
+          return 0;
+        }
+
         if (a.global && a.target) fail('--global and --target are mutually exclusive');
         const onConflict = a['on-conflict'] || 'skip';
         if (!xp.ON_CONFLICT_MODES.includes(onConflict)) fail(`--on-conflict must be ${xp.ON_CONFLICT_MODES.join('|')} (got ${onConflict})`);

--- a/src/core/folder-dialog.mjs
+++ b/src/core/folder-dialog.mjs
@@ -20,7 +20,14 @@
 
 import { spawn } from 'node:child_process';
 
-const PROMPT = 'Select a project folder';
+// The dialog title, by PURPOSE. A closed set, never caller text: the string is
+// interpolated into an osascript / PowerShell command line.
+const PROMPTS = Object.freeze({
+  project: 'Select a project folder',
+  export: 'Select the project folder to export into',
+  plugin: 'Select the plugin folder',
+});
+const promptFor = (purpose) => PROMPTS[purpose] || PROMPTS.project;
 // A dialog waits on a human; give it a long leash, then kill the process so a
 // forgotten dialog cannot pin server resources forever.
 const DIALOG_TIMEOUT_MS = 5 * 60 * 1000;
@@ -75,20 +82,22 @@ export const _testing = {
 /**
  * Open the platform's native folder picker and wait for the user.
  * Serialized: while one dialog is open, further calls resolve { status:'busy' }.
+ * @param {{purpose?: 'project'|'export'|'plugin'}} [opts] picks the dialog title
  * @returns {Promise<{status:'picked', path:string} | {status:'canceled'}
  *   | {status:'unsupported'} | {status:'busy'}>}
  */
-export async function pickFolderNative() {
+export async function pickFolderNative({ purpose } = {}) {
   if (_inFlight) return { status: 'busy' };
   _inFlight = true;
   try {
     const platform = _ov.platform || process.platform;
     const env = _ov.env || process.env;
     const run = _ov.runner || defaultRun;
+    const prompt = promptFor(purpose);
     if ((env.WORCA_NO_NATIVE_DIALOG || '') === '1') return { status: 'unsupported' };
-    if (platform === 'darwin') return await pickMac(run);
-    if (platform === 'win32') return await pickWindows(run);
-    if (platform === 'linux') return await pickLinux(run, env);
+    if (platform === 'darwin') return await pickMac(run, prompt);
+    if (platform === 'win32') return await pickWindows(run, prompt);
+    if (platform === 'linux') return await pickLinux(run, env, prompt);
     return { status: 'unsupported' };
   } finally {
     _inFlight = false;
@@ -101,10 +110,10 @@ function pickedOrCanceled(stdoutRaw) {
   return path ? { status: 'picked', path } : { status: 'canceled' };
 }
 
-async function pickMac(run) {
+async function pickMac(run, prompt) {
   const r = await run('osascript', [
     '-e', 'tell application "System Events" to activate',
-    '-e', `POSIX path of (choose folder with prompt "${PROMPT}")`,
+    '-e', `POSIX path of (choose folder with prompt "${prompt}")`,
   ]);
   if (r.ok) return pickedOrCanceled(r.stdout);
   // `choose folder` cancel: exit 1 + "execution error: User canceled. (-128)"
@@ -112,11 +121,11 @@ async function pickMac(run) {
   return { status: 'unsupported' }; // no GUI session, automation denied, ...
 }
 
-async function pickWindows(run) {
+async function pickWindows(run, prompt) {
   const script =
     'Add-Type -AssemblyName System.Windows.Forms | Out-Null; ' +
     '$d = New-Object System.Windows.Forms.FolderBrowserDialog; ' +
-    `$d.Description = '${PROMPT}'; $d.ShowNewFolderButton = $true; ` +
+    `$d.Description = '${prompt}'; $d.ShowNewFolderButton = $true; ` +
     "if ($d.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Out.WriteLine($d.SelectedPath) }";
   const r = await run('powershell.exe', ['-NoProfile', '-STA', '-Command', script]);
   if (!r.ok) return { status: 'unsupported' };
@@ -125,13 +134,13 @@ async function pickWindows(run) {
   return path ? { status: 'picked', path } : { status: 'canceled' };
 }
 
-async function pickLinux(run, env) {
+async function pickLinux(run, env, prompt) {
   if (!env.DISPLAY && !env.WAYLAND_DISPLAY) return { status: 'unsupported' };
-  const zen = await run('zenity', ['--file-selection', '--directory', `--title=${PROMPT}`]);
+  const zen = await run('zenity', ['--file-selection', '--directory', `--title=${prompt}`]);
   if (zen.ok) return pickedOrCanceled(zen.stdout);
   if (zen.code === 1 && !zen.timedOut) return { status: 'canceled' }; // user closed it
   // zenity missing (spawn error -> code -1) or broken: try kdialog.
-  const kd = await run('kdialog', ['--title', PROMPT, '--getexistingdirectory', env.HOME || '/']);
+  const kd = await run('kdialog', ['--title', prompt, '--getexistingdirectory', env.HOME || '/']);
   if (kd.ok) return pickedOrCanceled(kd.stdout);
   if (kd.code === 1 && !kd.timedOut) return { status: 'canceled' };
   return { status: 'unsupported' };

--- a/src/core/marketplaces.mjs
+++ b/src/core/marketplaces.mjs
@@ -122,12 +122,15 @@ async function syncEntry(entry, { exec } = {}) {
 export async function addMarketplace(url, { exec } = {}) {
   const norm = normalizeMarketplaceUrl(url);
   if (!norm) throw Object.assign(new Error('marketplace url is required'), { code: 'BAD_REQUEST' });
-  // A single PLUGIN folder (a worca-cc-plugin.json, no marketplace manifest) is
-  // not a marketplace — the natural mistake after `worca workflow export
-  // --format plugin`. Say so, name the fix, and carry the dir so the server
-  // route can link it on the user's behalf (code PLUGIN_FOLDER).
+  // A plain PLUGIN folder — a worca-cc-plugin.json, no marketplace manifest, and
+  // NOT a git repository (a git repo whose root is a plugin IS a marketplace:
+  // the fallback scan discovers it at depth 0) — is not a marketplace. It is the
+  // natural thing to paste after `worca workflow export --format plugin`. Say
+  // so, name the fix, and carry the dir so the server route can link it on the
+  // user's behalf (code PLUGIN_FOLDER).
   if (!/^[a-z+]+:\/\//i.test(norm) && !/^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:/.test(norm)
-    && existsSync(join(norm, 'worca-cc-plugin.json')) && !existsSync(join(norm, 'worca-cc-marketplace.json'))) {
+    && existsSync(join(norm, 'worca-cc-plugin.json')) && !existsSync(join(norm, 'worca-cc-marketplace.json'))
+    && !existsSync(join(norm, '.git'))) {
     throw Object.assign(
       new Error(`${norm} is a single plugin folder, not a marketplace — link it instead: worca plugin link ${norm}`),
       { code: 'PLUGIN_FOLDER', dir: norm });

--- a/src/core/marketplaces.mjs
+++ b/src/core/marketplaces.mjs
@@ -122,6 +122,16 @@ async function syncEntry(entry, { exec } = {}) {
 export async function addMarketplace(url, { exec } = {}) {
   const norm = normalizeMarketplaceUrl(url);
   if (!norm) throw Object.assign(new Error('marketplace url is required'), { code: 'BAD_REQUEST' });
+  // A single PLUGIN folder (a worca-cc-plugin.json, no marketplace manifest) is
+  // not a marketplace — the natural mistake after `worca workflow export
+  // --format plugin`. Say so, name the fix, and carry the dir so the server
+  // route can link it on the user's behalf (code PLUGIN_FOLDER).
+  if (!/^[a-z+]+:\/\//i.test(norm) && !/^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:/.test(norm)
+    && existsSync(join(norm, 'worca-cc-plugin.json')) && !existsSync(join(norm, 'worca-cc-marketplace.json'))) {
+    throw Object.assign(
+      new Error(`${norm} is a single plugin folder, not a marketplace — link it instead: worca plugin link ${norm}`),
+      { code: 'PLUGIN_FOLDER', dir: norm });
+  }
   const id = marketplaceId(norm);
   if (readMarketplaces().marketplaces[id]) { // cheap pre-check: fail before any git work
     throw Object.assign(new Error(`marketplace already added: ${norm}`), { code: 'EXISTS' });

--- a/src/core/plugin-manifest.mjs
+++ b/src/core/plugin-manifest.mjs
@@ -5,6 +5,7 @@
 
 import { readFileSync, readdirSync, readlinkSync, existsSync } from 'node:fs';
 import { join, resolve, dirname, sep, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { WORCA_PLUGIN_API, WORCA_PLUGIN_APIS } from './plugin-api.mjs';
 import { EFFORTS, isReservedModelEnvKey, assertModelCost } from './model-env.mjs';
 import { validateMetaV2, normalizeAgentMeta, indexByKey } from '../shared/graph/agent-meta.mjs';
@@ -19,7 +20,37 @@ const KEY_RE = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 const SOURCE_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 const FIELD_TYPES = new Set(['text', 'select']);
 const INPUT_TYPES = new Set(['text', 'select', 'remote-select', 'task-browser']);
-const KNOWN_TOP = new Set(['name', 'version', 'description', 'author', 'homepage', 'license', 'engines', 'taskSources', 'chatChannels', 'setup', 'models', 'modelSecrets']);
+// `worca` is a free-form tool-metadata block (the workflow exporter records
+// `worca.exports` there — issue #421); the loader never reads it.
+const KNOWN_TOP = new Set(['name', 'version', 'description', 'author', 'homepage', 'license', 'engines', 'taskSources', 'chatChannels', 'setup', 'models', 'modelSecrets', 'worca']);
+
+/** The built-in agent layer (repo agents/). Same URL math as agent-registry's
+ *  DEFAULT_AGENTS_DIR, duplicated because agent-registry imports THIS module
+ *  (declaredApi) and a back-import would be a cycle. */
+const BUILTIN_AGENTS_DIR = fileURLToPath(new URL('../../agents/', import.meta.url));
+
+/**
+ * Normalized meta v2 sidecars of the built-in layer, for the plugin-template
+ * isolation rule (#421): a template may reference built-ins (immutable, always
+ * present on every host) plus the plugin's own agents — never the user layer
+ * or another plugin. A sidecar that fails the v2 gate is skipped: it ships no
+ * ports, so a template naming it gets the same V4 the runtime would raise.
+ * @param {string} [dir]
+ * @returns {object[]}
+ */
+export function builtinAgentMetas(dir = BUILTIN_AGENTS_DIR) {
+  const out = [];
+  let files = [];
+  try { files = readdirSync(dir).filter((f) => f.endsWith('.meta.json')); } catch { return out; }
+  for (const f of files.sort()) {
+    let meta = null;
+    try { meta = JSON.parse(readFileSync(join(dir, f), 'utf8')); } catch { continue; }
+    if (Number(meta?.metaVersion) !== 2 || !KEY_RE.test(String(meta.key || ''))) continue;
+    if (validateMetaV2(meta).errors.length) continue;
+    out.push(normalizeAgentMeta(meta).meta);
+  }
+  return out;
+}
 const KNOWN_SOURCE = new Set(['id', 'displayName', 'module', 'configSchema', 'inputs', 'multiProfile']);
 const KNOWN_CHANNEL = new Set(['id', 'displayName', 'platform', 'module', 'ingress', 'capabilities', 'configSchema']);
 const CHANNEL_INGRESS = new Set(['connect', 'webhook']);
@@ -497,7 +528,7 @@ export function findEscapingSymlinks(root) {
  * strict: unknown-field warnings become errors.
  * @returns {{ok:boolean, manifest:object|null, problems:Array<{level:'error'|'warn', message:string}>}}
  */
-export function validatePluginDir(absDir, { strict = false } = {}) {
+export function validatePluginDir(absDir, { strict = false, builtinMetas } = {}) {
   const problems = [];
   const push = (level, message) => problems.push({ level, message });
 
@@ -592,12 +623,18 @@ export function validatePluginDir(absDir, { strict = false } = {}) {
 
   // workflows/*.json are v2 GRAPHS (API 3), validated by the SAME shared
   // validator the composer and POST /api/workflows use, over a ports function
-  // built from this plugin's OWN sidecars plus the engine's flow-card ports.
-  // The isolation rule stays: a template may reference only keys this plugin
-  // ships, so a host rename or a deleted user agent can never break it.
+  // built from the BUILT-IN sidecars plus this plugin's OWN, plus the engine's
+  // flow-card ports. The isolation rule (#421): a template may reference
+  // built-ins (immutable, present on every host) and keys this plugin ships —
+  // never the user layer or another plugin — so a host rename or a deleted
+  // user agent can never break it. The plugin's own sidecar wins the index on
+  // a key it shares with a built-in (the registry drops such a plugin agent at
+  // load; the template still validates against the ports it will run with).
   const wfDir = join(absDir, 'workflows');
   if (existsSync(wfDir)) {
-    const portsFn = portsFnFor(indexByKey(ownMetas));
+    const hostMetas = Array.isArray(builtinMetas) ? builtinMetas : builtinAgentMetas();
+    const hostKeys = new Set(hostMetas.map((m) => m.key));
+    const portsFn = portsFnFor(indexByKey([...hostMetas, ...ownMetas]));
     for (const f of readdirSync(wfDir).filter((x) => x.endsWith('.json'))) {
       let tpl = null;
       try { tpl = JSON.parse(readFileSync(join(wfDir, f), 'utf8')); }
@@ -607,14 +644,14 @@ export function validatePluginDir(absDir, { strict = false } = {}) {
       const keys = nodes.filter((n) => n && n.kind === 'agent').map((n) => n.key).filter(Boolean);
       let unresolved = false;
       for (const k of new Set(keys)) {
-        if (agentKeys.has(k)) continue;
+        if (agentKeys.has(k) || hostKeys.has(k)) continue;
         if (ungatedKeys.has(k)) {
           // The sidecar is this plugin's, it just did not pass. Report at the
           // DATA level so an API-1 plugin keeps installing (spec §9) instead of
           // being refused for a template that is fine.
           push(dataLevel, `workflows/${f}: references agent key "${k}" whose sidecar is not a valid meta v2 sidecar`);
         } else {
-          push('error', `workflows/${f}: references agent key "${k}" which this plugin does not ship`);
+          push('error', `workflows/${f}: references agent key "${k}" which is neither a built-in nor shipped by this plugin`);
         }
         unresolved = true;
       }

--- a/src/core/workflow-export.mjs
+++ b/src/core/workflow-export.mjs
@@ -14,9 +14,13 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { readFile, writeFile, mkdir, cp, readdir, rename } from 'node:fs/promises';
-import { join, resolve, dirname, sep } from 'node:path';
+import { join, resolve, dirname, sep, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readWorkflow, resolveGraph } from './workflows.mjs';
+import { exportGraphJson, workflowFileSlug, summarizeUnknownAgents } from './workflow-share.mjs';
+import { validatePluginDir, PLUGIN_NAME_RE } from './plugin-manifest.mjs';
+import { registryPortsFn } from './graph/registry-ports.mjs';
+import { validateGraph, formatIssue } from '../shared/graph/validate.mjs';
 import { EFFORTS as EFFORT_LIST } from './model-env.mjs';
 import { loadAgentRegistry } from './agent-registry.mjs';
 import { slugify } from './artifacts.mjs';
@@ -668,7 +672,18 @@ function makeWorkflowJson(set) {
 
 // ── Step 6: skill-dependency resolution — resolve-and-fill ───────────────────
 
-function resolveDepSkills(registry, agentKeys, dest, destination, projectDir, repoRootOverride) {
+/**
+ * Resolve-and-fill for the skills the given agents require. Exported for the
+ * plugin exporter (#421), which passes `layout:'plugin'` (the "already at the
+ * destination" probe becomes `<dest>/skills/<name>/SKILL.md`) and
+ * `skipSources:['bundle']` (a Worca-shipped skill is present on every host, so
+ * it is reported as skipped rather than copied — the agent analogue is "built-ins
+ * are never bundled"). Default options reproduce the Claude Code export exactly.
+ * @returns {Array<{skill, requiredBy, resolvedFrom, srcDir, fill:boolean, skipped?:true}>}
+ */
+export function resolveDepSkills(registry, agentKeys, dest, destination, projectDir, repoRootOverride, opts = {}) {
+  const layout = opts.layout === 'plugin' ? 'plugin' : 'claude';
+  const skipSources = new Set(Array.isArray(opts.skipSources) ? opts.skipSources : []);
   const required = collectRequiredSkills(registry, agentKeys);   // [{skill, requiredBy, origin?}]
   // fileURLToPath (not URL.pathname) — correct on Windows and for paths with spaces.
   const repoRoot = repoRootOverride || resolve(fileURLToPath(new URL('../../', import.meta.url)));
@@ -690,13 +705,19 @@ function resolveDepSkills(registry, agentKeys, dest, destination, projectDir, re
     // rather than via resolveSkill.source, because resolveSkill's chain probes the
     // source-repo `bundle` (repoRoot/skills) BEFORE the destination scopes — a bundle
     // hit is a SOURCE to copy from, not proof the dep is present at the destination.
-    const destSkillMd = join(dest, '.claude', 'skills', r.skill, 'SKILL.md');
+    const destSkillMd = layout === 'plugin'
+      ? join(dest, 'skills', r.skill, 'SKILL.md')
+      : join(dest, '.claude', 'skills', r.skill, 'SKILL.md');
     if (existsSync(destSkillMd)) {
       out.push({ ...r, resolvedFrom: 'destination', srcDir: dirname(destSkillMd), fill: false });
       continue;
     }
     // Not at the destination → locate a source (bundle/global/plugin/owner) to fill from.
     const hit = resolveSkill(r.skill, { ...ctx, origin: r.origin ?? null }); // {source, path, searched}
+    if (hit.source && skipSources.has(hit.source)) {
+      out.push({ ...r, resolvedFrom: hit.source, srcDir: hit.path, fill: false, skipped: true });
+      continue;
+    }
     if (hit.source) { out.push({ ...r, resolvedFrom: hit.source, srcDir: hit.path, fill: true }); continue; }
     missing.push({ ...r, searched: hit.searched });
   }
@@ -966,4 +987,183 @@ async function findOrphans(set, nameFor) {
     }
   }
   return orphans;
+}
+
+// ── Export to plugin (#421) ──────────────────────────────────────────────────
+// "Share this workflow with another Worca user", the durable way: a plugin
+// folder the recipient `worca plugin link`s (or publishes) and updates with
+// `worca plugin reimport`. Bundles the workflow (unstamped v2 graph), every USER
+// agent it references (built-ins are on every host; another plugin's agent is
+// refused — bundling it would create two owners) and every non-bundle skill
+// those agents require. Deterministic: a re-export of an unchanged workflow with
+// --keep-version is an all-no-op.
+
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/** Patch-bump a plain x.y.z; anything else yields null (caller warns). */
+function bumpPatch(version) {
+  const m = SEMVER_RE.exec(String(version || ''));
+  return m ? `${m[1]}.${m[2]}.${Number(m[3]) + 1}` : null;
+}
+
+async function readTextOrNull(path) {
+  try { return await readFile(path, 'utf8'); } catch { return null; }
+}
+
+/**
+ * Plan (dryRun) or write a plugin folder for one saved v2 workflow.
+ * @param {{workflowId:string, targetDir:string, pluginName?:string, keepVersion?:boolean,
+ *          dryRun?:boolean, repoRoot?:string}} opts
+ * @returns {Promise<{dir, name, slug, version, created:string[], updated:string[], noop:string[],
+ *   skipped:Array<{path:string, reason:string}>, conflicts:[], warnings:string[], orphans:[],
+ *   written:string[], validation:{ok:boolean, problems:Array}|null}>}
+ * Error codes: BAD_REQUEST | NOT_FOUND | UNSUPPORTED | INVALID_GRAPH | CONFLICT | MISSING_SKILL
+ */
+export async function exportWorkflowPlugin({ workflowId, targetDir, pluginName, keepVersion = false, dryRun = false, repoRoot } = {}) {
+  if (!workflowId || typeof workflowId !== 'string') throw err('workflowId is required', 'BAD_REQUEST');
+  if (!targetDir || typeof targetDir !== 'string' || !targetDir.trim()) throw err('a target plugin folder is required', 'BAD_REQUEST');
+  const dir = resolve(targetDir);
+  const tpl = await readWorkflow(workflowId);
+  if (!tpl) throw err(`workflow not found: ${workflowId}`, 'NOT_FOUND');
+  const payload = await exportGraphJson(workflowId);            // UNSUPPORTED for a v1 row
+  const slug = workflowFileSlug(tpl.id);
+  const warnings = [];
+
+  // ── Manifest identity: an explicit --name must match an existing manifest; absent
+  //    a --name, an existing manifest's name is adopted, else the folder's basename.
+  const manifestPath = join(dir, 'worca-cc-plugin.json');
+  let existing = null;
+  const existingText = await readTextOrNull(manifestPath);
+  if (existingText !== null) {
+    try { existing = JSON.parse(existingText); } catch (e) { throw err(`${manifestPath}: invalid JSON (${e.message})`, 'BAD_REQUEST'); }
+    if (!existing || typeof existing !== 'object' || Array.isArray(existing)) throw err(`${manifestPath}: not a JSON object`, 'BAD_REQUEST');
+  }
+  const askedName = typeof pluginName === 'string' && pluginName.trim() ? pluginName.trim() : '';
+  const name = askedName || (existing && typeof existing.name === 'string' && existing.name.trim()) || basename(dir);
+  if (!PLUGIN_NAME_RE.test(name) || name.length > 64) {
+    throw err(`plugin name must be kebab-case (got "${name}") — pass a --name`, 'BAD_REQUEST');
+  }
+  if (existing && askedName && existing.name !== askedName) {
+    throw err(`${dir} is plugin "${existing.name}" — pass --name ${existing.name} to update it, or choose another folder`, 'CONFLICT');
+  }
+
+  // ── The stored graph must be runnable HERE before it is shared: a stranded
+  //    key (deleted agent) would only surface at the recipient's link.
+  const registry = loadAgentRegistry();
+  const { errors } = validateGraph({ ...payload, id: tpl.id }, registryPortsFn(registry));
+  if (errors.length) {
+    const summary = summarizeUnknownAgents(errors);
+    throw Object.assign(
+      err(`workflow ${tpl.id} cannot be exported: ${summary || errors.map(formatIssue).join('; ')}`, 'INVALID_GRAPH'),
+      { errors, summary });
+  }
+
+  // ── Agents: user-owned are bundled, built-ins never, another plugin's refused.
+  const agentNodes = payload.nodes.filter((n) => n && n.kind === 'agent' && n.key);
+  const keys = distinctAgents([agentNodes]);
+  const userAgents = [];
+  const foreign = [];
+  const builtins = [];
+  for (const key of keys) {
+    const meta = registry[key];
+    if (!meta) continue;                                          // validateGraph refused above
+    const origin = String(meta.origin || '');
+    if (origin === 'builtin') builtins.push(key);
+    else if (origin.startsWith('plugin:')) foreign.push({ key, plugin: origin.slice('plugin:'.length) });
+    else userAgents.push({ key, meta });
+  }
+  if (foreign.length) {
+    const list = foreign.map((f) => `"${f.key}" (owned by plugin "${f.plugin}")`).join(', ');
+    throw err(`cannot bundle ${list} — a shared workflow bundles only your own agents; ` +
+      'the recipient installs that plugin alongside, or you duplicate the agent under your own name', 'UNSUPPORTED');
+  }
+  if (builtins.length) warnings.push(`built-in agent(s) not bundled (present on every Worca host): ${builtins.join(', ')}`);
+
+  // ── Skills the bundled agents require: filled from global/project/other-plugin
+  //    sources; a Worca-shipped (bundle) skill is skipped, like a built-in agent.
+  const depSkills = resolveDepSkills(registry, userAgents.map((a) => a.key), dir, 'plugin', null, repoRoot,
+    { layout: 'plugin', skipSources: ['bundle'] });
+
+  // ── Intended files ──
+  const targets = [];                                             // {path, text?, copyFrom?}
+  const skipped = [];
+  const noop = [];
+  targets.push({ path: join(dir, 'workflows', `${slug}.json`), text: JSON.stringify(payload, null, 2) + '\n' });
+  for (const { key, meta } of userAgents) {
+    const mdPath = meta.agentPath || null;
+    if (!mdPath || !existsSync(mdPath)) throw err(`agent source not found for "${key}"`, 'NOT_FOUND');
+    const sidecarPath = join(dirname(mdPath), `${key}.meta.json`);
+    if (!existsSync(sidecarPath)) throw err(`agent sidecar not found for "${key}" (${sidecarPath})`, 'NOT_FOUND');
+    // Byte-identical copies: the plugin ships exactly what the exporter runs.
+    targets.push({ path: join(dir, 'agents', `${key}.md`), text: await readFile(mdPath, 'utf8') });
+    targets.push({ path: join(dir, 'agents', `${key}.meta.json`), text: await readFile(sidecarPath, 'utf8') });
+  }
+  for (const s of depSkills) {
+    const skillMd = join(dir, 'skills', s.skill, 'SKILL.md');
+    if (s.skipped) skipped.push({ path: skillMd, reason: `skill "${s.skill}" ships with Worca (${s.resolvedFrom}) — not bundled` });
+    else if (!s.fill) noop.push(skillMd);                          // already in the folder: never touched
+    else targets.push({ path: skillMd, copyFrom: join(s.srcDir, 'SKILL.md') });
+  }
+
+  // ── Classify everything but the manifest (its version bump depends on this).
+  const created = [];
+  const updated = [];
+  for (const t of targets) {
+    if (t.copyFrom) { t.action = 'create'; created.push(t.path); continue; }   // fill:true == absent
+    const cur = await readTextOrNull(t.path);
+    if (cur === null) { t.action = 'create'; created.push(t.path); }
+    else if (cur === t.text) { t.action = 'noop'; noop.push(t.path); }
+    else { t.action = 'update'; updated.push(t.path); }
+  }
+
+  // ── Manifest: adopt what is there, record the export, bump the patch version
+  //    when this export changes a file (unless keepVersion).
+  const changed = created.length + updated.length > 0;
+  const manifest = existing ? { ...existing } : {
+    name, version: '0.1.0',
+    description: `Workflows shared from Worca — ${tpl.name}`,
+    engines: { 'worca-cc-api': '>=3 <4' },
+  };
+  if (!manifest.name) manifest.name = name;
+  let version = typeof manifest.version === 'string' ? manifest.version : '';
+  if (existing && changed && !keepVersion) {
+    const next = bumpPatch(version);
+    if (next) version = next;
+    else warnings.push(`manifest version "${version}" is not plain x.y.z — left unchanged (bump it yourself before publishing)`);
+  }
+  if (version) manifest.version = version;
+  const prevWorca = existing && existing.worca && typeof existing.worca === 'object' && !Array.isArray(existing.worca) ? existing.worca : {};
+  const prevExports = prevWorca.exports && typeof prevWorca.exports === 'object' && !Array.isArray(prevWorca.exports) ? prevWorca.exports : {};
+  manifest.worca = {
+    ...prevWorca,
+    exports: { ...prevExports, [slug]: { workflowId: tpl.id, name: tpl.name, updatedAt: tpl.updatedAt || null } },
+  };
+  const manifestText = JSON.stringify(manifest, null, 2) + '\n';
+  const manifestTarget = { path: manifestPath, text: manifestText };
+  if (existingText === null) { manifestTarget.action = 'create'; created.push(manifestPath); }
+  else if (existingText === manifestText) { manifestTarget.action = 'noop'; noop.push(manifestPath); }
+  else { manifestTarget.action = 'update'; updated.push(manifestPath); }
+  targets.push(manifestTarget);
+
+  const plan = {
+    dir, name, slug, version: manifest.version || null,
+    created, updated, noop, skipped, conflicts: [], warnings, orphans: [], written: [], validation: null,
+  };
+  if (dryRun) return plan;
+
+  // ── Apply ──
+  for (const t of targets) {
+    if (t.action === 'noop') continue;
+    await mkdir(dirname(t.path), { recursive: true });
+    // dep skill: copy the whole source dir; SKILL.md is absent by construction (fill:true), but
+    // the dir may hold unrelated user files — force:false leaves those untouched.
+    if (t.copyFrom) await cp(dirname(t.copyFrom), dirname(t.path), { recursive: true, force: false, errorOnExist: false });
+    else await writeFileAtomic(t.path, t.text);
+    plan.written.push(t.path);
+  }
+  // The folder must lint clean — the recipient's `worca plugin link` runs this same gate.
+  const v = validatePluginDir(dir);
+  plan.validation = { ok: v.ok, problems: v.problems };
+  for (const p of v.problems) warnings.push(`plugin validation ${p.level}: ${p.message}`);
+  return plan;
 }

--- a/src/core/workflow-export.mjs
+++ b/src/core/workflow-export.mjs
@@ -1041,7 +1041,7 @@ export async function exportWorkflowPlugin({ workflowId, targetDir, pluginName, 
   const askedName = typeof pluginName === 'string' && pluginName.trim() ? pluginName.trim() : '';
   const name = askedName || (existing && typeof existing.name === 'string' && existing.name.trim()) || basename(dir);
   if (!PLUGIN_NAME_RE.test(name) || name.length > 64) {
-    throw err(`plugin name must be kebab-case (got "${name}") — pass a --name`, 'BAD_REQUEST');
+    throw err(`plugin name must be kebab-case — lowercase letters, digits and hyphens (got "${name}")`, 'BAD_REQUEST');
   }
   if (existing && askedName && existing.name !== askedName) {
     throw err(`${dir} is plugin "${existing.name}" — pass --name ${existing.name} to update it, or choose another folder`, 'CONFLICT');

--- a/src/core/workflow-share.mjs
+++ b/src/core/workflow-share.mjs
@@ -1,0 +1,191 @@
+// src/core/workflow-share.mjs
+// "Share this workflow with another Worca user" (issue #421): the JSON round
+// trip. ONE validate-then-save path for a v2 graph that arrives from outside
+// the running composer, shared by POST /api/workflows (the composer's Save),
+// POST /api/workflows/import-json, `worca workflow import` and the plugin exporter,
+// so the CLI and the server can never disagree about what a legal graph is.
+//
+// Public surface:
+//   exportGraphJson(id)                -> { version:2, name, domain, nodes, wires, canvas? }
+//   saveGraphWorkflow(body)            -> composer semantics: keeps a legal `id`, 409 on a minted collision
+//   importGraphWorkflow(body, opts)    -> import semantics: id/origin ignored, name suffixed on collision
+//   nodeDefaultsError(raw, models, at) -> '' | reason  (per-node tunables vs the project-less catalog)
+//
+// Errors carry `.code` so surfaces map them to HTTP / exit codes:
+//   BAD_REQUEST | INVALID_GRAPH (+ .errors/.warnings/.summary) | RESERVED_NAME |
+//   ID_TAKEN (+ .id) | NOT_FOUND | UNSUPPORTED
+
+import { listModels } from './config.mjs';
+import { EFFORTS, subagentModelIssue } from './model-env.mjs';
+import { loadAgentRegistry, DEFAULT_AGENTS_DIR } from './agent-registry.mjs';
+import { registryPortsFn } from './graph/registry-ports.mjs';
+import { validateGraph, AGENT_TUNABLES } from '../shared/graph/validate.mjs';
+import { readWorkflow, writeGraphWorkflow } from './workflows.mjs';
+
+/** How many `Name (n)` retries an import makes before giving up. */
+export const SUFFIX_CAP = 20;
+
+function err(message, code, extra = {}) { return Object.assign(new Error(message), { code, ...extra }); }
+
+/**
+ * Validate one node-defaults block against the project-less catalog. Returns an
+ * error message, or '' when the block is acceptable. Mirrors setStep's rules so a
+ * workflow default can never name something a per-project override could not.
+ * (Moved here from ui/server.mjs so the CLI import applies the same gate.)
+ */
+export function nodeDefaultsError(raw, models, where) {
+  if (raw == null) return '';
+  if (typeof raw !== 'object' || Array.isArray(raw)) return `defaults for ${where} must be an object`;
+  const model = typeof raw.model === 'string' ? raw.model.trim() : '';
+  const effort = typeof raw.effort === 'string' ? raw.effort.trim() : '';
+  const entry = model ? models.find((m) => m.id === model) : null;
+  if (model && !entry) return `unknown model "${model}"`;
+  // subagentModel is a fixed alias enum, NOT a catalog id: validated via the
+  // shared helper so a typo is a 400 with the same message every writer uses.
+  const subIssue = subagentModelIssue(raw.subagentModel);
+  if (subIssue) return subIssue;
+  if (!effort) return '';
+  if (!EFFORTS.includes(effort)) return `unknown effort "${effort}"`;
+  if (!entry) return 'select a model before choosing an effort';
+  if (!entry.efforts.includes(effort)) return `model "${model}" does not support effort "${effort}"`;
+  return '';
+}
+
+/**
+ * The shareable form of a saved v2 workflow: the STORED row (not the resolved
+ * graph the Claude Code exporter snapshots — that one applies workspace-variant
+ * substitution and drops `canvas`). No id, origin or timestamps: the importer
+ * mints an id. Per-node `config` stays; project-layer overrides never ride along.
+ * @param {string} id
+ */
+export async function exportGraphJson(id) {
+  const tpl = await readWorkflow(id);
+  if (!tpl) throw err(`workflow not found: ${id}`, 'NOT_FOUND');
+  if (tpl.version !== 2) {
+    throw err(`workflow ${id} is a v1 template — open and save it in the composer first`, 'UNSUPPORTED');
+  }
+  const out = {
+    version: 2,
+    name: tpl.name,
+    domain: tpl.domain || 'general',
+    nodes: Array.isArray(tpl.nodes) ? tpl.nodes : [],
+    wires: Array.isArray(tpl.wires) ? tpl.wires : [],
+  };
+  if (tpl.canvas && typeof tpl.canvas === 'object') out.canvas = tpl.canvas;
+  return out;
+}
+
+/** Filename stem for a shared workflow: the id without its `wf_` prefix. */
+export function workflowFileSlug(id) {
+  const stem = String(id || '').replace(/^wf_/, '');
+  return stem.toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'workflow';
+}
+
+/**
+ * The V4 "unknown agent" issues folded into ONE actionable line, or null when
+ * the errors carry none. A workflow that references agents the recipient does
+ * not have is useless without them — which is what the plugin format is for.
+ * @param {Array<{code:string, message:string}>} errors
+ */
+export function summarizeUnknownAgents(errors) {
+  const keys = [];
+  for (const e of errors || []) {
+    if (e?.code !== 'V4') continue;
+    const m = /unknown agent "([^"]+)"/.exec(String(e.message || ''));
+    if (m && !keys.includes(m[1])) keys.push(m[1]);
+  }
+  if (!keys.length) return null;
+  return `this workflow references ${keys.length} agent${keys.length === 1 ? '' : 's'} not installed here `
+    + `(${keys.join(', ')}) — ask its author to share it as a plugin `
+    + '(worca workflow export <id> --format plugin), which bundles them';
+}
+
+/** Body -> the graph the validator and the store see. `keepId` is the composer's
+ *  re-save of a loaded row; an import never trusts an id from a file. */
+function prepareGraph(body, { keepId, name }) {
+  if (Number(body?.version) !== 2) {
+    throw err('v1 pipeline templates are no longer accepted — save a graph (version 2)', 'BAD_REQUEST');
+  }
+  const override = typeof name === 'string' ? name.trim() : '';
+  const graph = {
+    id: keepId && typeof body.id === 'string' ? body.id : undefined,
+    name: override || (typeof body.name === 'string' ? body.name.trim() : ''),
+    domain: typeof body.domain === 'string' ? body.domain : undefined,
+    nodes: Array.isArray(body.nodes) ? body.nodes : [],
+    wires: Array.isArray(body.wires) ? body.wires : [],
+    ...(body.canvas && typeof body.canvas === 'object' ? { canvas: body.canvas } : {}),
+  };
+  if (!graph.name) throw err('name is required', 'BAD_REQUEST');
+  return graph;
+}
+
+/** Catalog + structural validation. Throws BAD_REQUEST / INVALID_GRAPH; returns warnings. */
+async function validateForSave(graph, { registry, agentsDir }) {
+  // Catalog validation FIRST: a v2 node's `config` IS its defaults block (§4),
+  // so a value the per-project override could not name must not ride in
+  // through a template save. Only AGENT_TUNABLES are handed to nodeDefaultsError —
+  // topology keys (awaitAll, arity, planStoreSeed) never are.
+  const models = await listModels('');
+  for (const n of graph.nodes) {
+    if (!n || n.kind !== 'agent' || !n.config || typeof n.config !== 'object') continue;
+    const picked = Object.fromEntries(AGENT_TUNABLES.filter((k) => k in n.config).map((k) => [k, n.config[k]]));
+    const bad = nodeDefaultsError(picked, models, `node "${n.id}"`);
+    if (bad) throw err(bad, 'BAD_REQUEST');
+  }
+  const portsFn = registryPortsFn(registry || loadAgentRegistry(agentsDir || DEFAULT_AGENTS_DIR));
+  const { errors, warnings } = validateGraph({ ...graph, version: 2 }, portsFn);
+  if (errors.length) {
+    // The message stays the composer's verbatim 'invalid graph' (app.js renders
+    // the issue list); `summary` is the one-line V4 fold for the CLI and the
+    // import button, which have no issue list to show.
+    throw err('invalid graph', 'INVALID_GRAPH', { errors, warnings, summary: summarizeUnknownAgents(errors) });
+  }
+  return warnings;
+}
+
+/**
+ * The composer's Save. A legal `id` in the body is a re-save of that row; a
+ * body without one mints wf_<slug(name)> and REFUSES to land on a live row
+ * (ID_TAKEN carries the id so the dialog can offer rename/overwrite).
+ * @returns {Promise<{workflow: object, warnings: Array}>}
+ */
+export async function saveGraphWorkflow(body, { registry, agentsDir } = {}) {
+  const graph = prepareGraph(body || {}, { keepId: true });
+  const warnings = await validateForSave(graph, { registry, agentsDir });
+  const workflow = await writeGraphWorkflow(graph, { rejectCollision: true });
+  return { workflow, warnings };
+}
+
+const SUFFIX_RE = /\s\((\d+)\)$/;
+
+/**
+ * Import a shared graph into the library. The file's id/origin are ignored (the
+ * importer mints), `name` overrides the file's name, and a collision with a live
+ * row retries as `Name (2)`, `Name (3)`… up to SUFFIX_CAP — never overwrite.
+ * @param {object} body  the exportGraphJson shape
+ * @param {{name?: string, registry?: object, agentsDir?: string}} [opts]
+ * @returns {Promise<{workflow: object, warnings: Array, requestedName: string, renamed: boolean}>}
+ */
+export async function importGraphWorkflow(body, { name, registry, agentsDir } = {}) {
+  const graph = prepareGraph(body || {}, { keepId: false, name });
+  const warnings = await validateForSave(graph, { registry, agentsDir });
+  const requestedName = graph.name;
+  const m = SUFFIX_RE.exec(requestedName);
+  const base = m ? requestedName.slice(0, m.index) : requestedName;
+  let n = m ? Number(m[1]) : 1;
+  let candidate = requestedName;
+  for (let attempt = 0; attempt <= SUFFIX_CAP; attempt++) {
+    try {
+      const workflow = await writeGraphWorkflow({ ...graph, name: candidate }, { rejectCollision: true });
+      return { workflow, warnings, requestedName, renamed: candidate !== requestedName };
+    } catch (e) {
+      if (e?.code === 'RESERVED_NAME') {
+        throw err(`${e.message} (pass a different name to import it)`, 'RESERVED_NAME');
+      }
+      if (e?.code !== 'ID_TAKEN') throw e;
+      n += 1;
+      candidate = `${base} (${n})`;
+    }
+  }
+  throw err(`could not find a free name for "${requestedName}" after ${SUFFIX_CAP} tries — pass --name`, 'ID_TAKEN');
+}

--- a/src/core/workflows.mjs
+++ b/src/core/workflows.mjs
@@ -22,6 +22,7 @@ import { isSubagentModelValue } from './model-env.mjs';
 const validSubagentModel = (v) => (isSubagentModelValue(v) ? v : undefined);
 import { slugify } from './artifacts.mjs';
 import { DEFAULT_AGENTS_DIR, loadAgentRegistry } from './agent-registry.mjs'; // fileURLToPath-based (Windows-safe)
+import { readPluginsLock } from './plugins-lock.mjs';                 // a DISABLED plugin's rows are hidden
 import { validateGraph, formatIssue, AGENT_TUNABLES } from '../shared/graph/validate.mjs';
 import { classifyLoops } from '../shared/graph/loops.mjs';
 import { GRAPH_DEFAULT_WORKFLOW } from './graph/builtin-workflows.mjs';
@@ -373,15 +374,35 @@ export async function readWorkflow(id, opts = {}) {
 }
 
 /**
+ * A row owned by a plugin that is DISABLED in the lock. Disabling a plugin already
+ * withdraws its agents, skills and task sources (agent-registry / skills /
+ * sources honour `enabled:false`); its workflow templates follow the same rule,
+ * or the composer would list a pipeline whose agents are gone.
+ * @param {string|null} origin  'plugin:<name>' | null
+ * @param {object} lock         readPluginsLock()
+ */
+function pluginDisabled(origin, lock) {
+  if (typeof origin !== 'string' || !origin.startsWith('plugin:')) return false;
+  const entry = lock[origin.slice('plugin:'.length)];
+  return !!entry && entry.enabled === false;
+}
+
+/**
  * List user templates (NOT GRAPH_DEFAULT_WORKFLOW — callers prepend it), newest first by
- * createdAt. Archived rows are hidden unless asked for. Empty store => [].
+ * createdAt. Archived rows are hidden unless asked for; so are the rows of a
+ * disabled plugin (`includeDisabled` lifts that — the plugin lifecycle's own
+ * guards need to see them). Empty store => [].
  * @returns {Promise<object[]>}
  */
-export async function listWorkflows({ includeArchived = false } = {}) {
+export async function listWorkflows({ includeArchived = false, includeDisabled = false } = {}) {
   getDb();
   const where = includeArchived ? '' : 'WHERE archived_at IS NULL';
   const rows = prepare(`SELECT ${ROW_COLS} FROM workflows ${where} ORDER BY created_at DESC, id`).all();
-  return rows.filter((r) => r.id !== GRAPH_DEFAULT_WORKFLOW.id).map(rowToTpl);
+  const lock = includeDisabled ? null : readPluginsLock();
+  return rows
+    .filter((r) => r.id !== GRAPH_DEFAULT_WORKFLOW.id)
+    .filter((r) => includeDisabled || !pluginDisabled(r.origin, lock))
+    .map(rowToTpl);
 }
 
 /**
@@ -418,6 +439,14 @@ export async function assertRunnableWorkflow(id, { registry, checkGraph = true }
   const wanted = typeof id === 'string' && id.trim() ? id.trim() : GRAPH_DEFAULT_WORKFLOW.id;
   const live = await readWorkflow(wanted);
   if (live) {
+    // A disabled plugin's template is neither runnable nor openable: its agents
+    // are withdrawn with the plugin. Same posture as ARCHIVED — a coded refusal
+    // the callers map, with the fix in the message.
+    if (pluginDisabled(live.origin, readPluginsLock())) {
+      const plugin = live.origin.slice('plugin:'.length);
+      throw Object.assign(new Error(`workflow "${wanted}" belongs to plugin "${plugin}", which is disabled — `
+        + `enable the plugin (Plugins view, or: worca plugin enable ${plugin}) to use it`), { code: 'PLUGIN_DISABLED' });
+    }
     // A v1 row is not a graph: engine-select owns its refusal (V1_RUN_RETIRED).
     if (checkGraph && live.version === 2) assertValidGraph(live, registry);
     return live;

--- a/src/shared/graph/validate.mjs
+++ b/src/shared/graph/validate.mjs
@@ -269,7 +269,9 @@ export const RULES = [
       if (n.kind !== 'agent' || !metaOf(n.id)) continue;               // V3/V4 own an unresolved node
       for (const inp of inputsOf(n.id)) {
         if (!inp?.required || inp.loop || isLoopInput(n.id, inp.id)) continue;
-        if (!isWired(n.id, inp.id)) add(`required input '${n.id}.${inp.id}' is unwired`, { nodeId: n.id, portId: inp.id });
+        // `incomplete`: the graph is UNFINISHED here, not wrong — the composer shows
+        // these as work to do rather than as errors (Save stays gated either way).
+        if (!isWired(n.id, inp.id)) add(`required input '${n.id}.${inp.id}' is unwired`, { nodeId: n.id, portId: inp.id, incomplete: true });
       }
     }
   } },
@@ -474,7 +476,7 @@ export const RULES = [
       if (!metaOf(t.id)) continue;
       if (inputsOf(t.id).length) add(`task node '${t.id}' must declare zero inputs`, { nodeId: t.id });
       if (!liveWires.some((w) => w.from.node === t.id && w.from.port === 'task')) {
-        add(`task node '${t.id}' output 'task' must have at least one wire`, { nodeId: t.id });
+        add(`task node '${t.id}' output 'task' must have at least one wire`, { nodeId: t.id, incomplete: true });
       }
     }
   } },
@@ -485,7 +487,7 @@ export const RULES = [
     for (const e of endNodes) {
       if (!metaOf(e.id)) continue;
       if (outputsOf(e.id).length) add(`end node '${e.id}' must declare zero outputs`, { nodeId: e.id });
-      if (!isWired(e.id, 'result')) add(`end node '${e.id}' input 'result' must be wired`, { nodeId: e.id });
+      if (!isWired(e.id, 'result')) add(`end node '${e.id}' input 'result' must be wired`, { nodeId: e.id, incomplete: true });
     }
   } },
 ];

--- a/test/folder-dialog.test.mjs
+++ b/test/folder-dialog.test.mjs
@@ -99,3 +99,19 @@ test('a timed-out dialog maps to unsupported', async () => {
   runner({ ok: false, stdout: '', stderr: 'dialog timed out', code: -1, timedOut: true });
   assert.deepEqual(await pickFolderNative(), { status: 'unsupported' });
 });
+
+test('purpose picks the dialog title from a closed set; unknown purpose falls back to the project title', async () => {
+  _testing.set({ platform: 'darwin', env: {} });
+  const calls = runner({ ok: true, stdout: '/x\n', stderr: '', code: 0, timedOut: false });
+  await pickFolderNative({ purpose: 'plugin' });
+  await pickFolderNative({ purpose: 'export' });
+  await pickFolderNative({ purpose: 'rm -rf /' });           // never interpolated: not in the set
+  await pickFolderNative();
+  const prompts = calls.map((c) => /prompt "([^"]+)"/.exec(c.args[3])[1]);
+  assert.deepEqual(prompts, [
+    'Select the plugin folder',
+    'Select the project folder to export into',
+    'Select a project folder',
+    'Select a project folder',
+  ]);
+});

--- a/test/plugin-manifest.test.mjs
+++ b/test/plugin-manifest.test.mjs
@@ -277,7 +277,7 @@ test('validatePluginDir: workflow referencing an unshipped agent key = error', (
   assert.equal(v.ok, false);
   assert.match(
     v.problems.map((p) => p.message).join('\n'),
-    /alien\.json: references agent key "notMine" which this plugin does not ship/,
+    /alien\.json: references agent key "notMine" which is neither a built-in nor shipped by this plugin/,
   );
 });
 
@@ -583,19 +583,46 @@ test('a v2 template is validated V1-V21 against the PLUGIN\'S OWN ports', () => 
   assert.equal(v.ok, false);
 });
 
-test('a v2 template may reference ONLY the plugin\'s own agent keys', () => {
-  const dir = mkPluginDir({
+test('a v2 template may reference built-ins and the plugin\'s own keys — never a foreign one (#421)', () => {
+  // Built-in `planner` is present on every host, so a plugin template may run it
+  // (the ports come from the built-in sidecar: task in, plan out).
+  const withBuiltin = mkPluginDir({
     'worca-cc-plugin.json': JSON.stringify({ name: 'p', engines: { 'worca-cc-api': '>=3 <4' } }),
     'agents/helper.meta.json': V2_META('helper'),
     'agents/helper.md': '# helper\n',
-    'workflows/foreign.json': V2_GRAPH('planner'),
+    'workflows/builtin.json': JSON.stringify({
+      name: 'Builtin Flow', version: 2, domain: 'general',
+      nodes: [
+        { id: 'n_task', kind: 'task', x: 0, y: 0, config: {} },
+        { id: 'n_a', kind: 'agent', key: 'planner', x: 1, y: 0, config: {} },
+        { id: 'n_end', kind: 'end', x: 2, y: 0, config: {} },
+      ],
+      wires: [
+        { id: 'w1', from: { node: 'n_task', port: 'task' }, to: { node: 'n_a', port: 'task' } },
+        { id: 'w2', from: { node: 'n_a', port: 'plan' }, to: { node: 'n_end', port: 'result' } },
+      ],
+    }),
   });
-  // deepEqual, not includes: a foreign key SHORT-CIRCUITS the template (the
-  // `continue`), so exactly ONE clear cause is reported. Without the
-  // short-circuit the same template also fires V4/V5 for every wire touching
-  // the unknown node, and `.includes` would never notice.
-  assert.deepEqual(errs(validatePluginDir(dir)), [
-    'workflows/foreign.json: references agent key "planner" which this plugin does not ship',
+  assert.deepEqual(errs(validatePluginDir(withBuiltin)), []);
+
+  // A key that is neither built-in nor shipped (a user-layer agent, another
+  // plugin's) is refused. deepEqual, not includes: a foreign key SHORT-CIRCUITS
+  // the template (the `continue`), so exactly ONE clear cause is reported.
+  // Without the short-circuit the same template also fires V4/V5 for every wire
+  // touching the unknown node, and `.includes` would never notice.
+  const foreign = mkPluginDir({
+    'worca-cc-plugin.json': JSON.stringify({ name: 'p', engines: { 'worca-cc-api': '>=3 <4' } }),
+    'agents/helper.meta.json': V2_META('helper'),
+    'agents/helper.md': '# helper\n',
+    'workflows/foreign.json': V2_GRAPH('someUserAgent'),
+  });
+  assert.deepEqual(errs(validatePluginDir(foreign)), [
+    'workflows/foreign.json: references agent key "someUserAgent" which is neither a built-in nor shipped by this plugin',
+  ]);
+
+  // The built-in set is injectable, so a caller can pin what "built-in" means.
+  assert.deepEqual(errs(validatePluginDir(withBuiltin, { builtinMetas: [] })), [
+    'workflows/builtin.json: references agent key "planner" which is neither a built-in nor shipped by this plugin',
   ]);
 });
 
@@ -730,7 +757,7 @@ test('a template referencing a GATED-OUT sidecar reports ONE cause at the data l
     'workflows/flow.json': V2_GRAPH('notMine'),
   }));
   assert.ok(errs(alien).includes(
-    'workflows/flow.json: references agent key "notMine" which this plugin does not ship'));
+    'workflows/flow.json: references agent key "notMine" which is neither a built-in nor shipped by this plugin'));
 });
 
 test('models: `cost` is validated and normalized exactly like a global catalog entry', () => {

--- a/test/plugin-workflows.test.mjs
+++ b/test/plugin-workflows.test.mjs
@@ -252,3 +252,32 @@ test('referencedPluginAgents ignores the plugin\'s OWN imported rows', async () 
   await importPluginWorkflows('demo', versionDir);
   assert.deepEqual(referencedPluginAgents('demo'), []);
 });
+
+// Disabling a plugin withdraws its agents/skills/sources; its workflow templates
+// follow (#421 review): hidden from the list (the composer, the New Pipeline
+// picker, Ask's catalog all read listWorkflows) and refused by the run gate with
+// a coded error naming the fix. Re-enabling brings them back untouched.
+test('a disabled plugin\'s workflows are hidden from the list and refused by the run gate; enabling restores them', async () => {
+  const versionDir = installFakePlugin('demo', { 'simple.json': TPL });
+  await importPluginWorkflows('demo', versionDir);
+  await writeGraphWorkflow({ ...graphTpl('Mine', 'demoAgent'), name: 'Mine' });   // a user row stays visible throughout
+  const { listWorkflows, assertRunnableWorkflow } = await import('../src/core/workflows.mjs');
+  assert.ok((await listWorkflows()).some((w) => w.id === 'wfp_demo_simple'), 'precondition: listed while enabled');
+
+  writePluginsLock({ ...readPluginsLock(), demo: { ...readPluginsLock().demo, enabled: false } });
+  const visible = (await listWorkflows()).map((w) => w.id);
+  assert.ok(!visible.includes('wfp_demo_simple'), 'hidden while the plugin is disabled');
+  assert.ok(visible.includes('wf_mine'), 'the user row is untouched');
+  assert.ok((await listWorkflows({ includeDisabled: true })).some((w) => w.id === 'wfp_demo_simple'), 'includeDisabled lifts the filter');
+  await assert.rejects(assertRunnableWorkflow('wfp_demo_simple'), (e) => {
+    assert.equal(e.code, 'PLUGIN_DISABLED');
+    assert.match(e.message, /plugin "demo", which is disabled/);
+    assert.match(e.message, /worca plugin enable demo/);
+    return true;
+  });
+  assert.ok(await readWorkflow('wfp_demo_simple'), 'the row itself is still there (nothing deleted)');
+
+  writePluginsLock({ ...readPluginsLock(), demo: { ...readPluginsLock().demo, enabled: true } });
+  assert.ok((await listWorkflows()).some((w) => w.id === 'wfp_demo_simple'), 'back after enabling');
+  assert.equal((await assertRunnableWorkflow('wfp_demo_simple', { checkGraph: false })).id, 'wfp_demo_simple');
+});

--- a/test/ui-composer-app.test.mjs
+++ b/test/ui-composer-app.test.mjs
@@ -242,6 +242,23 @@ test('Export… opens the format dialog for a v2 row, not a v1 row', async () =>
 
   doc.getElementById('export-cancel').dispatchEvent(new win.Event('click'));
   assert.equal(modal.classList.contains('hidden'), true, 'Cancel closes the dialog');
+
+  // A successful export swaps the form for a result view (same card, not a second
+  // dialog): what was written, where, the next step, and a Done button.
+  rowById('wf_g').querySelector('.pl-export').dispatchEvent(new win.Event('click'));
+  win.HTMLAnchorElement.prototype.click = function () {};          // jsdom: no navigation on the download link
+  doc.getElementById('export-apply-btn').dispatchEvent(new win.Event('click'));
+  assert.equal(modal.classList.contains('hidden'), false, 'the dialog stays open');
+  assert.ok(hidden('export-form') && !hidden('export-done'), 'form swapped for the result view');
+  assert.equal(doc.getElementById('export-done-title').textContent, 'JSON file downloaded');
+  assert.match(doc.getElementById('export-done-lines').textContent, /g\.json/);
+  assert.match(doc.getElementById('export-done-next').textContent, /Import…/);
+  assert.ok(hidden('export-apply-btn') && hidden('export-cancel') && !hidden('export-done-close'));
+  doc.getElementById('export-done-close').dispatchEvent(new win.Event('click'));
+  assert.equal(modal.classList.contains('hidden'), true, 'Done closes it');
+  rowById('wf_g').querySelector('.pl-export').dispatchEvent(new win.Event('click'));
+  assert.ok(!hidden('export-form') && hidden('export-done'), 'reopening shows the form again');
+  doc.getElementById('export-cancel').dispatchEvent(new win.Event('click'));
 });
 
 // One tab per domain; the row no longer shows its domain; Import… selects the

--- a/test/ui-composer-app.test.mjs
+++ b/test/ui-composer-app.test.mjs
@@ -199,6 +199,10 @@ test('Export… opens the format dialog for a v2 row, not a v1 row', async () =>
   assert.ok(rowById('wf_g').querySelector('.pl-export'), 'a v2 workflow is exportable');
   assert.equal(rowById('wf_old').querySelector('.pl-export'), null, 'a v1 workflow is not exportable');
   assert.equal(rowById('wf_g').querySelectorAll('button, a').length, 2, 'Export… + delete only');
+  // Export… is the LAST element of every row (delete sits before it), so it lines
+  // up on the same right edge whether or not the row has a delete.
+  assert.ok(rowById('wf_g').querySelector('.pl-row').lastElementChild.classList.contains('pl-export'));
+  assert.ok(rowById('wf_default').querySelector('.pl-row').lastElementChild.classList.contains('pl-export'));
 
   const modal = doc.getElementById('export-modal');
   assert.ok(modal.classList.contains('hidden'), 'modal starts hidden');

--- a/test/ui-composer-app.test.mjs
+++ b/test/ui-composer-app.test.mjs
@@ -42,6 +42,14 @@ async function boot({ agentsFail = false, archived = [], workflows = null, del =
   const json = (v, status = 200) => Promise.resolve({ ok: status < 400, status, json: async () => v });
   window.fetch = (u, init) => {
     const url = String(u);
+    // POST /api/workflows/import-json — the Import… path: mint a row, echo the
+    // share contract ({workflow, renamed, requestedName, warnings}).
+    if (url.includes('/api/workflows/import-json')) {
+      const src = JSON.parse(init.body).workflow;
+      const row = { ...src, id: `wf_${String(src.name).toLowerCase().replace(/[^a-z0-9]+/g, '-')}`, origin: null };
+      rows.push(row);
+      return json({ workflow: row, renamed: false, requestedName: src.name, warnings: [] }, 201);
+    }
     if (init && init.method === 'DELETE') {
       deletes.push(url);
       if (del) return json(del.body, del.status);
@@ -92,7 +100,9 @@ test('entering the composer mounts once, preloads Task+End and lists saved rows'
   assert.equal(rows.length, 2);
   assert.ok(rows[0].querySelector('svg'), 'v2 row carries a thumbnail');
   assert.equal(rows[1].querySelector('.pl-legacy').textContent, 'legacy · runnable until the graph cut-over');
-  assert.equal(rows[1].querySelector('.pl-open'), null, 'a v1 row cannot be opened in the v2 composer');
+  assert.ok(rows[0].querySelector('.pl-row.pl-openable'), 'a v2 row IS the Open action');
+  assert.equal(rows[1].querySelector('.pl-row.pl-openable'), null, 'a v1 row cannot be opened in the v2 composer');
+  assert.equal(doc.querySelector('#gv-saved-list .pl-meta'), null, 'the domain lives in the tab, not the row');
   // re-entry re-fits without re-mounting
   win.location.hash = 'running'; win.dispatchEvent(new win.Event('hashchange'));
   win.location.hash = 'composer'; win.dispatchEvent(new win.Event('hashchange'));
@@ -173,29 +183,85 @@ test('a v1 workflow still produces v1 rows (no regression)', async () => {
   assert.deepEqual(np.buildFeedbackRows(V1_ROW, {}, { feedbacks: {} }), []);
 });
 
-// Export-to-Claude-Code: every v2 saved row (incl. the built-in) carries an export
-// button that opens the modal; a v1 row does not. Clicking it opens + populates the
-// modal, and Cancel closes it. (The plan/apply fetch is covered by the API suite.)
-test('the export button opens the export modal for a v2 row, not a v1 row', async () => {
+// Export…: every v2 saved row (incl. the built-in) carries ONE Export… button that
+// opens the dialog; a v1 row does not. The dialog asks for the format first (JSON
+// file / Claude Code skill / Worca plugin) and shows only that format's fields.
+// (The plan/apply/download fetches are covered by the API suites.)
+test('Export… opens the format dialog for a v2 row, not a v1 row', async () => {
   const win = await boot({ workflows: [DEFAULT_ROW, V2_ROW, V1_ROW] });
   const doc = win.document;
   const rowById = (id) => [...doc.querySelectorAll('#gv-saved-list .pl-item')].find((r) => r.dataset.id === id);
+  const hidden = (id) => doc.getElementById(id).classList.contains('hidden');
 
-  // v2 rows (built-in + user) get an export button; the v1 row does not.
-  assert.ok(rowById('wf_default').querySelector('.pl-export'), 'built-in default is exportable');
+  // v2 rows (built-in + user) get the button; the v1 row does not. No other row action
+  // except delete: Open is the row itself, JSON moved into the dialog.
+  assert.equal(rowById('wf_default').querySelector('.pl-export').textContent, 'Export…', 'built-in default is exportable');
   assert.ok(rowById('wf_g').querySelector('.pl-export'), 'a v2 workflow is exportable');
   assert.equal(rowById('wf_old').querySelector('.pl-export'), null, 'a v1 workflow is not exportable');
+  assert.equal(rowById('wf_g').querySelectorAll('button, a').length, 2, 'Export… + delete only');
 
   const modal = doc.getElementById('export-modal');
   assert.ok(modal.classList.contains('hidden'), 'modal starts hidden');
 
   rowById('wf_g').querySelector('.pl-export').dispatchEvent(new win.Event('click'));
-  assert.equal(modal.classList.contains('hidden'), false, 'clicking export opens the modal');
+  assert.equal(modal.classList.contains('hidden'), false, 'clicking Export… opens the dialog');
   assert.match(doc.getElementById('export-subtitle').textContent, /Graph one/);
+  // Default format: JSON — Download enabled, no Plan, no skill/plugin fields.
+  assert.ok(doc.querySelector('#export-format .seg-btn[data-format="json"]').classList.contains('on'));
+  assert.equal(doc.getElementById('export-apply-btn').textContent, 'Download');
+  assert.equal(doc.getElementById('export-apply-btn').disabled, false);
+  assert.ok(hidden('export-plan-btn') && hidden('export-slug-field') && hidden('export-dest-field') && hidden('export-plugin-field'));
+  // Skill: location + slug + agents; Apply waits for a Plan.
+  doc.querySelector('#export-format .seg-btn[data-format="skill"]').dispatchEvent(new win.Event('click'));
+  assert.equal(doc.getElementById('export-apply-btn').textContent, 'Apply');
+  assert.equal(doc.getElementById('export-apply-btn').disabled, true);
+  assert.ok(!hidden('export-plan-btn') && !hidden('export-slug-field') && !hidden('export-dest-field') && hidden('export-plugin-field'));
+  assert.ok(hidden('export-folder-field'), 'global location needs no folder');
   assert.equal(doc.getElementById('export-slug-preview').textContent, 'Command: /graph-one', 'slug preview from the name');
+  doc.querySelector('#export-dest .seg-btn[data-dest="project"]').dispatchEvent(new win.Event('click'));
+  assert.ok(!hidden('export-folder-field'), 'project location asks for the folder');
+  // Plugin: folder + plugin fields, no skill fields.
+  doc.querySelector('#export-format .seg-btn[data-format="plugin"]').dispatchEvent(new win.Event('click'));
+  assert.ok(!hidden('export-folder-field') && !hidden('export-plugin-field') && hidden('export-slug-field') && hidden('export-dest-field'));
+  assert.equal(doc.getElementById('export-folder-label').textContent, 'Plugin folder');
 
   doc.getElementById('export-cancel').dispatchEvent(new win.Event('click'));
-  assert.equal(modal.classList.contains('hidden'), true, 'Cancel closes the modal');
+  assert.equal(modal.classList.contains('hidden'), true, 'Cancel closes the dialog');
+});
+
+// One tab per domain; the row no longer shows its domain; Import… selects the
+// imported row's tab and pins a NEW pill on it for the page session.
+const GENERAL_ROW = { id: 'wf_gen', name: 'General one', version: 2, domain: 'general',
+  nodes: [{ id: 'n_task', kind: 'task', x: 60, y: 200, config: {} }, { id: 'n_end', kind: 'end', x: 960, y: 200, config: {} }], wires: [] };
+
+test('the saved list is tabbed by domain, and Import… lands on the imported row\'s tab with a NEW pill', async () => {
+  const win = await boot({ workflows: [DEFAULT_ROW, V2_ROW, GENERAL_ROW] });
+  const doc = win.document;
+  const tabs = () => [...doc.querySelectorAll('#gv-saved-tabs .gv-saved-tab')];
+  const listed = () => [...doc.querySelectorAll('#gv-saved-list .pl-item')].map((r) => r.dataset.id);
+  assert.deepEqual(tabs().map((t) => t.dataset.domain), ['coding', 'general'], 'alphabetical domain tabs');
+  assert.deepEqual(tabs().map((t) => t.querySelector('.gv-saved-tab-badge').textContent), ['2', '1']);
+  assert.ok(tabs()[0].classList.contains('active'), 'first tab selected by default');
+  assert.deepEqual(listed(), ['wf_default', 'wf_g'], 'only the selected domain is listed');
+  assert.equal(doc.getElementById('gv-saved-count').textContent, '· 3', 'the header count is the whole library');
+  tabs()[1].dispatchEvent(new win.MouseEvent('click', { bubbles: true }));
+  assert.deepEqual(listed(), ['wf_gen']);
+  assert.ok(tabs()[1].classList.contains('active'));
+  assert.equal(doc.getElementById('gv-import-btn').textContent, 'Import…');
+
+  // Import a coding pipeline while the general tab is selected.
+  const input = doc.getElementById('gv-import-file');
+  const file = { name: 'shared.json', text: async () => JSON.stringify({ ...V2_ROW, id: undefined, name: 'Shared In' }) };
+  Object.defineProperty(input, 'files', { value: [file], configurable: true });
+  input.dispatchEvent(new win.Event('change'));
+  await tick(8);
+  assert.ok(tabs()[0].classList.contains('active'), 'the imported row\'s domain tab is selected');
+  assert.deepEqual(listed(), ['wf_default', 'wf_g', 'wf_shared-in']);
+  const pill = doc.querySelector('#gv-saved-list .pl-item[data-id="wf_shared-in"] .pl-new');
+  assert.ok(pill && pill.textContent === 'NEW', 'the imported row carries a NEW pill');
+  assert.equal(doc.querySelector('#gv-saved-list .pl-item[data-id="wf_g"] .pl-new'), null, 'only the imported one');
+  assert.equal(doc.getElementById('gv-saved-msg').textContent, 'Imported "Shared In".');
+  assert.deepEqual(tabs().map((t) => t.querySelector('.gv-saved-tab-badge').textContent), ['3', '1']);
 });
 
 // MAJ-21: a flow card inside a loop must be named by the SHARED FLOW_LABEL table
@@ -226,7 +292,7 @@ test('MAJ-6: the saved list\'s Open asks before discarding unsaved edits', async
   const nodes = c.template().nodes.length;
   const depth = c.undoDepth();
   assert.equal(c.isDirty(), true, 'precondition: dirty');
-  doc.querySelector('#gv-saved-list .pl-item[data-id="wf_g"] .pl-open')
+  doc.querySelector('#gv-saved-list .pl-item[data-id="wf_g"] .pl-row')
     .dispatchEvent(new win.MouseEvent('click', { bubbles: true }));
   for (let i = 0; i < 4; i += 1) await new Promise((r) => setTimeout(r, 0));
   assert.equal(modalUp(doc), true, 'the confirm modal is up');
@@ -238,7 +304,7 @@ test('MAJ-6: the saved list\'s Open asks before discarding unsaved edits', async
   assert.equal(c.undoDepth(), depth, 'Cancel keeps the undo ring');
   assert.equal(c.isDirty(), true);
   // …and Confirm goes through.
-  doc.querySelector('#gv-saved-list .pl-item[data-id="wf_g"] .pl-open')
+  doc.querySelector('#gv-saved-list .pl-item[data-id="wf_g"] .pl-row')
     .dispatchEvent(new win.MouseEvent('click', { bubbles: true }));
   for (let i = 0; i < 4; i += 1) await new Promise((r) => setTimeout(r, 0));
   doc.getElementById('confirm-ok').dispatchEvent(new win.MouseEvent('click', { bubbles: true }));
@@ -299,14 +365,37 @@ test('MAJ-17: a successful delete clears the message and refreshes', async () =>
     'the list is refreshed: the deleted row is gone');
 });
 
-test('MAJ-17: the built-in Default row offers Open but no ×', async () => {
+test('MAJ-17: the built-in Default row opens but has no delete', async () => {
   const win = await boot({ workflows: [DEFAULT_ROW, V2_ROW, V1_ROW] });
   const doc = win.document;
   const def = doc.querySelector('#gv-saved-list .pl-item[data-id="wf_default"]');
   assert.ok(def, 'the built-in is listed');
-  assert.ok(def.querySelector('.pl-open'), 'Open stays — the built-in is editable as a copy');
-  assert.equal(def.querySelector('.pl-del'), null, 'no × on a row DELETE can never accept');
-  assert.ok(doc.querySelector('#gv-saved-list .pl-item[data-id="wf_g"] .pl-del'), 'every other v2 row keeps its ×');
+  assert.ok(def.querySelector('.pl-row.pl-openable'), 'opening stays — the built-in is editable as a copy');
+  assert.equal(def.querySelector('.pl-del'), null, 'no delete on a row DELETE can never accept');
+  const del = doc.querySelector('#gv-saved-list .pl-item[data-id="wf_g"] .pl-del');
+  assert.ok(del, 'every other v2 row keeps its delete');
+  assert.ok(del.querySelector('svg'), 'icon-only: the shared bin glyph');
+  assert.equal(del.textContent.trim(), '', 'no text label');
+  assert.equal(del.getAttribute('aria-label'), 'Delete "Graph one"');
+});
+
+test('the row\'s own actions do not open it, and Enter/Space on the row does', async () => {
+  const win = await boot({ workflows: [DEFAULT_ROW, V2_ROW] });
+  const doc = win.document;
+  const c = win.__gv().c;
+  const row = doc.querySelector('#gv-saved-list .pl-item[data-id="wf_g"] .pl-row');
+  assert.equal(row.getAttribute('role'), 'button');
+  assert.equal(row.tabIndex, 0);
+  // Clicking Export… (a button inside the row) must not ALSO open the row.
+  row.querySelector('.pl-export').dispatchEvent(new win.MouseEvent('click', { bubbles: true }));
+  await tick();
+  assert.notEqual(c.template().id, 'wf_g', 'Export… did not open the row');
+  assert.equal(doc.getElementById('export-modal').classList.contains('hidden'), false, 'it opened the dialog');
+  doc.getElementById('export-cancel').dispatchEvent(new win.Event('click'));
+  // Keyboard: Enter on the focused row opens it (the canvas is clean, so no guard).
+  row.dispatchEvent(new win.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+  await tick();
+  assert.equal(c.template().id, 'wf_g', 'Enter opens the row');
 });
 
 test('MAJ-17: the archived chip surfaces its refusal too', async () => {

--- a/test/ui-composer-app.test.mjs
+++ b/test/ui-composer-app.test.mjs
@@ -215,10 +215,12 @@ test('Export… opens the format dialog for a v2 row, not a v1 row', async () =>
   assert.equal(doc.getElementById('export-apply-btn').textContent, 'Download');
   assert.equal(doc.getElementById('export-apply-btn').disabled, false);
   assert.ok(hidden('export-plan-btn') && hidden('export-slug-field') && hidden('export-dest-field') && hidden('export-plugin-field'));
-  // Skill: location + slug + agents; Apply waits for a Plan.
+  // Skill: location + slug + agents; Export is live at once (it dry-runs itself),
+  // Preview is the optional look-first.
   doc.querySelector('#export-format .seg-btn[data-format="skill"]').dispatchEvent(new win.Event('click'));
-  assert.equal(doc.getElementById('export-apply-btn').textContent, 'Apply');
-  assert.equal(doc.getElementById('export-apply-btn').disabled, true);
+  assert.equal(doc.getElementById('export-apply-btn').textContent, 'Export');
+  assert.equal(doc.getElementById('export-apply-btn').disabled, false);
+  assert.equal(doc.getElementById('export-plan-btn').textContent, 'Preview');
   assert.ok(!hidden('export-plan-btn') && !hidden('export-slug-field') && !hidden('export-dest-field') && hidden('export-plugin-field'));
   assert.ok(hidden('export-folder-field'), 'global location needs no folder');
   assert.equal(doc.getElementById('export-slug-preview').textContent, 'Command: /graph-one', 'slug preview from the name');

--- a/test/ui-composer-app.test.mjs
+++ b/test/ui-composer-app.test.mjs
@@ -230,6 +230,15 @@ test('Export… opens the format dialog for a v2 row, not a v1 row', async () =>
   doc.querySelector('#export-format .seg-btn[data-format="plugin"]').dispatchEvent(new win.Event('click'));
   assert.ok(!hidden('export-folder-field') && !hidden('export-plugin-field') && hidden('export-slug-field') && hidden('export-dest-field'));
   assert.equal(doc.getElementById('export-folder-label').textContent, 'Plugin folder');
+  // The plugin name is normalized to kebab-case live: typed, else the folder's basename.
+  const preview = doc.getElementById('export-plugin-name-preview');
+  assert.equal(preview.textContent, 'Plugin name: (choose a folder first)');
+  doc.getElementById('export-folder').value = '/tmp/My Plugins/Full Special/';
+  doc.getElementById('export-folder').dispatchEvent(new win.Event('input'));
+  assert.equal(preview.textContent, 'Plugin name: full-special (from the folder name)');
+  doc.getElementById('export-plugin-name').value = 'Full-Special';
+  doc.getElementById('export-plugin-name').dispatchEvent(new win.Event('input'));
+  assert.equal(preview.textContent, 'Plugin name: full-special');
 
   doc.getElementById('export-cancel').dispatchEvent(new win.Event('click'));
   assert.equal(modal.classList.contains('hidden'), true, 'Cancel closes the dialog');

--- a/test/ui-composer-editor.test.mjs
+++ b/test/ui-composer-editor.test.mjs
@@ -295,6 +295,52 @@ test('errors disable Save, show the chip, pip the node, and centre it on click',
   assert.equal(s2.el.save.disabled, false);
 });
 
+// Unfinished is not wrong: a fresh canvas shows NO chip (Save stays gated, with a
+// tooltip saying what is missing); once the user starts working, still-unwired
+// mandatory ports get a quiet "N ports to wire" chip; only real mistakes are red.
+test('a pristine canvas shows no error chip; unfinished wiring is a quiet to-do, not an error', async () => {
+  const s = await open();
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+  s.c.loadTemplate(null);
+  await tick();
+  assert.equal(s.c.report().errors.length, 2, 'precondition: V20 + V21 fire on Task + End alone');
+  assert.ok(s.c.report().errors.every((e) => e.incomplete), 'both are flagged incomplete by the validator');
+  assert.equal(s.el.errors.hidden, true, 'no chip on a canvas nobody has touched');
+  assert.equal(s.el.save.disabled, true, 'Save is still gated');
+  assert.equal(s.el.save.title, 'Wire Task → … → End to save');
+
+  s.c.spawn({ key: 'planner' });
+  await tick();
+  assert.equal(s.el.errors.hidden, false, 'once the user works, the to-do shows');
+  assert.ok(s.el.errors.classList.contains('is-incomplete'), 'in the quiet dress');
+  assert.match(s.el.errors.textContent, /^\d+ ports to wire$/);
+  assert.equal(s.el.save.disabled, true);
+
+  // A REAL mistake (a second End) turns the chip red and counts only real errors.
+  s.c.commit('dup-end', () => { s.c.template().nodes.push({ id: 'n_end2', kind: 'end', x: 900, y: 400, config: {} }); });
+  await tick();
+  assert.equal(s.el.errors.classList.contains('is-incomplete'), false);
+  assert.match(s.el.errors.textContent, /^\d+ errors?$/);
+  assert.equal(s.el.save.title, 'Fix the errors to save');
+  s.c.undo();
+  await tick();
+
+  // Wiring Task → planner → End finishes the drawing: no chip, Save enabled.
+  const t = s.c.template();
+  const task = t.nodes.find((n) => n.kind === 'task'), end = t.nodes.find((n) => n.kind === 'end');
+  const agent = t.nodes.find((n) => n.kind === 'agent');
+  s.c.commit('wire', () => {
+    s.c.template().wires.push(
+      { id: 'w_a', from: { node: task.id, port: 'task' }, to: { node: agent.id, port: 'task' } },
+      { id: 'w_b', from: { node: agent.id, port: 'plan' }, to: { node: end.id, port: 'result' } },
+    );
+  });
+  await tick();
+  assert.equal(s.el.errors.hidden, true, JSON.stringify(s.c.report().errors));
+  assert.equal(s.el.save.disabled, false);
+  assert.equal(s.el.save.title, '');
+});
+
 test('validation runs ONCE per commit, never per frame', async () => {
   const s = await open();
   await new Promise((r) => setTimeout(r, 0));

--- a/test/workflow-export-plugin.test.mjs
+++ b/test/workflow-export-plugin.test.mjs
@@ -1,0 +1,208 @@
+// test/workflow-export-plugin.test.mjs
+// Export to plugin (issue #421): a saved workflow + the USER agents it uses +
+// the non-bundle skills they require become a plugin folder that validates,
+// links and reimports on a recipient. Built-ins are never copied, a bundle
+// skill is skipped, another plugin's agent is refused, and a re-export is
+// deterministic (all-no-op with --keep-version, patch-bump on a change).
+// Tests share ONE temp home and run in file order (node:test is sequential).
+import { test, after, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readFile, mkdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { useTempHome } from './helpers/temp-home.mjs';
+import { createV2Agent } from './helpers/export-fixtures.mjs';
+import { exportWorkflowPlugin } from '../src/core/workflow-export.mjs';
+import { exportGraphJson } from '../src/core/workflow-share.mjs';
+import { validatePluginDir } from '../src/core/plugin-manifest.mjs';
+import { readPluginWorkflows } from '../src/core/plugin-workflows.mjs';
+import { linkPlugin } from '../src/core/plugin-store.mjs';
+import { userAgentsDir } from '../src/core/agent-store.mjs';
+import { loadAgentRegistry } from '../src/core/agent-registry.mjs';
+import { readWorkflow, writeGraphWorkflow } from '../src/core/workflows.mjs';
+
+useTempHome(after);
+
+const dirs = [];
+const tmp = async (p = 'wf-exp-plg-') => { const d = await mkdtemp(join(tmpdir(), p)); dirs.push(d); return d; };
+after(async () => { await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true }))); });
+
+const GLOBAL_SKILL_MD = '---\nname: shared-skill\ndescription: a global skill the shared agent needs\n---\n\nGlobal skill body.\n';
+const BUNDLE_SKILL_MD = '---\nname: bundled-skill\ndescription: ships with Worca\n---\n\nBundle body.\n';
+
+// global skills live at <HOME>/.claude/skills; the bundle is a fixture repoRoot.
+let prevHome, repoRoot, workflowId;
+before(async () => {
+  prevHome = process.env.HOME;
+  const home = await tmp('wf-exp-plg-home-');
+  process.env.HOME = home;
+  await mkdir(join(home, '.claude', 'skills', 'shared-skill'), { recursive: true });
+  await writeFile(join(home, '.claude', 'skills', 'shared-skill', 'SKILL.md'), GLOBAL_SKILL_MD, 'utf8');
+  repoRoot = await tmp('wf-exp-plg-bundle-');
+  await mkdir(join(repoRoot, 'skills', 'bundled-skill'), { recursive: true });
+  await writeFile(join(repoRoot, 'skills', 'bundled-skill', 'SKILL.md'), BUNDLE_SKILL_MD, 'utf8');
+  await createV2Agent({
+    key: 'sharedAgent', displayName: 'Shared Agent', description: 'a user agent to bundle',
+    runnerType: 'producer', order: 50, requiresSkills: ['shared-skill', 'bundled-skill'],
+    markdown: '---\nname: sharedAgent\n---\n# Shared Agent\n\nUses shared-skill.\n',
+  });
+  // Hand-built (not writeKeyGraph): the exporter runs the FULL validator over
+  // the stored row before sharing it, and V2 pins node ids to /^n_[a-z0-9]+$/.
+  const tpl = await writeGraphWorkflow({
+    name: 'Shared Flow', domain: 'coding',
+    nodes: [
+      { id: 'n_task', kind: 'task', x: 0, y: 100, config: {} },
+      { id: 'n_plan', kind: 'agent', key: 'planner', x: 120, y: 100, config: {} },
+      { id: 'n_shared', kind: 'agent', key: 'sharedAgent', x: 240, y: 100, config: {} },
+      { id: 'n_end', kind: 'end', x: 360, y: 100, config: {} },
+    ],
+    wires: [
+      { id: 'w1', from: { node: 'n_task', port: 'task' }, to: { node: 'n_plan', port: 'task' } },
+      { id: 'w2', from: { node: 'n_plan', port: 'plan' }, to: { node: 'n_shared', port: 'task' } },
+      { id: 'w3', from: { node: 'n_shared', port: 'out' }, to: { node: 'n_end', port: 'result' } },
+    ],
+  });
+  workflowId = tpl.id;                                              // wf_shared-flow
+});
+after(() => { if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome; });
+
+let pluginDir;                                                      // <tmp>/my-shared-plugin
+
+test('dry-run classifies every intended file and writes nothing', async () => {
+  pluginDir = join(await tmp(), 'my-shared-plugin');
+  const plan = await exportWorkflowPlugin({ workflowId, targetDir: pluginDir, dryRun: true, repoRoot });
+  assert.equal(plan.name, 'my-shared-plugin', 'name defaults to the folder basename');
+  assert.equal(plan.slug, 'shared-flow', 'slug derives from the id, wf_ stripped');
+  assert.equal(plan.version, '0.1.0');
+  const rel = (p) => p.slice(pluginDir.length + 1).split('\\').join('/');
+  assert.deepEqual(plan.created.map(rel).sort(), [
+    'agents/sharedAgent.md', 'agents/sharedAgent.meta.json',
+    'skills/shared-skill/SKILL.md', 'worca-cc-plugin.json', 'workflows/shared-flow.json',
+  ]);
+  assert.deepEqual(plan.updated, []);
+  assert.deepEqual(plan.noop, []);
+  assert.equal(plan.skipped.length, 1);
+  assert.match(plan.skipped[0].reason, /bundled-skill.*ships with Worca \(bundle\)/);
+  assert.ok(plan.warnings.some((w) => /built-in agent\(s\) not bundled.*planner/.test(w)), plan.warnings.join('\n'));
+  assert.deepEqual(plan.written, []);
+  assert.equal(plan.validation, null);
+  assert.equal(existsSync(pluginDir), false, 'dry-run creates nothing');
+});
+
+test('apply writes the folder: unstamped graph, byte-identical agent pair, global skill; no built-in, no bundle skill', async () => {
+  const r = await exportWorkflowPlugin({ workflowId, targetDir: pluginDir, repoRoot });
+  assert.equal(r.written.length, 5, r.written.join('\n'));
+  assert.equal(r.validation.ok, true, JSON.stringify(r.validation.problems));
+
+  const graph = JSON.parse(await readFile(join(pluginDir, 'workflows', 'shared-flow.json'), 'utf8'));
+  assert.deepEqual(graph, await exportGraphJson(workflowId), 'exactly the JSON share payload');
+  assert.equal('_worca' in graph, false);
+
+  const srcDir = userAgentsDir();
+  assert.equal(await readFile(join(pluginDir, 'agents', 'sharedAgent.md'), 'utf8'), await readFile(join(srcDir, 'sharedAgent.md'), 'utf8'));
+  assert.equal(await readFile(join(pluginDir, 'agents', 'sharedAgent.meta.json'), 'utf8'), await readFile(join(srcDir, 'sharedAgent.meta.json'), 'utf8'));
+  assert.equal(existsSync(join(pluginDir, 'agents', 'planner.md')), false, 'built-ins are never bundled');
+  assert.equal(existsSync(join(pluginDir, 'agents', 'planner.meta.json')), false);
+
+  assert.equal(await readFile(join(pluginDir, 'skills', 'shared-skill', 'SKILL.md'), 'utf8'), GLOBAL_SKILL_MD);
+  assert.equal(existsSync(join(pluginDir, 'skills', 'bundled-skill')), false, 'a Worca-shipped skill is not bundled');
+
+  const manifest = JSON.parse(await readFile(join(pluginDir, 'worca-cc-plugin.json'), 'utf8'));
+  assert.equal(manifest.name, 'my-shared-plugin');
+  assert.equal(manifest.version, '0.1.0');
+  assert.deepEqual(manifest.engines, { 'worca-cc-api': '>=3 <4' });
+  assert.equal(manifest.worca.exports['shared-flow'].workflowId, workflowId);
+  assert.equal(manifest.worca.exports['shared-flow'].name, 'Shared Flow');
+
+  // The recipient's gates: validatePluginDir (link) and readPluginWorkflows (import).
+  const v = validatePluginDir(pluginDir, { strict: true });
+  assert.equal(v.ok, true, v.problems.map((p) => p.message).join('\n'));
+  const { ready, skipped } = readPluginWorkflows('my-shared-plugin', pluginDir, { quiet: true });
+  assert.deepEqual(skipped, []);
+  assert.equal(ready.length, 1);
+  assert.equal(ready[0].id, 'wfp_my-shared-plugin_shared-flow');
+  assert.equal(ready[0].rowName, 'Shared Flow');
+});
+
+test('re-export of an unchanged workflow is an all-no-op and keeps the version', async () => {
+  const r = await exportWorkflowPlugin({ workflowId, targetDir: pluginDir, repoRoot });
+  assert.deepEqual(r.created, []);
+  assert.deepEqual(r.updated, []);
+  assert.deepEqual(r.written, []);
+  assert.equal(r.noop.length, 5, r.noop.join('\n'));
+  assert.equal(r.version, '0.1.0', 'nothing changed => no bump');
+});
+
+test('a changed workflow updates the JSON in place, bumps the patch version, and never touches the skill dir', async () => {
+  const skillPath = join(pluginDir, 'skills', 'shared-skill', 'SKILL.md');
+  await writeFile(skillPath, GLOBAL_SKILL_MD + '\nrecipient-side edit\n', 'utf8');
+  const tpl = await readWorkflow(workflowId);
+  await writeGraphWorkflow({ ...tpl, name: 'Shared Flow v2' });
+  const r = await exportWorkflowPlugin({ workflowId, targetDir: pluginDir, repoRoot });
+  const rel = (p) => p.slice(pluginDir.length + 1).split('\\').join('/');
+  assert.deepEqual(r.updated.map(rel).sort(), ['worca-cc-plugin.json', 'workflows/shared-flow.json'], 'same filename: the recipient row updates in place');
+  assert.deepEqual(r.created, []);
+  assert.equal(r.version, '0.1.1');
+  assert.equal(await readFile(skillPath, 'utf8'), GLOBAL_SKILL_MD + '\nrecipient-side edit\n', 'an existing skill dir is left alone');
+  const manifest = JSON.parse(await readFile(join(pluginDir, 'worca-cc-plugin.json'), 'utf8'));
+  assert.equal(manifest.version, '0.1.1');
+  assert.equal(manifest.worca.exports['shared-flow'].name, 'Shared Flow v2');
+  // keepVersion: the next change lands without a bump.
+  await writeGraphWorkflow({ ...(await readWorkflow(workflowId)), name: 'Shared Flow v3' });
+  const kept = await exportWorkflowPlugin({ workflowId, targetDir: pluginDir, repoRoot, keepVersion: true });
+  assert.equal(kept.version, '0.1.1');
+  assert.ok(kept.updated.length >= 1);
+});
+
+test('manifest identity: an existing name is adopted, an explicit mismatch is CONFLICT, a bad name is BAD_REQUEST', async () => {
+  // Same folder, no --name: the manifest's name wins over the basename (they agree here).
+  const adopt = await exportWorkflowPlugin({ workflowId, targetDir: pluginDir, repoRoot, dryRun: true });
+  assert.equal(adopt.name, 'my-shared-plugin');
+  await assert.rejects(exportWorkflowPlugin({ workflowId, targetDir: pluginDir, pluginName: 'other-name', repoRoot }),
+    (e) => e.code === 'CONFLICT' && /pass --name my-shared-plugin/.test(e.message));
+  await assert.rejects(exportWorkflowPlugin({ workflowId, targetDir: join(await tmp(), 'Not_Kebab'), repoRoot }),
+    (e) => e.code === 'BAD_REQUEST' && /kebab-case/.test(e.message));
+  // Folder basename differs from the manifest: still adopted when no --name is passed.
+  const other = join(await tmp(), 'some-other-folder');
+  await mkdir(other, { recursive: true });
+  await writeFile(join(other, 'worca-cc-plugin.json'), JSON.stringify({ name: 'kept-name', version: '2.0.0', engines: { 'worca-cc-api': '>=3 <4' } }) + '\n');
+  const r = await exportWorkflowPlugin({ workflowId, targetDir: other, repoRoot, dryRun: true });
+  assert.equal(r.name, 'kept-name');
+  assert.equal(r.version, '2.0.1', 'a fresh export into an existing plugin is a change => bump');
+  await assert.rejects(exportWorkflowPlugin({ workflowId: 'wf_nope', targetDir: other, repoRoot }), (e) => e.code === 'NOT_FOUND');
+});
+
+test('round trip: the recipient links the folder, the workflow row and the agent arrive as plugin-owned', async () => {
+  // A recipient does not have the user agent. The store's deleteAgent refuses
+  // (the saved workflow references it), so drop the pair from the user layer
+  // directly — exactly the state a recipient's home is in.
+  const srcDir = userAgentsDir();
+  await rm(join(srcDir, 'sharedAgent.md'), { force: true });
+  await rm(join(srcDir, 'sharedAgent.meta.json'), { force: true });
+  assert.equal(loadAgentRegistry().sharedAgent, undefined);
+  const linked = await linkPlugin('my-shared-plugin', pluginDir);
+  assert.deepEqual(linked.workflows.imported, ['wfp_my-shared-plugin_shared-flow']);
+  assert.deepEqual(linked.workflows.skipped, []);
+  const row = await readWorkflow('wfp_my-shared-plugin_shared-flow');
+  assert.equal(row.origin, 'plugin:my-shared-plugin');
+  assert.equal(row.name, 'Shared Flow v3');
+  assert.deepEqual(row.nodes, (await exportGraphJson(workflowId)).nodes);
+  const meta = loadAgentRegistry().sharedAgent;
+  assert.equal(meta && meta.origin, 'plugin:my-shared-plugin');
+});
+
+test('another plugin\'s agent is refused — bundling it would create two owners', async () => {
+  // The exporter's own workflow now references sharedAgent through the LINKED plugin.
+  await assert.rejects(exportWorkflowPlugin({ workflowId, targetDir: join(await tmp(), 'second-plugin'), repoRoot }),
+    (e) => e.code === 'UNSUPPORTED' && /"sharedAgent" \(owned by plugin "my-shared-plugin"\)/.test(e.message));
+});
+
+test('a stranded workflow (deleted agent) is INVALID_GRAPH with the unknown-agent summary', async () => {
+  const tpl = await readWorkflow(workflowId);
+  const nodes = tpl.nodes.map((n) => (n.key === 'sharedAgent' ? { ...n, key: 'vanishedAgent' } : n));
+  const stranded = await writeGraphWorkflow({ name: 'Stranded', domain: tpl.domain, nodes, wires: tpl.wires });
+  await assert.rejects(exportWorkflowPlugin({ workflowId: stranded.id, targetDir: join(await tmp(), 'stranded-plugin'), repoRoot }),
+    (e) => e.code === 'INVALID_GRAPH' && /1 agent not installed here \(vanishedAgent\)/.test(e.message) && !!e.summary);
+});

--- a/test/workflow-share-api.test.mjs
+++ b/test/workflow-share-api.test.mjs
@@ -1,0 +1,132 @@
+// test/workflow-share-api.test.mjs
+// HTTP surface of issue #421: GET /api/workflows/:id/json (download),
+// POST /api/workflows/import-json(suffix-on-collision), and destination 'plugin'
+// on POST /api/workflows/:id/export. Boots the real server like
+// workflow-export-api.test.mjs.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { useTempHome } from './helpers/temp-home.mjs';
+
+useTempHome(after);
+
+let homeDir, srv, base, prevHome;
+const dirs = [];
+const tmp = async () => { const d = await mkdtemp(join(tmpdir(), 'wf-share-api-')); dirs.push(d); return d; };
+const JSONH = { 'Content-Type': 'application/json' };
+const post = (path, body) => fetch(`${base}${path}`, { method: 'POST', headers: JSONH, body: JSON.stringify(body) });
+
+before(async () => {
+  homeDir = await mkdtemp(join(tmpdir(), 'worca-cc-shareapi-'));
+  prevHome = process.env.WORCA_HOME;
+  process.env.WORCA_HOME = homeDir;
+  process.env.WORCA_MOCK = '1';
+  const { app } = await import('../ui/server.mjs');
+  srv = http.createServer(app);
+  await new Promise((r) => srv.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${srv.address().port}`;
+});
+
+after(async () => {
+  if (srv) await new Promise((r) => srv.close(r));
+  if (prevHome === undefined) delete process.env.WORCA_HOME; else process.env.WORCA_HOME = prevHome;
+  delete process.env.WORCA_MOCK;
+  await rm(homeDir, { recursive: true, force: true });
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+test('GET /api/workflows/:id/json serves the unstamped graph as a download', async () => {
+  const r = await fetch(`${base}/api/workflows/wf_default/json`);
+  assert.equal(r.status, 200);
+  assert.match(r.headers.get('content-disposition') || '', /attachment; filename="default\.json"/);
+  const j = await r.json();
+  assert.deepEqual(Object.keys(j), ['version', 'name', 'domain', 'nodes', 'wires']);
+  assert.equal('id' in j, false);
+  const missing = await fetch(`${base}/api/workflows/wf_nope/json`);
+  assert.equal(missing.status, 404);
+});
+
+test('POST /api/workflows/import-jsonmints an id and suffixes a taken name', async () => {
+  const src = await (await fetch(`${base}/api/workflows/wf_default/json`)).json();
+  const a = await post('/api/workflows/import-json', { workflow: { ...src, name: 'Shared In' } });
+  assert.equal(a.status, 201);
+  const ja = await a.json();
+  assert.equal(ja.workflow.name, 'Shared In');
+  assert.equal(ja.renamed, false);
+  const b = await post('/api/workflows/import-json', { workflow: { ...src, id: 'wf_default', name: 'Shared In' } });
+  assert.equal(b.status, 201);
+  const jb = await b.json();
+  assert.equal(jb.workflow.name, 'Shared In (2)');
+  assert.equal(jb.renamed, true);
+  assert.equal(jb.requestedName, 'Shared In');
+  assert.notEqual(jb.workflow.id, 'wf_default', 'the file id is ignored');
+  // `name` in the body overrides the file's name.
+  const c = await post('/api/workflows/import-json', { workflow: src, name: 'Body Name' });
+  assert.equal((await c.json()).workflow.name, 'Body Name');
+  // The list shows all three next to the built-in.
+  const list = (await (await fetch(`${base}/api/workflows`)).json()).workflows.map((w) => w.name);
+  assert.ok(list.includes('Shared In') && list.includes('Shared In (2)') && list.includes('Body Name'), list.join(', '));
+});
+
+test('POST /api/workflows/import-json: 400 without a workflow object, 422 + summary for unknown agents, 422 for the reserved name', async () => {
+  assert.equal((await post('/api/workflows/import-json', {})).status, 400);
+  assert.equal((await post('/api/workflows/import-json', { workflow: [] })).status, 400);
+  const src = await (await fetch(`${base}/api/workflows/wf_default/json`)).json();
+  const nodes = src.nodes.map((n) => (n.kind === 'agent' && n.key === 'planner' ? { ...n, key: 'ghostAgent' } : n));
+  const r = await post('/api/workflows/import-json', { workflow: { ...src, name: 'Ghost', nodes } });
+  assert.equal(r.status, 422);
+  const j = await r.json();
+  assert.equal(j.error, 'invalid graph');
+  assert.ok(Array.isArray(j.errors) && j.errors.some((e) => e.code === 'V4'));
+  assert.match(j.summary, /ghostAgent/);
+  const reserved = await post('/api/workflows/import-json', { workflow: { ...src, name: 'Default' } });
+  assert.equal(reserved.status, 422);
+  assert.match((await reserved.json()).error, /reserved/);
+});
+
+test('POST /api/workflows (composer save) still answers 409 on a minted collision and 422 with the issue list', async () => {
+  const src = await (await fetch(`${base}/api/workflows/wf_default/json`)).json();
+  const a = await post('/api/workflows', { ...src, name: 'Composer Row' });
+  assert.equal(a.status, 201);
+  const b = await post('/api/workflows', { ...src, name: 'Composer Row' });
+  assert.equal(b.status, 409);
+  assert.equal((await b.json()).id, (await a.json()).workflow.id);
+  const bad = await post('/api/workflows', { ...src, name: 'Bad', wires: [] });
+  assert.equal(bad.status, 422);
+  const jb = await bad.json();
+  assert.equal(jb.error, 'invalid graph');
+  assert.ok(Array.isArray(jb.errors) && jb.errors.length > 0);
+  assert.equal((await post('/api/workflows', { name: 'v1', steps: [] })).status, 400);
+});
+
+test('POST /api/workflows/:id/export destination=plugin: plan, apply, validation', async () => {
+  const bad = await post('/api/workflows/wf_default/export', { destination: 'plugin' });
+  assert.equal(bad.status, 400);
+  assert.match((await bad.json()).error, /pluginDir/);
+  const dest = join(await tmp(), 'default-as-plugin');
+  const plan = await post('/api/workflows/wf_default/export', { destination: 'plugin', pluginDir: dest, dryRun: true });
+  assert.equal(plan.status, 200);
+  const jp = await plan.json();
+  assert.equal(jp.name, 'default-as-plugin');
+  assert.equal(jp.slug, 'default');
+  assert.ok(jp.created.some((p) => p.endsWith('worca-cc-plugin.json')));
+  assert.deepEqual(jp.conflicts, []);
+  assert.equal(existsSync(dest), false, 'dry-run writes nothing');
+  const apply = await post('/api/workflows/wf_default/export', { destination: 'plugin', pluginDir: dest, pluginName: 'default-as-plugin' });
+  assert.equal(apply.status, 200);
+  const ja = await apply.json();
+  assert.equal(ja.validation.ok, true, JSON.stringify(ja.validation));
+  assert.ok(existsSync(join(dest, 'workflows', 'default.json')));
+  assert.ok(existsSync(join(dest, 'worca-cc-plugin.json')));
+  assert.equal(existsSync(join(dest, 'agents')), false, 'the default uses built-ins only: nothing to bundle');
+  const mismatch = await post('/api/workflows/wf_default/export', { destination: 'plugin', pluginDir: dest, pluginName: 'other' });
+  assert.equal(mismatch.status, 409);
+  const unknown = await post('/api/workflows/wf_default/export', { destination: 'elsewhere' });
+  assert.equal(unknown.status, 400);
+  assert.match((await unknown.json()).error, /'plugin'/);
+});

--- a/test/workflow-share-api.test.mjs
+++ b/test/workflow-share-api.test.mjs
@@ -130,3 +130,26 @@ test('POST /api/workflows/:id/export destination=plugin: plan, apply, validation
   assert.equal(unknown.status, 400);
   assert.match((await unknown.json()).error, /'plugin'/);
 });
+
+test('a plugin folder pasted into "Add marketplace" is linked, not registered; POST /api/plugins/link does the same', async () => {
+  const dir = join(await tmp(), 'link-me');
+  const exp = await post('/api/workflows/wf_default/export', { destination: 'plugin', pluginDir: dir });
+  assert.equal(exp.status, 200);
+  const r = await post('/api/marketplaces', { url: dir });
+  const text = await r.text();
+  assert.equal(r.status, 200, text);
+  const j = JSON.parse(text);
+  assert.equal(j.linked, true, 'a plugin folder is linked rather than added as a marketplace');
+  assert.equal(j.plugin.name, 'link-me');
+  assert.deepEqual(j.plugin.workflows.imported, ['wfp_link-me_default']);
+  const names = (await (await fetch(`${base}/api/marketplaces`)).json()).marketplaces.map((m) => m.url);
+  assert.ok(!names.includes(dir), 'no marketplace entry was recorded for it');
+  const rows = (await (await fetch(`${base}/api/workflows`)).json()).workflows;
+  const row = rows.find((w) => w.id === 'wfp_link-me_default');
+  assert.ok(row && row.origin === 'plugin:link-me', 'its workflow is in the library as plugin-owned');
+  // The direct route, and its refusal of a folder that is not a plugin.
+  const bad = await post('/api/plugins/link', { dir: await tmp() });
+  assert.equal(bad.status, 400);
+  assert.match((await bad.json()).error, /cannot link/);
+  assert.equal((await post('/api/plugins/link', {})).status, 400);
+});

--- a/test/workflow-share-cli.test.mjs
+++ b/test/workflow-share-cli.test.mjs
@@ -1,0 +1,133 @@
+// test/workflow-share-cli.test.mjs
+// `worca workflow export --format json|plugin` and `worca workflow import`
+// (issue #421), spawned like workflow-export-cli.test.mjs.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { useTempHome } from './helpers/temp-home.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, '..', 'src', 'cli', 'worca-cc.mjs');
+
+const home = useTempHome(after);
+const created = [];
+const scratchCwd = mkdtempSync(join(tmpdir(), 'worca-cc-wfs-cwd-'));
+created.push(scratchCwd);
+async function freshDir(prefix) {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  created.push(dir);
+  return dir;
+}
+after(() => Promise.all(created.map((d) => rm(d, { recursive: true, force: true }))));
+
+function run(args, { cwd, stdin } = {}) {
+  return new Promise((res) => {
+    const env = { ...process.env, WORCA_MOCK: '1', WORCA_HOME: home };
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env, cwd: cwd || scratchCwd, stdio: [stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'],
+    });
+    let stdout = ''; let stderr = '';
+    child.stdout.on('data', (b) => (stdout += b.toString()));
+    child.stderr.on('data', (b) => (stderr += b.toString()));
+    child.on('exit', (code) => res({ code: code ?? 0, stdout, stderr }));
+    if (stdin !== undefined) { child.stdin.end(stdin); }
+  });
+}
+
+test('workflow export --format json prints the unstamped graph; --out writes a file', async () => {
+  const r = await run(['workflow', 'export', 'wf_default', '--format', 'json']);
+  assert.equal(r.code, 0, r.stderr);
+  const j = JSON.parse(r.stdout);
+  assert.deepEqual(Object.keys(j), ['version', 'name', 'domain', 'nodes', 'wires']);
+  assert.equal(j.name, 'Default');
+  const dir = await freshDir('worca-cc-wfs-out-');
+  const out = join(dir, 'default.json');
+  const w = await run(['workflow', 'export', 'wf_default', '--format', 'json', '--out', out]);
+  assert.equal(w.code, 0, w.stderr);
+  assert.match(w.stdout, /wrote\t/);
+  assert.deepEqual(JSON.parse(await readFile(out, 'utf8')), j);
+  const bad = await run(['workflow', 'export', 'wf_default', '--format', 'yaml']);
+  assert.equal(bad.code, 2);
+  assert.match(bad.stderr, /--format must be/);
+});
+
+test('workflow import: mints, then suffixes on a second import; stdin works; bad JSON is a usage error', async () => {
+  const dir = await freshDir('worca-cc-wfs-imp-');
+  const file = join(dir, 'shared.json');
+  const src = JSON.parse((await run(['workflow', 'export', 'wf_default', '--format', 'json'])).stdout);
+  await writeFile(file, JSON.stringify({ ...src, name: 'From File' }), 'utf8');
+  const a = await run(['workflow', 'import', file]);
+  assert.equal(a.code, 0, a.stderr);
+  assert.match(a.stdout, /^imported\twf_[a-z0-9-]+\tFrom File$/m);
+  const b = await run(['workflow', 'import', file]);
+  assert.equal(b.code, 0, b.stderr);
+  assert.match(b.stdout, /imported\twf_[a-z0-9-]+\tFrom File \(2\)/);
+  assert.match(b.stdout, /renamed: "From File" was already taken/);
+  const c = await run(['workflow', 'import', '-', '--name', 'Via Stdin'], { stdin: JSON.stringify(src) });
+  assert.equal(c.code, 0, c.stderr);
+  assert.match(c.stdout, /imported\twf_via-stdin\tVia Stdin/);
+  const list = await run(['workflow', 'list']);
+  assert.match(list.stdout, /From File \(2\)/);
+  assert.match(list.stdout, /Via Stdin/);
+  await writeFile(file, '{ not json', 'utf8');
+  const bad = await run(['workflow', 'import', file]);
+  assert.equal(bad.code, 2);
+  assert.match(bad.stderr, /not valid JSON/);
+  const missing = await run(['workflow', 'import', join(dir, 'nope.json')]);
+  assert.equal(missing.code, 1);
+  assert.match(missing.stderr, /cannot read/);
+});
+
+test('workflow import refuses a graph that needs agents this host lacks, naming them and the plugin path', async () => {
+  const dir = await freshDir('worca-cc-wfs-ghost-');
+  const file = join(dir, 'ghost.json');
+  const src = JSON.parse((await run(['workflow', 'export', 'wf_default', '--format', 'json'])).stdout);
+  const nodes = src.nodes.map((n) => (n.kind === 'agent' && n.key === 'planner' ? { ...n, key: 'ghostAgent' } : n));
+  await writeFile(file, JSON.stringify({ ...src, name: 'Ghost', nodes }), 'utf8');
+  const r = await run(['workflow', 'import', file]);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /1 agent not installed here \(ghostAgent\)/);
+  assert.match(r.stderr, /--format plugin/);
+  assert.match(r.stderr, /- V4: unknown agent "ghostAgent"/);
+});
+
+test('workflow export --format plugin --target writes a linkable folder; --dry-run writes nothing', async () => {
+  const dir = join(await freshDir('worca-cc-wfs-plg-'), 'shared-default');
+  const dry = await run(['workflow', 'export', 'wf_default', '--format', 'plugin', '--target', dir, '--dry-run']);
+  assert.equal(dry.code, 0, dry.stderr);
+  assert.match(dry.stdout, /create\t.*worca-cc-plugin\.json/);
+  assert.match(dry.stdout, /create\t.*workflows[\\/]default\.json/);
+  assert.match(dry.stdout, /warn\tbuilt-in agent\(s\) not bundled/);
+  assert.equal(existsSync(dir), false);
+  const r = await run(['workflow', 'export', 'wf_default', '--format', 'plugin', '--target', dir]);
+  assert.equal(r.code, 0, r.stderr);
+  assert.match(r.stdout, /wrote\t.*workflows[\\/]default\.json/);
+  assert.match(r.stdout, /plugin "shared-default" v0\.1\.0 at /);
+  assert.match(r.stdout, /worca plugin link /);
+  assert.ok(existsSync(join(dir, 'worca-cc-plugin.json')));
+  // The recipient side: the folder lints clean under the CLI's own validator.
+  const v = await run(['plugin', 'validate', dir, '--strict']);
+  assert.equal(v.code, 0, v.stderr + v.stdout);
+  // Re-export: all no-op, version unchanged.
+  const again = await run(['workflow', 'export', 'wf_default', '--format', 'plugin', '--target', dir]);
+  assert.equal(again.code, 0, again.stderr);
+  assert.doesNotMatch(again.stdout, /wrote\t/);
+  assert.match(again.stdout, /v0\.1\.0 at /);
+  const usage = await run(['workflow', 'export', 'wf_default', '--format', 'plugin']);
+  assert.equal(usage.code, 2);
+  assert.match(usage.stderr, /requires --target/);
+});
+
+test('plugin init --with workflows no longer requires agents: the scaffold runs a built-in', async () => {
+  const dir = join(await freshDir('worca-cc-wfs-init-'), 'wf-only');
+  const r = await run(['plugin', 'init', 'wf-only', '--dir', dir, '--with', 'workflows']);
+  assert.equal(r.code, 0, r.stderr + r.stdout);
+  const tpl = JSON.parse(await readFile(join(dir, 'workflows', 'example-flow.json'), 'utf8'));
+  assert.equal(tpl.nodes.find((n) => n.kind === 'agent').key, 'planner');
+  assert.equal(existsSync(join(dir, 'agents')), false);
+});

--- a/test/workflow-share.test.mjs
+++ b/test/workflow-share.test.mjs
@@ -1,0 +1,128 @@
+// test/workflow-share.test.mjs
+// The JSON share round trip (issue #421): exportGraphJson (the stored row,
+// unstamped) and importGraphWorkflow (mint id, suffix on collision, shared
+// validator with the one-line unknown-agent fold), plus saveGraphWorkflow
+// keeping the composer's reject-on-collision semantics.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { useTempHome } from './helpers/temp-home.mjs';
+import { writeKeyGraph } from './helpers/export-fixtures.mjs';
+import {
+  exportGraphJson, importGraphWorkflow, saveGraphWorkflow, summarizeUnknownAgents, workflowFileSlug,
+} from '../src/core/workflow-share.mjs';
+import { readWorkflow, writeGraphWorkflow } from '../src/core/workflows.mjs';
+
+useTempHome(after);
+
+test('exportGraphJson: the STORED row — no id/origin/timestamps, canvas kept, fixed key order', async () => {
+  const tpl = await writeKeyGraph({ name: 'Share Me', keys: ['planner'] });
+  await writeGraphWorkflow({ ...tpl, canvas: { zoom: 1.5, x: 10 } });
+  const j = await exportGraphJson(tpl.id);
+  assert.deepEqual(Object.keys(j), ['version', 'name', 'domain', 'nodes', 'wires', 'canvas']);
+  assert.equal(j.version, 2);
+  assert.equal(j.name, 'Share Me');
+  assert.equal(j.domain, 'coding');
+  assert.deepEqual(j.nodes, tpl.nodes);
+  assert.deepEqual(j.wires, tpl.wires);
+  assert.deepEqual(j.canvas, { zoom: 1.5, x: 10 });
+  for (const k of ['id', 'origin', 'createdAt', 'updatedAt', 'archivedAt', '_worca']) assert.equal(k in j, false, `${k} must not leak`);
+});
+
+test('exportGraphJson: the built-in default is shareable; an unknown id is NOT_FOUND', async () => {
+  const j = await exportGraphJson('wf_default');
+  assert.equal(j.version, 2);
+  assert.ok(j.nodes.length > 0);
+  assert.equal('canvas' in j, false, 'no canvas => no key');
+  await assert.rejects(exportGraphJson('wf_no-such-thing'), (e) => e.code === 'NOT_FOUND');
+});
+
+test('workflowFileSlug: wf_ stripped, other ids sanitized, never empty', () => {
+  assert.equal(workflowFileSlug('wf_my-flow'), 'my-flow');
+  assert.equal(workflowFileSlug('wf_default'), 'default');
+  assert.equal(workflowFileSlug('wfp_demo_simple'), 'wfp_demo_simple');
+  assert.equal(workflowFileSlug('wf_'), 'workflow');
+});
+
+test('importGraphWorkflow mints an id and ignores the file\'s id/origin; canvas survives', async () => {
+  const src = await exportGraphJson('wf_default');
+  const r = await importGraphWorkflow({ ...src, id: 'wf_default', origin: 'plugin:x', name: 'Imported Default', canvas: { zoom: 2 } });
+  assert.ok(r.workflow.id.startsWith('wf_') && r.workflow.id !== 'wf_default', r.workflow.id);
+  assert.equal(r.workflow.origin, null, 'a file origin is never trusted');
+  assert.equal(r.renamed, false);
+  assert.equal(r.requestedName, 'Imported Default');
+  const row = await readWorkflow(r.workflow.id);
+  assert.equal(row.name, 'Imported Default');
+  assert.deepEqual(row.nodes, src.nodes);
+  assert.deepEqual(row.canvas, { zoom: 2 });
+  // The default itself is untouched.
+  assert.equal((await readWorkflow('wf_default')).name, 'Default');
+});
+
+test('importGraphWorkflow suffixes the name on a live collision — never overwrites', async () => {
+  const src = await exportGraphJson('wf_default');
+  const a = await importGraphWorkflow({ ...src, name: 'Twice' });
+  const b = await importGraphWorkflow({ ...src, name: 'Twice' });
+  const c = await importGraphWorkflow({ ...src, name: 'Twice' });
+  assert.equal(a.workflow.name, 'Twice');
+  assert.equal(b.workflow.name, 'Twice (2)');
+  assert.equal(c.workflow.name, 'Twice (3)');
+  assert.equal(b.renamed, true);
+  assert.equal(b.requestedName, 'Twice');
+  assert.equal(new Set([a.workflow.id, b.workflow.id, c.workflow.id]).size, 3, 'three distinct rows');
+  // A name that already carries a suffix continues counting from it.
+  const d = await importGraphWorkflow({ ...src, name: 'Twice (2)' });
+  assert.equal(d.workflow.name, 'Twice (4)');
+  // `name` overrides the file's name before any collision handling.
+  const e = await importGraphWorkflow({ ...src, name: 'Twice' }, { name: 'Renamed On Import' });
+  assert.equal(e.workflow.name, 'Renamed On Import');
+  assert.equal(e.renamed, false);
+});
+
+test('importGraphWorkflow refuses the reserved name (with a hint), a v1 body and a blank name', async () => {
+  const src = await exportGraphJson('wf_default');
+  await assert.rejects(importGraphWorkflow({ ...src, name: 'Default' }),
+    (e) => e.code === 'RESERVED_NAME' && /different name/.test(e.message));
+  await assert.rejects(importGraphWorkflow({ name: 'Old', steps: [[{ key: 'planner' }]], feedbacks: [] }),
+    (e) => e.code === 'BAD_REQUEST' && /version 2/.test(e.message));
+  await assert.rejects(importGraphWorkflow({ ...src, name: '   ' }), (e) => e.code === 'BAD_REQUEST' && /name is required/.test(e.message));
+});
+
+test('importGraphWorkflow folds unknown agents into ONE summary line that points at the plugin export', async () => {
+  const src = await exportGraphJson('wf_default');
+  const nodes = src.nodes.map((n) => (n.kind === 'agent' && n.key === 'planner' ? { ...n, key: 'ghostAgent' } : n));
+  assert.notDeepEqual(nodes, src.nodes, 'the default has a planner node to rename');
+  await assert.rejects(importGraphWorkflow({ ...src, name: 'Ghost', nodes }), (e) => {
+    assert.equal(e.code, 'INVALID_GRAPH');
+    assert.equal(e.message, 'invalid graph', 'the composer-facing message is unchanged');
+    assert.ok(e.errors.some((i) => i.code === 'V4'), 'the shared validator\'s V4 is the cause');
+    assert.match(e.summary, /1 agent not installed here \(ghostAgent\)/);
+    assert.match(e.summary, /--format plugin/);
+    return true;
+  });
+  assert.equal(summarizeUnknownAgents([{ code: 'V7', message: 'unknown agent "x"' }]), null, 'only V4 counts');
+  assert.match(summarizeUnknownAgents([
+    { code: 'V4', message: 'unknown agent "a" — no such key in the registry' },
+    { code: 'V4', message: 'unknown agent "a" — no such key in the registry' },
+    { code: 'V4', message: 'unknown agent "b" — no such key in the registry' },
+  ]), /2 agents not installed here \(a, b\)/);
+});
+
+test('importGraphWorkflow checks per-node tunables against the catalog (BAD_REQUEST)', async () => {
+  const src = await exportGraphJson('wf_default');
+  const nodes = src.nodes.map((n) => (n.kind === 'agent' ? { ...n, config: { ...(n.config || {}), model: 'no-such-model' } } : n));
+  await assert.rejects(importGraphWorkflow({ ...src, name: 'Bad Model', nodes }),
+    (e) => e.code === 'BAD_REQUEST' && /unknown model "no-such-model"/.test(e.message));
+});
+
+test('saveGraphWorkflow keeps composer semantics: a minted collision is ID_TAKEN, a legal id re-saves', async () => {
+  const src = await exportGraphJson('wf_default');
+  const a = await saveGraphWorkflow({ ...src, name: 'Composer Save' });
+  assert.ok(a.workflow.id.startsWith('wf_'));
+  await assert.rejects(saveGraphWorkflow({ ...src, name: 'Composer Save' }),
+    (e) => e.code === 'ID_TAKEN' && e.id === a.workflow.id);
+  const b = await saveGraphWorkflow({ ...src, id: a.workflow.id, name: 'Composer Save Renamed' });
+  assert.equal(b.workflow.id, a.workflow.id);
+  assert.equal(b.workflow.name, 'Composer Save Renamed');
+  await assert.rejects(saveGraphWorkflow({ name: 'v1', steps: [] }), (e) => e.code === 'BAD_REQUEST');
+});

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -16508,7 +16508,9 @@ async function exportApply(id, opts) { return exportCall(id, opts); }
 // format: 'json' (download the saved graph) | 'skill' (Claude Code skill; destination
 // global|project) | 'plugin' (Worca plugin folder). The dialog asks for the format
 // first — one Export… per row instead of one button per format.
-const exportModalState = { item: null, format: 'json', destination: 'global', conflicts: [] };
+// `planned`: a Preview (dry run) for the CURRENT inputs is on screen. Export runs
+// its own dry run when there is none, so the primary button is never dead.
+const exportModalState = { item: null, format: 'json', destination: 'global', conflicts: [], planned: false };
 
 function openExportModal(item) {
   const modal = document.getElementById('export-modal');
@@ -16517,6 +16519,7 @@ function openExportModal(item) {
   exportModalState.format = 'json';
   exportModalState.destination = 'global';
   exportModalState.conflicts = [];
+  exportModalState.planned = false;
   document.getElementById('export-slug').value = '';
   document.getElementById('export-folder').value = '';
   document.getElementById('export-plugin-name').value = '';
@@ -16546,12 +16549,13 @@ function exportSyncFormat() {
   show('export-plugin-field', plugin);
   show('export-slug-field', skill);
   show('export-agents-field', skill);
-  // JSON needs no plan: the primary action downloads straight away. The other two
-  // formats stay Plan → Apply (Apply enables once a plan has no open conflict).
+  // JSON downloads straight away. The other two formats offer an optional Preview
+  // (dry run); Export runs that dry run itself and writes unless it finds a
+  // conflict, which the user then resolves per file before exporting again.
   document.getElementById('export-plan-btn').classList.toggle('hidden', json);
   const apply = document.getElementById('export-apply-btn');
-  apply.textContent = json ? 'Download' : 'Apply';
-  if (json) apply.disabled = false;
+  apply.textContent = json ? 'Download' : 'Export';
+  apply.disabled = false;
   const name = exportModalState.item ? exportModalState.item.name : '';
   document.getElementById('export-subtitle').textContent = json
     ? `Download "${name}" as a JSON file another Worca user can import.`
@@ -16615,6 +16619,7 @@ function exportRenderPlan(plan) {
   }
   for (const o of plan.orphans || []) line('orphan', o);
   exportModalState.conflicts = plan.conflicts || [];
+  exportModalState.planned = true;
   for (const cf of exportModalState.conflicts) {
     const row = document.createElement('div');
     row.className = 'export-row export-conflict-row';
@@ -16654,12 +16659,14 @@ function exportUpdateApplyEnabled() {
 // matches what Apply would do — drop it and re-disable Apply so the user must re-Plan.
 function exportInvalidatePlan() {
   exportModalState.conflicts = [];
+  exportModalState.planned = false;
   const planEl = document.getElementById('export-plan');
   if (planEl) { planEl.textContent = ''; planEl.classList.add('hidden'); }
+  // Export re-plans on its own, so a stale preview never leaves the button dead.
   const applyBtn = document.getElementById('export-apply-btn');
-  if (applyBtn) applyBtn.disabled = exportModalState.format !== 'json';   // JSON never needs a plan
+  if (applyBtn) applyBtn.disabled = false;
   const msg = document.getElementById('export-msg');
-  if (msg && msg.textContent) msg.textContent = exportModalState.format === 'json' ? '' : 'Inputs changed — re-run Plan.';
+  if (msg) msg.textContent = '';
 }
 function bindExportModal() {
   const modal = document.getElementById('export-modal');
@@ -16688,15 +16695,19 @@ function bindExportModal() {
     openFolderBrowser(folder.value.trim(), set);
   });
   document.getElementById('export-cancel').addEventListener('click', closeExportModal);
+  // Preview: the optional dry run — shows what Export would write, writes nothing.
   document.getElementById('export-plan-btn').addEventListener('click', async () => {
     const msg = document.getElementById('export-msg');
-    msg.textContent = 'Planning…';
+    msg.textContent = 'Previewing…';
     try {
       const plan = await exportPlan(exportModalState.item.id, exportBuildOpts());
       exportRenderPlan(plan);
-      msg.textContent = plan.conflicts.length ? 'Resolve each conflict below, then Apply.' : 'Ready to apply.';
-    } catch (err) { msg.textContent = `Plan failed: ${err.message}`; }
+      msg.textContent = plan.conflicts.length ? 'Resolve each conflict below, then Export.' : 'Preview only — nothing is written until you click Export.';
+    } catch (err) { msg.textContent = `Preview failed: ${err.message}`; }
   });
+  // Export: writes. Without a preview for the current inputs it runs the dry run
+  // itself first; a conflict (only the skill format can raise one) stops it and is
+  // shown for per-file resolution — nothing is ever written past an unresolved one.
   document.getElementById('export-apply-btn').addEventListener('click', async () => {
     const msg = document.getElementById('export-msg');
     if (exportModalState.format === 'json') {
@@ -16710,8 +16721,16 @@ function bindExportModal() {
       closeExportModal();
       return;
     }
-    msg.textContent = 'Applying…';
+    msg.textContent = 'Exporting…';
     try {
+      if (!exportModalState.planned) {
+        const plan = await exportPlan(exportModalState.item.id, exportBuildOpts());
+        if ((plan.conflicts || []).length) {
+          exportRenderPlan(plan);
+          msg.textContent = 'Resolve each conflict below, then Export.';
+          return;
+        }
+      }
       const opts = { ...exportBuildOpts(), resolutions: exportGatherResolutions() };
       const applied = await exportApply(exportModalState.item.id, opts);
       // A conflict Apply left UNWRITTEN (e.g. a TOCTOU conflict between Plan and Apply that
@@ -16722,7 +16741,7 @@ function bindExportModal() {
       if (unwritten.length) {
         exportRenderPlan(applied);
         appendLog({ source: 'ui', level: 'error', text: `export of ${exportModalState.item.name} incomplete: ${applied.written.length} written, ${unwritten.length} conflict(s) left unwritten` });
-        msg.textContent = `${unwritten.length} unresolved conflict(s) were left unwritten — resolve below and Apply again.`;
+        msg.textContent = `${unwritten.length} unresolved conflict(s) were left unwritten — resolve below and Export again.`;
         return;
       }
       // A plugin folder that does not validate stays open: the recipient's
@@ -16739,7 +16758,7 @@ function bindExportModal() {
       closeExportModal();
     } catch (err) {
       exportInvalidatePlan();
-      msg.textContent = `Apply failed: ${err.message}`;
+      msg.textContent = `Export failed: ${err.message}`;
     }
   });
   // Backdrop click (the overlay itself, not the inner card) closes the modal.

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -8355,7 +8355,14 @@ async function addMarketplaceFromInput() {
   if (!ok) return setPluginsMsg(data.error || 'add failed', 'err');
   el.marketplaceUrl.value = '';
   el.marketplaceAddRow.classList.add('hidden');
-  setPluginsMsg(`Added ${data.marketplace.name} (${data.marketplace.plugins.length} plugins).`, 'ok');
+  if (data.linked) {
+    // The path was a single plugin folder (an Export… → Worca plugin result):
+    // the server linked it instead of registering a marketplace.
+    const n = (data.plugin.workflows?.imported || []).length;
+    setPluginsMsg(`Linked plugin "${data.plugin.name}" from ${data.plugin.dir} — ${n} pipeline template${n === 1 ? '' : 's'} added to your saved pipelines.`, 'ok');
+  } else {
+    setPluginsMsg(`Added ${data.marketplace.name} (${data.marketplace.plugins.length} plugins).`, 'ok');
+  }
   loadPluginsView();
 }
 
@@ -16528,6 +16535,7 @@ function openExportModal(item) {
   document.getElementById('export-msg').textContent = '';
   const planEl = document.getElementById('export-plan');
   planEl.textContent = ''; planEl.classList.add('hidden');
+  exportSetDone(false);
   exportSyncFormat();
   exportSyncSlugPreview();
   modal.classList.remove('hidden');
@@ -16535,6 +16543,51 @@ function openExportModal(item) {
 function closeExportModal() {
   const modal = document.getElementById('export-modal');
   if (modal) modal.classList.add('hidden');
+  exportSetDone(false);
+}
+/** Swap the form for the result view (or back). The dialog stays open so the
+ *  user reads where the export went and what to do next, then clicks Done. */
+function exportSetDone(done) {
+  const g = (id) => document.getElementById(id);
+  g('export-form').classList.toggle('hidden', done);
+  g('export-done').classList.toggle('hidden', !done);
+  for (const id of ['export-cancel', 'export-plan-btn', 'export-apply-btn']) g(id).classList.toggle('hidden', done);
+  if (!done && exportModalState.item) exportSyncFormat();          // Preview visibility is format-driven
+  g('export-done-close').classList.toggle('hidden', !done);
+  if (done) g('export-done-close').focus();
+}
+/** @param {{title:string, lines:Array<[string, string|Node]>, next?:string|Node}} r */
+function exportShowDone(r) {
+  const g = (id) => document.getElementById(id);
+  g('export-subtitle').textContent = '';
+  g('export-done-title').textContent = r.title;
+  const dl = g('export-done-lines');
+  dl.replaceChildren();
+  for (const [k, v] of r.lines) {
+    const dt = document.createElement('dt'); dt.textContent = k;
+    const dd = document.createElement('dd');
+    if (typeof v === 'string') dd.textContent = v; else dd.appendChild(v);
+    dl.append(dt, dd);
+  }
+  const next = g('export-done-next');
+  next.replaceChildren();
+  if (typeof r.next === 'string') next.textContent = r.next; else if (r.next) next.appendChild(r.next);
+  next.classList.toggle('hidden', !r.next);
+  exportSetDone(true);
+}
+/** "Then run <code>x</code>": a text + code fragment for the next-step line. */
+function exportNextStep(before, code, after = '') {
+  const frag = document.createDocumentFragment();
+  frag.appendChild(document.createTextNode(before));
+  const c = document.createElement('code'); c.textContent = code;
+  frag.appendChild(c);
+  if (after) frag.appendChild(document.createTextNode(after));
+  return frag;
+}
+/** Mirrors src/core/workflow-share.mjs workflowFileSlug (the download's filename). */
+function exportJsonFilename(id) {
+  const stem = String(id || '').replace(/^wf_/, '').toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return `${stem || 'workflow'}.json`;
 }
 function exportSyncFormat() {
   const { format, destination } = exportModalState;
@@ -16717,6 +16770,7 @@ function bindExportModal() {
     openFolderBrowser(folder.value.trim(), set);
   });
   document.getElementById('export-cancel').addEventListener('click', closeExportModal);
+  document.getElementById('export-done-close').addEventListener('click', closeExportModal);
   // Preview: the optional dry run — shows what Export would write, writes nothing.
   document.getElementById('export-plan-btn').addEventListener('click', async () => {
     const msg = document.getElementById('export-msg');
@@ -16740,7 +16794,11 @@ function bindExportModal() {
       document.body.appendChild(a);
       a.click();
       a.remove();
-      closeExportModal();
+      exportShowDone({
+        title: 'JSON file downloaded',
+        lines: [['File', exportJsonFilename(exportModalState.item.id)], ['Pipeline', exportModalState.item.name]],
+        next: 'Send the file to another Worca user — they pick it up with Import… in their saved pipelines. Agents and skills do not travel with it; share a plugin for those.',
+      });
       return;
     }
     msg.textContent = 'Exporting…';
@@ -16776,8 +16834,25 @@ function bindExportModal() {
         return;
       }
       appendLog({ source: 'ui', level: 'info', text: `exported ${exportModalState.item.name}: ${applied.written.length} written, ${applied.skipped.length} skipped` });
-      if (applied.validation) setGvSavedMsg(`Plugin "${applied.name}" v${applied.version} written to ${applied.dir} — share the folder; the recipient runs: worca plugin link`, 'ok');
-      closeExportModal();
+      const files = `${applied.written.length} written, ${(applied.noop || []).length} unchanged`;
+      if (applied.validation) {                                  // plugin
+        exportShowDone({
+          title: `Plugin "${applied.name}" v${applied.version} exported`,
+          lines: [['Folder', applied.dir], ['Files', files]],
+          next: exportNextStep('Share the folder. The recipient pastes its path into Plugins → Add marketplace, or runs ',
+            `worca plugin link ${applied.dir}`, ' — once; after a re-export they run worca plugin reimport.'),
+        });
+      } else {                                                    // Claude Code skill
+        const command = (document.getElementById('export-slug-preview').textContent.match(/\/[^\s]+/) || [''])[0];
+        const where = exportModalState.destination === 'project'
+          ? document.getElementById('export-folder').value.trim() : '~/.claude';
+        exportShowDone({
+          title: 'Claude Code skill exported',
+          lines: [['Skill', command || exportModalState.item.name], ['Location', where], ['Files', files]],
+          next: exportNextStep(exportModalState.destination === 'project' ? 'Open the project in Claude Code and run ' : 'In Claude Code, run ',
+            command || '/<skill>', ' — the pipeline runs there without Worca.'),
+        });
+      }
     } catch (err) {
       exportInvalidatePlan();
       msg.textContent = `Export failed: ${err.message}`;

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -1682,6 +1682,18 @@ const gvApi = {
     const d = await safeJson(res);
     return { ok: false, status: res.status, error: (d && d.error) || `delete failed (${res.status})` };
   },
+  // Import a JSON export (#421). 422 carries the shared validator's issues plus
+  // `summary` (the one-line "agents you do not have" fold) when that is the cause.
+  importWorkflow: async (workflow) => {
+    const res = await fetch('/api/workflows/import-json', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ workflow }),
+    });
+    const d = await safeJson(res);
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: (d && d.error) || `import failed (${res.status})`, summary: d && d.summary, issues: d && d.errors };
+    }
+    return { ok: true, workflow: d.workflow, renamed: !!d.renamed, requestedName: d.requestedName, warnings: d.warnings || [] };
+  },
 };
 
 function gvEls() {
@@ -1833,10 +1845,18 @@ async function gvRefreshSaved() {
       // Export to Claude Code — available for every v2 row incl. the built-in (you can
       // export the default). Opens the plan/apply modal; the server resolves the graph.
       const exportBtn = document.createElement('button');
-      exportBtn.type = 'button'; exportBtn.className = 'pl-export'; exportBtn.title = 'Export to Claude Code';
+      exportBtn.type = 'button'; exportBtn.className = 'pl-export'; exportBtn.title = 'Export as a Claude Code skill or a Worca plugin';
       exportBtn.textContent = '⇪';
       exportBtn.addEventListener('click', () => openExportModal({ id: wf.id, name: wf.name || wf.id }));
       row.appendChild(exportBtn);
+      // Download as JSON (#421): the stored v2 graph, unstamped, for another Worca
+      // user to Import. A plain download link — the server sets Content-Disposition.
+      const jsonBtn = document.createElement('a');
+      jsonBtn.className = 'pl-export pl-json'; jsonBtn.title = 'Download as JSON (share with another Worca user)';
+      jsonBtn.textContent = '{ }';
+      jsonBtn.href = `/api/workflows/${encodeURIComponent(wf.id)}/json`;
+      jsonBtn.setAttribute('download', '');
+      row.appendChild(jsonBtn);
       // No × on the built-in: DELETE /api/workflows/wf_default always answers
       // 400 (ui/server.mjs), so the button could only ever fail. Open stays —
       // the built-in is meant to be opened and saved as a copy.
@@ -16433,9 +16453,10 @@ function openExportModal(item) {
   exportModalState.item = item;
   exportModalState.destination = 'global';
   exportModalState.conflicts = [];
-  document.getElementById('export-subtitle').textContent = `Export "${item.name}" as a runnable /command skill.`;
   document.getElementById('export-slug').value = '';
   document.getElementById('export-folder').value = '';
+  document.getElementById('export-plugin-name').value = '';
+  document.getElementById('export-keep-version').checked = false;
   document.getElementById('export-include-agents').checked = true;
   document.getElementById('export-msg').textContent = '';
   const planEl = document.getElementById('export-plan');
@@ -16451,10 +16472,21 @@ function closeExportModal() {
 }
 function exportSyncDest() {
   const dest = exportModalState.destination;
+  const plugin = dest === 'plugin';
   for (const b of document.querySelectorAll('#export-dest .seg-btn')) {
     b.classList.toggle('on', b.dataset.dest === dest);
   }
-  document.getElementById('export-folder-field').classList.toggle('hidden', dest !== 'project');
+  // global/project share the skill fields; plugin swaps them for the plugin ones.
+  document.getElementById('export-folder-field').classList.toggle('hidden', dest === 'global');
+  document.getElementById('export-folder-label').textContent = plugin ? 'Plugin folder' : 'Folder';
+  document.getElementById('export-folder').placeholder = plugin ? '/path/to/my-plugin' : '/path/to/repo';
+  document.getElementById('export-plugin-field').classList.toggle('hidden', !plugin);
+  document.getElementById('export-slug-field').classList.toggle('hidden', plugin);
+  document.getElementById('export-agents-field').classList.toggle('hidden', plugin);
+  const name = exportModalState.item ? exportModalState.item.name : '';
+  document.getElementById('export-subtitle').textContent = plugin
+    ? `Export "${name}" as a Worca plugin folder to share with other Worca users.`
+    : `Export "${name}" as a runnable /command skill.`;
 }
 function exportSyncSlugPreview() {
   const raw = document.getElementById('export-slug').value;
@@ -16464,6 +16496,16 @@ function exportSyncSlugPreview() {
 }
 function exportBuildOpts() {
   const dest = exportModalState.destination;
+  if (dest === 'plugin') {
+    const opts = {
+      destination: 'plugin',
+      pluginDir: document.getElementById('export-folder').value.trim(),
+      keepVersion: document.getElementById('export-keep-version').checked,
+    };
+    const pluginName = document.getElementById('export-plugin-name').value.trim();
+    if (pluginName) opts.pluginName = pluginName;
+    return opts;
+  }
   const rawSlug = document.getElementById('export-slug').value.trim();
   const opts = {
     destination: dest,
@@ -16486,6 +16528,9 @@ function exportRenderPlan(plan) {
   for (const p of plan.created) line('create', p);
   for (const p of plan.updated) line('update', p);
   for (const p of plan.noop) line('no-op', p);
+  // A plugin plan's `skipped` entries are {path, reason} (a Worca-shipped skill
+  // that is not bundled); the skill export's are plain paths.
+  for (const s of plan.skipped || []) line('skip', typeof s === 'string' ? s : `${s.path} — ${s.reason}`);
   for (const w of plan.warnings || []) {
     const row = document.createElement('div');
     row.className = 'export-row';
@@ -16549,6 +16594,8 @@ function bindExportModal() {
   document.getElementById('export-slug').addEventListener('input', () => { exportSyncSlugPreview(); exportInvalidatePlan(); });
   document.getElementById('export-include-agents').addEventListener('change', exportInvalidatePlan);
   document.getElementById('export-folder').addEventListener('input', exportInvalidatePlan);
+  document.getElementById('export-plugin-name').addEventListener('input', exportInvalidatePlan);
+  document.getElementById('export-keep-version').addEventListener('change', exportInvalidatePlan);
   document.getElementById('export-browse').addEventListener('click', () => {
     const seed = document.getElementById('export-folder').value.trim();
     openFolderBrowser(seed, (p) => { document.getElementById('export-folder').value = p; exportInvalidatePlan(); });
@@ -16580,7 +16627,17 @@ function bindExportModal() {
         msg.textContent = `${unwritten.length} unresolved conflict(s) were left unwritten — resolve below and Apply again.`;
         return;
       }
+      // A plugin folder that does not validate stays open: the recipient's
+      // `worca plugin link` would refuse it, so the problems are the outcome.
+      if (applied.validation && !applied.validation.ok) {
+        exportRenderPlan(applied);
+        const problems = applied.validation.problems.filter((p) => p.level === 'error').map((p) => p.message);
+        appendLog({ source: 'ui', level: 'error', text: `plugin export of ${exportModalState.item.name} does not validate: ${problems.join('; ')}` });
+        msg.textContent = `Written, but the plugin folder does not validate: ${problems.join('; ')}`;
+        return;
+      }
       appendLog({ source: 'ui', level: 'info', text: `exported ${exportModalState.item.name}: ${applied.written.length} written, ${applied.skipped.length} skipped` });
+      if (applied.validation) setGvSavedMsg(`Plugin "${applied.name}" v${applied.version} written to ${applied.dir} — share the folder; the recipient runs: worca plugin link`, 'ok');
       closeExportModal();
     } catch (err) {
       exportInvalidatePlan();
@@ -16591,3 +16648,32 @@ function bindExportModal() {
   modal.addEventListener('click', (e) => { if (e.target === modal) closeExportModal(); });
 }
 bindExportModal();
+
+// Import JSON (#421) — the saved list's "Import JSON" button. Parses the file in
+// the browser (so a non-JSON file says so without a round trip) and hands the
+// object to POST /api/workflows/import-json; the outcome lands on the list's message
+// line, like a refused delete.
+function bindGvImport() {
+  const btn = document.getElementById('gv-import-btn');
+  const input = document.getElementById('gv-import-file');
+  if (!btn || !input) return;
+  btn.addEventListener('click', () => { input.value = ''; input.click(); });
+  input.addEventListener('change', async () => {
+    const f = input.files && input.files[0];
+    if (!f) return;
+    let obj;
+    try { obj = JSON.parse(await f.text()); }
+    catch (e) { setGvSavedMsg(`${f.name} is not valid JSON: ${e.message}`, 'err'); return; }
+    const r = await gvApi.importWorkflow(obj);
+    if (!r.ok) {
+      const issues = (r.issues || []).slice(0, 5).map((i) => `${i.code}: ${i.message}`).join(' · ');
+      setGvSavedMsg(r.summary || (issues ? `${r.error} — ${issues}` : r.error), 'err');
+      return;
+    }
+    setGvSavedMsg(r.renamed
+      ? `Imported as "${r.workflow.name}" — "${r.requestedName}" was already taken.`
+      : `Imported "${r.workflow.name}".`, 'ok');
+    gvRefreshSaved();
+  });
+}
+bindGvImport();

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -8355,6 +8355,9 @@ async function addMarketplaceFromInput() {
   if (!ok) return setPluginsMsg(data.error || 'add failed', 'err');
   el.marketplaceUrl.value = '';
   el.marketplaceAddRow.classList.add('hidden');
+  // Reload FIRST: loadPluginsView() clears the message line as it starts, so a
+  // message set before it never survived.
+  await loadPluginsView();
   if (data.linked) {
     // The path was a single plugin folder (an Export… → Worca plugin result):
     // the server linked it instead of registering a marketplace.
@@ -8363,7 +8366,6 @@ async function addMarketplaceFromInput() {
   } else {
     setPluginsMsg(`Added ${data.marketplace.name} (${data.marketplace.plugins.length} plugins).`, 'ok');
   }
-  loadPluginsView();
 }
 
 function openInstallConsent(entry) {

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -1788,13 +1788,57 @@ function composerExit() {
   if (gvComposer) gvComposer.suspend();
 }
 
+// Saved-list state that lives for the PAGE SESSION (not persisted): the selected
+// domain tab, the last fetched rows (tab switches re-render without a fetch),
+// and the ids imported since load — those carry a NEW pill until reload.
+let gvSavedTab = null;
+let gvSavedRows = [];
+const gvNewIds = new Set();
+const gvDomainOf = (wf) => wf.domain || 'general';
+
+/** Scroll the page to its top so the Workflow Composer title AND the canvas are in
+ *  view after a row is opened (the saved list sits below the fold). */
+function gvScrollToTop() {
+  const main = document.querySelector('.main');
+  try { if (main && typeof main.scrollTo === 'function') main.scrollTo({ top: 0, behavior: 'smooth' }); } catch { /* jsdom */ }
+  try { if (typeof window.scrollTo === 'function') window.scrollTo({ top: 0, behavior: 'smooth' }); } catch { /* jsdom */ }
+}
+
 async function gvRefreshSaved() {
+  gvSavedRows = await gvApi.listWorkflows();
+  gvRenderSaved();
+  await gvRefreshArchived();
+}
+
+function gvRenderSaved() {
   const els = gvEls();
-  const list = await gvApi.listWorkflows();
+  const list = gvSavedRows;
   els.savedCount.textContent = list.length ? `· ${list.length}` : '';
-  gvComposer.setSavedDomains([...new Set(list.map((w) => w.domain).filter(Boolean))]);
+  const domains = [...new Set(list.map(gvDomainOf))].sort();
+  gvComposer.setSavedDomains(domains);
+  if (!domains.includes(gvSavedTab)) gvSavedTab = domains[0] || null;
+  // ── One tab per domain (the row no longer repeats the domain) ──
+  const tabs = document.getElementById('gv-saved-tabs');
+  tabs.replaceChildren();
+  tabs.hidden = domains.length === 0;
+  for (const d of domains) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'gv-saved-tab' + (d === gvSavedTab ? ' active' : '');
+    b.dataset.domain = d;
+    b.setAttribute('role', 'tab');
+    b.setAttribute('aria-selected', d === gvSavedTab ? 'true' : 'false');
+    b.appendChild(document.createTextNode(d));
+    const badge = document.createElement('span');
+    badge.className = 'gv-saved-tab-badge';
+    badge.textContent = String(list.filter((w) => gvDomainOf(w) === d).length);
+    b.appendChild(badge);
+    b.addEventListener('click', () => { gvSavedTab = d; gvRenderSaved(); });
+    tabs.appendChild(b);
+  }
   els.savedList.replaceChildren();
   for (const wf of list) {
+    if (gvDomainOf(wf) !== gvSavedTab) continue;
     const item = document.createElement('div');
     item.className = 'pl-item';
     item.dataset.id = wf.id;
@@ -1815,10 +1859,15 @@ async function gvRefreshSaved() {
     const name = document.createElement('div');
     name.className = 'pl-name';
     name.textContent = wf.name || wf.id;
-    const meta = document.createElement('div');
-    meta.className = 'pl-meta';
-    meta.textContent = wf.domain || 'general';
-    main.append(name, meta);
+    // Imported this page session: a NEW pill until the next reload (gvNewIds is
+    // module state, so a reload clears it by construction).
+    if (gvNewIds.has(wf.id)) {
+      const pill = document.createElement('span');
+      pill.className = 'pl-new';
+      pill.textContent = 'NEW';
+      name.appendChild(pill);
+    }
+    main.append(name);
     row.appendChild(main);
     // A plugin-owned row is replaced wholesale by the next `worca plugin update`
     // (src/core/plugin-workflows.mjs upserts ON CONFLICT), so say so BEFORE the
@@ -1832,37 +1881,45 @@ async function gvRefreshSaved() {
       row.appendChild(tag);
     }
     if (wf.version === 2) {
-      const open = document.createElement('button');
-      open.type = 'button'; open.className = 'btn-ghost pl-open'; open.textContent = 'Open';
-      open.addEventListener('click', async () => {
+      // The ROW is the Open action (no Open button): click or Enter/Space on the
+      // card loads it. openTemplate asks before discarding unsaved edits (MAJ-6)
+      // and resolves null when refused — the canvas and the undo ring must then
+      // be left exactly as they were. On success the page scrolls to its top so
+      // the Composer title and the loaded canvas are both in view.
+      row.classList.add('pl-openable');
+      row.tabIndex = 0;
+      row.setAttribute('role', 'button');
+      row.title = `Open "${wf.name || wf.id}"`;
+      const open = async () => {
         const full = await gvApi.readWorkflow(wf.id);
         if (!full) return;
-        // openTemplate resolves null when the discard guard was refused — the
-        // canvas (and the undo ring) must then be left exactly as they were.
-        if (await gvComposer.openTemplate(full)) gvComposer.fit();
+        if (await gvComposer.openTemplate(full)) { gvComposer.fit(); gvScrollToTop(); }
+      };
+      row.addEventListener('click', (e) => {
+        if (e.target && e.target.closest && e.target.closest('button, a, input')) return;   // the row's own actions
+        open();
       });
-      row.appendChild(open);
-      // Export to Claude Code — available for every v2 row incl. the built-in (you can
-      // export the default). Opens the plan/apply modal; the server resolves the graph.
+      row.addEventListener('keydown', (e) => {
+        if (e.target !== row) return;
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+      });
+      // ONE Export… entry point (JSON file / Claude Code skill / Worca plugin): the
+      // dialog asks for the format. Available for every v2 row incl. the built-in.
       const exportBtn = document.createElement('button');
-      exportBtn.type = 'button'; exportBtn.className = 'pl-export'; exportBtn.title = 'Export as a Claude Code skill or a Worca plugin';
-      exportBtn.textContent = '⇪';
+      exportBtn.type = 'button'; exportBtn.className = 'btn-ghost pl-export';
+      exportBtn.title = 'Export as a JSON file, a Claude Code skill or a Worca plugin';
+      exportBtn.textContent = 'Export…';
       exportBtn.addEventListener('click', () => openExportModal({ id: wf.id, name: wf.name || wf.id }));
       row.appendChild(exportBtn);
-      // Download as JSON (#421): the stored v2 graph, unstamped, for another Worca
-      // user to Import. A plain download link — the server sets Content-Disposition.
-      const jsonBtn = document.createElement('a');
-      jsonBtn.className = 'pl-export pl-json'; jsonBtn.title = 'Download as JSON (share with another Worca user)';
-      jsonBtn.textContent = '{ }';
-      jsonBtn.href = `/api/workflows/${encodeURIComponent(wf.id)}/json`;
-      jsonBtn.setAttribute('download', '');
-      row.appendChild(jsonBtn);
-      // No × on the built-in: DELETE /api/workflows/wf_default always answers
-      // 400 (ui/server.mjs), so the button could only ever fail. Open stays —
+      // No delete on the built-in: DELETE /api/workflows/wf_default always answers
+      // 400 (ui/server.mjs), so the button could only ever fail. Opening stays —
       // the built-in is meant to be opened and saved as a copy.
       if (wf.id !== RESERVED_WORKFLOW_ID) {
         const del = document.createElement('button');
-        del.type = 'button'; del.className = 'pl-del'; del.textContent = '×';
+        del.type = 'button'; del.className = 'pl-del';
+        del.title = `Delete "${wf.name || wf.id}"`;
+        del.setAttribute('aria-label', `Delete "${wf.name || wf.id}"`);
+        del.innerHTML = TRASH_SVG;                          // the one bin icon (static markup)
         // A delete is destructive and unrecoverable: it asks first, in red — the
         // guard the v1 composer's saved list owned before it was retired.
         del.addEventListener('click', async () => {
@@ -1887,7 +1944,6 @@ async function gvRefreshSaved() {
     item.appendChild(row);
     els.savedList.appendChild(item);
   }
-  await gvRefreshArchived();
 }
 
 // The Archived footer only exists once V24 (P8) archives rows: it is rendered
@@ -16445,12 +16501,16 @@ async function exportCall(id, opts) {
 async function exportPlan(id, opts) { return exportCall(id, { ...opts, dryRun: true }); }
 async function exportApply(id, opts) { return exportCall(id, opts); }
 
-const exportModalState = { item: null, destination: 'global', conflicts: [] };
+// format: 'json' (download the saved graph) | 'skill' (Claude Code skill; destination
+// global|project) | 'plugin' (Worca plugin folder). The dialog asks for the format
+// first — one Export… per row instead of one button per format.
+const exportModalState = { item: null, format: 'json', destination: 'global', conflicts: [] };
 
 function openExportModal(item) {
   const modal = document.getElementById('export-modal');
   if (!modal) return;
   exportModalState.item = item;
+  exportModalState.format = 'json';
   exportModalState.destination = 'global';
   exportModalState.conflicts = [];
   document.getElementById('export-slug').value = '';
@@ -16461,8 +16521,7 @@ function openExportModal(item) {
   document.getElementById('export-msg').textContent = '';
   const planEl = document.getElementById('export-plan');
   planEl.textContent = ''; planEl.classList.add('hidden');
-  document.getElementById('export-apply-btn').disabled = true;
-  exportSyncDest();
+  exportSyncFormat();
   exportSyncSlugPreview();
   modal.classList.remove('hidden');
 }
@@ -16470,23 +16529,36 @@ function closeExportModal() {
   const modal = document.getElementById('export-modal');
   if (modal) modal.classList.add('hidden');
 }
-function exportSyncDest() {
-  const dest = exportModalState.destination;
-  const plugin = dest === 'plugin';
-  for (const b of document.querySelectorAll('#export-dest .seg-btn')) {
-    b.classList.toggle('on', b.dataset.dest === dest);
-  }
-  // global/project share the skill fields; plugin swaps them for the plugin ones.
-  document.getElementById('export-folder-field').classList.toggle('hidden', dest === 'global');
+function exportSyncFormat() {
+  const { format, destination } = exportModalState;
+  const json = format === 'json', skill = format === 'skill', plugin = format === 'plugin';
+  const show = (id, on) => document.getElementById(id).classList.toggle('hidden', !on);
+  for (const b of document.querySelectorAll('#export-format .seg-btn')) b.classList.toggle('on', b.dataset.format === format);
+  for (const b of document.querySelectorAll('#export-dest .seg-btn')) b.classList.toggle('on', b.dataset.dest === destination);
+  show('export-dest-field', skill);
+  show('export-folder-field', (skill && destination === 'project') || plugin);
   document.getElementById('export-folder-label').textContent = plugin ? 'Plugin folder' : 'Folder';
   document.getElementById('export-folder').placeholder = plugin ? '/path/to/my-plugin' : '/path/to/repo';
-  document.getElementById('export-plugin-field').classList.toggle('hidden', !plugin);
-  document.getElementById('export-slug-field').classList.toggle('hidden', plugin);
-  document.getElementById('export-agents-field').classList.toggle('hidden', plugin);
+  show('export-plugin-field', plugin);
+  show('export-slug-field', skill);
+  show('export-agents-field', skill);
+  // JSON needs no plan: the primary action downloads straight away. The other two
+  // formats stay Plan → Apply (Apply enables once a plan has no open conflict).
+  document.getElementById('export-plan-btn').classList.toggle('hidden', json);
+  const apply = document.getElementById('export-apply-btn');
+  apply.textContent = json ? 'Download' : 'Apply';
+  if (json) apply.disabled = false;
   const name = exportModalState.item ? exportModalState.item.name : '';
-  document.getElementById('export-subtitle').textContent = plugin
-    ? `Export "${name}" as a Worca plugin folder to share with other Worca users.`
-    : `Export "${name}" as a runnable /command skill.`;
+  document.getElementById('export-subtitle').textContent = json
+    ? `Download "${name}" as a JSON file another Worca user can import.`
+    : plugin
+      ? `Export "${name}" as a Worca plugin folder to share with other Worca users.`
+      : `Export "${name}" as a runnable /command skill.`;
+  document.getElementById('export-format-hint').textContent = json
+    ? 'The saved graph only — no agents or skills travel with it. The recipient uses Import… in their saved list.'
+    : plugin
+      ? 'Bundles the pipeline, your own agents it uses and the skills they need. Built-in agents are not copied. The recipient runs: worca plugin link <folder>'
+      : 'Writes a SKILL.md plus the agents it dispatches under .claude/, so the pipeline runs inside Claude Code without Worca.';
 }
 function exportSyncSlugPreview() {
   const raw = document.getElementById('export-slug').value;
@@ -16496,7 +16568,7 @@ function exportSyncSlugPreview() {
 }
 function exportBuildOpts() {
   const dest = exportModalState.destination;
-  if (dest === 'plugin') {
+  if (exportModalState.format === 'plugin') {
     const opts = {
       destination: 'plugin',
       pluginDir: document.getElementById('export-folder').value.trim(),
@@ -16581,15 +16653,18 @@ function exportInvalidatePlan() {
   const planEl = document.getElementById('export-plan');
   if (planEl) { planEl.textContent = ''; planEl.classList.add('hidden'); }
   const applyBtn = document.getElementById('export-apply-btn');
-  if (applyBtn) applyBtn.disabled = true;
+  if (applyBtn) applyBtn.disabled = exportModalState.format !== 'json';   // JSON never needs a plan
   const msg = document.getElementById('export-msg');
-  if (msg && msg.textContent) msg.textContent = 'Inputs changed — re-run Plan.';
+  if (msg && msg.textContent) msg.textContent = exportModalState.format === 'json' ? '' : 'Inputs changed — re-run Plan.';
 }
 function bindExportModal() {
   const modal = document.getElementById('export-modal');
   if (!modal) return;
+  for (const b of document.querySelectorAll('#export-format .seg-btn')) {
+    b.addEventListener('click', () => { exportModalState.format = b.dataset.format; exportInvalidatePlan(); exportSyncFormat(); });
+  }
   for (const b of document.querySelectorAll('#export-dest .seg-btn')) {
-    b.addEventListener('click', () => { exportModalState.destination = b.dataset.dest; exportSyncDest(); exportInvalidatePlan(); });
+    b.addEventListener('click', () => { exportModalState.destination = b.dataset.dest; exportInvalidatePlan(); exportSyncFormat(); });
   }
   document.getElementById('export-slug').addEventListener('input', () => { exportSyncSlugPreview(); exportInvalidatePlan(); });
   document.getElementById('export-include-agents').addEventListener('change', exportInvalidatePlan);
@@ -16612,6 +16687,17 @@ function bindExportModal() {
   });
   document.getElementById('export-apply-btn').addEventListener('click', async () => {
     const msg = document.getElementById('export-msg');
+    if (exportModalState.format === 'json') {
+      // A plain download of the stored graph — the server sets Content-Disposition.
+      const a = document.createElement('a');
+      a.href = `/api/workflows/${encodeURIComponent(exportModalState.item.id)}/json`;
+      a.setAttribute('download', '');
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      closeExportModal();
+      return;
+    }
     msg.textContent = 'Applying…';
     try {
       const opts = { ...exportBuildOpts(), resolutions: exportGatherResolutions() };
@@ -16649,10 +16735,26 @@ function bindExportModal() {
 }
 bindExportModal();
 
-// Import JSON (#421) — the saved list's "Import JSON" button. Parses the file in
-// the browser (so a non-JSON file says so without a round trip) and hands the
-// object to POST /api/workflows/import-json; the outcome lands on the list's message
-// line, like a refused delete.
+// Import… (#421) — the saved list's header button. Parses the file in the
+// browser (so a non-JSON file says so without a round trip) and hands the object
+// to POST /api/workflows/import-json; the outcome lands on the list's message
+// line, like a refused delete. On success the imported row's domain tab is
+// selected and the row carries a NEW pill until reload.
+async function gvImportWorkflowObject(obj) {
+  const r = await gvApi.importWorkflow(obj);
+  if (!r.ok) {
+    const issues = (r.issues || []).slice(0, 5).map((i) => `${i.code}: ${i.message}`).join(' · ');
+    setGvSavedMsg(r.summary || (issues ? `${r.error} — ${issues}` : r.error), 'err');
+    return false;
+  }
+  gvSavedTab = gvDomainOf(r.workflow);
+  gvNewIds.add(r.workflow.id);
+  setGvSavedMsg(r.renamed
+    ? `Imported as "${r.workflow.name}" — "${r.requestedName}" was already taken.`
+    : `Imported "${r.workflow.name}".`, 'ok');
+  await gvRefreshSaved();
+  return true;
+}
 function bindGvImport() {
   const btn = document.getElementById('gv-import-btn');
   const input = document.getElementById('gv-import-file');
@@ -16664,16 +16766,7 @@ function bindGvImport() {
     let obj;
     try { obj = JSON.parse(await f.text()); }
     catch (e) { setGvSavedMsg(`${f.name} is not valid JSON: ${e.message}`, 'err'); return; }
-    const r = await gvApi.importWorkflow(obj);
-    if (!r.ok) {
-      const issues = (r.issues || []).slice(0, 5).map((i) => `${i.code}: ${i.message}`).join(' · ');
-      setGvSavedMsg(r.summary || (issues ? `${r.error} — ${issues}` : r.error), 'err');
-      return;
-    }
-    setGvSavedMsg(r.renamed
-      ? `Imported as "${r.workflow.name}" — "${r.requestedName}" was already taken.`
-      : `Imported "${r.workflow.name}".`, 'ok');
-    gvRefreshSaved();
+    await gvImportWorkflowObject(obj);
   });
 }
 bindGvImport();

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -1910,7 +1910,8 @@ function gvRenderSaved() {
       exportBtn.title = 'Export as a JSON file, a Claude Code skill or a Worca plugin';
       exportBtn.textContent = 'Export…';
       exportBtn.addEventListener('click', () => openExportModal({ id: wf.id, name: wf.name || wf.id }));
-      row.appendChild(exportBtn);
+      // Appended AFTER delete (below): Export… is the last element of every row, so
+      // it sits on the same right edge whether or not the row has a delete.
       // No delete on the built-in: DELETE /api/workflows/wf_default always answers
       // 400 (ui/server.mjs), so the button could only ever fail. Opening stays —
       // the built-in is meant to be opened and saved as a copy.
@@ -1935,6 +1936,7 @@ function gvRenderSaved() {
         });
         row.appendChild(del);
       }
+      row.appendChild(exportBtn);
     } else {
       const tag = document.createElement('span');
       tag.className = 'pl-legacy';
@@ -7090,9 +7092,11 @@ function basenameOf(p) {
 }
 
 // Thin wrapper over the native picker endpoint; never throws.
-async function pickFolder() {
+async function pickFolder(purpose = 'project') {
   try {
-    const res = await fetch('/api/fs/pick-folder', { method: 'POST' });
+    const res = await fetch('/api/fs/pick-folder', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ purpose }),
+    });
     return await safeJson(res); // {status:'picked',path} | {status:'canceled'} | {status:'unsupported'} | {status:'busy'}
   } catch {
     return { status: 'unsupported' };
@@ -16671,9 +16675,17 @@ function bindExportModal() {
   document.getElementById('export-folder').addEventListener('input', exportInvalidatePlan);
   document.getElementById('export-plugin-name').addEventListener('input', exportInvalidatePlan);
   document.getElementById('export-keep-version').addEventListener('change', exportInvalidatePlan);
-  document.getElementById('export-browse').addEventListener('click', () => {
-    const seed = document.getElementById('export-folder').value.trim();
-    openFolderBrowser(seed, (p) => { document.getElementById('export-folder').value = p; exportInvalidatePlan(); });
+  // Browse…: the native OS folder dialog (the server opens it — a web page never
+  // learns an absolute path from its own file picker), exactly like Add Project;
+  // the in-app browser is the fallback when the native one is unsupported.
+  document.getElementById('export-browse').addEventListener('click', async () => {
+    const folder = document.getElementById('export-folder');
+    const set = (p) => { folder.value = p; exportInvalidatePlan(); };
+    const data = await pickFolder(exportModalState.format === 'plugin' ? 'plugin' : 'export');
+    if (data && data.status === 'picked' && data.path) { set(data.path); return; }
+    if (data && data.status === 'canceled') return;
+    if (data && data.status === 'busy') { document.getElementById('export-msg').textContent = 'A folder dialog is already open — finish or cancel it first.'; return; }
+    openFolderBrowser(folder.value.trim(), set);
   });
   document.getElementById('export-cancel').addEventListener('click', closeExportModal);
   document.getElementById('export-plan-btn').addEventListener('click', async () => {

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -16547,6 +16547,7 @@ function exportSyncFormat() {
   document.getElementById('export-folder-label').textContent = plugin ? 'Plugin folder' : 'Folder';
   document.getElementById('export-folder').placeholder = plugin ? '/path/to/my-plugin' : '/path/to/repo';
   show('export-plugin-field', plugin);
+  if (plugin) exportSyncPluginNamePreview();
   show('export-slug-field', skill);
   show('export-agents-field', skill);
   // JSON downloads straight away. The other two formats offer an optional Preview
@@ -16568,6 +16569,24 @@ function exportSyncFormat() {
       ? 'Bundles the pipeline, your own agents it uses and the skills they need. Built-in agents are not copied. The recipient runs: worca plugin link <folder>'
       : 'Writes a SKILL.md plus the agents it dispatches under .claude/, so the pipeline runs inside Claude Code without Worca.';
 }
+/** Plugin names are kebab-case (worca-cc-plugin.json `name`). Derive one from
+ *  what the user typed, else from the folder's basename, and say so under the
+ *  field — the same look-before-you-export the skill slug has. */
+function exportPluginName() {
+  const typed = document.getElementById('export-plugin-name').value.trim();
+  const folder = document.getElementById('export-folder').value.trim().replace(/[\\/]+$/, '');
+  const raw = typed || folder.split(/[\\/]/).pop() || '';
+  const name = raw.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 64);
+  return { raw, name, fromFolder: !typed };
+}
+function exportSyncPluginNamePreview() {
+  const { raw, name, fromFolder } = exportPluginName();
+  const el = document.getElementById('export-plugin-name-preview');
+  if (!raw) { el.textContent = 'Plugin name: (choose a folder first)'; return; }
+  el.textContent = name
+    ? `Plugin name: ${name}${fromFolder ? ' (from the folder name)' : ''}`
+    : 'Plugin name: needs at least one letter or digit';
+}
 function exportSyncSlugPreview() {
   const raw = document.getElementById('export-slug').value;
   const { preview, valid } = exportSlugPreview(raw, exportModalState.item ? exportModalState.item.name : '');
@@ -16582,8 +16601,10 @@ function exportBuildOpts() {
       pluginDir: document.getElementById('export-folder').value.trim(),
       keepVersion: document.getElementById('export-keep-version').checked,
     };
-    const pluginName = document.getElementById('export-plugin-name').value.trim();
-    if (pluginName) opts.pluginName = pluginName;
+    // Always the NORMALIZED name (typed, else the folder's basename): the server
+    // refuses anything but kebab-case, and "Full-Special" is a typo, not a choice.
+    const { name } = exportPluginName();
+    if (name) opts.pluginName = name;
     return opts;
   }
   const rawSlug = document.getElementById('export-slug').value.trim();
@@ -16680,7 +16701,8 @@ function bindExportModal() {
   document.getElementById('export-slug').addEventListener('input', () => { exportSyncSlugPreview(); exportInvalidatePlan(); });
   document.getElementById('export-include-agents').addEventListener('change', exportInvalidatePlan);
   document.getElementById('export-folder').addEventListener('input', exportInvalidatePlan);
-  document.getElementById('export-plugin-name').addEventListener('input', exportInvalidatePlan);
+  document.getElementById('export-plugin-name').addEventListener('input', () => { exportSyncPluginNamePreview(); exportInvalidatePlan(); });
+  document.getElementById('export-folder').addEventListener('input', () => { if (exportModalState.format === 'plugin') exportSyncPluginNamePreview(); });
   document.getElementById('export-keep-version').addEventListener('change', exportInvalidatePlan);
   // Browse…: the native OS folder dialog (the server opens it — a web page never
   // learns an absolute path from its own file picker), exactly like Add Project;

--- a/ui/public/graph/composer.mjs
+++ b/ui/public/graph/composer.mjs
@@ -175,12 +175,33 @@ export function createComposer(hostEls, { doc = globalThis.document, api, raf = 
     paintInspector();
     if (hooks.onRender) hooks.onRender();
   }
+  /** A canvas nobody has touched: the two bookends, no wires, no edits. */
+  function isPristine() {
+    return !dirty && tpl.wires.length === 0 && tpl.nodes.length === 2
+      && tpl.nodes.every((n) => n.kind === 'task' || n.kind === 'end');
+  }
   function paintChrome() {
+    // "Unfinished" (a mandatory port still to wire — validate.mjs flags those
+    // `incomplete`) is not "wrong". Save is gated by BOTH, but only real mistakes
+    // earn the red chip; unfinished wiring gets a quiet to-do chip, and a canvas
+    // nobody has touched yet shows no chip at all — a fresh drawing has nothing
+    // to shout about.
     const n = lastReport.errors.length;
-    if (hostEls.saveBtn) hostEls.saveBtn.disabled = n > 0 || !ready;
+    const real = lastReport.errors.filter((e) => !e.incomplete).length;
+    const todo = n - real;
+    if (hostEls.saveBtn) {
+      hostEls.saveBtn.disabled = n > 0 || !ready;
+      hostEls.saveBtn.title = real
+        ? 'Fix the errors to save'
+        : todo ? 'Wire Task → … → End to save' : '';
+    }
     if (hostEls.errors) {
-      hostEls.errors.hidden = n === 0;
-      hostEls.errors.textContent = n ? `${n} error${n === 1 ? '' : 's'}` : '';
+      const quiet = !real && todo > 0 && !isPristine();
+      hostEls.errors.hidden = !real && !quiet;
+      hostEls.errors.classList.toggle('is-incomplete', quiet);
+      hostEls.errors.textContent = real
+        ? `${real} error${real === 1 ? '' : 's'}`
+        : quiet ? `${todo} port${todo === 1 ? '' : 's'} to wire` : '';
     }
   }
 

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1379,8 +1379,10 @@
         <p id="export-msg" class="confirm-message"></p>
         <div class="confirm-actions">
           <button type="button" id="export-cancel" class="btn btn-ghost btn-mini">Cancel</button>
-          <button type="button" id="export-plan-btn" class="btn btn-ghost btn-mini">Plan</button>
-          <button type="button" id="export-apply-btn" class="btn btn-primary btn-mini" disabled>Apply</button>
+          <!-- Preview = dry run (optional). Export runs the dry run itself and writes
+               unless it hits a conflict, which it then shows for per-file resolution. -->
+          <button type="button" id="export-plan-btn" class="btn btn-ghost btn-mini">Preview</button>
+          <button type="button" id="export-apply-btn" class="btn btn-primary btn-mini">Export</button>
         </div>
       </div>
     </div>

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1358,9 +1358,12 @@
         <div id="export-plugin-field" class="export-field hidden">
           <span class="export-label">Plugin name</span>
           <input type="text" id="export-plugin-name" class="input" placeholder="(defaults to the folder name, or the existing manifest's name)" />
+          <!-- Re-export only: a changed export into an existing plugin folder bumps
+               the manifest's patch version (0.1.0 → 0.1.1) so the recipient's
+               `worca plugin update` sees it. A first export is always 0.1.0. -->
           <label class="confirm-checkbox">
             <input type="checkbox" id="export-keep-version" />
-            <span>Keep the manifest version (no patch bump on update)</span>
+            <span>Don't bump the plugin version when updating an existing plugin folder<br><span class="hint">A changed re-export normally goes 0.1.0 → 0.1.1 so recipients see an update. A first export is always 0.1.0.</span></span>
           </label>
         </div>
         <div class="export-field" id="export-slug-field">

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1357,7 +1357,10 @@
         </div>
         <div id="export-plugin-field" class="export-field hidden">
           <span class="export-label">Plugin name</span>
-          <input type="text" id="export-plugin-name" class="input" placeholder="(defaults to the folder name, or the existing manifest's name)" />
+          <input type="text" id="export-plugin-name" class="input" placeholder="(defaults to the folder name)" />
+          <!-- Live: what the manifest will actually be called — kebab-case, derived
+               from the typed name or, when blank, from the folder's basename. -->
+          <span id="export-plugin-name-preview" class="hint"></span>
           <!-- Re-export only: a changed export into an existing plugin folder bumps
                the manifest's patch version (0.1.0 → 0.1.1) so the recipient's
                `worca plugin update` sees it. A first export is always 0.1.0. -->

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -979,10 +979,13 @@
                    file goes through POST /api/workflows/import-json — the same validator
                    the composer's Save uses; a taken name gets a " (2)" suffix. -->
               <div class="saved-head-actions">
-                <button type="button" id="gv-import-btn" class="btn btn-ghost btn-mini" title="Import a pipeline shared as JSON">Import JSON</button>
+                <button type="button" id="gv-import-btn" class="btn btn-ghost btn-mini" title="Import a pipeline shared as a JSON file">Import…</button>
                 <input id="gv-import-file" type="file" accept=".json,application/json" hidden />
               </div>
             </div>
+            <!-- One tab per domain; the row itself no longer repeats the domain.
+                 Rendered by gvRenderSaved(); hidden while the library is empty. -->
+            <div class="gv-saved-tabs" id="gv-saved-tabs" role="tablist" aria-label="Pipeline domains" hidden></div>
             <div class="saved-list" id="gv-saved-list"></div>
             <div class="gv-archived" id="gv-archived" hidden></div>
             <!-- A refused DELETE (the built-in, a 404, a 500) has to land
@@ -1325,14 +1328,24 @@
           <h2 id="export-title">Export pipeline</h2>
         </div>
         <p id="export-subtitle" class="confirm-message"></p>
+        <!-- ONE Export… entry point per row; the dialog asks for the format first.
+             json = the saved graph as a file another Worca user imports (#421);
+             skill = a runnable Claude Code skill under .claude/ (#403);
+             plugin = a Worca plugin folder bundling agents + skills (#421). -->
         <div class="export-field">
-          <span class="export-label">Destination</span>
-          <!-- global/project = a runnable Claude Code skill (#403); plugin = a Worca
-               plugin folder to share with other Worca users (#421). -->
-          <div id="export-dest" class="seg" role="group" aria-label="Export destination">
+          <span class="export-label">Format</span>
+          <div id="export-format" class="seg" role="group" aria-label="Export format">
+            <button type="button" class="seg-btn on" data-format="json">JSON file</button>
+            <button type="button" class="seg-btn" data-format="skill">Claude Code skill</button>
+            <button type="button" class="seg-btn" data-format="plugin">Worca plugin</button>
+          </div>
+          <span id="export-format-hint" class="hint"></span>
+        </div>
+        <div id="export-dest-field" class="export-field hidden">
+          <span class="export-label">Location</span>
+          <div id="export-dest" class="seg" role="group" aria-label="Skill location">
             <button type="button" class="seg-btn on" data-dest="global">Global (~/.claude)</button>
             <button type="button" class="seg-btn" data-dest="project">Project folder</button>
-            <button type="button" class="seg-btn" data-dest="plugin">Plugin folder</button>
           </div>
         </div>
         <div id="export-folder-field" class="export-field hidden">
@@ -1349,7 +1362,6 @@
             <input type="checkbox" id="export-keep-version" />
             <span>Keep the manifest version (no patch bump on update)</span>
           </label>
-          <span class="hint">Bundles the pipeline, your own agents it uses and the skills they need. Built-in agents are not copied. The recipient runs <code>worca plugin link &lt;folder&gt;</code>.</span>
         </div>
         <div class="export-field" id="export-slug-field">
           <span class="export-label">Slug</span>

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1253,7 +1253,7 @@
             <p id="plugins-msg" class="form-msg" aria-live="polite"></p>
             <div class="card hidden" id="marketplace-add-row" style="padding:16px 20px;margin-bottom:14px">
               <div class="path-row">
-                <input id="marketplace-url" class="input" type="text" placeholder="https://github.com/owner/repo · owner/repo · /abs/path/to/repo" spellcheck="false" />
+                <input id="marketplace-url" class="input" type="text" placeholder="https://github.com/owner/repo · owner/repo · /abs/path/to/repo · /path/to/a/plugin-folder" spellcheck="false" />
                 <button type="button" id="marketplace-add" class="btn btn-primary btn-mini">Add</button>
               </div>
             </div>
@@ -1328,6 +1328,8 @@
           <h2 id="export-title">Export pipeline</h2>
         </div>
         <p id="export-subtitle" class="confirm-message"></p>
+        <!-- The form; swapped for #export-done after a successful export. -->
+        <div id="export-form">
         <!-- ONE Export… entry point per row; the dialog asks for the format first.
              json = the saved graph as a file another Worca user imports (#421);
              skill = a runnable Claude Code skill under .claude/ (#403);
@@ -1380,12 +1382,24 @@
         </label>
         <div id="export-plan" class="export-plan hidden"></div>
         <p id="export-msg" class="confirm-message"></p>
+        </div>
+        <!-- Result view: what was written, where, and the next step for the format.
+             Replaces the form (not a second dialog) once an export succeeded. -->
+        <div id="export-done" class="export-done hidden" role="status" aria-live="polite">
+          <div class="export-done-head">
+            <span class="export-done-check" aria-hidden="true">✓</span>
+            <b id="export-done-title"></b>
+          </div>
+          <dl id="export-done-lines" class="export-done-lines"></dl>
+          <p id="export-done-next" class="export-done-next"></p>
+        </div>
         <div class="confirm-actions">
           <button type="button" id="export-cancel" class="btn btn-ghost btn-mini">Cancel</button>
           <!-- Preview = dry run (optional). Export runs the dry run itself and writes
                unless it hits a conflict, which it then shows for per-file resolution. -->
           <button type="button" id="export-plan-btn" class="btn btn-ghost btn-mini">Preview</button>
           <button type="button" id="export-apply-btn" class="btn btn-primary btn-mini">Export</button>
+          <button type="button" id="export-done-close" class="btn btn-primary btn-mini hidden">Done</button>
         </div>
       </div>
     </div>

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -975,6 +975,13 @@
           <section class="card gv-saved">
             <div class="saved-head">
               <div><b>Saved pipelines</b><span class="cnt" id="gv-saved-count"></span></div>
+              <!-- Import a workflow another Worca user shared as JSON (#421): the
+                   file goes through POST /api/workflows/import-json — the same validator
+                   the composer's Save uses; a taken name gets a " (2)" suffix. -->
+              <div class="saved-head-actions">
+                <button type="button" id="gv-import-btn" class="btn btn-ghost btn-mini" title="Import a pipeline shared as JSON">Import JSON</button>
+                <input id="gv-import-file" type="file" accept=".json,application/json" hidden />
+              </div>
             </div>
             <div class="saved-list" id="gv-saved-list"></div>
             <div class="gv-archived" id="gv-archived" hidden></div>
@@ -1315,29 +1322,41 @@
     <div id="export-modal" class="viewer-modal hidden" role="dialog" aria-modal="true" aria-labelledby="export-title">
       <div class="card">
         <div class="card-head">
-          <h2 id="export-title">Export to Claude Code</h2>
+          <h2 id="export-title">Export pipeline</h2>
         </div>
         <p id="export-subtitle" class="confirm-message"></p>
         <div class="export-field">
           <span class="export-label">Destination</span>
+          <!-- global/project = a runnable Claude Code skill (#403); plugin = a Worca
+               plugin folder to share with other Worca users (#421). -->
           <div id="export-dest" class="seg" role="group" aria-label="Export destination">
             <button type="button" class="seg-btn on" data-dest="global">Global (~/.claude)</button>
             <button type="button" class="seg-btn" data-dest="project">Project folder</button>
+            <button type="button" class="seg-btn" data-dest="plugin">Plugin folder</button>
           </div>
         </div>
         <div id="export-folder-field" class="export-field hidden">
-          <span class="export-label">Folder</span>
+          <span class="export-label" id="export-folder-label">Folder</span>
           <div class="export-folder-row">
             <input type="text" id="export-folder" class="input" placeholder="/path/to/repo" />
             <button type="button" id="export-browse" class="btn btn-ghost btn-mini">Browse…</button>
           </div>
         </div>
-        <div class="export-field">
+        <div id="export-plugin-field" class="export-field hidden">
+          <span class="export-label">Plugin name</span>
+          <input type="text" id="export-plugin-name" class="input" placeholder="(defaults to the folder name, or the existing manifest's name)" />
+          <label class="confirm-checkbox">
+            <input type="checkbox" id="export-keep-version" />
+            <span>Keep the manifest version (no patch bump on update)</span>
+          </label>
+          <span class="hint">Bundles the pipeline, your own agents it uses and the skills they need. Built-in agents are not copied. The recipient runs <code>worca plugin link &lt;folder&gt;</code>.</span>
+        </div>
+        <div class="export-field" id="export-slug-field">
           <span class="export-label">Slug</span>
           <input type="text" id="export-slug" class="input" placeholder="(defaults to the workflow name)" />
           <span id="export-slug-preview" class="hint"></span>
         </div>
-        <label class="confirm-checkbox">
+        <label class="confirm-checkbox" id="export-agents-field">
           <input type="checkbox" id="export-include-agents" checked />
           <span>Include referenced agents (recommended)</span>
         </label>

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1068,6 +1068,18 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 /* A checkbox row directly under a text input needs its own breathing room:
    .confirm-checkbox ships margin:0 (it is built for the confirm dialog's stack). */
 .export-field .confirm-checkbox{margin-top:10px;}
+/* Result view after a successful export (replaces #export-form in the same card). */
+.export-done{margin:12px 0 4px;}
+.export-done.hidden{display:none;}
+.export-done-head{display:flex;align-items:center;gap:10px;font-size:14px;margin-bottom:12px;}
+.export-done-check{display:grid;place-items:center;width:26px;height:26px;border-radius:999px;
+  background:var(--green-bg,#e6f4ea);color:var(--green-ink,#1e6b3a);font-weight:700;font-size:14px;}
+.export-done-lines{display:grid;grid-template-columns:max-content 1fr;gap:6px 14px;margin:0;font-size:12.5px;}
+.export-done-lines dt{color:var(--ink-3);font-weight:600;}
+.export-done-lines dd{margin:0;color:var(--ink);word-break:break-all;}
+.export-done-lines code{font:12px var(--mono);background:var(--field);border-radius:6px;padding:1px 6px;}
+.export-done-next{margin:14px 0 0;padding:10px 12px;border-radius:10px;background:var(--field);font-size:12.5px;color:var(--ink-2);}
+.export-done-next code{font:12px var(--mono);}
 .export-label{display:block;font-weight:600;font-size:12.5px;color:var(--ink-2);margin-bottom:6px;}
 .export-folder-row{display:flex;gap:8px;align-items:center;}
 .export-folder-row .input{flex:1 1 auto;}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1061,17 +1061,10 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .pl-remove:disabled{opacity:.6;cursor:default;}
 .pl-remove svg{display:block;}
 
-.pl-export{flex:0 0 auto;width:34px;height:34px;border-radius:10px;border:1.5px solid var(--line-2);background:#fff;display:grid;place-items:center;cursor:pointer;color:var(--ink-3);transition:.12s;align-self:flex-start;}
-.pl-export:hover{border-color:var(--accent,#2b6);color:var(--ink);background:var(--field);}
-.pl-export svg{width:16px;height:16px;stroke-width:2;}
-/* JSON download (#421): an <a download> skinned like the export button. */
-a.pl-json{text-decoration:none;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;font-weight:700;letter-spacing:-.06em;}
-/* In the composer's saved list every row action (Open, ⇪, { }, ×) sits on the
-   row's center line — .pl-export's flex-start was the retired v1 list's. */
-.gv-saved .pl-export{align-self:center;}
-.saved-head-actions{display:flex;align-items:center;gap:8px;}
-/* Export-to-Claude-Code modal */
+/* Export dialog (JSON file / Claude Code skill / Worca plugin). The row's
+   Export… button itself is a .btn-ghost (see .gv-saved .pl-export). */
 .export-field{margin:12px 0;}
+.export-field .hint{display:block;margin-top:6px;}
 .export-label{display:block;font-weight:600;font-size:12.5px;color:var(--ink-2);margin-bottom:6px;}
 .export-folder-row{display:flex;gap:8px;align-items:center;}
 .export-folder-row .input{flex:1 1 auto;}
@@ -3667,11 +3660,27 @@ input.gv-name:focus-visible{outline:none;}
   padding:16px 20px;border-bottom:1px solid var(--line);}
 .saved-head b{font-size:15px;font-weight:600;letter-spacing:-.01em;}
 .saved-head .cnt{color:var(--ink-3);font-size:12.5px;font-weight:600;margin-left:9px;}
+.saved-head-actions{display:flex;align-items:center;gap:8px;}
+/* One tab per domain — the same pill tabs the History detail uses, one size down. */
+.gv-saved-tabs{display:flex;align-items:center;flex-wrap:wrap;gap:8px;padding:12px 20px;border-bottom:1px solid var(--line);}
+.gv-saved-tabs[hidden]{display:none;}
+.gv-saved-tab{display:flex;align-items:center;gap:8px;padding:7px 13px;border:1.5px solid var(--line);
+  border-radius:999px;background:var(--panel);font:600 12.5px var(--sans);color:var(--ink-2);cursor:pointer;}
+.gv-saved-tab:hover{border-color:var(--ink-3);color:var(--ink);}
+.gv-saved-tab.active{background:var(--ink);color:#fff;border-color:var(--ink);}
+.gv-saved-tab:focus-visible{outline:2px solid var(--ink);outline-offset:2px;}
+.gv-saved-tab-badge{padding:1px 7px;border-radius:999px;background:var(--field);color:var(--ink-3);font:600 10.5px var(--mono);}
+.gv-saved-tab.active .gv-saved-tab-badge{background:var(--blue-bg);color:var(--blue-ink);}
 .saved-list{display:flex;flex-direction:column;}
 .gv-saved .pl-item{border-bottom:1px solid var(--line);}
 .gv-saved .pl-item:last-child{border-bottom:none;}
 .gv-saved .pl-row{display:flex;align-items:center;gap:14px;padding:12px 20px;transition:background .12s;}
 .gv-saved .pl-row:hover{background:var(--field);}
+/* The row IS the Open action for a v2 pipeline. */
+.gv-saved .pl-row.pl-openable{cursor:pointer;}
+.gv-saved .pl-row.pl-openable:focus-visible{outline:2px solid var(--ink);outline-offset:-2px;}
+.gv-saved .pl-new{display:inline-block;margin-left:8px;padding:2px 7px;border-radius:999px;vertical-align:middle;
+  background:var(--blue-bg);color:var(--blue-ink);font:700 10px var(--mono);letter-spacing:.06em;}
 /* The thumbnail is a fixed TILE at the head of the row: the SVG carries its own
    width/height, so a percentage box would leave it stranded in dead space. */
 .gv-saved .pl-thumb{flex:0 0 auto;width:140px;height:54px;display:grid;place-items:center;overflow:hidden;
@@ -3684,14 +3693,16 @@ input.gv-name:focus-visible{outline:none;}
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .gv-saved .pl-meta{margin-top:4px;font-size:10.5px;font-weight:700;letter-spacing:.05em;
   text-transform:uppercase;color:var(--ink-3);}
-.gv-saved .pl-open{flex:0 0 auto;padding:7px 15px;font-size:12.5px;}
+.gv-saved .pl-export{flex:0 0 auto;padding:7px 15px;font-size:12.5px;}
 .gv-saved .pl-legacy,.gv-saved .pl-origin{flex:0 0 auto;background:var(--field);border:1px solid var(--line);color:var(--ink-3);
   border-radius:999px;padding:3px 10px;font-size:11px;font-weight:600;}
 .gv-saved .pl-origin{font-family:var(--mono);letter-spacing:-.01em;}
-.gv-saved .pl-del{flex:0 0 auto;width:34px;height:34px;border-radius:10px;border:1.5px solid var(--line-2);
-  background:#fff;display:grid;place-items:center;cursor:pointer;color:var(--ink-3);
-  font-family:inherit;font-size:15px;line-height:1;transition:.12s;}
-.gv-saved .pl-del:hover{border-color:var(--red);color:var(--red-ink);background:var(--red-bg);}
+/* Delete: the bin icon in the pipeline Archive button's dress (.hd-archive — red
+   ink on a red-bg hairline pill, fills on hover), icon-only at row-action size. */
+.gv-saved .pl-del{flex:0 0 auto;width:34px;height:34px;border-radius:999px;border:1.5px solid var(--red-bg);
+  background:var(--panel);display:grid;place-items:center;cursor:pointer;color:var(--red-ink);transition:.12s;}
+.gv-saved .pl-del svg{width:15px;height:15px;stroke-width:1.9;}
+.gv-saved .pl-del:hover{border-color:var(--red);background:var(--red-bg);}
 .gv-saved .pl-del:focus-visible{outline:2px solid var(--ink);outline-offset:2px;}
 .gv-saved .pl-empty{padding:30px 20px;text-align:center;color:var(--ink-3);font-size:13px;}
 .gv-archived{display:flex;flex-wrap:wrap;align-items:center;gap:7px;

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1066,6 +1066,9 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .pl-export svg{width:16px;height:16px;stroke-width:2;}
 /* JSON download (#421): an <a download> skinned like the export button. */
 a.pl-json{text-decoration:none;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;font-weight:700;letter-spacing:-.06em;}
+/* In the composer's saved list every row action (Open, ⇪, { }, ×) sits on the
+   row's center line — .pl-export's flex-start was the retired v1 list's. */
+.gv-saved .pl-export{align-self:center;}
 .saved-head-actions{display:flex;align-items:center;gap:8px;}
 /* Export-to-Claude-Code modal */
 .export-field{margin:12px 0;}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1065,6 +1065,9 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
    Export… button itself is a .btn-ghost (see .gv-saved .pl-export). */
 .export-field{margin:12px 0;}
 .export-field .hint{display:block;margin-top:6px;}
+/* A checkbox row directly under a text input needs its own breathing room:
+   .confirm-checkbox ships margin:0 (it is built for the confirm dialog's stack). */
+.export-field .confirm-checkbox{margin-top:10px;}
 .export-label{display:block;font-weight:600;font-size:12.5px;color:var(--ink-2);margin-bottom:6px;}
 .export-folder-row{display:flex;gap:8px;align-items:center;}
 .export-folder-row .input{flex:1 1 auto;}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1064,6 +1064,9 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 .pl-export{flex:0 0 auto;width:34px;height:34px;border-radius:10px;border:1.5px solid var(--line-2);background:#fff;display:grid;place-items:center;cursor:pointer;color:var(--ink-3);transition:.12s;align-self:flex-start;}
 .pl-export:hover{border-color:var(--accent,#2b6);color:var(--ink);background:var(--field);}
 .pl-export svg{width:16px;height:16px;stroke-width:2;}
+/* JSON download (#421): an <a download> skinned like the export button. */
+a.pl-json{text-decoration:none;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;font-weight:700;letter-spacing:-.06em;}
+.saved-head-actions{display:flex;align-items:center;gap:8px;}
 /* Export-to-Claude-Code modal */
 .export-field{margin:12px 0;}
 .export-label{display:block;font-weight:600;font-size:12.5px;color:var(--ink-2);margin-bottom:6px;}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -3482,6 +3482,8 @@ input.gv-name:focus-visible{outline:none;}
   padding:4px 11px;font:600 11.5px var(--sans);cursor:pointer;flex:0 0 auto;white-space:nowrap;}
 .gv-errchip:hover{filter:brightness(.97);}
 .gv-errchip[hidden]{display:none;}
+/* Unfinished wiring is a to-do, not a mistake: the same chip in a quiet dress. */
+.gv-errchip.is-incomplete{background:var(--field);color:var(--ink-2);border-color:var(--line-2);}
 /* Toolbar density: .btn-ghost/.btn-go are PAGE-level pills (13–14px of vertical
    padding, 20–28px horizontal). In a 52px bar they wrap their own labels, so
    the bar re-states them at .btn-mini metrics — same skin, toolbar size. */

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -3409,6 +3409,9 @@ app.get('/api/workflows/:id', async (req, res) => {
     if (err && (err.code === 'NOT_FOUND' || err.code === 'ARCHIVED')) {
       return res.status(404).json({ error: err.message });
     }
+    // The row exists but its plugin is disabled: a conflict with the plugin's
+    // state, not a missing row — the message names the fix.
+    if (err && err.code === 'PLUGIN_DISABLED') return res.status(409).json({ error: err.message });
     res.status(500).json({ error: err && err.message ? err.message : String(err) });
   }
 });

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -2481,9 +2481,11 @@ app.delete('/api/projects', async (req, res) => {
 // user's machine); when it reports `unsupported` the UI falls back to an
 // in-app modal fed by GET /api/fs/dirs. Localhost-only like every route here
 // (global isLocalRequest middleware).
-app.post('/api/fs/pick-folder', async (_req, res) => {
+app.post('/api/fs/pick-folder', async (req, res) => {
   try {
-    res.json(await pickFolderNative());
+    // `purpose` only picks the dialog title from a closed set (folder-dialog.mjs).
+    const purpose = typeof req.body?.purpose === 'string' ? req.body.purpose : undefined;
+    res.json(await pickFolderNative({ purpose }));
   } catch (err) {
     res.status(500).json({ error: err && err.message ? err.message : String(err) });
   }

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -107,8 +107,10 @@ import {
 } from '../src/core/workflows.mjs';
 import { registryPortsFn } from '../src/core/graph/registry-ports.mjs';
 import { sweepV1Runs, V1_RUN_RETIRED } from '../src/core/db.mjs';
-import { validateGraph, AGENT_TUNABLES } from '../src/shared/graph/validate.mjs';
-import { exportWorkflow, ON_CONFLICT_MODES, RESOLUTION_CHOICES } from '../src/core/workflow-export.mjs';
+import { exportWorkflow, exportWorkflowPlugin, ON_CONFLICT_MODES, RESOLUTION_CHOICES } from '../src/core/workflow-export.mjs';
+import {
+  saveGraphWorkflow, importGraphWorkflow, exportGraphJson, workflowFileSlug, nodeDefaultsError,
+} from '../src/core/workflow-share.mjs';
 import { loadAgentRegistry } from '../src/core/agent-registry.mjs';
 import {
   listLocalBranches, currentBranch, isValidSourceRef, sweepRunRoots, sweepLegacyWorktreesAll,
@@ -3348,25 +3350,35 @@ app.post('/api/models/:id/test', async (req, res) => {
 // /api/projects + /api/config delegation pattern: thin handlers, validation and
 // atomic persistence owned by src/core/workflows.mjs + workflow-validator.mjs.
 // ---------------------------------------------------------------------------
-// Validate one node-defaults block against the project-less catalog. Returns an
-// error message, or '' when the block is acceptable. Mirrors setStep's rules so a
-// workflow default can never name something a per-project override could not.
-function nodeDefaultsError(raw, models, where) {
-  if (raw == null) return '';
-  if (typeof raw !== 'object' || Array.isArray(raw)) return `defaults for ${where} must be an object`;
-  const model = typeof raw.model === 'string' ? raw.model.trim() : '';
-  const effort = typeof raw.effort === 'string' ? raw.effort.trim() : '';
-  const entry = model ? models.find((m) => m.id === model) : null;
-  if (model && !entry) return `unknown model "${model}"`;
-  // subagentModel is a fixed alias enum, NOT a catalog id: validated via the
-  // shared helper so a typo is a 400 with the same message every writer uses.
-  const subIssue = subagentModelIssue(raw.subagentModel);
-  if (subIssue) return subIssue;
-  if (!effort) return '';
-  if (!EFFORTS.includes(effort)) return `unknown effort "${effort}"`;
-  if (!entry) return 'select a model before choosing an effort';
-  if (!entry.efforts.includes(effort)) return `model "${model}" does not support effort "${effort}"`;
-  return '';
+// nodeDefaultsError (one node-defaults block vs the project-less catalog) lives
+// in src/core/workflow-share.mjs now, so `worca workflow import` applies the
+// same gate as the routes below.
+
+/** Error -> HTTP for the shared save/import/JSON path (workflow-share.mjs codes). */
+function sendWorkflowShareError(res, err) {
+  const code = err && err.code;
+  const message = err && err.message ? err.message : String(err);
+  if (code === 'BAD_REQUEST' || code === 'UNSUPPORTED') return badRequest(res, message);
+  // The 422 body is the SHARED validator's issue list, by construction: the
+  // composer renders exactly what it would have computed locally, so the server
+  // and the client can never disagree about why a graph is illegal. `summary`
+  // is the one-line V4 fold for surfaces with no issue list (the Import button).
+  if (code === 'INVALID_GRAPH') {
+    return res.status(422).json({
+      error: message, errors: err.errors || [], warnings: err.warnings || [],
+      ...(err.summary ? { summary: err.summary } : {}),
+    });
+  }
+  // C-3: a name that slugs onto the reserved wf_default is a caller error, not
+  // a server fault — 422, the same code the validator's refusal uses. MAJ-5: a
+  // minted id already in use is a 409 carrying that id, so the dialog can offer
+  // rename/overwrite. Both bodies carry NO issues/errors array on purpose:
+  // app.js's saveWorkflow maps `error` straight into the save dialog's message
+  // line, verbatim.
+  if (code === 'RESERVED_NAME') return res.status(422).json({ error: message });
+  if (code === 'ID_TAKEN') return res.status(409).json({ error: message, id: err.id });
+  if (code === 'NOT_FOUND') return res.status(404).json({ error: message });
+  return res.status(500).json({ error: message });
 }
 
 app.get('/api/workflows', async (req, res) => {
@@ -3400,58 +3412,53 @@ app.get('/api/workflows/:id', async (req, res) => {
 });
 
 app.post('/api/workflows', async (req, res) => {
-  const body = req.body || {};
   // The v1 pipeline format is RETIRED: only graphs are accepted (spec §10.2).
   // The whole v1 arm (its steps-borne node defaults, validateWorkflow and
   // writeWorkflow) died with it — nothing reaches the v1 store through the API.
-  if (body.version !== 2) {
-    return badRequest(res, 'v1 pipeline templates are no longer accepted — save a graph (version 2)');
-  }
   // ── v2 graph save ──────────────────────────────────────────────────────────
-  // The 422 body is the SHARED validator's issue list, by construction: the
-  // composer renders exactly what it would have computed locally, so the server
-  // and the client can never disagree about why a graph is illegal.
-  const graph = {
-    id: typeof body.id === 'string' ? body.id : undefined,
-    name: typeof body.name === 'string' ? body.name.trim() : '',
-    domain: typeof body.domain === 'string' ? body.domain : undefined,
-    nodes: Array.isArray(body.nodes) ? body.nodes : [],
-    wires: Array.isArray(body.wires) ? body.wires : [],
-    ...(body.canvas && typeof body.canvas === 'object' ? { canvas: body.canvas } : {}),
-  };
-  if (!graph.name) return badRequest(res, 'name is required');
+  // Catalog check + shared validator + rejectCollision persistence live in
+  // workflow-share.mjs (saveGraphWorkflow): the SAME path the JSON import
+  // route and `worca workflow import` take, so they can never drift. A body
+  // WITHOUT an id mints wf_<slug(name)> — a GUESS that must never silently
+  // replace a pipeline the user can see (MAJ-5 -> 409).
   try {
-    // Catalog validation FIRST: a v2 node's `config` IS its defaults block (§4),
-    // so a value the per-project override could not name must not ride in
-    // through a template save. nodeDefaultsError checks the tunables (model +
-    // effort against the catalog, subagentModel against the alias enum), so
-    // only AGENT_TUNABLES are handed to it — topology keys (awaitAll, arity,
-    // planStoreSeed) never are.
-    const models = await listModels('');
-    for (const n of graph.nodes) {
-      if (!n || n.kind !== 'agent' || !n.config || typeof n.config !== 'object') continue;
-      const picked = Object.fromEntries(
-        AGENT_TUNABLES.filter((k) => k in n.config).map((k) => [k, n.config[k]]));
-      const bad = nodeDefaultsError(picked, models, `node "${n.id}"`);
-      if (bad) return badRequest(res, bad);
-    }
-    const portsFn = registryPortsFn(loadAgentRegistry(AGENTS_DIR));
-    const { errors, warnings } = validateGraph({ ...graph, version: 2 }, portsFn);
-    if (errors.length) return res.status(422).json({ error: 'invalid graph', errors, warnings });
-    // rejectCollision (MAJ-5): the body carried no id, so wf_<slug(name)> is a
-    // GUESS — it must never silently replace a pipeline the user can see.
-    const workflow = await writeGraphWorkflow(graph, { rejectCollision: true });
+    const { workflow, warnings } = await saveGraphWorkflow(req.body || {}, { agentsDir: AGENTS_DIR });
     return res.status(201).json({ workflow, warnings });
   } catch (err) {
-    // C-3: a name that slugs onto the reserved wf_default is a caller error, not
-    // a server fault — 422, the same code the validator's refusal uses. MAJ-5: a
-    // minted id already in use is a 409 carrying that id, so the dialog can offer
-    // rename/overwrite. Both bodies carry NO issues/errors array on purpose:
-    // app.js's saveWorkflow maps `error` straight into the save dialog's message
-    // line, verbatim.
-    if (err && err.code === 'RESERVED_NAME') return res.status(422).json({ error: err.message });
-    if (err && err.code === 'ID_TAKEN') return res.status(409).json({ error: err.message, id: err.id });
-    return res.status(500).json({ error: err && err.message ? err.message : String(err) });
+    return sendWorkflowShareError(res, err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Share a workflow as JSON (issue #421). GET .../json is the unstamped v2 graph
+// of the STORED row (no id/origin/timestamps; `canvas` kept), served as a
+// download; POST /import-json feeds one back through the shared validator,
+// minting an id and suffixing the name (`Name (2)`) on a collision — never
+// overwrite. Registered BEFORE the /:id routes so the segment can never be read
+// as an id. (Not `/import`: test/shared-graph-purity.test.mjs scans ui/public
+// for `import '<spec>'` and a bare `import'` in app.js's fetch URL trips it.)
+// ---------------------------------------------------------------------------
+app.post('/api/workflows/import-json', async (req, res) => {
+  const body = req.body || {};
+  const src = body.workflow && typeof body.workflow === 'object' && !Array.isArray(body.workflow) ? body.workflow : null;
+  if (!src) return badRequest(res, 'workflow (the exported JSON object) is required');
+  try {
+    const r = await importGraphWorkflow(src, {
+      name: typeof body.name === 'string' ? body.name : undefined, agentsDir: AGENTS_DIR,
+    });
+    return res.status(201).json(r);
+  } catch (err) {
+    return sendWorkflowShareError(res, err);
+  }
+});
+
+app.get('/api/workflows/:id/json', async (req, res) => {
+  try {
+    const payload = await exportGraphJson(req.params.id);
+    res.setHeader('Content-Disposition', `attachment; filename="${workflowFileSlug(req.params.id)}.json"`);
+    res.type('application/json').send(JSON.stringify(payload, null, 2) + '\n');
+  } catch (err) {
+    sendWorkflowShareError(res, err);
   }
 });
 
@@ -3502,6 +3509,7 @@ app.delete('/api/workflows/:id', async (req, res) => {
 function workflowExportErrorStatus(code) {
   if (code === 'NOT_FOUND') return 404;
   if (code === 'BAD_REQUEST' || code === 'UNSUPPORTED' || code === 'MISSING_SKILL') return 400;
+  if (code === 'INVALID_GRAPH') return 422;
   if (code === 'CONFLICT' || code === 'CANCELLED') return 409;
   return 500;
 }
@@ -3509,8 +3517,27 @@ function workflowExportErrorStatus(code) {
 app.post('/api/workflows/:id/export', async (req, res) => {
   const body = req.body || {};
   const destination = body.destination;
-  if (destination !== 'global' && destination !== 'project') {
-    return badRequest(res, "destination must be 'global' or 'project'");
+  if (destination !== 'global' && destination !== 'project' && destination !== 'plugin') {
+    return badRequest(res, "destination must be 'global', 'project' or 'plugin'");
+  }
+  // ── destination 'plugin' (#421): a plugin folder the recipient links/reimports.
+  //    Same Plan/Apply shape as the Claude Code export, so the modal renders both.
+  if (destination === 'plugin') {
+    const pluginDir = resolveProjectDir(body.pluginDir);
+    if (!pluginDir) return badRequest(res, 'pluginDir is required for a plugin export');
+    try {
+      const result = await exportWorkflowPlugin({
+        workflowId: req.params.id, targetDir: pluginDir,
+        pluginName: typeof body.pluginName === 'string' ? body.pluginName : undefined,
+        keepVersion: !!body.keepVersion, dryRun: !!body.dryRun,
+      });
+      return res.json(result);
+    } catch (err) {
+      return res.status(workflowExportErrorStatus(err && err.code)).json({
+        error: err && err.message ? err.message : String(err),
+        ...(Array.isArray(err?.errors) ? { errors: err.errors } : {}),
+      });
+    }
   }
   let projectDir;
   if (destination === 'project') {

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -129,7 +129,7 @@ import { createAgentGen } from '../src/core/agent-gen.mjs';
 import { listAgents, readAgent, createAgent, updateAgent, deleteAgent, AGENT_KEY_RE } from '../src/core/agent-store.mjs';
 import {
   listInstalledPlugins, installPlugin, updatePlugin, uninstallPlugin,
-  setPluginEnabled, doctorPlugin,
+  setPluginEnabled, doctorPlugin, linkPlugin,
   listOrphanPluginData, purgePluginData,
 } from '../src/core/plugin-store.mjs';
 import { fetchCandidate } from '../src/core/plugin-repo.mjs';
@@ -152,7 +152,7 @@ import { createNotifier } from '../src/core/chat/notifier.mjs';
 import { TokenBucket } from '../src/core/chat/rate-limiter.mjs';
 import { renderTest } from '../src/core/chat/renderers.mjs';
 import { readPluginsLock, pluginCurrentDir } from '../src/core/plugins-lock.mjs';
-import { normalizeManifest, PLUGIN_NAME_RE as MANIFEST_PLUGIN_NAME_RE } from '../src/core/plugin-manifest.mjs';
+import { normalizeManifest, validatePluginDir, PLUGIN_NAME_RE as MANIFEST_PLUGIN_NAME_RE } from '../src/core/plugin-manifest.mjs';
 import { listTaskSources, retryWriteback } from '../src/core/sources.mjs';
 import { callSource, PluginOpError } from '../src/core/plugin-shim.mjs';
 import { HLJS_GRAMMAR_IDS } from './public/hljs-loader.mjs';
@@ -4686,12 +4686,45 @@ app.get('/api/marketplaces', (req, res) => {
   } catch (err) { sendPluginError(res, err); }
 });
 
+// Dev-mode link of a LOCAL plugin folder — the `worca plugin link <dir>` path
+// (validate, symlink current/, import its workflow templates). Reached directly
+// via POST /api/plugins/link, and by POST /api/marketplaces when the "marketplace"
+// handed in turns out to be a single plugin folder (the natural thing to paste
+// after `Export… → Worca plugin`, issue #421).
+async function linkPluginDir(dir) {
+  const abs = resolveProjectDir(dir);
+  if (!abs) throw Object.assign(new Error('dir is required'), { code: 'BAD_REQUEST' });
+  const v = validatePluginDir(abs);
+  if (!v.ok || !v.manifest) {
+    const lines = v.problems.filter((p) => p.level === 'error').map((p) => p.message);
+    throw Object.assign(new Error(`cannot link ${abs}: ${lines.join('; ') || 'not a valid plugin folder'}`), { code: 'BAD_REQUEST' });
+  }
+  let out;
+  try { out = await linkPlugin(v.manifest.name, abs); }
+  catch (err) { throw Object.assign(err instanceof Error ? err : new Error(String(err)), { code: err?.code || 'BAD_REQUEST' }); }
+  reloadChatWorkers(v.manifest.name);
+  return out; // { ok, name, dir, workflows: { imported, skipped } }
+}
+
+app.post('/api/plugins/link', async (req, res) => {
+  try {
+    res.json(await linkPluginDir(req.body && typeof req.body.dir === 'string' ? req.body.dir : ''));
+  } catch (err) { sendPluginError(res, err); }
+});
+
 app.post('/api/marketplaces', async (req, res) => {
   const url = req.body && typeof req.body.url === 'string' ? req.body.url.trim() : '';
   if (!url) return badRequest(res, 'url is required');
   try {
     res.json({ ok: true, marketplace: withInstalled([await addMarketplace(url)])[0] });
-  } catch (err) { sendPluginError(res, err); }
+  } catch (err) {
+    if (err && err.code === 'PLUGIN_FOLDER') {
+      // Not a marketplace but a plugin folder: link it, and SAY that is what happened.
+      try { return res.json({ ok: true, linked: true, plugin: await linkPluginDir(err.dir) }); }
+      catch (e) { return sendPluginError(res, e); }
+    }
+    sendPluginError(res, err);
+  }
 });
 
 // refresh-all (a distinct path from :id/refresh, so registration order is irrelevant).


### PR DESCRIPTION
Closes #421. Follow-up to #403 (Export to Claude Code): #403 answers "run this workflow without Worca", this PR answers **"share this workflow with another Worca user"** — as a one-off JSON file, or as a versioned plugin that bundles the custom agents and skills the workflow depends on.

## What's in it

### 1. JSON export / import
- **Core** `src/core/workflow-share.mjs` (new): `exportGraphJson(id)` returns the **stored** row as `{ version: 2, name, domain, nodes, wires, canvas? }` — no `id`/`origin`/timestamps, no `_worca` stamp. (Not the #403 snapshot: that one is the resolved graph, which applies workspace-variant substitution and drops `canvas`.) `importGraphWorkflow(body, { name })` runs the catalog check + the shared `validateGraph`, ignores any id/origin in the file, mints `wf_<slug(name)>` and retries a taken name as `Name (2)`, `Name (3)`… — nothing is ever overwritten. Unknown agent keys (the validator's V4) fold into one `summary` line pointing at the plugin export.
- The composer's `POST /api/workflows` now goes through the same module (`saveGraphWorkflow`), so the CLI and the server can never drift; its 201/400/409/422 contract is unchanged (422 bodies additionally carry `summary` when V4 is the cause).
- **CLI** `worca workflow export <id> --format json [--out <file>]`, `worca workflow import <file|-> [--name <name>]`.
- **Server** `GET /api/workflows/:id/json` (download, `Content-Disposition`), `POST /api/workflows/import-json` `{ workflow, name? }`. (Named `import-json`, not `import`: `test/shared-graph-purity.test.mjs` scans `ui/public` for `import '<spec>'` and a bare `import'` in the fetch URL trips it.)
- **UI** a `{ }` download link on every saved v2 row, an **Import JSON** button in the saved-list header (file picker; outcome on the list's message line, including the rename note).

### 2. Export to plugin
- **Core** `exportWorkflowPlugin({ workflowId, targetDir, pluginName?, keepVersion?, dryRun? })` in `workflow-export.mjs` writes a plugin folder:
  - `workflows/<slug>.json` — the JSON share payload. **`<slug>` derives from the workflow id** (`wf_` stripped), never the name, so a rename re-exports onto the same file and the recipient's `wfp_*` row updates in place on `worca plugin reimport`.
  - `agents/<key>.md` + `<key>.meta.json` — byte-identical copies of every **user** agent the workflow references. Built-ins are never copied (warning lists them); an agent owned by **another plugin** is refused (bundling it would create two owners).
  - `skills/<name>/` — every skill those user agents require, resolved through #403's `resolveDepSkills` (now exported, with `layout:'plugin'` and `skipSources:['bundle']`: a Worca-shipped skill is skipped like a built-in agent). An existing skill dir in the folder is never touched.
  - `worca-cc-plugin.json` — created (`0.1.0`, `engines`) or adopted; an explicit `--name` that disagrees with an existing manifest is a `CONFLICT`; the patch version bumps when the export changes a file unless `--keep-version`; a `worca.exports[<slug>] = { workflowId, name, updatedAt }` block records provenance (`worca` is now a known top-level manifest key, ignored by the loader).
  - The stored graph is validated before sharing (a stranded key is `INVALID_GRAPH`), and the written folder is run through `validatePluginDir` — the same gate `worca plugin link` applies — with problems returned as `validation`.
- **CLI** `worca workflow export <id> --format plugin --target <dir> [--name <plugin>] [--keep-version] [--dry-run]` (exit 1 if the folder does not validate).
- **Server** `POST /api/workflows/:id/export` with `destination: 'plugin'` + `pluginDir` (+ `pluginName`, `keepVersion`, `dryRun`) — same Plan/Apply shape as the skill export.
- **UI** a **Plugin folder** destination in the export modal (folder + plugin name + keep-version; slug/agents fields hidden), Plan/Apply reuse the existing plan renderer, a non-validating folder keeps the modal open with the problems.

### 3. Plugin isolation rule admits built-in agent keys
`validatePluginDir` refused any `workflows/*.json` node key the plugin did not ship, and `worca plugin init` enforced `--with workflows requires agents` for the same reason — so a plugin export of nearly any workflow (`planner`/`implementer`…) would have been unlinkable, and copying built-ins does not help (the registry drops a plugin agent whose key collides with a built-in).

Now the validator takes a `builtinMetas` option (default: a cycle-free scan of the repo `agents/` layer) and resolves built-in keys for both the key check and the ports function. A plugin template may reference built-ins plus its own agents, still never the user layer or another plugin; the message reads *"neither a built-in nor shipped by this plugin"*. `plugin init --with workflows` no longer requires `agents` (a workflow-only scaffold runs the built-in planner).

### Also
- `pluginArgs` accepts a lone `-` as a positional (stdin for `workflow import -`).
- Saved-row actions in the composer (Open, ⇪, `{ }`, ×) now share the row's center line — the export button carried `align-self:flex-start` from the retired v1 list.
- README: "Share a pipeline" bullet + CLI examples; `worca workflow help` rewritten.

## Tests
- `test/workflow-share.test.mjs` — JSON payload shape, mint/ignore-id, suffix loop (incl. continuing from an existing `(n)`), reserved name, V4 summary, tunables check, composer save semantics.
- `test/workflow-export-plugin.test.mjs` — dry-run, apply (byte-identical agent pair, global skill copied, bundle skill skipped, built-in not bundled), idempotent re-export, in-place update + patch bump + `keepVersion`, manifest identity rules, **round trip** (user agent removed → `linkPlugin` → `wfp_*` row + plugin-owned agent), foreign-plugin refusal, stranded graph.
- `test/workflow-share-api.test.mjs`, `test/workflow-share-cli.test.mjs` — the HTTP and CLI surfaces incl. `plugin validate --strict` on the CLI-written folder and `plugin init --with workflows`.
- `test/plugin-manifest.test.mjs` — updated for the built-in allowance (+ `builtinMetas: []` pin).

Full suite: 4664 tests, all green (one `orchestrator-workspace` failure in a first run was another session switching the main checkout's branch mid-run; it passes on its own).

Browser check (mock UI): saved list renders the JSON link + Import button, the modal's Plugin folder path plans and applies, the written folder passes `worca plugin validate --strict`, console clean.

## Notes for review
- The issue text says `POST /api/workflows/import`; the route landed as `/import-json` for the purity-scan reason above — I'll update the issue when this merges.
- `worca.exports[].updatedAt` is the row's `updatedAt`, not an export timestamp, so an unchanged re-export is a true all-no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxExPpCSCs6j5JnPzD5v6g
