### PR TITLE
skills: add /worca-changelog — ship-log changelog page from PRs since the last stable release

### DIFF
--- a/.claude/skills/worca-changelog/DESIGN.md
+++ b/.claude/skills/worca-changelog/DESIGN.md
@@ -1,0 +1,166 @@
+# Ship-log design reference
+
+The changelog page is the "Worca — 3-Day Ship Log" design: a warm off-white
+canvas, big rounded white cards, one accent ribbon, screenshots in browser
+frames, and a small animated demo beside every feature. It reads like a
+product launch page, not a release note. Everything here is already encoded
+in `template.html`; this document says what each part is for so the copy
+and the demos land in the right shape.
+
+## Principles
+
+1. **One capability per section.** A section has one headline, one
+   screenshot, one demo. If a theme needs two headlines it is two sections.
+2. **Show the mechanism, not the menu.** The demo animates the thing the
+   feature *does* — a flag appearing, a value being masked, a precedence
+   resolving — in a 2–3 second loop. It is never a second screenshot.
+3. **Outcome headlines.** *Spend caps that pause, not kill.* *Define once.
+   Use everywhere.* The h2 states what the user gets; the sub explains the
+   feature that delivers it.
+4. **Facts as chips.** Counts, limits, guarantees go in chips, numbers in
+   `<b>`. Chips are scannable proof; the sub is the argument.
+5. **Motion is progressive.** Content reveals on scroll, ribbons drift with
+   scroll position, demos loop on timers. With `prefers-reduced-motion`
+   everything is visible immediately in its final state — the page must be
+   complete with no motion at all.
+6. **Real pixels.** Screenshots come from a seeded, sandboxed Worca — never
+   mocked-up UI, never a private catalog.
+7. **One file.** Logo and screenshots are inlined as data URIs; the page has
+   no external requests and survives being saved, mailed, or published.
+
+## Tokens
+
+Defined on `:root` in the template. Do not add colours; pick from these.
+
+| Token | Value | Use |
+| --- | --- | --- |
+| `--bg` | `#ECEAE4` | page canvas |
+| `--card` / `--card-2` | `#FFFFFF` / `#F6F4EF` | section cards / demo cards, shot toolbar |
+| `--ink` / `--ink-2` / `--ink-3` | `#14151A` / `#56534C` / `#8B8780` | text / secondary / labels |
+| `--line` | `#E2DFD7` | every border |
+| `--ocean` / `--ocean-deep` | `#4B5ED2` / `#3A49AC` | accent: hero ribbon, kicker dot, rail, focus |
+| `--wash` / `--wash-2` | `#DDE3F7` / `#EBEEFA` | hero gradient |
+| `--coral` / `--coral-soft` | `#EEA47D` / `#F8E3D5` | receipts ribbon |
+| `--lime` / `--lime-2` | `#DEEFC4` / `#EDF6DC` | positive notes |
+| `--ok` / `--warn` / `--bad` / `--info` | `#38854F` / `#DFA23F` / `#C9524A` / `#5B94C8` | kicker dots by area, pills |
+| `--r-lg` / `--r-md` / `--r-sm` | 28 / 18 / 12 px | section / demo & shot / rows |
+| `--shadow` | `0 18px 50px -22px rgba(20,21,26,.28)` | shots, winning rows, float chips |
+
+Type: system sans (`--sans`), 16px/1.5 body; `--mono` for anything that is
+a value — dates, ids, env keys, counts in chips. Headlines are weight 800,
+tracking −0.035em, `text-wrap:balance`. `h1` clamps 44–92px, `h2` 34–58px.
+
+**Kicker dot colour by area** (keep the mapping stable across entries so
+readers learn it):
+
+| Area | Dot |
+| --- | --- |
+| New view / composer / UI | `--ocean` (default) |
+| Routing, models, connectivity | `--info` |
+| Budget, cost, limits | `--warn` |
+| Team, plugins, sharing-in | `--bad` |
+| Sharing-out, export, docs | `--ok` |
+| Receipts | `--coral` |
+
+## Page anatomy
+
+```
+.wrap (max 1280)
+├── .top            brand logo · mono chip "changelog · v1.1.1 → v1.2.0"
+├── section.sec.hero #s0
+│   ├── svg.ribbon  ocean band, mono uppercase feature names on a textPath
+│   ├── .sec-head   kicker · h1 (2 lines) · sub · chips (first one .acc)
+│   └── .shot       hero screenshot, rotated 1.6°, two .float-chip "NEW · X"
+├── section.sec #s1 … #sN-1      one per feature
+│   ├── .sec-head   kicker(dot) · h2 · sub · chips
+│   └── .grid2[.flip]   .demo + .shot   (or .demo + .demo when there is no UI)
+├── section.sec.polish #sN       receipts
+│   ├── svg.p-ribbon  coral band "TESTS · NUMBERS · PROOF"
+│   ├── .sec-head   kicker(coral) · h2 "Shipped, tested, verified live."
+│   └── .bubs       six .bub — a circle (number or cropped image) + two lines
+├── .foot           "WORCA · changelog · <range>"  ·  mono date
+└── nav.rail        fixed dots, one per section, built from the ids
+```
+
+Alternate `.grid2` and `.grid2.flip` from section to section so the
+screenshot swaps sides; the eye keeps moving.
+
+## Components
+
+- **`.kicker`** — pill with a dot. Text is 1–2 words, uppercase by CSS.
+- **`.chip`** — pill fact. `.chip.acc` is the dark one; only the hero's first
+  chip uses it. `<b>` inside a chip is mono and dark — for numbers.
+- **`.shot`** — browser frame: three-dot toolbar + `.crop` + `<img>`. Zoom
+  with inline styles on the img (`width:130%;max-width:none;margin:-6% 0 0 -18%`)
+  and `max-height` on `.crop`. Always follow with `.shot-cap`.
+- **`.float-chip`** — absolutely-positioned callout on the hero shot:
+  `<small>New</small><span>Feature</span>`. Two per hero, no more.
+- **`.demo`** — card-2 background, `.dlabel` uppercase label first, then the
+  animation. Ends with `.env-note` when a one-line takeaway helps.
+- **`.rv`** — reveal-on-scroll. Put it on `.sec-head`, each `.grid2` child,
+  each `.bub`. `.d1`/`.d2` stagger siblings by 80ms steps.
+- **`.bub`** — receipts item. `.im` is an 86px circle holding either
+  `<span class="big">2,273</span>` or a cropped `<img>` (`width:300%` and a
+  negative `left`/`top` to aim at the interesting part).
+
+## Demo recipes
+
+Every demo is markup + a class toggle on a `setInterval`. The template ships
+these six; reuse before inventing:
+
+| Recipe | Shows | Mechanism |
+| --- | --- | --- |
+| **Precedence** (`.cat-demo`) | layers resolving to one winner | rows with `.win` / `.dim`; static, no loop needed |
+| **Mask / reveal** (`.env-demo`) | a secret shown only on demand | toggle `.reveal` every 2.6s, button text flips |
+| **Meter + flag** (`.meter-run`, `.cost-banner`, `.cap-steps`) | a run crossing a threshold | 4-phase loop: fill width, pill text, banner `.show`, numbered steps `.on` |
+| **Grouped picker** (`.dd-demo`) | grouping + a collision suffix | toggle `.collide` to fade `.sfx` in |
+| **Review rows** (`.con-demo`) | red-flagged changes + a green guarantee | static `.red-chip` rows + `.con-note` |
+| **Policy flip** (`.pol-demo`) | a heuristic changing a default | toggle `.flip` on one `.prow`; the `.warn-note` sibling fades in |
+
+Inventing a new one: keep it to one toggled class, one interval of 2–3s,
+≤ 20 lines of CSS, and add its final state to the reduced-motion block in
+the script (`if (reduced) { … add the class …; return; }`).
+
+## Voice
+
+- **Headlines** are outcomes: *If the endpoint hides costs, you'll know.*
+  *Ship your models to the team.* Present tense, second person implied,
+  ≤ 7 words, ending in a period.
+- **Subs** explain the change in one or two sentences and may name the
+  feature. Prefer concrete nouns (`base URL`, `--yes`, `0600`) to
+  adjectives. Never "we've added", "now supports", "improved".
+- **Chips** are noun phrases or short guarantees: `merged at spawn`,
+  `secrets never exported`, `<b>3</b> groups`. A chip can carry one glyph
+  (`⚠cost`) when the product shows it that way.
+- **Captions** (`.shot-cap`) tell the reader where they are looking: *The
+  editor: efforts, label, and the full routing env per model.*
+- **Receipts** are two lines: a bold claim (`Tests green`) and the number
+  behind it (`8 new suites · +1,703 test lines`). Middle dots separate
+  facts, never commas.
+- Use `·` between facts, `—` for an aside inside a sub, `→` only inside
+  mono text. No exclamation marks anywhere on the page.
+
+## Screenshots
+
+- 1440 × 900, light theme, seeded demo data per `docs/screenshots.md`.
+- Hero: the one view that carries the release. Sections: the surface the
+  feature lives on, zoomed so the feature is the largest thing in frame.
+- JPEG at quality ~82 for full views; PNG only for crops that are mostly
+  text and under 150 KB.
+- Alt text names the view and the state: *Model editor — routing env with
+  masked values, copy and reveal.*
+
+## Index
+
+`docs/changelog/README.md` starts with this header and gains one row per
+entry, newest first:
+
+```markdown
+# Changelog
+
+Each entry is a self-contained page in the ship-log design, built with
+`/worca-changelog` from the PRs merged since the previous release.
+
+| Version | Since | Date | Page | Artifact |
+| --- | --- | --- | --- | --- |
+```

