### PR TITLE
Title generation is catalog-aware; tier keys for endpoint-routed models; hide built-ins (#422)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ and durations, the clarify Q&A, agent transcripts, and logs:
   per-model routing environment (e.g. `ANTHROPIC_BASE_URL`) that is merged
   into that model's agent spawns. Share a model catalog as a plugin, with
   secrets required at install time.
+- **No first-party account needed** — run and chat titles are written by the
+  model the run or chat itself uses (Settings › General › Title generation picks
+  a fixed one instead), endpoint-routed models carry Claude Code's internal
+  haiku/sonnet/opus/fable tier keys so nothing falls back to the Anthropic API,
+  and *Hide built-in models* (Settings › Models) drops the built-ins from every
+  picker.
 
 ### Storage
 

--- a/configurable-models-design.md
+++ b/configurable-models-design.md
@@ -151,7 +151,15 @@ Per decision: keep the CLI-default fallback but make it observable. The CLI's st
 
 ### 4.8 Auxiliary call sites
 
-Title generation (`src/core/title.mjs:5-6`), overview, agent-gen, and workspace-scan keep their current model choices (hardcoded haiku + `WORCA_TITLE_MODEL`, or CLI default). The one change: each routes its chosen id through `resolveModelEnv` before spawning, so a catalog entry matching that id carries its routing env everywhere the id is used. No new configuration surface for these.
+Overview, agent-gen, and workspace-scan run on the caller's model (`this.claude.model`) and route it through `resolveModelEnv` before spawning, so a catalog entry matching that id carries its routing env everywhere the id is used.
+
+Title generation (`src/core/title.mjs`) used to hard-code a first-party Haiku id captured at import, which left an install with no first-party model unable to title anything (#422). It now decides its model **per call** (`resolveTitleModel`): an explicit `opts.model` → a non-empty `WORCA_TITLE_MODEL` (verbatim, an operator escape hatch) → the stored `titleModel` setting, only while it is still a catalog member (a stale id is reported and skipped) → **the model of the run or chat that asked** (`runModel`, passed by both callers) → the built-in `claude-haiku-4-5`. The default is therefore "same as the run's model", which makes a first-party-free install work with zero configuration. Aux calls run at `AUX_EFFORT` (`low`, a CLI-valid tier below `EFFORTS`, deliberately not clamped into it), and a failed title call reports once through `onError` so the run log / server log says why a provisional title stuck.
+
+The one configuration surface is **Settings › General › Title generation**: a select over the project-less catalog (never free text — an id `resolveModelEnv` cannot route would only surface as a missing title mid-run), a Test button reusing `POST /api/models/:id/test`, and a loud hint when the stored id has left the catalog. The Ask Worca picker's initial pick likewise degrades to the first model the user owns when the D8 default is hidden.
+
+**Tier keys.** Claude Code resolves its own internal calls (session titles, the `haiku|sonnet|opus|fable` alias tiers, quota probes) through `ANTHROPIC_DEFAULT_{HAIKU,SONNET,OPUS,FABLE}_MODEL` and the older `ANTHROPIC_SMALL_FAST_MODEL`. An endpoint-routed entry (`ANTHROPIC_BASE_URL` set) that leaves them unset made the CLI fall back to first-party ids the endpoint never served (`unrecognized_model` in run logs). `resolveModelEnv` now fills every one the entry leaves unset with the entry's own wire id (`ANTHROPIC_MODEL`, else the catalog id; `model-env.mjs#withTierModelEnv`). Deliberately not user-configurable — keys the entry sets itself always win — and disclosed by the `endpoint-routed` badge on the Models view plus the Spawn diagnostics line.
+
+**Hide built-in models** (Settings › Models, one checkbox, stored as `hideBuiltinModels`): `composeCatalog` marks the unshadowed built-ins `hidden: true` and every picker (New Pipeline, composer inspector, Ask Worca, the Title select) skips them unless one is the current selection. Cosmetic + defaults only: a hidden id still resolves, so stored runs and plugin references keep working.
 
 ### 4.9 Migration and deprecation of per-project custom models
 
@@ -224,6 +232,10 @@ Each lands as its own PR against `dev`, tests first, per repo workflow.
 | Scrub interaction | Model env survives scrub, wins collisions, reserved keys excepted | Explicit config outranks ambient-env hygiene |
 | Unknown-id failure mode | Validate at write time; pass-through at runtime | Matches setStep precedent; CLI owns runtime resolution |
 | Cost reliability | Observed at runtime (zero/absent cost from an env-routed endpoint), not statically assumed | A proxy that reports real costs is not falsely badged; observation is derived state in the DB, auto-cleared on a positive-cost run |
+| Title model (#422) | Per-call precedence ending in **the run's model**; one optional `titleModel` select | Reverses the §4.8 "no configuration surface" call: a hard-coded first-party id cannot work on an install that has none, and the run's model is the one id guaranteed to route |
+| Aux effort | `AUX_EFFORT = 'low'`, kept outside `EFFORTS` | The CLI accepts `low`; clamping titles into the pipeline list would only make the cheapest call cost more |
+| Tier keys | Synthesized in `resolveModelEnv` for endpoint-routed entries, never user-edited | Three-to-five env rows per model in the editor would be documentation, not a feature; explicit keys still win |
+| Hidden built-ins | A `hidden` flag pickers skip, not a removal from the catalog | Hiding must never stop an id resolving — stored runs and plugin references name built-ins |
 
 ## 8. Out of scope / future
 

--- a/src/core/ask/models.mjs
+++ b/src/core/ask/models.mjs
@@ -47,7 +47,12 @@ export function createAskModels({
   /** The D8 initial pick, validated against the live catalog (D5). */
   function pickDefault(models) {
     const want = String(defaults.defaultModel || '').toLowerCase();
-    const hit = models.find((m) => m.id.toLowerCase() === want) || models[0] || null;
+    // Hidden built-ins (#422) are never the initial pick: on an install that
+    // hides them the default is the first model the user actually owns. They
+    // stay in `models` so a stored thread on one keeps validating.
+    const visible = models.filter((m) => !m.hidden);
+    const pool = visible.length ? visible : models;
+    const hit = pool.find((m) => m.id.toLowerCase() === want) || pool[0] || null;
     if (!hit) return null;
     const efforts = hit.efforts.length ? hit.efforts : [...EFFORTS];
     const effort = efforts.includes(defaults.defaultEffort)
@@ -83,6 +88,7 @@ export function createAskModels({
         hasEnv: m.hasEnv === true,
       };
       if (custom === 'plugin' && typeof m.plugin === 'string' && m.plugin) entry.plugin = m.plugin;
+      if (m.hidden === true) entry.hidden = true;   // the picker skips it; validation does not (#422)
       // Only globals and plugin entries can arrive flagged: composeCatalog emits an
       // UNSHADOWED built-in as {...m, custom:false, hasEnv:false} with no
       // ...unreliable(lc) (src/core/config.mjs:200), so a built-in in model_cost_flags

--- a/src/core/ask/turn.mjs
+++ b/src/core/ask/turn.mjs
@@ -439,6 +439,11 @@ class AskTurn extends EventEmitter {
         tools: [], strictMcpConfig: true, settingSources: ['project'],
         disableSlashCommands: true, envScrub: true, envAllowlist: [],
         permissionMode: 'dontAsk',
+        // The chat's own model is the title default (#422) — a chat on a
+        // custom endpoint titles itself there, not on a first-party Haiku.
+        runModel: this.model,
+        onError: ({ model, error }) => console.warn(
+          `[worca-ask] thread ${this.threadId}: title generation failed (model ${model}): ${error?.message || error} — keeping the fallback title`),
       }))
       .then((generated) => {
         // The route stamps NOTHING before the 202 (the header reads "Ask Worca"

--- a/src/core/config.mjs
+++ b/src/core/config.mjs
@@ -15,8 +15,8 @@
 import { getDb, prepare, tx } from './db.mjs';
 import { projectKey } from './store.mjs';
 import { loadAgentRegistry, registryToSteps } from './agent-registry.mjs';
-import { EFFORTS, prepareModelEnv, isSubagentModelValue, subagentModelIssue } from './model-env.mjs';
-import { listGlobalModels, addGlobalModel, removeGlobalModel } from './settings.mjs';
+import { EFFORTS, prepareModelEnv, withTierModelEnv, isSubagentModelValue, subagentModelIssue } from './model-env.mjs';
+import { listGlobalModels, addGlobalModel, removeGlobalModel, hideBuiltinModels } from './settings.mjs';
 import { listPluginModels, allPluginModels, flattenPluginModelEnv } from './plugin-models.mjs';
 
 /**
@@ -184,6 +184,11 @@ function composeCatalog(projectCustom = []) {
   const seen = new Set();
   const unreliable = (lc) => (flagged.has(lc) ? { costUnreliable: true } : {});
   const routedOf = (env) => !!(env && 'ANTHROPIC_BASE_URL' in env);
+  // "Hide built-in models" (#422): a cosmetic flag on the UNSHADOWED built-ins,
+  // read by every picker. The entry stays in the catalog — hiding an id must
+  // never stop it resolving, or a stored run / plugin reference that names it
+  // would break — so pickers skip `hidden`, validators ignore it.
+  const hidden = hideBuiltinModels() ? { hidden: true } : {};
   const pluginShape = (id, m, lc) => ({
     id, label: m.label, efforts: [...m.efforts], custom: 'plugin', plugin: m.plugin,
     hasEnv: !!m.env, routed: routedOf(m.env), ...unreliable(lc),
@@ -196,7 +201,7 @@ function composeCatalog(projectCustom = []) {
       ? { id: m.id, label: shadow.label, efforts: [...shadow.efforts], custom: 'global', hasEnv: !!shadow.env, routed: routedOf(shadow.env), ...unreliable(lc) }
       : pshadow
         ? pluginShape(m.id, pshadow, lc)
-        : { ...m, custom: false, hasEnv: false, routed: false });
+        : { ...m, custom: false, hasEnv: false, routed: false, ...hidden });
     seen.add(lc);
   }
   for (const m of globals) {
@@ -486,10 +491,12 @@ export function resolveModelEnv(modelId) {
   const lc = id.toLowerCase();
   let rawEnv;
   let who;
+  let canonicalId = id;
   const entry = listGlobalModels().find((m) => m.id.toLowerCase() === lc);
   if (entry && entry.env) {
     rawEnv = entry.env;
     who = JSON.stringify(entry.id);
+    canonicalId = entry.id;
   } else if (!entry) {
     const pm = listPluginModels().find((m) => m.id.toLowerCase() === lc);
     if (pm && pm.env) {
@@ -499,6 +506,7 @@ export function resolveModelEnv(modelId) {
       }
       rawEnv = env;
       who = `${JSON.stringify(pm.id)} (plugin "${pm.plugin}")`;
+      canonicalId = pm.id;
     }
   }
   if (!rawEnv) return undefined;
@@ -506,7 +514,27 @@ export function resolveModelEnv(modelId) {
   for (const k of dropped) {
     console.warn(`[worca] model ${who}: dropping env key ${JSON.stringify(k)} (reserved or unresolvable \${VAR} ref)`);
   }
-  return Object.keys(env).length ? env : undefined;
+  if (!Object.keys(env).length) return undefined;
+  // Endpoint-routed entries also carry the CLI's internal tier keys, pointed at
+  // this entry's own wire id (#422, model-env.mjs#withTierModelEnv) — so the
+  // CLI's session-title / alias / probe calls never fall back to a first-party
+  // id the endpoint has never heard of. Keys the entry sets itself win.
+  return withTierModelEnv(env, canonicalId);
+}
+
+/**
+ * Whether `modelId` names a catalog member — built-in, global, or plugin —
+ * regardless of the hide-built-ins flag (hidden entries still resolve).
+ * Case-insensitive like every other id lookup here. Synchronous; never throws.
+ * @param {string} modelId
+ */
+export function catalogHasModel(modelId) {
+  const id = typeof modelId === 'string' ? modelId.trim() : '';
+  if (!id) return false;
+  const lc = id.toLowerCase();
+  return PREDEFINED_MODELS.some((m) => m.id.toLowerCase() === lc)
+    || listGlobalModels().some((m) => m.id.toLowerCase() === lc)
+    || listPluginModels().some((m) => m.id.toLowerCase() === lc);
 }
 
 /**

--- a/src/core/model-env.mjs
+++ b/src/core/model-env.mjs
@@ -17,6 +17,47 @@
  *  without importing the core graph. */
 export const EFFORTS = ['medium', 'high', 'xhigh', 'max'];
 
+// The effort worca's own auxiliary calls run at (title generation, the Models
+// view Test button). Deliberately BELOW the pipeline list: the CLI accepts
+// `--effort low` (claude --help, 2.1.259) and a one-line summary needs nothing
+// more, so the cheapest tier is the right one. EFFORTS omits it on purpose —
+// pipeline nodes are not offered `low` — which is why it lives here as its own
+// constant instead of being clamped into that list (#422).
+export const AUX_EFFORT = 'low';
+
+// Claude Code resolves its OWN internal calls — session titles, the alias tiers
+// a Task `model: haiku|sonnet|opus|fable` expands to, quota probes — through
+// these keys. A catalog entry that routes to a custom endpoint (ANTHROPIC_BASE_URL)
+// routinely sets ANTHROPIC_MODEL and nothing else, so the CLI falls back to
+// first-party ids against an endpoint that does not serve them (the
+// `unrecognized_model` noise in run logs). withTierModelEnv fills every one the
+// entry left unset with the entry's own wire id (#422). ANTHROPIC_SMALL_FAST_MODEL
+// is the pre-DEFAULT_HAIKU spelling older CLIs still read.
+export const TIER_MODEL_ENV_KEYS = Object.freeze([
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL', 'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL', 'ANTHROPIC_DEFAULT_FABLE_MODEL',
+  'ANTHROPIC_SMALL_FAST_MODEL',
+]);
+
+/**
+ * The tier keys an endpoint-routed model env should carry, synthesized from
+ * the env's wire id. Pure: a non-routed env (no ANTHROPIC_BASE_URL) comes back
+ * untouched, an explicit key in the env is never overwritten, and with no wire
+ * id to point at (no ANTHROPIC_MODEL and no model id) nothing is added.
+ * @param {Record<string,string>|undefined} env  a PREPARED model env
+ * @param {string} [modelId]  the catalog id — the wire id when ANTHROPIC_MODEL is unset (#374)
+ * @returns {Record<string,string>|undefined}
+ */
+export function withTierModelEnv(env, modelId) {
+  if (!env || typeof env !== 'object' || !('ANTHROPIC_BASE_URL' in env)) return env;
+  const wire = (typeof env.ANTHROPIC_MODEL === 'string' && env.ANTHROPIC_MODEL.trim())
+    || (typeof modelId === 'string' ? modelId.trim() : '');
+  if (!wire) return env;
+  const out = { ...env };
+  for (const k of TIER_MODEL_ENV_KEYS) if (!(k in out)) out[k] = wire;
+  return out;
+}
+
 // Env keys a model entry may NOT set (§4.4): process fundamentals and worca's
 // own runtime knobs, any of which injection could otherwise subvert (mock
 // mode, the claude binary path, the effort flag name). Everything else —

--- a/src/core/model-test.mjs
+++ b/src/core/model-test.mjs
@@ -7,6 +7,7 @@
 
 import { runClaude } from './claude-runner.mjs';
 import { resolveModelEnv } from './config.mjs';
+import { AUX_EFFORT } from './model-env.mjs';
 import { classifyError } from './recoverable-error.mjs';
 
 const TEST_TIMEOUT_MS = 60_000;
@@ -52,7 +53,7 @@ export async function testModel(id, { signal, bin, run = runClaude } = {}) {
       prompt: 'Reply with exactly OK.',
       model: id,
       modelEnv: resolveModelEnv(id),
-      effort: 'low',
+      effort: AUX_EFFORT,
       permissionMode: 'acceptEdits',
       allowedTools: [],          // empty → no --allowedTools flag; pure text gen
       signal: ctrl.signal,

--- a/src/core/run-harness.mjs
+++ b/src/core/run-harness.mjs
@@ -3641,6 +3641,13 @@ export class RunHarness extends EventEmitter {
       signal: this.abort.signal,
       bin: this.claude.bin,
       mock: this.claude.mock,
+      // The run's own model is the title default (#422, title.mjs#resolveTitleModel):
+      // an install with no first-party model titles its runs with no setup.
+      runModel: this.claude.model,
+      // A failed title used to vanish into a kept provisional title. Say so in
+      // the run log — once per run, there is only ever one title call.
+      onError: ({ model, error }) => this._log('orchestrator', 'warn',
+        `title generation failed (model ${model}): ${clipMiddle(error?.message || error, 300)} — keeping the provisional title`),
       // Same env policy as the pipeline nodes. Both undefined on an unconfigured
       // project ⇒ byte-identical spawn env (legacy parity).
       envScrub: this.guardrails?.envScrub || undefined,

--- a/src/core/settings.mjs
+++ b/src/core/settings.mjs
@@ -543,7 +543,68 @@ export const SETTINGS_POST_KEYS = Object.freeze([
   'pipelineCostLimitUsd', 'totalCostLimitUsd', 'costLimitResetPeriod',
   'askMaxTurns', 'askMaxBudgetUsd',
   'debugSpawnEnabled',
+  'titleModel', 'hideBuiltinModels',
 ]);
+
+// ── Title-generation model + hidden built-ins (#422) ─────────────────────────
+// `titleModel` is the catalog id every run/chat title is written with; absent
+// means "the model of the run or chat that asked for the title" (title.mjs owns
+// that precedence, and the catalog check — settings.mjs cannot import config.mjs).
+// `hideBuiltinModels` drops the first-party built-ins from every model picker
+// for an install with no first-party account; it is cosmetic + defaults only,
+// a hidden id still resolves (config.mjs#composeCatalog). Both are read at use
+// time like every other stored setting — a UI save reaches the next title call.
+export const DEFAULT_HIDE_BUILTIN_MODELS = false;
+const TITLE_MODEL_MAX_LEN = 200;
+
+const isTitleModelId = (v) => typeof v === 'string' && v.trim().length > 0 && v.length <= TITLE_MODEL_MAX_LEN;
+
+/** The STORED title model id (trimmed), or null when unset/invalid (loudly). */
+export function titleModel() {
+  const v = readSettings().titleModel;
+  if (v === undefined) return null;
+  if (isTitleModelId(v)) return v.trim();
+  console.warn(`[worca] invalid titleModel ${JSON.stringify(v)} — titles use the run's model`);
+  return null;
+}
+
+/** @throws {Error} unless `input` is a non-empty model id (or empty, which clears). */
+export function assertTitleModelInput(input) {
+  if (isClearInput(input)) return;
+  if (!isTitleModelId(input)) throw new Error(`titleModel must be a model id of at most ${TITLE_MODEL_MAX_LEN} characters, or empty to use the run's model`);
+}
+
+export async function setTitleModel(input) {
+  assertTitleModelInput(input);
+  const settings = readSettings();
+  if (isClearInput(input)) delete settings.titleModel;
+  else settings.titleModel = input.trim();
+  await persistSettings(settings);
+  return { titleModel: titleModel() };
+}
+
+/** Whether built-in (first-party) models are hidden from every picker. */
+export function hideBuiltinModels() {
+  const v = readSettings().hideBuiltinModels;
+  if (v === undefined) return DEFAULT_HIDE_BUILTIN_MODELS;
+  if (typeof v === 'boolean') return v;
+  console.warn(`[worca] invalid hideBuiltinModels ${JSON.stringify(v)} — using the default (${DEFAULT_HIDE_BUILTIN_MODELS})`);
+  return DEFAULT_HIDE_BUILTIN_MODELS;
+}
+
+/** @throws {Error} unless `input` is a boolean. */
+export function assertHideBuiltinModelsInput(input) {
+  if (typeof input !== 'boolean') throw new Error('hideBuiltinModels must be true or false');
+}
+
+export async function setHideBuiltinModels(input) {
+  assertHideBuiltinModelsInput(input);
+  const settings = readSettings();
+  if (input === DEFAULT_HIDE_BUILTIN_MODELS) delete settings.hideBuiltinModels;
+  else settings.hideBuiltinModels = input;
+  await persistSettings(settings);
+  return { hideBuiltinModels: hideBuiltinModels() };
+}
 
 // ── Spawn-debug diagnostics toggle (the stored side of WORCA_DEBUG_SPAWN) ────
 // Like every other stored setting (skillMount, the cost caps, the ask caps) this

--- a/src/core/title.mjs
+++ b/src/core/title.mjs
@@ -1,11 +1,61 @@
 // src/core/title.mjs
 import { runClaude } from './claude-runner.mjs';
-import { resolveModelEnv } from './config.mjs';
+import { resolveModelEnv, catalogHasModel } from './config.mjs';
+import { titleModel as storedTitleModel } from './settings.mjs';
+import { AUX_EFFORT } from './model-env.mjs';
 
-// A fast, cheap model is enough for a one-line summary. Overridable for tests/cost tuning.
-const DEFAULT_TITLE_MODEL =
-  process.env.WORCA_TITLE_MODEL || 'claude-haiku-4-5-20251001';
+// The last-resort title model: the BUILT-IN Haiku id (config.mjs PREDEFINED_MODELS),
+// not the dated API id it used to be — a global entry that shadows the built-in
+// (to route it) must match, or its routing env would never reach a title call.
+export const DEFAULT_TITLE_MODEL = 'claude-haiku-4-5';
 const MAX_LEN = 70;
+
+/**
+ * Which model writes a title, decided PER CALL (#422) — nothing is captured at
+ * import, so a Settings save or an env change reaches the very next title:
+ *   1. `opts.model`            — an explicit caller choice
+ *   2. WORCA_TITLE_MODEL       — a non-empty env override (tests, cost tuning);
+ *                                verbatim, no catalog check: an operator escape hatch
+ *   3. the stored `titleModel` — only while it is still a catalog member; a stale
+ *                                id (plugin removed, entry deleted) is reported and skipped
+ *   4. `opts.runModel`         — the model of the run / chat that asked for the title,
+ *                                which is what makes an install with NO first-party
+ *                                model produce titles with zero configuration
+ *   5. DEFAULT_TITLE_MODEL     — the built-in Haiku
+ * Pure apart from the injectable readers. Exported for tests and for the
+ * settings API (describeTitleModel below).
+ * @param {{model?:string, runModel?:string}} [opts]
+ * @param {{env?:NodeJS.ProcessEnv, stored?:()=>string|null, inCatalog?:(id:string)=>boolean}} [deps]
+ * @returns {{model:string, source:'explicit'|'env'|'settings'|'run'|'builtin', stale:string|null}}
+ */
+export function resolveTitleModel(opts = {}, { env = process.env, stored = storedTitleModel, inCatalog = catalogHasModel } = {}) {
+  const str = (v) => (typeof v === 'string' && v.trim() ? v.trim() : '');
+  const explicit = str(opts.model);
+  if (explicit) return { model: explicit, source: 'explicit', stale: null };
+  const fromEnv = str(env.WORCA_TITLE_MODEL);
+  if (fromEnv) return { model: fromEnv, source: 'env', stale: null };
+  let stale = null;
+  const configured = str(stored());
+  if (configured) {
+    if (inCatalog(configured)) return { model: configured, source: 'settings', stale: null };
+    stale = configured;
+  }
+  const runModel = str(opts.runModel);
+  if (runModel) return { model: runModel, source: 'run', stale };
+  return { model: DEFAULT_TITLE_MODEL, source: 'builtin', stale };
+}
+
+/**
+ * What the Settings card shows: the stored id, whether the environment
+ * overrides it, and a stale stored id that no longer resolves. `model` is
+ * null when titles follow the run's model (the default).
+ * @returns {{model:string|null, source:'env'|'settings'|'run', stale:string|null}}
+ */
+export function describeTitleModel(deps) {
+  const r = resolveTitleModel({}, deps);
+  if (r.source === 'env' || r.source === 'settings') return { model: r.model, source: r.source, stale: null };
+  return { model: null, source: 'run', stale: r.stale };
+}
 
 const SYSTEM = [
   'You write a SHORT, human-readable title for a software task.',
@@ -60,24 +110,34 @@ export function isRefusalTitle(t) {
  * failure/abort/empty input so the caller keeps the provisional title.
  * `permissionMode` (default 'acceptEdits') exists for Ask Worca: its title call
  * passes 'dontAsk' so the mock dispatcher can never reach a file-writing role.
+ * `runModel` is the model of the run/chat asking (resolveTitleModel step 4).
+ * `onError` fires ONCE when the call yields no usable title for any reason but
+ * an abort (a spawn failure, a refusal, an empty reply) — the caller logs it on
+ * its own channel; the return value stays '' so every existing caller is unchanged.
  * @param {string} prompt
- * @param {{cwd:string, signal?:AbortSignal, model?:string, bin?:string, mock?:boolean, envScrub?:boolean, envAllowlist?:string[], tools?:string[], strictMcpConfig?:boolean, settingSources?:string[], disableSlashCommands?:boolean, mcpConfigPath?:string, permissionMode?:string}} opts
+ * @param {{cwd:string, signal?:AbortSignal, model?:string, runModel?:string, onError?:(info:{model:string, error:Error})=>void, bin?:string, mock?:boolean, envScrub?:boolean, envAllowlist?:string[], tools?:string[], strictMcpConfig?:boolean, settingSources?:string[], disableSlashCommands?:boolean, mcpConfigPath?:string, permissionMode?:string}} opts
  * @returns {Promise<string>}
  */
 export async function generateTitle(prompt, opts = {}) {
   const text = String(prompt || '').trim();
   if (!text) return '';
+  const { model, stale } = resolveTitleModel(opts);
+  if (stale) console.warn(`[worca] titleModel ${JSON.stringify(stale)} is no longer in the catalog — titles use ${model}`);
+  const report = (error) => {
+    if (typeof opts.onError !== 'function') return;
+    try { opts.onError({ model, error }); } catch { /* a logging sink must never fail the caller */ }
+  };
   try {
     const { text: out } = await runClaude({
       cwd: opts.cwd || process.cwd(),
       systemPrompt: SYSTEM,
       prompt: `Write the title for this task:\n\n${text.slice(0, 4000)}`,
-      model: opts.model || DEFAULT_TITLE_MODEL,
+      model,
       // Aux calls keep their model choice but still route through the catalog's
       // env (design §4.8) — a global entry matching this id carries its routing
       // env everywhere the id is used.
-      modelEnv: resolveModelEnv(opts.model || DEFAULT_TITLE_MODEL),
-      effort: 'low',
+      modelEnv: resolveModelEnv(model),
+      effort: AUX_EFFORT,
       permissionMode: opts.permissionMode || 'acceptEdits',
       allowedTools: [],            // empty → no --allowedTools flag → claude defaults; pure text gen
       signal: opts.signal,
@@ -103,9 +163,12 @@ export async function generateTitle(prompt, opts = {}) {
       onEvent: () => {},
     });
     const title = sanitizeTitle(out);
-    return isRefusalTitle(title) ? '' : title;
+    if (!title) { report(new Error('the model returned an empty reply')); return ''; }
+    if (isRefusalTitle(title)) { report(new Error(`the model did not write a title: ${title.slice(0, 120)}`)); return ''; }
+    return title;
   } catch (err) {
     if (err && err.name === 'AbortError') return ''; // run was stopped — caller keeps provisional
+    report(err instanceof Error ? err : new Error(String(err)));
     return '';
   }
 }

--- a/test/api-models.test.mjs
+++ b/test/api-models.test.mjs
@@ -442,3 +442,70 @@ test('a plugin model\'s manifest price reaches GET /api/models and Edit-a-copy',
   assert.deepEqual(copy.body.cost, { perMtok: { input: 1, output: 3 } });
   assert.equal((await jfetch(`/api/plugins/priced-plug/model-env?${q({ id: 'pp-plain' })}`)).body.cost, undefined);
 });
+
+// ── #422: hidden built-ins over HTTP, the title-model setting, a testable built-in ──
+
+test('#422: hideBuiltinModels flags built-ins in /api/config, is echoed by /api/models, and the ask default skips them', async () => {
+  const on = await post('/api/settings', { hideBuiltinModels: true });
+  assert.equal(on.status, 200, JSON.stringify(on.body));
+  assert.equal(on.body.hideBuiltinModels, true);
+  try {
+    const cfg = await jfetch('/api/config');
+    const builtins = cfg.body.models.filter((m) => m.custom === false);
+    assert.ok(builtins.length > 0 && builtins.every((m) => m.hidden === true), 'unshadowed built-ins carry hidden:true');
+    assert.ok(cfg.body.models.filter((m) => m.custom).every((m) => m.hidden === undefined), 'owned entries never hidden');
+    const models = await jfetch('/api/models');
+    assert.equal(models.body.hideBuiltinModels, true);
+    assert.ok(models.body.predefined.length > 0, 'predefined still shipped — the view collapses it, the id still resolves');
+    const ask = await jfetch('/api/ask/models');
+    assert.ok(ask.body.default && !ask.body.models.find((m) => m.id === ask.body.default.model).hidden, 'default is a visible model');
+  } finally {
+    const off = await post('/api/settings', { hideBuiltinModels: false });
+    assert.equal(off.status, 200);
+    assert.equal(off.body.hideBuiltinModels, false);
+  }
+  const cfg = await jfetch('/api/config');
+  assert.ok(cfg.body.models.every((m) => m.hidden === undefined), 'flag gone once unset');
+  const bad = await post('/api/settings', { hideBuiltinModels: 'yes' });
+  assert.equal(bad.status, 400);
+  assert.match(bad.body.error, /true or false/);
+});
+
+test('#422: POST /api/settings titleModel — catalog member stored, unknown id refused, "" clears; stale id reported', async () => {
+  const { PREDEFINED_MODELS } = await import('../src/core/config.mjs');
+  const unknown = await post('/api/settings', { titleModel: 'no-such-model' });
+  assert.equal(unknown.status, 400);
+  assert.match(unknown.body.error, /unknown model "no-such-model"/);
+  const builtin = await post('/api/settings', { titleModel: PREDEFINED_MODELS[0].id });
+  assert.equal(builtin.status, 200, JSON.stringify(builtin.body));
+  assert.equal(builtin.body.titleModel, PREDEFINED_MODELS[0].id);
+  assert.deepEqual(builtin.body.titleModelEffective, { model: PREDEFINED_MODELS[0].id, source: 'settings', stale: null });
+  // A global entry picked, then deleted → the setting is stale and says so.
+  const add = await post('/api/models', { id: 'title-only-model', label: 'T', efforts: [], env: {} });
+  assert.equal(add.status, 200, JSON.stringify(add.body));
+  const pick = await post('/api/settings', { titleModel: 'title-only-model' });
+  assert.equal(pick.status, 200);
+  const del = await jfetch('/api/models/title-only-model', { method: 'DELETE' });
+  assert.equal(del.status, 200, JSON.stringify(del.body));
+  const stale = await jfetch('/api/settings');
+  assert.equal(stale.body.titleModel, 'title-only-model', 'stored id kept verbatim');
+  assert.deepEqual(stale.body.titleModelEffective, { model: null, source: 'run', stale: 'title-only-model' });
+  const clear = await post('/api/settings', { titleModel: '' });
+  assert.equal(clear.status, 200);
+  assert.equal(clear.body.titleModel, null);
+  assert.deepEqual(clear.body.titleModelEffective, { model: null, source: 'run', stale: null });
+});
+
+test('#422: POST /api/models/:id/test accepts a BUILT-IN id (the Title-generation card offers them)', async () => {
+  const { PREDEFINED_MODELS } = await import('../src/core/config.mjs');
+  const prev = process.env.WORCA_MOCK;
+  process.env.WORCA_MOCK = '1';           // never a real spawn under the test PATH guard
+  try {
+    const r = await post(`/api/models/${PREDEFINED_MODELS[0].id}/test`, {});
+    assert.notEqual(r.status, 404, JSON.stringify(r.body));
+    assert.equal(r.status, 200);
+    assert.equal(typeof r.body.ok, 'boolean');
+  } finally {
+    if (prev === undefined) delete process.env.WORCA_MOCK; else process.env.WORCA_MOCK = prev;
+  }
+});

--- a/test/ask-panel-pickers.test.mjs
+++ b/test/ask-panel-pickers.test.mjs
@@ -493,3 +493,48 @@ test('ask-panel-pickers: ask-history-cleared closes the popover and resets the a
   assert.equal(ctx.doc.querySelector('.ask-title').textContent, 'Ask Worca');
   assert.equal(ctx.fetchCalls.length, fetchesBefore);
 });
+
+test('ask-panel-pickers (#422): hidden built-ins leave the list; the default falls to the first visible model', async () => {
+  const hiddenCatalog = {
+    models: [
+      { id: 'claude-opus-5', label: 'Opus 5', efforts: ['medium', 'high'], custom: false, hidden: true },
+      { id: 'claude-haiku-4-5', label: 'Haiku 4.5', efforts: ['medium', 'high'], custom: false, hidden: true },
+      { id: 'my-corp-model', label: 'Corp', efforts: ['high'], custom: 'global' },
+    ],
+    efforts: ['medium', 'high', 'xhigh', 'max'],
+    default: { model: 'my-corp-model', effort: 'high' },
+  };
+  const base = handler();
+  const ctx = makePanel({ fetchHandler: (url, opts) => (url === '/api/ask/models' ? { ok: true, status: 200, json: async () => hiddenCatalog } : base(url, opts)) });
+  ctx.panel.open();
+  await ctx.tick(); await ctx.tick();
+  assert.match(ctx.doc.querySelector('[data-ask-model-btn]').textContent, /Corp/, 'initial pick is a model the user owns');
+  ctx.doc.querySelector('[data-ask-model-btn]').click();
+  await ctx.tick();
+  const names = [...ctx.doc.querySelectorAll('.ask-pop-model .ask-model-name')].map((n) => n.textContent);
+  assert.deepEqual(names, ['Corp']);
+});
+
+test('ask-panel-pickers (#422): a STORED pick on a hidden built-in stays visible and selected (it still resolves)', async () => {
+  const hiddenCatalog = {
+    models: [
+      { id: 'claude-opus-5', label: 'Opus 5', efforts: ['medium', 'high'], custom: false, hidden: true },
+      { id: 'my-corp-model', label: 'Corp', efforts: ['high'], custom: 'global' },
+    ],
+    efforts: ['medium', 'high', 'xhigh', 'max'],
+    default: { model: 'my-corp-model', effort: 'high' },
+  };
+  const base = handler();
+  // The stored pick is read when the panel is BUILT — seed storage first.
+  const storage = new Map();
+  const storageApi = { getItem: (k) => (storage.has(k) ? storage.get(k) : null), setItem: (k, v) => storage.set(k, String(v)), removeItem: (k) => storage.delete(k) };
+  storageApi.setItem('worca-cc.ask.model', JSON.stringify({ model: 'claude-opus-5', effort: 'high' }));
+  const ctx = makePanel({ storage: storageApi, fetchHandler: (url, opts) => (url === '/api/ask/models' ? { ok: true, status: 200, json: async () => hiddenCatalog } : base(url, opts)) });
+  ctx.panel.open();
+  await ctx.tick(); await ctx.tick();
+  assert.match(ctx.doc.querySelector('[data-ask-model-btn]').textContent, /Opus 5/);
+  ctx.doc.querySelector('[data-ask-model-btn]').click();
+  await ctx.tick();
+  const names = [...ctx.doc.querySelectorAll('.ask-pop-model .ask-model-name')].map((n) => n.textContent);
+  assert.deepEqual(names, ['Opus 5', 'Corp']);
+});

--- a/test/ask-turn.test.mjs
+++ b/test/ask-turn.test.mjs
@@ -380,6 +380,8 @@ test('title: fires on the first turn with the R-D + dontAsk option set; rename g
   assert.equal(o.envScrub, true);
   assert.deepEqual(o.envAllowlist, []);
   assert.equal(o.permissionMode, 'dontAsk');
+  assert.equal(o.runModel, 'claude-opus-5', '#422: the chat\'s own model is the title default');
+  assert.equal(typeof o.onError, 'function', '#422: a failed title is reported, not swallowed');
   assert.equal(o.signal, undefined, 'no signal — fires after ANY terminal, incl. a stop that aborted the controller');
   assert.equal(getThread(s.thread.id).title, 'Fable Title');
   assert.deepEqual(outOfTurn, [{ type: 'ask-title', title: 'Fable Title' }]);

--- a/test/config-models-global.test.mjs
+++ b/test/config-models-global.test.mjs
@@ -18,7 +18,7 @@ import {
   PREDEFINED_MODELS,
 } from '../src/core/config.mjs';
 import { addGlobalModel, listGlobalModels } from '../src/core/settings.mjs';
-import { EFFORTS } from '../src/core/model-env.mjs';
+import { EFFORTS, TIER_MODEL_ENV_KEYS } from '../src/core/model-env.mjs';
 import { getDb, _resetForTests } from '../src/core/db.mjs';
 import { projectKey } from '../src/core/store.mjs';
 
@@ -102,12 +102,15 @@ test('resolveModelEnv: global env only, ${VAR} expanded, case-insensitive id, un
 
   process.env.GM_TEST_TOKEN = 'sk-42';
   try {
-    assert.deepEqual(resolveModelEnv('GLM-4.7'), { ANTHROPIC_BASE_URL: 'https://x', ANTHROPIC_AUTH_TOKEN: 'sk-42' });
+    // An endpoint-routed entry also carries the CLI tier keys = its own id (#422,
+    // test/model-env-tier.test.mjs) — the canonical spelling, not the lookup's.
+    const tier = Object.fromEntries(TIER_MODEL_ENV_KEYS.map((k) => [k, 'glm-4.7']));
+    assert.deepEqual(resolveModelEnv('GLM-4.7'), { ANTHROPIC_BASE_URL: 'https://x', ANTHROPIC_AUTH_TOKEN: 'sk-42', ...tier });
   } finally {
     delete process.env.GM_TEST_TOKEN;
   }
   // Unset ref -> that key dropped, the rest survives.
-  assert.deepEqual(resolveModelEnv('glm-4.7'), { ANTHROPIC_BASE_URL: 'https://x' });
+  assert.deepEqual(resolveModelEnv('glm-4.7'), { ANTHROPIC_BASE_URL: 'https://x', ...Object.fromEntries(TIER_MODEL_ENV_KEYS.map((k) => [k, 'glm-4.7'])) });
   assert.equal(resolveModelEnv('plain-model'), undefined);   // global, no env
   assert.equal(resolveModelEnv('proj-model'), undefined);    // legacy: never env
   assert.equal(resolveModelEnv('claude-opus-5'), undefined); // predefined, unshadowed

--- a/test/model-env-dispatch.test.mjs
+++ b/test/model-env-dispatch.test.mjs
@@ -42,7 +42,9 @@ test('runOpts resolves modelEnv from the dispatched model id', async () => {
   await addGlobalModel({ id: 'routed-model', env: { ANTHROPIC_BASE_URL: 'https://proxy.test/v1' } });
   const opts = runOpts({ ...CTX_BASE, claudeOpts: { model: 'routed-model' } }, CALL);
   assert.equal(opts.model, 'routed-model');
-  assert.deepEqual(opts.modelEnv, { ANTHROPIC_BASE_URL: 'https://proxy.test/v1' });
+  assert.equal(opts.modelEnv.ANTHROPIC_BASE_URL, 'https://proxy.test/v1');
+  // #422: a routed env also carries the CLI tier keys pointed at this id.
+  assert.equal(opts.modelEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL, 'routed-model');
 });
 
 test('runOpts leaves modelEnv undefined for env-less and unconfigured models', async () => {

--- a/test/model-env-tier.test.mjs
+++ b/test/model-env-tier.test.mjs
@@ -1,0 +1,88 @@
+// test/model-env-tier.test.mjs
+// #422: an endpoint-routed model env carries Claude Code's internal tier keys
+// (ANTHROPIC_DEFAULT_{HAIKU,SONNET,OPUS,FABLE}_MODEL + ANTHROPIC_SMALL_FAST_MODEL)
+// pointed at the entry's own wire id, so the CLI's session-title / alias /
+// probe calls never fall back to a first-party id the endpoint does not serve.
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { withTierModelEnv, TIER_MODEL_ENV_KEYS, isReservedModelEnvKey } from '../src/core/model-env.mjs';
+import { resolveModelEnv } from '../src/core/config.mjs';
+import { addGlobalModel } from '../src/core/settings.mjs';
+import { _resetForTests } from '../src/core/db.mjs';
+
+const dirs = [];
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
+before(async () => {
+  const home = await mkdtemp(join(tmpdir(), 'worca-cc-tier-home-'));
+  const whome = await mkdtemp(join(tmpdir(), 'worca-cc-tier-whome-'));
+  dirs.push(home, whome);
+  _resetForTests();
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  process.env.WORCA_HOME = whome;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1';
+});
+after(async () => {
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+const allTier = (wire) => Object.fromEntries(TIER_MODEL_ENV_KEYS.map((k) => [k, wire]));
+
+test('TIER_MODEL_ENV_KEYS: the four DEFAULT tiers + the legacy small-fast key, none reserved', () => {
+  assert.deepEqual([...TIER_MODEL_ENV_KEYS], [
+    'ANTHROPIC_DEFAULT_HAIKU_MODEL', 'ANTHROPIC_DEFAULT_SONNET_MODEL',
+    'ANTHROPIC_DEFAULT_OPUS_MODEL', 'ANTHROPIC_DEFAULT_FABLE_MODEL',
+    'ANTHROPIC_SMALL_FAST_MODEL',
+  ]);
+  for (const k of TIER_MODEL_ENV_KEYS) assert.equal(isReservedModelEnvKey(k), false, k);
+});
+
+test('withTierModelEnv: routed env gets every unset tier key = the catalog id', () => {
+  const env = { ANTHROPIC_BASE_URL: 'https://gw', ANTHROPIC_AUTH_TOKEN: 't' };
+  const out = withTierModelEnv(env, 'my-model');
+  assert.deepEqual(out, { ...env, ...allTier('my-model') });
+  assert.deepEqual(env, { ANTHROPIC_BASE_URL: 'https://gw', ANTHROPIC_AUTH_TOKEN: 't' }, 'input untouched');
+});
+
+test('withTierModelEnv: ANTHROPIC_MODEL (the wire id, #374) outranks the catalog id', () => {
+  const out = withTierModelEnv({ ANTHROPIC_BASE_URL: 'https://gw', ANTHROPIC_MODEL: 'wire-7' }, 'catalog-id');
+  assert.deepEqual(out, { ANTHROPIC_BASE_URL: 'https://gw', ANTHROPIC_MODEL: 'wire-7', ...allTier('wire-7') });
+});
+
+test('withTierModelEnv: an explicit tier key is never overwritten', () => {
+  const out = withTierModelEnv({ ANTHROPIC_BASE_URL: 'https://gw', ANTHROPIC_DEFAULT_HAIKU_MODEL: 'small-one' }, 'big-one');
+  assert.equal(out.ANTHROPIC_DEFAULT_HAIKU_MODEL, 'small-one');
+  assert.equal(out.ANTHROPIC_DEFAULT_OPUS_MODEL, 'big-one');
+});
+
+test('withTierModelEnv: non-routed env, undefined env, and no wire id all pass through untouched', () => {
+  const plain = { ANTHROPIC_AUTH_TOKEN: 't' };
+  assert.equal(withTierModelEnv(plain, 'x'), plain);
+  assert.equal(withTierModelEnv(undefined, 'x'), undefined);
+  const routedNoId = { ANTHROPIC_BASE_URL: 'https://gw' };
+  assert.deepEqual(withTierModelEnv(routedNoId, ''), routedNoId);
+  assert.deepEqual(withTierModelEnv(routedNoId, undefined), routedNoId);
+});
+
+test('resolveModelEnv: an endpoint-routed GLOBAL entry carries the tier keys; a plain one does not', async () => {
+  await addGlobalModel({ id: 'Routed-Model', env: { ANTHROPIC_BASE_URL: 'https://gw/v1', ANTHROPIC_AUTH_TOKEN: 'tok' } });
+  await addGlobalModel({ id: 'unrouted-model', env: { ANTHROPIC_AUTH_TOKEN: 'tok' } });
+  await addGlobalModel({ id: 'wire-model', env: { ANTHROPIC_BASE_URL: 'https://gw/v1', ANTHROPIC_MODEL: 'gw-wire', ANTHROPIC_DEFAULT_SONNET_MODEL: 'gw-sonnet' } });
+  // case-insensitive lookup, but the synthesized id is the entry's CANONICAL spelling
+  assert.deepEqual(resolveModelEnv('routed-model'), {
+    ANTHROPIC_BASE_URL: 'https://gw/v1', ANTHROPIC_AUTH_TOKEN: 'tok', ...allTier('Routed-Model'),
+  });
+  assert.deepEqual(resolveModelEnv('unrouted-model'), { ANTHROPIC_AUTH_TOKEN: 'tok' });
+  assert.deepEqual(resolveModelEnv('wire-model'), {
+    ANTHROPIC_BASE_URL: 'https://gw/v1', ANTHROPIC_MODEL: 'gw-wire', ...allTier('gw-wire'), ANTHROPIC_DEFAULT_SONNET_MODEL: 'gw-sonnet',
+  });
+});

--- a/test/models-view.test.mjs
+++ b/test/models-view.test.mjs
@@ -461,3 +461,32 @@ test('list: only global cards get Duplicate — plugin cards already have Edit a
   assert.equal(el.querySelector('.mv-legacy .mv-duplicate'), null);
   assert.equal(el.querySelector('.mv-builtin .mv-duplicate'), null);
 });
+
+// ── #422: hide-built-ins checkbox, collapsed built-ins, endpoint-routed badge ──
+
+test('list (#422): the hide-built-ins checkbox sits at the top and mirrors the flag; built-ins collapse when hidden', () => {
+  const shown = renderModelsList({ globals: [GLOBAL], plugins: [], predefined: PREDEFINED, efforts: EFFORTS, hideBuiltin: false }, { doc });
+  const cb = shown.querySelector('.mv-hide-builtin');
+  assert.ok(cb && cb.type === 'checkbox' && cb.checked === false);
+  assert.equal(shown.firstElementChild.className, 'mv-hide-builtin-row', 'top of the pane, above Your models');
+  assert.equal(shown.querySelectorAll('.mv-builtin').length, PREDEFINED.length);
+  assert.ok(shown.querySelector('.mv-section.mv-builtins-shown'));
+
+  const hidden = renderModelsList({ globals: [GLOBAL], plugins: [], predefined: PREDEFINED, efforts: EFFORTS, hideBuiltin: true }, { doc });
+  assert.equal(hidden.querySelector('.mv-hide-builtin').checked, true);
+  assert.equal(hidden.querySelectorAll('.mv-builtin').length, 0, 'no built-in rows');
+  const sec = hidden.querySelector('.mv-section.mv-builtins-hidden');
+  assert.ok(sec, 'the section stays, collapsed');
+  assert.match(sec.textContent, /Hidden from every picker \(2 built-ins\)/);
+});
+
+test('list (#422): endpoint-routed badge on global + plugin cards whose env carries ANTHROPIC_BASE_URL, and only those', () => {
+  const plain = { id: 'plain', label: 'Plain', efforts: [], env: { ANTHROPIC_AUTH_TOKEN: '••••' } };
+  const plug = { id: 'pm', label: 'PM', efforts: [], plugin: 'p', env: { ANTHROPIC_BASE_URL: '••••' }, secrets: [] };
+  const root = renderModelsList({ globals: [GLOBAL, plain], plugins: [plug], predefined: PREDEFINED, efforts: EFFORTS }, { doc });
+  const badgeOf = (id) => root.querySelector(`.mv-card[data-id="${id}"] .mv-routed`);
+  assert.ok(badgeOf('glm-4.7'), 'routed global');
+  assert.equal(badgeOf('plain'), null, 'no base url → no badge');
+  assert.ok(badgeOf('pm'), 'routed plugin');
+  assert.match(badgeOf('glm-4.7').title, /haiku\/sonnet\/opus\/fable/);
+});

--- a/test/settings-api.test.mjs
+++ b/test/settings-api.test.mjs
@@ -131,6 +131,7 @@ test('every SETTINGS_POST_KEYS key is exempt from the legacy "no known key clear
     const probes = {
       projectsRoot: '', chat: {}, pipelineCostLimitUsd: '', totalCostLimitUsd: '', costLimitResetPeriod: '',
       askMaxTurns: '', askMaxBudgetUsd: '', debugSpawnEnabled: false,
+      titleModel: '', hideBuiltinModels: false,
     };
     for (const k of SETTINGS_POST_KEYS) {
       if (k === 'root') continue;

--- a/test/settings-projects-root.test.mjs
+++ b/test/settings-projects-root.test.mjs
@@ -310,7 +310,11 @@ test('GET /api/settings returns {root, projectsRoot, projectsRootDefault, defaul
   await withEnv(undefined, async () => {
     const j = await getApi();
     assert.deepEqual(Object.keys(j).sort(), ['askMaxBudgetUsd', 'askMaxTurns', 'chat', 'costLimitResetPeriod',
-      'debugSpawnEffective', 'debugSpawnEnabled', 'default', 'pipelineCostLimitUsd', 'projectsRoot', 'projectsRootDefault', 'root', 'totalCostLimitUsd']);
+      'debugSpawnEffective', 'debugSpawnEnabled', 'default', 'hideBuiltinModels', 'pipelineCostLimitUsd', 'projectsRoot', 'projectsRootDefault', 'root',
+      'titleModel', 'titleModelEffective', 'totalCostLimitUsd']);
+    assert.equal(j.titleModel, null, 'no title model stored -> the run\'s model');
+    assert.deepEqual(j.titleModelEffective, { model: null, source: 'run', stale: null });
+    assert.equal(j.hideBuiltinModels, false);
     assert.equal(j.root, '', 'nothing set yet');
     assert.equal(j.projectsRoot, '', 'the RAW setting — "" when unset, exactly like root');
     assert.equal(j.projectsRootDefault, defaultRoot(), 'what applies while it is blank');

--- a/test/title-model-settings.test.mjs
+++ b/test/title-model-settings.test.mjs
@@ -1,0 +1,119 @@
+// test/title-model-settings.test.mjs
+// #422: the two new stored settings (titleModel, hideBuiltinModels), the
+// `hidden` flag composeCatalog puts on UNSHADOWED built-ins, catalogHasModel,
+// and the Ask default that skips hidden built-ins while still validating them.
+import { test, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  settingsFile, titleModel, setTitleModel, assertTitleModelInput,
+  hideBuiltinModels, setHideBuiltinModels, assertHideBuiltinModelsInput, SETTINGS_POST_KEYS, addGlobalModel,
+} from '../src/core/settings.mjs';
+import { listModels, catalogHasModel, PREDEFINED_MODELS } from '../src/core/config.mjs';
+import { createAskModels } from '../src/core/ask/models.mjs';
+import { _resetForTests } from '../src/core/db.mjs';
+
+let home, whome;
+const prevEnv = {
+  HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, WORCA_HOME: process.env.WORCA_HOME,
+  WORCA_TEST_ALLOW_HOME_FALLBACK: process.env.WORCA_TEST_ALLOW_HOME_FALLBACK,
+};
+before(async () => {
+  home = await mkdtemp(join(tmpdir(), 'worca-cc-tms-home-'));
+  whome = await mkdtemp(join(tmpdir(), 'worca-cc-tms-whome-'));
+  _resetForTests();
+  process.env.HOME = home; process.env.USERPROFILE = home;
+  process.env.WORCA_HOME = whome;
+  process.env.WORCA_TEST_ALLOW_HOME_FALLBACK = '1';
+});
+beforeEach(async () => {
+  await mkdir(join(home, '.worca-cc'), { recursive: true });
+  await writeFile(settingsFile(), '{}\n', 'utf8');
+});
+after(async () => {
+  _resetForTests();
+  for (const k of ['HOME', 'USERPROFILE', 'WORCA_HOME', 'WORCA_TEST_ALLOW_HOME_FALLBACK']) {
+    if (prevEnv[k] === undefined) delete process.env[k]; else process.env[k] = prevEnv[k];
+  }
+  await Promise.all([home, whome].map((d) => rm(d, { recursive: true, force: true })));
+});
+
+test('both keys are registered in SETTINGS_POST_KEYS (the route\'s clear-root exemption)', () => {
+  assert.ok(SETTINGS_POST_KEYS.includes('titleModel'));
+  assert.ok(SETTINGS_POST_KEYS.includes('hideBuiltinModels'));
+});
+
+test('titleModel: null by default; set/clear round-trips; whitespace trimmed; invalid stored value warns to null', async () => {
+  assert.equal(titleModel(), null);
+  assert.deepEqual(await setTitleModel('  my-model '), { titleModel: 'my-model' });
+  assert.equal(JSON.parse(await readFile(settingsFile(), 'utf8')).titleModel, 'my-model');
+  assert.deepEqual(await setTitleModel(''), { titleModel: null });
+  assert.equal('titleModel' in JSON.parse(await readFile(settingsFile(), 'utf8')), false, 'clear deletes the key');
+  await writeFile(settingsFile(), JSON.stringify({ titleModel: 42 }), 'utf8');
+  const warn = console.warn; const lines = [];
+  console.warn = (...a) => lines.push(a.join(' '));
+  try { assert.equal(titleModel(), null); } finally { console.warn = warn; }
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /invalid titleModel/);
+});
+
+test('assertTitleModelInput: empty/null clear; non-string, blank, or over-long rejected', () => {
+  assertTitleModelInput(''); assertTitleModelInput(null); assertTitleModelInput(undefined); assertTitleModelInput('x');
+  for (const bad of [42, true, '   ', 'y'.repeat(201), {}]) assert.throws(() => assertTitleModelInput(bad), /titleModel must be a model id/);
+});
+
+test('hideBuiltinModels: false by default; true persists; false deletes the key; only booleans accepted', async () => {
+  assert.equal(hideBuiltinModels(), false);
+  assert.deepEqual(await setHideBuiltinModels(true), { hideBuiltinModels: true });
+  assert.equal(JSON.parse(await readFile(settingsFile(), 'utf8')).hideBuiltinModels, true);
+  assert.deepEqual(await setHideBuiltinModels(false), { hideBuiltinModels: false });
+  assert.equal('hideBuiltinModels' in JSON.parse(await readFile(settingsFile(), 'utf8')), false);
+  for (const bad of ['true', 1, null, undefined]) assert.throws(() => assertHideBuiltinModelsInput(bad), /must be true or false/);
+});
+
+test('composeCatalog: hideBuiltinModels marks UNSHADOWED built-ins hidden — a global copy of a built-in id is not hidden', async () => {
+  await addGlobalModel({ id: PREDEFINED_MODELS[0].id, label: 'my copy' });
+  await addGlobalModel({ id: 'own-model' });
+  let cat = await listModels('');
+  assert.ok(cat.every((m) => m.hidden === undefined), 'nothing hidden by default');
+  await setHideBuiltinModels(true);
+  cat = await listModels('');
+  const shadowed = cat.find((m) => m.id === PREDEFINED_MODELS[0].id);
+  assert.equal(shadowed.custom, 'global');
+  assert.equal(shadowed.hidden, undefined, 'the user OWNS this entry');
+  assert.equal(cat.find((m) => m.id === 'own-model').hidden, undefined);
+  const builtins = cat.filter((m) => m.custom === false);
+  assert.equal(builtins.length, PREDEFINED_MODELS.length - 1);
+  assert.ok(builtins.every((m) => m.hidden === true), 'every other built-in is hidden');
+  assert.equal(cat.length, PREDEFINED_MODELS.length + 1, 'hidden entries are STILL in the catalog (they must resolve)');
+});
+
+test('catalogHasModel: built-in, global, plugin-less; case-insensitive; hidden built-ins still count', async () => {
+  await addGlobalModel({ id: 'own-model' });
+  await setHideBuiltinModels(true);
+  assert.equal(catalogHasModel(PREDEFINED_MODELS[0].id), true);
+  assert.equal(catalogHasModel(PREDEFINED_MODELS[0].id.toUpperCase()), true);
+  assert.equal(catalogHasModel('OWN-model'), true);
+  assert.equal(catalogHasModel('nope'), false);
+  assert.equal(catalogHasModel(''), false);
+  assert.equal(catalogHasModel(undefined), false);
+});
+
+test('askCatalog: the D8 default skips hidden built-ins → first owned model; a hidden id still validates', async () => {
+  const fake = [
+    { id: 'claude-opus-5', label: 'Opus 5', efforts: ['medium', 'high'], custom: false, hasEnv: false, hidden: true },
+    { id: 'claude-haiku-4-5', label: 'Haiku', efforts: ['medium', 'high'], custom: false, hasEnv: false, hidden: true },
+    { id: 'corp-model', label: 'Corp', efforts: ['high'], custom: 'global', hasEnv: true },
+  ];
+  const { askCatalog, validateModelEffort } = createAskModels({ listModels: async () => fake, pluginModels: () => [] });
+  const cat = await askCatalog();
+  assert.deepEqual(cat.default, { model: 'corp-model', effort: 'high' });
+  assert.equal(cat.models.find((m) => m.id === 'claude-opus-5').hidden, true, 'flag shipped to the picker');
+  assert.equal(cat.models.find((m) => m.id === 'corp-model').hidden, undefined);
+  assert.deepEqual(await validateModelEffort('claude-opus-5', 'high'), { ok: true, model: 'claude-opus-5', effort: 'high' });
+  // With every entry hidden the default is still SOMETHING (never null on a non-empty catalog).
+  const { askCatalog: allHidden } = createAskModels({ listModels: async () => fake.slice(0, 2), pluginModels: () => [] });
+  assert.equal((await allHidden()).default.model, 'claude-opus-5');
+});

--- a/test/title-model.test.mjs
+++ b/test/title-model.test.mjs
@@ -1,0 +1,128 @@
+// test/title-model.test.mjs
+// #422: the title model is decided PER CALL — explicit > WORCA_TITLE_MODEL >
+// stored titleModel (only while it is a catalog member) > the run's model >
+// the built-in Haiku. Aux calls run at AUX_EFFORT ('low'), and a failed title
+// call reports ONCE through onError instead of vanishing.
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, readFile, chmod, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveTitleModel, describeTitleModel, generateTitle, DEFAULT_TITLE_MODEL } from '../src/core/title.mjs';
+import { AUX_EFFORT } from '../src/core/model-env.mjs';
+import { PREDEFINED_MODELS } from '../src/core/config.mjs';
+import { createOrchestrator } from '../src/core/orchestrator.mjs';
+import { useTempHome } from './helpers/temp-home.mjs';
+
+useTempHome(after);
+const POSIX_SHIM = { skip: process.platform === 'win32' ? 'fake claude shim is a POSIX shell script (no .exe stand-in on Windows)' : false };
+
+const deps = (over = {}) => ({ env: {}, stored: () => null, inCatalog: () => true, ...over });
+
+test('DEFAULT_TITLE_MODEL is the BUILT-IN Haiku id, so a global entry shadowing it routes title calls', () => {
+  assert.ok(PREDEFINED_MODELS.some((m) => m.id === DEFAULT_TITLE_MODEL), `${DEFAULT_TITLE_MODEL} must be a PREDEFINED_MODELS id`);
+});
+
+test('resolveTitleModel: precedence explicit > env > stored > run > built-in', () => {
+  assert.deepEqual(resolveTitleModel({ model: ' x ', runModel: 'r' }, deps({ env: { WORCA_TITLE_MODEL: 'e' }, stored: () => 's' })),
+    { model: 'x', source: 'explicit', stale: null });
+  assert.deepEqual(resolveTitleModel({ runModel: 'r' }, deps({ env: { WORCA_TITLE_MODEL: 'e' }, stored: () => 's' })),
+    { model: 'e', source: 'env', stale: null });
+  assert.deepEqual(resolveTitleModel({ runModel: 'r' }, deps({ stored: () => 's' })),
+    { model: 's', source: 'settings', stale: null });
+  assert.deepEqual(resolveTitleModel({ runModel: 'r' }, deps()),
+    { model: 'r', source: 'run', stale: null });
+  assert.deepEqual(resolveTitleModel({}, deps()),
+    { model: DEFAULT_TITLE_MODEL, source: 'builtin', stale: null });
+});
+
+test('resolveTitleModel: an EMPTY env override is not an override; the env id is not catalog-checked', () => {
+  assert.equal(resolveTitleModel({ runModel: 'r' }, deps({ env: { WORCA_TITLE_MODEL: '   ' } })).source, 'run');
+  assert.deepEqual(resolveTitleModel({}, deps({ env: { WORCA_TITLE_MODEL: 'off-catalog' }, inCatalog: () => false })),
+    { model: 'off-catalog', source: 'env', stale: null });
+});
+
+test('resolveTitleModel: a stored id that left the catalog is reported as stale and skipped', () => {
+  assert.deepEqual(resolveTitleModel({ runModel: 'r' }, deps({ stored: () => 'gone', inCatalog: (id) => id !== 'gone' })),
+    { model: 'r', source: 'run', stale: 'gone' });
+  assert.deepEqual(resolveTitleModel({}, deps({ stored: () => 'gone', inCatalog: () => false })),
+    { model: DEFAULT_TITLE_MODEL, source: 'builtin', stale: 'gone' });
+});
+
+test('describeTitleModel: what the Settings card paints', () => {
+  assert.deepEqual(describeTitleModel(deps()), { model: null, source: 'run', stale: null });
+  assert.deepEqual(describeTitleModel(deps({ stored: () => 's' })), { model: 's', source: 'settings', stale: null });
+  assert.deepEqual(describeTitleModel(deps({ env: { WORCA_TITLE_MODEL: 'e' }, stored: () => 's' })), { model: 'e', source: 'env', stale: null });
+  assert.deepEqual(describeTitleModel(deps({ stored: () => 'gone', inCatalog: () => false })), { model: null, source: 'run', stale: 'gone' });
+});
+
+test('generateTitle spawns with the RUN model and --effort low when nothing else is configured', POSIX_SHIM, async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'worca-cc-title-model-'));
+  const out = join(dir, 'argv.txt');
+  const bin = join(dir, 'fake-claude.sh');
+  // The runner parses stream-json: the reply rides a `result` frame.
+  const frame = join(dir, 'frame.json');
+  await writeFile(frame, JSON.stringify({ type: 'result', result: 'Some Title' }) + '\n', 'utf8');
+  await writeFile(bin, '#!/bin/sh\nprintf "%s\\n" "$@" > ' + JSON.stringify(out) + '\ncat ' + JSON.stringify(frame) + '\nexit 0\n', 'utf8');
+  await chmod(bin, 0o755);
+  const prev = { WORCA_MOCK: process.env.WORCA_MOCK, WORCA_TITLE_MODEL: process.env.WORCA_TITLE_MODEL };
+  delete process.env.WORCA_MOCK; delete process.env.WORCA_TITLE_MODEL;
+  try {
+    const t = await generateTitle('some task', { cwd: dir, bin, runModel: 'endpoint-model-x' });
+    assert.equal(t, 'Some Title');
+    const argv = (await readFile(out, 'utf8')).split('\n');
+    assert.equal(argv[argv.indexOf('--model') + 1], 'endpoint-model-x', 'the run model is the title model');
+    assert.equal(argv[argv.indexOf('--effort') + 1], AUX_EFFORT, 'aux effort, not a pipeline EFFORTS member');
+    assert.equal(AUX_EFFORT, 'low');
+  } finally {
+    for (const [k, v] of Object.entries(prev)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('generateTitle reports a failed call ONCE through onError (with the model), still returns ""', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'worca-cc-title-err-'));
+  const prev = process.env.WORCA_MOCK;
+  delete process.env.WORCA_MOCK;
+  const calls = [];
+  try {
+    const t = await generateTitle('some task', {
+      cwd: dir, bin: join(dir, 'no-such-claude'), runModel: 'm1', mock: false,
+      onError: (info) => calls.push(info),
+    });
+    assert.equal(t, '');
+    assert.equal(calls.length, 1, 'exactly one report');
+    assert.equal(calls[0].model, 'm1');
+    assert.ok(calls[0].error instanceof Error && calls[0].error.message, 'carries the spawn error');
+  } finally {
+    if (prev === undefined) delete process.env.WORCA_MOCK; else process.env.WORCA_MOCK = prev;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('generateTitle: a throwing onError sink never breaks the caller; no report in mock mode success', async () => {
+  const t = await generateTitle('Add a settings page with dark mode', {
+    cwd: process.cwd(), mock: true, runModel: 'm1', onError: () => { throw new Error('sink boom'); },
+  });
+  assert.ok(t.length > 0, 'mock title produced');
+});
+
+test('run-harness passes the run model + an onError sink to generateTitle', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'worca-cc-title-harness-'));
+  try {
+    const orch = createOrchestrator({ projectDir: dir, prompt: 'p', auto: true, claude: { mock: true, model: 'run-model-z' } });
+    const o = orch._titleGenOpts();
+    assert.equal(o.runModel, 'run-model-z');
+    assert.equal(o.mock, true);
+    assert.equal(typeof o.onError, 'function');
+    // The sink writes a warn line into the run log rather than throwing.
+    const logged = [];
+    orch._log = (source, level, text) => logged.push({ source, level, text });
+    o.onError({ model: 'run-model-z', error: new Error('boom') });
+    assert.equal(logged.length, 1);
+    assert.equal(logged[0].level, 'warn');
+    assert.match(logged[0].text, /title generation failed \(model run-model-z\): boom/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/ui-settings-title-model.test.mjs
+++ b/test/ui-settings-title-model.test.mjs
@@ -1,0 +1,179 @@
+// test/ui-settings-title-model.test.mjs
+// Settings "Title generation" card (#422): a SELECT over the project-less
+// catalog with the New Pipeline optgroups, "Same as the run's model" as the
+// empty default, a stale stored id painted disabled + "not installed" with a
+// warn hint, the env-override note, Save/Use default posting exactly
+// { titleModel }, and Test hitting POST /api/models/:id/test. Boot copied from
+// test/ui-settings-debug-spawn.test.mjs. Fetch-stubbed only — no disk.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+const htmlPath = fileURLToPath(new URL('../ui/public/index.html', import.meta.url));
+const appPath = fileURLToPath(new URL('../ui/public/app.js', import.meta.url));
+
+const CATALOG = [
+  { id: 'claude-opus-5', label: 'Opus 5', efforts: ['medium', 'high'], custom: false, hasEnv: false },
+  { id: 'claude-haiku-4-5', label: 'Haiku 4.5', efforts: ['medium', 'high'], custom: false, hasEnv: false },
+  { id: 'corp-model', label: 'Corp', efforts: ['high'], custom: 'global', hasEnv: true },
+  { id: 'plug-model', label: 'Plug', efforts: ['high'], custom: 'plugin', plugin: 'vendor', hasEnv: true },
+  { id: 'legacy-model', label: 'Legacy', efforts: ['high'], custom: 'project', hasEnv: false },
+];
+
+const GET_BODY = ({ titleModel = null, titleModelEffective = { model: null, source: 'run', stale: null } } = {}) => ({
+  root: '/w', projectsRoot: '/p', projectsRootDefault: '/p', default: {}, chat: {},
+  pipelineCostLimitUsd: null, totalCostLimitUsd: null, costLimitResetPeriod: 'monthly',
+  askMaxTurns: 40, askMaxBudgetUsd: 2, debugSpawnEnabled: false, debugSpawnEffective: { enabled: false, source: 'settings' },
+  titleModel, titleModelEffective, hideBuiltinModels: false,
+});
+
+async function boot({ initial = {}, catalog = CATALOG, postResponse, testResponse } = {}) {
+  const dom = new JSDOM(readFileSync(htmlPath, 'utf8'), { url: 'http://localhost:4317/' });
+  const { window } = dom;
+  window.Element.prototype.scrollIntoView = function () {};
+  window.WebSocket = class { constructor() { this.readyState = 1; } send() {} close() {} addEventListener() {} };
+  const posts = [];
+  const tests = [];
+  window.fetch = (url, opts = {}) => {
+    const u = String(url);
+    const method = (opts.method || 'GET').toUpperCase();
+    if (u.includes('/api/settings')) {
+      if (method === 'POST') {
+        const body = JSON.parse(opts.body);
+        posts.push(body);
+        return Promise.resolve(postResponse || {
+          ok: true, status: 200,
+          json: async () => GET_BODY({
+            titleModel: body.titleModel || null,
+            titleModelEffective: body.titleModel ? { model: body.titleModel, source: 'settings', stale: null } : { model: null, source: 'run', stale: null },
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => GET_BODY(initial) });
+    }
+    if (/\/api\/models\/[^/]+\/test$/.test(u) && method === 'POST') {
+      tests.push(decodeURIComponent(u.match(/\/api\/models\/([^/]+)\/test$/)[1]));
+      return Promise.resolve(testResponse || { ok: true, status: 200, json: async () => ({ ok: true, text: 'OK' }) });
+    }
+    if (u.includes('/api/budget'))
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ pipelineLimitUsd: null, totalLimitUsd: null, resetPeriod: 'monthly', windowStartMs: 0, windowEndMs: 0, msUntilReset: 0, windowSpendUsd: 0, allTimeSpendUsd: 0, remainingUsd: null, blocked: false }) });
+    if (u.includes('/api/projects'))
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ projects: [] }) });
+    return Promise.resolve({ ok: true, status: 200, json: async () => ({ config: { steps: {}, customModels: [] }, models: catalog, efforts: ['medium', 'high'] }) });
+  };
+  for (const k of ['window', 'document', 'location', 'localStorage', 'WebSocket', 'fetch', 'navigator']) {
+    try { Object.defineProperty(globalThis, k, { value: window[k], configurable: true, writable: true }); } catch { /* keep */ }
+  }
+  globalThis.window = window; globalThis.document = window.document;
+  await import(pathToFileURL(appPath).href + `?b=${Date.now()}_${Math.random()}`);
+  await new Promise((r) => setTimeout(r, 0));
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+  const $ = (sel) => window.document.querySelector(sel);
+  const openSettings = async () => {
+    window.location.hash = 'settings';
+    window.dispatchEvent(new window.Event('hashchange'));
+    await tick(); await tick(); await tick();
+  };
+  return { window, posts, tests, tick, $, openSettings };
+}
+
+const optionsOf = ($) => [...$('#titleModel').options].map((o) => ({ value: o.value, text: o.textContent, group: o.parentElement.tagName === 'OPTGROUP' ? o.parentElement.label : null, disabled: o.disabled }));
+
+test('ui-settings-title-model: default paints "Same as the run\'s model" selected + the three optgroups, legacy project models excluded', async () => {
+  const { $, openSettings } = await boot();
+  await openSettings();
+  const sel = $('#titleModel');
+  assert.ok(sel, 'card rendered');
+  assert.equal(sel.value, '');
+  const opts = optionsOf($);
+  assert.deepEqual(opts[0], { value: '', text: "Same as the run's model", group: null, disabled: false });
+  assert.deepEqual(opts.filter((o) => o.group).map((o) => [o.group, o.value]), [
+    ['Your models', 'corp-model'], ['From plugins', 'plug-model'], ['Built-in', 'claude-haiku-4-5'], ['Built-in', 'claude-opus-5'],
+  ]);
+  assert.equal(opts.find((o) => o.value === 'plug-model').text, 'Plug (vendor)', 'plugin provenance suffix');
+  assert.ok(!opts.some((o) => o.value === 'legacy-model'), 'legacy per-project models are not global');
+  assert.equal($('#titleModelTest').disabled, true, 'nothing to test on the default');
+  assert.equal($('#titleModelEnvNote').textContent, '');
+});
+
+test('ui-settings-title-model: a stored id is selected; hidden built-ins leave the list unless stored', async () => {
+  const catalog = CATALOG.map((m) => (m.custom === false ? { ...m, hidden: true } : m));
+  const { $, openSettings } = await boot({ initial: { titleModel: 'claude-opus-5', titleModelEffective: { model: 'claude-opus-5', source: 'settings', stale: null } }, catalog });
+  await openSettings();
+  assert.equal($('#titleModel').value, 'claude-opus-5');
+  const opts = optionsOf($);
+  assert.ok(opts.some((o) => o.value === 'claude-opus-5' && o.group === 'Built-in'), 'the stored built-in stays');
+  assert.ok(!opts.some((o) => o.value === 'claude-haiku-4-5'), 'other hidden built-ins are gone');
+  assert.equal($('#titleModelTest').disabled, false);
+});
+
+test('ui-settings-title-model: a stale stored id paints disabled + "not installed" and a warn hint; Save refuses it', async () => {
+  const { $, posts, openSettings, tick } = await boot({ initial: { titleModel: 'gone-model', titleModelEffective: { model: null, source: 'run', stale: 'gone-model' } } });
+  await openSettings();
+  const sel = $('#titleModel');
+  assert.equal(sel.value, 'gone-model');
+  const o = optionsOf($).find((x) => x.value === 'gone-model');
+  assert.deepEqual(o, { value: 'gone-model', text: 'gone-model — not installed', group: null, disabled: true });
+  assert.match($('#titleModelEnvNote').textContent, /"gone-model" is no longer in the catalog — titles fall back to the run's model/);
+  assert.ok($('#titleModelEnvNote').className.includes('warn'));
+  assert.equal($('#titleModelTest').disabled, true);
+  $('#titleModelSave').click();
+  await tick();
+  assert.equal(posts.length, 0, 'a not-installed id is never posted');
+  assert.match($('#titleModelMsg').textContent, /no longer installed/);
+});
+
+test('ui-settings-title-model: env override note', async () => {
+  const { $, openSettings } = await boot({ initial: { titleModel: 'corp-model', titleModelEffective: { model: 'env-model', source: 'env', stale: null } } });
+  await openSettings();
+  assert.match($('#titleModelEnvNote').textContent, /WORCA_TITLE_MODEL is set in the environment: titles use env-model regardless/);
+});
+
+test('ui-settings-title-model: Save posts exactly { titleModel }, Use default posts { titleModel: "" }, and the card repaints', async () => {
+  const { $, posts, openSettings, tick } = await boot();
+  await openSettings();
+  $('#titleModel').value = 'corp-model';
+  $('#titleModel').dispatchEvent(new (globalThis.window.Event)('change'));
+  assert.equal($('#titleModelTest').disabled, false, 'Test enables on a real pick');
+  $('#titleModelSave').click();
+  await tick(); await tick(); await tick();
+  assert.deepEqual(posts, [{ titleModel: 'corp-model' }]);
+  assert.equal($('#titleModel').value, 'corp-model');
+  assert.match($('#titleModelMsg').textContent, /Saved\. Applies to the next title/);
+  $('#titleModelReset').click();
+  await tick(); await tick(); await tick();
+  assert.deepEqual(posts[1], { titleModel: '' });
+  assert.equal($('#titleModel').value, '');
+});
+
+test('ui-settings-title-model: a 400 from the server surfaces in the hint', async () => {
+  const { $, openSettings, tick } = await boot({ postResponse: { ok: false, status: 400, json: async () => ({ error: 'unknown model "corp-model" — pick one from the catalog' }) } });
+  await openSettings();
+  $('#titleModel').value = 'corp-model';
+  $('#titleModelSave').click();
+  await tick(); await tick();
+  assert.match($('#titleModelMsg').textContent, /unknown model "corp-model"/);
+  assert.ok($('#titleModelMsg').className.includes('err'));
+});
+
+test('ui-settings-title-model: Test posts to /api/models/:id/test and paints the reply / the hint', async () => {
+  const ok = await boot({ initial: { titleModel: 'corp-model', titleModelEffective: { model: 'corp-model', source: 'settings', stale: null } } });
+  await ok.openSettings();
+  ok.$('#titleModelTest').click();
+  await ok.tick(); await ok.tick();
+  assert.deepEqual(ok.tests, ['corp-model']);
+  assert.match(ok.$('#titleModelMsg').textContent, /✓ corp-model replied: OK/);
+  assert.equal(ok.$('#titleModelTest').disabled, false, 're-enabled after the call');
+
+  const bad = await boot({
+    initial: { titleModel: 'corp-model', titleModelEffective: { model: 'corp-model', source: 'settings', stale: null } },
+    testResponse: { ok: true, status: 200, json: async () => ({ ok: false, errorClass: 'auth', message: 'x', hint: 'authentication failed — check the token/secret for this model' }) },
+  });
+  await bad.openSettings();
+  bad.$('#titleModelTest').click();
+  await bad.tick(); await bad.tick();
+  assert.match(bad.$('#titleModelMsg').textContent, /✗ authentication failed/);
+  assert.ok(bad.$('#titleModelMsg').className.includes('err'));
+});

--- a/test/ui-settings-tooltips.test.mjs
+++ b/test/ui-settings-tooltips.test.mjs
@@ -17,10 +17,10 @@ const settingsView = () => {
   return dom.window.document.querySelector('.view[data-view="settings"]');
 };
 
-test('settings: eleven info-tip icons, each with non-empty tip content', () => {
+test('settings: twelve info-tip icons, each with non-empty tip content', () => {
   const view = settingsView();
   const tips = [...view.querySelectorAll('button.info-tip')];
-  assert.equal(tips.length, 11, 'eleven ⓘ icons (2 folder fields, budget heading, 3 budget fields, ask heading, 2 ask fields, chat history, spawn diagnostics)');
+  assert.equal(tips.length, 12, 'twelve ⓘ icons (2 folder fields, budget heading, 3 budget fields, ask heading, 2 ask fields, chat history, title generation, spawn diagnostics)');
   for (const tip of tips) {
     assert.equal(tip.getAttribute('type'), 'button', 'icon must not submit anything');
     assert.match(tip.getAttribute('aria-label') || '', /^About /, 'icon names its setting');

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -2490,7 +2490,9 @@ function renderModelEffortPair(modelSel, effortSel, caption, sel = {}) {
   };
   optgroup('Your models', state.models.filter((m) => m.custom && m.custom !== 'plugin').sort(byLabel));
   optgroup('Plugins', state.models.filter((m) => m.custom === 'plugin').sort(byLabel));
-  optgroup('Built-in', state.models.filter((m) => !m.custom).sort(byLabel));
+  // "Hide built-in models" (#422): a hidden built-in leaves the list — unless
+  // it is THIS selection, which still resolves and must stay visible.
+  optgroup('Built-in', state.models.filter((m) => !m.custom && (!m.hidden || m.id === sel.model)).sort(byLabel));
   modelSel.appendChild(option('__add__', '+ Add model…'));
   modelSel.value = sel.model || '';
 
@@ -7790,6 +7792,7 @@ async function loadSettings() {
     paintBudgetSettings(data);
     paintAskSettings(data);
     paintDebugSpawnSettings(data);
+    await paintTitleModelSettings(data);
     paintBudgetReadout();
     refreshBudget();
     paintChatSettings(data.chat);
@@ -8232,6 +8235,105 @@ function saveDebugSpawn() {
 }
 document.getElementById('debugSpawnSave')?.addEventListener('click', saveDebugSpawn);
 document.getElementById('debugSpawnReset')?.addEventListener('click', () => postDebugSpawn({ debugSpawnEnabled: false }));
+
+// ---- Title generation card (#422) ----
+// A SELECT over the project-less catalog, never a text field: free text could
+// store an id resolveModelEnv cannot route, and the failure would only show up
+// as a missing title minutes into a run. Same optgroups + order as the New
+// Pipeline picker. `titleModelCatalog` is fetched on every Settings paint so the
+// options track catalog edits without a reload.
+const TITLE_MODEL_DEFAULT_LABEL = "Same as the run's model";
+let titleModelCatalog = [];
+function setTitleModelMsg(text, kind) { setHintMsg('titleModelMsg', text, kind); }
+async function fetchTitleModelCatalog() {
+  try {
+    const res = await fetch('/api/config');
+    const data = await safeJson(res);
+    return res.ok && Array.isArray(data.models) ? data.models : [];
+  } catch { return []; }
+}
+function buildTitleModelOptions(sel, stored) {
+  sel.innerHTML = '';
+  sel.appendChild(option('', TITLE_MODEL_DEFAULT_LABEL));
+  const byLabel = (a, b) => (a.label || a.id).localeCompare(b.label || b.id, undefined, { sensitivity: 'base' });
+  // Legacy per-project entries are not global — titles are; hidden built-ins
+  // stay out unless one IS the stored pick (it still resolves).
+  const models = titleModelCatalog.filter((m) => m && m.custom !== 'project' && (!m.hidden || m.id === stored));
+  const group = (label, xs) => {
+    if (!xs.length) return;
+    const og = document.createElement('optgroup');
+    og.label = label;
+    for (const m of xs) og.appendChild(option(m.id, (m.label || m.id) + (m.custom === 'plugin' && m.plugin ? ` (${m.plugin})` : '')));
+    sel.appendChild(og);
+  };
+  group('Your models', models.filter((m) => m.custom && m.custom !== 'plugin').sort(byLabel));
+  group('From plugins', models.filter((m) => m.custom === 'plugin').sort(byLabel));
+  group('Built-in', models.filter((m) => !m.custom).sort(byLabel));
+  if (stored && !models.some((m) => m.id === stored)) {
+    // Loud degrade: the stored id left the catalog (plugin removed, entry deleted).
+    const o = option(stored, `${stored} — not installed`);
+    o.disabled = true;
+    sel.appendChild(o);
+  }
+  sel.value = stored;
+}
+async function paintTitleModelSettings(data) {
+  const sel = document.getElementById('titleModel');
+  if (!sel) return;
+  titleModelCatalog = await fetchTitleModelCatalog();
+  const stored = typeof data.titleModel === 'string' ? data.titleModel : '';
+  buildTitleModelOptions(sel, stored);
+  const eff = data.titleModelEffective || {};
+  let note = '', kind = '';
+  if (eff.source === 'env') {
+    note = `WORCA_TITLE_MODEL is set in the environment: titles use ${eff.model} regardless of this setting.`; kind = 'warn';
+  } else if (eff.stale) {
+    note = `Model "${eff.stale}" is no longer in the catalog — titles fall back to the run's model.`; kind = 'warn';
+  }
+  setHintMsg('titleModelEnvNote', note, kind);
+  const testBtn = document.getElementById('titleModelTest');
+  if (testBtn) testBtn.disabled = !sel.value || sel.options[sel.selectedIndex]?.disabled;
+}
+function postTitleModel(body) {
+  return postSettingsCard(body, {
+    setMsg: setTitleModelMsg, paint: paintTitleModelSettings,
+    savedText: 'Saved. Applies to the next title — no restart needed.',
+  });
+}
+document.getElementById('titleModelSave')?.addEventListener('click', () => {
+  const sel = document.getElementById('titleModel');
+  const opt = sel.options[sel.selectedIndex];
+  if (opt && opt.disabled) { setTitleModelMsg('that model is no longer installed — pick another or use the default', 'err'); return; }
+  postTitleModel({ titleModel: sel.value || '' });
+});
+document.getElementById('titleModelReset')?.addEventListener('click', () => postTitleModel({ titleModel: '' }));
+document.getElementById('titleModel')?.addEventListener('change', () => {
+  const sel = document.getElementById('titleModel');
+  const testBtn = document.getElementById('titleModelTest');
+  if (testBtn) testBtn.disabled = !sel.value || sel.options[sel.selectedIndex]?.disabled;
+});
+// Test = the Models-view Test button verbatim (POST /api/models/:id/test): one
+// tiny spawn through the id's catalog routing. Without it the first evidence of
+// a bad pick is a missing title three minutes into a run.
+document.getElementById('titleModelTest')?.addEventListener('click', async () => {
+  const sel = document.getElementById('titleModel');
+  const btn = document.getElementById('titleModelTest');
+  const id = sel.value;
+  if (!id) return;
+  btn.disabled = true;
+  setTitleModelMsg(`Testing ${id}…`);
+  try {
+    const res = await fetch(`/api/models/${encodeURIComponent(id)}/test`, { method: 'POST' });
+    const data = await safeJson(res);
+    if (!res.ok) setTitleModelMsg(`✗ ${data.error || `HTTP ${res.status}`}`, 'err');
+    else if (data.ok) setTitleModelMsg(`✓ ${id} replied: ${data.text}`);
+    else setTitleModelMsg(`✗ ${data.hint || data.message}`, 'err');
+  } catch (e) {
+    setTitleModelMsg(`✗ ${e.message}`, 'err');
+  } finally {
+    btn.disabled = false;
+  }
+});
 
 // Browse… for the projects root: native OS dialog, in-app modal fallback —
 // the same two endpoints the add-project Browse button uses (app.js:3793).
@@ -8889,9 +8991,32 @@ function renderModelsViewBody() {
     plugins: d.plugin || [],
     predefined: d.predefined || [],
     efforts: d.efforts || [],
+    hideBuiltin: !!d.hideBuiltinModels,
     projectName: pp ? pp.split('/').pop() : '',
   }));
   el.modelsList.replaceChildren(frag);
+}
+
+// "Hide built-in models" (#422): one settings key, saved on change. Every picker
+// reads the flag off /api/config, so the refresh below repaints them all.
+async function saveHideBuiltinModels(cb) {
+  const wanted = cb.checked;
+  cb.disabled = true;
+  try {
+    const res = await fetch('/api/settings', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hideBuiltinModels: wanted }),
+    });
+    const data = await safeJson(res);
+    if (!res.ok) { cb.checked = !wanted; return setModelsMsg(data.error || `HTTP ${res.status}`, 'err'); }
+    setModelsMsg(wanted ? 'Built-in models hidden from every picker. Runs that already use one keep working.' : 'Built-in models shown again.');
+    await refreshModelsEverywhere();
+  } catch (e) {
+    cb.checked = !wanted;
+    setModelsMsg(e.message, 'err');
+  } finally {
+    cb.disabled = false;
+  }
 }
 
 // "Edit a copy" prefill (design §9.6): create-mode editor seeded from a plugin
@@ -9197,6 +9322,10 @@ async function testModelFlow(btn) {
 }
 
 if (el.modelsList) {
+  el.modelsList.addEventListener('change', (ev) => {
+    const t = ev.target;
+    if (t && t.classList && t.classList.contains('mv-hide-builtin')) saveHideBuiltinModels(t);
+  });
   el.modelsList.addEventListener('click', (ev) => {
     const t = ev.target.closest('button');
     if (!t) return;

--- a/ui/public/ask-panel.mjs
+++ b/ui/public/ask-panel.mjs
@@ -829,8 +829,9 @@ export function createAskPanel({ doc, win, fetch, sendWs, confirm, getPageContex
     };
     const list = st.catalog && Array.isArray(st.catalog.models) ? st.catalog.models : [];
     const wantedEntry = catalogEntry(wanted.model);
-    // Unknown stored/default id -> the backend default -> the first model we do have.
-    const entry = wantedEntry || catalogEntry(fallback.model) || list[0] || null;
+    // Unknown stored/default id -> the backend default -> the first model we do
+    // have that is not a hidden built-in (#422; a hidden id is still a valid pick).
+    const entry = wantedEntry || catalogEntry(fallback.model) || list.find((m) => m && !m.hidden) || list[0] || null;
     if (!entry) { updatePickerButton(); return; }  // empty catalog: keep what we have
     const effort = wantedEntry ? wanted.effort : fallback.effort;
     const next = { model: entry.id, effort: coerceEffort(entry, effort) };
@@ -885,6 +886,7 @@ export function createAskPanel({ doc, win, fetch, sendWs, confirm, getPageContex
     const seen = new Set();
     for (const m of st.catalog ? st.catalog.models : []) {
       if (!m || typeof m.id !== 'string') continue;
+      if (m.hidden && m.id !== st.picker.model) continue;         // hidden built-in (#422); the current pick stays
       if (m.custom === 'global') { primary.push(m); continue; }   // user models are never demoted
       const fam = familyKey(m);
       // The picked model always shows up front so its ✓ is visible and it is one click away.

--- a/ui/public/graph/inspector.mjs
+++ b/ui/public/graph/inspector.mjs
@@ -93,8 +93,11 @@ export function renderNodeInspector(node, { template, portsFn, meta = null, mode
 
   if (node.kind === 'agent') {
     root.appendChild(head(doc, (meta && meta.displayName) || node.key || node.id, `${node.key} · ${node.id}`));
+    // Hidden built-ins (#422) leave the list unless one is THIS node's stored
+    // pick — it still resolves at run time and must stay visible here.
+    const offered = models.filter((m) => m && (!m.hidden || m.id === node.config.model));
     body.appendChild(select(doc, 'ins-model', 'model', 'Model',
-      [{ value: '', text: 'inherit' }, ...models.map((m) => ({ value: m.id, text: m.label || m.id }))], node.config.model));
+      [{ value: '', text: 'inherit' }, ...offered.map((m) => ({ value: m.id, text: m.label || m.id }))], node.config.model));
     body.appendChild(select(doc, 'ins-effort', 'effort', 'Effort',
       [{ value: '', text: 'default' }, ...efforts.map((e) => ({ value: e, text: e }))], node.config.effort));
     if (meta && meta.fanOut) {

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1156,6 +1156,39 @@
               </div>
             </section>
 
+            <!-- Title generation (#422): which model writes run/chat titles.
+                 Empty = the model of the run or chat itself (title.mjs
+                 resolveTitleModel), so a first-party-free install needs no setup.
+                 The select is built from the project-less catalog; a stored id
+                 that left the catalog paints disabled + "not installed". -->
+            <section class="card settings-card" id="title-model-settings-card">
+              <div class="card-head">
+                <div class="label-row">
+                  <h2>Title generation</h2>
+                  <button type="button" class="info-tip" aria-label="About title generation">i<span class="tip-content hidden">
+                    Every run and chat gets a short LLM-written title. By default it is written by the
+                    model the run or chat itself uses, so an install without a first-party Anthropic
+                    account needs no setup here. Pick a model to write every title with it instead;
+                    the change applies to the next title, no restart. A non-empty
+                    <code>WORCA_TITLE_MODEL</code> in the environment overrides this setting.
+                  </span></button>
+                </div>
+              </div>
+              <div class="field">
+                <div class="label-row">
+                  <label for="titleModel">Model</label>
+                </div>
+                <select id="titleModel" class="select" aria-label="Title model"></select>
+              </div>
+              <small class="hint" id="titleModelEnvNote"></small>
+              <div class="add-project-actions" style="margin-top:14px">
+                <button type="button" id="titleModelTest" class="btn btn-ghost btn-mini" title="Send one tiny prompt to the selected model">Test</button>
+                <button type="button" id="titleModelReset" class="btn btn-ghost btn-mini">Use default</button>
+                <button type="button" id="titleModelSave" class="btn btn-primary btn-mini">Save</button>
+              </div>
+              <small class="hint" id="titleModelMsg"></small>
+            </section>
+
             <!-- Spawn-debug diagnostics: the stored side of WORCA_DEBUG_SPAWN.
                  claude-runner.mjs reads the setting per spawn (UI server AND CLI);
                  a non-empty env var overrides it. This card only flips the gate —

--- a/ui/public/models-view.mjs
+++ b/ui/public/models-view.mjs
@@ -77,7 +77,7 @@ export function suggestDuplicateId(id, takenIds = []) {
  * `globals` come MASKED from GET /api/models. `predefinedShadowedIds` marks
  * built-ins currently overridden by a global entry.
  */
-export function renderModelsList({ globals = [], legacy = [], plugins = [], predefined = [], efforts = [], projectName = '' } = {}, { doc = globalThis.document } = {}) {
+export function renderModelsList({ globals = [], legacy = [], plugins = [], predefined = [], efforts = [], hideBuiltin = false, projectName = '' } = {}, { doc = globalThis.document } = {}) {
   const root = h(doc, 'div', 'mv-list');
   const predefLc = new Set(predefined.map((m) => m.id.toLowerCase()));
   const pluginLc = new Set(plugins.map((m) => m.id.toLowerCase()));
@@ -88,6 +88,30 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
     if (hint) s.appendChild(h(doc, 'small', 'hint', hint));
     return s;
   };
+
+  // The endpoint-routed badge (#422): honest disclosure that worca points the
+  // CLI's internal haiku/sonnet/opus/fable lookups at this model's own id
+  // (config.mjs#resolveModelEnv), so nothing falls back to the Anthropic API.
+  // The masked env still carries its KEYS, so presence is decidable here.
+  const routedBadge = (m) => {
+    if (!m.env || !Object.prototype.hasOwnProperty.call(m.env, 'ANTHROPIC_BASE_URL')) return null;
+    const b = h(doc, 'span', 'badge waiting mv-routed', 'endpoint-routed');
+    b.title = "worca points Claude Code's internal haiku/sonnet/opus/fable lookups at this model, so it never falls back to the Anthropic API.";
+    return b;
+  };
+
+  // ── Hide built-in models (#422) — one checkbox, top of the pane ──
+  const hideRow = h(doc, 'div', 'mv-hide-builtin-row');
+  const hideLabel = h(doc, 'label', 'check-row');
+  const hideCb = h(doc, 'input', 'mv-hide-builtin');
+  hideCb.type = 'checkbox';
+  hideCb.checked = !!hideBuiltin;
+  hideLabel.appendChild(hideCb);
+  hideLabel.appendChild(doc.createTextNode(" Hide built-in models (you don't use a first-party Anthropic account)"));
+  hideRow.appendChild(hideLabel);
+  hideRow.appendChild(h(doc, 'small', 'hint',
+    'Drops the built-ins from every model picker — new pipelines, the composer, Ask Worca, title generation. Cosmetic only: a run or reference that already names one keeps working.'));
+  root.appendChild(hideRow);
 
   // ── Your models (global) ──
   const yours = section('Your models', 'Defined once, available in every project. An entry with a built-in id overrides that built-in.');
@@ -102,6 +126,8 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
     head.appendChild(h(doc, 'b', 'mv-name', m.label || m.id));
     if (predefLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadow', 'overrides built-in'));
     else if (pluginLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadow', 'overrides plugin'));
+    const rb = routedBadge(m);
+    if (rb) head.appendChild(rb);
     // The §4.6 "unreliable" badge is meaningless once an override GOVERNS this
     // model's spend — and the backend only lifts the stored flag on the model's
     // next result event, so suppress it here the moment pricing is pinned.
@@ -169,6 +195,8 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
       head.appendChild(h(doc, 'b', 'mv-name', m.label || m.id));
       head.appendChild(h(doc, 'span', 'badge waiting mv-origin', `plugin: ${m.plugin}`));
       if (globalLc.has(m.id.toLowerCase())) head.appendChild(h(doc, 'span', 'badge violet mv-shadowed', 'overridden by your copy'));
+      const prb = routedBadge(m);
+      if (prb) head.appendChild(prb);
       // Same rule as a global card: a manifest-pinned price governs the spend,
       // so the §4.6 "unreliable" flag says nothing about it.
       if (m.costUnreliable && !m.cost) head.appendChild(h(doc, 'span', 'badge waiting mv-cost', 'cost not verified'));
@@ -199,8 +227,11 @@ export function renderModelsList({ globals = [], legacy = [], plugins = [], pred
   }
 
   // ── Built-ins (read-only) ──
-  const builtins = section('Built-in models', 'Shipped with worca. Add a model with the same id to override its label, efforts, or routing.');
-  for (const m of predefined) {
+  const builtins = section('Built-in models', hideBuiltin
+    ? `Hidden from every picker (${predefined.length} built-in${predefined.length === 1 ? '' : 's'}) — untick the box above to show them.`
+    : 'Shipped with worca. Add a model with the same id to override its label, efforts, or routing.');
+  builtins.classList.add(hideBuiltin ? 'mv-builtins-hidden' : 'mv-builtins-shown');
+  for (const m of hideBuiltin ? [] : predefined) {
     const row = h(doc, 'div', 'mv-builtin');
     row.dataset.id = m.id;
     row.appendChild(h(doc, 'b', 'mv-name', m.label));

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1624,6 +1624,8 @@ fieldset.source legend{font-weight:600;font-size:13px;padding:0 6px;color:var(--
 /* ---- Models view (configurable-models-design.md §4.10) ---- */
 .mv-list{display:grid;gap:18px;}
 .mv-section{display:grid;gap:10px;}
+.mv-hide-builtin-row{display:grid;gap:6px;padding:10px 12px;border:1px solid var(--line-2,#e6e6ec);border-radius:10px;}
+.mv-hide-builtin-row .hint{margin:0;}
 .mv-section-title{margin:4px 0 0;font-size:13px;text-transform:uppercase;letter-spacing:.04em;opacity:.75;}
 .mv-card{padding:16px 20px;display:flex;align-items:center;gap:14px;}
 .mv-body{flex:1 1 auto;min-width:0;}

--- a/ui/server.mjs
+++ b/ui/server.mjs
@@ -42,7 +42,10 @@ import {
   askMaxTurns, askMaxBudgetUsd, setAskMaxTurns, setAskMaxBudgetUsd, assertAskLimitInputs,
   chatPrefs, setChatPrefs,
   debugSpawnEnabled as storedDebugSpawnEnabled, effectiveDebugSpawn, setDebugSpawnEnabled, assertDebugSpawnInput, SETTINGS_POST_KEYS,
+  titleModel as storedTitleModel, setTitleModel, assertTitleModelInput,
+  hideBuiltinModels, setHideBuiltinModels, assertHideBuiltinModelsInput,
 } from '../src/core/settings.mjs';
+import { describeTitleModel } from '../src/core/title.mjs';
 import {
   ASK_ID_RE, createThread as askCreateThread, getThread as askGetThread,
   listThreads as askListThreads, updateThread as askUpdateThread,
@@ -85,7 +88,7 @@ import { pickFolderNative } from '../src/core/folder-dialog.mjs';
 import { listFolders } from '../src/core/fs-browse.mjs';
 import {
   readConfig, setStep, addCustomModel, removeCustomModel, listModels,
-  PREDEFINED_MODELS, agentSteps, EFFORTS,
+  PREDEFINED_MODELS, agentSteps, EFFORTS, catalogHasModel,
   readRunConfig, setNodeModel, setFeedbackCycles, setWireCycles, setActiveWorkflow, resetWorkflowConfig,
   globalModelRefs, removeGlobalModelAndRefs, promoteCustomModel, costUnreliableModelIds,
 } from '../src/core/config.mjs';
@@ -2793,6 +2796,9 @@ const settingsState = () => ({
   askMaxBudgetUsd: askMaxBudgetUsd(),
   debugSpawnEnabled: storedDebugSpawnEnabled(),          // what is STORED (the checkbox)
   debugSpawnEffective: effectiveDebugSpawn(),             // what the next spawn will DO, and why
+  titleModel: storedTitleModel(),                         // the STORED id (the select), null = run's model
+  titleModelEffective: describeTitleModel(),              // env override / stale id, for the hint line (#422)
+  hideBuiltinModels: hideBuiltinModels(),
 });
 
 // ---------------------------------------------------------------------------
@@ -2852,6 +2858,12 @@ app.post('/api/settings', async (req, res) => {
   const hasBudgetKey = has('pipelineCostLimitUsd') || has('totalCostLimitUsd') || has('costLimitResetPeriod');
   const hasAskKey = has('askMaxTurns') || has('askMaxBudgetUsd');
   const hasDebugSpawnKey = has('debugSpawnEnabled');
+  const hasTitleModelKey = has('titleModel');
+  const hasHideBuiltinKey = has('hideBuiltinModels');
+  // #422: the title model is a SELECT over the catalog, so an id that is not a
+  // catalog member is a client bug (or a stale option) — refuse it here rather
+  // than store an id resolveModelEnv could never route.
+  const titleModelInput = hasTitleModelKey ? (body.titleModel ?? '') : undefined;
   // Normalize the budget keys first, then validate them as a SET before ANY write.
   // Each setter persists on its own, so a two-key POST whose second key is invalid
   // used to answer 400 with the first key already on disk, no budget-changed
@@ -2873,6 +2885,13 @@ app.post('/api/settings', async (req, res) => {
     assertCostLimitInputs(budget);
     assertAskLimitInputs(ask);
     if (hasDebugSpawnKey) assertDebugSpawnInput(body.debugSpawnEnabled);
+    if (hasTitleModelKey) {
+      assertTitleModelInput(titleModelInput);
+      if (titleModelInput !== '' && titleModelInput !== null && !catalogHasModel(titleModelInput)) {
+        throw new Error(`unknown model ${JSON.stringify(String(titleModelInput))} — pick one from the catalog`);
+      }
+    }
+    if (hasHideBuiltinKey) assertHideBuiltinModelsInput(body.hideBuiltinModels);
     // Root first: it is the one key whose setter can still fail AFTER the asserts
     // above (an unusable path), so every other key's write must come after it or
     // a mixed POST would answer 400 with those keys already applied on disk.
@@ -2891,10 +2910,12 @@ app.post('/api/settings', async (req, res) => {
     if (has('askMaxTurns')) await setAskMaxTurns(ask.askMaxTurns);
     if (has('askMaxBudgetUsd')) await setAskMaxBudgetUsd(ask.askMaxBudgetUsd);
     if (hasDebugSpawnKey) await setDebugSpawnEnabled(body.debugSpawnEnabled);
+    if (hasTitleModelKey) await setTitleModel(titleModelInput);
+    if (hasHideBuiltinKey) await setHideBuiltinModels(body.hideBuiltinModels);
     if (hasBudgetKey) emitChanged('budget-changed');
     // Other open tabs repaint their Settings cards (a stale tab could otherwise
     // "save" its old checkbox state over this one with no feedback to either).
-    if (hasAskKey || hasDebugSpawnKey) emitChanged('settings-changed');
+    if (hasAskKey || hasDebugSpawnKey || hasTitleModelKey || hasHideBuiltinKey) emitChanged('settings-changed');
     res.json({ ...settingsState(), chat: chatPrefs() });
   } catch (err) {
     // The setters throw only on an unusable path -> client error (400).
@@ -3115,7 +3136,10 @@ const pluginModelsPayload = () => {
 };
 
 app.get('/api/models', (req, res) => {
-  res.json({ models: maskedGlobalModels(), plugin: pluginModelsPayload(), predefined: PREDEFINED_MODELS, efforts: EFFORTS });
+  res.json({
+    models: maskedGlobalModels(), plugin: pluginModelsPayload(), predefined: PREDEFINED_MODELS, efforts: EFFORTS,
+    hideBuiltinModels: hideBuiltinModels(),   // the Models-view checkbox (#422)
+  });
 });
 
 app.post('/api/models', async (req, res) => {
@@ -3328,7 +3352,10 @@ app.post('/api/models/:id/test', async (req, res) => {
   const lc = id.toLowerCase();
   const global = listGlobalModels().find((m) => m.id.toLowerCase() === lc);
   const plugin = global ? null : listPluginModels().find((m) => m.id.toLowerCase() === lc);
-  if (!global && !plugin) return res.status(404).json({ error: `unknown model id ${JSON.stringify(id)}` });
+  // A built-in is testable too (#422): the Title-generation card offers it, and
+  // a first-party id with no routing env is exactly the spawn a run would make.
+  const builtin = !global && !plugin && PREDEFINED_MODELS.some((m) => m.id.toLowerCase() === lc);
+  if (!global && !plugin && !builtin) return res.status(404).json({ error: `unknown model id ${JSON.stringify(id)}` });
   if (plugin && plugin.secrets.length) {
     // Don't burn a spawn guaranteed to fail — resolveModelEnv drops unset secrets.
     const unset = pluginModelSecretStatus(plugin.plugin)


### PR DESCRIPTION
Closes #422.

worca can already be pointed entirely at third-party / self-hosted inference through the model catalog, but several code paths still assumed a first-party Anthropic id was reachable. The most visible one was title generation, which hard-coded `claude-haiku-4-5-20251001` at module load. This PR makes an install with **no first-party model** work with zero configuration, and adds the two small opt-in surfaces the issue asked for.

## What changed

### 1. Title generation defaults to the caller's model (no UI)
- `title.mjs` decides its model **per call** (`resolveTitleModel`): explicit `opts.model` → non-empty `WORCA_TITLE_MODEL` → stored `titleModel` setting (only while it is still a catalog member; a stale id is reported and skipped) → **the run's / chat's model** → built-in `claude-haiku-4-5`.
- Both callers now pass their model: the run harness passes `this.claude.model`, the Ask turn passes `this.model`.
- The last-resort id is the **built-in** `claude-haiku-4-5`, not the dated API id, so a global entry that shadows the built-in Haiku actually routes title calls.
- A failed title call reports once through `onError`; the harness writes a `warn` line into the run log, the Ask turn to the server log. Return contract (`''`) unchanged.
- Effort stays `low` — the CLI accepts it (`--effort low|medium|high|xhigh|max` in 2.1.259) and it is the cheapest tier. It is now `AUX_EFFORT` in `model-env.mjs`, shared with the Models-view Test button, deliberately outside `EFFORTS` (the issue's "clamp to EFFORTS" criterion would have made titles cost more).

### 2. Tier keys for endpoint-routed models (no UI)
`resolveModelEnv` fills `ANTHROPIC_DEFAULT_{HAIKU,SONNET,OPUS,FABLE}_MODEL` and the legacy `ANTHROPIC_SMALL_FAST_MODEL` with the entry's wire id (`ANTHROPIC_MODEL`, else the catalog id) whenever `ANTHROPIC_BASE_URL` is set and the entry leaves them unset. Explicit keys always win. Four tiers, not three: the installed CLI binary also resolves a `FABLE` tier. Every consumer of `resolveModelEnv` (pipeline nodes, Ask, title, overview, agent-gen, model test) gets it. Disclosed by an `endpoint-routed` badge on Models-view cards and in the existing Spawn diagnostics line.

### 3. Hide built-in models (one checkbox, Settings › Models)
Stored as `hideBuiltinModels`. `composeCatalog` marks the *unshadowed* built-ins `hidden: true`; the New Pipeline picker, composer inspector, Ask picker, and the Title select skip them unless one is the current selection. A hidden id **still resolves** — stored runs and plugin references keep working; validation never looks at the flag.

### 4. Title generation card (Settings › General, under Ask Worca)
A `<select>` over the project-less catalog (Your models / From plugins / Built-in), default option *"Same as the run's model"*, a Test button reusing `POST /api/models/:id/test` (which now accepts built-in ids too), Save / Use default, and a loud hint when the stored id has left the catalog or when `WORCA_TITLE_MODEL` overrides it. The server refuses a `titleModel` that is not a catalog member (400).

### 5. Ask Worca default (no UI)
`pickDefault` skips hidden built-ins, so on an install that hides them the picker opens on the first model the user owns. The panel's cold-start literal is unchanged (it is replaced as soon as the catalog loads).

## Acceptance criteria from the issue
- [x] No-first-party install produces LLM titles for runs and chats with no settings change — `runModel` precedence, `test/title-model.test.mjs`
- [x] Changing the title model applies to the next title, no restart — per-call resolution, `test/ui-settings-title-model.test.mjs`
- [x] A title model that left the catalog degrades to the run's model **and says so** — `titleModelEffective.stale`, disabled "not installed" option + warn hint
- [~] `title.mjs` passes a valid effort — it passes `AUX_EFFORT = 'low'`, which the CLI accepts; see §1 for why it is not clamped into `EFFORTS`
- [x] Endpoint-routed model spawns with the tier keys set — `test/model-env-tier.test.mjs`
- [x] With "Hide built-in models" ticked no built-in appears in any picker, but a stored run referencing one still resolves — `hidden` flag, `test/title-model-settings.test.mjs`, `test/api-models.test.mjs`
- [x] The Ask panel's initial pick is a catalog member on a no-first-party install — `test/ask-panel-pickers.test.mjs`

## Docs
`configurable-models-design.md` §4.8 rewritten (it previously said "no configuration surface for aux calls") + four decision-log rows; README Models bullet.

## Testing
- `npm test`: 4 new files, 6 existing files updated; the only pre-existing assertions that changed are the ones that pinned a routed env's exact key set.
- `npm run verify:composer` and `npm run verify:run-monitor` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA6XFrEAiHacvJEr6chmdL