--- a/.claude/skills/worca-changelog/SKILL.md
+++ b/.claude/skills/worca-changelog/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: worca-changelog
+description: Build a "What's new in Worca" changelog page for @worca/app — a scroll-revealed, screenshot-led ship log in the established Worca design (hero ribbon, kicker/headline/chips per feature, live demo cards, receipts) — from the merged PRs since a reference version, then publish it as an Artifact. Triggers on "changelog", "what's new", "ship log", "release notes", "worca-changelog", or any request to write up what shipped since a version.
+---
+
+# Worca changelog entry
+
+A changelog entry is a **self-contained HTML page** in the ship-log design,
+built from the PRs merged since a reference version, and published as an
+Artifact. It is not a bullet list of commits: every section sells one
+user-facing capability with a headline, a screenshot, and a small live demo
+of the mechanism.
+
+The design, layout and writing rules live next to this file — read both
+before writing a line of copy or markup:
+
+- `DESIGN.md` — tokens, components, section anatomy, demo recipes, voice.
+- `template.html` — the page skeleton with every component wired up. Copy
+  it; never restyle it.
+- `inline-assets.mjs` — turns local `<img src>` paths into data URIs so the
+  page publishes as one file.
+
+**Usage:**
+
+- `/worca-changelog` — offer the last stable release as the delta start
+- `/worca-changelog --from:1.1.1` — delta since that version (tag or bare version)
+- `/worca-changelog --from:1.1.1 --to:worca-app-v1.2.0-rc.3` — explicit end ref (default `HEAD`)
+- `/worca-changelog --no-publish` — build the file, skip the Artifact
+
+---
+
+## Step 1: Resolve the range
+
+The delta runs from a **reference version** to an **end ref**. A stable
+release is the natural reference: it is the last thing a `latest` user has,
+so "what's new since it" is exactly the RC's story.
+
+```bash
+# Last stable release: highest worca-app-v tag with no pre-release suffix.
+git fetch --quiet --tags origin
+STABLE=$(git tag --sort=-v:refname | grep -E '^worca-app-v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+LAST_RC=$(git tag --sort=-v:refname | grep -E '^worca-app-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' | head -1)
+echo "stable: $STABLE   npm latest: $(npm view @worca/app version)   last rc: $LAST_RC"
+node -p "require('./package.json').version"     # the version this entry describes
+```
+
+If `--from:` was **not given**, do not pick silently: **offer the last stable
+release** with `AskUserQuestion`. Put it first and mark it recommended; the
+other options are the last RC and "other" (free text). If the stable tag and
+`npm view @worca/app version` disagree, say so in the question — one of them
+is stale.
+
+A bare version (`1.1.1`) means the tag `worca-app-v1.1.1`. Verify the tag
+exists (`git rev-parse -q --verify refs/tags/<tag>`) before using it; stop on
+a miss rather than guessing at a nearby tag.
+
+The end ref defaults to `HEAD`. The entry's **version label** is
+`package.json`'s version at the end ref (`git show <to>:package.json`).
+
+Print the resolved range and continue:
+
+```
+Changelog range:  worca-app-v1.1.1  →  HEAD  (1.2.0-rc.3)
+```
+
+---
+
+## Step 2: Collect the delta
+
+Both views, always — PRs give the story, the first-parent log catches what
+landed without a PR.
+
+```bash
+FROM=worca-app-v1.1.1; TO=HEAD
+SINCE=$(git log -1 --format=%cI "$FROM")
+gh pr list --state merged --base dev --search "merged:>=${SINCE%%T*}" --limit 200 \
+  --json number,title,body,mergedAt,url,labels \
+  --jq "[.[] | select(.mergedAt > \"$SINCE\")] | sort_by(.mergedAt) | .[] | \"#\(.number)\t\(.mergedAt[:10])\t\(.title)\""
+git log "$FROM".."$TO" --first-parent --format='%h %s'
+```
+
+Read every PR body (`gh pr view <n> --json body --jq .body`). The body is
+where the user-facing framing lives; the title is often internal.
+
+Then **cluster into 4–7 themes**. A theme is something a user can point at
+in the product: a new view, a new command, a behaviour that changed. Fold
+these in rather than giving them a section:
+
+- `chore(release)` bumps, CI, test-only and Windows-path fixes → the
+  receipts section, as numbers.
+- Refactors and internal plumbing → mention in the sub of the feature they
+  enable, or drop.
+- Bug fixes → one "Fixes" theme only if there are several visible ones;
+  otherwise a chip on the relevant feature (`<span class="chip">no more X</span>`).
+
+Order themes by how much a user will care, biggest first. The hero's chips
+and ribbon list them in that order.
+
+---
+
+## Step 3: Collect the receipts
+
+The closing section carries six numbers. Compute them; never estimate.
+
+```bash
+git diff --shortstat "$FROM".."$TO"                      # files, +lines, -lines
+git rev-list --count --first-parent "$FROM".."$TO"      # commits on dev
+gh pr list --state merged --base dev --search "merged:>=${SINCE%%T*}" --json mergedAt \
+  --jq "[.[] | select(.mergedAt > \"$SINCE\")] | length"  # PRs merged
+git diff --stat "$FROM".."$TO" -- '*.test.mjs' 'test/' | tail -1   # test lines
+npm test 2>&1 | grep -E '^# (tests|pass|fail) '           # suite size, must be 0 fail
+```
+
+Pick the six that tell the story (tests green, lines landed, PRs merged,
+schema versions bumped, a security property, a round-trip proven). Two of
+the six may be a cropped screenshot instead of a number — see `DESIGN.md`.
+
+---
+
+## Step 4: Capture screenshots
+
+Every feature section wants a real screenshot; a section with no UI surface
+(a CLI change, a policy) gets two demo cards instead, as `template.html`
+shows for `s3`.
+
+Follow the sandbox recipe in `docs/screenshots.md` — `WORCA_HOME` set to a
+throwaway dir, seeded mock runs, demo projects with plausible names — so
+nothing private lands in a published page. Then, with the UI running (the
+`run` skill knows how), capture at **1440 × 900**, light theme, and save as
+PNG under:
+
+```
+docs/changelog/shots/<VERSION>/<section-id>.png     e.g. shots/1.2.0-rc.3/s1.png
+```
+
+Crop in markup, not in the file: the `.shot .crop` container takes
+`max-height`, and the `<img>` takes `width:130%;max-width:none;margin:…` to
+zoom on the part that matters. Keep the original so a later re-crop is free.
+
+Compress before inlining — screenshots dominate the page weight:
+
+```bash
+sips -s format jpeg -s formatOptions 82 s1.png --out s1.jpg      # macOS; ~5× smaller
+```
+
+---
+
+## Step 5: Write the copy, then the page
+
+Read `DESIGN.md` → *Voice* before writing. The shape of every section is
+fixed; only the words and the demo change:
+
+| Slot | Rule |
+| --- | --- |
+| kicker | 1–2 words naming the area: `Budget`, `Routing`, `Team`. Dot colour from the palette table. |
+| h2 | ≤ 7 words, a full sentence with a period, states the outcome not the feature: *Spend caps that pause, not kill.* |
+| sub | 1–2 sentences, ≤ 52ch measure. What changed, why it matters. No "we", no "now supports". |
+| chips | 3–4 facts. Numbers go in `<b>` (`<b>11</b> built-ins`). No sentences. |
+| demo | A 10–20 line CSS/JS loop that shows the *mechanism* — precedence, masking, a flag appearing. Reuse a recipe from `DESIGN.md` before inventing one. |
+| shot | The screenshot in a `.shot` frame with a one-line `.shot-cap` that says what the reader is looking at. |
+
+Build the page:
+
+1. Copy `template.html` to `docs/changelog/worca-app-v<VERSION>.src.html`.
+2. Fill every `{{…}}` slot; delete the sections you don't need, duplicate
+   the ones you do. Keep ids sequential (`s0` hero … `sN` receipts) — the
+   dot rail is built from them.
+3. Set the hero ribbon text to the section names, uppercased, `·`-separated,
+   **repeated twice** so the drift never shows the end.
+4. Point every `<img src>` at the local file (logo: `ui/public/assets/worca-logo.png`).
+5. Inline and check weight:
+
+```bash
+node .claude/skills/worca-changelog/inline-assets.mjs \
+  docs/changelog/worca-app-v<VERSION>.src.html \
+  docs/changelog/worca-app-v<VERSION>.html
+```
+
+The script fails above 15 MB (the Artifact ceiling is 16 MB) and warns
+above 4 MB — the sibling ship logs weigh ~1.6 MB. Over 4 MB means a
+screenshot went in as PNG; go back to Step 4.
+
+6. Open the built file in a browser and check, in this order: reveals fire
+   as you scroll; every demo loops; the rail dot follows the section; no
+   horizontal scroll at 390 px wide; `prefers-reduced-motion` shows every
+   demo in its final state. Fix in the `.src.html`, rebuild.
+
+The `.src.html` is the editable source and is committed alongside the built
+file — the built one is what gets published, the source is what gets edited
+next time.
+
+---
+
+## Step 6: Publish
+
+Unless `--no-publish`:
+
+1. Load the `artifact-design` skill (the Artifact tool requires it before
+   any publish; the page's design is already settled, so the pass is
+   confirmation, not redesign).
+2. Publish `docs/changelog/worca-app-v<VERSION>.html` with:
+   - title: `Worca — What's new in <VERSION>` (the `<title>` tag already says this)
+   - favicon: `🚢` on first publish, omitted on redeploys
+   - description: one sentence — the hero sub is usually right.
+3. Record it in the index, `docs/changelog/README.md` — one row per entry:
+   version, range, date, artifact URL. Create the file from the header in
+   `DESIGN.md` → *Index* if it does not exist.
+
+Redeploys of the same version go to the same URL: edit the source, rebuild,
+publish the same path again. A new version is a new file and a new URL.
+
+---
+
+## Step 7: Commit
+
+Repo rules apply: a branch off `dev`, a PR with `--base dev`, no direct
+push. Commit the source, the built page, the shots, and the index together:
+
+```bash
+git checkout -b docs/changelog-<VERSION> dev
+git add docs/changelog/
+git commit -m "docs(changelog): what's new in <VERSION>"
+```
+
+Finish with the summary:
+
+```
+Changelog entry ready
+
+  Range:      worca-app-v1.1.1 → HEAD (1.2.0-rc.3)
+  Sections:   6 features + receipts
+  Page:       docs/changelog/worca-app-v1.2.0-rc.3.html  (1.4 MB)
+  Artifact:   <url>   |   not published (--no-publish)
+  PR:         <url>
+```

--- a/.claude/skills/worca-changelog/inline-assets.mjs
+++ b/.claude/skills/worca-changelog/inline-assets.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Inline every local <img src="…"> in an HTML file as a data URI so the page
+// publishes as one self-contained file. Paths resolve relative to the input
+// file, then to the repo root. Remote (http/data) sources are left alone.
+//
+//   node .claude/skills/worca-changelog/inline-assets.mjs <in.html> <out.html>
+//
+// Exits 1 on a missing file or a result above the Artifact ceiling.
+
+import { readFileSync, writeFileSync, existsSync, statSync } from 'node:fs';
+import { resolve, dirname, extname } from 'node:path';
+
+const [, , inPath, outPath] = process.argv;
+if (!inPath || !outPath) {
+  console.error('usage: inline-assets.mjs <in.html> <out.html>');
+  process.exit(2);
+}
+
+const MIME = {
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp', '.gif': 'image/gif', '.svg': 'image/svg+xml', '.avif': 'image/avif',
+};
+const HARD_LIMIT = 15 * 1024 * 1024;   // Artifact ceiling is 16 MB
+const SOFT_LIMIT = 4 * 1024 * 1024;    // a ship log weighs ~1.6 MB; above this a PNG slipped in
+
+const html = readFileSync(inPath, 'utf8');
+const baseDir = dirname(resolve(inPath));
+const repoRoot = process.cwd();
+const seen = new Map();
+let missing = 0;
+const sizes = [];
+
+const out = html.replace(/(<img\b[^>]*?\bsrc=")([^"]+)(")/g, (m, pre, src, post) => {
+  if (/^(data:|https?:|\/\/)/i.test(src)) return m;
+  const candidates = [resolve(baseDir, src), resolve(repoRoot, src)];
+  const file = candidates.find((p) => existsSync(p));
+  if (!file) {
+    console.error(`missing: ${src}  (tried ${candidates.join(', ')})`);
+    missing++;
+    return m;
+  }
+  if (!seen.has(file)) {
+    const mime = MIME[extname(file).toLowerCase()];
+    if (!mime) {
+      console.error(`unsupported image type: ${src}`);
+      missing++;
+      return m;
+    }
+    const buf = readFileSync(file);
+    sizes.push([src, buf.length]);
+    seen.set(file, `data:${mime};base64,${buf.toString('base64')}`);
+  }
+  return pre + seen.get(file) + post;
+});
+
+if (missing) process.exit(1);
+
+writeFileSync(outPath, out);
+const total = statSync(outPath).size;
+const mb = (n) => (n / 1024 / 1024).toFixed(2) + ' MB';
+
+for (const [src, n] of sizes.sort((a, b) => b[1] - a[1])) {
+  const flag = n > 600 * 1024 ? '   ← large; convert to JPEG q82' : '';
+  console.log(`  ${(n / 1024).toFixed(0).padStart(6)} KB  ${src}${flag}`);
+}
+console.log(`\n${outPath}: ${mb(total)} (${seen.size} images inlined)`);
+
+if (total > HARD_LIMIT) {
+  console.error(`ERROR: ${mb(total)} exceeds the ${mb(HARD_LIMIT)} limit — compress the screenshots`);
+  process.exit(1);
+}
+if (total > SOFT_LIMIT) {
+  console.warn(`WARN: ${mb(total)} is heavy for a ship log (~1.6 MB); check for PNG screenshots`);
+}

--- a/.claude/skills/worca-changelog/template.html
+++ b/.claude/skills/worca-changelog/template.html
@@ -1,0 +1,482 @@
+<title>Worca — What's new in {{VERSION}}</title>
+<!--
+  Ship-log changelog template. Copy to docs/changelog/worca-app-v<VERSION>.src.html,
+  fill every {{SLOT}}, delete the sections you don't need, duplicate the ones
+  you do (keep ids sequential: s0 hero … sN receipts — the rail is built from
+  them). Then run inline-assets.mjs. See DESIGN.md for what each part is for.
+-->
+<style>
+  :root{
+    --bg:#ECEAE4; --card:#FFFFFF; --card-2:#F6F4EF;
+    --ink:#14151A; --ink-2:#56534C; --ink-3:#8B8780; --line:#E2DFD7;
+    --ocean:#4B5ED2; --ocean-deep:#3A49AC; --wash:#DDE3F7; --wash-2:#EBEEFA;
+    --coral:#EEA47D; --coral-soft:#F8E3D5; --lime:#DEEFC4; --lime-2:#EDF6DC;
+    --dark:#131419; --dark-2:#1C1D25; --on-dark:#F4F3EE; --on-dark-2:#9EA0AC;
+    --ok:#38854F; --warn:#DFA23F; --bad:#C9524A; --info:#5B94C8;
+    --r-lg:28px; --r-md:18px; --r-sm:12px;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+    --mono:ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace;
+    --shadow:0 18px 50px -22px rgba(20,21,26,.28);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
+    font-size:16px;line-height:1.5;-webkit-font-smoothing:antialiased}
+  img{max-width:100%;display:block}
+  .wrap{max-width:1280px;margin:0 auto;padding:18px 22px 90px}
+
+  /* ---------- shared bits ---------- */
+  .kicker{display:inline-flex;align-items:center;gap:8px;background:var(--card);
+    border:1px solid var(--line);border-radius:999px;padding:7px 15px;
+    font-size:11.5px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-2)}
+  .kicker .dot{width:8px;height:8px;border-radius:50%;background:var(--ocean)}
+  h1,h2{margin:0;letter-spacing:-.035em;line-height:1.02;text-wrap:balance;font-weight:800}
+  h1{font-size:clamp(44px,7vw,92px)}
+  h2{font-size:clamp(34px,4.6vw,58px)}
+  .sub{color:var(--ink-2);font-size:clamp(16px,1.6vw,19px);max-width:52ch;margin:0}
+  .chips{display:flex;flex-wrap:wrap;gap:10px}
+  .chip{background:var(--card);border:1px solid var(--line);border-radius:999px;
+    padding:8px 16px;font-size:13.5px;font-weight:600;color:var(--ink-2);white-space:nowrap}
+  .chip b{color:var(--ink);font-family:var(--mono);font-weight:700}
+  .chip.acc{background:var(--ink);border-color:var(--ink);color:#fff}
+  .mono{font-family:var(--mono);font-variant-numeric:tabular-nums}
+
+  .sec{border-radius:var(--r-lg);background:var(--card);margin-top:26px;
+    padding:clamp(28px,4.4vw,64px);position:relative;overflow:hidden}
+  .sec-head{display:flex;flex-direction:column;align-items:flex-start;gap:18px;max-width:900px;position:relative;z-index:2}
+  .grid2{display:grid;grid-template-columns:5fr 6fr;gap:clamp(22px,3vw,44px);align-items:center;margin-top:38px}
+  .grid2.flip{grid-template-columns:6fr 5fr}
+  @media (max-width:920px){.grid2,.grid2.flip{grid-template-columns:1fr}}
+
+  /* screenshot frame */
+  .shot{border-radius:var(--r-md);overflow:hidden;background:var(--card);
+    border:1px solid var(--line);box-shadow:var(--shadow)}
+  .shot .bar{height:32px;background:var(--card-2);border-bottom:1px solid var(--line);
+    display:flex;align-items:center;gap:6px;padding:0 14px}
+  .shot .bar i{width:10px;height:10px;border-radius:50%;background:#DDD9CF;display:block}
+  .shot .bar i:first-child{background:#E8B4AC}.shot .bar i:nth-child(2){background:#EAD3A2}.shot .bar i:nth-child(3){background:#BCD8B4}
+  .shot .crop{overflow:hidden;position:relative}
+  .shot img{height:auto}
+  .shot-cap{margin:12px 4px 0;font-size:13px;color:var(--ink-3);font-weight:600}
+
+  /* reveals */
+  .rv{opacity:0;transform:translateY(26px);transition:opacity .7s ease,transform .7s cubic-bezier(.2,.7,.2,1)}
+  .rv.in{opacity:1;transform:none}
+  .rv.d1{transition-delay:.08s}.rv.d2{transition-delay:.16s}.rv.d3{transition-delay:.24s}
+
+  /* ---------- topbar ---------- */
+  .top{display:flex;justify-content:space-between;align-items:center;padding:10px 6px 4px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:800;letter-spacing:.02em;font-size:18px}
+  .top .chip{background:transparent}
+
+  /* ---------- hero ---------- */
+  .hero{background:linear-gradient(135deg,var(--wash) 0%,var(--wash-2) 60%,#F2EFFA 100%)}
+  .hero-grid{display:grid;grid-template-columns:6fr 5fr;gap:clamp(24px,3vw,48px);align-items:center;position:relative;z-index:2}
+  @media (max-width:920px){.hero-grid{grid-template-columns:1fr}}
+  .hero .shot{transform:rotate(1.6deg)}
+  .hero .sec-head{position:relative;z-index:4}
+  .ribbon{position:absolute;inset:0;z-index:3;pointer-events:none}
+  @media (max-width:920px){.ribbon{display:none}}
+  .ribbon text{font-family:var(--mono);font-size:15px;font-weight:700;letter-spacing:.30em;fill:#fff}
+  .float-chip{position:absolute;z-index:3;background:var(--card);border-radius:14px;box-shadow:var(--shadow);
+    border:1px solid var(--line);padding:10px 16px;font-size:13px;font-weight:700}
+  .float-chip small{display:block;font-weight:600;color:var(--ink-3);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase}
+
+  /* ---------- demo cards ---------- */
+  .demo{border-radius:var(--r-md);background:var(--card-2);border:1px solid var(--line);padding:26px;position:relative}
+  .demo .dlabel{font-size:10.5px;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:var(--ink-3);margin-bottom:18px}
+  .env-note{margin:14px 2px 0;font-size:12.5px;color:var(--ink-3);font-weight:600}
+  .badge{font-size:10px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;border-radius:6px;padding:3px 7px;white-space:nowrap}
+  .badge.violet{background:#E7E4F8;color:#4A3E9E}
+  .badge.grey{background:var(--card-2);color:var(--ink-3);border:1px solid var(--line)}
+  .pill{font-size:10.5px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;border-radius:999px;padding:4px 10px}
+  .pill.run{background:#E4F0E7;color:var(--ok)}
+  .pill.flag{background:#FBEEDC;color:#9A6A17}
+  .ghost-btn{border:1.5px solid var(--ink);border-radius:999px;background:var(--card);
+    padding:7px 14px;font-size:12px;font-weight:700;white-space:nowrap;transition:.3s;display:inline-block}
+  .ghost-btn.pulse{transform:scale(1.06);box-shadow:0 0 0 6px rgba(75,94,210,.18)}
+
+  /* recipe: precedence — layers resolve into one winner */
+  .cat-demo{display:flex;flex-direction:column;gap:10px}
+  .cat-row{border-radius:var(--r-sm);border:1px solid var(--line);background:var(--card);padding:13px 16px;
+    display:flex;align-items:center;gap:12px;transition:.35s ease}
+  .cat-row .t{font-weight:700;font-size:13.5px;flex:1}
+  .cat-row .src{font-family:var(--mono);font-size:11.5px;color:var(--ink-2)}
+  .cat-row.dim{opacity:.45}
+  .cat-row.win{border-color:var(--ink);box-shadow:var(--shadow)}
+
+  /* recipe: mask / reveal — a secret shown only on demand */
+  .env-demo .erow{background:var(--card);border:1px solid var(--line);border-radius:var(--r-sm);padding:14px 16px;
+    display:flex;align-items:center;gap:14px}
+  .env-demo .ekey{font-family:var(--mono);font-size:12.5px;color:var(--ink-2);flex:0 0 auto}
+  .env-demo .eval{font-family:var(--mono);font-size:13px;font-weight:700;position:relative;flex:1;height:20px;overflow:hidden}
+  .env-demo .eval span{position:absolute;inset:0;transition:opacity .4s}
+  .env-demo .eval .raw{opacity:0}
+  .env-demo.reveal .eval .raw{opacity:1}
+  .env-demo.reveal .eval .msk{opacity:0}
+
+  /* recipe: meter + flag — a run crossing a threshold */
+  .meter-run{background:var(--card);border:1px solid var(--line);border-radius:var(--r-sm);padding:16px 18px}
+  .meter-top{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+  .meter-top .t{font-weight:700;font-size:14px}
+  .meter{height:12px;border-radius:999px;background:var(--line);position:relative}
+  .meter .fill{height:100%;border-radius:999px;width:0%;background:var(--info);transition:width 1.4s ease}
+  .meter-amt{display:flex;justify-content:space-between;margin-top:10px;font-family:var(--mono);font-size:12.5px;color:var(--ink-2)}
+  .cost-banner{margin-top:14px;border-radius:var(--r-sm);background:#FBF3E4;border:1px solid #EDD9AE;
+    padding:13px 16px;display:flex;justify-content:space-between;align-items:center;gap:10px;
+    opacity:.22;transform:translateY(-4px);transition:.45s ease}
+  .cost-banner.show{opacity:1;transform:none}
+  .cost-banner .msg{font-size:13px;font-weight:600;color:#7A5A1A}
+  .cap-steps{list-style:none;margin:22px 0 0;padding:0;display:flex;flex-direction:column;gap:9px}
+  .cap-steps li{display:flex;gap:11px;align-items:center;font-size:13.5px;font-weight:600;color:var(--ink-3);transition:.35s}
+  .cap-steps .n{width:23px;height:23px;border-radius:50%;background:var(--card);border:1px solid var(--line);flex:none;
+    display:grid;place-items:center;font-family:var(--mono);font-size:11px;font-weight:700;transition:.35s}
+  .cap-steps li.on{color:var(--ink)}
+  .cap-steps li.on .n{background:var(--ink);color:#fff;border-color:var(--ink)}
+
+  /* recipe: grouped picker — grouping + a collision suffix */
+  .dd-demo .grp{margin-bottom:12px}
+  .dd-demo .glabel{font-size:10.5px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-3);margin:0 0 7px 4px}
+  .dd-opt{border:1px solid var(--line);border-radius:10px;background:var(--card);padding:10px 14px;
+    font-size:13.5px;font-weight:600;margin-bottom:6px;display:flex;align-items:center;gap:8px}
+  .dd-opt .sfx{font-family:var(--mono);font-size:11.5px;color:var(--ink-3);opacity:0;transition:opacity .5s}
+  .dd-demo.collide .dd-opt .sfx{opacity:1}
+  .dd-opt.sel{border-color:var(--ink);box-shadow:var(--shadow)}
+
+  /* recipe: review rows — red-flagged changes + a green guarantee */
+  .con-demo .crow{background:var(--card);border:1px solid var(--line);border-radius:var(--r-sm);padding:13px 16px;margin-bottom:10px;
+    font-size:13px;font-weight:600;display:flex;flex-wrap:wrap;align-items:center;gap:8px}
+  .red-chip{background:#FCE9E4;color:#A03A31;border-radius:6px;padding:3px 8px;font-size:11px;font-weight:700;font-family:var(--mono)}
+  .con-note{border-radius:var(--r-sm);background:var(--lime-2);border:1px solid #CFE3A8;padding:12px 16px;
+    display:flex;align-items:center;justify-content:space-between;font-size:12.5px;font-weight:600;color:#41611F}
+
+  /* recipe: policy flip — a heuristic changing a default */
+  .pol-demo .prow{background:var(--card);border:1px solid var(--line);border-radius:var(--r-sm);padding:13px 16px;margin-bottom:10px;
+    display:flex;align-items:center;gap:12px}
+  .pol-demo .pkey{font-family:var(--mono);font-size:12px;color:var(--ink-2);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis}
+  .pol-demo .pmode{font-size:12px;font-weight:700;border:1px solid var(--line);border-radius:8px;padding:6px 12px;background:var(--card-2);
+    position:relative;min-width:150px;text-align:center;height:31px;overflow:hidden}
+  .pol-demo .pmode span{position:absolute;inset:0;display:grid;place-items:center;transition:opacity .4s}
+  .pol-demo .pmode .b{opacity:0;color:#A03A31}
+  .pol-demo .prow.flip .pmode .a{opacity:0}
+  .pol-demo .prow.flip .pmode .b{opacity:1}
+  .pol-demo .warn-note{font-size:11.5px;color:var(--bad);font-weight:700;opacity:0;transition:opacity .4s}
+  .pol-demo .prow.flip ~ .warn-note{opacity:1}
+
+  /* ---------- receipts section ---------- */
+  .polish{background:linear-gradient(160deg,#F7EFE7,#FBF6EF)}
+  .p-ribbon{position:absolute;inset:0;pointer-events:none;z-index:1}
+  .p-ribbon text{font-family:var(--mono);font-size:14px;font-weight:700;letter-spacing:.28em;fill:#fff}
+  .bubs{position:relative;z-index:2;display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:40px}
+  @media (max-width:920px){.bubs{grid-template-columns:1fr 1fr}}
+  @media (max-width:560px){.bubs{grid-template-columns:1fr}}
+  .bub{background:var(--card);border-radius:20px;border:1px solid var(--line);padding:18px;display:flex;gap:16px;align-items:center}
+  .bub .im{width:86px;height:86px;border-radius:50%;overflow:hidden;flex:none;border:1px solid var(--line);position:relative;
+    display:grid;place-items:center;background:var(--card-2)}
+  .bub .im img{width:300%;max-width:none;position:absolute}
+  .bub .im .big{font-family:var(--mono);font-weight:800;font-size:19px;letter-spacing:-.02em}
+  .bub .tx b{display:block;font-size:14.5px;letter-spacing:-.01em}
+  .bub .tx span{font-size:12.5px;color:var(--ink-2)}
+
+  .foot{display:flex;justify-content:space-between;align-items:center;padding:34px 8px 0;color:var(--ink-3);font-size:13px}
+
+  /* dot rail */
+  .rail{position:fixed;right:16px;top:50%;transform:translateY(-50%);display:flex;flex-direction:column;gap:9px;z-index:50}
+  .rail a{width:8px;height:8px;border-radius:50%;background:var(--ink-3);opacity:.35;transition:.25s}
+  .rail a.on{opacity:1;background:var(--ocean);transform:scale(1.35)}
+  @media (max-width:1360px){.rail{display:none}}
+
+  a{color:inherit}
+  :focus-visible{outline:2.5px solid var(--ocean);outline-offset:2px;border-radius:4px}
+
+  @media (prefers-reduced-motion:reduce){
+    *,*::before,*::after{animation:none!important;transition:none!important}
+    html{scroll-behavior:auto}
+    .rv{opacity:1;transform:none}
+    .cost-banner{opacity:1;transform:none}
+    .env-demo .eval .raw{position:static}
+  }
+</style>
+
+<div class="wrap">
+
+  <!-- top -->
+  <div class="top">
+    <div class="brand">
+      <img src="ui/public/assets/worca-logo.png" alt="Worca" style="height:34px;width:auto;mix-blend-mode:multiply">
+    </div>
+    <span class="chip mono">changelog · v{{FROM}} → v{{VERSION}}</span>
+  </div>
+
+  <!-- ================= HERO ================= -->
+  <section class="sec hero" id="s0">
+    <svg class="ribbon" viewBox="0 0 1280 640" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+      <path id="rb" d="M -120 690 C 300 640, 540 530, 750 400 S 1120 150, 1400 160" fill="none" stroke="#4B5ED2" stroke-width="42" stroke-linecap="round" opacity=".92"></path>
+      <!-- section names, uppercase, ·-separated, repeated twice -->
+      <text><textPath id="rbt" href="#rb" startOffset="-12%">{{RIBBON}} · {{RIBBON}} · </textPath></text>
+    </svg>
+    <div class="hero-grid">
+      <div class="sec-head rv in">
+        <span class="kicker"><span class="dot"></span>What's new · v{{VERSION}}</span>
+        <h1>{{H1_LINE_1}}<br>{{H1_LINE_2}}</h1>
+        <p class="sub">{{HERO_SUB}}</p>
+        <div class="chips">
+          <span class="chip acc">{{theme 1}}</span><span class="chip">{{theme 2}}</span><span class="chip">{{theme 3}}</span><span class="chip">{{theme 4}}</span><span class="chip">{{theme 5}}</span>
+        </div>
+      </div>
+      <div class="rv d1 in" style="position:relative;z-index:2">
+        <div class="shot"><div class="bar"><i></i><i></i><i></i></div><div class="crop" style="max-height:560px"><img src="docs/changelog/shots/{{VERSION}}/s0.jpg" alt="{{hero view — state}}"></div></div>
+        <div class="float-chip" style="right:-8px;top:-16px"><small>New</small><span>{{Feature A}}</span></div>
+        <div class="float-chip" style="right:24px;bottom:-18px"><small>New</small><span>{{Feature B}}</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= S1 · precedence recipe + shot ================= -->
+  <section class="sec" id="s1">
+    <div class="sec-head rv">
+      <span class="kicker"><span class="dot"></span>{{Area}}</span>
+      <h2>{{Outcome headline, ≤ 7 words.}}</h2>
+      <p class="sub">{{One or two sentences: what changed and why it matters.}}</p>
+      <div class="chips">
+        <span class="chip"><b>{{N}}</b> {{fact}}</span><span class="chip">{{fact}}</span><span class="chip">{{fact}}</span><span class="chip">{{fact}}</span>
+      </div>
+    </div>
+    <div class="grid2">
+      <div class="demo rv">
+        <div class="dlabel">{{What the demo shows}}</div>
+        <div class="cat-demo">
+          <div class="cat-row win"><span class="t">{{Item}}</span><span class="badge violet">yours</span><span class="src">wins</span></div>
+          <div class="cat-row dim"><span class="t">{{Item}}</span><span class="badge grey">plugin</span><span class="src">shadowed</span></div>
+          <div class="cat-row dim"><span class="t">{{Item}}</span><span class="badge grey">built-in</span><span class="src">overridable</span></div>
+        </div>
+        <p class="env-note">{{One-line takeaway.}}</p>
+      </div>
+      <div class="rv d1">
+        <div class="shot"><div class="bar"><i></i><i></i><i></i></div><div class="crop" style="max-height:460px"><img src="docs/changelog/shots/{{VERSION}}/s1.jpg" alt="{{view — state}}" style="width:130%;max-width:none;margin:-6% 0 0 -18%"></div></div>
+        <p class="shot-cap">{{Where the reader is looking.}}</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= S2 · mask/reveal recipe + shot ================= -->
+  <section class="sec" id="s2">
+    <div class="sec-head rv">
+      <span class="kicker"><span class="dot" style="background:var(--info)"></span>{{Area}}</span>
+      <h2>{{Outcome headline.}}</h2>
+      <p class="sub">{{Sub.}}</p>
+      <div class="chips">
+        <span class="chip">{{fact}}</span><span class="chip">{{fact}}</span><span class="chip">{{fact}}</span>
+      </div>
+    </div>
+    <div class="grid2">
+      <div class="demo rv env-demo" id="envDemo">
+        <div class="dlabel">{{Masked by default — yours to reveal}}</div>
+        <div class="erow">
+          <span class="ekey">{{ENV_KEY}}</span>
+          <span class="eval"><span class="msk">••••••1234</span><span class="raw">{{sk-…1234}}</span></span>
+        </div>
+        <div style="margin-top:14px"><span class="ghost-btn" id="revealBtn">Show values</span></div>
+        <p class="env-note">{{Takeaway.}}</p>
+      </div>
+      <div class="rv d1">
+        <div class="shot"><div class="bar"><i></i><i></i><i></i></div><div class="crop" style="max-height:560px"><img src="docs/changelog/shots/{{VERSION}}/s2.jpg" alt="{{view — state}}"></div></div>
+        <p class="shot-cap">{{Caption.}}</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= S3 · no UI surface: two demo cards (meter + picker) ================= -->
+  <section class="sec" id="s3">
+    <div class="sec-head rv">
+      <span class="kicker"><span class="dot" style="background:var(--warn)"></span>{{Area}}</span>
+      <h2>{{Outcome headline.}}</h2>
+      <p class="sub">{{Sub.}}</p>
+      <div class="chips">
+        <span class="chip">{{fact}}</span><span class="chip">{{fact}}</span><span class="chip">{{fact}}</span>
+      </div>
+    </div>
+    <div class="grid2">
+      <div class="demo rv">
+        <div class="dlabel">{{How the threshold is crossed}}</div>
+        <div class="meter-run">
+          <div class="meter-top"><span class="t">{{Run title · model}}</span><span class="pill run" id="costPill">Running</span></div>
+          <div class="meter"><div class="fill" id="costFill" style="width:8%"></div></div>
+          <div class="meter-amt"><span id="costTok">tokens: 1,204</span><span id="costUsd">reported cost: $0.00</span></div>
+        </div>
+        <div class="cost-banner" id="costBanner">
+          <span class="msg">{{What the flag says}}</span>
+        </div>
+        <ol class="cap-steps" id="costSteps">
+          <li><span class="n">1</span>{{Step one}}</li>
+          <li><span class="n">2</span>{{Step two}}</li>
+          <li><span class="n">3</span>{{Step three}}</li>
+        </ol>
+      </div>
+      <div class="demo rv d1 dd-demo" id="ddDemo">
+        <div class="dlabel">{{Grouping, with a collision suffix}}</div>
+        <div class="grp">
+          <p class="glabel">{{Group A}}</p>
+          <div class="dd-opt sel">{{Option}}</div>
+        </div>
+        <div class="grp">
+          <p class="glabel">{{Group B}}</p>
+          <div class="dd-opt">{{Option}} <span class="sfx">({{suffix}})</span></div>
+          <div class="dd-opt">{{Option}}</div>
+        </div>
+        <p class="env-note">{{Takeaway.}}</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= S4 · flipped: shot + review-rows recipe ================= -->
+  <section class="sec" id="s4">
+    <div class="sec-head rv">
+      <span class="kicker"><span class="dot" style="background:var(--bad)"></span>{{Area}}</span>
+      <h2>{{Outcome headline.}}</h2>
+      <p class="sub">{{Sub.}}</p>
+      <div class="chips">
+        <span class="chip">{{fact}}</span><span class="chip">{{fact}}</span><span class="chip">{{fact}}</span><span class="chip">{{fact}}</span>
+      </div>
+    </div>
+    <div class="grid2 flip">
+      <div class="rv">
+        <div class="shot"><div class="bar"><i></i><i></i><i></i></div><div class="crop" style="max-height:520px"><img src="docs/changelog/shots/{{VERSION}}/s4.jpg" alt="{{view — state}}" style="width:128%;max-width:none;margin:-4% 0 0 -14%"></div></div>
+        <p class="shot-cap">{{Caption.}}</p>
+      </div>
+      <div class="demo rv d1 con-demo">
+        <div class="dlabel">{{What the review catches}}</div>
+        <div class="crow"><span>{{item}}</span><span class="red-chip">{{FLAGGED — why}}</span></div>
+        <div class="crow"><span>{{item}}</span><span class="red-chip">{{FLAGGED — why}}</span></div>
+        <div class="con-note"><span>{{Guarantee}}</span><span class="mono">{{proof · ✓}}</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= S5 · flipped: shot + policy-flip recipe ================= -->
+  <section class="sec" id="s5">
+    <div class="sec-head rv">
+      <span class="kicker"><span class="dot" style="background:var(--ok)"></span>{{Area}}</span>
+      <h2>{{Outcome headline.}}</h2>
+      <p class="sub">{{Sub.}}</p>
+      <div class="chips">
+        <span class="chip">{{fact}}</span><span class="chip">{{fact}}</span><span class="chip">{{fact}}</span>
+      </div>
+    </div>
+    <div class="grid2 flip">
+      <div class="rv">
+        <div class="shot"><div class="bar"><i></i><i></i><i></i></div><div class="crop" style="max-height:560px"><img src="docs/changelog/shots/{{VERSION}}/s5.jpg" alt="{{view — state}}"></div></div>
+        <p class="shot-cap">{{Caption.}}</p>
+      </div>
+      <div class="demo rv d1 pol-demo" id="polDemo">
+        <div class="dlabel">{{The heuristic in action}}</div>
+        <div class="prow"><span class="pkey">{{KEY_ONE}}</span><span class="pmode"><span class="a">{{Default}}</span></span></div>
+        <div class="prow" id="polFlip"><span class="pkey">{{KEY_TWO}}</span><span class="pmode"><span class="a">{{Default}}</span><span class="b">{{Flipped}}</span></span></div>
+        <p class="warn-note">{{why it flipped}}</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= RECEIPTS (always last) ================= -->
+  <section class="sec polish" id="s6">
+    <svg class="p-ribbon" viewBox="0 0 1280 760" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+      <path id="pb" d="M -60 78 C 260 8, 520 140, 760 92 S 1160 6, 1360 96" fill="none" stroke="#EEA47D" stroke-width="34" stroke-linecap="round" opacity=".9"></path>
+      <text><textPath id="pbt" href="#pb" startOffset="-10%">TESTS · NUMBERS · PROOF · TESTS · NUMBERS · PROOF · TESTS · NUMBERS · PROOF · TESTS · NUMBERS · PROOF · </textPath></text>
+    </svg>
+    <div class="sec-head rv" style="margin-top:110px">
+      <span class="kicker"><span class="dot" style="background:var(--coral)"></span>And the receipts</span>
+      <h2>Shipped, tested, verified live.</h2>
+    </div>
+    <div class="bubs">
+      <div class="bub rv"><span class="im"><span class="big">{{4,705}}</span></span><div class="tx"><b>Tests green</b><span>{{N new suites · +N test lines}}</span></div></div>
+      <div class="bub rv d1"><span class="im"><span class="big">{{+N}}</span></span><div class="tx"><b>Lines landed</b><span>{{N files · N commits}}</span></div></div>
+      <div class="bub rv d2"><span class="im"><span class="big">{{N}}</span></span><div class="tx"><b>PRs merged</b><span>{{since vFROM · N days}}</span></div></div>
+      <div class="bub rv"><span class="im"><img src="docs/changelog/shots/{{VERSION}}/r1.jpg" style="width:340%;left:-160%;top:-40%" alt="{{crop}}"></span><div class="tx"><b>{{Claim}}</b><span>{{proof}}</span></div></div>
+      <div class="bub rv d1"><span class="im"><img src="docs/changelog/shots/{{VERSION}}/r2.jpg" style="width:500%;left:-115%;top:-16%" alt="{{crop}}"></span><div class="tx"><b>{{Claim}}</b><span>{{proof}}</span></div></div>
+      <div class="bub rv d2"><span class="im"><span class="big">{{v27}}</span></span><div class="tx"><b>{{Claim}}</b><span>{{proof}}</span></div></div>
+    </div>
+  </section>
+
+  <div class="foot">
+    <span>WORCA · changelog · <span class="mono">v{{FROM}} → v{{VERSION}}</span></span>
+    <span class="mono">{{Mon D – Mon D, YYYY}}</span>
+  </div>
+</div>
+
+<nav class="rail" id="rail" aria-label="Sections">
+  <a href="#s0" aria-label="What's new" class="on"></a><a href="#s1" aria-label="{{Section 1}}"></a><a href="#s2" aria-label="{{Section 2}}"></a><a href="#s3" aria-label="{{Section 3}}"></a><a href="#s4" aria-label="{{Section 4}}"></a><a href="#s5" aria-label="{{Section 5}}"></a><a href="#s6" aria-label="Receipts"></a>
+</nav>
+
+<script>
+(function () {
+  var reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var $ = function (id) { return document.getElementById(id); };
+
+  // scroll reveals
+  var io = new IntersectionObserver(function (es) {
+    es.forEach(function (e) { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.18 });
+  document.querySelectorAll('.rv').forEach(function (el) { io.observe(el); });
+
+  // dot rail follows the section in the middle of the viewport
+  var secs = [].slice.call(document.querySelectorAll('.sec'));
+  var dots = [].slice.call(document.querySelectorAll('.rail a'));
+  var so = new IntersectionObserver(function (es) {
+    es.forEach(function (e) {
+      if (e.isIntersecting) {
+        var i = secs.indexOf(e.target);
+        dots.forEach(function (d, j) { d.classList.toggle('on', j === i); });
+      }
+    });
+  }, { rootMargin: '-45% 0px -45% 0px' });
+  secs.forEach(function (s) { so.observe(s); });
+
+  // ribbons drift with scroll position
+  var rbt = $('rbt'), pbt = $('pbt');
+  if (!reduced) addEventListener('scroll', function () {
+    var p = scrollY / Math.max(1, document.body.scrollHeight - innerHeight);
+    if (rbt) rbt.setAttribute('startOffset', (-12 + p * 30) + '%');
+    if (pbt) pbt.setAttribute('startOffset', (-10 + p * 26) + '%');
+  }, { passive: true });
+
+  // Reduced motion: every demo in its final state, no timers.
+  // Add one line here for every demo you add.
+  if (reduced) {
+    if ($('envDemo')) $('envDemo').classList.add('reveal');
+    if ($('costBanner')) $('costBanner').classList.add('show');
+    if ($('ddDemo')) $('ddDemo').classList.add('collide');
+    if ($('polFlip')) $('polFlip').classList.add('flip');
+    return;
+  }
+
+  // recipe: mask / reveal
+  var env = $('envDemo'), btn = $('revealBtn');
+  if (env && btn) setInterval(function () {
+    var on = env.classList.toggle('reveal');
+    btn.textContent = on ? 'Hide values' : 'Show values';
+    btn.classList.toggle('pulse', on);
+  }, 2600);
+
+  // recipe: meter + flag — run → threshold → flag → clear
+  var pill = $('costPill'), fill = $('costFill'), tok = $('costTok'), usd = $('costUsd'), banner = $('costBanner');
+  var steps = [].slice.call(document.querySelectorAll('#costSteps li'));
+  if (pill && fill) { var phase = 0; setInterval(function () {
+    phase = (phase + 1) % 4;
+    steps.forEach(function (li, i) { li.classList.toggle('on', i === Math.min(phase, 2) && phase > 0); });
+    if (phase === 0) { pill.textContent = 'Running'; pill.className = 'pill run';
+      fill.style.width = '8%'; tok.textContent = 'tokens: 1,204'; usd.textContent = 'reported cost: $0.00'; banner.classList.remove('show'); }
+    if (phase === 1) { fill.style.width = '86%'; tok.textContent = 'tokens: 148,022'; }
+    if (phase === 2) { pill.textContent = '⚠ flagged'; pill.className = 'pill flag'; banner.classList.add('show'); }
+    if (phase === 3) { pill.textContent = 'cleared'; pill.className = 'pill run';
+      usd.textContent = 'reported cost: $1.84'; banner.classList.remove('show'); }
+  }, 2100); }
+
+  // recipe: grouped picker — collision suffix
+  var dd = $('ddDemo');
+  if (dd) setInterval(function () { dd.classList.toggle('collide'); }, 2800);
+
+  // recipe: policy flip
+  var pf = $('polFlip');
+  if (pf) setInterval(function () { pf.classList.toggle('flip'); }, 2400);
+})();
+</script>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -177,6 +177,10 @@ to be on the released branch, because the next release computes its number from
 > the post-publish verification in §4.3. Use it in preference to running the
 > commands by hand; what follows is the specification it implements, and the
 > fallback when something goes wrong.
+>
+> Its companion `/worca-changelog` (`.claude/skills/worca-changelog/`) writes
+> the "What's new" page for a release from the PRs merged since the previous
+> stable version and publishes it as an Artifact.
 
 ### 4.1 Release candidates
 


### PR DESCRIPTION
## What

A project-level skill, `/worca-changelog`, that turns the PRs merged since a reference version into a "What's new in Worca" page in the established ship-log design and publishes it as an Artifact.

- `.claude/skills/worca-changelog/SKILL.md` — the procedure: resolve the range (offers the **last stable release** as the delta start when `--from:` is not given), collect merged PRs + first-parent log, compute receipts, capture sandboxed screenshots, write copy to the voice rules, build, verify, publish, commit.
- `DESIGN.md` — tokens, page anatomy, components, six demo recipes, voice, index format.
- `template.html` — the page skeleton with every component and recipe wired up, including reduced-motion end states. Rendered headlessly to confirm it lays out correctly before filling.
- `inline-assets.mjs` — inlines local `<img src>` as data URIs so the page is one file; fails on a missing image or above 15 MB, warns above 4 MB.
- `docs/RELEASING.md` — one pointer next to the `/worca-release` note.

## Design source

The design follows the "Worca — 3-Day Ship Log" artifacts (same tokens, hero ribbon, kicker/h2/sub/chips, `.shot` frames, demo cards, receipts, dot rail). The CSS/JS were lifted from the `· Models` sibling, which is the same template; nothing was restyled.

## Output layout an entry produces

```
docs/changelog/README.md                        index (version · since · date · page · artifact)
docs/changelog/worca-app-v<V>.src.html          editable source
docs/changelog/worca-app-v<V>.html              built, self-contained, what gets published
docs/changelog/shots/<V>/s0.jpg … r2.jpg        screenshots
```

## Test

- `inline-assets.mjs` exits 1 on the unfilled template (missing shots), exits 0 with the logo inlined when shots point at real files.
- Built template rendered in headless Chrome at 1440 px with `--force-prefers-reduced-motion`: all sections, demos, ribbon, rail visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF8mQ2AAzeni5GUzZFmP1B